### PR TITLE
Migrate error pages to Fluent (Fixes #9807) [skip l10n]

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -2,12 +2,11 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% set_lang_files "mozorg/404" %}
 {% extends "base-error.html" %}
 
 {% block gtm_page_id %}data-gtm-page-id="404"{% endblock %}
 
-{% block page_title %}{{ _('404: Page Not Found') }}{% endblock %}
+{% block page_title %}{{ ftl('not-found-page-not-found-page-page-not-found') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('page_not_found') }}
@@ -17,82 +16,43 @@
 {% block canonical_urls %}{% endblock %}
 
 {% block content %}
-  {% if l10n_has_tag('404_update_2020') %}
-    <main role="main">
-      <section class="mzp-l-content message-section">
-        <h1 class="error-header">{{ _('Sorry, we can’t find that page') }}</h1>
-        <p>{{_('We’re all about a healthy internet but sometimes broken URLs happen.') }}</p>
-        <div class="hide-back" id="go-back">
-          <a class="back-button">{{ _('Go Back') }}</a>
-        </div>
-      </section>
-      <section class="mzp-l-content">
-        <ul>
-          <li>
-            <section class="has-icon">
-              <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-                <p class="list-content">
-                  {% trans about=url('mozorg.about.index') %}
-                    <a href="{{ about }}">Learn</a> about Mozilla, the non-profit behind Firefox.
-                  {% endtrans %}
-                </p>
-            </section>
-          </li>
-          <li>
-            <section class="has-icon">
-              <img class="list-icon" alt="" src="{{ static('protocol/img/logos/firefox/logo-flat.svg') }}" width="30" height="30">
-              <p class="list-content">
-              {% trans explore=url('firefox') %}
-                <a href={{ explore }}>Explore</a> the entire family for Firefox products designed to respect your privacy.
-              {% endtrans %}
-              </p>
-            </section>
-          </li>
-          <li>
-            <section class="has-icon">
-              <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
-              <p class="list-content">
-              {% trans download=url('firefox.new') %}
-                <a href={{ download }}>Download</a> the Firefox browser for your mobile device or desktop
-              {% endtrans %}
-              </p>
-            </section>
-          </li>
-        </ul>
-      </section>
-    </main>
-
-  {% else %}
-
-    <main>
-      <div class="mzp-l-content message-section">
-        <header>
-          <h1 class="error-header"><span>{{ _('Whoops!') }}</span></h1>
-          <p class="error-helper">{{ _('Did you make a left at that last URL instead of a right? No problem. Here are some tips to get you back on your way:') }}</p>
-        </header>
-        <div class="error-content">
-          <ul class="mzp-u-list-style">
-            <li class="fallback-list-content">{{ _('If you typed in the address, check your spelling. Could just be a typo.') }}</li>
-            <li class="fallback-list-content">
-            {% trans bugzilla='https://bugzilla.mozilla.org/enter_bug.cgi?product=www.mozilla.org' %}
-              If you’ve found an issue with one of our websites, we’d appreciate it if you could report the problem in Bugzilla, our <a href="{{ bugzilla }}">bug tracker</a>. One of our developers will take a look at it as soon as possible.
-            {% endtrans %}
-            </li>
-            <li class="fallback-list-content">{{ _('If you followed a link, it’s probably broken.') }}</li>
-            <li class="fallback-list-content">
-            {% trans  url=url('mozorg.home') %}
-              If you’re not sure what you’re looking for, start at <a href="{{ url }}">mozilla.org</a>.
-            {% endtrans %}
-            </li>
-          </ul>
-        </div>
-        <aside class="download-firefox">
-          {{ download_firefox() }}
-        </aside>
+  <main role="main">
+    <section class="mzp-l-content message-section">
+      <h1 class="error-header">{{ ftl('not-found-page-sorry-we-cant-find-that-page') }}</h1>
+      <p>{{ftl('not-found-page-were-all-about-a-healthy-internet') }}</p>
+      <div class="hide-back" id="go-back">
+        <a class="back-button">{{ ftl('not-found-page-go-back') }}</a>
       </div>
-    </main>
-
-  {% endif %}
+    </section>
+    <section class="mzp-l-content">
+      <ul>
+        <li>
+          <section class="has-icon">
+            <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
+              <p class="list-content">
+                {{ ftl('not-found-page-learn-about-mozilla-the-non', about=url('mozorg.about.index')) }}
+              </p>
+          </section>
+        </li>
+        <li>
+          <section class="has-icon">
+            <img class="list-icon" alt="" src="{{ static('protocol/img/logos/firefox/logo-flat.svg') }}" width="30" height="30">
+            <p class="list-content">
+            {{ ftl('not-found-page-explore-the-entire-family-for', explore=url('firefox')) }}
+            </p>
+          </section>
+        </li>
+        <li>
+          <section class="has-icon">
+            <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
+            <p class="list-content">
+            {{ ftl('not-found-page-download-the-firefox-browser', download=url('firefox.new')) }}
+            </p>
+          </section>
+        </li>
+      </ul>
+    </section>
+  </main>
 {% endblock %}
 
 {% block js %}

--- a/bedrock/base/templates/500.html
+++ b/bedrock/base/templates/500.html
@@ -2,46 +2,22 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% set_lang_files "mozorg/500" %}
-
 {% extends "base-error.html" %}
 
 {% block gtm_page_id %}data-gtm-page-id="500"{% endblock %}
 
-{% block page_title %}{{ _('500: Internal Server Error') }}{% endblock %}
+{% block page_title %}{{ ftl('error-page-error-page-internal-server-error') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('page_not_found') }}
 {% endblock %}
 
 {% block content %}
-  {% if l10n_has_tag('404_update_2020') %}
-    <main role="main">
-      <section class="mzp-l-content">
-        <h1 class="error-header">{{ _('Something went wrong') }}</h1>
-        <p>{{ _('It’s probably just a server error and we’re working to fix it.') }}<br>
-        {% trans firefox="https://firefox.com", mozilla=url('mozorg.home') %}
-          You can also try refreshing this page or go to <a href={{ firefox }}>firefox.com</a> or <a href={{ mozilla }}>mozilla.org</a>
-        {% endtrans %}</p>
-      </section>
-    </main>
-  {% else %}
-    <main>
-      <div class="mzp-l-content message-section">
-        <header>
-          <h1 class="error_header">{{ _('An error occurred.') }}</h1>
-        </header>
-        <div class="error-content">
-          <p class="error-helper">
-          {% trans bugzilla='https://bugzilla.mozilla.org/enter_bug.cgi?product=www.mozilla.org' %}
-            If you’ve found an issue with one of our websites, we’d appreciate it if you could report the problem in Bugzilla, our <a href="{{ bugzilla }}">bug tracker</a>. One of our developers will take a look at it as soon as possible.
-          {% endtrans %}
-          </p>
-        </div>
-        <aside class="download-firefox">
-          {{ download_firefox() }}
-        </aside>
-      </div>
-    </main>
-  {% endif %}
+  <main role="main">
+    <section class="mzp-l-content">
+      <h1 class="error-header">{{ ftl('error-page-something-went-wrong') }}</h1>
+      <p>{{ ftl('error-page-its-probably-just-a-server-error') }}<br>
+      {{ ftl('error-page-you-can-also-try-refreshing', firefox="https://firefox.com", mozilla=url('mozorg.home')) }}</p>
+    </section>
+  </main>
 {% endblock %}

--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -175,9 +175,9 @@ def cron_health_check(request):
 
 def server_error_view(request, template_name='500.html'):
     """500 error handler that runs context processors."""
-    return l10n_utils.render(request, template_name, status=500)
+    return l10n_utils.render(request, template_name, ftl_files=['500'], status=500)
 
 
 def page_not_found_view(request, exception=None, template_name='404.html'):
     """404 error handler that runs context processors."""
-    return l10n_utils.render(request, template_name, status=404)
+    return l10n_utils.render(request, template_name, ftl_files=['404'], status=404)

--- a/l10n/en/404.ftl
+++ b/l10n/en/404.ftl
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/404/
+
+not-found-page-not-found-page-page-not-found = 404: Page Not Found
+not-found-page-sorry-we-cant-find-that-page = Sorry, we can’t find that page
+not-found-page-were-all-about-a-healthy-internet = We’re all about a healthy internet but sometimes broken URLs happen.
+not-found-page-go-back = Go Back
+
+# Variables:
+#   $about (url) - link to https://www.mozilla.org/about/
+not-found-page-learn-about-mozilla-the-non = <a href="{ $about }">Learn</a> about { -brand-name-mozilla }, the not-for-profit behind { -brand-name-firefox }.
+
+# Variables:
+#   $explore (url) - link to https://www.mozilla.org/firefox/
+not-found-page-explore-the-entire-family-for = <a href={ $explore }>Explore</a> the entire family for { -brand-name-firefox } products designed to respect your privacy.
+
+# Variables:
+#   $download (url) - link to https://www.mozilla.org/firefox/new/
+not-found-page-download-the-firefox-browser = <a href={ $download }>Download</a> the { -brand-name-firefox } browser for your mobile device or desktop

--- a/l10n/en/500.ftl
+++ b/l10n/en/500.ftl
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+error-page-error-page-internal-server-error = 500: Internal Server Error
+error-page-something-went-wrong = Something went wrong
+error-page-its-probably-just-a-server-error = It’s probably just a server error and we’re working to fix it.
+
+# Variables:
+#   $firefox (url) - link to https://firefox.com/
+#   $mozilla (url) - link to https://www.mozilla.org/
+error-page-you-can-also-try-refreshing = You can also try refreshing this page or go to <a href={ $firefox }>firefox.com</a> or <a href={ $mozilla }>mozilla.org</a>

--- a/lib/fluent_migrations/404.py
+++ b/lib/fluent_migrations/404.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+not_found = "mozorg/404.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/base/templates/404.html, part {index}."""
+
+    ctx.add_transforms(
+        "404.ftl",
+        "404.ftl",
+        transforms_from("""
+not-found-page-not-found-page-page-not-found = {COPY(not_found, "404: Page Not Found",)}
+not-found-page-sorry-we-cant-find-that-page = {COPY(not_found, "Sorry, we can’t find that page",)}
+not-found-page-were-all-about-a-healthy-internet = {COPY(not_found, "We’re all about a healthy internet but sometimes broken URLs happen.",)}
+not-found-page-go-back = {COPY(not_found, "Go Back",)}
+""", not_found=not_found) + [
+            FTL.Message(
+                id=FTL.Identifier("not-found-page-learn-about-mozilla-the-non"),
+                value=REPLACE(
+                    not_found,
+                    "<a href=\"%(about)s\">Learn</a> about Mozilla, the non-profit behind Firefox.",
+                    {
+                        "%%": "%",
+                        "%(about)s": VARIABLE_REFERENCE("about"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("not-found-page-explore-the-entire-family-for"),
+                value=REPLACE(
+                    not_found,
+                    "<a href=%(explore)s>Explore</a> the entire family for Firefox products designed to respect your privacy.",
+                    {
+                        "%%": "%",
+                        "%(explore)s": VARIABLE_REFERENCE("explore"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("not-found-page-download-the-firefox-browser"),
+                value=REPLACE(
+                    not_found,
+                    "<a href=%(download)s>Download</a> the Firefox browser for your mobile device or desktop",
+                    {
+                        "%%": "%",
+                        "%(download)s": VARIABLE_REFERENCE("download"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+    )

--- a/lib/fluent_migrations/500.py
+++ b/lib/fluent_migrations/500.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+error_page = "mozorg/500.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/base/templates/500.html, part {index}."""
+
+    ctx.add_transforms(
+        "500.ftl",
+        "500.ftl",
+        transforms_from("""
+error-page-error-page-internal-server-error = {COPY(error_page, "500: Internal Server Error",)}
+error-page-something-went-wrong = {COPY(error_page, "Something went wrong",)}
+error-page-its-probably-just-a-server-error = {COPY(error_page, "It’s probably just a server error and we’re working to fix it.",)}
+""", error_page=error_page) + [
+            FTL.Message(
+                id=FTL.Identifier("error-page-you-can-also-try-refreshing"),
+                value=REPLACE(
+                    error_page,
+                    "You can also try refreshing this page or go to <a href=%(firefox)s>firefox.com</a> or <a href=%(mozilla)s>mozilla.org</a>",
+                    {
+                        "%%": "%",
+                        "%(firefox)s": VARIABLE_REFERENCE("firefox"),
+                        "%(mozilla)s": VARIABLE_REFERENCE("mozilla"),
+                    }
+                )
+            ),
+        ]
+    )


### PR DESCRIPTION
## Description
- http://localhost:8000/en-US/404/
- http://localhost:8000/en-US/500/

## Issue / Bugzilla link
#9807

## Testing
```
./manage.py l10n_update
```