### PR TITLE
Pass through experiment and variation parameters to FxA links (Issue #9922)

### DIFF
--- a/media/js/base/fxa-utm-referral-init.js
+++ b/media/js/base/fxa-utm-referral-init.js
@@ -5,8 +5,8 @@
 (function () {
     'use strict';
 
-    var urlParams = new window._SearchParams().utmParams();
+    var urlParams = new window._SearchParams();
 
-    // Track external UTM referrals for Firefox Accounts related CTAs.
-    Mozilla.UtmUrl.init(urlParams);
+    // Track external URL parameter referrals for Firefox Accounts related CTAs.
+    Mozilla.UtmUrl.init(urlParams.params);
 })();

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -47,6 +47,44 @@ describe('fxa-utm-referral.js', function() {
             expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
         });
 
+        it('should return a additional entrypoint params if present', function () {
+            var validObj = {
+                'utm_source': 'desktop-snippet',
+                'utm_content': 'rel-esr',
+                'utm_medium': 'referral',
+                'utm_term': 4242,
+                'utm_campaign': 'F100_4242_otherstuff_in_here',
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation'
+            };
+
+            var validData = {
+                'utm_source': 'desktop-snippet',
+                'utm_content': 'rel-esr',
+                'utm_medium': 'referral',
+                'utm_term': '4242',
+                'utm_campaign': 'F100_4242_otherstuff_in_here',
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
+        });
+
+        it('should return entrypoint params if not utms are present', function () {
+            var validObj = {
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation'
+            };
+
+            var validData = {
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
+        });
+
         it('should return an object without any danagerous params', function () {
             var dangerousSource = {
                 'utm_source': 'www.mozilla.org',
@@ -203,6 +241,33 @@ describe('fxa-utm-referral.js', function() {
             var url = 'https://accounts.firefox.com:8000/grande/nofat.html?spice=pumpkin';
 
             expect(Mozilla.UtmUrl.appendToDownloadURL(url, data)).toEqual('https://accounts.firefox.com:8000/grande/nofat.html?spice=pumpkin&utm_source=test-source');
+        });
+
+        it('adds additional entrypoint parameters if present', function() {
+            var data = {
+                'utm_source': 'desktop-snippet',
+                'utm_content': 'rel-esr',
+                'utm_medium': 'referral',
+                'utm_term': 4242,
+                'utm_campaign': 'F100_4242_otherstuff_in_here',
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation'
+            };
+
+            var url = 'https://accounts.firefox.com/';
+
+            expect(Mozilla.UtmUrl.appendToDownloadURL(url, data)).toEqual('https://accounts.firefox.com/?utm_source=desktop-snippet&utm_content=rel-esr&utm_medium=referral&utm_term=4242&utm_campaign=F100_4242_otherstuff_in_here&entrypoint_experiment=test-id&entrypoint_variation=test-variation');
+        });
+
+        it('does not wipe out existing utms if only enytrpoint params are present', function() {
+            var data = {
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation'
+            };
+
+            var url = 'https://accounts.firefox.com/?utm_medium=medium-one&utm_term=term-one&utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
+
+            expect(Mozilla.UtmUrl.appendToDownloadURL(url, data)).toEqual('https://accounts.firefox.com/?utm_medium=medium-one&utm_term=term-one&utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one&entrypoint_experiment=test-id&entrypoint_variation=test-variation');
         });
 
     });

--- a/tests/unit/spec/ie/mozilla-utils-ie.js
+++ b/tests/unit/spec/ie/mozilla-utils-ie.js
@@ -21,7 +21,7 @@ describe('mozilla-utils-ie.js', function() {
     describe('initDownloadLinks (regular download button)', function () {
 
         beforeEach(function () {
-            var link = '<a class="download-link" data-direct-link="test-download-url">Download</a>';
+            var link = '<a href="#download" class="download-link" data-direct-link="test-download-url">Download</a>';
             document.body.insertAdjacentHTML('beforeend', link);
         });
 


### PR DESCRIPTION
## Description
- http://localhost:8000/en-US/firefox/accounts/?entrypoint_experiment=test&entrypoint_variation=test
- http://localhost:8000/en-US/firefox/accounts/?utm_source=test&utm_campaign=test&entrypoint_experiment=test&entrypoint_variation=test

## Issue / Bugzilla link
#9922

## Testing
- [x] When loading the URLs above, `entrypoint_experiment` and `entrypoint_variation` params should be passed through to the page's FxA / Firefox Monitor buttons.