### PR TITLE
Remove SMS feature for send to device (#9864)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -54,7 +54,7 @@
 
 {# Docs: https://bedrock.readthedocs.io/en/latest/send-to-device.html #}
 {% macro send_to_device(platform='all', product='firefox', message_set='default', id='send-to-device', class='horizontal', include_title=True, title_text=None, input_label=None, legal_note_email=None, spinner_color='#000', button_class=None) %}
-  <section id="{{ id }}" class="send-to-device {{ class }}">
+  <section id="{{ id }}" class="send-to-device {{ class }}" data-spinner-color="{{ spinner_color }}">
     <div class="form-container">
       {% if include_title %}
         <h2 class="form-heading">

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -53,8 +53,8 @@
 
 
 {# Docs: https://bedrock.readthedocs.io/en/latest/send-to-device.html #}
-{% macro send_to_device(platform='all', product='firefox', message_set='default', id='send-to-device', class='horizontal', include_title=True, title_text=None, input_label=None, legal_note_email=None, legal_note_sms=None, spinner_color='#000', input_label_alt=None, button_class=None) %}
-  <section id="{{ id }}" class="send-to-device {{ class }}" data-countries="{{ send_to_device_sms_countries(message_set) }}" data-spinner-color="{{ spinner_color }}">
+{% macro send_to_device(platform='all', product='firefox', message_set='default', id='send-to-device', class='horizontal', include_title=True, title_text=None, input_label=None, legal_note_email=None, spinner_color='#000', button_class=None) %}
+  <section id="{{ id }}" class="send-to-device {{ class }}">
     <div class="form-container">
       {% if include_title %}
         <h2 class="form-heading">
@@ -68,9 +68,6 @@
       <h2 class="mzp-u-title-xs thank-you hidden">{{ ftl('send-to-device-your-download-link') }}</h2>
       <form class="send-to-device-form" action="{{ url('firefox.send-to-device-post') }}" method="post">
         <ul class="mzp-c-form-errors hidden">
-          <li class="sms">
-            {{ ftl('send-to-device-sorry-we-cant-send', fallback='send-to-device-sorry-this-number') }}
-          </li>
           <li class="email">{{ ftl('send-to-device-please-enter-an-email') }}</li>
           <li class="system">{{ ftl('send-to-device-an-error-occured') }}</li>
         </ul>
@@ -82,27 +79,18 @@
             <input type="hidden" name="product" value="{{ product }}">
           </div>
           <div class="mzp-c-field mzp-l-stretch">
-            <label class="mzp-c-field-label" for="{{ id }}-input" data-alt="{% if input_label_alt %}{{ input_label_alt }}{% else %}{{ ftl('send-to-device-enter-your-email-or-phone', fallback='send-to-device-enter-your-email-or-phone-10-digit') }}{% endif %}">
+            <label class="mzp-c-field-label" for="{{ id }}-input">
               {% if input_label %}
                 {{ input_label }}
               {% else %}
                 {{ ftl('send-to-device-enter-your-email') }}
               {% endif %}
             </label>
-            <input id="{{ id }}-input" class="mzp-c-field-control send-to-device-input" name="phone-or-email" type="text" required>
+            <input id="{{ id }}-input" class="mzp-c-field-control send-to-device-input" name="s2d-email" type="text" required>
           </div>
           <div class="mzp-c-button-container mzp-l-stretch">
             <button type="submit" class="button mzp-c-button {% if button_class %} {{ button_class }} {% else %} mzp-t-product {% endif %}">{{ ftl('send-to-device-send') }}</button>
           </div>
-          <p class="mzp-c-button-info sms">
-            {% if legal_note_sms %}
-              {{ legal_note_sms }}
-            {% else %}
-                {{ ftl('send-to-device-sms-service-available-in-select', fallback='send-to-device-sms-service-available-to-us') }}
-                {{ ftl('send-to-device-intended-recipient-email-sms') }}
-            {% endif %}
-            <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
-          </p>
           <p class="mzp-c-button-info email">
             {% if legal_note_email %}
               {{ legal_note_email }}
@@ -113,7 +101,6 @@
           </p>
         </div>
         <div class="thank-you hidden">
-          <p class="sms">{{ ftl('send-to-device-check-your-device-email-sms') }}</p>
           <p class="email">{{ ftl('send-to-device-check-your-device-email') }}</p>
           <a href="#" role="button" class="more send-another">{{ ftl('send-to-device-send-to-another') }}</a>
         </div>

--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -18,15 +18,6 @@ JS_TEMPLATE = '<script type="text/javascript" src="%s" charset="utf-8"></script>
 
 
 @library.global_function
-def send_to_device_sms_countries(message_set):
-    try:
-        countries = settings.SEND_TO_DEVICE_MESSAGE_SETS[message_set]['sms_countries']
-    except KeyError:
-        countries = ['US']
-    return '|%s|' % '|'.join(cc.lower() for cc in countries)
-
-
-@library.global_function
 @jinja2.contextfunction
 def switch(cxt, name, locales=None):
     """A template helper that replaces waffle

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -10,19 +10,11 @@ from bedrock.base.templatetags import helpers
 jinja_env = Jinja2.get_default()
 SEND_TO_DEVICE_MESSAGE_SETS = {
     'default': {
-        'sms_countries': ['US', 'DE'],
-        'sms': {
-            'ios': 'ff-ios-download',
-            'android': 'SMS_Android',
-        },
         'email': {
             'android': 'download-firefox-android',
             'ios': 'download-firefox-ios',
             'all': 'download-firefox-mobile',
         }
-    },
-    'other': {
-        'sms_countries': ['US', 'FR'],
     }
 }
 
@@ -48,13 +40,6 @@ class HelpersTests(TestCase):
         # non-ascii
         context = {'key': u'\xe4'}
         assert render(template, context) == '<a href="?var=%C3%A4">'
-
-
-@override_settings(SEND_TO_DEVICE_MESSAGE_SETS=SEND_TO_DEVICE_MESSAGE_SETS)
-def test_send_to_device_sms_countries():
-    assert helpers.send_to_device_sms_countries('default') == '|us|de|'
-    assert helpers.send_to_device_sms_countries('other') == '|us|fr|'
-    assert helpers.send_to_device_sms_countries('none') == '|us|'
 
 
 @override_settings(LANG_GROUPS={'en': ['en-US', 'en-GB']})

--- a/bedrock/firefox/forms.py
+++ b/bedrock/firefox/forms.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
-
 from django import forms
 
 

--- a/bedrock/firefox/forms.py
+++ b/bedrock/firefox/forms.py
@@ -8,17 +8,9 @@ from django import forms
 
 
 class SendToDeviceWidgetForm(forms.Form):
-    number = forms.CharField(max_length=20, min_length=4, required=False)
     email = forms.EmailField(max_length=100, required=False)
     platform = forms.ChoiceField(choices=(
         ('ios', 'ios'),
         ('android', 'android'),
         ('all', 'all'),
     ), required=False)
-
-    def clean_number(self):
-        number = self.cleaned_data['number']
-        if number:
-            number = re.sub(r'\D+', '', number)
-
-        return number

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx80.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx80.html
@@ -6,6 +6,10 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
+{% block html_attrs %}
+data-whatsnew80-redirect-url="{{ settings.FXA_ENDPOINT + 'sms/?' + utm_params }}"
+{% endblock %}
+
 {% block page_title %}{{ ftl('whatsnew80-page-title') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx80.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx80.html
@@ -6,10 +6,6 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block html_attrs %}
-data-whatsnew80-redirect-url="{{ settings.FXA_ENDPOINT + 'sms/?' + utm_params }}"
-{% endblock %}
-
 {% block page_title %}{{ ftl('whatsnew80-page-title') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
@@ -48,7 +44,7 @@ data-whatsnew80-redirect-url="{{ settings.FXA_ENDPOINT + 'sms/?' + utm_params }}
 
       {% if show_send_to_device %}
         <div id="send-to-device-wrapper" class="primary-cta">
-        {{ send_to_device(include_title=False, message_set='fx-whatsnew', input_label_alt=ftl('whatsnew80-primary-cta-description'), class='vertical') }}
+        {{ send_to_device(include_title=False, message_set='fx-whatsnew', class='vertical') }}
         </div>
       {% else %}
         <div class="qr-code-wrapper">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx81.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx81.html
@@ -37,7 +37,7 @@
 
       {% if show_send_to_device %}
         <div id="send-to-device-wrapper" class="primary-cta">
-        {{ send_to_device(include_title=False, message_set='fx-whatsnew', input_label=ftl('whatsnew81-send-form-label'), input_label_alt=ftl('whatsnew81-send-form-label-alt'), class='vertical') }}
+        {{ send_to_device(include_title=False, message_set='fx-whatsnew', input_label=ftl('whatsnew81-send-form-label'), class='vertical') }}
         </div>
       {% else %}
         <div class="qr-code-wrapper">

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -201,9 +201,6 @@ def send_to_device_ajax(request):
         'email': email,
     }
 
-    # populate data type in form data dict
-    data[data_type] = email
-
     # instantiate the form with processed POST data
     form = SendToDeviceWidgetForm(data)
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -186,11 +186,11 @@ def sign_attribution_codes(codes):
 @csrf_exempt
 def send_to_device_ajax(request):
     locale = l10n_utils.get_locale(request)
-    phone_or_email = request.POST.get('phone-or-email')
+    email = request.POST.get('s2d-email')
 
     # ensure a value was entered in phone or email field
-    if not phone_or_email:
-        return JsonResponse({'success': False, 'errors': ['phone-or-email']})
+    if not email:
+        return JsonResponse({'success': False, 'errors': ['s2d-email']})
 
     # pull message set from POST (not part of form, so wont be in cleaned_data)
     message_set = request.POST.get('message-set', 'default')
@@ -199,16 +199,16 @@ def send_to_device_ajax(request):
     data = {'platform': request.POST.get('platform')}
 
     # determine if email or phone number was submitted
-    data_type = 'email' if '@' in phone_or_email else 'number'
+    data_type = 'email' if '@' in email else 'number'
 
     # populate data type in form data dict
-    data[data_type] = phone_or_email
+    data[data_type] = email
 
     # instantiate the form with processed POST data
     form = SendToDeviceWidgetForm(data)
 
     if form.is_valid():
-        phone_or_email = form.cleaned_data.get(data_type)
+        email = form.cleaned_data.get(data_type)
         platform = form.cleaned_data.get('platform')
 
         # if no platform specified, default to 'all'
@@ -221,48 +221,20 @@ def send_to_device_ajax(request):
         else:
             MESSAGES = SEND_TO_DEVICE_MESSAGE_SETS[message_set]
 
-        if data_type == 'number':
-
-            # for testing purposes return success
-            if phone_or_email == '5555555555':
-                return JsonResponse({'success': True})
-
-            if platform in MESSAGES['sms']:
-                data = {
-                    'mobile_number': phone_or_email,
-                    'msg_name': MESSAGES['sms'][platform],
-                    'lang': locale,
-                }
-                country = request.POST.get('country')
-                if country and re.match(r'^[a-z]{2}$', country, flags=re.I):
-                    data['country'] = country
-
-                try:
-                    basket.request('post', 'subscribe_sms', data=data)
-                except basket.BasketException as e:
-                    if e.desc == 'mobile_number is invalid':
-                        return JsonResponse({'success': False, 'errors': ['number']})
-                    else:
-                        return JsonResponse(
-                            {'success': False, 'errors': ['system']}, status=400
-                        )
-            else:
-                return JsonResponse({'success': False, 'errors': ['platform']})
-        else:  # email
-            if platform in MESSAGES['email']:
-                try:
-                    basket.subscribe(
-                        phone_or_email,
-                        MESSAGES['email'][platform],
-                        source_url=request.POST.get('source-url'),
-                        lang=locale,
-                    )
-                except basket.BasketException:
-                    return JsonResponse(
-                        {'success': False, 'errors': ['system']}, status=400
-                    )
-            else:
-                return JsonResponse({'success': False, 'errors': ['platform']})
+        if platform in MESSAGES['email']:
+            try:
+                basket.subscribe(
+                    email,
+                    MESSAGES['email'][platform],
+                    source_url=request.POST.get('source-url'),
+                    lang=locale,
+                )
+            except basket.BasketException:
+                return JsonResponse(
+                    {'success': False, 'errors': ['system']}, status=400
+                )
+        else:
+            return JsonResponse({'success': False, 'errors': ['platform']})
 
         resp_data = {'success': True}
     else:

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -196,10 +196,10 @@ def send_to_device_ajax(request):
     message_set = request.POST.get('message-set', 'default')
 
     # begin collecting data to pass to form constructor
-    data = {'platform': request.POST.get('platform')}
-
-    # determine if email or phone number was submitted
-    data_type = 'email' if '@' in email else 'number'
+    data = {
+        'platform': request.POST.get('platform'),
+        'email': email,
+    }
 
     # populate data type in form data dict
     data[data_type] = email
@@ -208,7 +208,7 @@ def send_to_device_ajax(request):
     form = SendToDeviceWidgetForm(data)
 
     if form.is_valid():
-        email = form.cleaned_data.get(data_type)
+        email = form.cleaned_data.get('email')
         platform = form.cleaned_data.get('platform')
 
         # if no platform specified, default to 'all'

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -336,7 +336,6 @@ NOINDEX_URLS = [
     r'^contribute/(embed|event)/',
     r'^firefox/retention/thank-you/',
     r'^firefox/set-as-default/thanks/',
-    r'^firefox/sms/sent/',
     r'^firefox/unsupported/',
     r'^firefox/send-to-device-post',
     r'^firefox/feedback',
@@ -1066,11 +1065,6 @@ SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US',
 
 SEND_TO_DEVICE_MESSAGE_SETS = {
     'default': {
-        'sms_countries': config('STD_SMS_COUNTRIES_DEFAULT', default='US', parser=ListOf(str)),
-        'sms': {
-            'ios': 'ff-ios-download',
-            'android': 'SMS_Android',
-        },
         'email': {
             'android': 'download-firefox-android',
             'ios': 'download-firefox-ios',
@@ -1078,11 +1072,6 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
         }
     },
     'fx-android': {
-        'sms_countries': config('STD_SMS_COUNTRIES_ANDROID', default='US', parser=ListOf(str)),
-        'sms': {
-            'ios': 'ff-ios-download',
-            'android': 'android-download-embed',
-        },
         'email': {
             'android': 'get-android-embed',
             'ios': 'download-firefox-ios',
@@ -1090,61 +1079,36 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
         }
     },
     'fx-mobile-download-desktop': {
-        'sms_countries': config('STD_SMS_COUNTRIES_DESKTOP', default='US', parser=ListOf(str)),
-        'sms': {
-            'all': 'mobile-heartbeat',
-        },
         'email': {
             'all': 'download-firefox-mobile-reco',
         }
     },
     'fx-whatsnew': {
-        'sms_countries': config('STD_SMS_COUNTRIES_WHATSNEW50', default='US', parser=ListOf(str)),
-        'sms': {
-            'all': 'whatsnewfifty',
-        },
         'email': {
             'all': 'download-firefox-mobile-whatsnew',
         }
     },
     'fx-focus': {
-        'sms_countries': config('STD_SMS_COUNTRIES_WHATSNEW61', default='US', parser=ListOf(str)),
-        'sms': {
-            'all': 'focus_sms_whatsnew',
-        },
         'email': {
             'all': 'download-focus-mobile-whatsnew',
         }
     },
     'fx-klar': {
-        'sms_countries': config('STD_SMS_COUNTRIES_WHATSNEW61', default='US', parser=ListOf(str)),
-        'sms': {
-            'all': 'focus_sms_whatsnew',
-        },
         'email': {
             'all': 'download-klar-mobile-whatsnew',
         }
     },
     'download-firefox-rocket': {
-        'sms_countries': '',
         'email': {
             'all': 'download-firefox-rocket',
         }
     },
     'firefox-mobile-welcome': {
-        'sms_countries': config('STD_SMS_COUNTRIES_MOBILE_WELCOME', default='US,DE,FR', parser=ListOf(str)),
-        'sms': {
-            'all': 'firefox-mobile-welcome',
-        },
         'email': {
             'all': 'firefox-mobile-welcome',
         }
     },
     'lockwise-welcome-download': {
-        'sms_countries': config('STD_SMS_COUNTRIES_MOBILE_WELCOME', default='US,DE,FR', parser=ListOf(str)),
-        'sms': {
-            'all': 'lockwise-welcome-download',
-        },
         'email': {
             'all': 'lockwise-welcome-download',
         }

--- a/docs/send-to-device.rst
+++ b/docs/send-to-device.rst
@@ -8,11 +8,11 @@
 Send to Device Widget
 =====================
 
-The *Send to Device* widget is a single macro form which facilitates the sending of a download link from a desktop browser to a mobile device. The form allows sending via SMS or email, although the SMS copy & messaging is shown only to those in the configured countries. Geo-location is handled in JavaScript using a `bedrock view <https://github.com/mozilla/bedrock/blob/7ae0f693ab0347057b56397462351f7085205e3c/bedrock/base/views.py#L31>`_ that gets the request country from `CloudFlare CDN headers <https://support.cloudflare.com/hc/en-us/articles/200168236-What-does-CloudFlare-IP-Geolocation-do->`_. For users without JavaScript, the widget falls back to a standard email form.
+The *Send to Device* widget is a single macro form which facilitates the sending of a download link from a desktop browser to a mobile device. The form allows sending via email.
 
 .. important:: This widget should only be shown to a limited set of locales who are set up to receive the emails. For those locales not in the list, direct links to the respective app stores should be shown instead. If a user is on iOS or Android, CTA buttons should also link directly to respective app stores instead of showing the widget. This logic should be handled on a page-by-page basis to cover individual needs.
 
-.. note:: A full list of supported locales can be found in ``settings/base.py`` under ``SEND_TO_DEVICE_LOCALES``, which can be used in the template logic for each page to show the form. The countries enabled for SMS for each message are defined in the `running configuration <https://mozmeao.github.io/www-config/configs/>`_ per the environment names in ``SEND_TO_DEVICE_MESSAGE_SETS`` in the settings file.
+.. note:: A full list of supported locales can be found in ``settings/base.py`` under ``SEND_TO_DEVICE_LOCALES``, which can be used in the template logic for each page to show the form.
 
 Usage
 -----
@@ -72,23 +72,6 @@ The Jinja macro supports parameters as follows (* indicates a required parameter
 +----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+
 |    legal_note_email  | Provides a custom legal note for email use.                            | Localizable String.  | _('The intended recipient of the email must have consented.')      |
 +----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+
-|    legal_note_sms    | Provides a custom legal note for SMS or email.                         | Localizable string   | _('SMS service available in select countries only.')               |
-+----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+
 |    spinner_color     | Hex color for the form spinner. Defaults to '#000'.                    | String               | '#fff'                                                             |
 +----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+
 
-
-Geolocation Callback
---------------------
-
-You can piggy-back on the widget's geolocation call by providing a callback function to be executed when the lookup has completed::
-
-  var form = new Mozilla.SendToDevice();
-  form.geoCallback = function(countryCode) {
-    console.log(countryCode);
-  }
-  form.init();
-
-The callback function will be passed a single argument - the country code returned from the geolocation lookup.
-
-If the geolocation lookup fails, the country code passed to the callback function will be an empty string.

--- a/l10n/en/firefox/whatsnew/whatsnew-fx80.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-fx80.ftl
@@ -12,7 +12,6 @@ whatsnew80-up-to-date-banner = Congrats! You’re using the latest version of { 
 # Main title
 whatsnew80-main-title = Do just about everything, a little faster
 whatsnew80-main-intro = Move from computer to phone without missing a beat. Get { -brand-name-firefox } for mobile.
-whatsnew80-primary-cta-description = Enter your email or phone number for a download link
 
 # content buckets below hero
 whatsnew80-password-fatigue = Password fatigue is real

--- a/l10n/en/firefox/whatsnew/whatsnew-fx81.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-fx81.ftl
@@ -11,7 +11,6 @@ whatsnew81-page-title = What’s new with { -brand-name-firefox }
 whatsnew81-main-title = A new { -brand-name-firefox } for every device
 whatsnew81-main-intro = Whatever operating system you’ve got, there’s a better-than-ever, non-profit-backed mobile browser to put on it.
 whatsnew81-send-form-label = Enter your email for a download link
-whatsnew81-send-form-label-alt = Enter your email or phone number for a download link
 whatsnew81-scan-this-qr-code = Scan this QR code to download
 
 # content blocks below hero

--- a/l10n/en/send_to_device.ftl
+++ b/l10n/en/send_to_device.ftl
@@ -4,18 +4,10 @@
 
 send-to-device-send-firefox = Send { -brand-name-firefox } to your smartphone or tablet
 send-to-device-your-download-link = Your download link was sent.
-send-to-device-sorry-we-cant-send = Sorry, we can’t send SMS messages to this phone number.
-send-to-device-sorry-this-number = Sorry. This number isn’t valid. Please enter a U.S. phone number.
 send-to-device-please-enter-an-email = Please enter an email address.
 send-to-device-an-error-occured = An error occurred in our system. Please try again later.
 send-to-device-enter-your-email = Enter your email
-send-to-device-enter-your-email-or-phone = Enter your email or phone number
-send-to-device-enter-your-email-or-phone-10-digit = Enter your email or 10-digit phone number
 send-to-device-send = Send
-send-to-device-sms-service-available-in-select = SMS service available in select countries only. SMS &amp; data rates may apply.
-send-to-device-sms-service-available-to-us = SMS service available to U.S. phone numbers only. SMS &amp; data rates may apply.
-send-to-device-intended-recipient-email-sms = The intended recipient of the email or SMS must have consented.
 send-to-device-intended-recipient-email = The intended recipient of the email must have consented.
-send-to-device-check-your-device-email-sms = Check your device for the email or text message!
 send-to-device-check-your-device-email = Check your device for the email!
 send-to-device-send-to-another = Send to another device

--- a/media/css/protocol/components/send-to-device.scss
+++ b/media/css/protocol/components/send-to-device.scss
@@ -37,22 +37,6 @@ $image-path: '/media/protocol/img';
     .more {
         color: inherit;
     }
-
-    .sms-country {
-        .email {
-            display: none;
-        }
-    }
-
-    .sms {
-        display: none;
-    }
-
-    .sms-country {
-        .sms {
-            display: block;
-        }
-    }
 }
 
 // horizontal

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -356,7 +356,6 @@ URLS = flatten((
     url_test('/firefox/{performance,happy,speed,memory}/', '/firefox/features/fast/'),
     url_test('/firefox/security/', '/firefox/features/independent/'),
     url_test('/firefox/technology/', 'https://developer.mozilla.org/docs/Tools'),
-    url_test('/firefox/sms/{,sent}', '/firefox/'),
 
     # Bug 979527
     url_test('{/products,}/firefox/central{/,.html}', '/firefox/new/',

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -356,6 +356,7 @@ URLS = flatten((
     url_test('/firefox/{performance,happy,speed,memory}/', '/firefox/features/fast/'),
     url_test('/firefox/security/', '/firefox/features/independent/'),
     url_test('/firefox/technology/', 'https://developer.mozilla.org/docs/Tools'),
+    url_test('/firefox/sms/{,sent}', '/firefox/'),
 
     # Bug 979527
     url_test('{/products,}/firefox/central{/,.html}', '/firefox/new/',


### PR DESCRIPTION
## Description

Remove SMS feature for send to device 
- rename form field from  `phone-or-email` to `s2d-email` (unique name makes it easier to trace the path through the code)
- remove `legal_note_sms` and `input_label_alt` from macro
- remove sms error and thank you messages and form labeling
- remove geolocation check from helpers and javascript
- remove sms from message sets (keep message sets because not all countries get email option)
- remove sms tests
  - convert one test from sms to email
- update docs to remove sms references
- remove sms strings from ftl files
- update JS and CSS to remove sms behaviour and styles
- update JS tests

## Issue / Bugzilla link

See #9864 

## Testing

Testing values: success@example.com, failure@example.com, invalid@email.
Should still fallback to QR codes for languages without translated emails (eg. AR)

http://localhost:8000/en-US/firefox/mobile/
http://localhost:8000/en-US/firefox/mobile/get-app/
http://localhost:8000/en-US/firefox/whatsnew/all/
http://localhost:8000/en-US/firefox/79.0/whatsnew/all/
http://localhost:8000/en-US/firefox/80.0/whatsnew/all/
http://localhost:8000/en-US/firefox/81.0/whatsnew/all/
http://localhost:8000/en-US/firefox/welcome/4/
http://localhost:8000/en-US/firefox/welcome/5/
http://localhost:8000/en-US/firefox/welcome/6/
http://localhost:8000/en-US/firefox/welcome/7/