### PR TITLE
Remove switch for new VPN subscription URLs (#10126)

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -7,8 +7,6 @@ import jinja2
 from django.conf import settings
 from django_jinja import library
 
-from bedrock.base.waffle import switch
-
 
 def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
     separator = '&' if '?' in product_url else '?'
@@ -68,34 +66,29 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, plan=None, class_name=None, l
         {{ vpn_subscribe_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN') }}
     """
 
-    # Switching to the new subscription URL format will be co-ordinated with the VPN product team (issue 10126).
-    if switch('vpn-new-subscription-url-format'):
+    # Subscription links currently support variable pricing in Euros for Germany and France only.
+    if plan in ['12-month', '6-month', 'monthly']:
 
-        # Subscription links currently support variable pricing in Euros for Germany and France only.
-        if plan in ['12-month', '6-month', 'monthly']:
-
-            # Set a default plan ID using page locale. This acts as a fallback should geo-location fail.
-            if lang in ['de', 'fr']:
-                plan_default = settings.VPN_VARIABLE_PRICING[lang][plan]
-            else:
-                plan_default = ''
-
-            # HTML data-attributes are used by client side JS to set the correct plan ID based on geo.
-            plan_attributes = {
-                'data-plan-de': settings.VPN_VARIABLE_PRICING['de'][plan],
-                'data-plan-fr': settings.VPN_VARIABLE_PRICING['fr'][plan]
-            }
-        # All other subscription links default to fixed monthly pricing in $US.
+        # Set a default plan ID using page locale. This acts as a fallback should geo-location fail.
+        if lang in ['de', 'fr']:
+            plan_default = settings.VPN_VARIABLE_PRICING[lang][plan]
         else:
-            plan_default = settings.VPN_FIXED_PRICE_MONTHLY_USD
-            plan_attributes = None
+            plan_default = ''
 
-        if (plan_attributes):
-            optional_attributes = optional_attributes or {}
-            optional_attributes.update(plan_attributes)
-
-        product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe/products/{settings.VPN_PRODUCT_ID}?plan={plan_default}'
+        # HTML data-attributes are used by client side JS to set the correct plan ID based on geo.
+        plan_attributes = {
+            'data-plan-de': settings.VPN_VARIABLE_PRICING['de'][plan],
+            'data-plan-fr': settings.VPN_VARIABLE_PRICING['fr'][plan]
+        }
+    # All other subscription links default to fixed monthly pricing in $US.
     else:
-        product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe'
+        plan_default = settings.VPN_FIXED_PRICE_MONTHLY_USD
+        plan_attributes = None
+
+    if (plan_attributes):
+        optional_attributes = optional_attributes or {}
+        optional_attributes.update(plan_attributes)
+
+    product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe/products/{settings.VPN_PRODUCT_ID}?plan={plan_default}'
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -2,13 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from django_jinja.backend import Jinja2
-from mock import patch
 
 from bedrock.mozorg.tests import TestCase
 
@@ -54,24 +51,6 @@ class TestVPNSubscribeLink(TestCase):
                       entrypoint, link_text, plan, class_name, lang, optional_parameters, optional_attributes),
                       {'request': req})
 
-    @patch.dict(os.environ, SWITCH_VPN_NEW_SUBSCRIPTION_URL_FORMAT='False')
-    def test_vpn_subscribe_link_fixed_monthly_usd_old_format(self):
-        """Should return expected markup for default fixed monthly plan in US$ using old format"""
-        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
-                              plan=None, class_name='mzp-c-button', lang='en-US',
-                              optional_parameters={'utm_campaign': 'vpn-product-page'},
-                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
-                                                   'fxa-vpn', 'data-cta-position': 'primary'})
-        expected = (
-            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe?entrypoint=www.mozilla.org-vpn-product-page'
-            u'&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral'
-            u'&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
-            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary">'
-            u'Get Mozilla VPN</a>')
-        self.assertEqual(markup, expected)
-
-    @patch.dict(os.environ, SWITCH_VPN_NEW_SUBSCRIPTION_URL_FORMAT='True')
     def test_vpn_subscribe_link_fixed_monthly_usd(self):
         """Should return expected markup for default fixed monthly plan in US$"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
@@ -88,7 +67,6 @@ class TestVPNSubscribeLink(TestCase):
             u'Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
-    @patch.dict(os.environ, SWITCH_VPN_NEW_SUBSCRIPTION_URL_FORMAT='True')
     def test_vpn_subscribe_link_variable_12_month(self):
         """Should return expected markup for variable 12-month plan"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
@@ -106,7 +84,6 @@ class TestVPNSubscribeLink(TestCase):
             u'Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
-    @patch.dict(os.environ, SWITCH_VPN_NEW_SUBSCRIPTION_URL_FORMAT='True')
     def test_vpn_subscribe_link_variable_6_month(self):
         """Should return expected markup for variable 6-month plan"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
@@ -124,7 +101,6 @@ class TestVPNSubscribeLink(TestCase):
             u'Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
-    @patch.dict(os.environ, SWITCH_VPN_NEW_SUBSCRIPTION_URL_FORMAT='True')
     def test_vpn_subscribe_link_variable_monthly(self):
         """Should return expected markup for variable monthly plan"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',


### PR DESCRIPTION
## Description
Removes `vpn-new-subscription-url-format` switch (new URLs went live in prod yesterday).

http://localhost:8000/en-US/products/vpn/

## Issue / Bugzilla link
#10126

## Testing
- [ ] "Get Mozilla VPN" links should now all use the new `/r/vpn/subscribe/products/` format.