### PR TITLE
Fix string on VPN desktop page [fix #10082]

### DIFF
--- a/bedrock/products/templates/products/vpn/platforms/desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/desktop.html
@@ -102,7 +102,7 @@
       image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
       class_name='vpn-content-media-right-half',
     ) %}
-      <p>{{ ftl('vpn-desktop-servers-copy', servers=vpn_servers) }}</p>
+      <p>{{ ftl('vpn-desktop-servers-copy-updated', fallback='vpn-desktop-servers-copy', servers=vpn_servers) }}</p>
     {% endcall %}
 
     {% call vpn_content_media(

--- a/l10n/en/products/vpn/platforms/desktop.ftl
+++ b/l10n/en/products/vpn/platforms/desktop.ftl
@@ -30,6 +30,9 @@ vpn-desktop-servers-headline = Connect to servers all over the world
 
 # Variables:
 #   $servers (number) - number of available servers
+vpn-desktop-servers-copy-updated = Browse from Brazil. Game from Japan. Stream from Mexico. { -brand-name-mozilla-vpn } lets you change your phone or computer’s location to one of { $servers } servers.
+
+# Obsolete string
 vpn-desktop-servers-copy = Browse from Brazil. Game from Japan. Stream from Mexico. { -brand-name-mozilla-vpn } lets you change your phone or computer’s location to one of { $servers }.
 
 # Variables:


### PR DESCRIPTION
## Description
The word "servers" was missing from the end of the sentence, after the number.

## Issue / Bugzilla link
#10082 

## Testing
http://localhost:8000/products/vpn/desktop/ about halfway down the page under "Connect to servers all over the world"