### PR TITLE
Migrate /firefox/retention/thank-you/ to Fluent (Fixes #9811)

### DIFF
--- a/bedrock/firefox/templates/firefox/retention/thank-you.html
+++ b/bedrock/firefox/templates/firefox/retention/thank-you.html
@@ -4,12 +4,10 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% add_lang_files "firefox/retention/thank-you" %}
-
-{% block page_title %}{{ _('Thank You') }}{% endblock %}
+{% block page_title %}{{ ftl('thank-you-thank-you') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 
-{% block page_desc %}{{ _('Thank you page.') }}{% endblock %}
+{% block page_desc %}{{ ftl('thank-you-thank-you-page') }}{% endblock %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
@@ -31,32 +29,32 @@
         <span class="white">It’s all</span><br/>
         thanks to you
       {% else %}
-        {{ _('It’s all thanks to you') }}
+        {{ ftl('thank-you-its-all-thanks-to-you') }}
       {% endif %}
       </h1>
       <p>
-        {{ _('Choosing Firefox helps Mozilla make the Internet a better place. Here’s what you can do next:') }}
+        {{ ftl('thank-you-choosing-firefox-helps') }}
       </p>
     </header>
     <section>
       <article>
-        <h2>{{ _('Make Firefox your default browser') }}</h2>
-        <div class="time">{{ _('1 min action') }}</div>
-        <a data-link-type="link" data-link-name="Set as your default" href="{{ url('firefox.set-as-default.landing') }}">{{ _('Set as your default') }}</a>
+        <h2>{{ ftl('thank-you-make-firefox-your-default') }}</h2>
+        <div class="time">{{ ftl('thank-you-1-min-action') }}</div>
+        <a data-link-type="link" data-link-name="Set as your default" href="{{ url('firefox.set-as-default.landing') }}">{{ ftl('thank-you-set-as-your-default') }}</a>
       </article>
       <article>
-        <h2>{{ _('Get Firefox on your phone') }}</h2>
-        <div class="time">{{ _('2 min install') }}</div>
-        <a data-link-type="link" data-link-name="Download Firefox" href="{{ url('firefox.mobile.index') }}">{{ _('Download Firefox') }}</a>
+        <h2>{{ ftl('thank-you-get-firefox-on-your-phone') }}</h2>
+        <div class="time">{{ ftl('thank-you-2-min-install') }}</div>
+        <a data-link-type="link" data-link-name="Download Firefox" href="{{ url('firefox.mobile.index') }}">{{ ftl('thank-you-download-firefox') }}</a>
       </article>
       <article>
-        <h2>{{ _('Tell your friends about Firefox') }}</h2>
-        <div class="time">{{ _('1 min share') }}</div>
-        <a data-link-type="link" data-link-name="Send a tweet" href="{{ 'https://www.twitter.com/intent/tweet?url=%s&text=%s%s'|format('https://mozilla.org/firefox/new'|urlencode, '%F0%9F%94%A5%2B%F0%9F%A6%8A=%F0%9F%99%8C%F0%9F%8F%BE%20', _('Join me in the fight for an open web by choosing Firefox!')|urlencode)|e }}">{{ _('Send a tweet') }}</a>
+        <h2>{{ ftl('thank-you-tell-your-friends-about') }}</h2>
+        <div class="time">{{ ftl('thank-you-1-min-share') }}</div>
+        <a data-link-type="link" data-link-name="Send a tweet" href="{{ 'https://www.twitter.com/intent/tweet?url=%s&text=%s%s'|format('https://mozilla.org/firefox/new'|urlencode, '%F0%9F%94%A5%2B%F0%9F%A6%8A=%F0%9F%99%8C%F0%9F%8F%BE%20', ftl('thank-you-join-me-in-the-fight-for')|urlencode)|e }}">{{ ftl('thank-you-send-a-tweet') }}</a>
       </article>
       <article>
-        <h2>{{ _('Make the Internet a safer place') }}</h2>
-        <div class="time">{{ _('4 min read') }}</div>
+        <h2>{{ ftl('thank-you-make-the-internet-a-safer') }}</h2>
+        <div class="time">{{ ftl('thank-you-4-min-read') }}</div>
         <a data-link-type="link" data-link-name="Make the Internet as Safer Place" href="https://foundation.mozilla.org/internet-health/">{{ ftl('ui-learn-more') }}</a>
       </article>
     </section>
@@ -66,8 +64,8 @@
   <div class="mzp-l-content mzp-t-content-md">
     {{ email_newsletter_form(
        newsletters='mozilla-foundation',
-       title=_('Stay in touch for more cool stuff'),
-       desc=_('Get the latest & greatest from Firefox delivered straight to your inbox.'),
+       title=ftl('thank-you-stay-in-touch-for-more'),
+       desc=ftl('thank-you-get-the-latest-greatest'),
        spinner_color='#fff')
     }}
   </div>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -172,7 +172,7 @@ urlpatterns = (
     page('firefox/set-as-default', 'firefox/set-as-default/landing.html', ftl_files='firefox/set-as-default/landing'),
 
     # Issue 8536
-    page('firefox/retention/thank-you', 'firefox/retention/thank-you.html'),
+    page('firefox/retention/thank-you', 'firefox/retention/thank-you.html', ftl_files='firefox/retention/thank-you'),
 
     # Unfck campaign
     page('firefox/unfck', 'firefox/campaign/unfck/index.html', active_locales=['de', 'en-US', 'fr']),

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -150,6 +150,19 @@ locales = [
     reference = "en/firefox/products/**/*.ftl"
     l10n = "{locale}/firefox/products/**/*.ftl"
 [[paths]]
+    reference = "en/firefox/retention/**/*.ftl"
+    l10n = "{locale}/firefox/retention/**/*.ftl"
+    locales = [
+        "de",
+        "es-ES",
+        "fr",
+        "id",
+        "pl",
+        "pt-BR",
+        "ru",
+        "zh-TW"
+    ]
+[[paths]]
     reference = "en/firefox/set-as-default/**/*.ftl"
     l10n = "{locale}/firefox/set-as-default/**/*.ftl"
 [[paths]]

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -63,7 +63,6 @@
 -brand-name-firefox-devtools = Firefox DevTools
 -brand-name-firefox-lockwise = Firefox Lockwise
 -brand-name-firefox-monitor = Firefox Monitor
--brand-name-firefox-send = Firefox Send
 -brand-name-firefox-sync = Firefox Sync
 -brand-name-firefox-relay = Firefox Relay
 -brand-name-firefox-private-network = Firefox Private Network
@@ -73,7 +72,6 @@
 -brand-name-devtools = DevTools
 -brand-name-lockwise = Lockwise
 -brand-name-monitor = Monitor
--brand-name-send = Send
 -brand-name-sync = Sync
 -brand-name-relay = Relay
 -brand-name-fpn = FPN
@@ -83,6 +81,8 @@
 -brand-name-firefox-marketplace = Firefox Marketplace
 -brand-name-firefox-os = Firefox OS
 -brand-name-firefox-better-web = Firefox Better Web
+-brand-name-firefox-send = Firefox Send
+-brand-name-send = Send
 
 ## Pocket
 

--- a/l10n/en/firefox/retention/thank-you.ftl
+++ b/l10n/en/firefox/retention/thank-you.ftl
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/retention/thank-you/
+
+thank-you-thank-you = Thank You
+thank-you-thank-you-page = Thank you page.
+thank-you-its-all-thanks-to-you = It’s all thanks to you
+thank-you-choosing-firefox-helps = Choosing { -brand-name-firefox } helps { -brand-name-mozilla } make the internet a better place. Here’s what you can do next:
+thank-you-make-firefox-your-default = Make { -brand-name-firefox } your default browser
+thank-you-1-min-action = 1 min action
+thank-you-set-as-your-default = Set as your default
+thank-you-get-firefox-on-your-phone = Get { -brand-name-firefox } on your phone
+thank-you-2-min-install = 2 min install
+thank-you-download-firefox = Download { -brand-name-firefox }
+thank-you-tell-your-friends-about = Tell your friends about { -brand-name-firefox }
+thank-you-1-min-share = 1 min share
+thank-you-join-me-in-the-fight-for = Join me in the fight for an open web by choosing { -brand-name-firefox }!
+thank-you-send-a-tweet = Send a tweet
+thank-you-make-the-internet-a-safer = Make the internet a safer place
+thank-you-4-min-read = 4 min read
+thank-you-stay-in-touch-for-more = Stay in touch for more cool stuff
+thank-you-get-the-latest-greatest = Get the latest & greatest from { -brand-name-firefox } delivered straight to your inbox.

--- a/lib/fluent_migrations/firefox/retention/thank-you.py
+++ b/lib/fluent_migrations/firefox/retention/thank-you.py
@@ -1,0 +1,108 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+thank_you = "firefox/retention/thank-you.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/retention/thank-you.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/retention/thank-you.ftl",
+        "firefox/retention/thank-you.ftl",
+        transforms_from("""
+thank-you-thank-you = {COPY(thank_you, "Thank You",)}
+thank-you-thank-you-page = {COPY(thank_you, "Thank you page.",)}
+thank-you-its-all-thanks-to-you = {COPY(thank_you, "It’s all thanks to you",)}
+""", thank_you=thank_you) + [
+            FTL.Message(
+                id=FTL.Identifier("thank-you-choosing-firefox-helps"),
+                value=REPLACE(
+                    thank_you,
+                    "Choosing Firefox helps Mozilla make the Internet a better place. Here’s what you can do next:",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("thank-you-make-firefox-your-default"),
+                value=REPLACE(
+                    thank_you,
+                    "Make Firefox your default browser",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+thank-you-1-min-action = {COPY(thank_you, "1 min action",)}
+thank-you-set-as-your-default = {COPY(thank_you, "Set as your default",)}
+""", thank_you=thank_you) + [
+            FTL.Message(
+                id=FTL.Identifier("thank-you-get-firefox-on-your-phone"),
+                value=REPLACE(
+                    thank_you,
+                    "Get Firefox on your phone",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+thank-you-2-min-install = {COPY(thank_you, "2 min install",)}
+""", thank_you=thank_you) + [
+            FTL.Message(
+                id=FTL.Identifier("thank-you-download-firefox"),
+                value=REPLACE(
+                    thank_you,
+                    "Download Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("thank-you-tell-your-friends-about"),
+                value=REPLACE(
+                    thank_you,
+                    "Tell your friends about Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+thank-you-1-min-share = {COPY(thank_you, "1 min share",)}
+""", thank_you=thank_you) + [
+            FTL.Message(
+                id=FTL.Identifier("thank-you-join-me-in-the-fight-for"),
+                value=REPLACE(
+                    thank_you,
+                    "Join me in the fight for an open web by choosing Firefox!",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+thank-you-send-a-tweet = {COPY(thank_you, "Send a tweet",)}
+thank-you-make-the-internet-a-safer = {COPY(thank_you, "Make the Internet a safer place",)}
+thank-you-4-min-read = {COPY(thank_you, "4 min read",)}
+thank-you-stay-in-touch-for-more = {COPY(thank_you, "Stay in touch for more cool stuff",)}
+""", thank_you=thank_you) + [
+            FTL.Message(
+                id=FTL.Identifier("thank-you-get-the-latest-greatest"),
+                value=REPLACE(
+                    thank_you,
+                    "Get the latest & greatest from Firefox delivered straight to your inbox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description
http://127.0.0.1:8000/en-US/firefox/retention/thank-you/

## Issue / Bugzilla link
#9811

## Testing
```
./manage.py l10n_update
```