### PR TITLE
Migrate /legal pages to Fluent (Fixes #9808)

### DIFF
--- a/bedrock/legal/templates/legal/docs-base.html
+++ b/bedrock/legal/templates/legal/docs-base.html
@@ -2,11 +2,10 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "legal/index" %}
 {% extends "base-article.html" %}
 
 {% block page_css %}
- {{ css_bundle('legal') }}
+  {{ css_bundle('legal') }}
 {% endblock %}
 
 {% block body_class %}mzp-t-mozilla{% endblock %}
@@ -27,7 +26,7 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.index') }}">{{ ftl('legal-back-to-legal') }}</a></li>
     </ul>
   </section>
 </nav>

--- a/bedrock/legal/templates/legal/eula.html
+++ b/bedrock/legal/templates/legal/eula.html
@@ -4,7 +4,7 @@
 
 {% extends "base-article.html" %}
 
-{% block page_title %}{{_('Mozilla Foundation End-User Licensing Agreements')}}{% endblock %}
+{% block page_title %}Mozilla Foundation End-User Licensing Agreements{% endblock %}
 
 {% block page_css %}
 {{ css_bundle('legal') }}
@@ -18,7 +18,7 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.index') }}">Back to Legal</a></li>
     </ul>
   </section>
 </nav>
@@ -26,18 +26,16 @@
 
 {% block article %}
 <header>
-  <h1 class="mzp-c-article-title">{{_('Mozilla Foundation End-User Licensing Agreements')}}</h1>
+  <h1 class="mzp-c-article-title">Mozilla Foundation End-User Licensing Agreements</h1>
 </header>
 
 <p>
-  {% trans link=url('mozorg.mpl.2.0.index') %}
   Mozilla software is made available to you under the terms of the
-  <a href="{{ link }}">Mozilla Public License 2</a>,
+  <a href="{{ url('mozorg.mpl.2.0.index') }}">Mozilla Public License 2</a>,
   a free software license, which gives you the right to run the program
   for any purpose, to study how it works, to give copies to your friends
   and to modify it to meet your needs better. There is no
   separate End User License Agreement (EULA).
-  {% endtrans %}
 </p>
 
 <a href="{{ url('mozorg.mpl.2.0.index') }}" class="main-license">View the Mozilla Public License 2</a>
@@ -46,10 +44,10 @@
 <h3>Mozilla End-user Software License Agreements</h3>
 
 <ul class="mzp-u-list-styled">
-  <li><a href="{{ url('legal.eula.firefox-2-eula') }}">{{ _('Firefox 2.0') }}</a></li>
-  <li><a href="{{ url('legal.eula.firefox-3-eula') }}">{{ _('Firefox 3.0') }}</a></li>
-  <li><a href="{{ url('legal.eula.thunderbird-1.5-eula') }}">{{ _('Thunderbird 1.5') }}</a></li>
-  <li><a href="{{ url('legal.eula.thunderbird-2-eula') }}">{{ _('Thunderbird 2') }}</a></li>
+  <li><a href="{{ url('legal.eula.firefox-2-eula') }}">Firefox 2.0</a></li>
+  <li><a href="{{ url('legal.eula.firefox-3-eula') }}">Firefox 3.0</a></li>
+  <li><a href="{{ url('legal.eula.thunderbird-1.5-eula') }}">Thunderbird 1.5</a></li>
+  <li><a href="{{ url('legal.eula.thunderbird-2-eula') }}">Thunderbird 2</a></li>
 </ul>
 
 {% endblock %}

--- a/bedrock/legal/templates/legal/eula/firefox-2-eula.html
+++ b/bedrock/legal/templates/legal/eula/firefox-2-eula.html
@@ -18,8 +18,8 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.eula') }}">{{ _('Mozilla Foundation End-User Licensing Agreements') }}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.eula') }}">Mozilla Foundation End-User Licensing Agreements</a></li>
+      <li><a href="{{ url('legal.index') }}">Back to Legal</a></li>
     </ul>
   </section>
 </nav>

--- a/bedrock/legal/templates/legal/eula/firefox-3-eula.html
+++ b/bedrock/legal/templates/legal/eula/firefox-3-eula.html
@@ -18,8 +18,8 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.eula') }}">{{ _('Mozilla Foundation End-User Licensing Agreements') }}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.eula') }}">Mozilla Foundation End-User Licensing Agreements</a></li>
+      <li><a href="{{ url('legal.index') }}">Back to Legal</a></li>
     </ul>
   </section>
 </nav>

--- a/bedrock/legal/templates/legal/eula/thunderbird-1.5-eula.html
+++ b/bedrock/legal/templates/legal/eula/thunderbird-1.5-eula.html
@@ -18,8 +18,8 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.eula') }}">{{ _('Mozilla Foundation End-User Licensing Agreements') }}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.eula') }}">Mozilla Foundation End-User Licensing Agreements</a></li>
+      <li><a href="{{ url('legal.index') }}">Back to Legal</a></li>
     </ul>
   </section>
 </nav>

--- a/bedrock/legal/templates/legal/eula/thunderbird-2-eula.html
+++ b/bedrock/legal/templates/legal/eula/thunderbird-2-eula.html
@@ -18,8 +18,8 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.eula') }}">{{ _('Mozilla Foundation End-User Licensing Agreements') }}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.eula') }}">Mozilla Foundation End-User Licensing Agreements</a></li>
+      <li><a href="{{ url('legal.index') }}">Back to Legal</a></li>
     </ul>
   </section>
 </nav>

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -4,7 +4,7 @@
 
 {% extends "base-article.html" %}
 
-{% block page_title %}{{_('Violating Website Report')}}{% endblock %}
+{% block page_title %}Violating Website Report{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('legal') }}
@@ -20,7 +20,7 @@
 
   <section class="mzp-c-sidemenu-main" id="sidebar-menu">
     <ul>
-      <li><a href="{{ url('legal.index') }}">{{ _('Back to Legal') }}</a></li>
+      <li><a href="{{ url('legal.index') }}">Back to Legal</a></li>
     </ul>
   </section>
 </nav>
@@ -30,80 +30,69 @@
 
 {% if form_submitted %}
 <aside class="mzp-c-notification-bar mzp-t-success">
-  <p><strong>{{ _('Your report has been sent.') }}</strong></p>
-  <p>{{ _('Thank you for your help. It’s our community that makes us great.') }}</p>
+  <p><strong>Your report has been sent</strong></p>
+  <p>Thank you for your help. It’s our community that makes us great.</p>
 </aside>
 {% endif %}
 
 {% if form_error %}
 <aside class="mzp-c-notification-bar mzp-t-error">
-  <p><strong>{{ _('An error has occurred with your submission. Please review your information and try again.') }}</strong></p>
+  <p><strong>An error has occurred with your submission. Please review your information and try again.</strong></p>
 </aside>
 {% endif %}
 
-{# L10n: The line break below is for visual formatting only #}
-<h1 class="mzp-c-article-title">{{_('Protect the Fox<br> (and More!)')}}</h1>
-<h2>{{ _('Help us safeguard Mozilla’s trademarks by reporting misuse.') }}</h2>
+<h1 class="mzp-c-article-title">Protect the Fox<br> (and More!)</h1>
+<h2>Help us safeguard Mozilla’s trademarks by reporting misuse.</h2>
 
 <p>
-  {% trans %}
-    The Firefox name or logo on a product or webpage tells you that you
-    are getting a free, high quality, open source browser that has
-    been tested and released by Mozilla. In order to make sure others
-    are not using our trademarks to mislead users into downloading
-    malware, paying for the software, or providing personal
-    information, we need your help.
-  {% endtrans %}
+  The Firefox name or logo on a product or webpage tells you that you
+  are getting a free, high quality, open source browser that has
+  been tested and released by Mozilla. In order to make sure others
+  are not using our trademarks to mislead users into downloading
+  malware, paying for the software, or providing personal
+  information, we need your help.
 </p>
 
 <section class="mzp-c-emphasis-box">
   <p>
-    <strong>{{ _('Please use this form to report any websites or mobile app stores that are:') }}</strong>
+    <strong>Please use this form to report any websites or mobile app stores that are:</strong>
   </p>
 
   <ol class="mzp-u-list-styled">
     <li>
-      {{ _('Distributing harmful products under Mozilla brands such as Firefox.') }}
+      Distributing harmful products under Mozilla brands such as Firefox.
     </li>
     <li>
-      {{ _('Charging for Firefox, Thunderbird, or any of the Mozilla products.') }}
+      Charging for Firefox, Thunderbird, or any of the Mozilla products.
     </li>
     <li>
-    {% trans %}
       Collecting personal information as a condition to download any
       of the Mozilla software (registration requirement).
-    {% endtrans %}
     </li>
     <li>
-    {% trans %}
       Using the Mozilla trademarks to mislead the public into
       thinking the site is an official Mozilla site or sponsored by
       Mozilla.
-    {% endtrans %}
     </li>
     <li>
-    {% trans %}
       Distributing modified versions of Firefox, or any of our
       Mozilla software, and still using the trademark. Note: anyone
       may modify Mozilla software, but once modified, it may no
       longer use Mozilla trademark(s) (e.g. be called Firefox)
       without a license.
-    {% endtrans %}
     </li>
     <li>
-    {% trans url=url('foundation.trademarks.policy') %}
       Using the Mozilla trademarks (including logos) in any other way
-      that violates our <a href="{{ url }}">Trademark Policy</a>
+      that violates our <a href="{{ url('foundation.trademarks.policy') }}">Trademark Policy</a>
       (e.g. trademark is modified or used for commercial purposes).
-    {% endtrans %}
     </li>
   </ol>
-  <p><strong>{{ _('Thank you for your help!') }}</strong></p>
+  <p><strong>Thank you for your help!</strong></p>
 </section>
 
 <section>
   {% if not form_submitted or (form_submitted and form_error) %}
-  <h2>{{ _('Fraud Report') }}</h2>
+  <h2>Fraud Report</h2>
 
   <form class="mzp-c-form" action="{{ url('legal.fraud-report') }}" method="post" name="reportForm" id="reportForm" enctype="multipart/form-data">
 
@@ -111,14 +100,14 @@
 
     <div class="mzp-c-field" id="url">
       {{ form.input_url.errors }}
-      <label for="input_url" class="mzp-c-field-label">{{ _('URL') }}</label>
+      <label for="input_url" class="mzp-c-field-label">URL</label>
       {{ form.input_url }}
-      <p class="mzp-c-field-info">{{ _('The URL of the violating website. e.g. http://offendingsite.com/') }}</p>
+      <p class="mzp-c-field-info">The URL of the violating website. e.g. http://offendingsite.com/</p>
     </div>
 
     <div class="mzp-c-field" id="category">
       {{ form.input_category.errors }}
-      <label for="input_category" class="mzp-c-field-label">{{ _('Category') }}</label>
+      <label for="input_category" class="mzp-c-field-label">Category</label>
       {{ form.input_category }}
     </div>
 
@@ -126,49 +115,47 @@
 
     <div class="mzp-c-field" id="product">
       {{ form.input_product.errors }}
-      <label for="input_product" class="mzp-c-field-label">{{ _('Product') }}</label>
+      <label for="input_product" class="mzp-c-field-label">Product</label>
       {{ form.input_product }}
     </div>
 
     <div class="mzp-c-field" id="specific_product">
       {{ form.input_specific_product.errors }}
-      <label for="input_specific_product" class="mzp-c-field-label">{{ _('Name a more specific product, if needed') }}</label>
+      <label for="input_specific_product" class="mzp-c-field-label">Name a more specific product, if needed</label>
       {{ form.input_specific_product }}
     </div>
 
     <div class="mzp-c-field" id="details">
       {{ form.input_details.errors }}
-      <label for="input_details" class="mzp-c-field-label">{{ _('Please provide additional details') }}</label>
+      <label for="input_details" class="mzp-c-field-label">Please provide additional details</label>
       {{ form.input_details }}
     </div>
 
     <div class="mzp-c-field" id="attachment">
       {{ form.input_attachment.errors }}
-      <label for="input_attachment" class="mzp-c-field-label">{{ _('Attachment') }}</label>
+      <label for="input_attachment" class="mzp-c-field-label">Attachment</label>
       {{ form.input_attachment }}
-      <p class="mzp-c-field-info">{{ _('Images only. Maximum file size is 5 MB.') }}</p>
+      <p class="mzp-c-field-info">Images only. Maximum file size is 5 MB.</p>
     </div>
 
     <div class="mzp-c-field" id="attachment_desc">
       {{ form.input_attachment_desc.errors }}
-      <label for="input_attachment_desc" class="mzp-c-field-label">{{ _('Attachment Description') }}</label>
+      <label for="input_attachment_desc" class="mzp-c-field-label">Attachment Description</label>
       {{ form.input_attachment_desc }}
-      <p class="mzp-c-field-info">{{ _('Please describe what you are attaching.') }}</p>
+      <p class="mzp-c-field-info">Please describe what you are attaching.</p>
     </div>
 
     <div class="mzp-c-field" id="email">
       {{ form.input_email.errors }}
-      <label for="input_email" class="mzp-c-field-label">{{ _('Email address (optional)') }}</label>
+      <label for="input_email" class="mzp-c-field-label">Email address (optional)</label>
       {{ form.input_email }}
       <p class="mzp-c-field-info">
-        {% trans url=url('privacy') %}
           If you choose to provide it, your email address will only be
           used to contact you about this report. Please see our
-          <a href="{{ url }}">Privacy Policy</a> for more information.
-        {% endtrans %}
+          <a href="{{ url('privacy') }}">Privacy Policy</a> for more information.
       </p>
     </div>
-    <button type="submit" name="submit_form" class="mzp-c-button">{{ _('Send Report') }}</button>
+    <button type="submit" name="submit_form" class="mzp-c-button">Send Report</button>
   </form>
 {% endif %}
 </section>

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -4,7 +4,7 @@
 
 {% extends "base-article.html" %}
 
-{% block page_title %}{{ _('Legal') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-legal') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('legal') }}
@@ -25,17 +25,17 @@
     <ul>
       <li class="mzp-is-current"><a href="{{ url('legal.index') }}">{{ self.page_title() }}</a></li>
       <li>
-        <a href="{{ url('mozorg.contribute.index') }}">{{ _('Get involved') }}</a>
+        <a href="{{ url('mozorg.contribute.index') }}">{{ ftl('legal-get-involved') }}</a>
       </li>
       <li>
-        <a href="{{ url('legal.fraud-report') }} ">{{ _('Protect the Fox') }}</a>
+        <a href="{{ url('legal.fraud-report') }} ">{{ ftl('legal-protect-the-fox') }}</a>
       </li>
       <li>
-        <a href="{{ url('legal.report-infringement') }}">{{ _('Takedown requests') }}</a>
+        <a href="{{ url('legal.report-infringement') }}">{{ ftl('legal-takedown-requests') }}</a>
       </li>
       {% if LANG == 'de' %}
       <li>
-        <a href="{{ url('legal.impressum') }}">{{ _('Impressum') }}</a>
+        <a href="{{ url('legal.impressum') }}">Impressum</a>
       </li>
       {% endif %}
     </ul>
@@ -45,42 +45,42 @@
 
 {% block article %}
 <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
-<p>{{ _('Special thanks to all of you who help report abuses of Mozilla marks, participate in governance forums, give feedback on our localizations & legal terms, and contribute your skills to the success of the Mozilla project.') }}</p>
+<p>{{ ftl('legal-special-thanks-to-all-of-you') }}</p>
 
-<h2>{{ _('Terms') }}</h2>
+<h2>{{ ftl('legal-terms') }}</h2>
 
 <ul class="mzp-u-list-styled">
   <li>
-    <a href="{{ url('legal.terms.mozilla') }}">{{ _('Our Websites') }}</a>
+    <a href="{{ url('legal.terms.mozilla') }}">{{ ftl('legal-our-websites') }}</a>
   </li>
   <li>
-    <a href="{{ url('legal.terms.services') }}">{{ _('Firefox Services') }}</a>
+    <a href="{{ url('legal.terms.services') }}">{{ ftl('legal-firefox-services') }}</a>
   </li>
   <li>
-    <a href="{{ url('legal.terms.betterweb') }}">{{ _('Firefox Better Web') }}</a>
+    <a href="{{ url('legal.terms.betterweb') }}">{{ ftl('legal-firefox-better-web') }}</a>
   </li>
   <li>
-    <a href="https://webmaker.org/#/legal">{{ _('Webmaker') }}</a>
+    <a href="https://webmaker.org/#/legal">{{ ftl('legal-webmaker') }}</a>
   </li>
 </ul>
 
-<h2>{{ _('Privacy & trademarks') }}</h2>
+<h2>{{ ftl('legal-privacy-trademarks') }}</h2>
 <ul class="mzp-u-list-styled">
   <li>
-    <a href="{{ url('privacy') }}">{{ _('Privacy Notices and Policy') }}</a>
+    <a href="{{ url('privacy') }}">{{ ftl('legal-privacy-notices-and-policy') }}</a>
   </li>
   <li>
     <a href="{{ url('foundation.trademarks.policy' ) }}">{{ _('Mozilla Trademark Guidelines') }}</a>
   </li>
 </ul>
 
-<h2>{{ _('Downloadable software notices') }}</h2>
+<h2>{{ ftl('legal-downloadable-software-notices') }}</h2>
 <ul class="mzp-u-list-styled">
   <li>
-    <a href="{{ url('legal.terms.firefox') }}">{{ _('Firefox') }}</a>
+    <a href="{{ url('legal.terms.firefox') }}">{{ ftl('legal-firefox') }}</a>
   </li>
   <li>
-    <a href="{{ url('legal.terms.thunderbird') }}">{{ _('Thunderbird') }}</a>
+    <a href="{{ url('legal.terms.thunderbird') }}">{{ ftl('legal-thunderbird') }}</a>
   </li>
 </ul>
 {% endblock %}
@@ -94,8 +94,8 @@
     <div class="newsletter-content">
       {% if LANG.startswith('en-') %}
       {{ email_newsletter_form(
-            title=_('Love the Web?'),
-            desc=_('Get the Mozilla newsletter and help us keep it open and free.')) }}
+            title='Love the Web?',
+            desc='Get the Mozilla newsletter and help us keep it open and free.') }}
       {% else %}
       {{ email_newsletter_form() }}
       {% endif %}
@@ -105,6 +105,6 @@
 {% endblock %}
 
 {% block site_js %}
-{{ super() }}
-{{ js_bundle('legal') }}
+  {{ super() }}
+  {{ js_bundle('legal') }}
 {% endblock %}

--- a/bedrock/legal/templates/legal/report-infringement.html
+++ b/bedrock/legal/templates/legal/report-infringement.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Report Copyright or Trademark Infringement') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-report-copyright') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/acceptable-use.html
+++ b/bedrock/legal/templates/legal/terms/acceptable-use.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Acceptable Use Policy') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-acceptable-use-policy') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/betterweb.html
+++ b/bedrock/legal/templates/legal/terms/betterweb.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox Better Web Terms of Service') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-better-web-terms') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox-lite-reward.html
+++ b/bedrock/legal/templates/legal/terms/firefox-lite-reward.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox Lite: About Your Rights') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-light-rights') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox-lite.html
+++ b/bedrock/legal/templates/legal/terms/firefox-lite.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox Lite: About Your Rights') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-light-rights') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox-private-network.html
+++ b/bedrock/legal/templates/legal/terms/firefox-private-network.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox Private Network Terms of Service') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-private-network-terms') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox-reality.html
+++ b/bedrock/legal/templates/legal/terms/firefox-reality.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox Reality: About Your Rights') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-reality-rights') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox-relay.html
+++ b/bedrock/legal/templates/legal/terms/firefox-relay.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}Firefox Relay Terms of Service{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-relay-terms') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox.html
+++ b/bedrock/legal/templates/legal/terms/firefox.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox: About Your Rights') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-rights') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/mozilla-vpn.html
+++ b/bedrock/legal/templates/legal/terms/mozilla-vpn.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Mozilla VPN Terms of Service') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-mozilla-vpn-terms') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/mozilla.html
+++ b/bedrock/legal/templates/legal/terms/mozilla.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Websites & Communications Terms of Use') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-websites-and-communications') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/services.html
+++ b/bedrock/legal/templates/legal/terms/services.html
@@ -5,10 +5,10 @@
 {% extends "legal/docs-base.html" %}
 
 {% block page_css %}
-{{ css_bundle('legal') }}
+  {{ css_bundle('legal') }}
 {% endblock %}
 
-{% block page_title %}{{ _('Firefox Cloud Services: Terms of Service') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-firefox-cloud-services') }}{% endblock %}
 
 {% block article %}
   <section itemscope itemtype="http://schema.org/Article">

--- a/bedrock/legal/templates/legal/terms/thunderbird.html
+++ b/bedrock/legal/templates/legal/terms/thunderbird.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Thunderbird: About Your Rights') }}{% endblock %}
+{% block page_title %}{{ ftl('legal-thunderbird-rights') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/vpn.html
+++ b/bedrock/legal/templates/legal/terms/vpn.html
@@ -8,7 +8,7 @@
   {{ css_bundle('legal') }}
 {% endblock %}
 
-{% block page_title %}{{ _('VPN') }}{% endblock %}
+{% block page_title %}VPN{% endblock %}
 
 {% block article %}
 <header>

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -10,7 +10,7 @@ from bedrock.legal import views
 from bedrock.legal_docs.views import LegalDocView
 
 urlpatterns = (
-    page('', 'legal/index.html'),
+    page('', 'legal/index.html', ftl_files=['mozorg/about/legal']),
 
     page('eula', 'legal/eula.html'),
     page('eula/firefox-2', 'legal/eula/firefox-2-eula.html'),

--- a/bedrock/legal_docs/views.py
+++ b/bedrock/legal_docs/views.py
@@ -65,7 +65,8 @@ class LegalDocView(TemplateView):
         response_kwargs.setdefault('content_type', self.content_type)
         return l10n_utils.render(self.request,
                                  self.get_template_names()[0],
-                                 context, **response_kwargs)
+                                 context, ftl_files=['mozorg/about/legal'],
+                                 **response_kwargs)
 
     def get_context_data(self, **kwargs):
         legal_doc = self.get_legal_doc()

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -190,6 +190,9 @@ locales = [
     reference = "en/mozorg/about/history.ftl"
     l10n = "{locale}/mozorg/about/history.ftl"
 [[paths]]
+    reference = "en/mozorg/about/legal.ftl"
+    l10n = "{locale}/mozorg/about/legal.ftl"
+[[paths]]
     reference = "en/mozorg/about/manifesto.ftl"
     l10n = "{locale}/mozorg/about/manifesto.ftl"
 [[paths]]

--- a/l10n/en/mozorg/about/legal.ftl
+++ b/l10n/en/mozorg/about/legal.ftl
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/about/legal/
+
+legal-legal = Legal
+legal-get-involved = Get involved
+legal-protect-the-fox = Protect the Fox
+legal-takedown-requests = Takedown requests
+legal-back-to-legal = Back to Legal
+legal-special-thanks-to-all-of-you = Special thanks to all of you who help report abuses of { -brand-name-mozilla } marks, participate in governance forums, give feedback on our localizations & legal terms, and contribute your skills to the success of the { -brand-name-mozilla } project.
+legal-terms = Terms
+legal-our-websites = Our Websites
+legal-firefox-services = { -brand-name-firefox } Services
+legal-webmaker = { -brand-name-webmaker }
+legal-privacy-trademarks = Privacy & trademarks
+legal-privacy-notices-and-policy = Privacy Notices and Policy
+legal-downloadable-software-notices = Downloadable software notices
+legal-firefox = { -brand-name-firefox }
+legal-firefox-rights = { -brand-name-firefox }: About Your Rights
+legal-thunderbird = { -brand-name-thunderbird }
+legal-thunderbird-rights = { -brand-name-thunderbird }: About Your Rights
+legal-websites-and-communications = Websites & Communications Terms of Use
+legal-acceptable-use-policy = Acceptable Use Policy
+legal-firefox-cloud-services = { -brand-name-firefox } Cloud Services: Terms of Service
+legal-firefox-better-web = { -brand-name-firefox-better-web }
+legal-firefox-better-web-terms = { -brand-name-firefox-better-web } Terms of Service
+legal-firefox-light-rights = { -brand-name-firefox-lite }: About Your Rights
+legal-firefox-private-network-terms = { -brand-name-firefox-private-network } Terms of Service
+legal-firefox-reality-rights = { -brand-name-firefox-reality }: About Your Rights
+legal-firefox-relay-terms = { -brand-name-firefox-relay } Terms of Service
+legal-mozilla-vpn-terms = { -brand-name-mozilla-vpn } Terms of Service
+legal-report-copyright = Report Copyright or Trademark Infringement

--- a/lib/fluent_migrations/legal/index.py
+++ b/lib/fluent_migrations/legal/index.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+index = "legal/index.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/legal/templates/legal/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "mozorg/about/legal.ftl",
+        "mozorg/about/legal.ftl",
+        transforms_from("""
+legal-legal = {COPY(index, "Legal",)}
+legal-get-involved = {COPY(index, "Get involved",)}
+legal-protect-the-fox = {COPY(index, "Protect the Fox",)}
+legal-takedown-requests = {COPY(index, "Takedown requests",)}
+legal-back-to-legal = {COPY(index, "Back to Legal",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("legal-special-thanks-to-all-of-you"),
+                value=REPLACE(
+                    index,
+                    "Special thanks to all of you who help report abuses of Mozilla marks, participate in governance forums, give feedback on our localizations & legal terms, and contribute your skills to the success of the Mozilla project.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+legal-terms = {COPY(index, "Terms",)}
+legal-our-websites = {COPY(index, "Our Websites",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("legal-firefox-services"),
+                value=REPLACE(
+                    index,
+                    "Firefox Services",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("legal-webmaker"),
+                value=REPLACE(
+                    index,
+                    "Webmaker",
+                    {
+                        "Webmaker": TERM_REFERENCE("brand-name-webmaker"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+legal-privacy-trademarks = {COPY(index, "Privacy & trademarks",)}
+legal-privacy-notices-and-policy = {COPY(index, "Privacy Notices and Policy",)}
+legal-downloadable-software-notices = {COPY(index, "Downloadable software notices",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("legal-firefox"),
+                value=REPLACE(
+                    index,
+                    "Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("legal-thunderbird"),
+                value=REPLACE(
+                    index,
+                    "Thunderbird",
+                    {
+                        "Thunderbird": TERM_REFERENCE("brand-name-thunderbird"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+legal-websites-and-communications = {COPY(index, "Websites & Communications Terms of Use",)}
+legal-acceptable-use-policy = {COPY(index, "Acceptable Use Policy",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("legal-firefox-cloud-services"),
+                value=REPLACE(
+                    index,
+                    "Firefox Cloud Services: Terms of Service",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/about/legal/

## Issue / Bugzilla link
#9808

## Testing
```
./manage.py l10n_update
```