### PR TITLE
Swap subheading for tagline in Hero (Fix #9977)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -26,17 +26,21 @@
 {%- endmacro %}
 
 {# Hero: https://protocol.mozilla.org/patterns/organisms/hero.html #}
-{% macro hero(title, subheading, desc=None, class=None, include_cta=False, heading_level=2, subheading_level=3, image_url=None, include_highres_image=False, l10n_image=False, image_alt='') -%}
+{% macro hero(title, tagline, desc=None, class=None, include_cta=False, heading_level=2, image_url=None, include_highres_image=False, l10n_image=False, image_alt='') -%}
 <section class="mzp-c-hero{% if class %} {{ class }}{% endif %}{%if image_url%} mzp-has-image{% endif %}">
   <div class="mzp-l-content">
     <div class="mzp-c-hero-body">
       <h{{ heading_level }} class="mzp-c-hero-title">{{ title }}</h{{ heading_level }}>
-      {% if subheading %}
-      <h{{ subheading_level }} class="hero-subheading">{{ subheading }}</h{{ subheading_level }}>
-      {% endif %}
-      {% if desc %}
+      {% if desc or tagline %}
       <div class="mzp-c-hero-desc">
-        <p>{{ desc }}</p>
+        {% if tagline %}
+        <div class="mzp-c-hero-tagline">
+          <p>{{ tagline }}</p>
+        </div>
+        {% endif %}
+        {% if desc %}
+          <p>{{ desc }}</p>
+        {% endif %}
       </div>
       {% endif %}
       {% if include_cta %}

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -59,13 +59,12 @@
     {% endif %}
     {% call hero(
       title=ftl('lockwise-firefox-lockwise'),
-      subheading=ftl('lockwise-take-your-passwords-everywhere'),
+      tagline=ftl('lockwise-take-your-passwords-everywhere'),
       desc=ftl('lockwise-securely-access-the-passwords'),
       class='mzp-c-hero mzp-has-image lockwise-hero',
       image_url= _img,
       include_cta=True,
       heading_level=1,
-      subheading_level=2,
     ) %}
 
       <div class="mobile-download-buttons">

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -80,10 +80,6 @@ h1 {
     margin-bottom: $spacing-md;
 }
 
-.hero-subheading {
-    @include text-title-md;
-}
-
 @media #{$mq-sm} {
     .mobile-download-buttons {
         margin-bottom: $spacing-lg;


### PR DESCRIPTION
## Description

Swaps custom subheading for Protocol supported tagline.

## Issue / Bugzilla link

Fix #9977

## Testing

Only place with a tagline:
https://www-demo-pr-9978.herokuapp.com/en-US/firefox/lockwise/

Other hero components to make sure I didn't break anything:
https://www-demo-pr-9978.herokuapp.com/en-US/firefox/features/
https://www-demo-pr-9978.herokuapp.com/en-US/firefox/privacy/
