### PR TITLE
Fix #1004 - Update /firefox/central redirect

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -1,5 +1,4 @@
-from bedrock.redirects.util import (redirect, is_firefox_redirector,
-                                    platform_redirector, no_redirect)
+from bedrock.redirects.util import (redirect, platform_redirector, no_redirect)
 
 
 def firefox_mobile_faq(request, *args, **kwargs):

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -164,10 +164,8 @@ redirectpatterns = (
     redirect(r'^firefox/security/?$', 'firefox.features.independent'),
     redirect(r'^firefox/technology/?$', 'https://developer.mozilla.org/docs/Tools'),
 
-    # Bug 979527
-    redirect(r'^(products/)?firefox/central(/|\.html|-lite\.html)?$', is_firefox_redirector(
-        'https://support.mozilla.org/kb/get-started-firefox-overview-main-features',
-        'firefox.new'), cache_timeout=0),
+    # Previously Bug 979527 / Github #10004 "Getting Started" Page
+    redirect(r'^(products/)?firefox/central(/|\.html|-lite\.html)?$', 'firefox'),
 
     # bug 868169
     redirect(r'^mobile/android-download\.html$',

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -358,16 +358,8 @@ URLS = flatten((
     url_test('/firefox/technology/', 'https://developer.mozilla.org/docs/Tools'),
     url_test('/firefox/sms/{,sent}', '/firefox/'),
 
-    # Bug 979527
-    url_test('{/products,}/firefox/central{/,.html}', '/firefox/new/',
-             req_headers={'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) '
-                                        'Gecko/20121202 Firefox/17.0 Iceweasel/17.0.1'},
-             resp_headers={'Cache-Control': 'max-age=0'}),
-    url_test('{/products,}/firefox/central{/,.html}',
-             'https://support.mozilla.org/kb/get-started-firefox-overview-main-features',
-             req_headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:42.0) '
-                                        'Gecko/20100101 Firefox/42.0'},
-             resp_headers={'Cache-Control': 'max-age=0'}),
+    # Previously Bug 979527 / Github #10004 "Getting Started" Page
+    url_test('{/products,}/firefox/central{/,.html}', '/firefox/'),
 
     # bug 868169
     url_test('/mobile/android-download.html?dude=abiding',


### PR DESCRIPTION
## Description

Update http://mozilla.org/firefox/central redirect to /firefox, instead of SUMO page. 

## Issue / Bugzilla link

#10004

## Testing

1. Go to http://localhost:8000/en-US/firefox/central
2. Should redirect to http://localhost:8000/en-US/firefox/
