### PR TITLE
VPN: pricing position experiment (Fixes #10193)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -5,7 +5,7 @@
 {% from "products/vpn/includes/macros.html" import vpn_content_block with context %}
 
 <div class="vpn-variable-pricing-block hide-from-legacy-ie">
-  <h2 class="vpn-pricing-variable-heading">{{ ftl('vpn-shared-pricing-variable-heading') }}</h2>
+  <h2 class="vpn-pricing-variable-heading">{{ ftl('vpn-shared-pricing-variable-heading-v2', fallback='vpn-shared-pricing-variable-heading') }}</h2>
 
   <h3 class="vpn-pricing-variable-sub-heading">{{ ftl('vpn-shared-pricing-variable-sub-heading') }}</h3>
 

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -20,6 +20,12 @@
 {# switches to a graphic that indludes French and German flags #}
 {% set countries_image = 'img/products/vpn/landing/vpn-cntwell-05-v2.png' if switch('vpn-launch-germany-france') else 'img/products/vpn/landing/vpn-cntwell-05.png' %}
 
+{% block experiments %}
+  {% if switch('vpn-landing-page-sub-position-experiment') %}
+    {{ js_bundle('vpn-landing-page-sub-position-experiment') }}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {{ css_bundle('mozilla-vpn-landing') }}
 {% endblock %}
@@ -83,6 +89,8 @@
 
   <div class="mzp-l-content mzp-t-content-xl">
 
+    {% block top_pricing_position %}{% endblock %}
+
     {% call vpn_content_media(
       heading=ftl('vpn-landing-privacy-heading'),
       image_url='img/products/vpn/landing/vpn-cntwell-01.png',
@@ -92,6 +100,8 @@
     ) %}
       <p>{{ ftl('vpn-landing-privacy-desc') }}</p>
     {% endcall %}
+
+    {% block middle_pricing_position %}{% endblock %}
 
     {% call vpn_content_media(
       heading=ftl('vpn-landing-fast-secure-heading'),
@@ -149,14 +159,15 @@
     <div class="js-target-secondary-cta"></div>
     {% endcall %}
 
-    {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
-    <div id="pricing" class="mzp-is-anchor-link">
-      {% include 'products/vpn/includes/pricing-fixed.html' %}
-      {% include 'products/vpn/includes/pricing-variable.html' %}
-    </div>
+    {% block default_pricing_position %}
+      {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+      <div id="pricing" class="mzp-is-anchor-link">
+        {% include 'products/vpn/includes/pricing-fixed.html' %}
+        {% include 'products/vpn/includes/pricing-variable.html' %}
+      </div>
 
-    {% include 'products/vpn/includes/featured-press.html' %}
-
+      {% include 'products/vpn/includes/featured-press.html' %}
+    {% endblock %}
   </div>
 
   <section id="faq" class="vpn-faq mzp-l-content mzp-t-content-lg">

--- a/bedrock/products/templates/products/vpn/variants/pricing-a.html
+++ b/bedrock/products/templates/products/vpn/variants/pricing-a.html
@@ -1,0 +1,5 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}

--- a/bedrock/products/templates/products/vpn/variants/pricing-b.html
+++ b/bedrock/products/templates/products/vpn/variants/pricing-b.html
@@ -1,0 +1,17 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}
+
+{% block top_pricing_position %}
+  {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+  <div id="pricing" class="mzp-is-anchor-link">
+    {% include 'products/vpn/includes/pricing-fixed.html' %}
+    {% include 'products/vpn/includes/pricing-variable.html' %}
+  </div>
+
+  {% include 'products/vpn/includes/featured-press.html' %}
+{% endblock %}
+
+{% block default_pricing_position %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/variants/pricing-c.html
+++ b/bedrock/products/templates/products/vpn/variants/pricing-c.html
@@ -1,0 +1,22 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('vpn-landing-page-sub-position-experiment') }}
+{% endblock %}
+
+{% block middle_pricing_position %}
+  {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+  <div id="pricing" class="mzp-is-anchor-link">
+    {% include 'products/vpn/includes/pricing-fixed.html' %}
+    {% include 'products/vpn/includes/pricing-variable.html' %}
+  </div>
+
+  {% include 'products/vpn/includes/featured-press.html' %}
+{% endblock %}
+
+{% block default_pricing_position %}{% endblock %}

--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -100,3 +100,27 @@ class TestVPNLandingPage(TestCase):
         view(req)
         template = render_mock.call_args[0][1]
         assert template == 'products/vpn/landing.html'
+
+    def test_vpn_landing_page_variant_a_template(self, render_mock):
+        req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=a')
+        req.locale = 'en-US'
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == 'products/vpn/variants/pricing-a.html'
+
+    def test_vpn_landing_page_variant_b_template(self, render_mock):
+        req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=b')
+        req.locale = 'en-US'
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == 'products/vpn/variants/pricing-b.html'
+
+    def test_vpn_landing_page_variant_c_template(self, render_mock):
+        req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=c')
+        req.locale = 'en-US'
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == 'products/vpn/variants/pricing-c.html'

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -32,8 +32,21 @@ def vpn_variable_price_countries():
 @require_safe
 def vpn_landing_page(request):
     ftl_files = ['products/vpn/landing', 'products/vpn/shared']
-    template_name = 'products/vpn/landing.html'
     sub_not_found = request.GET.get('vpn-sub-not-found', None)
+    entrypoint_experiment = request.GET.get('entrypoint_experiment', None)
+    entrypoint_variation = request.GET.get('entrypoint_variation', None)
+
+    # ensure experiment parameters matches pre-defined values
+    if entrypoint_variation not in ['a', 'b', 'c']:
+        entrypoint_variation = None
+
+    if entrypoint_experiment != 'vpn-landing-page-sub-position':
+        entrypoint_variation = None
+
+    if entrypoint_experiment and entrypoint_variation:
+        template_name = 'products/vpn/variants/pricing-{}.html'.format(entrypoint_variation)
+    else:
+        template_name = 'products/vpn/landing.html'
 
     # error message for visitors who try to sign-in without a subscription (issue 10002)
     if sub_not_found == 'true':

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -68,7 +68,11 @@ vpn-shared-wireguard-copyright = { -brand-name-wireguard } is a registered trade
 
 ## Pricing options. Some offers may be only shown in select countries (e.g. German and France).
 
+vpn-shared-pricing-variable-heading-v2 = Choose a subscription plan that works for you
+
+# Outdated string
 vpn-shared-pricing-variable-heading = Choose a plan that works for you
+
 vpn-shared-pricing-variable-sub-heading = All of our plans include:
 vpn-shared-pricing-recommended-offer = Recommended
 vpn-shared-pricing-plan-6-month = 6 Month

--- a/media/css/products/vpn/components/hero.scss
+++ b/media/css/products/vpn/components/hero.scss
@@ -12,7 +12,7 @@ $image-path: '/media/protocol/img';
 // Hero component
 
 .vpn-hero {
-    margin: $layout-md 0;
+    margin: $layout-md 0 0;
     text-align: center;
 }
 
@@ -89,12 +89,8 @@ $image-path: '/media/protocol/img';
 }
 
 @media #{$mq-lg} {
-    .vpn-hero {
-        padding: $spacing-2xl 0;
-
-        .mzp-l-content {
-            min-height: 480px;
-        }
+    .vpn-hero .mzp-l-content {
+        min-height: 480px;
     }
 
     .vpn-hero-body {

--- a/media/css/products/vpn/sub-position-experiment.scss
+++ b/media/css/products/vpn/sub-position-experiment.scss
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+
+#pricing {
+    margin-top: $layout-xl;
+
+    @media #{$mq-md} {
+        margin-top: $layout-2xl;
+    }
+}

--- a/media/js/products/vpn/sub-position-experiment.js
+++ b/media/js/products/vpn/sub-position-experiment.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    var href = window.location.href;
+
+    var initTrafficCop = function () {
+        if (href.indexOf('entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=') !== -1) {
+            if (href.indexOf('entrypoint_variation=a') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'a',
+                    'data-ex-name': 'vpn-landing-page-sub-position'
+                });
+            } else if (href.indexOf('entrypoint_variation=b') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'b',
+                    'data-ex-name': 'vpn-landing-page-sub-position'
+                });
+            } else if (href.indexOf('entrypoint_variation=c') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'c',
+                    'data-ex-name': 'vpn-landing-page-sub-position'
+                });
+            }
+        } else {
+            var cop = new Mozilla.TrafficCop({
+                id: 'vpn-landing-page-sub-position-experiment',
+                variations: {
+                    'entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=a': 33,
+                    'entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=b': 33,
+                    'entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=c': 33,
+                }
+            });
+
+            cop.init();
+        }
+    };
+
+    // Avoid entering automated tests into random experiments.
+    if (href.indexOf('automation=true') === -1) {
+        initTrafficCop();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -836,6 +836,12 @@
     },
     {
       "files": [
+        "css/products/vpn/sub-position-experiment.scss"
+      ],
+      "name": "vpn-landing-page-sub-position-experiment"
+    },
+    {
+      "files": [
         "css/products/vpn/components/hero.scss",
         "css/products/vpn/components/block.scss",
         "css/products/vpn/common.scss"
@@ -1546,6 +1552,13 @@
         "js/products/vpn/landing.js"
       ],
       "name": "mozilla-vpn-landing"
+    },
+    {
+      "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/products/vpn/sub-position-experiment.js"
+      ],
+      "name": "vpn-landing-page-sub-position-experiment"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds a multi-variant test for different posions of the pricing section on the VPN landing page.

- http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=a (control, pricing at bottom of page)
- http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=b (pricing underneath hero)
- http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=c (pricing underneath one-tap to privacy section)

Also adds a new string to address https://github.com/mozilla/bedrock/issues/10189

## Issue / Bugzilla link
#10193
#10189

## Testing
Note: test in a browser with DNT disabled.

- [ ] TC experiment fires as expected when visiting http://localhost:8000/en-US/products/vpn/, showing one of the three variations.