### PR TITLE
Migrate about/history page to Fluent (Fixes #9805) [skip l10n]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/history.html
+++ b/bedrock/mozorg/templates/mozorg/about/history.html
@@ -2,198 +2,83 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "mozorg/about/history-details" "mozorg/about" %}
-
 {% extends "mozorg/about-base.html" %}
 
-{% block page_title %}{{ _('History of the Mozilla Project') }}{% endblock %}
+{% block page_title %}{{ ftl('history-history-of-the-mozilla-project') }}{% endblock %}
 {% block body_class %}mzp-t-mozilla{% endblock %}
 
 {% set body_id = 'about-history' %}
 
 {% block article %}
-  <h1 class="mzp-c-article-title">{{ _('History of the Mozilla Project') }}</h1>
+  <h1 class="mzp-c-article-title">{{ ftl('history-history-of-the-mozilla-project') }}</h1>
 
   <p>
-    {% trans coderush='https://air.mozilla.org/code-rush/',
-             sourcerelease='http://web.archive.org/web/20021001071727/wp.netscape.com/newsref/pr/newsrelease558.html'
-    %}
-      The Mozilla project was <a href="{{ coderush}}">created in 1998</a>
-      with the <a href="{{ sourcerelease }}">release of the Netscape browser
-      suite source code</a>.
-    {% endtrans %}
-    {% trans %}
-      It was intended to harness the creative power of thousands of
-      programmers on the Internet and fuel unprecedented levels of
-      innovation in the browser market.
-    {% endtrans %}
-    {% trans firstyear='http://www-archive.mozilla.org/mozilla-at-one.html' %}
-      Within the <a href="{{ firstyear }}">first year</a>, new community
-      members from around the world had already contributed new
-      functionality, enhanced existing features and became engaged in the
-      management and planning of the project itself.
-    {% endtrans %}
+    {{ ftl('history-the-mozilla-project-was',
+           coderush='https://air.mozilla.org/code-rush/',
+           sourcerelease='https://web.archive.org/web/20021001071727/wp.netscape.com/newsref/pr/newsrelease558.html') }}
+    {{ ftl('history-it-was-intended-to-harness') }}
+    {{ ftl('history-within-the-first-year-new', firstyear='http://www-archive.mozilla.org/mozilla-at-one.html') }}
   </p>
 
   <p>
-    {% trans stevecase='http://www-archive.mozilla.org/stevecase.html' %}
-      By creating an open community, the Mozilla project had become
-      <a href="{{ stevecase }}">larger than any one company</a>.
-    {% endtrans %}
-    {% trans mission='http://www-archive.mozilla.org/mission.html',
+    {{ ftl('history-by-creating-an-open-community', stevecase='http://www-archive.mozilla.org/stevecase.html') }}
+    {{ ftl('history-community-members-got-involved', mission='http://www-archive.mozilla.org/mission.html',
              browsers='http://www.oreillynet.com/pub/a/mozilla/2002/09/12/mozilla_browsers.html',
-             bugzilla='http://www.bugzilla.org',
-             projects=url('firefox')
-    %}
-      Community members got involved and expanded the scope of the project’s
-      <a href="{{ mission }}">original mission</a> — instead of just working
-      on Netscape’s next browser, people started creating
-      <a href="{{ browsers }}">a variety of browsers</a>,
-      <a href="{{ bugzilla }}">development tools</a> and a range of other
-      <a href="{{ projects }}">projects</a>.
-    {% endtrans %}
-    {% trans %}
-      People contributed to Mozilla in different ways, but everyone was
-      passionate about creating free software that would enable people to
-      have a choice in how they experienced the Internet.
-    {% endtrans %}
+             bugzilla='https://www.bugzilla.org',
+             projects=url('firefox')) }}
+    {{ ftl('history-people-contributed-to-mozilla') }}
   </p>
 
   <p>
-    {% trans mozilla1='http://www.mozillazine.org/articles/article2278.html' %}
-      After several years of development,
-      <a href="{{ mozilla1 }}">Mozilla 1.0</a>, the first major version, was
-      released in 2002. This version featured many improvements to the
-      browser, email client and other applications included in the suite,
-      but not many people were using it.
-    {% endtrans %}
-    {% trans over90='http://www.onestat.com/html/aboutus_pressbox4.html' %}
-      By 2002, <a href="{{ over90 }}">well over 90% of Internet users</a>
-      were browsing with Internet Explorer.
-    {% endtrans %}
-    {% trans charter='http://www-archive.mozilla.org/projects/firefox/charter.html' %}
-      Not many people noticed at the time,
-      but the first version of Phoenix (later renamed to Firefox) was also
-      released by Mozilla community members that year with the goal of
-      providing the <a href="{{ charter }}">best possible browsing experience</a>
-      to the widest possible set of people.
-    {% endtrans %}
+    {{ ftl('history-after-several-years-of-development', mozilla1='http://www.mozillazine.org/articles/article2278.html') }}
+    {{ ftl('history-by-2002-well-over-90', over90='http://www.onestat.com/html/aboutus_pressbox4.html') }}
+    {{ ftl('history-not-many-people-noticed', charter='https://www-archive.mozilla.org/projects/firefox/charter.html') }}
   </p>
 
   <p>
-    {% trans foundation='https://blog.mozilla.org/press/2003/07/mozilla-org-announces-launch-of-the-mozilla-foundation-to-lead-open-source-browser-efforts/' %}
-      In 2003, the Mozilla project created the Mozilla Foundation, an
-      <a href="{{ foundation }}">independent non-profit organization</a>
-      supported by individual donors and a variety of companies.
-    {% endtrans %}
-    {% trans manifesto=url('mozorg.about.manifesto') %}
-      The new Mozilla Foundation continued the role of managing the daily
-      operations of the project and also officially took on the role of
-      promoting <a href="{{ manifesto }}">openness, innovation and opportunity</a>
-      on the Internet.
-    {% endtrans %}
-    {% trans grants=url('mozorg.moss.index') %}
-      It did this by continuing to release software, such as Firefox and
-      Thunderbird, and expanding to new areas, such as providing
-      <a href="{{ grants }}">grants</a> to support accessibility
-      improvements on the Web.
-    {% endtrans %}
+    {{ ftl('history-in-2003-the-mozilla-project', foundation='https://blog.mozilla.org/press/2003/07/mozilla-org-announces-launch-of-the-mozilla-foundation-to-lead-open-source-browser-efforts/') }}
+    {{ ftl('history-the-new-mozilla-foundation', manifesto=url('mozorg.about.manifesto')) }}
+    {{ ftl('history-it-did-this-by-continuing', grants=url('mozorg.moss.index')) }}
   </p>
 
   <p>
-    {% trans firefox1='https://blog.mozilla.org/press/2004/11/mozilla-foundation-releases-the-highly-anticipated-mozilla-firefox-1-0-web-browser/',
-             millions='https://blog.mozilla.org/press/2005/10/firefox-surpasses-100-million-downloads/'
-    %}
-      <a href="{{ firefox1 }}">Firefox 1.0</a> was released in 2004 and
-      became a big success — in less than a year, it was downloaded
-      <a href="{{ millions }}">over 100 million times</a>.
-    {% endtrans %}
-    {% trans %}
-      New versions of Firefox have come out regularly since then and keep
-      setting new records. The popularity of Firefox has helped bring choice
-      back to users.
-    {% endtrans %}
-    {% trans innovation='https://blog.mozilla.org/press/2006/12/the-world-economic-forum-announces-technology-pioneers-2007-mozilla-selected/' %}
-      The renewed competition has
-      <a href="{{ innovation }}">accelerated innovation</a> and improved the
-      Internet for everyone.
-    {% endtrans %}
+    {{ ftl('history-firefox-10-was-released',
+           firefox1='https://blog.mozilla.org/press/2004/11/mozilla-foundation-releases-the-highly-anticipated-mozilla-firefox-1-0-web-browser/',
+           millions='https://blog.mozilla.org/press/2005/10/firefox-surpasses-100-million-downloads/') }}
+    {{ ftl('history-new-versions-of-firefox') }}
+    {{ ftl('history-the-renewed-competition', innovation='https://blog.mozilla.org/press/2006/12/the-world-economic-forum-announces-technology-pioneers-2007-mozilla-selected/') }}
   </p>
 
   <p>
-    {% trans firefoxos='https://support.mozilla.org/products/firefox-os' %}
-      In 2013, we launched <a href="{{ firefoxos }}">Firefox OS</a> to
-      unleash the full power of the Web on smartphones and once again offer
-      control and choice to a new generation of people coming online.
-    {% endtrans %}
+    {{ ftl('history-in-2013-we-launched-firefox', firefoxos='https://support.mozilla.org/products/firefox-os') }}
   </p>
 
   <p>
-    {% trans %}
-      Mozilla also celebrated its 15th anniversary in 2013.
-    {% endtrans %}
-    {% trans %}
-      The community has shown that commercial companies can benefit by
-      collaborating in open source projects and that great end user products
-      can be produced as open source software.
-    {% endtrans %}
-    {% trans all=firefox_url('desktop', 'all') %}
-      More people than ever before are using the Internet and are
-      experiencing it <a href="{{ all }}">in their own language</a>.
-    {% endtrans %}
-    {% trans range='http://www.wikipedia.org',
-             areas='http://creativecommons.org/'
-    %}
-      A sustainable organization has been created that uses market mechanisms
-      to support a public benefit mission and this model has been reused by
-      others to create open, transparent and collaborative organizations in
-      a <a href="{{ range }}">broad range</a>
-      <a href="{{ areas }}">of areas</a>.
-    {% endtrans %}
+    {{ ftl('history-mozilla-also-celebrated') }}
+    {{ ftl('history-the-community-has-shown') }}
+    {{ ftl('history-more-people-than-ever-before', all=firefox_url('desktop', 'all')) }}
+    {{ ftl('history-a-sustainable-organization', range='https://www.wikipedia.org', areas='https://creativecommons.org/') }}
   </p>
 
   <p>
-    {% trans %}
-      The future is full of challenges and opportunities equal to those of
-      our past.
-    {% endtrans %}
-    {% trans %}
-      There’s no guarantee that the Internet will remain open or enjoyable
-      or safe.
-    {% endtrans %}
-    {% trans %}
-      Mozilla will continue to provide an opportunity for people to make
-      their voices heard and to shape their own online lives.
-    {% endtrans %}
-    {% trans %}
-      Of course, we’re not alone in doing this.
-    {% endtrans %}
-    {% trans %}
-      The Mozilla community, together with other open source projects and
-      other public benefit organizations, exists only because of the people
-      who are engaged in making our common goals a reality.
-    {% endtrans %}
-    {% trans contribute=url('mozorg.contribute.index') %}
-      If you want to join us in our mission, please
-      <a href="{{ contribute }}">get involved</a>.
-    {% endtrans %}
+    {{ ftl('history-the-future-is-full-of-challenges') }}
+    {{ ftl('history-theres-no-guarantee-that') }}
+    {{ ftl('history-mozilla-will-continue-to') }}
+    {{ ftl('history-of-course-were-not-alone') }}
+    {{ ftl('history-the-mozilla-community-together') }}
+    {{ ftl('history-if-you-want-to-join-us-in', contribute=url('mozorg.contribute.index')) }}
   </p>
 
   <p>
-    {% trans %}
-      For more information about Mozilla’s history, see the following:
-    {% endtrans %}
+    {{ ftl('history-for-more-information-about') }}
   </p>
 
   <ul>
-    <li><a href="https://wiki.mozilla.org/Historical_Documents">{{ _('Mozilla Bookmarks') }}</a></li>
-    <li><a href="https://wiki.mozilla.org/Timeline">{{ _('Timeline of Mozilla Project') }}</a></li>
-    <li><a href="http://mozillamemory.org/index.php">{{ _('Mozilla Digital Memory Bank') }}</a></li>
+    <li><a href="https://wiki.mozilla.org/Historical_Documents">{{ ftl('history-mozilla-bookmarks') }}</a></li>
+    <li><a href="https://wiki.mozilla.org/Timeline">{{ ftl('history-timeline-of-mozilla-project') }}</a></li>
+    <li><a href="http://mozillamemory.org/index.php">{{ ftl('history-mozilla-digital-memory-bank') }}</a></li>
     <li>
-      {% trans link="http://www.foxkeh.com/downloads/" %}
-        <a href="{{ link }}">The History of Firefox and Mozilla Posters</a>
-        (available in English and Japanese)
-      {% endtrans %}
+      {{ ftl('history-the-history-of-firefox-and', link="https://www.foxkeh.com/downloads/") }}
     </li>
   </ul>
 {% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -26,7 +26,7 @@ urlpatterns = (
     page('book', 'mozorg/book.html'),
     url('^credits/$', views.credits_view, name='mozorg.credits'),
     page('credits/faq', 'mozorg/credits-faq.html'),
-    page('about/history', 'mozorg/about/history.html'),
+    page('about/history', 'mozorg/about/history.html', ftl_files=['mozorg/about/history']),
     # Bug 981063, catch all for old calendar urls.
     # must be here to avoid overriding the above
     redirect(r'^projects/calendar/', 'https://www.thunderbird.net/calendar/', locale_prefix=False),

--- a/l10n/en/mozorg/about/history.ftl
+++ b/l10n/en/mozorg/about/history.ftl
@@ -1,0 +1,101 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/about/history/
+
+history-history-of-the-mozilla-project = History of the { -brand-name-mozilla } Project
+
+# Variables:
+#   $coderush (url) - link to https://air.mozilla.org/code-rush/
+#   $sourcerelease (url) - link to https://web.archive.org/web/20021001071727/wp.netscape.com/newsref/pr/newsrelease558.html'
+history-the-mozilla-project-was = The { -brand-name-mozilla } project was <a href="{ $coderush }">created in 1998</a> with the <a href="{ $sourcerelease }">release of the { -brand-name-netscape } browser suite source code</a>.
+
+history-it-was-intended-to-harness = It was intended to harness the creative power of thousands of programmers on the internet and fuel unprecedented levels of innovation in the browser market.
+
+# Variables:
+#   $firstyear (url) link to https://www-archive.mozilla.org/mozilla-at-one.html
+history-within-the-first-year-new = Within the <a href="{ $firstyear }">first year</a>, new community members from around the world had already contributed new functionality, enhanced existing features and became engaged in the management and planning of the project itself.
+
+# Variables:
+#   $stevecase (url) link to https://www-archive.mozilla.org/stevecase.html
+history-by-creating-an-open-community = By creating an open community, the { -brand-name-mozilla } project had become <a href="{ $stevecase }">larger than any one company</a>.
+
+# Variables:
+#   $mission (url) link to https://www-archive.mozilla.org/mission.html
+#   $browsers (url) link to http://www.oreillynet.com/pub/a/mozilla/2002/09/12/mozilla_browsers.html
+#   $bugzilla (url) link to https://www.bugzilla.org
+#   $projects (url) link to https://www.mozilla.org/firefox/
+history-community-members-got-involved = Community members got involved and expanded the scope of the project’s <a href="{ $mission }">original mission</a> — instead of just working on { -brand-name-netscape }’s next browser, people started creating <a href="{ $browsers }">a variety of browsers</a>, <a href="{ $bugzilla }">development tools</a> and a range of other <a href="{ $projects }">projects</a>.
+
+history-people-contributed-to-mozilla = People contributed to { -brand-name-mozilla } in different ways, but everyone was passionate about creating free software that would enable people to have a choice in how they experienced the internet.
+
+# Variables:
+#   $mozilla1 (url) link to http://www.mozillazine.org/articles/article2278.html
+history-after-several-years-of-development = After several years of development, <a href="{ $mozilla1 }">{ -brand-name-mozilla } 1.0</a>, the first major version, was released in 2002. This version featured many improvements to the browser, email client and other applications included in the suite, but not many people were using it.
+
+# Variables:
+#   $over90 (url) link to http://www.onestat.com/html/aboutus_pressbox4.html
+history-by-2002-well-over-90 = By 2002, <a href="{ $over90 }">well over 90% of internet users</a> were browsing with { -brand-name-ie }.
+
+# Variables:
+#   $charter (url) link to https://www-archive.mozilla.org/projects/firefox/charter.html
+history-not-many-people-noticed = Not many people noticed at the time, but the first version of Phoenix (later renamed to { -brand-name-firefox }) was also released by { -brand-name-mozilla } community members that year with the goal of providing the <a href="{ $charter }">best possible browsing experience</a> to the widest possible set of people.
+
+# Variables:
+#   $foundation (url) link to https://blog.mozilla.org/press/2003/07/mozilla-org-announces-launch-of-the-mozilla-foundation-to-lead-open-source-browser-efforts/
+history-in-2003-the-mozilla-project = In 2003, the { -brand-name-mozilla } project created the { -brand-name-mozilla-foundation }, an <a href="{ $foundation }">independent non-profit organization</a> supported by individual donors and a variety of companies.
+
+# Variables:
+#   $manifesto (url) link to https://www.mozilla.org/about/manifesto/
+history-the-new-mozilla-foundation = The new { -brand-name-mozilla-foundation } continued the role of managing the daily operations of the project and also officially took on the role of promoting <a href="{ $manifesto }">openness, innovation and opportunity</a> on the internet.
+
+# Variables:
+#   $grants (url) link to https://www.mozilla.org/moss/
+history-it-did-this-by-continuing = It did this by continuing to release software, such as { -brand-name-firefox } and { -brand-name-thunderbird }, and expanding to new areas, such as providing <a href="{ $grants }">grants</a> to support accessibility improvements on the web.
+
+# Variables:
+#   $firefox1 (url) link to https://blog.mozilla.org/press/2004/11/mozilla-foundation-releases-the-highly-anticipated-mozilla-firefox-1-0-web-browser/
+#   $millions (url) link to https://blog.mozilla.org/press/2005/10/firefox-surpasses-100-million-downloads/
+history-firefox-10-was-released = <a href="{ $firefox1 }">{ -brand-name-firefox } 1.0</a> was released in 2004 and became a big success — in less than a year, it was downloaded <a href="{ $millions }">over 100 million times</a>.
+
+history-new-versions-of-firefox = New versions of { -brand-name-firefox } have come out regularly since then and keep setting new records. The popularity of { -brand-name-firefox } has helped bring choice back to users.
+
+# Variables:
+#   $innovation (url) link to https://blog.mozilla.org/press/2006/12/the-world-economic-forum-announces-technology-pioneers-2007-mozilla-selected/
+history-the-renewed-competition = The renewed competition has <a href="{ $innovation }">accelerated innovation</a> and improved the internet for everyone.
+
+# Variables:
+#   $firefoxos (url) link to https://support.mozilla.org/products/firefox-os
+history-in-2013-we-launched-firefox = In 2013, we launched <a href="{ $firefoxos }">{ -brand-name-firefox-os }</a> to unleash the full power of the web on smartphones and once again offer control and choice to a new generation of people coming online.
+
+history-mozilla-also-celebrated = { -brand-name-mozilla } also celebrated its 15th anniversary in 2013.
+history-the-community-has-shown = The community has shown that commercial companies can benefit by collaborating in open source projects and that great end user products can be produced as open source software.
+
+# Variables:
+#   $all (url) link to https://www.mozilla.org/firefox/all/
+history-more-people-than-ever-before = More people than ever before are using the internet and are experiencing it <a href="{ $all }">in their own language</a>.
+
+# Variables:
+#   $range (url) link to https://www.wikipedia.org
+#   $areas (url) link to https://creativecommons.org/
+history-a-sustainable-organization = A sustainable organization has been created that uses market mechanisms to support a public benefit mission and this model has been reused by others to create open, transparent and collaborative organizations in a <a href="{ $range }">broad range</a> <a href="{ $areas }">of areas</a>.
+
+history-the-future-is-full-of-challenges = The future is full of challenges and opportunities equal to those of our past.
+history-theres-no-guarantee-that = There’s no guarantee that the internet will remain open or enjoyable or safe.
+history-mozilla-will-continue-to = { -brand-name-mozilla } will continue to provide an opportunity for people to make their voices heard and to shape their own online lives.
+history-of-course-were-not-alone = Of course, we’re not alone in doing this.
+history-the-mozilla-community-together = The { -brand-name-mozilla } community, together with other open source projects and other public benefit organizations, exists only because of the people who are engaged in making our common goals a reality.
+
+# Variables:
+#   $contribute (url) link to https://www.mozilla.org/contribute/
+history-if-you-want-to-join-us-in = If you want to join us in our mission, please <a href="{ $contribute }">get involved</a>.
+
+history-for-more-information-about = For more information about { -brand-name-mozilla }’s history, see the following:
+history-mozilla-bookmarks = { -brand-name-mozilla } Bookmarks
+history-timeline-of-mozilla-project = Timeline of { -brand-name-mozilla } Project
+history-mozilla-digital-memory-bank = { -brand-name-mozilla } Digital Memory Bank
+
+# Variables:
+#   $link (url) link to https://www.foxkeh.com/downloads/
+history-the-history-of-firefox-and = <a href="{ $link }">The History of { -brand-name-firefox } and { -brand-name-mozilla } Posters</a> (available in English and Japanese)

--- a/lib/fluent_migrations/mozorg/about/history.py
+++ b/lib/fluent_migrations/mozorg/about/history.py
@@ -1,0 +1,342 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+history = "mozorg/about/history.lang"
+history_details = "mozorg/about/history-details.lang"
+about = "mozorg/about.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/mozorg/templates/mozorg/about/history.html, part {index}."""
+
+    ctx.add_transforms(
+        "mozorg/about/history.ftl",
+        "mozorg/about/history.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("history-history-of-the-mozilla-project"),
+                value=REPLACE(
+                    history_details,
+                    "History of the Mozilla Project",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-the-mozilla-project-was"),
+                value=REPLACE(
+                    history_details,
+                    "The Mozilla project was <a href=\"%(coderush)s\">created in 1998</a> with the <a href=\"%(sourcerelease)s\">release of the Netscape browser suite source code</a>.",
+                    {
+                        "%%": "%",
+                        "%(coderush)s": VARIABLE_REFERENCE("coderush"),
+                        "%(sourcerelease)s": VARIABLE_REFERENCE("sourcerelease"),
+                        "Netscape": TERM_REFERENCE("brand-name-netscape"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+history-it-was-intended-to-harness = {COPY(history_details, "It was intended to harness the creative power of thousands of programmers on the Internet and fuel unprecedented levels of innovation in the browser market.",)}
+""", history_details=history_details) + [
+            FTL.Message(
+                id=FTL.Identifier("history-within-the-first-year-new"),
+                value=REPLACE(
+                    history_details,
+                    "Within the <a href=\"%(firstyear)s\">first year</a>, new community members from around the world had already contributed new functionality, enhanced existing features and became engaged in the management and planning of the project itself.",
+                    {
+                        "%%": "%",
+                        "%(firstyear)s": VARIABLE_REFERENCE("firstyear"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-by-creating-an-open-community"),
+                value=REPLACE(
+                    history_details,
+                    "By creating an open community, the Mozilla project had become <a href=\"%(stevecase)s\">larger than any one company</a>.",
+                    {
+                        "%%": "%",
+                        "%(stevecase)s": VARIABLE_REFERENCE("stevecase"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-community-members-got-involved"),
+                value=REPLACE(
+                    history_details,
+                    "Community members got involved and expanded the scope of the project’s <a href=\"%(mission)s\">original mission</a> — instead of just working on Netscape’s next browser, people started creating <a href=\"%(browsers)s\">a variety of browsers</a>, <a href=\"%(bugzilla)s\">development tools</a> and a range of other <a href=\"%(projects)s\">projects</a>.",
+                    {
+                        "%%": "%",
+                        "%(mission)s": VARIABLE_REFERENCE("mission"),
+                        "%(browsers)s": VARIABLE_REFERENCE("browsers"),
+                        "%(bugzilla)s": VARIABLE_REFERENCE("bugzilla"),
+                        "%(projects)s": VARIABLE_REFERENCE("projects"),
+                        "Netscape": TERM_REFERENCE("brand-name-netscape"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-people-contributed-to-mozilla"),
+                value=REPLACE(
+                    history_details,
+                    "People contributed to Mozilla in different ways, but everyone was passionate about creating free software that would enable people to have a choice in how they experienced the Internet.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-after-several-years-of-development"),
+                value=REPLACE(
+                    history_details,
+                    "After several years of development, <a href=\"%(mozilla1)s\">Mozilla 1.0</a>, the first major version, was released in 2002. This version featured many improvements to the browser, email client and other applications included in the suite, but not many people were using it.",
+                    {
+                        "%%": "%",
+                        "%(mozilla1)s": VARIABLE_REFERENCE("mozilla1"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-by-2002-well-over-90"),
+                value=REPLACE(
+                    history_details,
+                    "By 2002, <a href=\"%(over90)s\">well over 90%% of Internet users</a> were browsing with Internet Explorer.",
+                    {
+                        "%%": FTL.TextElement("%"),
+                        "%(over90)s": VARIABLE_REFERENCE("over90"),
+                        "Internet Explorer": TERM_REFERENCE("brand-name-ie"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-not-many-people-noticed"),
+                value=REPLACE(
+                    history_details,
+                    "Not many people noticed at the time, but the first version of Phoenix (later renamed to Firefox) was also released by Mozilla community members that year with the goal of providing the <a href=\"%(charter)s\">best possible browsing experience</a> to the widest possible set of people.",
+                    {
+                        "%%": "%",
+                        "%(charter)s": VARIABLE_REFERENCE("charter"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-in-2003-the-mozilla-project"),
+                value=REPLACE(
+                    history_details,
+                    "In 2003, the Mozilla project created the Mozilla Foundation, an <a href=\"%(foundation)s\">independent non-profit organization</a> supported by individual donors and a variety of companies.",
+                    {
+                        "%%": "%",
+                        "%(foundation)s": VARIABLE_REFERENCE("foundation"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Mozilla Foundation": TERM_REFERENCE("brand-name-mozilla-foundation"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-the-new-mozilla-foundation"),
+                value=REPLACE(
+                    history_details,
+                    "The new Mozilla Foundation continued the role of managing the daily operations of the project and also officially took on the role of promoting <a href=\"%(manifesto)s\">openness, innovation and opportunity</a> on the Internet.",
+                    {
+                        "%%": "%",
+                        "%(manifesto)s": VARIABLE_REFERENCE("manifesto"),
+                        "Mozilla Foundation": TERM_REFERENCE("brand-name-mozilla-foundation"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-it-did-this-by-continuing"),
+                value=REPLACE(
+                    history_details,
+                    "It did this by continuing to release software, such as Firefox and Thunderbird, and expanding to new areas, such as providing <a href=\"%(grants)s\">grants</a> to support accessibility improvements on the Web.",
+                    {
+                        "%%": "%",
+                        "%(grants)s": VARIABLE_REFERENCE("grants"),
+                        "Thunderbird": TERM_REFERENCE("brand-name-thunderbird"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-firefox-10-was-released"),
+                value=REPLACE(
+                    history_details,
+                    "<a href=\"%(firefox1)s\">Firefox 1.0</a> was released in 2004 and became a big success — in less than a year, it was downloaded <a href=\"%(millions)s\">over 100 million times</a>.",
+                    {
+                        "%%": "%",
+                        "%(firefox1)s": VARIABLE_REFERENCE("firefox1"),
+                        "%(millions)s": VARIABLE_REFERENCE("millions"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-new-versions-of-firefox"),
+                value=REPLACE(
+                    history_details,
+                    "New versions of Firefox have come out regularly since then and keep setting new records. The popularity of Firefox has helped bring choice back to users.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-the-renewed-competition"),
+                value=REPLACE(
+                    history_details,
+                    "The renewed competition has <a href=\"%(innovation)s\">accelerated innovation</a> and improved the Internet for everyone.",
+                    {
+                        "%%": "%",
+                        "%(innovation)s": VARIABLE_REFERENCE("innovation"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-in-2013-we-launched-firefox"),
+                value=REPLACE(
+                    history_details,
+                    "In 2013, we launched <a href=\"%(firefoxos)s\">Firefox OS</a> to unleash the full power of the Web on smartphones and once again offer control and choice to a new generation of people coming online.",
+                    {
+                        "%%": "%",
+                        "%(firefoxos)s": VARIABLE_REFERENCE("firefoxos"),
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-mozilla-also-celebrated"),
+                value=REPLACE(
+                    history_details,
+                    "Mozilla also celebrated its 15th anniversary in 2013.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+history-the-community-has-shown = {COPY(history_details, "The community has shown that commercial companies can benefit by collaborating in open source projects and that great end user products can be produced as open source software.",)}
+""", history_details=history_details) + [
+            FTL.Message(
+                id=FTL.Identifier("history-more-people-than-ever-before"),
+                value=REPLACE(
+                    history_details,
+                    "More people than ever before are using the Internet and are experiencing it <a href=\"%(all)s\">in their own language</a>.",
+                    {
+                        "%%": "%",
+                        "%(all)s": VARIABLE_REFERENCE("all"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-a-sustainable-organization"),
+                value=REPLACE(
+                    history_details,
+                    "A sustainable organization has been created that uses market mechanisms to support a public benefit mission and this model has been reused by others to create open, transparent and collaborative organizations in a <a href=\"%(range)s\">broad range</a> <a href=\"%(areas)s\">of areas</a>.",
+                    {
+                        "%%": "%",
+                        "%(range)s": VARIABLE_REFERENCE("range"),
+                        "%(areas)s": VARIABLE_REFERENCE("areas"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+history-the-future-is-full-of-challenges = {COPY(history_details, "The future is full of challenges and opportunities equal to those of our past.",)}
+history-theres-no-guarantee-that = {COPY(history_details, "There’s no guarantee that the Internet will remain open or enjoyable or safe.",)}
+""", history_details=history_details) + [
+            FTL.Message(
+                id=FTL.Identifier("history-mozilla-will-continue-to"),
+                value=REPLACE(
+                    history_details,
+                    "Mozilla will continue to provide an opportunity for people to make their voices heard and to shape their own online lives.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+history-of-course-were-not-alone = {COPY(history_details, "Of course, we’re not alone in doing this.",)}
+""", history_details=history_details) + [
+            FTL.Message(
+                id=FTL.Identifier("history-the-mozilla-community-together"),
+                value=REPLACE(
+                    history_details,
+                    "The Mozilla community, together with other open source projects and other public benefit organizations, exists only because of the people who are engaged in making our common goals a reality.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-if-you-want-to-join-us-in"),
+                value=REPLACE(
+                    history_details,
+                    "If you want to join us in our mission, please <a href=\"%(contribute)s\">get involved</a>.",
+                    {
+                        "%%": "%",
+                        "%(contribute)s": VARIABLE_REFERENCE("contribute"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-for-more-information-about"),
+                value=REPLACE(
+                    history_details,
+                    "For more information about Mozilla’s history, see the following:",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-mozilla-bookmarks"),
+                value=REPLACE(
+                    history_details,
+                    "Mozilla Bookmarks",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-timeline-of-mozilla-project"),
+                value=REPLACE(
+                    history_details,
+                    "Timeline of Mozilla Project",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-mozilla-digital-memory-bank"),
+                value=REPLACE(
+                    history_details,
+                    "Mozilla Digital Memory Bank",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("history-the-history-of-firefox-and"),
+                value=REPLACE(
+                    history_details,
+                    "<a href=\"%(link)s\">The History of Firefox and Mozilla Posters</a> (available in English and Japanese)",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description

http://localhost:8000/about/history/

## Issue / Bugzilla link
#9805

## Testing
```
./manage.py l10n_update
```