### PR TITLE
fix bug 9983 - wrong capitalization of Yandex on the download page

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download_yandex.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download_yandex.html
@@ -77,7 +77,7 @@
     title='Загрузите последнюю версию браузера Firefox.',
     class='mzp-t-product-firefox mzp-t-firefox')
   %}
-    {{ download_firefox(alt_copy='Скачать Firefox без яндекса', dom_id='download-secondary', locale_in_transition=True, download_location='secondary cta') }}
+    {{ download_firefox(alt_copy='Скачать Firefox без Яндекса', dom_id='download-secondary', locale_in_transition=True, download_location='secondary cta') }}
   {% endcall %}
 
   </div>


### PR DESCRIPTION
**Description**
Hello @alexgibson Sir This is my first commit.
The main changes to this PR is to capitalize the first letter of Yandex on the download page in Russian language.
![Screenshot 2021-03-17 232515](https://user-images.githubusercontent.com/73520373/111515006-4ea20b80-8778-11eb-90d5-6ec2fd4878aa.png)


**Issue / Bugzilla link**

#9983
https://bugzilla.mozilla.org/show_bug.cgi?id=1696476

**Testing**

https://www.mozilla.org/ru/firefox/new/?geo=ru
