### PR TITLE
Add support for staging instances to VPN product buttons (Fixes #9952)

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -44,9 +44,9 @@ def vpn_sign_in_link(ctx, entrypoint, link_text, class_name=None, optional_param
     In Template
     -----------
 
-        {{ vpn_sign_in_link(entrypoint='mozilla.org', button_text='Sign In') }}
+        {{ vpn_sign_in_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Sign In') }}
     """
-    product_url = 'https://vpn.mozilla.org/oauth/init/'
+    product_url = f'{settings.VPN_ENDPOINT}oauth/init/'
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)
 
@@ -63,8 +63,8 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, class_name=None, optional_par
     In Template
     -----------
 
-        {{ vpn_subscribe_link(entrypoint='mozilla.org', button_text='Try Mozilla VPN') }}
+        {{ vpn_subscribe_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Try Mozilla VPN') }}
     """
-    product_url = 'https://vpn.mozilla.org/r/vpn/subscribe/'
+    product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe/'
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -11,6 +11,7 @@ from bedrock.mozorg.tests import TestCase
 
 
 TEST_FXA_ENDPOINT = 'https://accounts.firefox.com/'
+TEST_VPN_ENDPOINT = 'https://vpn.mozilla.org/'
 
 jinja_env = Jinja2.get_default()
 
@@ -21,6 +22,7 @@ def render(s, context=None):
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+@override_settings(VPN_ENDPOINT=TEST_VPN_ENDPOINT)
 class TestVPNSubscribeLink(TestCase):
     rf = RequestFactory()
 
@@ -35,13 +37,13 @@ class TestVPNSubscribeLink(TestCase):
         """Should return expected markup"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Try Mozilla VPN',
                               class_name='vpn-button try js-try-vpn',
-                              optional_parameters={'utm_campaign': 'vpn-landing-page'},
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
                               optional_attributes={'data-cta-text': 'Try Mozilla VPN', 'data-cta-type':
                                                    'fxa-vpn', 'data-cta-position': 'primary'})
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/?entrypoint=www.mozilla.org-vpn-product-page'
             u'&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral'
-            u'&utm_campaign=vpn-landing-page" data-action="https://accounts.firefox.com/" '
+            u'&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
             u'class="js-fxa-cta-link js-fxa-product-button vpn-button try js-try-vpn" '
             u'data-cta-text="Try Mozilla VPN" data-cta-type="fxa-vpn" data-cta-position="primary">'
             u'Try Mozilla VPN</a>')
@@ -49,6 +51,7 @@ class TestVPNSubscribeLink(TestCase):
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+@override_settings(VPN_ENDPOINT=TEST_VPN_ENDPOINT)
 class TestVPNSignInLink(TestCase):
     rf = RequestFactory()
 
@@ -62,13 +65,13 @@ class TestVPNSignInLink(TestCase):
     def test_vpn_sign_in_link(self):
         """Should return expected markup"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Sign In', class_name='mzp-c-cta-link',
-                              optional_parameters={'utm_campaign': 'vpn-landing-page'},
-                              optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type':
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'VPN Sign In', 'data-cta-type':
                                                    'fxa-vpn', 'data-cta-position': 'navigation'})
         expected = (
             u'<a href="https://vpn.mozilla.org/oauth/init/?entrypoint=www.mozilla.org-vpn-product-page'
             u'&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral'
-            u'&utm_campaign=vpn-landing-page" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="Sign In" '
+            u'&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '
             u'data-cta-type="fxa-vpn" data-cta-position="navigation">Sign In</a>')
         self.assertEqual(markup, expected)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1315,6 +1315,12 @@ if config('SWITCH_TRACKING_PIXEL', default=str(DEV), parser=bool):
 # Issue 7508 - Convert.com experiment sandbox
 CONVERT_PROJECT_ID = ('10039-1003350' if DEV else '10039-1003343')
 
+# Mozilla VPN product links
+#   - https://vpn.mozilla.org/ (prod)
+#   - https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/ (stage)
+VPN_ENDPOINT = config('VPN_ENDPOINT',
+                       default='https://vpn.mozilla.org/')
+
 # Mozilla VPN Geo restrictions
 # https://github.com/mozilla-services/guardian-website/blob/master/server/constants.ts
 VPN_ALLOWED_COUNTRY_CODES = [

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -186,7 +186,6 @@ Usage
 For more information on the available parameters, read the "CTA button parameters"
 section below.
 
-
 CTA button parameters
 ---------------------
 
@@ -198,7 +197,7 @@ all support the same standard parameters:
 +============================+========================================================================================================================+==========================================================+========================================================================================================+
 |    entrypoint*             | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.       | 'mozilla.org-firefox-pocket'                             | 'mozilla.org-firefox-pocket'                                                                           |
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-|    button_text*            | The button copy to be used in the call to action.  Default to a well localized string.                                 | Localizable string                                       | _('Try Pocket Now')                                                                                    |
+|    button_text*            | The button copy to be used in the call to action.                                                                      | Localizable string                                       | 'Try Pocket Now'                                                                                       |
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 |    class_name              | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'pocket-main-cta-button'                                                                               |
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
@@ -217,11 +216,43 @@ all support the same standard parameters:
     which accepts the values ``signup``, ``signin``, and ``email`` for
     configuring the type of authentication flow.
 
+Linking to vpn.mozilla.org
+--------------------------
+
+Use the ``vpn_subscribe_link`` and ``vpn_sign_in_link`` helpers to link to https://vpn.mozilla.org/ via a
+Firefox Accounts auth flow.
+
+Usage
+~~~~~
+
+.. code-block:: jinja
+
+    {{ vpn_subscribe_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Try Mozilla VPN') }}
+
+.. code-block:: jinja
+
+    {{ vpn_sign_in_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Sign In') }}
+
+Both helpers for Mozilla VPN support the same parameters (* indicates a required parameter)
+
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    Parameter name          |                                                       Definition                                                       |                          Format                          |                                                Example                                                 |
++============================+========================================================================================================================+==========================================================+========================================================================================================+
+|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.       | 'www.mozilla.org-page-name'                              | 'www.mozilla.org-vpn-product-page'                                                                     |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    link_text*              | The link copy to be used in the call to action.                                                                        | Localizable string                                       | 'Try Mozilla VPN'                                                                                      |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    class_name              | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'vpn-button'                                                                                           |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optional_parameters     | An dictionary of key value pairs containing additional parameters to append the the href.                              | Dictionary                                               | {'utm_campaign': 'vpn-product-page'}                                                                   |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optiona_attributes      | An dictionary of key value pairs containing additional data attributes to include in the button.                       | Dictionary                                               | {'data-cta-text': 'VPN Sign In', 'data-cta-type': 'fxa-vpn', 'data-cta-position': 'navigation'}        |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 
 CTA button dependencies
 -----------------------
 
-When using any of the FxA button helpers, a templates's respective JavaScript
+When using any of the FxA or VPN button helpers, a templates's respective JavaScript
 bundle should also include the following dependencies:
 
 .. code-block:: text
@@ -293,6 +324,12 @@ Set the following in your local ``.env`` file:
 .. code-block:: text
 
     FXA_ENDPOINT=https://stable.dev.lcip.org/
+
+For Mozilla VPN links you can also set:
+
+.. code-block:: text
+
+    VPN_ENDPOINT=https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/
 
 **Configuring a demo Server:**
 


### PR DESCRIPTION
## Description
- Add env variable for setting VPN product links to point to staging.
- Add documentation for VPN link helpers.

## Issue / Bugzilla link
#9952

## Testing
- [ ] Setting `VPN_ENDPOINT=https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/` in your `.env` should make VPN subscription / sign in links point to https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/