### PR TITLE
Update vpn.mozilla.org links on /whatsnew to point to /products/vpn/ (Fixes #9942)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx84.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx84.html
@@ -29,7 +29,7 @@
       <p class="wnp-main-tagline">Mozilla VPN (Virtual Private Network) protects your entire internet connection on your computer, your tablet, and even your phone. For even more security, it comes with a 30-day money back guarantee.</p>
 
       <div class="wnp-main-cta">
-        <a href="https://vpn.mozilla.org/?{{ utm_params }}" class="mzp-c-button mzp-t-product mzp-t-lg" rel="external" data-cta-text="Get Mozilla VPN Now" data-cta-type="button">Get Mozilla VPN Now</a>
+        <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button mzp-t-product mzp-t-lg" rel="external" data-cta-text="Get Mozilla VPN Now" data-cta-type="button">Get Mozilla VPN Now</a>
       </div>
     </div>
   </section>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx85.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx85.html
@@ -29,7 +29,7 @@
       <p class="wnp-main-tagline">Mozilla VPN (Virtual Private Network) protects your entire internet connection on your computer, your tablet, and even your phone. For even more security, it comes with a 30-day money back guarantee.</p>
 
       <div class="wnp-main-cta">
-        <a href="https://vpn.mozilla.org/?{{ utm_params }}" class="mzp-c-button mzp-t-product mzp-t-lg" rel="external" data-cta-text="Get Mozilla VPN Now" data-cta-type="button">Get Mozilla VPN Now</a>
+        <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button mzp-t-product mzp-t-lg" rel="external" data-cta-text="Get Mozilla VPN Now" data-cta-type="button">Get Mozilla VPN Now</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Description
- http://localhost:8000/en-US/firefox/84.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/85.0/whatsnew/all/

## Issue / Bugzilla link
#9942

## Testing
- [ ] No stray links to vpn.mozilla.org remain in bedrock.