### PR TITLE
Revise UX/Behavior of Sticky Download Promo 

### DIFF
--- a/media/css/firefox/sticky-promo.scss
+++ b/media/css/firefox/sticky-promo.scss
@@ -73,7 +73,7 @@ $image-path: '/media/protocol/img';
 }
 
 @media #{$mq-md} {
-    .mzp-c-sticky-promo.mzp-a-slide-in {
+    .mzp-c-sticky-promo.mzp-a-slide-in, .mzp-c-sticky-promo.is-displayed {
         display: block;
     }
 }

--- a/media/css/firefox/sticky-promo.scss
+++ b/media/css/firefox/sticky-promo.scss
@@ -73,7 +73,8 @@ $image-path: '/media/protocol/img';
 }
 
 @media #{$mq-md} {
-    .mzp-c-sticky-promo.mzp-a-slide-in, .mzp-c-sticky-promo.is-displayed {
+    .mzp-c-sticky-promo.mzp-a-slide-in,
+    .mzp-c-sticky-promo.is-displayed {
         display: block;
     }
 }

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -4,12 +4,6 @@
 
 @import '../../../protocol/css/includes/lib';
 
-// This class is added to address an issue with the sticky promo component on specific pages overlapping the language selection box in the footer.
-.c-footer.is-intersecting-sticky-overlay {
-    position: relative;
-    z-index: 11;
-}
-
 .c-footer {
     @include font-base;
     background: $color-marketing-gray-10;

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -5,6 +5,16 @@
 (function() {
     'use strict';
 
+    function isInViewport(element) {
+        // Calculate on each scroll if the footer is in the view port.
+        var elementTop = element.offsetTop;
+        var elementBottom = elementTop + element.offsetHeight;
+        var viewportTop = window.scrollY || window.pageYOffset;
+        var viewportBottom = viewportTop + window.screen.height;
+
+        return elementBottom > viewportTop && elementTop < viewportBottom;
+    }
+
     function onLoad(){
         // Check if promo exists on the page or if smaller than tablet.
         var matchMediaDesktop = window.matchMedia('(min-width: 768px)').matches;
@@ -50,6 +60,19 @@
             var footer = document.querySelector('.c-footer');
             if (footer) {
                 footer.classList.add('is-intersecting-sticky-overlay');
+
+                document.addEventListener('scroll', function () {
+                    // If the footer is in the viewport, fade out the promo.
+                    // Animate it back in when the footer leaves the viewport
+                    // if the user did not dismiss it.
+                    if (isInViewport(footer)) {
+                        promo.classList.replace('mzp-a-slide-in', 'mzp-a-fade-out');
+                    } else if (!promo.classList.contains('user-dismiss')) {
+                        promo.classList.replace('mzp-a-fade-out', 'mzp-a-slide-in');
+                    }
+                }, {
+                    passive: true
+                });
             }
 
             // Set Close Button event
@@ -57,7 +80,11 @@
 
             stickyBtnClose.addEventListener('click', function(){
                 StickyPromo.setCookie(STICKY_PROMO_COOKIE_ID);
+                promo.classList.add('user-dismiss');
             });
+
+
+
         };
 
         // Check on page load

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -53,8 +53,14 @@
         };
 
         StickyPromo.show = function (){
-        // Open promo
-            Mzp.StickyPromo.open();
+            var stickyPromoShowInit = false;
+            document.addEventListener('scroll', function () {
+                if (!stickyPromoShowInit) {
+                    // Open promo
+                    Mzp.StickyPromo.open();
+                    stickyPromoShowInit = true;
+                }
+            });
 
             // Add modifier class to the footer to make sure the language selection drop-down is not obscured by the sticky promo
             var footer = document.querySelector('.c-footer');
@@ -82,9 +88,6 @@
                 StickyPromo.setCookie(STICKY_PROMO_COOKIE_ID);
                 promo.classList.add('user-dismiss');
             });
-
-
-
         };
 
         // Check on page load

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -93,7 +93,7 @@
             var footer = document.querySelector('.c-footer');
             if (footer) {
                 footer.classList.add('is-intersecting-sticky-overlay');
-                document.addEventListener('scroll', checkForFooterOnScroll, true);
+                document.addEventListener('scroll', checkForFooterOnScroll, false);
             }
 
             // Set Close Button event

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -83,16 +83,17 @@
                 // Animate it back in when the footer leaves the viewport
                 // if the user did not dismiss it.
                 if (isInViewport(footer)) {
-                    promo.classList.replace('mzp-a-slide-in', 'mzp-a-fade-out');
+                    promo.classList.remove('mzp-a-slide-in');
+                    promo.classList.add('mzp-a-fade-out');
                 } else if (!promo.classList.contains('user-dismiss')) {
-                    promo.classList.replace('mzp-a-fade-out', 'mzp-a-slide-in');
+                    promo.classList.remove('mzp-a-fade-out');
+                    promo.classList.add('mzp-a-slide-in');
                 }
             }, 100);
 
             // Add modifier class to the footer to make sure the language selection drop-down is not obscured by the sticky promo
             var footer = document.querySelector('.c-footer');
             if (footer) {
-                footer.classList.add('is-intersecting-sticky-overlay');
                 document.addEventListener('scroll', checkForFooterOnScroll, false);
             }
 

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -53,14 +53,14 @@
         };
 
         StickyPromo.show = function (){
-            var stickyPromoShowInit = false;
-            document.addEventListener('scroll', function () {
-                if (!stickyPromoShowInit) {
-                    // Open promo
-                    Mzp.StickyPromo.open();
-                    stickyPromoShowInit = true;
-                }
-            });
+
+            function openOnScroll(){
+                // Open promo
+                Mzp.StickyPromo.open();
+                document.removeEventListener('scroll', openOnScroll, false);
+            }
+
+            document.addEventListener('scroll', openOnScroll, false);
 
             // Add modifier class to the footer to make sure the language selection drop-down is not obscured by the sticky promo
             var footer = document.querySelector('.c-footer');

--- a/tests/functional/firefox/browsers/compare/test_browsers.py
+++ b/tests/functional/firefox/browsers/compare/test_browsers.py
@@ -34,14 +34,3 @@ def test_download_buttons_are_displayed(slug, base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', [
-    ('chrome')])
-def test_sticky_promo(slug, base_url, selenium):
-    page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_best_browser.py
+++ b/tests/functional/firefox/browsers/test_best_browser.py
@@ -11,12 +11,3 @@ from pages.firefox.browsers.best_browser import BestBrowserPage
 def test_download_button_is_displayed(base_url, selenium):
     page = BestBrowserPage(selenium, base_url).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = BestBrowserPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_browser_history.py
+++ b/tests/functional/firefox/browsers/test_browser_history.py
@@ -13,12 +13,3 @@ def test_download_buttons_are_displayed(base_url, selenium):
     page = BrowserHistoryPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = BrowserHistoryPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_incognito_browser.py
+++ b/tests/functional/firefox/browsers/test_incognito_browser.py
@@ -13,12 +13,3 @@ def test_download_buttons_are_displayed(base_url, selenium):
     page = IncognitoBrowserPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = IncognitoBrowserPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_what_is_a_browser.py
+++ b/tests/functional/firefox/browsers/test_what_is_a_browser.py
@@ -13,12 +13,3 @@ def test_download_buttons_are_displayed(base_url, selenium):
     page = WhatIsABrowserPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = WhatIsABrowserPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_windows_64_bit.py
+++ b/tests/functional/firefox/browsers/test_windows_64_bit.py
@@ -12,12 +12,3 @@ from pages.firefox.browsers.windows_64_bit import Windows64BitPage
 def test_download_button_is_displayed(base_url, selenium):
     page = Windows64BitPage(selenium, base_url).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = Windows64BitPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_adblocker.py
+++ b/tests/functional/firefox/features/test_adblocker.py
@@ -11,12 +11,3 @@ from pages.firefox.features.adblocker import FeatureAdblockerPage
 def test_download_button_is_displayed(base_url, selenium):
     page = FeatureAdblockerPage(selenium, base_url).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = FeatureAdblockerPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_features.py
+++ b/tests/functional/firefox/features/test_features.py
@@ -18,15 +18,3 @@ from pages.firefox.features.feature import FeaturePage
 def test_download_button_is_displayed(slug, base_url, selenium):
     page = FeaturePage(selenium, base_url, slug=slug).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', [
-    ('private-browsing')])
-def test_sticky_promo(slug, base_url, selenium):
-    page = FeaturePage(selenium, base_url, slug=slug).open()
-    page.init_promo()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_features.py
+++ b/tests/functional/firefox/features/test_features.py
@@ -26,6 +26,7 @@ def test_download_button_is_displayed(slug, base_url, selenium):
     ('private-browsing')])
 def test_sticky_promo(slug, base_url, selenium):
     page = FeaturePage(selenium, base_url, slug=slug).open()
+    page.init_promo()
     assert page.promo.is_displayed
     page.promo.close()
     assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_landing.py
+++ b/tests/functional/firefox/features/test_landing.py
@@ -11,12 +11,3 @@ from pages.firefox.features.landing import FeaturesLandingPage
 def test_download_button_is_displayed(base_url, selenium):
     page = FeaturesLandingPage(selenium, base_url).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = FeaturesLandingPage(selenium, base_url).open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/functional/firefox/new/test_sticky_promo.py
+++ b/tests/functional/firefox/new/test_sticky_promo.py
@@ -10,6 +10,7 @@ from pages.firefox.new.sticky_promo import StickyPromoPage
 @pytest.mark.nondestructive
 def test_sticky_promo(base_url, selenium):
     page = StickyPromoPage(selenium, base_url).open()
+    page.init_promo()
     assert page.promo.is_displayed
     page.promo.close()
     assert not page.promo.is_displayed

--- a/tests/functional/firefox/test_home.py
+++ b/tests/functional/firefox/test_home.py
@@ -16,7 +16,9 @@ def test_download_menu_list_displays(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.skip_if_not_firefox(reason='FB Container link shown only to Firefox users.')
-def test_fb_container_fx(base_url, selenium):
+def test_sticky_promo(base_url, selenium):
     page = FirefoxHomePage(selenium, base_url).open()
-    assert page.fb_container_is_displayed
+    page.init_promo()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/test_releasenotes.py
+++ b/tests/functional/firefox/test_releasenotes.py
@@ -137,12 +137,3 @@ def test_secondary_download_button_android_nightly_displayed(base_url, selenium)
 def test_secondary_download_button_ios_displayed(base_url, selenium):
     page = FirefoxReleaseNotesPage(selenium, base_url, slug='ios/25.0').open()
     assert page.is_secondary_app_store_button_displayed
-
-
-@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
-@pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = FirefoxReleaseNotesPage(selenium, base_url, slug='84.0').open()
-    assert page.promo.is_displayed
-    page.promo.close()
-    assert not page.promo.is_displayed

--- a/tests/pages/firefox/browsers/best_browser.py
+++ b/tests/pages/firefox/browsers/best_browser.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class BestBrowserPage(BasePage):
@@ -14,24 +13,8 @@ class BestBrowserPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/browsers/best-browser/'
 
     _download_button_locator = (By.ID, 'safebrowser-hero-download')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/browser_history.py
+++ b/tests/pages/firefox/browsers/browser_history.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class BrowserHistoryPage(BasePage):
@@ -15,7 +14,6 @@ class BrowserHistoryPage(BasePage):
 
     _primary_download_button_locator = (By.ID, 'download-button-primary')
     _secondary_download_button_locator = (By.ID, 'download-button-secondary')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button(self):
@@ -27,22 +25,7 @@ class BrowserHistoryPage(BasePage):
         el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)
 
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
-
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/compare.py
+++ b/tests/pages/firefox/browsers/compare.py
@@ -7,7 +7,6 @@ from selenium.webdriver.common.by import By
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
 from pages.regions.menu_list import MenuList
-from pages.regions.sticky_promo import StickyPromo
 
 
 class BrowserComparisonPage(BasePage):
@@ -17,18 +16,6 @@ class BrowserComparisonPage(BasePage):
     _primary_download_button_locator = (By.ID, 'download-button-thanks')
     _secondary_download_button_locator = (By.ID, 'download-secondary')
     _browser_menu_list_locator = (By.CSS_SELECTOR, '.mzp-c-menu-list.mzp-t-download')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def primary_download_button(self):
@@ -44,7 +31,3 @@ class BrowserComparisonPage(BasePage):
     def browser_menu_list(self):
         el = self.find_element(*self._browser_menu_list_locator)
         return MenuList(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/incognito_browser.py
+++ b/tests/pages/firefox/browsers/incognito_browser.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class IncognitoBrowserPage(BasePage):
@@ -15,7 +14,6 @@ class IncognitoBrowserPage(BasePage):
 
     _primary_download_button_locator = (By.ID, 'download-button-primary')
     _secondary_download_button_locator = (By.ID, 'download-button-secondary')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button(self):
@@ -27,22 +25,7 @@ class IncognitoBrowserPage(BasePage):
         el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)
 
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
-
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/what_is_a_browser.py
+++ b/tests/pages/firefox/browsers/what_is_a_browser.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class WhatIsABrowserPage(BasePage):
@@ -15,7 +14,6 @@ class WhatIsABrowserPage(BasePage):
 
     _primary_download_button_locator = (By.ID, 'download-button-primary')
     _secondary_download_button_locator = (By.ID, 'download-button-secondary')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button(self):
@@ -27,22 +25,7 @@ class WhatIsABrowserPage(BasePage):
         el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)
 
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
-
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/windows_64_bit.py
+++ b/tests/pages/firefox/browsers/windows_64_bit.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class Windows64BitPage(BasePage):
@@ -14,24 +13,8 @@ class Windows64BitPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/browsers/windows-64-bit/'
 
     _download_button_locator = (By.ID, 'win64-hero-download')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/features/adblocker.py
+++ b/tests/pages/firefox/features/adblocker.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class FeatureAdblockerPage(BasePage):
@@ -14,24 +13,8 @@ class FeatureAdblockerPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/features/adblocker/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class FeaturePage(BasePage):
@@ -15,29 +14,7 @@ class FeaturePage(BasePage):
 
     _download_button_locator = (By.ID, 'features-header-download')
 
-    # Used as a scroll target to move down the page, to trigger the sticky promo element
-    _page_main_content_locator = (By.CSS_SELECTOR, '.main-content')
-
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo')
-
-    def init_promo(self):
-        assert not self.is_promo_displayed, 'Promo detail is not displayed'
-        # scroll down page to trigger promo to display
-        self.scroll_element_into_view(*self._page_main_content_locator)
-
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-    @property
-    def is_promo_displayed(self):
-        return self.is_element_displayed(*self._sticky_promo_modal_content_locator)
-
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class FeaturePage(BasePage):
@@ -14,7 +15,29 @@ class FeaturePage(BasePage):
 
     _download_button_locator = (By.ID, 'features-header-download')
 
+    # Used as a scroll target to move down the page, to trigger the sticky promo element
+    _page_main_content_locator = (By.CSS_SELECTOR, '.main-content')
+
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo')
+
+    def init_promo(self):
+        assert not self.is_promo_displayed, 'Promo detail is not displayed'
+        # scroll down page to trigger promo to display
+        self.scroll_element_into_view(*self._page_main_content_locator)
+
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+    @property
+    def is_promo_displayed(self):
+        return self.is_element_displayed(*self._sticky_promo_modal_content_locator)
+
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class FeaturePage(BasePage):
@@ -14,24 +13,8 @@ class FeaturePage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/features/{slug}/'
 
     _download_button_locator = (By.ID, 'features-header-download')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/features/landing.py
+++ b/tests/pages/firefox/features/landing.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class FeaturesLandingPage(BasePage):
@@ -14,24 +13,8 @@ class FeaturesLandingPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/features/'
 
     _download_button_locator = (By.ID, 'features-header-download')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)

--- a/tests/pages/firefox/home.py
+++ b/tests/pages/firefox/home.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as expected
 
 from pages.base import BasePage
 from pages.regions.menu_list import MenuList
@@ -21,7 +20,7 @@ class FirefoxHomePage(BasePage):
     _facebook_container_link_locator = (By.ID, 'test-fbc')
 
     # floating/sticky box - download link
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo')
 
     # Used as a scroll target to move down the page, to trigger the sticky promo element
     _page_promise_content_locator = (By.CSS_SELECTOR, '.t-promise')
@@ -39,8 +38,8 @@ class FirefoxHomePage(BasePage):
         assert not self.is_promo_displayed, 'Promo detail is not displayed'
         # scroll down page to trigger promo to display
         self.scroll_element_into_view(*self._page_promise_content_locator)
-        self.wait.until(expected.visibility_of_element_located(
-            self._sticky_promo_modal_content_locator))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
 
     @property
     def is_promo_displayed(self):

--- a/tests/pages/firefox/home.py
+++ b/tests/pages/firefox/home.py
@@ -3,9 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
 
 from pages.base import BasePage
 from pages.regions.menu_list import MenuList
+from pages.regions.sticky_promo import StickyPromo
 
 
 class FirefoxHomePage(BasePage):
@@ -18,6 +20,12 @@ class FirefoxHomePage(BasePage):
     # facebook container extention link visiability
     _facebook_container_link_locator = (By.ID, 'test-fbc')
 
+    # floating/sticky box - download link
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    # Used as a scroll target to move down the page, to trigger the sticky promo element
+    _page_promise_content_locator = (By.CSS_SELECTOR, '.t-promise')
+
     @property
     def fb_container_is_displayed(self):
         return self.is_element_displayed(*self._facebook_container_link_locator)
@@ -26,3 +34,18 @@ class FirefoxHomePage(BasePage):
     def browser_menu_list(self):
         el = self.find_element(*self._browser_menu_list_locator)
         return MenuList(self, root=el)
+
+    def init_promo(self):
+        assert not self.is_promo_displayed, 'Promo detail is not displayed'
+        # scroll down page to trigger promo to display
+        self.scroll_element_into_view(*self._page_promise_content_locator)
+        self.wait.until(expected.visibility_of_element_located(
+            self._sticky_promo_modal_content_locator))
+
+    @property
+    def is_promo_displayed(self):
+        return self.is_element_displayed(*self._sticky_promo_modal_content_locator)
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/new/sticky_promo.py
+++ b/tests/pages/firefox/new/sticky_promo.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
 
 from pages.base import BasePage
 from pages.regions.sticky_promo import StickyPromo
@@ -12,14 +13,20 @@ class StickyPromoPage(BasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/new/'
 
+    # Used as a scroll target to move down the page, to trigger the sticky promo element
+    _page_highlights_content_locator = (By.CSS_SELECTOR, '.t-highlights')
     _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
+    def init_promo(self):
+        assert not self.is_promo_displayed, 'Promo detail is not displayed'
+        # scroll down page to trigger promo to display
+        self.scroll_element_into_view(*self._page_highlights_content_locator)
+        self.wait.until(expected.visibility_of_element_located(
+            self._sticky_promo_modal_content_locator))
+
+    @property
+    def is_promo_displayed(self):
+        return self.is_element_displayed(*self._sticky_promo_modal_content_locator)
 
     @property
     def promo(self):

--- a/tests/pages/firefox/new/sticky_promo.py
+++ b/tests/pages/firefox/new/sticky_promo.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as expected
 
 from pages.base import BasePage
 from pages.regions.sticky_promo import StickyPromo
@@ -15,14 +14,14 @@ class StickyPromoPage(BasePage):
 
     # Used as a scroll target to move down the page, to trigger the sticky promo element
     _page_highlights_content_locator = (By.CSS_SELECTOR, '.t-highlights')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo')
 
     def init_promo(self):
         assert not self.is_promo_displayed, 'Promo detail is not displayed'
         # scroll down page to trigger promo to display
         self.scroll_element_into_view(*self._page_highlights_content_locator)
-        self.wait.until(expected.visibility_of_element_located(
-            self._sticky_promo_modal_content_locator))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
 
     @property
     def is_promo_displayed(self):

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.sticky_promo import StickyPromo
 
 
 class FirefoxReleaseNotesPage(BasePage):
@@ -33,18 +32,6 @@ class FirefoxReleaseNotesPage(BasePage):
     _secondary_play_store_button_locator = (By.ID, 'download-android-secondary')
     _primary_app_store_button_locator = (By.ID, 'download-ios-primary')
     _secondary_app_store_button_locator = (By.ID, 'download-ios-secondary')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-
-        # Sticky promo is shown to non-Firefox browsers only.
-        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
-            promo = self.find_element(*self._sticky_promo_modal_content_locator)
-            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-
-        return self
 
     @property
     def primary_download_button_release(self):
@@ -145,7 +132,3 @@ class FirefoxReleaseNotesPage(BasePage):
     @property
     def is_pre_releases_menu_displayed(self):
         return self.is_element_displayed(*self._pre_releases_menu_locator)
-
-    @property
-    def promo(self):
-        return StickyPromo(self)


### PR DESCRIPTION
## Description

This PR adds two revisions to the UX of the [sticky download promo](https://protocol.mozilla.org/patterns/molecules/sticky-promo.html):

1. When the footer is in the viewport, the promo box is hidden. 
2. The promo box is not displayed until a user scrolls on the page. 

TODO: 

- [x] Revise/remove tests that are no longer needed 

## Issue / Bugzilla link

#9717

## Testing

*Be sure to delete any `localhost` cookeis you may have*

1. Go to http://localhost:8000/en-US/firefox/new/
2. Scroll down the page some. 
3. Expected: Promo should appear
4. Scroll down to where the footer is in view. 
5. Expected: Promo should dissapear 
6. Scrioll back up to where the footer is no longer in view
7. Expected: Promo should reappear 

Notes: 
- I couldn't find a page that had the promo that was so short that the footer was already in view. It is assumed that the promo would not be displayed. 
- If you dismiss the promo, and continue to scroll (including into and out of the footer), it remains hidden. On refresh/reload, the promo is not loaded (per the current logic) 

