### PR TITLE
Remove jQuery from base-page-init.js and other misc files (Fixes #7523)

### DIFF
--- a/bedrock/press/templates/press/speaker-request.html
+++ b/bedrock/press/templates/press/speaker-request.html
@@ -62,14 +62,14 @@
       <div class="mzp-c-field {% if form.sr_event_date.errors %}mzp-is-error{% endif %}">
         <label class="mzp-c-field-label"  for="sr_event_date">{{ _('Date') }}</label>
         {{ field_with_attrs(form.sr_event_date, class='mzp-c-field-control'|safe) }}
-        <p class="mzp-c-field-info">{{ _('2015-03-14 or March 14, 2015') }}</p>
+        <p class="mzp-c-field-info date-note">{{ _('2015-03-14 or March 14, 2015') }}</p>
         <div class="mzp-c-field-info">{{ form.sr_event_date.errors }}</div>
       </div>
 
       <div class="mzp-c-field {% if form.sr_event_time.errors %}mzp-is-error{% endif %}">
         <label class="mzp-c-field-label"  for="sr_event_time">{{ _('Time') }}</label>
         {{ field_with_attrs(form.sr_event_time, class='mzp-c-field-control'|safe) }}
-        <p class="mzp-c-field-info">{{ _('2:30 PM or 14:30') }}</p>
+        <p class="mzp-c-field-info time-note">{{ _('2:30 PM or 14:30') }}</p>
         <div class="mzp-c-field-info">{{ form.sr_event_time.errors }}</div>
       </div>
 

--- a/media/js/base/base-page-init.js
+++ b/media/js/base/base-page-init.js
@@ -5,48 +5,31 @@
 /**
  * General DOM ready handler applied to all pages in base template.
  */
-(function($) {
+(function() {
     'use strict';
 
-    // page must be loaded and ready before onWindowLoad fires
-    var loaded = false;
-    var ready = false;
+    if (typeof Mozilla.Utils !== 'undefined') {
+        Mozilla.Utils.onDocumentReady(function() {
+            var utils = Mozilla.Utils;
 
-    function onWindowLoad() {
-        $('html').addClass('loaded');
+            utils.initMobileDownloadLinks();
+            utils.trackDownloadThanksButton();
+
+            /* Bug 1264843: In partner distribution of desktop Firefox, switch the
+            downloads to corresponding partner build of Firefox for Android. */
+            if (typeof Mozilla.Client !== 'undefined') {
+                var client = Mozilla.Client;
+
+                if (client.isFirefoxDesktop) {
+                    client.getFirefoxDetails(utils.maybeSwitchToChinaRepackImages);
+                }
+            }
+        });
     }
 
-    $(document).ready(function() {
+    // The `loaded` class is used mostly as a signal for functional tests to run.
+    window.addEventListener('load', function() {
+        document.getElementsByTagName('html')[0].classList.add('loaded');
+    }, false);
 
-        var client = Mozilla.Client;
-        var utils = Mozilla.Utils;
-
-        utils.initMobileDownloadLinks();
-        utils.trackDownloadThanksButton();
-
-        /* Bug 1264843: In partner distribution of desktop Firefox, switch the
-        downloads to corresponding partner build of Firefox for Android. */
-        if (client.isFirefoxDesktop) {
-            client.getFirefoxDetails(utils.maybeSwitchToChinaRepackImages);
-        }
-
-        // if window.load happened already, fire onWindowLoad
-        if (loaded) {
-            onWindowLoad();
-        }
-
-        // note that document.ready happened to inform window.load
-        ready = true;
-    });
-
-    $(window).on('load', function () {
-        // if document.ready happened already, fire onWindowLoad
-        if (ready) {
-            onWindowLoad();
-        }
-
-        // note that window.load happened in case document.ready hasn't
-        // finished yet
-        loaded = true;
-    });
-})(window.jQuery);
+})();

--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // init core dataLayer object and push into dataLayer
-$(function() {
+(function() {
     'use strict';
 
     var analytics = Mozilla.Analytics;
@@ -33,22 +33,32 @@ $(function() {
         }
     }
 
-    client.getFxaDetails(function(details) {
-        dataLayer.push(analytics.formatFxaDetails(details));
-        fxaDetailsComplete = true;
-        checkSendCoreDataLayer();
-    });
-
-    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
-        client.getFirefoxDetails(function(details) {
-            dataLayer.push(details);
-            firefoxDetailsComplete = true;
+    function initCoreDataLayer() {
+        client.getFxaDetails(function(details) {
+            dataLayer.push(analytics.formatFxaDetails(details));
+            fxaDetailsComplete = true;
             checkSendCoreDataLayer();
         });
-    } else {
-        firefoxDetailsComplete = true;
-        checkSendCoreDataLayer();
+
+        if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
+            client.getFirefoxDetails(function(details) {
+                dataLayer.push(details);
+                firefoxDetailsComplete = true;
+                checkSendCoreDataLayer();
+            });
+        } else {
+            firefoxDetailsComplete = true;
+            checkSendCoreDataLayer();
+        }
+
+        analytics.updateDataLayerPush();
     }
 
-    analytics.updateDataLayerPush();
-});
+    // Init dataLayer event on DOM Ready.
+    if (typeof Mozilla.Utils !== 'undefined') {
+        Mozilla.Utils.onDocumentReady(function() {
+            initCoreDataLayer();
+        });
+    }
+
+})();

--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -17,7 +17,7 @@ if (typeof window.Mozilla === 'undefined') {
         if (document.readyState !== 'loading') {
             callback();
         } else {
-            document.addEventListener('DOMContentLoaded', callback);
+            document.addEventListener('DOMContentLoaded', callback, false);
         }
     };
 

--- a/media/js/firefox/whatsnew/whatsnew.js
+++ b/media/js/firefox/whatsnew/whatsnew.js
@@ -7,14 +7,14 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-(function($, Mozilla) {
+(function() {
     'use strict';
 
     var sendTo = document.getElementById('send-to-device');
 
     if (sendTo) {
-        var form = new Mozilla.SendToDevice();
+        var form = new window.Mozilla.SendToDevice();
         form.init();
     }
 
-})(window.jQuery, window.Mozilla);
+})();

--- a/media/js/press/speaker-request.js
+++ b/media/js/press/speaker-request.js
@@ -2,17 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-(function($, Modernizr) {
+(function() {
     'use strict';
 
-    $(document).ready(function(){
+    if (window.Modernizr.inputtypes.date) {
+        document.querySelector('.date-note').style.display = 'none';
+    }
 
-        if (Modernizr.inputtypes.date) {
-            $('.date-note').hide();
-        }
+    if (window.Modernizr.inputtypes.time) {
+        document.querySelector('.time-note').style.display = 'none';
+    }
 
-        if (Modernizr.inputtypes.time) {
-            $('.time-note').hide();
-        }
-    });
-})(window.jQuery, window.Modernizr);
+})();

--- a/media/js/privacy/privacy-firefox.js
+++ b/media/js/privacy/privacy-firefox.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 (function() {
     'use strict';
 


### PR DESCRIPTION
## Description
- Updates DOM Ready and window load events to use vanilla JS in `base-page-init.js`.
- Updates a few other misc files that had stray references to jQuery.

## Issue / Bugzilla link
#7523

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/303962734