### PR TITLE
Pass attribution from /whatsnew pages to the VPN landing page (Fixes #10053)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-de.html
@@ -102,7 +102,8 @@
     </div>
 
     <p class="wnp-more-cta">
-      <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Learn more about Mozilla VPN">
+      {% set landing_source = '?source=' + campaign if campaign else '' %}
+      <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}{{ landing_source }}" data-cta-type="link" data-cta-text="Learn more about Mozilla VPN">
         Mehr über Mozilla VPN erfahren
       </a>
     </p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx87-fr.html
@@ -102,7 +102,8 @@
     </div>
 
     <p class="wnp-more-cta">
-      <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Learn more about Mozilla VPN">
+      {% set landing_source = '?source=' + campaign if campaign else '' %}
+      <a class="mzp-c-button mzp-t-secondary" href="{{ url('products.vpn.landing') }}{{ landing_source }}" data-cta-type="link" data-cta-text="Learn more about Mozilla VPN">
         En savoir plus sur Mozilla VPN
       </a>
     </p>

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -21,12 +21,14 @@ if (typeof window.Mozilla === 'undefined') {
         'https://latest.dev.lcip.org/',
         'https://stable.dev.lcip.org/',
         'https://vpn.mozilla.org/',
-        'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/'
+        'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/',
+        'https://guardian-dev.herokuapp.com/'
     ];
 
     var utms = ['utm_source', 'utm_campaign', 'utm_content', 'utm_term', 'utm_medium'];
     var entrypointParams = ['entrypoint_experiment', 'entrypoint_variation'];
-    var acceptedParams = utms.concat(entrypointParams);
+    var sameSiteParams = ['source'];
+    var acceptedParams = utms.concat(entrypointParams, sameSiteParams);
 
     /**
      * Returns the hostname for a given URL.
@@ -54,6 +56,31 @@ if (typeof window.Mozilla === 'undefined') {
                 if ((allowedChars).test(foundParam)) {
                     finalParams[acceptedParam] = foundParam;
                 }
+            }
+        }
+
+        /**
+         * Occasionally we link to a mozorg product landing page (e.g. VPN) via an in-product page such as /whatsnew.
+         * Here we want to avoid using utm params on internal links since that's bad, so instead we support the option
+         * of passing a `source` parameter to help connect attribution with FxA link referrals.
+         */
+        if (Object.prototype.hasOwnProperty.call(finalParams, 'source')) {
+            if (finalParams['source'].indexOf('whatsnew') !== -1) {
+
+                // utm_source and entrypoint should always be the same and omit the /whatsnew version number.
+                finalParams['utm_source'] = 'www.mozilla.org-whatsnew';
+                finalParams['entrypoint'] = 'www.mozilla.org-whatsnew';
+
+                // utm_campaign should indicate which version of /whatsnew the referral came from e.g. `whatsnew88`.
+                finalParams['utm_campaign'] = finalParams['source'];
+
+                // delete the original source param afterward as it's no longer needed.
+                delete finalParams['source'];
+
+                return finalParams;
+            } else {
+                // if source doesn't contain a supported value then delete it.
+                delete finalParams['source'];
             }
         }
 

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -19,7 +19,8 @@ if (typeof window.Mozilla === 'undefined') {
         'https://latest.dev.lcip.org/',
         'https://accounts.firefox.com.cn/',
         'https://vpn.mozilla.org/',
-        'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/'
+        'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/',
+        'https://guardian-dev.herokuapp.com/'
     ];
 
     var _buttons;

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -85,6 +85,28 @@ describe('fxa-utm-referral.js', function() {
             expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
         });
 
+        it('should return entrypoint and utm params if supported source attribute is present', function() {
+            var validObj = {
+                'source': 'whatsnew88'
+            };
+
+            var validData = {
+                'entrypoint': 'www.mozilla.org-whatsnew',
+                'utm_source': 'www.mozilla.org-whatsnew',
+                'utm_campaign': 'whatsnew88'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
+        });
+
+        it('should return null if source attribute is non-specific', function() {
+            var validObj = {
+                'source': 'the-dude'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(validObj)).toBeNull();
+        });
+
         it('should return an object without any danagerous params', function () {
             var dangerousSource = {
                 'utm_source': 'www.mozilla.org',
@@ -152,7 +174,7 @@ describe('fxa-utm-referral.js', function() {
             expect(Mozilla.UtmUrl.getAttributionData(specialData)).toEqual(specialSource);
         });
 
-        it('decode URL components', function () {
+        it('should decode URL components', function () {
             var encodedData = {
                 'utm_source': '%25',
                 'utm_campaign': '%2F'


### PR DESCRIPTION
## Description
- http://localhost:8000/de/firefox/87.0/whatsnew/all/
- http://localhost:8000/fr/firefox/87.0/whatsnew/all/
- http://localhost:8000/de/firefox/88.0/whatsnew/all/
- http://localhost:8000/fr/firefox/88.0/whatsnew/all/

## Issue / Bugzilla link
#10053

## Testing
1. On each /whatsnew page, click the "Learn more about Mozilla VPN" link at the bottom of the page.
2. Once on the VPN landing page, verify that the URL includes a `source` param specific to the /whatsnew page where the click occured e.g. http://localhost:8000/de/products/vpn/?source=whatsnew88
3. Verify that the VPN subscription links in the landing page have been updated with related utm and entrypoint params e.g.
  - `entrypoint=www.mozilla.org-whatsnew`
  - `utm_source=www.mozilla.org-whatsnew`
  - `utm_campaign=whatsnew88`