### PR TITLE
Fix typo on WNP88 :facepalm: [no bug]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx88-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx88-en.html
@@ -30,7 +30,7 @@
     <div class="mzp-l-content c-page-header-inner">
       <h2 class="c-page-header-logo-fx">{{ ftl('whatsnew-firefox-browser') }}</h2>
       <div class="mzp-c-notification-bar mzp-t-success up-to-date">
-        <p>Congrats! You’re using now version <span data-audio="/media/img/firefox/whatsnew/whatsnew88-en/jingle.mp3" class="flux" id="outatime">88</span> of Firefox.</p>
+        <p>Congrats! You’re now using version <span data-audio="/media/img/firefox/whatsnew/whatsnew88-en/jingle.mp3" class="flux" id="outatime">88</span> of Firefox.</p>
       </div>
       <div class="mzp-c-notification-bar out-of-date">
         <p>{{ ftl('whatsnew-out-of-date-notification') }}</p>


### PR DESCRIPTION
## Description
The old "using now" <-> "now using" switcheroo.

## Testing
http://localhost:8000/en-US/firefox/88.0/whatsnew/all/