### PR TITLE
Update internal links to point to /products/vpn/ (#9942)

### DIFF
--- a/bedrock/base/templates/includes/sticky-promo.html
+++ b/bedrock/base/templates/includes/sticky-promo.html
@@ -30,7 +30,7 @@
             <img src="{{ static('protocol/img/logos/pocket/pocket.svg') }}" width="32" height="29" alt="">
             {{ ftl('firefox-sticky-promo-pocket') }}
           </a>
-          <a data-link-name="Mozilla VPN" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://vpn.mozilla.org/{{ referral|safe }}{{ promo_referrals }}">
+          <a data-link-name="Mozilla VPN" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="{{ url('products.vpn.landing') }}">
             <img src="{{ static('img/icons/connection.svg') }}" width="32" height="35" alt="">
             {{ ftl('firefox-sticky-promo-mozilla-vpn') }}
           </a>

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -112,7 +112,7 @@
         <h2>{{ ftl('does-firefox-have') }}</h2>
         <p>{{ ftl('firefox-does-not',
               url='https://fpn.firefox.com/?utm_source=www.mozilla.org-firefox-faq&amp;utm_medium=referral&amp;utm_campaign=seo',
-              url2='https://vpn.mozilla.org/?utm_source=www.mozilla.org-firefox-faq&amp;utm_medium=referral&amp;utm_campaign=seo') }}</p>
+              url2=url('products.vpn.landing')) }}</p>
         <small>{{ ftl('related-questions-ip') }}</small>
       </li>
       <li>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx79.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx79.html
@@ -82,7 +82,7 @@
           <h3 class="c-picto-block-title">{{ ftl('whatsnew79-secure-your-connection') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ ftl('whatsnew79-with-one-tap-mozilla-vpn') }}</p>
-            <a class="mzp-c-cta-link" href="https://vpn.mozilla.org/?{{ utm_params }}">{{ ftl('whatsnew79-get-started') }}</a>
+            <a class="mzp-c-cta-link" href="{{ url('products.vpn.landing') }}">{{ ftl('whatsnew79-get-started') }}</a>
           </div>
         </div>
         {% endif %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx82.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx82.html
@@ -29,7 +29,7 @@
       <p class="wnp-main-tagline">Mozilla VPN (Virtual Private Network) protects your entire internet connection on your computer, your tablet, and even your phone. For even more security, it comes with a 30-day money back guarantee.</p>
 
       <div class="wnp-main-cta">
-        <a href="https://vpn.mozilla.org/?utm_source=mozilla.org-whatsnew82&utm_medium=referral&utm_campaign=whatsnew82&entrypoint=mozilla.org-whatsnew82" class="mzp-c-button mzp-t-product mzp-t-lg" rel="external" data-cta-text="Get Mozilla VPN Now" data-cta-type="button">Get Mozilla VPN Now</a>
+        <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button mzp-t-product mzp-t-lg" rel="external" data-cta-text="Get Mozilla VPN Now" data-cta-type="button">Get Mozilla VPN Now</a>
       </div>
     </div>
   </section>

--- a/bedrock/foundation/templates/foundation/annualreport/2019/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2019/index.html
@@ -812,9 +812,9 @@
       <div class="mzp-c-card-feature-content-container">
         <img src="{{ static('img/foundation/annualreport/2019/modal-dots-2.svg') }}" alt="">
         <h2 class="mzp-c-card-feature-title"><span class="highlight green">Launched Mozilla VPN</span></h2>
-        <p class="mzp-c-card-feature-desc">In July, we launched <a href="https://vpn.mozilla.org/?{{ referrals }}">Mozilla VPN</a>, a service that people can trust to keep their connection to the internet safe and private on all their devices. While the VPN market is full of options for consumers, we saw two opportunities: 1) consumer demand for a truly trustworthy VPN and 2) our continued expansion into paid products.</p>
+        <p class="mzp-c-card-feature-desc">In July, we launched <a href="{{ url('products.vpn.landing') }}">Mozilla VPN</a>, a service that people can trust to keep their connection to the internet safe and private on all their devices. While the VPN market is full of options for consumers, we saw two opportunities: 1) consumer demand for a truly trustworthy VPN and 2) our continued expansion into paid products.</p>
         <p class="mzp-c-card-feature-desc">We adhere to easy, no-nonsense <a href="{{ url('firefox.privacy.index') }}">Data Privacy Principles</a>, which means we’re not sucking up user data ourselves, as some VPNs do. And since we are <a href="{{ url('mozorg.mission') }}">mission-driven</a>, consumers can trust that the dollars spent for Mozilla VPN will not only ensure top-notch security, but will be put to work making the internet better for everyone.</p>
-        <a target="_blank" rel="external noopener" class="mzp-c-button mzp-t-secondary" href="https://vpn.mozilla.org/?{{ referrals }}">Learn more</a>
+        <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing' )}}">Learn more</a>
       </div>
     </div>
   </section>

--- a/l10n/en/firefox/faq.ftl
+++ b/l10n/en/firefox/faq.ftl
@@ -81,7 +81,7 @@ does-firefox-have = Does { -brand-name-firefox } have a built-in VPN?
 
 # Variables:
 # $url (url) - link to https://fpn.firefox.com/
-# $url2 (url) - link to https://vpn.mozilla.org/
+# $url2 (url) - link to https://www.mozilla.org/products/vpn/
 
 firefox-does-not = { -brand-name-firefox } does not have a built-in VPN (virtual private network), but there are two products made by { -brand-name-mozilla }/{ -brand-name-firefox } that you can use in addition to the private { -brand-name-firefox-browser } that can protect either your browser (<a href="{ $url }">{ -brand-name-firefox-private-network }</a>) or device (<a href="{ $url2 }">{ -brand-name-mozilla-vpn }</a>) connection on WiFi, as well as your IP address.
 


### PR DESCRIPTION
## Description
Changes internal links from `vpn.mozilla.org` to `/products/vpn/`. This is to begin funnelling some traffic to the new VPN landing page.

**Note:** I'm deliberately leaving out WNP 84 and 85 for now, since those currently attribute ~80% of total traffic to vpn.mozilla.org. We can update these WNPs to point to /products/vpn/ when we're ready to retire the old landing page.

## Issue / Bugzilla link
#9942

## Testing

- http://localhost:8000/en-US/firefox/79.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/82.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/
- http://localhost:8000/en-US/firefox/faq/
- http://localhost:8000/en-US/foundation/annualreport/2019/
