### PR TITLE
Fix heading overflow on German VPN legal page (Fixes #10141)

### DIFF
--- a/media/css/legal/legal.scss
+++ b/media/css/legal/legal.scss
@@ -17,6 +17,9 @@ $image-path: '/media/protocol/img';
 .mzp-c-article {
     h1 {
         @include text-title-xl;
+        -webkit-hyphens: auto;
+        hyphens: auto;
+        overflow-wrap: break-word;
     }
 
     h2 {
@@ -26,6 +29,13 @@ $image-path: '/media/protocol/img';
 
     h3 {
         @include text-title-xs;
+    }
+
+    @media #{$mq-lg} {
+        h1 {
+            -webkit-hyphens: none;
+            hyphens: none;
+        }
     }
 }
 


### PR DESCRIPTION
## Description
The word "Servicebedingungen" is so long here that reducing the default font size on small screens isn't really a viable option, so this is the best I can come up with.

http://localhost:8000/de/about/legal/terms/mozilla-vpn/

## Issue / Bugzilla link
#10141

## Testing
- [x] Heading should no longer overflow the viewport at small screen sizes.