### PR TITLE
Add Mozilla VPN logo to privacy notice page (Fixes #10025)

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/mozilla-vpn.html
+++ b/bedrock/privacy/templates/privacy/notices/mozilla-vpn.html
@@ -6,4 +6,4 @@
 
 {% set body_id = "mozilla-vpn" %}
 
-{% block article_header_logo %}{% endblock %}
+{% block article_header_logo %}{{ static('img/logos/vpn/logo-with-wordmark.svg') }}{% endblock %}


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/privacy/mozilla-vpn/

## Issue / Bugzilla link
#10025