### PR TITLE
Only try and swap out images for China Repack builds (Fixes #10157)

### DIFF
--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -97,11 +97,17 @@ if (typeof window.Mozilla === 'undefined') {
 
     // Bug 1264843: link to China build of Fx4A, for display within Fx China repack
     Utils.maybeSwitchToChinaRepackImages = function(client) {
-        if (!client.distribution || client.distribution === 'default') {
+        if (!client.distribution) {
             return;
         }
 
         var distribution = client.distribution.toLowerCase();
+
+        // only swap out images for China Repack builds (issue 10157)
+        if (distribution !== 'mozillaonline') {
+            return;
+        }
+
         var images = document.querySelectorAll('img[data-' + distribution + '-link]');
 
         for (var j = 0; j < images.length; j++) {

--- a/tests/unit/spec/base/mozilla-utils.js
+++ b/tests/unit/spec/base/mozilla-utils.js
@@ -58,7 +58,7 @@ describe('mozilla-utils.js', function() {
         var partnerASrc = '/img/foo.png';
 
         beforeEach(function () {
-            var img = '<img class="test-image" src="' + defaultSrc + '" data-partnera-link="' + partnerASrc + '">';
+            var img = '<img class="test-image" src="' + defaultSrc + '" data-mozillaonline-link="' + partnerASrc + '">';
             document.body.insertAdjacentHTML('beforeend', img);
         });
 
@@ -68,9 +68,9 @@ describe('mozilla-utils.js', function() {
             });
         });
 
-        it('should use specified image for certain distributions', function () {
+        it('should use specified image for mozillaonline distributions', function () {
             Mozilla.Utils.maybeSwitchToChinaRepackImages({
-                distribution: 'PartnerA'
+                distribution: 'mozillaonline'
             });
             var img = document.querySelector('.test-image');
             expect(img.src).toContain(partnerASrc);
@@ -78,7 +78,7 @@ describe('mozilla-utils.js', function() {
 
         it('should use default image for other distributions', function () {
             Mozilla.Utils.maybeSwitchToChinaRepackImages({
-                distribution: 'PartnerB'
+                distribution: 'regata os'
             });
             var img = document.querySelector('.test-image');
             expect(img.src).toContain(defaultSrc);


### PR DESCRIPTION
## Description
Changes the `Mozilla.Utils.maybeSwitchToChinaRepackImages()` function so it will only look for matching selectors if the distribution ID is specifically `mozillaonline`.

Should fix errors such as: https://sentry.prod.mozaws.net/operations/bedrock-prod/?query=is%3Aunresolved+SyntaxError%3A+%27img%5Bdata&sort=freq

## Issue / Bugzilla link
#10157

## Testing
- [ ] Running `Mozilla.Utils.maybeSwitchToChinaRepackImages({distribution: 'regata os'});` should no longer throw an error.