### PR TITLE
Fix URL scheme to match HTML page.

### DIFF
--- a/media/MPL/2.0/index.txt
+++ b/media/MPL/2.0/index.txt
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE


### PR DESCRIPTION
## Description

The [HTML version](https://www.mozilla.org/en-US/MPL/2.0/) of the license points to the HTTPS URL:
https://github.com/mozilla/bedrock/blob/564f4fcbb62755a9aea3e78138d2616361a77e56/bedrock/mozorg/templates/mozorg/mpl/2.0/index.html#L135
but the [plaintext version](https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt) is still using the legacy HTTP URL.

## Issue / Bugzilla link

No bug

## Testing

1. Go to <https://www.mozilla.org/en-US/MPL/>.
2. Click on the *plain text* link in the second paragraph.
3. Search for `https:`.