### PR TITLE
Move the L3 single-voucher requirement under L3

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
@@ -53,8 +53,6 @@ Therefore, a good policy balances the use of technical and social controls to mi
 
 <p>{{ _('Each level of permission implies having the previous levels - e.g. level 2 implies level 1. A module owner creating a new tree can decide at what level that tree should live, depending on the trade-off they want to make between control and ease of access.') }}</p>
 
-<p>{{ _('Someone can be upgraded from level 2 to level 3 by being vouched for by a single module owner of level-3-stored code.') }}</p>
-
 <h2 id="Level1">{{ _('Level 1 - Try/User/Incubator Access') }}</h2>
 
 <p>{{ _('Requirements: one voucher - any other user with level 2 or above access') }}</p>
@@ -99,6 +97,8 @@ This is the lowest level of access. It allows someone to check in to the <a href
 <h2 id="Level3">{{ _('Level 3 - Core Product Access') }}</h2>
 
 <p>{{ _('Requirements: two vouchers - module owners or peers of code stored at this level, or owners or peers of the "Tree Sheriffs" module') }}</p>
+
+<p>{{ _('Someone can be upgraded from level 2 to level 3 by being vouched for by a single module owner of level-3-stored code.') }}</p>
 
 <p>{{ _('This permission gives access to check into any tree from which executable code becomes part of our core products - Firefox, Firefox for Android and Thunderbird. To put it another way, the unifying factor is that it should not be possible to break core product tinderboxes unless you have this access. This is fundamentally a statement of trust in and familiarity with an individual, and so access to one such tree gives access to all such trees, although social controls may prevent people checking in to certain ones. (Peers can vouch because the number of modules at this level is smaller, and because if you are working only in a single area of the code, there may not be multiple module owners familiar with your work.)') }}</p>
 


### PR DESCRIPTION
## Description

'Mozilla Commit Access Policy' describes a mechanism by which a user can go from L2 to L3 with one vouch.  It lists this in the middle of the doc rather than near the L3 section.  This led to multiple people missing the policy exception and a dev being idled for that time.

## Issue / Bugzilla link
N/A, though technically inspired by bug 1697933.

## Testing
None, I moved a line.  Test / change / wordsmith as you see fit.  If you think it should fold into the 'Requirements' line above it, that's totally cool too.