### PR TITLE
WNP 86 for /de/ and /fr/ (Fixes #9926)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-mobile-qrcode-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-mobile-qrcode-de.html
@@ -1,0 +1,75 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{#- This will appear as <meta property="og:description"> which can be used for social share -#}
+{% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{#- Override <meta property="og:url"> for social share -#}
+{% block page_og_url %}{{ url('firefox.mobile.index') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew-mobile-qr-code-de{% endblock %}
+{% block body_class %}{{ super() }}{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_mobile_qrcode_de') }}
+{% endblock %}
+
+{% block content %}
+<main role="main" class="content-wrapper mzp-t-firefox">
+  {% include 'firefox/whatsnew/includes/header.html' %}
+
+  <section class="wnp-content-main">
+    <div class="mzp-l-content">
+      {{ high_res_img('protocol/img/logos/firefox/browser/logo-md.png', {'alt': '', 'width': '96', 'height': '96', 'class': 'wnp-main-image'}) }}
+      <h1 class="wnp-main-title">Der neue Firefox jetzt auch für dein Smartphone</h1>
+      <p class="wnp-main-tagline">Superschnell. Standardmäßig privat. Individuell anpassbar.</p>
+
+      <h2 class="wnp-main-subtitle">Hol dir Firefox Mobile</h2>
+      <p>Scanne den QR Code, um loszulegen.</p>
+
+      <div class="wnp-qr-code-wrapper">
+        {{ qrcode('https://app.adjust.com/vhrf030') }}
+      </div>
+
+      <div class="l-columns-two">
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/whatsnew/whatsnew85-de/icon-android.svg') }}" width="120" height="90" alt="">
+          </div>
+          <h3 class="c-picto-block-title">Firefox für Android</h3>
+          <div class="c-picto-block-body">
+            <p><a href="https://www.chip.de/news/Das-Android-Starterkit-2021-Absolute-Must-Have-Apps_105025279.html" target="_blank" rel="external noopener noreferrer" data-cta-type="link" data-cta-text="chip de">Chip.de</a> sagt: Eine der wichtigsten Android-Anwendungen für 2021. Firefox ist ein <em>“klasse Browser im minimalistischen Design.”</em></em></p>
+          </div>
+        </div>
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/whatsnew/whatsnew85-de/icon-ios.svg') }}" width="120" height="90" alt="">
+          </div>
+          <h3 class="c-picto-block-title">Firefox für iOS</h3>
+          <div class="c-picto-block-body">
+            <p>Wir sagen: Darf auch auf iOS nicht fehlen. Mach Firefox auch auf dem iPhone zu deinem Standardbrowser.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="mzp-l-content c-utilities">
+    {% set releasenotes_url = url('firefox.releases.index') if not version else '/firefox/%s/releasenotes/'|format(version) %}
+    <p>{{ ftl('whatsnew-release-notes', url=releasenotes_url) }}</p>
+  </aside>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -476,6 +476,26 @@ class TestWhatsNew(TestCase):
 
     # end 85.0 whatsnew tests
 
+    # begin 86.0 whatsnew tests
+
+    def test_fx_86_0_0_de(self, render_mock):
+        """Should use whatsnew-mobile-qrcode-de template for 86.0 in German"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'de'
+        self.view(req, version='86.0')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/whatsnew-mobile-qrcode-de.html']
+
+    def test_fx_86_0_0_fr(self, render_mock):
+        """Should use whatsnew-fx81 template for 86.0 in French"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'fr'
+        self.view(req, version='86.0')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/whatsnew-fx81.html']
+
+    # end 86.0 whatsnew tests
+
 
 @patch('bedrock.firefox.views.l10n_utils.render', return_value=HttpResponse())
 class TestWhatsNewFirefoxLite(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -563,6 +563,7 @@ class WhatsnewView(L10nTemplateView):
         'firefox/whatsnew/whatsnew-fx84.html': ['firefox/whatsnew/whatsnew-fx80', 'firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx85.html': ['firefox/whatsnew/whatsnew-fx80', 'firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-mobile-de.html': ['firefox/whatsnew/whatsnew'],
+        'firefox/whatsnew/whatsnew-mobile-qrcode-de.html': ['firefox/whatsnew/whatsnew'],
     }
 
     def get_context_data(self, **kwargs):
@@ -618,13 +619,17 @@ class WhatsnewView(L10nTemplateView):
                 template = 'firefox/developer/whatsnew.html'
             else:
                 template = 'firefox/whatsnew/index.html'
+        elif version.startswith('86.') and locale == 'de':
+            template = 'firefox/whatsnew/whatsnew-mobile-qrcode-de.html'
+        elif version.startswith('86.') and locale == 'fr':
+            template = 'firefox/whatsnew/whatsnew-fx81.html'
         elif version.startswith('85.') and locale.startswith('en-'):
             template = 'firefox/whatsnew/whatsnew-fx85.html'
-        elif version.startswith('85.') and locale == ('de'):
+        elif version.startswith('85.') and locale == 'de':
             template = 'firefox/whatsnew/whatsnew-mobile-de.html'
         elif version.startswith('84.') and locale.startswith('en-'):
             template = 'firefox/whatsnew/whatsnew-fx84.html'
-        elif version.startswith('83.') and locale == ('de'):
+        elif version.startswith('83.') and locale == 'de':
             template = 'firefox/whatsnew/whatsnew-fx83-de.html'
         elif version.startswith('83.') and locale.startswith('en-'):
             template = 'firefox/whatsnew/whatsnew-fx83-en.html'

--- a/media/css/firefox/whatsnew/whatsnew-mobile-qrcode-de.scss
+++ b/media/css/firefox/whatsnew/whatsnew-mobile-qrcode-de.scss
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/notification-bar';
+@import 'includes/header';
+
+//* -------------------------------------------------------------------------- */
+// Main content
+
+.wnp-content-main {
+    padding: 0;
+    text-align: center;
+}
+
+.wnp-main-title,
+.wnp-main-subtitle {
+    color: get-theme('title-text-color');
+    margin: $spacing-md auto;
+    max-width: 14em;
+}
+
+.wnp-main-title {
+    @include text-title-md;
+}
+
+.wnp-main-subtitle {
+    @include text-title-xs;
+    margin-top: $layout-lg;
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+}
+
+.wnp-qr-code-wrapper {
+    background: $color-white;
+    border: 1px solid $color-black;
+    display: inline-block;
+
+    svg {
+        height: 280px;
+        vertical-align: middle;
+        width: 280px;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// To be replaced by revamped picto card. See https://github.com/mozilla/protocol/issues/382
+
+.c-picto-block {
+    @include border-box;
+    margin: 0 auto $spacing-2xl;
+    max-width: $content-md - ($layout-md * 2);
+    padding: 0 $layout-md;
+
+    .c-picto-block-title {
+        @include text-title-xs;
+        color: get-theme('title-text-color');
+    }
+
+    .c-picto-block-image {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+        margin: 0 auto $spacing-lg;
+        max-width: $content-xs;
+        min-height: $layout-md;
+    }
+}
+
+.l-columns-two {
+    margin-top: $layout-lg;
+
+    @media #{$mq-md} {
+        display: flex;
+        flex-wrap: wrap;
+        margin: $layout-xl auto 0;
+        max-width: $content-lg;
+        padding: 0 $layout-md;
+
+        .c-picto-block {
+            flex: 1 1 50%;
+            padding: 0 $layout-lg;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Utilities (link to release notes)
+
+.c-utilities {
+    @include text-body-sm;
+    max-width: $content-md;
+    padding-bottom: $layout-xl;
+    text-align: center;
+}
+
+//* -------------------------------------------------------------------------- */
+// For dark mode
+
+@media (prefers-color-scheme: dark) {
+    .content-wrapper {
+        background: $color-dark-gray-60;
+        color: $color-white;
+    }
+
+    .wnp-main-title,
+    .wnp-main-subtitle {
+        color: get-theme('title-text-color-inverse');
+    }
+
+    .c-picto-block {
+        .c-picto-block-title {
+            color: get-theme('title-text-color-inverse');
+        }
+
+        .c-picto-block-body {
+            @include light-links;
+        }
+    }
+
+    .c-utilities {
+        @include light-links;
+    }
+
+    .c-footer {
+        background: $color-dark-gray-60;
+        color: $color-white;
+
+        a:link,
+        a:visited {
+            color: $color-light-gray-20;
+            text-decoration: underline;
+
+            &:hover,
+            &:focus,
+            &:active {
+                color: $color-white;
+            }
+        }
+
+        .c-footer-sections {
+            border-color: $color-dark-gray-30;
+        }
+    }
+
+    .c-footer-list-social li {
+        a.twitter {
+            background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+        }
+
+        a.instagram {
+            background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+        }
+
+        a.youtube {
+            background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+        }
+    }
+
+    .c-footer-primary-logo a {
+        background-image: url('/media/protocol/img/logos/mozilla/white.svg');
+    }
+}

--- a/media/js/firefox/whatsnew/up-to-date.js
+++ b/media/js/firefox/whatsnew/up-to-date.js
@@ -5,6 +5,10 @@
 (function() {
     'use strict';
 
+    if (typeof Mozilla.Client === 'undefined' || typeof Mozilla.UITour === 'undefined') {
+        return;
+    }
+
     var client = Mozilla.Client;
 
     function checkUpToDate() {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -358,6 +358,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-mobile-qrcode-de.scss"
+      ],
+      "name": "firefox_whatsnew_mobile_qrcode_de"
+    },
+    {
+      "files": [
         "css/firefox/firstrun/nightly.scss"
       ],
       "name": "nightly_firstrun"
@@ -1223,6 +1229,12 @@
         "js/firefox/whatsnew/whatsnew.js"
       ],
       "name": "firefox_whatsnew"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/up-to-date.js"
+      ],
+      "name": "firefox_whatsnew_update"
     },
     {
       "files": [

--- a/tests/functional/firefox/whatsnew/test_whatsnew_86.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_86.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.whatsnew.whatsnew_86 import FirefoxWhatsNew86Page
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_send_to_device_success(base_url, selenium):
+    page = FirefoxWhatsNew86Page(selenium, base_url, locale='fr').open()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('success@example.com')
+    send_to_device.click_send()
+    assert send_to_device.send_successful
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_send_to_device_failure(base_url, selenium):
+    page = FirefoxWhatsNew86Page(selenium, base_url, locale='fr').open()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_qr_code_is_displayed(base_url, selenium):
+    page = FirefoxWhatsNew86Page(selenium, base_url, locale='de').open()
+    assert page.is_qrcode_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_86.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_86.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.send_to_device import SendToDevice
+
+
+class FirefoxWhatsNew86Page(BasePage):
+
+    _URL_TEMPLATE = '/{locale}/firefox/86.0/whatsnew/all/'
+
+    _qrcode_locator = (By.CSS_SELECTOR, '.wnp-qr-code-wrapper > svg')
+
+    @property
+    def send_to_device(self):
+        return SendToDevice(self)
+
+    @property
+    def is_qrcode_displayed(self):
+        return self.is_element_displayed(*self._qrcode_locator)


### PR DESCRIPTION
## Description
- http://localhost:8000/de/firefox/86.0/whatsnew/all/ (Firefox Mobile promo with QRCode)
- http://localhost:8000/fr/firefox/86.0/whatsnew/all/ (Template from WNP81 with Send to Device)

## Issue / Bugzilla link
#9926

## Testing
- [x] Scanning QRCode should redirect to app store / play store.

Demo
- https://www-demo2.allizom.org/de/firefox/86.0/whatsnew/all/
- https://www-demo2.allizom.org/fr/firefox/86.0/whatsnew/all/