### PR TITLE
Update obsolete links on German Firefox nightly Firstrun page, fix heading visibility (fixes #9930)

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/firstrun.cs.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.cs.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-  <div class="mzp-l-content mzp-t-content-md locale-specific">
+  <div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
     <h3>Zjistěte více o místní komunitě Mozilla</h3>
     <p>
       Česká komunita Mozilla překládá aplikace Mozilly do češtiny, pomáhá uživatelům a popularizuje projekt.

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.de.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.de.html
@@ -7,20 +7,13 @@
 {% block locale_promo %}
   <div class="mzp-l-content mzp-t-content-md locale-specific">
     <h3>Erfahren Sie mehr über die lokale Mozilla-Community</h3>
-    <p>Unsere Projekte bieten einige vielfältige Möglichkeiten, wie sich wirklich jeder aktiv einbringen kann: Helfen Sie Anwendern von Mozilla-Software, arbeiten Sie an der Übersetzung der Mozilla-Software von Webseiten mit oder planen Sie Veranstaltungen für das WebMaker-Projekt.</p>
+    <p>Unsere Projekte bieten einige vielfältige Möglichkeiten, wie sich wirklich jeder aktiv einbringen kann: Helfen Sie Anwendern von Mozilla-Software oder arbeiten Sie an der Übersetzung der Mozilla-Software und -Webseiten mit.</p>
 
     <p>Werden Sie Teil der Gemeinschaft</p>
     <ul>
-      <li><a href="http://www.mozilla.de/">www.mozilla.de</a></li>
-      <li><a href="http://www.mibbit.com/?server=irc.mozilla.org&amp;channel=%23mozilla.de">IRC-Chat: #mozilla.de</a></li>
-      <li><a href="https://lists.mozilla.org/listinfo/community-german">Mailing-Liste</a></li>
-      <li><a href="https://twitter.com/mozilla_deutsch">@mozilla_deutsch</a></li>
-      <li><a href="https://www.facebook.com/mozilla.de">Facebook</a></li>
+      <li><a href="https://www.soeren-hentzschel.at/">Mozilla-Neuigkeiten von Sören Hentzschel</a></li>
+      <li><a href="https://chat.mozilla.org/#/room/#mozilla.de:mozilla.org">Element-Chat: #mozilla.de</a></li>
+      <li><a href="https://discourse.mozilla.org/c/communities/germany/59">Forum der Gemeinschaft</a></li>
     </ul>
-
-    <h4>Aktuelle Veranstaltungen</h4>
-      <ul>
-        <li>Open Mozilla Nights (Berlin) &ndash; jeden 2. Donnerstag &ndash; <a href="https://www.meetup.com/de-DE/Berlin-Mozilla-Meetup/">Meetup</a> &ndash; <a href="https://twitter.com/MozillaNight">Twitter</a></li>
-      </ul>
   </div>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.de.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.de.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-  <div class="mzp-l-content mzp-t-content-md locale-specific">
+  <div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
     <h3>Erfahren Sie mehr über die lokale Mozilla-Community</h3>
     <p>Unsere Projekte bieten einige vielfältige Möglichkeiten, wie sich wirklich jeder aktiv einbringen kann: Helfen Sie Anwendern von Mozilla-Software oder arbeiten Sie an der Übersetzung der Mozilla-Software und -Webseiten mit.</p>
 

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.es-AR.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.es-AR.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-<div class="mzp-l-content mzp-t-content-md locale-specific">
+<div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
   <h3>¡Conocé a la comunidad argentina!</h3>
   <p>Mozilla es una organización sin fines de lucro conformada por una comunidad en la que cualquiera puede ser parte. Sólo tenés que traer tus ganas de participar y aprender. Desde la página de colabora podés acercar tus ganas de participar. También podés visitar <a href="http://www.mozilla-hispano.org/">la página de Mozilla Hispano</a> para enterarte de las últimas novedades sobre Mozilla.</p>
   <p>Y si querés juntarte con vecinos en Argentina, podés suscribirte a la <a href="https://listas.usla.org.ar/cgi-bin/mailman/listinfo/mozilla-general">lista de correo</a>, o pasearte por la sala de IRC de Mozilla Hispano.</p>

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.es-ES.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.es-ES.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-<div class="mzp-l-content mzp-t-content-md locale-specific">
+<div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
   <h3>¡Descubre tu comunidad en español!</h3>
   <p>Mozilla Hispano es la comunidad de Mozilla que reúne a desarrolladores, traductores y usuarios de quince comunidades de habla hispana a uno y otro lado del Atlántico. Infórmate sobre nuestros proyectos, productos y principios diseñados para que la gente se haga con el control y explore el pleno potencial de sus vidas digitales.<p>Visita <a href="http://www.mozilla-hispano.org/">la página de Mozilla Hispano</a> para enterarte de las últimas novedades sobre Mozilla. Y si te interesa participar, en esta <a href="https://www.mozilla.org/es-ES/contribute/">página </a> puedes encontrar toda la información.</p>
   <p>¡Gracias por usar Firefox Nightly!</p>

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.fr.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.fr.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-  <div class="mzp-l-content mzp-t-content-md locale-specific">
+  <div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
     <h3>La communauté Mozilla francophone a besoin de vous&nbsp;!</h3>
     <p>Traduction, participation à des évènements locaux du Web ou du libre, développement, assistance aux utilisateurs, promotion du libre et des valeurs de Mozilla, enseignement. Les possibilités de participation au projet Mozilla directement dans votre langue ne manquent pas&nbsp;!</p>
 

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.it.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.it.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-  <div class="mzp-l-content mzp-t-content-md locale-specific">
+  <div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
     <h3>La comunità italiana ha bisogno del tuo aiuto</h3>
     <p>Da oltre dieci anni esiste in Italia una comunità di volontari che si occupa principalmente di traduzione e supporto per i software Mozilla. Siamo alla costante ricerca di volontari per diffondere la cultura di Mozilla in Italia, contribuire all’organizzazione di eventi, alle traduzioni, al supporto per gli utenti e molto altro ancora.</p>
     <p>Scopri la comunità italiana di Mozilla:</p>

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.ru.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.ru.html
@@ -5,7 +5,7 @@
 {% extends "/firefox/nightly/firstrun.html" %}
 
 {% block locale_promo %}
-  <div class="mzp-l-content mzp-t-content-md locale-specific">
+  <div class="mzp-l-content mzp-t-content-md mzp-t-dark locale-specific">
     <h3>Вы нужны сообществу Mozilla Россия&nbsp;!</h3>
     <p>Окажите помощь пользователям, примите участие в разработке, участвуйте в переводе, осуществляйте развитие открытых и свободных программ от Mozilla. Не пропустите возможность принять участие в проекте Mozilla на своем языке! </p>
     <p>Узнайте больше о Mozilla Россия, русскоязычном сообществе Mozilla:</p>


### PR DESCRIPTION
## Description
This change updates the obsolete text and links on the German Firefox nightly Firstrun page. Additionally, it fixes the visibility of all headings in the German page and other custom locales.

## Issue / Bugzilla link
This fixes #9930, related to https://bugzilla.mozilla.org/show_bug.cgi?id=1692600

## Testing
Run the server locally and visit http://localhost:8000/de/firefox/nightly/firstrun/. The links should be up-to-date and the heading "Erfahren Sie mehr über die lokale Mozilla-Community" should be visible. Additionally, the headings for the other locales `cs`, `es-AR`, `es-ES`, `fr`, `it`, `ru` should now be visible too.
