### PR TITLE
Add VPN site banner for DE/FR (Fixes #10178)

### DIFF
--- a/bedrock/base/templates/includes/banners/vpn/vpn-promo.html
+++ b/bedrock/base/templates/includes/banners/vpn/vpn-promo.html
@@ -1,0 +1,32 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<aside class="c-banner hide-from-legacy-ie" id="vpn-promo-banner">
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+    <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>
+    <div class="mzp-l-content">
+      <div class="c-banner-main">
+
+        <h2 class="c-banner-title">
+          {% if LANG == 'de' %}
+            Mozilla VPN ist jetzt in Deutschland verfügbar!
+          {% else %}
+            Mozilla VPN est disponible en France
+          {% endif %}
+        </h2>
+
+        <div class="c-cta">
+          <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button mzp-t-secondary" data-cta-type="link" data-cta-text="VPN Learn More" data-cta-position="banner">
+          {% if LANG == 'de' %}
+            Mehr Infos
+          {% else %}
+            Plus d’information
+          {% endif %}
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -12,13 +12,17 @@
 {% block page_css %}
   {{ css_bundle('firefox-browsers-products') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ css_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
@@ -169,7 +173,9 @@
 {% block js %}
   {{ js_bundle('firefox-browsers-products') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -33,7 +33,9 @@
 {% block page_css %}
   {{ css_bundle('firefox-master') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ css_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
@@ -68,7 +70,9 @@
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
@@ -274,7 +278,9 @@
 {% block js %}
   {{ js_bundle('firefox-master') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -13,12 +13,22 @@
 {% block page_css %}
   {{ super() }}
   {{ css_bundle('firefox-privacy-products') }}
+
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ css_bundle('vpn-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block body_class %}{{ super() }} privacy-products{% endblock %}
 
 {% set _entrypoint = 'mozilla.org-privacy-products' %}
 {% set _utm_campaign = 'privacy-products' %}
+
+{% block page_banner %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% endif %}
+{% endblock %}
 
 {% block hub_content %}
 
@@ -178,4 +188,8 @@
 
 {% block js %}
   {{ js_bundle('firefox-privacy-products') }}
+
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -12,13 +12,17 @@
 {% block page_css %}
   {{ css_bundle('firefox-browsers-products') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ css_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
@@ -135,7 +139,9 @@
 {% block js %}
   {{ js_bundle('firefox-browsers-products') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -20,6 +20,16 @@
   {% endif %}
 {% endblock %}
 
+{% block page_banner %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% elif switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
+  {% elif switch('fundraising-banner-eoy2020') and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
+    {% include 'includes/banners/fundraiser.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block main %}
 <main>
   <header class="main-page-heading">
@@ -121,4 +131,16 @@
   {% endcall %}
 
 </main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('home') }}
+
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
+  {% elif switch('fundraising-banner-eoy2020') %}
+    {{ js_bundle('fundraising-banner') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -11,7 +11,9 @@
 {% block page_css %}
   {{ css_bundle('home-2018') }}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('vpn-promo-banner') %}
+    {{ css_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ css_bundle('fundraising-banner') }}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -38,7 +38,7 @@
 {% block page_css %}
   {{ css_bundle('home-en') }}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ css_bundle('fundraising-banner') }}
@@ -46,7 +46,9 @@
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% elif switch('fundraising-banner-eoy2020') and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
     {% include 'includes/banners/fundraiser.html' %}
@@ -195,7 +197,9 @@
 {% block js %}
   {{ js_bundle('home') }}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ js_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ js_bundle('fundraising-banner') }}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -46,9 +46,7 @@
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
-    {% include 'includes/banners/vpn/vpn-promo.html' %}
-  {% elif switch('firefox-daylight-promo-banner') %}
+  {% if switch('firefox-daylight-promo-banner') %}
     {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% elif switch('fundraising-banner-eoy2020') and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
     {% include 'includes/banners/fundraiser.html' %}
@@ -197,9 +195,7 @@
 {% block js %}
   {{ js_bundle('home') }}
 
-  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
-    {{ js_bundle('vpn-promo-banner') }}
-  {% elif switch('firefox-daylight-promo-banner') %}
+  {% if switch('firefox-daylight-promo-banner') %}
     {{ js_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ js_bundle('fundraising-banner') }}

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -13,7 +13,9 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
 {% block page_css %}
   {{ css_bundle('home-2018') }}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('vpn-promo-banner') %}
+    {{ css_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ css_bundle('fundraising-banner') }}

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -22,6 +22,16 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
   {% endif %}
 {% endblock %}
 
+{% block page_banner %}
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {% include 'includes/banners/vpn/vpn-promo.html' %}
+  {% elif switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
+  {% elif switch('fundraising-banner-eoy2020') and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
+    {% include 'includes/banners/fundraiser.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block main %}
 <main>
   <header class="main-page-heading">
@@ -122,4 +132,16 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
   {% endcall %}
 
 </main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('home') }}
+
+  {% if switch('vpn-promo-banner', ['de', 'fr']) %}
+    {{ js_bundle('vpn-promo-banner') }}
+  {% elif switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
+  {% elif switch('fundraising-banner-eoy2020') %}
+    {{ js_bundle('fundraising-banner') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -27,7 +27,7 @@
 {% block page_css %}
   {{ css_bundle('home') }}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('firefox-daylight-promo-banner') %}
     {{ css_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ css_bundle('fundraising-banner') }}
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('firefox-daylight-promo-banner') %}
     {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% elif switch('fundraising-banner-eoy2020') and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
     {% include 'includes/banners/fundraiser.html' %}
@@ -176,7 +176,7 @@
 {% block js %}
   {{ js_bundle('newsletter') }}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
+  {% if switch('firefox-daylight-promo-banner') %}
     {{ js_bundle('daylight-promo-banner') }}
   {% elif switch('fundraising-banner-eoy2020') %}
     {{ js_bundle('fundraising-banner') }}

--- a/media/css/base/banners/vpn-promo.scss
+++ b/media/css/base/banners/vpn-promo.scss
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+
+#vpn-promo-banner {
+    &.c-banner {
+        @include clearfix;
+        background: #c4c6fc;
+        border-bottom: 1px solid rgba(0, 0, 0, .25) inset;
+        color: $color-ink-80;
+        position: relative;
+        z-index: 3;
+
+        // hide by default if JS is available to avoid flicker
+        // (if visitor previously dismissed)
+        .js & {
+            display: none;
+        }
+
+        // conditional class used to display the banner.
+        &.c-banner-is-visible {
+            display: block;
+        }
+    }
+
+    .c-banner-title {
+        @include bidi(((padding-right, $spacing-lg, 0), (padding-left, 0, $spacing-lg),)); // make room for the close button
+        @include font-size(24px);
+    }
+
+    @media #{$mq-md} {
+        .c-banner-main {
+            display: flex;
+            align-items: center;
+        }
+
+        .c-banner-title {
+            margin: 0;
+            padding: 0;
+        }
+
+        .c-cta {
+            line-height: 0;
+            min-width: 180px;
+            padding: 0 $spacing-xl;
+        }
+    }
+
+    // Close button
+    .c-banner-close {
+        @include background-size(20px 20px);
+        @include bidi((
+            (right, $spacing-sm, auto),
+            (left, auto, $spacing-sm),
+        ));
+        @include image-replaced;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
+        border: none;
+        cursor: pointer;
+        display: none;
+        height: 42px;
+        min-width: 0;
+        padding: 0;
+        position: absolute;
+        top: $spacing-sm;
+        width: 42px;
+        z-index: 1;
+
+        &:hover,
+        &:focus {
+            @include transition(transform .1s ease-in-out);
+            @include transform(scale(1.1));
+        }
+
+        &:focus {
+            outline: 1px dotted $color-white;
+        }
+
+        // hide the 'Close' text
+        span {
+            @include visually-hidden;
+        }
+
+        // only display when JS is available
+        .js & {
+            display: block;
+        }
+    }
+}

--- a/media/js/base/banners/vpn-promo-banner-init.js
+++ b/media/js/base/banners/vpn-promo-banner-init.js
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(function() {
+    'use strict';
+
+    function onLoad() {
+
+        window.Mozilla.Banner.init('vpn-promo-banner');
+    }
+
+    window.Mozilla.run(onLoad);
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -241,6 +241,12 @@
     },
     {
       "files": [
+        "css/base/banners/vpn-promo.scss"
+      ],
+      "name": "vpn-promo-banner"
+    },
+    {
+      "files": [
         "css/base/banners/native-android-exp.scss"
       ],
       "name": "native-android-exp-banner"
@@ -1132,6 +1138,13 @@
         "js/mozorg/home/daylight-promo-banner-init.js"
       ],
       "name": "daylight-promo-banner"
+    },
+    {
+      "files": [
+        "js/base/banners/mozilla-banner.js",
+        "js/base/banners/vpn-promo-banner-init.js"
+      ],
+      "name": "vpn-promo-banner"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds Mozilla VPN banner to the following pages:

- http://localhost:8000/de/
- http://localhost:8000/de/firefox/
- http://localhost:8000/de/firefox/privacy/products/
- http://localhost:8000/de/firefox/browsers/
- http://localhost:8000/de/firefox/products/
- http://localhost:8000/fr/
- http://localhost:8000/fr/firefox/
- http://localhost:8000/fr/firefox/privacy/products/
- http://localhost:8000/fr/firefox/browsers/
- http://localhost:8000/fr/firefox/products/

## Issue / Bugzilla link
#10178

## Testing
- [ ] VPN banner should only be visible for `de` and `fr` locales.
- [ ] Other locales should continue to see Firefox Daylight promo where applicable.