### PR TITLE
Fix typo (originsd -> origins)

### DIFF
--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -111,7 +111,7 @@
     </tr>
   </tbody>
   </table>
-  <p><sup>0</sup>UXSS is defined as the ability to execute privileged JavaScript in a way that allows you access to data from arbitrary originsd or to affect Firefox preferences or settings.</p>
+  <p><sup>0</sup>UXSS is defined as the ability to execute privileged JavaScript in a way that allows you access to data from arbitrary origins or to affect Firefox preferences or settings.</p>
 
   <p><sup>1</sup>Sandbox escapes that assume arbitrary code execution in the content process - such as invoking an IPC method with attacker-controlled parameters - do qualify for Highest Impact.</p>
 


### PR DESCRIPTION
Just fixing a typo I randomly found.. CCing @tomrittervg 

## Description

The client bounty page has a typo (extra letter)

## Issue / Bugzilla link

None. Is this needed for simple changes?

## Testing

N/A