### PR TITLE
Adding dockerhub creds to circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   test_py:
     docker:
       - image: circleci/python:3.7-stretch
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - setup_remote_docker:
@@ -14,6 +17,9 @@ jobs:
   test_js:
     docker:
       - image: "circleci/node:12-browsers"
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
## Description

Adding our dockerhub creds to pull images, so we can avoid getting rate limited.

## Issue / Bugzilla link

## Testing
The build failed when I put bad creds into the env variables, and passed when good creds were added.
Checked that the username/password wasn't echo'd in the logs, and that seems to be true for both jobs.