### PR TITLE
Enable VPN variable pricing for wave 1 countries (Fixes #10199)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/pricing-fixed.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-fixed.html
@@ -4,7 +4,7 @@
 
 {% from "products/vpn/includes/macros.html" import vpn_content_block with context %}
 
-<div class="vpn-fixed-pricing-block">
+<div class="vpn-fixed-pricing-block {% if switch('vpn-variable-pricing-wave-1') %}hide-from-legacy-ie{% endif %}">
   {% call vpn_content_block(
     class_name='vpn-content-block-price t-highlight'
   ) %}

--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -4,7 +4,7 @@
 
 {% from "products/vpn/includes/macros.html" import vpn_content_block with context %}
 
-<div class="vpn-variable-pricing-block hide-from-legacy-ie">
+<div class="vpn-variable-pricing-block {% if not switch('vpn-variable-pricing-wave-1') %}hide-from-legacy-ie{% endif %}">
   <h2 class="vpn-pricing-variable-heading">{{ ftl('vpn-shared-pricing-variable-heading-v2', fallback='vpn-shared-pricing-variable-heading') }}</h2>
 
   <h3 class="vpn-pricing-variable-sub-heading">{{ ftl('vpn-shared-pricing-variable-sub-heading') }}</h3>
@@ -25,7 +25,7 @@
   ) %}
     <p class="vpn-pricing-variable-plan-tag">{{ ftl('vpn-shared-pricing-recommended-offer') }}</p>
     <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-6-month') }}</h2>
-    <h3 class="vpn-content-block-sub-heading">{{ ftl('vpn-shared-pricing-monthly', amount=variable_6_month_price) }}</h3>
+    <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='6-month', lang=LANG) }}</h3>
 
     {{ vpn_subscribe_link(
       entrypoint=_utm_source,
@@ -44,15 +44,15 @@
     ) }}
 
     <p class="refund-policy"><a href="#faq-refunds">{{ ftl('vpn-shared-refund-policy') }}</a></p>
-    <p class="vpn-pricing-variable-saving">{{ ftl('vpn-shared-pricing-save-percent', percent=30) }}</p>
-    <p class="vpn-pricing-variable-total">{{ ftl('vpn-shared-pricing-total', amount=variable_6_month_price_total) }}</p>
+    <p class="vpn-pricing-variable-saving">{{ vpn_saving(plan='6-month', lang=LANG) }}</p>
+    <p class="vpn-pricing-variable-total">{{ vpn_total_price(plan='6-month', lang=LANG) }}</p>
   {% endcall %}
 
    {% call vpn_content_block(
      class_name='vpn-pricing-12-months'
    ) %}
      <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-12-month') }}</h2>
-     <h3 class="vpn-content-block-sub-heading">{{ ftl('vpn-shared-pricing-monthly', amount=variable_12_month_price) }}</h3>
+     <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='12-month', lang=LANG) }}</h3>
 
      {{ vpn_subscribe_link(
        entrypoint=_utm_source,
@@ -71,15 +71,15 @@
      ) }}
 
      <p class="refund-policy"><a href="#faq-refunds">{{ ftl('vpn-shared-refund-policy') }}</a></p>
-     <p class="vpn-pricing-variable-saving">{{ ftl('vpn-shared-pricing-save-percent', percent=50) }}</p>
-     <p class="vpn-pricing-variable-total">{{ ftl('vpn-shared-pricing-total', amount=variable_12_month_price_total) }}</p>
+     <p class="vpn-pricing-variable-saving">{{ vpn_saving(plan='12-month', lang=LANG) }}</p>
+     <p class="vpn-pricing-variable-total">{{ vpn_total_price(plan='12-month', lang=LANG) }}</p>
    {% endcall %}
 
    {% call vpn_content_block(
      class_name='vpn-pricing-monthly'
      ) %}
      <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-monthly') }}</h2>
-     <h3 class="vpn-content-block-sub-heading">{{ ftl('vpn-shared-pricing-monthly', amount=variable_monthly_price) }}</h3>
+     <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='monthly', lang=LANG) }}</h3>
 
      {{ vpn_subscribe_link(
        entrypoint=_utm_source,

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -13,14 +13,16 @@
 
 {% block body_id %}mozilla-vpn-landing{% endblock %}
 
+{% block body_class %}{% if switch('vpn-variable-pricing-wave-1') %}wave-1-variable-pricing{% else %}wave-1-fixed-pricing{% endif %}{% endblock %}
+
 {% set _utm_source = 'www.mozilla.org-vpn-product-page' %}
 {% set _utm_campaign = 'vpn-product-page' %}
 {% set _params = '?utm_source=' ~ _utm_source ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign %}
 
 {% block experiments %}
-  {% if switch('vpn-landing-page-download-first-experiment') %}
+  {% if switch('vpn-landing-page-download-first-experiment') and not switch('vpn-variable-pricing-wave-1') %}
     {{ js_bundle('vpn-landing-page-download-first-experiment') }}
-  {% elif switch('vpn-landing-page-sub-position-experiment') %}
+  {% elif switch('vpn-landing-page-sub-position-experiment') and not switch('vpn-variable-pricing-wave-1') %}
     {{ js_bundle('vpn-landing-page-sub-position-experiment') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -7,6 +7,10 @@ import jinja2
 from django.conf import settings
 from django_jinja import library
 
+from lib.l10n_utils.fluent import ftl
+
+FTL_FILES = ['products/vpn/shared']
+
 
 def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
     separator = '&' if '?' in product_url else '?'
@@ -76,16 +80,14 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, plan=None, class_name=None, l
     if plan in ['12-month', '6-month', 'monthly']:
 
         # Set a default plan ID using page locale. This acts as a fallback should geo-location fail.
-        if lang in ['de', 'fr']:
-            plan_default = settings.VPN_VARIABLE_PRICING[lang][plan]
-        else:
-            plan_default = ''
+        pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
+        plan_default = pricing_params[plan]['id']
+        plan_attributes = {}
 
         # HTML data-attributes are used by client side JS to set the correct plan ID based on geo.
-        plan_attributes = {
-            'data-plan-de': settings.VPN_VARIABLE_PRICING['de'][plan],
-            'data-plan-fr': settings.VPN_VARIABLE_PRICING['fr'][plan]
-        }
+        for country in settings.VPN_VARIABLE_PRICING.items():
+            plan_attributes.update({f'data-plan-{country[0]}': country[1][plan]['id']})
+
     # All other subscription links default to fixed monthly pricing in $US.
     else:
         plan_default = settings.VPN_FIXED_PRICE_MONTHLY_USD
@@ -98,3 +100,111 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, plan=None, class_name=None, l
     product_url = f'{settings.VPN_ENDPOINT}r/vpn/subscribe/products/{settings.VPN_PRODUCT_ID}?plan={plan_default}'
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)
+
+
+@library.global_function
+@jinja2.contextfunction
+def vpn_monthly_price(ctx, plan='monthly', lang=None):
+    """
+    Render a localized string displaying VPN monthly plan price.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ vpn_monthly_price(plan='12-month') }}
+    """
+
+    pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
+    default_amount = pricing_params[plan]['price']
+    euro_amount = settings.VPN_VARIABLE_PRICING['de'][plan]['price']
+    usd_amount = settings.VPN_VARIABLE_PRICING['us'][plan]['price']
+    default_text = ftl('vpn-shared-pricing-monthly', amount=default_amount, ftl_files=FTL_FILES)
+
+    # HTML data-attributes are used by client side JS to set the correct display price based on geo.
+    attributes = {
+        'data-price-usd': ftl('vpn-shared-pricing-monthly', amount=usd_amount, ftl_files=FTL_FILES),
+        'data-price-euro': ftl('vpn-shared-pricing-monthly', amount=euro_amount, ftl_files=FTL_FILES),
+    }
+
+    attrs = ' '.join('%s="%s"' % (attr, val) for attr, val in attributes.items())
+
+    markup = (f'<span class="js-vpn-monthly-price-display" {attrs}>'
+              f'{default_text}'
+              f'</span>')
+
+    return jinja2.Markup(markup)
+
+
+@library.global_function
+@jinja2.contextfunction
+def vpn_total_price(ctx, plan='12-month', lang=None):
+    """
+    Render a localized string displaying VPN total plan price.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ vpn_total_price(plan='6-month') }}
+    """
+
+    pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
+    default_amount = pricing_params[plan]['total']
+    euro_amount = settings.VPN_VARIABLE_PRICING['de'][plan]['total']
+    usd_amount = settings.VPN_VARIABLE_PRICING['us'][plan]['total']
+    default_text = ftl('vpn-shared-pricing-total', amount=default_amount, ftl_files=FTL_FILES)
+
+    # HTML data-attributes are used by client side JS to set the correct display price based on geo.
+    attributes = {
+        'data-price-usd': ftl('vpn-shared-pricing-total', amount=usd_amount, ftl_files=FTL_FILES),
+        'data-price-euro': ftl('vpn-shared-pricing-total', amount=euro_amount, ftl_files=FTL_FILES),
+    }
+
+    attrs = ' '.join('%s="%s"' % (attr, val) for attr, val in attributes.items())
+
+    markup = (f'<span class="js-vpn-total-price-display" {attrs}>'
+              f'{default_text}'
+              f'</span>')
+
+    return jinja2.Markup(markup)
+
+
+@library.global_function
+@jinja2.contextfunction
+def vpn_saving(ctx, plan='12-month', lang=None):
+    """
+    Render a localized string displaying saving (as a percentage) of a given VPN subscription plan.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ vpn_saving(plan='6-month') }}
+    """
+
+    pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
+    default_amount = pricing_params[plan]['saving']
+    euro_amount = settings.VPN_VARIABLE_PRICING['de'][plan]['saving']
+    usd_amount = settings.VPN_VARIABLE_PRICING['us'][plan]['saving']
+    default_text = ftl('vpn-shared-pricing-save-percent', percent=default_amount, ftl_files=FTL_FILES)
+
+    # HTML data-attributes are used by client side JS to set the correct saving based on geo.
+    attributes = {
+        'data-price-usd': ftl('vpn-shared-pricing-save-percent', percent=usd_amount, ftl_files=FTL_FILES),
+        'data-price-euro': ftl('vpn-shared-pricing-save-percent', percent=euro_amount, ftl_files=FTL_FILES),
+    }
+
+    attrs = ' '.join('%s="%s"' % (attr, val) for attr, val in attributes.items())
+
+    markup = (f'<span class="js-vpn-saving-display" {attrs}>'
+              f'{default_text}'
+              f'</span>')
+
+    return jinja2.Markup(markup)

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -85,8 +85,8 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, plan=None, class_name=None, l
         plan_attributes = {}
 
         # HTML data-attributes are used by client side JS to set the correct plan ID based on geo.
-        for country in settings.VPN_VARIABLE_PRICING.items():
-            plan_attributes.update({f'data-plan-{country[0]}': country[1][plan]['id']})
+        for country, attrs in settings.VPN_VARIABLE_PRICING.items():
+            plan_attributes.update({f'data-plan-{country}': attrs[plan]['id']})
 
     # All other subscription links default to fixed monthly pricing in $US.
     else:

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -16,14 +16,55 @@ TEST_VPN_PRODUCT_ID = 'prod_FvnsFHIfezy3ZI'
 TEST_VPN_FIXED_PRICE_MONTHLY_USD = 'plan_FvnxS1j9oFUZ7Y'
 TEST_VPN_VARIABLE_PRICING = {
     'de': {
-        '12-month': 'price_1IgwblJNcmPzuWtRynC7dqQa',
-        '6-month': 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
-        'monthly': 'price_1IgwZVJNcmPzuWtRg9Wssh2y'
+        '12-month': {
+            'id': 'price_1IgwblJNcmPzuWtRynC7dqQa',
+            'price': '4,99 €',
+            'total': '59,88 €'
+        },
+        '6-month': {
+            'id': 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
+            'price': '6,99 €',
+            'total': '41,94 €'
+        },
+        'monthly': {
+            'id': 'price_1IgwZVJNcmPzuWtRg9Wssh2y',
+            'price': '9,99‎ €',
+            'total': None
+        }
     },
     'fr': {
-        '12-month': 'price_1IgnlcJNcmPzuWtRjrNa39W4',
-        '6-month': 'price_1IgoxGJNcmPzuWtRG7l48EoV',
-        'monthly': 'price_1IgowHJNcmPzuWtRzD7SgAYb'
+        '12-month': {
+            'id': 'price_1IgnlcJNcmPzuWtRjrNa39W4',
+            'price': '4,99 €',
+            'total': '59,88 €'
+        },
+        '6-month': {
+            'id': 'price_1IgoxGJNcmPzuWtRG7l48EoV',
+            'price': '6,99 €',
+            'total': '41,94 €'
+        },
+        'monthly': {
+            'id': 'price_1IgowHJNcmPzuWtRzD7SgAYb',
+            'price': '9,99‎ €',
+            'total': None
+        }
+    },
+    'us': {
+        '12-month': {
+            'id': 'price_1Iw85dJNcmPzuWtRyhMDdtM7',
+            'price': 'TBD',
+            'total': 'TBD'
+        },
+        '6-month': {
+            'id': 'price_1Iw87cJNcmPzuWtRefuyqsOd',
+            'price': 'TBD',
+            'total': 'TBD'
+        },
+        'monthly': {
+            'id': 'price_1Iw7qSJNcmPzuWtRMUZpOwLm',
+            'price': 'TBD',
+            'total': None
+        }
     }
 }
 
@@ -61,13 +102,64 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=plan_FvnxS1j9oFUZ7Y'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
-            u'data-cta-type="fxa-vpn" data-cta-position="primary">Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
-    def test_vpn_subscribe_link_variable_12_month(self):
-        """Should return expected markup for variable 12-month plan"""
+    def test_vpn_subscribe_link_variable_12_month_en(self):
+        """Should return expected markup for variable 12-month plan for en-US"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='12-month', class_name='mzp-c-button', lang='en-US',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_6_month_en(self):
+        """Should return expected markup for variable 6-month plan for en-US"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='6-month', class_name='mzp-c-button', lang='en-US',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw87cJNcmPzuWtRefuyqsOd'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_monthly_en(self):
+        """Should return expected markup for variable monthly plan for en-US"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='monthly', class_name='mzp-c-button', lang='en-US',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw7qSJNcmPzuWtRMUZpOwLm'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_12_month_de(self):
+        """Should return expected markup for variable 12-month plan for de"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
                               plan='12-month', class_name='mzp-c-button', lang='de',
                               optional_parameters={'utm_campaign': 'vpn-product-page'},
@@ -76,14 +168,15 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgwblJNcmPzuWtRynC7dqQa'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
-            u'data-cta-type="fxa-vpn" data-cta-position="primary" data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" '
-            u'data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4">Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
-    def test_vpn_subscribe_link_variable_6_month(self):
-        """Should return expected markup for variable 6-month plan"""
+    def test_vpn_subscribe_link_variable_6_month_de(self):
+        """Should return expected markup for variable 6-month plan for de"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
                               plan='6-month', class_name='mzp-c-button', lang='de',
                               optional_parameters={'utm_campaign': 'vpn-product-page'},
@@ -92,14 +185,15 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgwaHJNcmPzuWtRuUfSR4l7'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
-            u'data-cta-type="fxa-vpn" data-cta-position="primary" data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" '
-            u'data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV">Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
-    def test_vpn_subscribe_link_variable_monthly(self):
-        """Should return expected markup for variable monthly plan"""
+    def test_vpn_subscribe_link_variable_monthly_de(self):
+        """Should return expected markup for variable monthly plan for de"""
         markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
                               plan='monthly', class_name='mzp-c-button', lang='de',
                               optional_parameters={'utm_campaign': 'vpn-product-page'},
@@ -108,10 +202,62 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgwZVJNcmPzuWtRg9Wssh2y'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_12_month_fr(self):
+        """Should return expected markup for variable 12-month plan for fr"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='12-month', class_name='mzp-c-button', lang='fr',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgnlcJNcmPzuWtRjrNa39W4'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_6_month_fr(self):
+        """Should return expected markup for variable 6-month plan for fr"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='6-month', class_name='mzp-c-button', lang='fr',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgoxGJNcmPzuWtRG7l48EoV'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
-            u'data-cta-type="fxa-vpn" data-cta-position="primary" data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" '
-            u'data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb">Get Mozilla VPN</a>')
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_monthly_fr(self):
+        """Should return expected markup for variable monthly plan for fr"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='monthly', class_name='mzp-c-button', lang='fr',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgowHJNcmPzuWtRzD7SgAYb'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
 
@@ -138,4 +284,87 @@ class TestVPNSignInLink(TestCase):
             u'&utm_campaign=vpn-product-page&data_cta_position=navigation" data-action="https://accounts.firefox.com/" '
             u'class="js-fxa-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '
             u'data-cta-type="fxa-vpn" data-cta-position="navigation">Sign In</a>')
+        self.assertEqual(markup, expected)
+
+
+class TestVPNMonthlyPrice(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, plan):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        return render("{{{{ vpn_monthly_price('{0}') }}}}".format(plan), {'request': req})
+
+    def test_vpn_monthly_price(self):
+        """Should return expected markup"""
+        markup = self._render(plan='monthly')
+        expected = (
+            u'<span class="js-vpn-monthly-price-display" data-price-usd="US$9.99<span>/month</span>" '
+            u'data-price-euro="9,99‎ €<span>/month</span>">US$9.99<span>/month</span></span>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_6_month_price(self):
+        """Should return expected markup"""
+        markup = self._render(plan='6-month')
+        expected = (
+            u'<span class="js-vpn-monthly-price-display" data-price-usd="US$7.99<span>/month</span>" '
+            u'data-price-euro="6,99 €<span>/month</span>">US$7.99<span>/month</span></span>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price(self):
+        """Should return expected markup"""
+        markup = self._render(plan='12-month')
+        expected = (
+            u'<span class="js-vpn-monthly-price-display" data-price-usd="US$4.99<span>/month</span>" '
+            u'data-price-euro="4,99 €<span>/month</span>">US$4.99<span>/month</span></span>')
+        self.assertEqual(markup, expected)
+
+
+class TestVPNTotalPrice(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, plan):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        return render("{{{{ vpn_total_price('{0}') }}}}".format(plan), {'request': req})
+
+    def test_vpn_6_month_total_price(self):
+        """Should return expected markup"""
+        markup = self._render(plan='6-month')
+        expected = (
+            u'<span class="js-vpn-total-price-display" data-price-usd="US$47.94 total" '
+            u'data-price-euro="41,94 € total">US$47.94 total</span>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price(self):
+        """Should return expected markup"""
+        markup = self._render(plan='12-month')
+        expected = (
+            u'<span class="js-vpn-total-price-display" data-price-usd="US$59.88 total" '
+            u'data-price-euro="59,88 € total">US$59.88 total</span>')
+        self.assertEqual(markup, expected)
+
+
+class TestVPNSaving(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, plan):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        return render("{{{{ vpn_saving('{0}') }}}}".format(plan), {'request': req})
+
+    def test_vpn_6_month_saving(self):
+        """Should return expected markup"""
+        markup = self._render(plan='6-month')
+        expected = (
+            u'<span class="js-vpn-saving-display" data-price-usd="Save 20%" '
+            u'data-price-euro="Save 30%">Save 20%</span>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_saving(self):
+        """Should return expected markup"""
+        markup = self._render(plan='12-month')
+        expected = (
+            u'<span class="js-vpn-saving-display" data-price-usd="Save 50%" '
+            u'data-price-euro="Save 50%">Save 50%</span>')
         self.assertEqual(markup, expected)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1290,24 +1290,69 @@ VPN_FIXED_PRICE_MONTHLY_USD = config('VPN_FIXED_PRICE_MONTHLY_USD',
 # Plan IDs for VPN variable price subscriptions in Euros.
 VPN_VARIABLE_PRICING = {
     'de': {
-        '12-month': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgwblJNcmPzuWtRynC7dqQa',
-        '6-month': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
-        'monthly': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgwZVJNcmPzuWtRg9Wssh2y'
+        '12-month': {
+            'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgwblJNcmPzuWtRynC7dqQa',
+            'price': '4,99 €',
+            'total': '59,88 €',
+            'saving': 50
+        },
+        '6-month': {
+            'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
+            'price': '6,99 €',
+            'total': '41,94 €',
+            'saving': 30
+        },
+        'monthly': {
+            'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgwZVJNcmPzuWtRg9Wssh2y',
+            'price': '9,99‎ €',
+            'total': None,
+            'saving': None
+        }
     },
     'fr': {
-        '12-month': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgnlcJNcmPzuWtRjrNa39W4',
-        '6-month': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgoxGJNcmPzuWtRG7l48EoV',
-        'monthly': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgowHJNcmPzuWtRzD7SgAYb'
+        '12-month': {
+            'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgnlcJNcmPzuWtRjrNa39W4',
+            'price': '4,99 €',
+            'total': '59,88 €',
+            'saving': 50
+        },
+        '6-month': {
+            'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgoxGJNcmPzuWtRG7l48EoV',
+            'price': '6,99 €',
+            'total': '41,94 €',
+            'saving': 30
+        },
+        'monthly': {
+            'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgowHJNcmPzuWtRzD7SgAYb',
+            'price': '9,99‎ €',
+            'total': None,
+            'saving': None
+        }
+    },
+    'us': {
+        '12-month': {
+            'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1Iw85dJNcmPzuWtRyhMDdtM7',
+            'price': 'US$4.99',
+            'total': 'US$59.88',
+            'saving': 50
+        },
+        '6-month': {
+            'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1Iw87cJNcmPzuWtRefuyqsOd',
+            'price': 'US$7.99',
+            'total': 'US$47.94',
+            'saving': 20
+        },
+        'monthly': {
+            'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1Iw7qSJNcmPzuWtRMUZpOwLm',
+            'price': 'US$9.99',
+            'total': None,
+            'saving': None
+        }
     }
 }
 
 # Product variables used in VPN landing page(s)
 VPN_FIXED_MONTHLY_PRICE = 'US$4.99'
-VPN_VARIABLE_MONTHLY_PRICE = '9,99‎ €'
-VPN_VARIABLE_6_MONTH_PRICE = '6,99 €'
-VPN_VARIABLE_12_MONTH_PRICE = '4,99 €'
-VPN_VARIABLE_6_MONTH_PRICE_TOTAL = '41,94 €'
-VPN_VARIABLE_12_MONTH_PRICE_TOTAL = '59,88 €'
 
 # Mozilla VPN Geo restrictions
 # https://github.com/mozilla-services/guardian-website/blob/master/server/constants.ts

--- a/media/css/products/vpn/common.scss
+++ b/media/css/products/vpn/common.scss
@@ -13,13 +13,15 @@ $image-path: '/media/protocol/img';
 /* stylelint-disable declaration-no-important */
 
 // hide content that is only shown conditionally.
-.vpn-variable-pricing-block,
+.wave-1-fixed-pricing .vpn-variable-pricing-block,
+.wave-1-variable-pricing .vpn-fixed-pricing-block,
 .js-more-countries-coming-soon {
     display: none !important;
 }
 
-// if JS is enabled then hide fixed pricing content until we know to show it.
+// if JS is enabled then hide pricing content until we know to show it.
 .js .js-vpn-fixed-pricing,
+.js .vpn-variable-pricing-block,
 .js .vpn-fixed-pricing-block {
     display: none !important;
 }

--- a/media/css/products/vpn/components/block.scss
+++ b/media/css/products/vpn/components/block.scss
@@ -358,7 +358,7 @@ $image-path: '/media/protocol/img';
     .vpn-content-block-sub-heading {
         @include text-title-md;
 
-        span {
+        .js-vpn-monthly-price-display span {
             @include text-title-2xs;
             display: inline;
         }
@@ -414,7 +414,7 @@ $image-path: '/media/protocol/img';
             }
         }
 
-        .vpn-content-block-sub-heading span {
+        .vpn-content-block-sub-heading .js-vpn-monthly-price-display span {
             display: block;
             margin-top: $spacing-md;
         }
@@ -461,7 +461,7 @@ $image-path: '/media/protocol/img';
             }
         }
 
-        .vpn-content-block-sub-heading span {
+        .vpn-content-block-sub-heading .js-vpn-monthly-price-display span {
             display: inline;
         }
 

--- a/tests/functional/products/vpn/test_landing.py
+++ b/tests/functional/products/vpn/test_landing.py
@@ -7,6 +7,7 @@ import pytest
 from pages.products.vpn.landing import VPNLandingPage
 
 
+@pytest.mark.skip(reason='Skipped until variable pricing for wave 1 countries is enabled: issue 10199.')
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('country', [('us'), ('ca'), ('my'), ('nz'), ('sg'), ('gb')])
 def test_vpn_fixed_price_available_in_country(country, base_url, selenium):


### PR DESCRIPTION
## Description
- Enables variable pricing for VPN in wave 1 countries.
- Feature toggled via `SWITCH_VPN_VARIABLE_PRICING_WAVE_1=on`

## Issue / Bugzilla link
#10199

## Testing
Variable pricing should be shown in US$ for wave 1 countries (clicking "Get Mozilla VPN" should scroll to pricing section):

- [x] http://localhost:8000/en-US/products/vpn/?geo=us
- [x] http://localhost:8000/en-US/products/vpn/?geo=ca
- [x] http://localhost:8000/en-US/products/vpn/?geo=my
- [x] http://localhost:8000/en-US/products/vpn/?geo=nz
- [x] http://localhost:8000/en-US/products/vpn/?geo=sg
- [x] http://localhost:8000/en-US/products/vpn/?geo=gb

Variable pricing should be shown in Euros for wave 2 countries (clicking "Get Mozilla VPN" should scroll to pricing section):

- [x] http://localhost:8000/en-US/products/vpn/?geo=de
- [x] http://localhost:8000/en-US/products/vpn/?geo=fr

Waitlist should be displayed for countries where VPN is not yet available:

- [x] http://localhost:8000/en-US/products/vpn/?geo=es