### PR TITLE
Fix JS error e.browserServices.sync is undefined (Fixes #10118)

### DIFF
--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -113,8 +113,8 @@ if (typeof window.Mozilla.Analytics === 'undefined') {
                     }
 
                     // variables to compare to determine the segments
-                    var mobileDevices = FxaDetails.browserServices.sync.mobileDevices;
-                    var desktopDevices = FxaDetails.browserServices.sync.desktopDevices;
+                    var mobileDevices = FxaDetails.browserServices.sync ? FxaDetails.browserServices.sync.mobileDevices : null;
+                    var desktopDevices = FxaDetails.browserServices.sync ? FxaDetails.browserServices.sync.desktopDevices : null;
 
                     // set FxAMobileSync
                     if (mobileDevices > 0) {

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -406,6 +406,24 @@ describe('core-datalayer.js', function() {
                 FxASegment: 'Not Firefox'
             };
 
+            // browserServices.sync is unexpectedly undefined (issue 10118).
+            var input14 = {
+                'firefox': true,
+                'legacy': false,
+                'mobile': false,
+                'setup': true,
+                'browserServices': {
+                    'sync': undefined
+                }
+            };
+
+            var output14 = {
+                FxALogin: true,
+                FxAMultiDesktopSync: 'unknown',
+                FxAMobileSync: 'unknown',
+                FxASegment: 'Logged in'
+            };
+
             // we could do a loop for this but then we loose line specific error reporting
             expect(Mozilla.Analytics.formatFxaDetails(input1)).toEqual(output1);
             expect(Mozilla.Analytics.formatFxaDetails(input2)).toEqual(output2);
@@ -420,6 +438,7 @@ describe('core-datalayer.js', function() {
             expect(Mozilla.Analytics.formatFxaDetails(input11)).toEqual(output11);
             expect(Mozilla.Analytics.formatFxaDetails(input12)).toEqual(output12);
             expect(Mozilla.Analytics.formatFxaDetails(input13)).toEqual(output13);
+            expect(Mozilla.Analytics.formatFxaDetails(input14)).toEqual(output14);
         });
     });
 


### PR DESCRIPTION
## Description
Fixes an error where some logged-in FF clients can return `undefined` when querying `browserServices.sync`.

## Issue / Bugzilla link
#10118

## Testing
- I added a unit test for this that should cover things.