### PR TITLE
Fallback to variable pricing only if country is unknown and switch is enabled (Fixes #10169)

### DIFF
--- a/media/js/products/vpn/geo.js
+++ b/media/js/products/vpn/geo.js
@@ -123,7 +123,7 @@
         return 'not-available';
     };
 
-    VPN.setAvailability = function(availability, language) {
+    VPN.setAvailability = function(availability, language, variablePricing) {
         if (availability === 'fixed-price') {
             // If VPN is available in countries that support fixed pricing,
             // show the fixed pricing subscribe links.
@@ -138,8 +138,11 @@
         } else {
             // If we can't determine someone's country then fall back to page language.
             // Both /de/ and /fr/ get variable pricing, and the rest get fixed.
-            var lang = document.getElementsByTagName('html')[0].getAttribute('lang') || language;
-            if (lang === 'de' || lang === 'fr') {
+            var html = document.getElementsByTagName('html')[0];
+            var lang = html.getAttribute('lang') || language;
+            var variablePricingAvailable = html.getAttribute('data-vpn-variable-price-country-codes') || variablePricing;
+
+            if ((lang === 'de' || lang === 'fr') && variablePricingAvailable) {
                 VPN.showVariablePricing();
             } else {
                 VPN.showFixedPricing();

--- a/tests/unit/spec/vpn/geo.js
+++ b/tests/unit/spec/vpn/geo.js
@@ -143,14 +143,20 @@ describe('geo.js', function() {
         });
 
         it('should fallback to page language if availability is not known', function() {
-            Mozilla.VPN.setAvailability('unknown', 'en-US');
+            Mozilla.VPN.setAvailability('unknown', 'en-US', true);
             expect(Mozilla.VPN.showFixedPricing).toHaveBeenCalled();
 
-            Mozilla.VPN.setAvailability('unknown', 'de');
+            Mozilla.VPN.setAvailability('unknown', 'de', true);
             expect(Mozilla.VPN.showVariablePricing).toHaveBeenCalled();
 
-            Mozilla.VPN.setAvailability('unknown', 'fr');
+            Mozilla.VPN.setAvailability('unknown', 'fr', true);
             expect(Mozilla.VPN.showVariablePricing).toHaveBeenCalled();
+
+            Mozilla.VPN.setAvailability('unknown', 'de', false);
+            expect(Mozilla.VPN.showFixedPricing).toHaveBeenCalled();
+
+            Mozilla.VPN.setAvailability('unknown', 'fr', false);
+            expect(Mozilla.VPN.showFixedPricing).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Description
Fixes an edge case bug where variable pricing can be shown irrespective of switch state.

## Issue / Bugzilla link
#10169

## Testing
1.) Set `SWITCH_VPN_LAUNCH_GERMANY_FRANCE=off` in your `.env`.
2.) Set `Dev=False` in your `.env` (this will make `country_code.json` 404 when running localhost, which is useful for triggering this bug).
3.) Open http://localhost:8000/de/products/vpn/#pricing
4.) Verify that the page falls back to fixed pricing (US$4.99/Month).