### PR TITLE
VPN platform pages should use shared variables (Fixes #10107)

### DIFF
--- a/bedrock/products/templates/products/vpn/platforms/android.html
+++ b/bedrock/products/templates/products/vpn/platforms/android.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-android-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/desktop.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-desktop-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/ios.html
+++ b/bedrock/products/templates/products/vpn/platforms/ios.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-ios-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/linux.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-linux-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/mac.html
+++ b/bedrock/products/templates/products/vpn/platforms/mac.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-mac-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/mobile.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-mobile-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/platforms/windows.html
+++ b/bedrock/products/templates/products/vpn/platforms/windows.html
@@ -6,9 +6,9 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% set vpn_countries = 30 %}
-{% set vpn_devices = 5 %}
-{% set vpn_servers = 750 %}
+{% set vpn_countries = settings.VPN_CONNECT_COUNTRIES %}
+{% set vpn_devices = settings.VPN_CONNECT_DEVICES %}
+{% set vpn_servers = settings.VPN_CONNECT_SERVERS %}
 
 {% block page_title_full %}{{ ftl('vpn-windows-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/products/vpn/desktop/

## Issue / Bugzilla link
#10107

## Testing
- [ ] VPN platform pages should continue to display the appropriate numbers based on values in settings.