### PR TITLE
Do not send basket update when nothing changed on newsletter preference page

### DIFF
--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import json
 import uuid
-from unittest import expectedFailure
 
 from django.http import HttpResponse
 from django.test.client import RequestFactory
@@ -260,7 +259,6 @@ class TestExistingNewsletterView(TestCase):
         url = reverse("newsletter.updated")
         assert rsp["Location"] == url
 
-    @expectedFailure
     @patch("bedrock.newsletter.utils.get_newsletters")
     def test_remove_all(self, get_newsletters, mock_basket_request):
         get_newsletters.return_value = newsletters

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -419,14 +419,14 @@ def existing(request, token=None):
             # Also pass their updated list of newsletters they want to be
             # subscribed to, for basket to implement.
             kwargs = {}
-            if settings.BASKET_API_KEY:
-                kwargs["api_key"] = settings.BASKET_API_KEY
             for k in ["lang", "format", "country"]:
                 if user[k] != data[k]:
                     kwargs[k] = data[k]
             if not remove_all:
                 kwargs["newsletters"] = ",".join(newsletters)
             if kwargs:
+                if settings.BASKET_API_KEY:
+                    kwargs["api_key"] = settings.BASKET_API_KEY
                 # always send lang so basket doesn't try to guess
                 kwargs["lang"] = data["lang"]
                 try:


### PR DESCRIPTION
## Description

Apply ``BASKET_API_KEY`` to the basket update ``kwargs`` after checking if any of the settings from the newsletter preference page changed. This prevents detecting that the page always has changes, and avoids sending a needless update to Basket when unsubscribing from all newsletters.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/10205

## Testing

Unit testing only. I added ``BASKET_API_KEY`` to all ``TestExistingNewsletterView``, which required some test changes and caused ``test_remove_all`` to fail, replicating the issue from basket-dev.  The second commit changes the view logic, and the test now passes again.