### PR TITLE
Add sub-nav to VPN landing page (Fixes #10106)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/subnav.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav.html
@@ -1,0 +1,18 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% if ftl_has_messages('vpn-subnav-whats-a-vpn', 'vpn-subnav-faqs', 'vpn-subnav-get-help') %}
+  <nav class="c-sub-navigation">
+    <div class="mzp-l-content">
+      <div class="c-sub-navigation-content">
+        <h2 class="c-sub-navigation-title"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
+        <ul class="c-sub-navigation-list">
+          <li class="c-sub-navigation-item"><a href="#faq-usecases" data-link-type="nav" data-link-position="subnav" data-link-name="What’s a VPN?">{{ ftl('vpn-subnav-whats-a-vpn') }}</a></li>
+          <li class="c-sub-navigation-item"><a href="#faq" data-link-type="nav" data-link-position="subnav" data-link-name="FAQs">{{ ftl('vpn-subnav-faqs') }}</a></li>
+          <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/firefox-private-network-vpn{{ _params }}&utm_content=vpn-sub-nav-link" data-link-type="nav" data-link-position="subnav" data-link-name="Get Help">{{ ftl('vpn-subnav-get-help') }}</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+{% endif %}

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -38,6 +38,10 @@
   {% endwith %}
 {% endblock %}
 
+{% block sub_navigation %}
+  {% include 'products/vpn/includes/subnav.html' %}
+{% endblock %}
+
 {% block content %}
 <main>
   {# error message for visitors who try to sign-in without a subscription (issue 10002) #}
@@ -155,7 +159,7 @@
 
   </div>
 
-  <section class="vpn-faq mzp-l-content mzp-t-content-lg">
+  <section id="faq" class="vpn-faq mzp-l-content mzp-t-content-lg">
     <h2 class="vpn-faq-section-heading">{{ ftl('vpn-landing-faq-heading') }}</h2>
 
     <details id="faq-usecases" class="vpn-faq-item mzp-is-anchor-link">
@@ -199,14 +203,50 @@
       <summary class="vpn-faq-item-heading">
         <h3>{{ ftl('vpn-landing-faq-compatibility-question-heading') }}</h3>
       </summary>
-      <p class="vpn-faq-item-detail">{{ ftl('vpn-landing-faq-compatibility-question-desc') }}</p>
+      <p class="vpn-faq-item-detail">
+        {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-v2') %}
+          {{ ftl('vpn-landing-faq-compatibility-question-desc-v2', mobile=url('products.vpn.platforms.mobile'), desktop=url('products.vpn.platforms.desktop')) }}
+        {% else %}
+          {{ ftl('vpn-landing-faq-compatibility-question-desc') }}
+        {% endif %}
+      </p>
 
       <ul class="vpn-faq-item-detail mzp-u-list-styled">
-        <li>{{ ftl('vpn-landing-faq-compatibility-question-desc-windows') }}</li>
-        <li>{{ ftl('vpn-landing-faq-compatibility-question-desc-mac') }}</li>
-        <li>{{ ftl('vpn-landing-faq-compatibility-question-desc-android') }}</li>
-        <li>{{ ftl('vpn-landing-faq-compatibility-question-desc-ios') }}</li>
-        <li>{{ ftl('vpn-landing-faq-compatibility-question-desc-linux') }}</li>
+        <li>
+          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-windows-v2') %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-windows-v2', url=url('products.vpn.platforms.windows')) }}
+          {% else %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-windows') }}
+          {% endif %}
+        </li>
+        <li>
+          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-mac-v2') %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-mac-v2', url=url('products.vpn.platforms.mac')) }}
+          {% else %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-mac') }}
+          {% endif %}
+        </li>
+        <li>
+          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-android-v2') %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-android-v2', url=url('products.vpn.platforms.android')) }}
+          {% else %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-android') }}
+          {% endif %}
+        </li>
+        <li>
+          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-ios-v2') %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v2', url=url('products.vpn.platforms.ios')) }}
+          {% else %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios') }}
+          {% endif %}
+        </li>
+        <li>
+          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-linux-v2') %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-linux-v2', url=url('products.vpn.platforms.linux')) }}
+          {% else %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-linux') }}
+          {% endif %}
+        </li>
       </ul>
     </details>
 

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -70,12 +70,50 @@ vpn-landing-faq-competition-question-heading = How does { -brand-name-mozilla-vp
 vpn-landing-faq-competition-question-desc = While free VPNs seem attractive, they do not make the same commitments to privacy as { -brand-name-mozilla-vpn } and may sell or store your data. Other paid VPNs don’t have { -brand-name-mozilla }’s over 20-year <a href="{ $url }">track record</a> of building products that put people and privacy first.
 
 vpn-landing-faq-compatibility-question-heading = What devices is { -brand-name-mozilla-vpn } compatible with?
+
+# Variables:
+#   $mobile (url) - link to https://www.mozilla.org/products/vpn/mobile/
+#   $desktop (url) - link to https://www.mozilla.org/products/vpn/desktop/
+vpn-landing-faq-compatibility-question-desc-v2 = { -brand-name-mozilla-vpn } is compatible with <a href="{ $mobile }">mobile</a>, tablet, and <a href="{ $desktop }">desktop</a> on:
+
+# Outdated string
 vpn-landing-faq-compatibility-question-desc = { -brand-name-mozilla-vpn } is compatible with:
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/windows/
+vpn-landing-faq-compatibility-question-desc-windows-v2 = <a href="{ $url }">{ -brand-name-windows }</a> 10 (64-bit only)
+
+# Outdated string
 vpn-landing-faq-compatibility-question-desc-windows = { -brand-name-windows } 10 (64-bit only)
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/mac/
+vpn-landing-faq-compatibility-question-desc-mac-v2 = <a href="{ $url }">{ -brand-name-mac }</a> (10.15 and up)
+
+# Outdated string
 vpn-landing-faq-compatibility-question-desc-mac = { -brand-name-mac } (10.15 and up)
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/products/vpn/mobile/android/
+vpn-landing-faq-compatibility-question-desc-android-v2 = <a href="{ $url }">{ -brand-name-android }</a> (version 6 and up)
+
+# Outdated string
 vpn-landing-faq-compatibility-question-desc-android = { -brand-name-android } (version 6 and up)
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/products/vpn/mobile/ios/
+vpn-landing-faq-compatibility-question-desc-ios-v2 = <a href="{ $url }">{ -brand-name-ios }</a> (13.0 and up)
+
+# Outdated string
 vpn-landing-faq-compatibility-question-desc-ios = { -brand-name-ios } (13.0 and up)
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/linux/
+vpn-landing-faq-compatibility-question-desc-linux-v2 = <a href="{ $url }">{ -brand-name-linux }</a> ({ -brand-name-ubuntu }-only)
+
+# Outdated string
 vpn-landing-faq-compatibility-question-desc-linux = { -brand-name-linux } ({ -brand-name-ubuntu }-only)
+
 vpn-landing-faq-refund-question-heading = What is { -brand-name-mozilla-vpn }’s refund policy?
 vpn-landing-faq-refund-question-desc = You can get your money back within 30 days of purchasing your subscription. Contact us and submit the refund request by tapping the “Get Help” button in Settings on your { -brand-name-mozilla-vpn } app.
 vpn-landing-faq-manage-subscription-question-heading = How do I manage my subscription?

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -108,6 +108,9 @@ vpn-shared-platform-what-youll-get = What you’ll get with { -brand-name-mozill
 
 # Subnav strings
 vpn-subnav-title = { -brand-name-mozilla-vpn }
+vpn-subnav-whats-a-vpn = What’s a VPN?
+vpn-subnav-faqs = FAQs
+vpn-subnav-get-help = Get Help
 vpn-subnav-platform-android = { -brand-name-android }
 vpn-subnav-platform-desktop = Desktop
 vpn-subnav-platform-ios = { -brand-name-ios }

--- a/media/js/products/vpn/landing.js
+++ b/media/js/products/vpn/landing.js
@@ -35,7 +35,7 @@
     function openFaqItem(id) {
         var faq = document.getElementById(id);
 
-        if (faq && !faq.hasAttribute('open')) {
+        if (faq && faq.classList.contains('vpn-faq-item') && !faq.hasAttribute('open')) {
             var summary = faq.querySelector('summary');
 
             if (summary) {


### PR DESCRIPTION
## Description
- Add sub navigation to VPN landing page.
- Link to VPN platform pages from within FAQ content.

## Issue / Bugzilla link
#10106

## Testing
- [ ] In-page sub nav links should scroll to appropriate FAQ sections.
- [ ] New FAQ copy should link to appropriate VPN platforms pages.