### PR TITLE
Differentiate headings for installations stuff [ fixes #10063]

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -25,7 +25,7 @@
       {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-md.png', {'alt': '', 'width': '368', 'height': '68'}) }}
 
       {% if ftl_has_messages('firefox-developer-congrats-you-now-have', 'firefox-developer-welcome-to-your-new-favorite') %}
-        {% if oldversion and ftl_has_messages('firefox-developer-congrats-you-now-have-latest') %}
+        {% if ftl_has_messages('firefox-developer-congrats-you-now-have-latest') %}
           <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-latest') }}</h1>
         {% else %}
           <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have') }}</h1>

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -25,11 +25,7 @@
       {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-md.png', {'alt': '', 'width': '368', 'height': '68'}) }}
 
       {% if ftl_has_messages('firefox-developer-congrats-you-now-have', 'firefox-developer-welcome-to-your-new-favorite') %}
-        {% if ftl_has_messages('firefox-developer-congrats-you-now-have-latest') %}
-          <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-latest') }}</h1>
-        {% else %}
-          <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have') }}</h1>
-        {% endif %}
+        <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-latest', fallback='firefox-developer-congrats-you-now-have') }}</h1>
         <p class="intro-tagline">{{ ftl('firefox-developer-welcome-to-your-new-favorite') }}</p>
       {% else %}
         <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-firefox') }}</h1>

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -25,7 +25,11 @@
       {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-md.png', {'alt': '', 'width': '368', 'height': '68'}) }}
 
       {% if ftl_has_messages('firefox-developer-congrats-you-now-have', 'firefox-developer-welcome-to-your-new-favorite') %}
-        <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have') }}</h1>
+        {% if oldversion and ftl_has_messages('firefox-developer-congrats-you-now-have-latest') %}
+          <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-latest') }}</h1>
+        {% else %}
+          <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have') }}</h1>
+        {% endif %}
         <p class="intro-tagline">{{ ftl('firefox-developer-welcome-to-your-new-favorite') }}</p>
       {% else %}
         <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-firefox') }}</h1>
@@ -61,5 +65,5 @@
   {{ js_bundle('firefox_developer') }}
 {% endblock %}
 
-{# Exclude stub attribution for in-product pages: issus 9620 #}
+{# Exclude stub attribution for in-product pages: issue 9620 #}
 {% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -613,12 +613,6 @@ class WhatsnewView(L10nTemplateView):
 
         ctx['variant'] = variant
 
-        oldversion = self.request.GET.get('oldversion', '')
-        # old versions of Firefox sent a prefixed version
-        if oldversion and oldversion.startswith('rv:'):
-            oldversion = oldversion[3:]
-        ctx['oldversion'] = oldversion
-
         return ctx
 
     def get_template_names(self):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -613,6 +613,12 @@ class WhatsnewView(L10nTemplateView):
 
         ctx['variant'] = variant
 
+        oldversion = self.request.GET.get('oldversion', '')
+        # old versions of Firefox sent a prefixed version
+        if oldversion and oldversion.startswith('rv:'):
+            oldversion = oldversion[3:]
+        ctx['oldversion'] = oldversion
+
         return ctx
 
     def get_template_names(self):

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -84,3 +84,4 @@ firefox-developer-all-the-latest = All the latest developer tools in beta, plus 
 firefox-developer-a-separate-profile = A <strong>separate profile and path</strong> so you can easily run it alongside Release or { -brand-name-beta } { -brand-name-firefox }.
 firefox-developer-preferences-tailored = Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.
 firefox-developer-congrats-you-now-have = Congrats. You now have { -brand-name-firefox-browser } { -brand-name-developer-edition }.
+firefox-developer-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox-browser } { -brand-name-developer-edition }.


### PR DESCRIPTION
## Description
It fixes issue #10063. It works same as the bugzilla issue https://bugzilla.mozilla.org/show_bug.cgi?id=1700518 suggests. 

## Issue / Bugzilla link
#10063
## Testing
go to http://127.0.0.1:8000/en-US/firefox/88.0a2/whatsnew/all/?oldversion=87.0 . Remove the oldversion attribute from the link and compare the change in the heading.