### PR TITLE
Show VPN waitlist signup for WNP 88 (DE/FR) (Fixes #10049)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-de.html
@@ -101,7 +101,11 @@
       </div>
     </div>
 
-    <p class="wnp-more-cta"><a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}">Mehr über Mozilla VPN erfahren</a></p>
+    <p class="wnp-more-cta">
+      <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Learn more about Mozilla VPN">
+        Mehr über Mozilla VPN erfahren
+      </a>
+    </p>
   </div>
 
   <aside class="mzp-l-content c-utilities">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-fr.html
@@ -101,7 +101,11 @@
       </div>
     </div>
 
-    <p class="wnp-more-cta"><a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}">En savoir plus sur Mozilla VPN</a></p>
+    <p class="wnp-more-cta">
+      <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Learn more about Mozilla VPN">
+        En savoir plus sur Mozilla VPN
+      </a>
+    </p>
   </div>
 
   <aside class="mzp-l-content c-utilities">

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -548,6 +548,34 @@ class TestWhatsNew(TestCase):
 
     # end 87.0 whatsnew tests
 
+    # begin 88.0 whatsnew tests
+
+    def test_fx_88_0_0_de(self, render_mock):
+        """Should use VPN waitlist signup template for 88.0 in German"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'de'
+        self.view(req, version='88.0')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/whatsnew-fx87-de.html']
+
+    def test_fx_88_0_0_fr(self, render_mock):
+        """Should use VPN waitlist signup template for 88.0 in French"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'fr'
+        self.view(req, version='88.0')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/whatsnew-fx87-fr.html']
+
+    def test_fx_88_0_0_locale(self, render_mock):
+        """Should use standard whatsnew template for 88.0 in other locales"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'es-ES'
+        self.view(req, version='88.0')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/index-account.html']
+
+    # end 88.0 whatsnew tests
+
 
 @patch('bedrock.firefox.views.l10n_utils.render', return_value=HttpResponse())
 class TestWhatsNewFirefoxLite(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -585,8 +585,8 @@ class WhatsnewView(L10nTemplateView):
         if channel not in pre_release_channels:
             channel = ''
 
-        # add VPN waitlist form for WNP 87 (Issue 9956)
-        if version.startswith('87.') and locale in ['de', 'fr']:
+        # add VPN waitlist form for WNP 87/88 (Issue 9956, 10049)
+        if version.startswith('87.') or version.startswith('88.') and locale in ['de', 'fr']:
             ctx['newsletter_form'] = VPNWaitlistForm(locale)
 
         analytics_version = str(num_version) + channel
@@ -620,6 +620,10 @@ class WhatsnewView(L10nTemplateView):
                 template = 'firefox/developer/whatsnew.html'
             else:
                 template = 'firefox/whatsnew/index.html'
+        elif version.startswith('88.') and locale == 'de':
+            template = 'firefox/whatsnew/whatsnew-fx87-de.html'
+        elif version.startswith('88.') and locale == 'fr':
+            template = 'firefox/whatsnew/whatsnew-fx87-fr.html'
         elif version.startswith('87.') and locale == 'en-US':
             template = 'firefox/whatsnew/whatsnew-fx87-en.html'
         elif version.startswith('87.') and locale == 'de':


### PR DESCRIPTION
## Description
- http://localhost:8000/de/firefox/88.0/whatsnew/all/
- http://localhost:8000/fr/firefox/88.0/whatsnew/all/

## Issue / Bugzilla link
#10049

## Testing
- [ ] Both URLs should show the same content we displayed for WNP 87.