### PR TITLE
Fix send-to-device success header color

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-account.scss
+++ b/media/css/firefox/whatsnew/whatsnew-account.scss
@@ -79,6 +79,10 @@ $image-path: '/media/protocol/img';
 
     .send-to-device {
         color: $color-white;
+
+        h2.thank-you {
+            color: get-theme('title-text-color-inverse');
+        }
     }
 
     .c-utilities {

--- a/media/css/firefox/whatsnew/whatsnew-mobile-de.scss
+++ b/media/css/firefox/whatsnew/whatsnew-mobile-de.scss
@@ -119,9 +119,11 @@ $image-path: '/media/protocol/img';
     .send-to-device {
         color: $color-white;
 
-        .form-heading {
+        .form-heading,
+        h2.thank-you {
             color: get-theme('title-text-color-inverse');
         }
+
     }
 
     .c-utilities {

--- a/media/css/firefox/whatsnew/whatsnew.scss
+++ b/media/css/firefox/whatsnew/whatsnew.scss
@@ -69,6 +69,10 @@ $image-path: '/media/protocol/img';
 
     .send-to-device {
         color: $color-white;
+
+        h2.thank-you {
+            color: get-theme('title-text-color-inverse');
+        }
     }
 
     .c-utilities {


### PR DESCRIPTION
## Description

Using dark theme colors, the "Your download link was sent" is not currently readable.

- http://localhost:8000/de/firefox/85.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/60.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/whatsnew/all/

## Issue / Bugzilla link
None

## Testing
- [ ] "Your download link was sent" header should be visible on both light and dark color schemes upon entering an email address.