### PR TITLE
Fix common strings on privacy policies

### DIFF
--- a/bedrock/legal_docs/views.py
+++ b/bedrock/legal_docs/views.py
@@ -65,7 +65,7 @@ class LegalDocView(TemplateView):
         response_kwargs.setdefault('content_type', self.content_type)
         return l10n_utils.render(self.request,
                                  self.get_template_names()[0],
-                                 context, ftl_files=['mozorg/about/legal'],
+                                 context, ftl_files=['mozorg/about/legal', 'privacy/index'],
                                  **response_kwargs)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Description
Adds reference to `privacy/index` Fluent file to the legal doc view so all privacy pages can get those strings in the sidebar.

## Testing
http://localhost:8000/privacy/firefox/