### PR TITLE
Move QR Code generator cache from file system to memory

### DIFF
--- a/bedrock/mozorg/tests/test_helper_qrcode.py
+++ b/bedrock/mozorg/tests/test_helper_qrcode.py
@@ -6,17 +6,17 @@ from bedrock.mozorg.tests import TestCase
 from bedrock.mozorg.templatetags.qrcode import qrcode
 
 
-@patch('bedrock.mozorg.templatetags.qrcode.QR_CACHE_PATH')
+@patch('bedrock.mozorg.templatetags.qrcode.cache')
 @patch('bedrock.mozorg.templatetags.qrcode.qr')
 class TestQRCode(TestCase):
-    def test_qrcode_cache_cold(self, qr_mock, qrcp_mock):
-        qrcp_mock.joinpath().exists.return_value = False
+    def test_qrcode_cache_cold(self, qr_mock, cache_mock):
+        cache_mock.get.return_value = None
         data = 'https://dude.abide'
         qrcode(data, 20)
         qr_mock.make.assert_called_with(data, image_factory=SvgPathImage, box_size=20)
 
-    def test_qrcode_cache_warm(self, qr_mock, qrcp_mock):
-        qrcp_mock.joinpath().exists.return_value = True
+    def test_qrcode_cache_warm(self, qr_mock, cache_mock):
+        cache_mock.get.return_value = '<svg>stuff</svg>'
         data = 'https://dude.abide'
         qrcode(data, 20)
         qr_mock.make.assert_not_called()

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -79,6 +79,17 @@ CACHES['externalfiles'] = {
     }
 }
 
+# cache for generated QR codes
+CACHES['qrcode'] = {
+    'BACKEND': 'bedrock.base.cache.SimpleDictCache',
+    'LOCATION': 'qrcode',
+    'TIMEOUT': None,
+    'OPTIONS': {
+        'MAX_ENTRIES': 20,
+        'CULL_FREQUENCY': 4,  # 1/4 entries deleted if max reached
+    }
+}
+
 MEDIA_URL = CDN_BASE_URL + MEDIA_URL
 STATIC_URL = CDN_BASE_URL + STATIC_URL
 logging.config.dictConfig(LOGGING)


### PR DESCRIPTION
Some deployments (e.g. Demos) don't have writable file systems.
Also it seems to be frowned upon to write to the FS in Docker in
general. This should work as well or better.
