### PR TITLE
clarify domain takeovers for S3 buckets

### DIFF
--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -101,7 +101,7 @@
     <li>Significant actions only, such as changing email/passwords, deleting accounts, etc.</li>
     <li>Must be able to conduct significant action (i.e., not defacement, phishing, cookie injection, etc.)</li>
     <li>For *.mozilla.org, *.mozilla.com, *.mozilla.net, and *.firefox.com.</li>
-    <li>For all other domains excluding *.ngrok.io and similar development-only domains.</li>
+    <li>For all other domains excluding *.ngrok.io, *.s3.amazonaws.com, and similar domains used only for development or logging.</li>
     <li>Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty</li>
   </ol>
 


### PR DESCRIPTION
## Description

Add an exception for S3 buckets and logging domains for subdomain takeovers to the web bug bounty policy 

### Background / Motivation

We've received a number of bugs for takeovers of S3 buckets found in infra repos with limited security impact.

I'd like to consider an S3 bucket takeover as a security bug only when reporters can demonstrate additional security impact such as:

* use as a plausible phishing domain e.g. from an alias to the bucket content
* bucket content used on a public site, CDN, or internal service (so XSS or CSS/HTML injection risk; adding malicious binaries or updates for public consumption or that an internal service will use)
* receives confidential info or PII with a sample e.g. here's an API key or logs

Bugs filed before this change plus some grace period of a week or two would be handled under the old policy.

Happy to revisit wording to try to make things clearer. 

r? @foxliz @claudijd @ajvb 

