### PR TITLE
Fix #10033 - Update VPN server count to 750

### DIFF
--- a/bedrock/products/templates/products/vpn/platforms/android.html
+++ b/bedrock/products/templates/products/vpn/platforms/android.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-android-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/desktop.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-desktop-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/ios.html
+++ b/bedrock/products/templates/products/vpn/platforms/ios.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-ios-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/linux.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-linux-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/mac.html
+++ b/bedrock/products/templates/products/vpn/platforms/mac.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-mac-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/mobile.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-mobile-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/windows.html
+++ b/bedrock/products/templates/products/vpn/platforms/windows.html
@@ -8,7 +8,7 @@
 
 {% set vpn_countries = 30 %}
 {% set vpn_devices = 5 %}
-{% set vpn_servers = 280 %}
+{% set vpn_servers = 750 %}
 
 {% block page_title_full %}{{ ftl('vpn-windows-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}


### PR DESCRIPTION
## Description

Updated server count for VPN platform pages

## Issue / Bugzilla link

#10033

## Testing

Confirm the instance of `750` on these pages:

- http://localhost:8000/en-US/products/vpn/desktop/    
- http://localhost:8000/en-US/products/vpn/desktop/linux/
- http://localhost:8000/en-US/products/vpn/desktop/mac/
- http://localhost:8000/en-US/products/vpn/desktop/windows/
- http://localhost:8000/en-US/products/vpn/mobile/
- http://localhost:8000/en-US/products/vpn/mobile/android/
- http://localhost:8000/en-US/products/vpn/mobile/ios/

