### PR TITLE
Add VPN staging domain to allowedList for FxA metrics (#9952)

### DIFF
--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -20,7 +20,8 @@ if (typeof window.Mozilla === 'undefined') {
         'https://getpocket.com/',
         'https://latest.dev.lcip.org/',
         'https://stable.dev.lcip.org/',
-        'https://vpn.mozilla.org/'
+        'https://vpn.mozilla.org/',
+        'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/'
     ];
 
     var utms = ['utm_source', 'utm_campaign', 'utm_content', 'utm_term', 'utm_medium'];

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -18,7 +18,8 @@ if (typeof window.Mozilla === 'undefined') {
         'https://getpocket.com/',
         'https://latest.dev.lcip.org/',
         'https://accounts.firefox.com.cn/',
-        'https://vpn.mozilla.org/'
+        'https://vpn.mozilla.org/',
+        'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/'
     ];
 
     var _buttons;


### PR DESCRIPTION
## Description
A small update to https://github.com/mozilla/bedrock/issues/9952 to ensure FxA metric and utm params are added to VPN links when set to staging.

http://localhost:8000/en-US/products/vpn/?utm_source=test&utm_campaign=test

## Issue / Bugzilla link
#9952

## Testing
Set the following in your `.env` file to test locally:

```
FXA_ENDPOINT=https://stable.dev.lcip.org/
VPN_ENDPOINT=https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/
```

- [ ] "Try Mozilla VPN" link should point to VPN staging server, and pass through `utm_source=test`, and `utm_campaign=test` params, as well as `device_id`, `flow_begin_time`, and `flow_id`