### PR TITLE
Add exception for domain takeovers to include a proof of concept

### DIFF
--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -63,7 +63,7 @@
         <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
       </tr>
       <tr>
-        <th scope="row">Domain Takeovers</th>
+        <th scope="row">Domain Takeovers<sup>8</sup></th>
         <td>$5000</td>
         <td>$2000</td>
         <td>$500<sup>5</sup>/$200<sup>6</sup></td>
@@ -103,6 +103,7 @@
     <li>For *.mozilla.org, *.mozilla.com, *.mozilla.net, and *.firefox.com.</li>
     <li>For all other domains excluding *.ngrok.io, *.s3.amazonaws.com, and similar domains used only for development or logging.</li>
     <li>Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty</li>
+    <li>Requires a proof of concept to be eligible</li>
   </ol>
 
   <p>Any bounty that receives a payout also obtains inclusion on our <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">Hall of Fame</a>.</p>


### PR DESCRIPTION
Adds an exception to domain takeovers, requiring a proof of concept, where previously this was not required.
