### PR TITLE
Force full installer for Firefox Beta on Windows (Fixes #9836)

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -21,7 +21,7 @@
     desc=ftl('firefox-channel-test-about-to-be-released'),
     class='mzp-t-product-beta mzp-t-firefox') %}
 
-    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=ftl('download-button-download'), dom_id="desktop-beta-download") }}
+    {{ download_firefox('beta', platform='desktop', force_direct=True, force_full_installer=True, alt_copy=ftl('download-button-download'), dom_id="desktop-beta-download") }}
   {% endcall %}
 
   <div class="l-notes mzp-l-content">


### PR DESCRIPTION
Fixes: https://github.com/mozilla/bedrock/issues/9836
