### PR TITLE
fix: remove trailing slash from vpn urls to save a redirect

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -46,7 +46,7 @@ def vpn_sign_in_link(ctx, entrypoint, link_text, class_name=None, optional_param
 
         {{ vpn_sign_in_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Sign In') }}
     """
-    product_url = f'{settings.VPN_ENDPOINT}oauth/init/'
+    product_url = f'{settings.VPN_ENDPOINT}oauth/init'
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)
 
@@ -65,6 +65,6 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, class_name=None, optional_par
 
         {{ vpn_subscribe_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Try Mozilla VPN') }}
     """
-    product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe/'
+    product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe'
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -41,7 +41,7 @@ class TestVPNSubscribeLink(TestCase):
                               optional_attributes={'data-cta-text': 'Try Mozilla VPN', 'data-cta-type':
                                                    'fxa-vpn', 'data-cta-position': 'primary'})
         expected = (
-            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/?entrypoint=www.mozilla.org-vpn-product-page'
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe?entrypoint=www.mozilla.org-vpn-product-page'
             u'&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral'
             u'&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
             u'class="js-fxa-cta-link js-fxa-product-button vpn-button try js-try-vpn" '
@@ -69,7 +69,7 @@ class TestVPNSignInLink(TestCase):
                               optional_attributes={'data-cta-text': 'VPN Sign In', 'data-cta-type':
                                                    'fxa-vpn', 'data-cta-position': 'navigation'})
         expected = (
-            u'<a href="https://vpn.mozilla.org/oauth/init/?entrypoint=www.mozilla.org-vpn-product-page'
+            u'<a href="https://vpn.mozilla.org/oauth/init?entrypoint=www.mozilla.org-vpn-product-page'
             u'&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral'
             u'&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
             u'class="js-fxa-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '


### PR DESCRIPTION
## Description

I noticed the extra redirect when inspecting network traffic.

## Issue / Bugzilla link

## Testing
