### PR TITLE
Add html anchor to pricing section of VPN Product page (Fixes #10039)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -143,7 +143,10 @@
       </p>
     {% endcall %}
 
-    {% include 'products/vpn/includes/pricing-fixed.html' %}
+    {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+    <div id="pricing" class="mzp-is-anchor-link">
+      {% include 'products/vpn/includes/pricing-fixed.html' %}
+    </div>
 
   </div>
 


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/products/vpn/#pricing

## Issue / Bugzilla link
#10039

## Testing
- [ ] `#pricing` hash should link to the pricing section in the landing page.