### PR TITLE
Fix #9984 - Policy Page Updates

### DIFF
--- a/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
@@ -48,13 +48,13 @@
 
     <li>{{ _('You may not collect personal information in the context of your distribution of the software.') }}</li>
 
-    <li>{{ _('You may not add to, remove, or change any part of the software, including the Mozilla trademarks themselves. For example, you may not add any extensions to Firefox.') }}</li>
+    <li>{{ _('You may not add to, remove, or change any part of the software, including the Mozilla trademarks themselves. For example, you may not add any extensions to Firefox, change default settings, or alter search codes.') }}</li>
 
     <li>{{ _('You may not modify the installation process of the software or use it to install any other themes, plugins, extensions, or software.') }}</li>
 
     <li>
-      {% trans 
-      mozorg=url('mozorg.home'), 
+      {% trans
+      mozorg=url('mozorg.home'),
       mozdownloads=url('firefox.new') %}
       We suggest that if you want to distribute Mozilla software, you do so by linking to official downloads at <a href="{{ mozorg }}">Mozilla.org</a> to help ensure safe, reliable downloads. For example, if you wish to directly distribute copies of Firefox yourself, you must distribute the latest stable version available at <a href="{{ mozdownloads }}">Mozilla.org</a>.
       {% endtrans %}

--- a/bedrock/foundation/templates/foundation/trademarks/policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/policy.html
@@ -17,7 +17,7 @@
   <p>{% trans list=url('foundation.trademarks.list') %}A list of Mozilla’s and its affiliates’ trademarks can be found here: <a href="{{ list }}">Trademarks List</a>. However, that is not a complete list of our names, logos, and brand features, all of which are subject to these guidelines.{% endtrans %}</p>
 
   <p>{% trans report=url('legal.fraud-report') %}If you want to report misuse of a Mozilla trademark, please contact us here:<br>
-  <a href="{{ report }}">https://www.mozilla.org/about/legal/fraud-report/</a>{% endtrans %}</p>
+  <a href="{{ report }}">https://www.mozilla.org/about/legal/defend-mozilla-trademarks/</a>{% endtrans %}</p>
 
   <h2>{{ _('When do I need specific permission to use a Mozilla trademark?') }}</h2>
 

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -64,10 +64,10 @@
       The <a href="https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work">Phishing and Malware Protection</a> in Firefox uses the <a href="https://safebrowsing.google.com/">Google Safe Browsing</a> service.
     </li>
     <li>
-      Phishing sites can be reported to Google Safe Browsing at this link: <a href="https://safebrowsing.google.com/safebrowsing/report_phish/">https://safebrowsing.google.com/safebrowsing/report_phish/</a>
+      Report phishing sites by using the <a href="https://safebrowsing.google.com/safebrowsing/report_phish/">Report Phishing form</a> from Google Safe Browsing.
     </li>
     <li>
-      Websites that contain malicious software can be reported to Google Safe Browsing at this link: <a href="https://safebrowsing.google.com/safebrowsing/report_badware/">https://safebrowsing.google.com/safebrowsing/report_badware/</a>
+      Report websites that contain malicious software by using the <a href="https://safebrowsing.google.com/safebrowsing/report_badware/">Malicious Software form</a> from Google Safe Browsing.
     </li>
     <li>
       Once again, the form on this page is <strong>ONLY</strong> for reporting infringement of Mozilla trademarks. <strong>DO NOT</strong> submit other kinds of malicious sites via this form. Mozilla cannot and will not respond to other reports submitted via this page.

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -41,7 +41,7 @@
 </aside>
 {% endif %}
 
-<h1 class="mzp-c-article-title">Protect the Fox<br> (and More!)</h1>
+<h1 class="mzp-c-article-title">Protect the Fox</h1>
 <h2>Help us safeguard Mozilla’s trademarks by reporting misuse.</h2>
 
 <p>
@@ -54,6 +54,27 @@
 </p>
 
 <section class="mzp-c-emphasis-box">
+
+  <p>
+    <strong>This form is ONLY for reporting infringement of Mozilla’s trademarks. Other kinds of malicious sites should be reported to Google Safe Browsing:</strong>
+  </p>
+
+  <ol class="mzp-u-list-styled">
+    <li>
+      The <a href="https://support.mozilla.org/en-US/kb/how-does-phishing-and-malware-protection-work">Phishing and Malware Protection</a> in Firefox uses the <a href="https://safebrowsing.google.com/">Google Safe Browsing</a> service.
+    </li>
+    <li>
+      Phishing sites can be reported to Google Safe Browsing at this link: <a href="https://safebrowsing.google.com/safebrowsing/report_phish/">https://safebrowsing.google.com/safebrowsing/report_phish/</a>
+    </li>
+    <li>
+      Websites that contain malicious software can be reported to Google Safe Browsing at this link: <a href="https://safebrowsing.google.com/safebrowsing/report_badware/">https://safebrowsing.google.com/safebrowsing/report_badware/</a>
+    </li>
+    <li>
+      Once again, the form on this page is <strong>ONLY</strong> for reporting infringement of Mozilla trademarks. <strong>DO NOT</strong> submit other kinds of malicious sites via this form. Mozilla cannot and will not respond to other reports submitted via this page.
+    </li>
+
+  </ol>
+
   <p>
     <strong>Please use this form to report any websites or mobile app stores that are:</strong>
   </p>
@@ -92,7 +113,7 @@
 
 <section>
   {% if not form_submitted or (form_submitted and form_error) %}
-  <h2>Fraud Report</h2>
+  <h2>Report of Misuse of Mozilla Trademarks</h2>
 
   <form class="mzp-c-form" action="{{ url('legal.fraud-report') }}" method="post" name="reportForm" id="reportForm" enctype="multipart/form-data">
 

--- a/bedrock/legal/tests/test_forms.py
+++ b/bedrock/legal/tests/test_forms.py
@@ -60,7 +60,7 @@ class TestFraudReport(TestCase):
         response = legal_views.fraud_report(request)
 
         assert response.status_code == 302
-        assert response['Location'] == '/en-US/about/legal/fraud-report/?submitted=True'
+        assert response['Location'] == '/en-US/about/legal/defend-mozilla-trademarks/?submitted=True'
 
     def test_view_post_missing_data(self):
         """

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -63,5 +63,5 @@ urlpatterns = (
     url(r'^report-infringement/$', LegalDocView.as_view(template_name='legal/report-infringement.html', legal_doc_name='report_infringement'),
         name='legal.report-infringement'),
 
-    url('^fraud-report/$', views.fraud_report, name='legal.fraud-report'),
+    url('^defend-mozilla-trademarks/$', views.fraud_report, name='legal.fraud-report'),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -740,4 +740,7 @@ redirectpatterns = (
 
     # Issue 9254
     redirect(r'^grants(/.*)?$', 'mozorg.moss.index'),
+
+    # Issue 9984
+    redirect(r'^/about/legal/fraud-report/?$', '/about/legal/defend-mozilla-trademarks/'),
 )

--- a/bedrock/mozorg/templates/mozorg/mpl/license-policy.html
+++ b/bedrock/mozorg/templates/mozorg/mpl/license-policy.html
@@ -10,7 +10,7 @@
 
 {% block article %}
   <h1 class="mzp-c-article-title">Mozilla Source Code License Policy</h1>
-  <p class="version"><em>Version 4.0</em></p>
+  <p class="version"><em>Version 4.1</em></p>
 
   <section>
     <h2 id="Introduction">Introduction</h2>
@@ -22,28 +22,30 @@
       <li>New files in, or modifications to, an existing, consistently-licensed area of code should be under the same license as the existing code.</li>
       <li>New projects should be under the <a href="{{ url('mozorg.mpl.2.0.index') }}">MPL 2.0</a> or <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a> - see below for guidance on choosing which.</li>
       <li>You must consult <a href='#Filing_Bugs'>the licensing team</a> before importing third-party code which is not under the MPL or Apache 2.0.</li>
+      <li>Mozilla employees can consult the <a href="https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=130927170">Licensing & Contributor Agreements Runbook</a> for more details.</li>
     </ul>
   </section>
 
   <section>
     <h2 id="Types_of_Code">Types of Code</h2>
-    <p><b>Mozilla Code</b> is code in Mozilla Repositories which originated with the Mozilla Project. Code which is not Mozilla Code is <b>Third Party Code</b>.</p>
-    <p><b>Product Code</b> means all files any part of which is included in nightly binaries of the Mozilla family of Internet clients - Firefox, Thunderbird, SeaMonkey and Camino - plus the Gecko parts of Boot2Gecko. Note that this definition excludes the code of tools used merely to build these products, such as system libraries.</p>
-    <p><b>Test Code</b> means test cases for automated test frameworks (but not the frameworks themselves).</p>
+    <p><strong>Mozilla Code</strong> is code in Mozilla Repositories which originated with the Mozilla Project. Code which is not Mozilla Code is <strong>Third Party Code</strong>.</p>
+    <p><strong>Product Code</strong> means all files any part of which is included in nightly binaries of client-side Mozilla products. Note that this definition excludes the code of tools used merely to build these products, such as system libraries.</p>
+    <p><strong>Test Code</strong> means test cases for automated test frameworks (but not the frameworks themselves).</p>
   </section>
 
   <section>
     <h2 id="Licensing_of_Mozilla_Code">Licensing of Mozilla Code</h2>
     <p>New files in, modifications to, or code designed to integrate with or build on an existing, consistently-licensed area of Mozilla Code should be under the same license as the existing code. This means that modifications to Product Code will be MPL 2.</p>
     <p>New projects which are Mozilla Code may choose either the MPL 2.0 or the Apache License 2.0. No other license is acceptable, because Mozilla is committed to using modern open source licenses with patent grant clauses. The licensing team recommends MPL 2.0 for client-side code; please consult the team before going against this recommendation.</p>
-    <p>Trivial bits of Mozilla Code, such as testcases or snippets of code used in documentation, should be put in the public domain in order to facilitate re-use. To do that, apply the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Public Domain Dedication</a> by using the following boilerplate: </p>
+    <p>Trivial bits of Mozilla Code, such as test cases or snippets of code used in documentation, should be put in the public domain in order to facilitate re-use. To do that, apply the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Public Domain Dedication</a> by using the following boilerplate: </p>
     <p>
 <pre>
 Any copyright is dedicated to the Public Domain.
 http://creativecommons.org/publicdomain/zero/1.0/
-</pre>
-</p>
-    <p>Note that, for historical reasons, some trivial support code, such as <a href="https://developer.mozilla.org/Project:Copyrights">old code samples in developer.mozilla.org</a>, may be under the MIT license.</p> <p><b>PD Test Code</b> is Test Code (1) that is Mozilla Code, (2) that does not carry an explicit license header, and (3) that was either committed to a Mozilla Repository on or after 23rd September 2014, or was committed before that date but for which all contributors up to that date were Mozilla employees, contractors or interns. PD Test Code is placed in the public domain pursuant to the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Public Domain Dedication</a>. Test Code which has not been demonstrated to be PD Test Code should be considered to be under the MPL 2.</p>
+</pre><br/>
+
+    <p>Note that, for historical reasons, some trivial support code, such as <a href="https://developer.mozilla.org/en-US/docs/MDN/About#Copyrights_and_licenses">old code samples in developer.mozilla.org</a>, may be under the MIT license.</p>
+    <p><strong>PD Test Code</strong> is test cases for automated test frameworks that (1) is Mozilla Code, (2) does not carry an explicit license header, and (3) was either committed to a Mozilla Repository on or after 23rd September 2014, or was committed before that date but for which all contributors up to that date were Mozilla employees, contractors or interns. PD Test Code is placed in the public domain pursuant to the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Public Domain Dedication</a>. Test Code which has not been demonstrated to be PD Test Code should be considered to be under the MPL 2.</p>
   </section>
 
   <section>


### PR DESCRIPTION
## Description

- [x] Distribution Policy copy edits
- [x] Licensing Policy copy edits
- [x] Report Fraud copy edits
- [x] Update fraud report page URL
- [x] Add redirect for previous Report fraud page

## Issue / Bugzilla link

#9984 

## Testing

Confirm copy edits on the following pages: 

- https://www-demo-pr-10102.herokuapp.com/en-US/foundation/trademarks/distribution-policy/ 
- https://www-demo-pr-10102.herokuapp.com/en-US/MPL/license-policy/
- https://www-demo-pr-10102.herokuapp.com/en-US/about/legal/defend-mozilla-trademarks/

Redirects: 
- The old Fraud Report page should redirect to the new URL: 
https://www-demo-pr-10102.herokuapp.com/en-US/about/legal/fraud-report/ -> https://www-demo-pr-10102.herokuapp.com/en-US/about/legal/defend-mozilla-trademarks/
