### PR TITLE
Fix sub navigation when viewport is exactly 768px wide (Fixes #10123)

### DIFF
--- a/media/js/base/protocol/protocol-sub-navigation.js
+++ b/media/js/base/protocol/protocol-sub-navigation.js
@@ -15,7 +15,7 @@
 
             // check browser supports matchMedia
             if (Mzp.Supports.matchMedia) {
-                var _mqWide = matchMedia('(max-width: 768px)');
+                var _mqWide = matchMedia('(max-width: 767px)');
 
                 // initialize details if screen is small
                 if (_mqWide.matches) {


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/products/vpn/

## Issue / Bugzilla link
#10123

## Testing
- [ ] Sub navigation drop down functional and styled correctly when viewport is exactly 768px wide.