### PR TITLE
Fix WNP88 Firefox wordmark in dark mode [fix #10150]

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-88-en.scss
+++ b/media/css/firefox/whatsnew/whatsnew-88-en.scss
@@ -10,6 +10,13 @@ $image-path: '/media/protocol/img';
 @import 'includes/header';
 
 
+// Override _header.scss since this page doesn't support dark mode
+@media (prefers-color-scheme: dark) {
+    .c-page-header-logo-fx {
+        background-image: url($image-path + '/logos/firefox/browser/logo-word-hor-sm.png');
+    }
+}
+
 //* -------------------------------------------------------------------------- */
 // Main content
 .wnp-content-main {


### PR DESCRIPTION
## Description
The en-US whatsnew page for Fx88 doesn't support dark mode, but the included styles from `_header.scss` still swap the wordmark. This fix overrides that styling.

## Issue / Bugzilla link
#10150 

## Testing
http://localhost:8000/en-US/firefox/88.0/whatsnew/all/

Set your OS to dark mode and ensure the wordmark is still readable.