### PR TITLE
Add primary/secondary download buttons to SEO pages (Fixes #9712)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -48,6 +48,8 @@
     <h1 class="mzp-c-article-title">{{ ftl('browser-history-the-history-of-web') }}</h1>
     <p class="mzp-c-article-intro">{{ ftl('browser-history-world-history-is') }}</p>
 
+    {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
+
     <img src="{{ static('img/firefox/browsers/browser-history/browser-history-a.png') }}" alt="" class="c-article-image">
 
     <h2 class="c-section-title">{{ ftl('browser-history-before-web-era') }}</h2>
@@ -109,7 +111,7 @@
   class='mzp-t-product-firefox mzp-t-firefox'
 ) %}
   <div class="download-firefox">
-    {{ download_firefox(download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-button-secondary', download_location='secondary') }}
   </div>
 {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
@@ -23,6 +23,8 @@
     <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
     <p class="mzp-c-article-intro">{{ _('Firefox calls it private browsing, Chrome calls it incognito mode. Both let you browse the web without saving your browsing history.') }}</p>
 
+    {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
+
     <img src="{{ static('img/firefox/browsers/incognito-browser/incognito-browser-a.png') }}" alt="" class="c-article-image">
 
     <h2 class="c-section-title">{{ _('What Incognito/Private Mode Does') }}</h2>
@@ -205,7 +207,7 @@
   class='mzp-t-product-firefox mzp-t-firefox'
 ) %}
   <div class="download-firefox">
-    {{ download_firefox(download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-button-secondary', download_location='secondary') }}
   </div>
 {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/browsers/update-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/update-browser.html
@@ -22,6 +22,8 @@
     <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
     <p class="mzp-c-article-intro">{{ _('One of the most important things you can do to have a safe, fast and secure online browsing experience is to make sure your browser is up to date. Update your browser like you would update your apps. No matter which browser you use, make sure you’re using the latest version.') }}</p>
 
+    {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
+
     <img src="{{ static('img/firefox/browsers/update-browser/fast.png') }}" alt="" class="c-article-image">
 
     <h2 class="c-section-title">{{ _('Stay safe, browse safe') }}</h2>
@@ -79,7 +81,7 @@
   class='mzp-t-product-firefox mzp-t-firefox'
 ) %}
   <div class="download-firefox">
-    {{ download_firefox(download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-button-secondary', download_location='secondary') }}
   </div>
 {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -39,6 +39,8 @@
     <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
     <p class="mzp-c-article-intro">{{ ftl('what-is-a-browser-a-web-browser') }}</p>
 
+    {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
+
     <img src="{{ static('img/firefox/browsers/what-is-a-browser/illo-browser.png') }}" alt="" class="c-article-image">
 
     <p>{{ ftl('what-is-a-browser-the-web-is-a-vast') }}</p>
@@ -79,7 +81,7 @@
     <p>{{ ftl('what-is-a-browser-nearly-all-major') }}</p>
 
     <div class="download-firefox">
-      {{ download_firefox(download_location='primary cta') }}
+      {{ download_firefox_thanks(dom_id='download-button-secondary', download_location='secondary') }}
     </div>
 
     <p>{{ ftl('what-is-a-browser-firefox-helps') }}</p>

--- a/media/css/firefox/browsers/browser-history.scss
+++ b/media/css/firefox/browsers/browser-history.scss
@@ -26,5 +26,14 @@ $image-path: '/media/protocol/img';
         display: block;
         margin: $layout-md auto;
     }
+
+    .mzp-c-button-download-container {
+        display: block;
+        margin-bottom: 0;
+
+        .is-firefox & {
+            display: none;
+        }
+    }
 }
 

--- a/media/css/firefox/browsers/incognito-browser.scss
+++ b/media/css/firefox/browsers/incognito-browser.scss
@@ -11,7 +11,7 @@ $image-path: '/media/protocol/img';
 
 
 .mzp-c-article {
-    margin: 0 auto $layout-lg;
+    margin: $layout-lg auto;
 
     .mzp-c-article-title {
         @include text-title-lg;
@@ -30,6 +30,15 @@ $image-path: '/media/protocol/img';
     .c-article-image {
         display: block;
         margin: $layout-md auto;
+    }
+
+    .mzp-c-button-download-container {
+        display: block;
+        margin-bottom: 0;
+
+        .is-firefox & {
+            display: none;
+        }
     }
 }
 

--- a/media/css/firefox/browsers/update-browser.scss
+++ b/media/css/firefox/browsers/update-browser.scss
@@ -11,7 +11,7 @@ $image-path: '/media/protocol/img';
 
 
 .mzp-c-article {
-    margin: 0 auto $layout-lg;
+    margin: $layout-lg auto;
 
     .mzp-c-article-title {
         @include text-title-lg;
@@ -25,6 +25,15 @@ $image-path: '/media/protocol/img';
     .c-article-image {
         display: block;
         margin: $layout-md auto;
+    }
+
+    .mzp-c-button-download-container {
+        display: block;
+        margin-bottom: 0;
+
+        .is-firefox & {
+            display: none;
+        }
     }
 }
 

--- a/media/css/firefox/browsers/what-is-a-browser.scss
+++ b/media/css/firefox/browsers/what-is-a-browser.scss
@@ -25,15 +25,13 @@ $image-path: '/media/protocol/img';
         display: block;
         margin: $layout-md auto;
     }
-}
-
-/* -------------------------------------------------------------------------- */
-// Download button
-
-.download-firefox {
-    text-align: center;
 
     .mzp-c-button-download-container {
+        display: block;
         margin: $spacing-lg 0;
+
+        .is-firefox & {
+            display: none;
+        }
     }
 }

--- a/tests/functional/firefox/browsers/test_browser_history.py
+++ b/tests/functional/firefox/browsers/test_browser_history.py
@@ -8,6 +8,8 @@ from pages.firefox.browsers.browser_history import BrowserHistoryPage
 
 
 @pytest.mark.nondestructive
-def test_download_button_is_displayed(base_url, selenium):
+@pytest.mark.skip_if_firefox(reason='Primary download button shown only to Firefox users.')
+def test_download_buttons_are_displayed(base_url, selenium):
     page = BrowserHistoryPage(selenium, base_url).open()
-    assert page.download_button.is_displayed
+    assert page.primary_download_button.is_displayed
+    assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/browsers/test_incognito_browser.py
+++ b/tests/functional/firefox/browsers/test_incognito_browser.py
@@ -8,6 +8,8 @@ from pages.firefox.browsers.incognito_browser import IncognitoBrowserPage
 
 
 @pytest.mark.nondestructive
-def test_download_button_is_displayed(base_url, selenium):
+@pytest.mark.skip_if_firefox(reason='Primary download button shown only to Firefox users.')
+def test_download_buttons_are_displayed(base_url, selenium):
     page = IncognitoBrowserPage(selenium, base_url).open()
-    assert page.download_button.is_displayed
+    assert page.primary_download_button.is_displayed
+    assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/browsers/test_update_browser.py
+++ b/tests/functional/firefox/browsers/test_update_browser.py
@@ -8,6 +8,8 @@ from pages.firefox.browsers.update_browser import UpdateBrowserPage
 
 
 @pytest.mark.nondestructive
-def test_download_button_is_displayed(base_url, selenium):
+@pytest.mark.skip_if_firefox(reason='Primary download button shown only to Firefox users.')
+def test_download_buttons_are_displayed(base_url, selenium):
     page = UpdateBrowserPage(selenium, base_url).open()
-    assert page.download_button.is_displayed
+    assert page.primary_download_button.is_displayed
+    assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/browsers/test_what_is_a_browser.py
+++ b/tests/functional/firefox/browsers/test_what_is_a_browser.py
@@ -8,6 +8,8 @@ from pages.firefox.browsers.what_is_a_browser import WhatIsABrowserPage
 
 
 @pytest.mark.nondestructive
-def test_download_button_is_displayed(base_url, selenium):
+@pytest.mark.skip_if_firefox(reason='Primary download button shown only to Firefox users.')
+def test_download_buttons_are_displayed(base_url, selenium):
     page = WhatIsABrowserPage(selenium, base_url).open()
-    assert page.download_button.is_displayed
+    assert page.primary_download_button.is_displayed
+    assert page.secondary_download_button.is_displayed

--- a/tests/pages/firefox/browsers/browser_history.py
+++ b/tests/pages/firefox/browsers/browser_history.py
@@ -12,9 +12,15 @@ class BrowserHistoryPage(BasePage):
 
     _URL_TEMPLATE = '/{locale}/firefox/browsers/browser-history/'
 
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _primary_download_button_locator = (By.ID, 'download-button-primary')
+    _secondary_download_button_locator = (By.ID, 'download-button-secondary')
 
     @property
-    def download_button(self):
-        el = self.find_element(*self._download_button_locator)
+    def primary_download_button(self):
+        el = self.find_element(*self._primary_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button(self):
+        el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)

--- a/tests/pages/firefox/browsers/incognito_browser.py
+++ b/tests/pages/firefox/browsers/incognito_browser.py
@@ -12,9 +12,15 @@ class IncognitoBrowserPage(BasePage):
 
     _URL_TEMPLATE = '/{locale}/firefox/browsers/incognito-browser/'
 
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _primary_download_button_locator = (By.ID, 'download-button-primary')
+    _secondary_download_button_locator = (By.ID, 'download-button-secondary')
 
     @property
-    def download_button(self):
-        el = self.find_element(*self._download_button_locator)
+    def primary_download_button(self):
+        el = self.find_element(*self._primary_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button(self):
+        el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)

--- a/tests/pages/firefox/browsers/update_browser.py
+++ b/tests/pages/firefox/browsers/update_browser.py
@@ -12,9 +12,15 @@ class UpdateBrowserPage(BasePage):
 
     _URL_TEMPLATE = '/{locale}/firefox/browsers/update-your-browser/'
 
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _primary_download_button_locator = (By.ID, 'download-button-primary')
+    _secondary_download_button_locator = (By.ID, 'download-button-secondary')
 
     @property
-    def download_button(self):
-        el = self.find_element(*self._download_button_locator)
+    def primary_download_button(self):
+        el = self.find_element(*self._primary_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button(self):
+        el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)

--- a/tests/pages/firefox/browsers/what_is_a_browser.py
+++ b/tests/pages/firefox/browsers/what_is_a_browser.py
@@ -12,9 +12,15 @@ class WhatIsABrowserPage(BasePage):
 
     _URL_TEMPLATE = '/{locale}/firefox/browsers/what-is-a-browser/'
 
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _primary_download_button_locator = (By.ID, 'download-button-primary')
+    _secondary_download_button_locator = (By.ID, 'download-button-secondary')
 
     @property
-    def download_button(self):
-        el = self.find_element(*self._download_button_locator)
+    def primary_download_button(self):
+        el = self.find_element(*self._primary_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button(self):
+        el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)


### PR DESCRIPTION
## Description
Adds primary/secondary download buttons to several SEO pages:

- http://localhost:8000/en-US/firefox/browsers/update-your-browser/
- http://localhost:8000/en-US/firefox/browsers/what-is-a-browser/
- http://localhost:8000/en-US/firefox/browsers/incognito-browser/
- http://localhost:8000/en-US/firefox/browsers/browser-history/

## Issue / Bugzilla link
#9712

## Testing
- [x] Primary download buttons should be visible to non-Firefox visitors only.

Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/237141339