### PR TITLE
Add error message for VPN sign-ins without a subscription (Fixes #10002)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -43,6 +43,13 @@
 
 {% block content %}
 <main>
+  {# error message for visitors who try to sign-in without a subscription (issue 10002) #}
+  {% if sub_not_found %}
+    <div class="mzp-c-notification-bar mzp-t-error">
+      <p>{{ ftl('vpn-landing-sub-not-found') }}</p>
+    </div>
+  {% endif %}
+
   {% block hero %}
     {% call vpn_hero(
       heading=ftl('vpn-shared-product-name'),

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -37,8 +37,15 @@ def vpn_landing_page(request):
     ftl_files = ['products/vpn/landing', 'products/vpn/shared']
 
     locale = l10n_utils.get_locale(request)
+    sub_not_found = request.GET.get('vpn-sub-not-found', None)
     entrypoint_experiment = request.GET.get('entrypoint_experiment', None)
     entrypoint_variation = request.GET.get('entrypoint_variation', None)
+
+    # error message for visitors who try to sign-in without a subscription (issue 10002)
+    if sub_not_found == 'true':
+        sub_not_found = True
+    else:
+        sub_not_found = False
 
     # ensure experiment parameters matches pre-defined values
     if entrypoint_variation not in ['a', 'b', 'c', 'd']:
@@ -63,7 +70,8 @@ def vpn_landing_page(request):
         'available_countries': VPN_AVAILABLE_COUNTRIES,
         'connect_servers': VPN_CONNECT_SERVERS,
         'connect_countries': VPN_CONNECT_COUNTRIES,
-        'connect_devices': VPN_CONNECT_DEVICES
+        'connect_devices': VPN_CONNECT_DEVICES,
+        'sub_not_found': sub_not_found
     }
 
     return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -82,6 +82,9 @@ vpn-landing-faq-manage-subscription-question-desc = If you’re already subscrib
 
 vpn-landing-faq-link = See more FAQs
 
+# message shown to visitors who try to sign-in without an active subscription.
+vpn-landing-sub-not-found = Oops! It looks like you haven’t subscribed yet.
+
 ## Invite page https://www-dev.allizom.org/products/vpn/invite/
 
 vpn-landing-invite-page-title = Join the Waitlist: { -brand-name-mozilla-vpn }

--- a/media/css/products/vpn/landing.scss
+++ b/media/css/products/vpn/landing.scss
@@ -7,6 +7,7 @@ $image-path: '/media/protocol/img';
 
 @import '../../../protocol/css/includes/lib';
 @import '../../../protocol/css/components/inline-list';
+@import '../../../protocol/css/components/notification-bar';
 
 //* -------------------------------------------------------------------------- */
 // Featured Press Logos


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/products/vpn/?vpn-sub-not-found=true

## Issue / Bugzilla link
#10002

## Testing
- [ ] Error notification should be displayed when `?vpn-sub-not-found=true` param is present.