### PR TITLE
Curly apostrophes on VPN pages [fix #10086]

### DIFF
--- a/l10n/en/products/vpn/platforms/mobile.ftl
+++ b/l10n/en/products/vpn/platforms/mobile.ftl
@@ -22,7 +22,7 @@ vpn-mobile-wifi-headline = Feel safe using public wifi
 vpn-mobile-wifi-copy = Our VPN shields your internet connection from hackers and spies, so you can shop from the coffee shop, check your bank account from the train and go about your online business knowing that your IP address is protected.
 
 vpn-mobile-about-headline = About { -brand-name-mozilla }
-vpn-mobile-about-copy = Best known for our { -brand-name-firefox-browser }, { -brand-name-mozilla } is a global community of users, contributors and developers dedicated to keeping the power of the internet in people's hands. Founded in 1998, we’re one of the pioneers of the free and open web — and it’s our mission to keep it that way.
+vpn-mobile-about-copy = Best known for our { -brand-name-firefox-browser }, { -brand-name-mozilla } is a global community of users, contributors and developers dedicated to keeping the power of the internet in people’s hands. Founded in 1998, we’re one of the pioneers of the free and open web — and it’s our mission to keep it that way.
 
 vpn-mobile-privacy-headline = Privacy in one click
 vpn-mobile-privacy-copy = The { -brand-name-mozilla-vpn } app encrypts your internet connection and hides the IP address on your mobile phone or tablet using { -brand-name-wireguard }® advanced protocol.

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -94,7 +94,7 @@ vpn-shared-pricing-total = { $amount } total
 
 # Platform subpage shared strings
 
-vpn-shared-platform-cta-headline = Let's get started
+vpn-shared-platform-cta-headline = Let’s get started
 vpn-shared-platform-cta-button = See pricing & availability
 
 vpn-shared-platform-privacy-promise = Your privacy is our promise


### PR DESCRIPTION
## Description
Replaces straight apostrophes with curly ones (en-* only, don't need to change string IDs)

## Issue / Bugzilla link
#10086 

## Testing
http://localhost:8000/products/vpn/mobile/