### PR TITLE
Enable target-linking on privacy notice pages (Fixes #10186)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -88,7 +88,7 @@
       <div class="c-footer-legal">
         <ul class="c-footer-terms">
           <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
-          <li><a href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ ftl('footer-websites-cookies') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}#user-choices" data-link-type="footer" data-link-name="Cookies">{{ ftl('footer-websites-cookies') }}</a></li>
           <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ ftl('footer-websites-legal') }}</a></li>
           <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-type="footer" data-link-name="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
         </ul>

--- a/media/js/privacy/privacy-firefox.js
+++ b/media/js/privacy/privacy-firefox.js
@@ -39,14 +39,14 @@
         section.appendChild(container);
 
         // handle clicks on the data choices "Choose" button
-        $('#choose').on('click', function() {
+        document.getElementById('choose').addEventListener('click', function() {
             // if the uitour did not load, just return
             if (Mozilla.UITour === undefined) {
                 return;
             }
 
             Mozilla.UITour.openPreferences('privacy-reports');
-        });
+        }, false);
     }
 
     // Don't execute if features aren't supported and client isn't desktop Firefox

--- a/media/js/privacy/privacy-protocol.js
+++ b/media/js/privacy/privacy-protocol.js
@@ -13,20 +13,52 @@
     window.Mzp.Details.init('.format-headings .privacy-body section section > h3');
     window.Mzp.Details.init('.format-paragraphs .summary');
 
-    buttons = document.querySelectorAll('.is-summary button');
-    for (var i = 0; i < buttons.length; i++) {
-        buttons[i].setAttribute('data-open', openText);
-        buttons[i].setAttribute('data-close', closeText);
-    }
-    
-    var cookieButton = document.querySelector('#user-choices button');
-    var cookieText = document.getElementById('expand-formatparagraphssummary-2');
-    
-    if (window.location.hash === '#cookies') {
-        if (cookieButton && cookieText) {
-            cookieButton.setAttribute('aria-expanded', 'true');
-            cookieText.classList.remove('is-closed');
-            cookieText.setAttribute('aria-hidden', 'false');
+    // Add "Learn more" / "Show less" text.
+    if (openText && closeText) {
+        buttons = document.querySelectorAll('.is-summary button');
+
+        for (var i = 0; i < buttons.length; i++) {
+            buttons[i].setAttribute('data-open', openText);
+            buttons[i].setAttribute('data-close', closeText);
         }
     }
+
+    function openPrivacyItem(id) {
+        var item = document.getElementById(id);
+
+        // Pages such as /privacy/firefox/ use 'is-details', whilst other pages like /privacy/websites/ use 'is-summary'.
+        // This is likely due to how the privacy notice markdown file is structured.
+        if (item && (item.classList.contains('is-details') || item.classList.contains('is-summary'))) {
+            var button = item.querySelector('button');
+
+            // Only expand the section if it is hidden.
+            if (button && button.getAttribute('aria-expanded') !== true) {
+                button.click();
+            }
+        }
+    }
+
+    function getHash() {
+        var hash = window.location.hash;
+        if (hash.indexOf('#') > -1) {
+            hash = hash.split('#')[1];
+        }
+
+        return hash;
+    }
+
+    function handleHashChange() {
+        var hash = getHash();
+
+        if (hash) {
+            openPrivacyItem(hash);
+        }
+    }
+
+    // Open relevant Privacy section is URL contains a matching hash.
+    if (window.location.hash) {
+        handleHashChange();
+    }
+
+    window.addEventListener('hashchange', handleHashChange, false);
 })();


### PR DESCRIPTION
## Description
- Enabled link targeting on privacy notice pages.
- Fixes broken cookies link in website footer.

## Issue / Bugzilla link
#10186

## Testing
- [ ] Landing on http://localhost:8000/en-US/privacy/websites/#user-choices should open the relevant section of the notice.
- [ ] Landing on http://localhost:8000/en-US/privacy/firefox/#health-report should do the same.