### PR TITLE
Fix #10047 - Update strings to correct spelling of 'Add-ons'

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -44,7 +44,7 @@
       <ul class="c-sub-navigation-list">
         <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/ios/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="iOS Support">{{ ftl('sub-navigation-ios-support', fallback='navigation-ios-support') }}</a></li>
         <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/mobile/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="Android Support">{{ ftl('sub-navigation-android-support', fallback='navigation-android-support') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="https://addons.mozilla.org/android/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="Android Addons">{{ ftl('sub-navigation-android-addons') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="https://addons.mozilla.org/android/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="Android Addons">{{ ftl('sub-navigation-android-add-ons', fallback='sub-navigation-android-addons') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
       </ul>
     </div>
@@ -224,4 +224,3 @@
     {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -52,7 +52,7 @@
           <a href="https://support.mozilla.org/products/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-name="Support">{{ ftl('sub-navigation-support', fallback='navigation-support') }}</a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="https://addons.mozilla.org/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-name="Addons">{{ ftl('sub-navigation-addons', fallback='navigation-add-ons') }}</a>
+          <a href="https://addons.mozilla.org/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-name="Addons">{{ ftl('sub-navigation-add-ons', fallback='sub-navigation-addons') }}</a>
         </li>
         <li class="c-sub-navigation-item">
           <a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a>

--- a/l10n/en/sub_navigation.ftl
+++ b/l10n/en/sub_navigation.ftl
@@ -24,12 +24,20 @@ sub-navigation-desktop-beta-and-developer = Desktop { -brand-name-beta } & { -br
 sub-navigation-desktop-nightly = Desktop { -brand-name-nightly }
 sub-navigation-features = Features
 sub-navigation-support = Support
+
+# Obsolete string. Used as fallback for `sub-navigation-add-ons` string :
 sub-navigation-addons = Addons
+
+sub-navigation-add-ons = Add-ons
 sub-navigation-faq = FAQ
 sub-navigation-learn-more = Learn More
 sub-navigation-developer-edition = { -brand-name-developer-edition }
 sub-navigation-firefox-for-mobile = { -brand-name-firefox } for Mobile
+
+# Obsolete string. Used as fallback for `sub-navigation-android-addons` string:
 sub-navigation-android-addons = { -brand-name-android } Addons
+
+sub-navigation-android-add-ons = { -brand-name-android } Add-ons
 sub-navigation-chromebook = { -brand-name-chromebook }
 sub-navigation-firefox-accounts = { -brand-name-firefox-accounts }
 sub-navigation-sync = { -brand-name-sync }


### PR DESCRIPTION
## Description

Update all instances of "Addons" across the site with "Add-ons" 

## Issue / Bugzilla link

#10047

## Testing

- http://localhost:8000/en-US/firefox/new/
- http://localhost:8000/en-US/firefox/mobile/

_Note - Both instances are in the subnavigation._
