### PR TITLE
Migrate `ms` from Pontoon to Smartling

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -71,7 +71,6 @@ locales = [
     "mk",
     "ml",
     "mr",
-    "ms",
     "my",
     "nb-NO",
     "ne-NP",

--- a/l10n/configs/vendor.toml
+++ b/l10n/configs/vendor.toml
@@ -4,26 +4,7 @@
 basepath = ".."
 
 locales = [
-    "cs",
-    "de",
-    "es-AR",
-    "es-ES",
-    "es-MX",
-    "fr",
-    "hi-IN",
-    "hu",
-    "id",
-    "it",
-    "ja",
     "ms",
-    "nl",
-    "pl",
-    "pt-BR",
-    "ru",
-    "tr",
-    "vi",
-    "zh-CN",
-    "zh-TW",
 ]
 
 ## Examples:


### PR DESCRIPTION
- Switch Malay (ms) to vendor supported locale
- Remove it from Pontoon
- Add to vendor supported list.

Ref: https://github.com/mozilla-l10n/www-l10n/pull/176

**DO NOT** merge once approved. Needs to be coordinated with  Smartling/L10n team
