### PR TITLE
Update links to sync and accounts (Fix #9860)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -106,7 +106,7 @@ redirectpatterns = (
              anchor='product-desktop-esr'),
 
     # bug 729329
-    redirect(r'^mobile/sync', 'firefox.accounts'),
+    redirect(r'^mobile/sync', 'firefox.sync'),
 
     # bug 882845
     redirect(r'^firefox/toolkit/download-to-your-devices', 'firefox.new'),
@@ -153,7 +153,7 @@ redirectpatterns = (
 
     # Bug 1110927
     redirect(r'^(products/)?firefox/start/central\.html$', 'firefox.new'),
-    redirect(r'^firefox/sync/firstrun\.html$', 'firefox.accounts'),
+    redirect(r'^firefox/sync/firstrun\.html$', 'firefox.sync'),
 
     # Bug 920212
     redirect(r'^firefox/fx(/.*)?', 'firefox'),

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -124,7 +124,7 @@
             image_url='img/firefox/mobile/protocol/account.svg',
             aspect_ratio='mzp-has-aspect-1-1',
             class='mzp-l-card-feature-right-half mzp-t-firefox',
-            link_url=url('firefox.accounts'),
+            link_url=url('firefox.sync'),
             link_cta=ftl('ui-learn-more')
           ) %}
           <p>{{ ftl('firefox-mobile-sync-your-history-passwords') }}</p>

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -216,7 +216,7 @@ URLS = flatten((
     url_test('/firefox/organizations/all.html', '/firefox/all/#product-desktop-esr'),
 
     # bug 729329
-    url_test('/mobile/sync/is/da/best/', '/firefox/accounts/'),
+    url_test('/mobile/sync/is/da/best/', '/firefox/sync/'),
 
     # bug 882845
     url_test('/firefox/toolkit/download-to-your-devices/because-i-say-so/', '/firefox/new/'),
@@ -311,7 +311,7 @@ URLS = flatten((
 
     # Bug 1110927
     url_test('/firefox/start/central.html', '/firefox/new/'),
-    url_test('/firefox/sync/firstrun.html', '/firefox/accounts/'),
+    url_test('/firefox/sync/firstrun.html', '/firefox/sync/'),
 
     # bug 876810
     url_test('/hacking/commit-access-policy/',


### PR DESCRIPTION
## Description

Over time the content of the pages at /sync and /accounts have changed. This PR updates some redirects and content links to point to the more appropriate of the two locations.
 
## Issue / Bugzilla link

Fix #9860

## Testing

http://localhost:8000/en-US/firefox/mobile/