### PR TITLE
Update design on /new varients (#9266)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/protocol/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/protocol/base_download.html
@@ -74,11 +74,14 @@
   {% call hero(
     title=hero_title,
     desc=hero_tagline,
-    class='mzp-has-image mzp-t-dark hero-firefox',
+    class='mzp-has-image hero-firefox',
     include_cta=True,
     image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
+
+
+    <div class="c-intro-download">
 
       {# **WARNING**
 
@@ -99,13 +102,14 @@
         </ul>
 
         <ul class="small-links android">
-            <li><a href="{{ firefox_url('android', 'all') }}">{{ ftl('new-platform-download-in-another') }}</a></li>
-            <li><a rel="external" href="https://support.mozilla.org/products/mobile/?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=need-help-link">{{ ftl('new-platform-need-help') }}</a></li>
+          <li><a href="{{ firefox_url('android', 'all') }}">{{ ftl('new-platform-download-in-another') }}</a></li>
+          <li><a rel="external" href="https://support.mozilla.org/products/mobile/?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=need-help-link">{{ ftl('new-platform-need-help') }}</a></li>
         </ul>
 
         <ul class="small-links ios">
-            <li><a rel="external" href="https://support.mozilla.org/products/ios/?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=need-help-link">{{ ftl('new-platform-need-help') }}</a></li>
+          <li><a rel="external" href="https://support.mozilla.org/products/ios/?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=need-help-link">{{ ftl('new-platform-need-help') }}</a></li>
         </ul>
+      </div>
     {% endcall %}
 
   <section class="features">

--- a/bedrock/firefox/templates/firefox/new/trailhead/base.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/base.html
@@ -35,5 +35,3 @@
 {% block old_ie_styles %}{% endblock %}
 {% block site_css %}{% endblock %}
 {% block page_css %}{% endblock %}
-
-{% block site_header %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/trailhead/download-yandex.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download-yandex.html
@@ -21,7 +21,7 @@
   {% call hero(
     title='Firefox с Яндексом',
     desc='Скачать версию Firefox с сервисами Яндекса на русском языке',
-    class='mzp-has-image mzp-t-dark hero-yandex',
+    class='mzp-has-image hero-yandex',
     include_cta=True,
     image_url='img/firefox/new/yandex/yandex.jpg',
     include_highres_image=True,

--- a/bedrock/firefox/templates/firefox/new/trailhead/download.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download.html
@@ -30,7 +30,7 @@
   {% call hero(
     title=ftl('firefox-new-get-the-latest-firefox'),
     desc=ftl('firefox-new-automatic-privacy-is-here', fallback='firefox-new-and-start-getting-the-respect'),
-    class='mzp-has-image mzp-t-dark hero-firefox t-narrow',
+    class='mzp-has-image hero-firefox t-narrow',
     include_cta=True,
     image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1

--- a/media/css/firefox/new/trailhead/download.scss
+++ b/media/css/firefox/new/trailhead/download.scss
@@ -12,12 +12,10 @@ $image-path: '/media/protocol/img';
 @import '../../../../protocol/css/templates/card-layout';
 
 
-.mzp-c-hero.mzp-t-dark {
-    @include background-size(auto 100%);
-    background-color: $color-ink-80;
+.mzp-c-hero {
 
     .mzp-c-hero-title {
-        @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', 260px, 48px);
+        @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-sm.png', 260px, 48px);
         background-position: top center;
         background-repeat: no-repeat;
         padding-top: $layout-xl;
@@ -33,33 +31,51 @@ $image-path: '/media/protocol/img';
         box-shadow: $box-shadow-sm;
     }
 
+    .c-intro-download {
+        .mzp-c-button-download-container {
+            margin-bottom: 0;
+        }
+    }
+
     .small-links {
-        @include text-body-xs;
-        @include white-links;
-        margin-top: $spacing-2xl;
+        & {
+            @include text-body-xs;
+            color: $color-dark-gray-30;
+            display: block;
+        }
 
         li {
-            line-height: 2.5;
+            margin-top: $spacing-md;
+        }
+
+        a:link,
+        a:visited {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            text-decoration: underline;
         }
 
         .platform-modal-button {
             @include text-body-xs;
             background: none;
             border: none;
-            color: $color-white;
+            color: $color-dark-gray-30;
             cursor: pointer;
-            text-decoration: underline;
             margin: 0;
             padding: 0;
 
-            @media #{$mq-md} {
-                @include bidi(((text-align, left, right),));
-            }
-
-            &:active,
             &:focus,
             &:hover {
-                text-decoration: none;
+                text-decoration: underline;
+            }
+
+            @media #{$mq-md} {
+                @include bidi(((text-align, left, right),));
             }
 
             // Hide modal link for Linux users on Arm as they already get alternate messaging.
@@ -79,13 +95,8 @@ $image-path: '/media/protocol/img';
     }
 
     @media #{$mq-md} {
-        @include bidi((
-            (background-image, url('/media/img/firefox/new/trailhead/hero-bg.svg'), url('/media/img/firefox/new/trailhead/hero-bg-rtl.svg')),
-            (background-position, top right -600px, top left -600px),
-        ));
-        background-repeat: no-repeat;
 
-        .mzp-c-hero-title {
+        &.mzp-has-image .mzp-c-hero-title {
             @include bidi(((background-position, top left, top right),));
         }
 
@@ -95,6 +106,12 @@ $image-path: '/media/protocol/img';
 
         .mzp-c-hero-desc {
             max-width: 21em;
+        }
+
+        .c-intro-download {
+            .mzp-c-button-download-container {
+                @include bidi(((text-align, left, right),));
+            }
         }
     }
 


### PR DESCRIPTION
## Description

- remove background images from platform and Yandex pages

## Issue / Bugzilla link

#9266

## Testing

http://localhost:8000/en-US/firefox/mac/
http://localhost:8000/ru/firefox/new/?geo=ru
http://localhost:8000/ru/firefox/new/
http://localhost:8000/eu/firefox/new/ (you will have to switch your environment to `DEBUG=False` to view this page using the fallback, or you can edit the view)