### PR TITLE
L10n fixes for VPN landing page on mobile (Fixes #10130)

### DIFF
--- a/media/css/products/vpn/common.scss
+++ b/media/css/products/vpn/common.scss
@@ -166,30 +166,38 @@ main .mzp-c-button.mzp-t-xl {
 
 .vpn-feature-list.mzp-u-list-styled {
     @include bidi(((text-align, left, right),));
-    @include text-body-xl;
+    @include text-body-lg;
     display: inline-block;
     list-style: none;
-    margin-bottom: $spacing-lg;
+    margin: 0 0 $spacing-lg 0;
 
     li {
         @include bidi((
-            (background-position, top 7px left, top 7px right),
-            (padding-left, (18px + $spacing-md), padding-right, 0),
+            (background-position, top 3px left, top 3px right),
+            (padding-left, (18px + $spacing-sm), padding-right, 0),
         ));
         background: url('/media/img/products/vpn/common/check-black.svg') no-repeat;
     }
 
     &.l-columns-two {
         margin-bottom: $layout-lg;
-    }
 
-    @media #{$mq-md} {
-        margin-bottom: 0;
-
-        &.l-columns-two {
+        @media #{$mq-md} {
             column-count: 2;
             column-gap: $spacing-2xl;
             margin-bottom: $layout-xl;
+        }
+    }
+
+    @media #{$mq-lg} {
+        @include text-body-xl;
+        margin-bottom: 0;
+
+        li {
+            @include bidi((
+                (background-position, top 7px left, top 7px right),
+                (padding-left, (18px + $spacing-md), padding-right, 0),
+            ));
         }
     }
 }

--- a/media/css/products/vpn/components/block.scss
+++ b/media/css/products/vpn/components/block.scss
@@ -39,7 +39,7 @@ $image-path: '/media/protocol/img';
 
     .vpn-content-block-container {
         margin: 0 auto;
-        padding: $spacing-lg $spacing-xl;
+        padding: $spacing-md;
         width: 100%;
     }
 
@@ -79,6 +79,12 @@ $image-path: '/media/protocol/img';
 
         .guarantee-copy {
             margin-bottom: $spacing-md;
+        }
+    }
+
+    @media #{$mq-sm} {
+        .vpn-content-block-container {
+            padding: $spacing-lg;
         }
     }
 
@@ -140,17 +146,17 @@ $image-path: '/media/protocol/img';
     }
 
     .vpn-content-media-desc {
-        @include text-body-xl;
+        @include text-body-lg;
         color: $color-marketing-gray-90;
     }
 
     .vpn-content-media-copy {
-        padding: $spacing-lg $spacing-xl;
+        padding: $spacing-lg $spacing-md;
         padding-top: 0;
     }
 
     .vpn-content-media-image-container {
-        padding: $spacing-lg $spacing-xl;
+        padding: $spacing-lg $spacing-md;
         padding-bottom: 0;
     }
 
@@ -170,6 +176,13 @@ $image-path: '/media/protocol/img';
             top: 0;
             width: 100%;
             z-index: -1;
+        }
+    }
+
+    @media #{$mq-sm} {
+        .vpn-content-media-copy,
+        .vpn-content-media-image-container {
+            padding: $spacing-lg $spacing-lg;
         }
     }
 
@@ -213,6 +226,12 @@ $image-path: '/media/protocol/img';
             .vpn-content-media-image-container {
                 @include bidi(((float, left, right),));
             }
+        }
+    }
+
+    @media #{$mq-lg} {
+        .vpn-content-media-desc {
+            @include text-body-xl;
         }
     }
 
@@ -284,12 +303,19 @@ $image-path: '/media/protocol/img';
     }
 
     .vpn-feature-list.mzp-u-list-styled {
+        @include text-body-md;
         margin-bottom: 0;
     }
 
     @media #{$mq-md} {
         @include bidi(((text-align, left, right),));
         margin-bottom: $layout-2xl;
+    }
+
+    @media #{$mq-lg} {
+        .vpn-feature-list.mzp-u-list-styled {
+            @include text-body-xl;
+        }
     }
 }
 

--- a/media/css/products/vpn/components/hero.scss
+++ b/media/css/products/vpn/components/hero.scss
@@ -35,12 +35,12 @@ $image-path: '/media/protocol/img';
 }
 
 .vpn-hero-sub-heading {
-    @include text-title-lg;
+    @include text-title-md;
     margin-bottom: $spacing-md;
 }
 
 .vpn-hero-desc {
-    @include text-body-xl;
+    @include text-body-lg;
     margin-bottom: $spacing-md;
 }
 
@@ -75,6 +75,16 @@ $image-path: '/media/protocol/img';
     &[data-illustration="n-4"] .n-4,
     &[data-illustration="n-5"] .n-5 {
         opacity: 1;
+    }
+}
+
+@media #{mq-md} {
+    .vpn-hero-sub-heading {
+        @include text-title-lg;
+    }
+
+    .vpn-hero-desc {
+        @include text-body-xl;
     }
 }
 


### PR DESCRIPTION
## Description
Some CSS fixes to better cater for longer strings (such as German) on small viewports. This is mostly just making copy a little smaller on mobile screen sizes. Large viewports should be uneffected.

- Reduce hero font size on small screens.
- Reduce block component padding & font-size on small screens.
- Reduce feature list font size / spacing on small screens.

I've tried to ensure things are still readable (i.e. not truncated or cut off screen) down to 320px in German.

- http://localhost:8000/en-US/products/vpn/
- http://localhost:8000/de/products/vpn/
- http://localhost:8000/fr/products/vpn/

## Issue / Bugzilla link
#10130

## Testing
- [x] Content is readbale and not truncated in German even at small screen sizes.