### PR TITLE
Updates to email preferences center [fix #10092]

### DIFF
--- a/bedrock/newsletter/templates/newsletter/confirm.html
+++ b/bedrock/newsletter/templates/newsletter/confirm.html
@@ -17,7 +17,7 @@
     {% if success %}
       <h1>{{ ftl('newsletters-thanks-for-subscribing') }}</h1>
       <p>{{ ftl('newsletters-your-newsletter-subscription') }}</p>
-      <p>{{ ftl('newsletters-please-be-sure-to-add-our') }}</p>
+      <p>{{ ftl('newsletters-please-be-sure-to-add-our-v2') }}</p>
     {% elif token_error %}
       <p>{{ ftl('newsletters-the-supplied-link-has-expired') }}</p>
     {% elif generic_error %}

--- a/bedrock/newsletter/templates/newsletter/country_success.html
+++ b/bedrock/newsletter/templates/newsletter/country_success.html
@@ -12,5 +12,5 @@
 {% block messages %}
   <h1>Thanks for updating your country or region!</h1>
   <p>We'll now be able to keep you up to date on interesting things happening near you.</p>
-  <p>Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.</p>
+  <p>Please be sure to add our sending address: mozilla@email.mozilla.org to your address book to ensure we always reach your inbox.</p>
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -22,7 +22,7 @@
       <p>
         {{ ftl('newsletters-youre-awesome') }}
         {{ ftl('newsletters-and-were-not-just-saying') }}
-        {{ ftl('newsletters-please-be-sure-to-add-mozillaemozillaorg') }}
+        {{ ftl('newsletters-please-be-sure-to-add-mozillaemailmozillaorg') }}
       </p>
 
       <p>
@@ -109,7 +109,7 @@
               </thead>
               <tbody>
                 {% for formpart in formset %} {# each newsletter is a formset #}
-                <tr>
+                <tr {% if formpart.initial['indented'] %}class="indented"{% endif %}>
                   <th>
                     <h4>{{ formpart.initial['title'] }}</h4>
                     {# hidden field: #}

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -138,10 +138,10 @@ NEWSLETTER_STRINGS = {
         'description': ftl_lazy('newsletters-get-how-tos', ftl_files=FTL_FILES),
         'title': ftl_lazy('newsletters-firefox-news', ftl_files=FTL_FILES)},
     u'mozilla-festival': {
-        'description': ftl_lazy('newsletters-special-announcements-about-mozilla', ftl_files=FTL_FILES),
+        'description': ftl_lazy('newsletters-special-announcements-about-mozilla-v2', ftl_files=FTL_FILES),
         'title': ftl_lazy('newsletters-mozilla-festival', ftl_files=FTL_FILES)},
     u'mozilla-foundation': {
-        'description': ftl_lazy('newsletters-regular-updates-to-keep', ftl_files=FTL_FILES),
+        'description': ftl_lazy('newsletters-regular-updates-to-keep-v2', ftl_files=FTL_FILES),
         'title': ftl_lazy('newsletters-mozilla-news', ftl_files=FTL_FILES)},
     u'mozilla-general': {
         'description': ftl_lazy('newsletters-special-accouncements-and-messages', ftl_files=FTL_FILES),
@@ -496,7 +496,7 @@ REASONS = [
     ftl_lazy('newsletters-your-content-wasnt-relevant', ftl_files=FTL_FILES),
     ftl_lazy('newsletters-your-email-design', ftl_files=FTL_FILES),
     ftl_lazy('newsletters-i-didnt-sign-up', ftl_files=FTL_FILES),
-    ftl_lazy('newsletters-im-keeping-in-touch', ftl_files=FTL_FILES),
+    ftl_lazy('newsletters-im-keeping-in-touch-v2', ftl_files=FTL_FILES),
 ]
 
 

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -24,11 +24,17 @@ newsletters-newsletter-confirm = Newsletter confirm
 
 newsletters-thanks-for-subscribing = Thanks for Subscribing!
 newsletters-your-newsletter-subscription = Your newsletter subscription has been confirmed.
+newsletters-please-be-sure-to-add-our-v2 = Please be sure to add our sending address: mozilla@email.mozilla.org to your address book to ensure we always reach your inbox.
+
+# Obsolete string
 newsletters-please-be-sure-to-add-our = Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.
 newsletters-the-supplied-link-has-expired = The supplied link has expired. You will receive a new one in the next newsletter.
 newsletters-something-is-amiss-with = Something is amiss with our system, sorry! Please try again later.
 newsletters-youre-awesome = You’re awesome!
 newsletters-and-were-not-just-saying = And we’re not just saying that because you trusted us with your email address.
+newsletters-please-be-sure-to-add-mozillaemailmozillaorg = Please be sure to add mozilla@email.mozilla.org to your address book to ensure we always reach your inbox.
+
+# Obsolete string
 newsletters-please-be-sure-to-add-mozillaemozillaorg = Please be sure to add mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.
 newsletters-mozilla-touches-on-a-variety = { -brand-name-mozilla } touches on a variety of important issues.
 newsletters-open-your-inbox-and-your = Open your inbox (and your heart) even more — take a look at other topics we cover.
@@ -133,6 +139,9 @@ newsletters-i-didnt-sign-up = I didn't sign up for this.
 #   $url (url) - link to https://www.mozilla.org/newsletter/
 newsletters-this-email-address-is-not = This email address is not in our system. Please double check your address or <a href="{ $url }">subscribe to our newsletters.</a>
 
+newsletters-im-keeping-in-touch-v2 = I'm keeping in touch with { -brand-name-mozilla } on { -brand-name-twitter } instead.
+
+# Obsolete string
 newsletters-im-keeping-in-touch = I'm keeping in touch with { -brand-name-mozilla } on { -brand-name-facebook } and { -brand-name-twitter } instead.
 
 # Headline for https://www.mozilla.org/newsletter/mozilla/
@@ -347,12 +356,18 @@ newsletters-get-how-tos = Get how-tos, advice and news to make your { -brand-nam
 newsletters-mozilla-festival = { -brand-name-mozilla-festival }
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Festival)
+newsletters-special-announcements-about-mozilla-v2 = Special announcements about our annual festival dedicated to forging the future of the open web.
+
+# Obsolete string
 newsletters-special-announcements-about-mozilla = Special announcements about { -brand-name-mozilla }'s annual, hands-on festival dedicated to forging the future of the open Web.
 
 # Name for the newsletter in Newsletter subscription page
 newsletters-mozilla-news = { -brand-name-mozilla } News
 
 # Description for the newsletter in Newsletter subscription page (Mozilla News)
+newsletters-regular-updates-to-keep-v2 = Regular updates to help you get smarter about your online life and active in our fight for a better internet.
+
+# Obsolete string
 newsletters-regular-updates-to-keep = Regular updates to keep you informed and active in our fight for a better internet.
 
 # Name for the newsletter in Newsletter subscription page

--- a/media/css/newsletter/newsletter.scss
+++ b/media/css/newsletter/newsletter.scss
@@ -15,7 +15,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/notification-bar';
 @import '../../protocol/css/templates/card-layout';
 
-/* -------------------------------------------------------------------------- */
+//* -------------------------------------------------------------------------- */
 // Global styles.
 
 h1 {
@@ -44,7 +44,7 @@ main {
 }
 
 
-/* -------------------------------------------------------------------------- */
+//* -------------------------------------------------------------------------- */
 // newsletter/existing custom styles.
 
 .c-column {
@@ -62,7 +62,7 @@ main {
     }
 
     .c-column-content {
-        text-align: left;
+        @include bidi(((text-align, left, right),));
 
         h2 {
             margin-bottom: $spacing-xl;
@@ -106,6 +106,13 @@ main {
             }
 
         }
+
+        tr.indented th {
+            @include bidi((
+                (padding-left, $spacing-xl, 0),
+                (padding-right, 0, $spacing-xl),
+            ));
+        }
     }
 }
 
@@ -124,7 +131,7 @@ main {
     }
 }
 
-/* -------------------------------------------------------------------------- */
+//* -------------------------------------------------------------------------- */
 // newsletter/updated custom styles.
 
 .c-updated-block {
@@ -189,7 +196,7 @@ main {
     }
 }
 
-/* -------------------------------------------------------------------------- */
+//* -------------------------------------------------------------------------- */
 // newsletter/country/ custom styles.
 
 


### PR DESCRIPTION
## Description
This is mostly string changes and some minor front-end tweaks. Other requested updates will happen in basket.

- Updates the email address for allow-listing.
- Updates blurb for Mozilla News.
- Removes Facebook mention from the unsubscribe confirmation.
- Adds a class for indentation.

## Issue / Bugzilla link
#10092 

## Testing
http://localhost:8000/newsletter/existing/ (you'll need a working token to get to the management page)