### PR TITLE
Hide price for VPN if not available (Fixes #10070)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/pricing-fixed.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-fixed.html
@@ -8,7 +8,7 @@
   ) %}
   <div class="l-columns-two">
     <div class="l-column-first">
-      <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-monthly', amount=fixed_monthly_price) }}</h2>
+      <h2 class="vpn-content-block-heading js-text-vpn-fixed-price-available">{{ ftl('vpn-shared-pricing-monthly', amount=fixed_monthly_price) }}</h2>
 
       {{ vpn_subscribe_link(
         entrypoint=_utm_source,


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/products/vpn/?geo=de

![image](https://user-images.githubusercontent.com/400117/113278776-3b478200-92da-11eb-95c2-89276af4df60.png)

## Issue / Bugzilla link
#10070

## Testing
- [ ] Price should not be visible on the page if VPN is not yet available.