### PR TITLE
Replace 'master password' terminology with 'primary password' (Fixes #9738)

### DIFF
--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -39,7 +39,7 @@
     aspect_ratio='mzp-has-aspect-1-1',
     class='mzp-l-card-feature-right-half mzp-t-firefox',
   ) %}
-   <p>{{ ftl('password-manager-forget-the-reset-v2', fallback='password-manager-forget-the-reset', url='https://support.mozilla.org/kb/use-master-password-protect-stored-logins') }}</p>
+   <p>{{ ftl('password-manager-forget-the-reset-v2', fallback='password-manager-forget-the-reset', url='https://support.mozilla.org/kb/use-primary-password-protect-stored-logins') }}</p>
   {% endcall %}
 
   {% call feature_card(

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -39,7 +39,7 @@
     aspect_ratio='mzp-has-aspect-1-1',
     class='mzp-l-card-feature-right-half mzp-t-firefox',
   ) %}
-   <p>{{ ftl('password-manager-forget-the-reset', url='https://support.mozilla.org/kb/use-master-password-protect-stored-logins') }}</p>
+   <p>{{ ftl('password-manager-forget-the-reset-v2', fallback='password-manager-forget-the-reset', url='https://support.mozilla.org/kb/use-master-password-protect-stored-logins') }}</p>
   {% endcall %}
 
   {% call feature_card(

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -217,7 +217,7 @@
       <li>{{ ftl('privacy-book-some-online-services') }}</li>
       <li>
         <p>{{ ftl('privacy-book-wondering-how-youre') }}</p>
-        <p>{{ ftl('privacy-book-there-are-several') }}</p>
+        <p>{{ ftl('privacy-book-there-are-several-v2', fallback='privacy-book-there-are-several') }}</p>
       </li>
     </ol>
   </div>

--- a/l10n/en/firefox/features/password-manager.ftl
+++ b/l10n/en/firefox/features/password-manager.ftl
@@ -16,7 +16,7 @@ password-manager-give-up-the-memory = Give up the memory game with { -brand-name
 password-manager-password-hero = Password hero
 
 # Variables:
-#   $url (url) = link to https://support.mozilla.org/kb/use-master-password-protect-stored-logins
+#   $url (url) = link to https://support.mozilla.org/kb/use-primary-password-protect-stored-logins
 password-manager-forget-the-reset-v2 = Forget the reset. { -brand-name-firefox } Password Manager keeps all your passwords so you can log in automatically, or find saved passwords easily. For super security, give your computer a <a href="{ $url }">primary password</a>.
 
 # Obsolete string

--- a/l10n/en/firefox/features/password-manager.ftl
+++ b/l10n/en/firefox/features/password-manager.ftl
@@ -17,6 +17,11 @@ password-manager-password-hero = Password hero
 
 # Variables:
 #   $url (url) = link to https://support.mozilla.org/kb/use-master-password-protect-stored-logins
+password-manager-forget-the-reset-v2 = Forget the reset. { -brand-name-firefox } Password Manager keeps all your passwords so you can log in automatically, or find saved passwords easily. For super security, give your computer a <a href="{ $url }">primary password</a>.
+
+# Obsolete string
+# Variables:
+#   $url (url) = link to https://support.mozilla.org/kb/use-master-password-protect-stored-logins
 password-manager-forget-the-reset = Forget the reset. { -brand-name-firefox } Password Manager keeps all your passwords so you can log in automatically, or find saved passwords easily. For super security, give your computer a <a href="{ $url }">master password</a>.
 
 password-manager-password-magician = Password magician

--- a/l10n/en/firefox/privacy/book.ftl
+++ b/l10n/en/firefox/privacy/book.ftl
@@ -120,6 +120,9 @@ privacy-book-some-online-services = <strong>Some online services will ask you to
 
 privacy-book-wondering-how-youre = <strong>Wondering how you’re supposed to come up with and remember all your passwords and security answers?</strong> Please don’t write them on a piece of paper that you keep next to your computer (yep, people do that). Instead, get a password manager that not only safely store your passwords, security answers and other private information, but also helps you generate random passwords and lets you easily use them across all of your devices.
 
+privacy-book-there-are-several-v2 = There are several great password managers on the market; some are encrypted with a primary password, others with biometric features (fingerprint, face scan). Choose whichever works best for you – and maybe you want to give { -brand-name-firefox-lockwise } a try? It will store all of your passwords securely and is available for your mobile devices as well as your desktop browser, so that you have your login information ready whenever you need it.
+
+# Obsolete string
 privacy-book-there-are-several = There are several great password managers on the market; some are encrypted with a master password, others with biometric features (fingerprint, face scan). Choose whichever works best for you – and maybe you want to give { -brand-name-firefox-lockwise } a try? It will store all of your passwords securely and is available for your mobile devices as well as your desktop browser, so that you have your login information ready whenever you need it.
 
 privacy-book-not-just-for = Not just for IT professionals:


### PR DESCRIPTION
## Description
- Updates pages that used outdated terminology.
- Changes to `pontoon.toml` and `brands.ftl` relate to what's in master in the L10n repo (see https://github.com/mozilla/bedrock/pull/9827 and https://github.com/mozilla/bedrock/pull/9829)

URLs:
- http://localhost:8000/en-US/firefox/features/password-manager/
- http://localhost:8000/en-US/firefox/privacy/book/

## Issue / Bugzilla link
#9738

## Testing
- [ ] Pages should use the term "primary password".