### PR TITLE
VPN download-first experiment (Fixes #10209)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/footer-download-exp.html
+++ b/bedrock/products/templates/products/vpn/includes/footer-download-exp.html
@@ -1,0 +1,21 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "products/vpn/includes/macros.html" import vpn_content_block with context %}
+
+{% call vpn_content_block(
+  class_name='vpn-footer-subscribe'
+) %}
+  <div class="js-vpn-fixed-pricing">
+    <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="secondary">
+      {{ ftl('vpn-shared-subscribe-link') }}
+    </a>
+
+    <p class="guarantee-copy">
+      {{ ftl('vpn-shared-money-back-guarantee') }}
+    </p>
+  </div>
+
+  <div class="js-target-footer-cta"></div>
+{% endcall %}

--- a/bedrock/products/templates/products/vpn/includes/pricing-fixed.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-fixed.html
@@ -23,7 +23,7 @@
           optional_attributes={
             'data-cta-type': 'fxa-vpn',
             'data-cta-text': 'Get Mozilla VPN monthly',
-            'data-cta-position': 'secondary',
+            'data-cta-position': 'pricing',
           }
         ) }}
 

--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -38,7 +38,8 @@
       },
       optional_attributes={
         'data-cta-type': 'fxa-vpn',
-        'data-cta-text': 'Get Mozilla VPN 6-month'
+        'data-cta-text': 'Get Mozilla VPN 6-month',
+        'data-cta-position': 'pricing'
       }
     ) }}
 
@@ -64,7 +65,8 @@
        },
        optional_attributes={
          'data-cta-type': 'fxa-vpn',
-         'data-cta-text': 'Get Mozilla VPN 12-month'
+         'data-cta-text': 'Get Mozilla VPN 12-month',
+         'data-cta-position': 'pricing'
        }
      ) }}
 
@@ -90,7 +92,8 @@
        },
        optional_attributes={
          'data-cta-type': 'fxa-vpn',
-         'data-cta-text': 'Get Mozilla VPN monthly'
+         'data-cta-text': 'Get Mozilla VPN monthly',
+         'data-cta-position': 'pricing'
        }
      ) }}
 

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -18,7 +18,9 @@
 {% set _params = '?utm_source=' ~ _utm_source ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign %}
 
 {% block experiments %}
-  {% if switch('vpn-landing-page-sub-position-experiment') %}
+  {% if switch('vpn-landing-page-download-first-experiment') %}
+    {{ js_bundle('vpn-landing-page-download-first-experiment') }}
+  {% elif switch('vpn-landing-page-sub-position-experiment') %}
     {{ js_bundle('vpn-landing-page-sub-position-experiment') }}
   {% endif %}
 {% endblock %}
@@ -61,19 +63,21 @@
       desc=ftl('vpn-landing-hero-desc')
     ) %}
       <div class="js-vpn-fixed-pricing">
-        {{ vpn_subscribe_link(
-          entrypoint=_utm_source,
-          link_text=ftl('vpn-shared-subscribe-link'),
-          class_name='mzp-c-button mzp-t-xl ',
-          optional_parameters={
-            'utm_campaign': _utm_campaign
-          },
-          optional_attributes={
-            'data-cta-type': 'fxa-vpn',
-            'data-cta-text': 'Get Mozilla VPN monthly',
-            'data-cta-position': 'primary',
-          }
-        ) }}
+        {% block get_mozilla_vpn_hero %}
+          {{ vpn_subscribe_link(
+            entrypoint=_utm_source,
+            link_text=ftl('vpn-shared-subscribe-link'),
+            class_name='mzp-c-button mzp-t-xl ',
+            optional_parameters={
+              'utm_campaign': _utm_campaign
+            },
+            optional_attributes={
+              'data-cta-type': 'fxa-vpn',
+              'data-cta-text': 'Get Mozilla VPN monthly',
+              'data-cta-position': 'primary',
+            }
+          ) }}
+        {% endblock %}
 
         <p class="guarantee-copy">
           {{ ftl('vpn-shared-money-back-guarantee') }}
@@ -125,19 +129,21 @@
       <p>{{ ftl('vpn-shared-features-full-list-servers', url='https://mullvad.net/servers/', attrs='target="_blank" rel="external noopener noreferrer"') }}</p>
 
       <div class="js-vpn-fixed-pricing">
-        {{ vpn_subscribe_link(
-          entrypoint=_utm_source,
-          link_text=ftl('vpn-shared-subscribe-link'),
-          class_name='mzp-c-button mzp-t-xl',
-          optional_parameters={
-            'utm_campaign': _utm_campaign
-          },
-          optional_attributes={
-            'data-cta-type': 'fxa-vpn',
-            'data-cta-text': 'Get Mozilla VPN monthly',
-            'data-cta-position': 'secondary',
-          }
-        ) }}
+        {% block get_mozilla_vpn_connect %}
+          {{ vpn_subscribe_link(
+            entrypoint=_utm_source,
+            link_text=ftl('vpn-shared-subscribe-link'),
+            class_name='mzp-c-button mzp-t-xl',
+            optional_parameters={
+              'utm_campaign': _utm_campaign
+            },
+            optional_attributes={
+              'data-cta-type': 'fxa-vpn',
+              'data-cta-text': 'Get Mozilla VPN monthly',
+              'data-cta-position': 'secondary',
+            }
+          ) }}
+        {% endblock %}
 
         <p class="guarantee-copy">
           {{ ftl('vpn-shared-money-back-guarantee') }}
@@ -288,14 +294,18 @@
   </section>
 
   <footer class="vpn-footer mzp-l-content mzp-t-content-xl">
-    {% include 'products/vpn/includes/footer-subscribe.html' %}
+    {% block footer_subscribe %}
+      {% include 'products/vpn/includes/footer-subscribe.html' %}
+    {% endblock %}
     {% include 'products/vpn/includes/footer-legal.html' %}
   </footer>
 
 </main>
 
 {# HTML templates for common elements that are shown conditionally via JS #}
-{% include 'products/vpn/includes/templates.html' %}
+{% block templates %}
+  {% include 'products/vpn/includes/templates.html' %}
+{% endblock %}
 
 {% endblock %}
 

--- a/bedrock/products/templates/products/vpn/variants/download-a.html
+++ b/bedrock/products/templates/products/vpn/variants/download-a.html
@@ -1,0 +1,5 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}

--- a/bedrock/products/templates/products/vpn/variants/download-b.html
+++ b/bedrock/products/templates/products/vpn/variants/download-b.html
@@ -1,0 +1,67 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}
+
+{% block body_class %}mozilla-vpn-landing-download-first{% endblock %}
+
+{% macro vpn_nav_download(link_text, alt_link_text, sign_in_link_text, utm_source, utm_campaign) -%}
+  <div class="vpn-nav-cta">
+    <span class="js-vpn-fixed-pricing">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-md js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="navigation">
+        {{ link_text }}
+      </a>
+    </span>
+
+    <span class="js-target-navigation-cta"></span>
+
+    {{ vpn_sign_in_link(
+        entrypoint=utm_source,
+        link_text=sign_in_link_text,
+        class_name='mzp-c-cta-link',
+        optional_parameters={
+          'utm_campaign': utm_campaign
+        },
+        optional_attributes={
+          'data-cta-type': 'fxa-vpn',
+          'data-cta-text': 'VPN Sign In',
+          'data-cta-position': 'navigation',
+        }
+    ) }}
+  </div>
+{%- endmacro %}
+
+{% block site_header %}
+  {% with
+    custom_nav_cta=vpn_nav_download(
+      link_text=ftl('vpn-shared-subscribe-link'),
+      alt_link_text=ftl('vpn-shared-waitlist-link'),
+      sign_in_link_text=ftl('vpn-shared-sign-in-link'),
+      utm_source=_utm_source,
+      utm_campaign=_utm_campaign,
+    )
+  %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block get_mozilla_vpn_hero %}
+  <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="primary">
+    {{ ftl('vpn-shared-subscribe-link') }}
+  </a>
+{% endblock %}
+
+{% block get_mozilla_vpn_connect %}
+  <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="secondary">
+    {{ ftl('vpn-shared-subscribe-link') }}
+  </a>
+{% endblock %}
+
+{% block footer_subscribe %}
+  {% include 'products/vpn/includes/footer-download-exp.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('vpn-landing-page-download-first-geo-callback') }}
+{% endblock %}

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -22,6 +22,12 @@ def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optio
     if optional_attributes:
         attrs += ' '.join('%s="%s"' % (attr, val) for attr, val in optional_attributes.items())
 
+        # If there's a `data-cta-position` attribute for GA, also pass that as a query param to vpn.m.o.
+        position = optional_attributes.get('data-cta-position', None)
+
+        if position:
+            href += f'&data_cta_position={position}'
+
     if class_name:
         css_class += f' {class_name}'
 

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -61,10 +61,9 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=plan_FvnxS1j9oFUZ7Y'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
-            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary">'
-            u'Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
+            u'data-cta-type="fxa-vpn" data-cta-position="primary">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_12_month(self):
@@ -77,11 +76,10 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgwblJNcmPzuWtRynC7dqQa'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
-            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4">'
-            u'Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
+            u'data-cta-type="fxa-vpn" data-cta-position="primary" data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" '
+            u'data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_6_month(self):
@@ -94,11 +92,10 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgwaHJNcmPzuWtRuUfSR4l7'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
-            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV">'
-            u'Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
+            u'data-cta-type="fxa-vpn" data-cta-position="primary" data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" '
+            u'data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_monthly(self):
@@ -111,11 +108,10 @@ class TestVPNSubscribeLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgwZVJNcmPzuWtRg9Wssh2y'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
-            u'&utm_medium=referral&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
-            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb">'
-            u'Get Mozilla VPN</a>')
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" '
+            u'data-cta-type="fxa-vpn" data-cta-position="primary" data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" '
+            u'data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
 
@@ -139,7 +135,7 @@ class TestVPNSignInLink(TestCase):
         expected = (
             u'<a href="https://vpn.mozilla.org/oauth/init?entrypoint=www.mozilla.org-vpn-product-page'
             u'&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral'
-            u'&utm_campaign=vpn-product-page" data-action="https://accounts.firefox.com/" '
+            u'&utm_campaign=vpn-product-page&data_cta_position=navigation" data-action="https://accounts.firefox.com/" '
             u'class="js-fxa-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '
             u'data-cta-type="fxa-vpn" data-cta-position="navigation">Sign In</a>')
         self.assertEqual(markup, expected)

--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -101,7 +101,9 @@ class TestVPNLandingPage(TestCase):
         template = render_mock.call_args[0][1]
         assert template == 'products/vpn/landing.html'
 
-    def test_vpn_landing_page_variant_a_template(self, render_mock):
+    # start pricing position experiment tests
+
+    def test_vpn_landing_page_pricing_position_a_template(self, render_mock):
         req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=a')
         req.locale = 'en-US'
         view = views.vpn_landing_page
@@ -109,7 +111,7 @@ class TestVPNLandingPage(TestCase):
         template = render_mock.call_args[0][1]
         assert template == 'products/vpn/variants/pricing-a.html'
 
-    def test_vpn_landing_page_variant_b_template(self, render_mock):
+    def test_vpn_landing_page_pricing_position_b_template(self, render_mock):
         req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=b')
         req.locale = 'en-US'
         view = views.vpn_landing_page
@@ -117,10 +119,32 @@ class TestVPNLandingPage(TestCase):
         template = render_mock.call_args[0][1]
         assert template == 'products/vpn/variants/pricing-b.html'
 
-    def test_vpn_landing_page_variant_c_template(self, render_mock):
+    def test_vpn_landing_page_pricing_position_c_template(self, render_mock):
         req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-sub-position&entrypoint_variation=c')
         req.locale = 'en-US'
         view = views.vpn_landing_page
         view(req)
         template = render_mock.call_args[0][1]
         assert template == 'products/vpn/variants/pricing-c.html'
+
+    # end pricing position experiment tests
+
+    # start download first experiment tests
+
+    def test_vpn_landing_page_download_first_a_template(self, render_mock):
+        req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=a')
+        req.locale = 'en-US'
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == 'products/vpn/variants/download-a.html'
+
+    def test_vpn_landing_page_download_first_b_template(self, render_mock):
+        req = RequestFactory().get('/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=b')
+        req.locale = 'en-US'
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == 'products/vpn/variants/download-b.html'
+
+    # end download first experiment tests

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -33,13 +33,9 @@ def vpn_landing_page(request):
     entrypoint_variation = request.GET.get('entrypoint_variation', None)
 
     # ensure experiment parameters matches pre-defined values
-    if entrypoint_variation not in ['a', 'b', 'c']:
-        entrypoint_variation = None
-
-    if entrypoint_experiment != 'vpn-landing-page-sub-position':
-        entrypoint_variation = None
-
-    if entrypoint_experiment and entrypoint_variation:
+    if entrypoint_experiment == 'vpn-landing-page-download-first' and entrypoint_variation in ['a', 'b']:
+        template_name = 'products/vpn/variants/download-{}.html'.format(entrypoint_variation)
+    elif entrypoint_experiment == 'vpn-landing-page-sub-position' and entrypoint_variation in ['a', 'b', 'c']:
         template_name = 'products/vpn/variants/pricing-{}.html'.format(entrypoint_variation)
     else:
         template_name = 'products/vpn/landing.html'

--- a/media/css/products/vpn/common.scss
+++ b/media/css/products/vpn/common.scss
@@ -47,8 +47,27 @@ $image-path: '/media/protocol/img';
     }
 
     .vpn-fixed-pricing-block,
-    .js-vpn-pricing-fixed {
+    .js-vpn-fixed-pricing {
         display: none !important;
+    }
+}
+
+// VPN downlaod first experiment: issue 10209
+.mozilla-vpn-landing-download-first.show-vpn-variable-pricing {
+    // Hide the "scroll to pricing" CTA buttons
+    .js-vpn-variable-pricing,
+    .js-target-navigation-cta {
+        display: none !important;
+    }
+
+    // Display the default CTA buttons that have been replaced by direct
+    // download links in the treatment variation.
+    div.js-vpn-fixed-pricing {
+        display: block !important;
+    }
+
+    span.js-vpn-fixed-pricing {
+        display: inline-block !important;
     }
 }
 

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -26,9 +26,9 @@ if (typeof window.Mozilla === 'undefined') {
     ];
 
     var utms = ['utm_source', 'utm_campaign', 'utm_content', 'utm_term', 'utm_medium'];
-    var entrypointParams = ['entrypoint_experiment', 'entrypoint_variation'];
+    var fxaParams = ['device_id', 'flow_id', 'flow_begin_time', 'entrypoint_experiment', 'entrypoint_variation'];
     var sameSiteParams = ['source'];
-    var acceptedParams = utms.concat(entrypointParams, sameSiteParams);
+    var acceptedParams = utms.concat(fxaParams, sameSiteParams);
 
     /**
      * Returns the hostname for a given URL.
@@ -89,6 +89,27 @@ if (typeof window.Mozilla === 'undefined') {
             }
         }
 
+        /**
+         * This is a special-case for Issue 10209: VPN download-first experiment.
+         * As part of the flow for this experiment, the VPN Client will open /products/vpn/ with a set of FxA params in the page URL.
+         * Only if experiment params are present, then we pass FxA params through.
+         */
+        if (!Object.prototype.hasOwnProperty.call(finalParams, 'entrypoint_experiment') ||
+            !Object.prototype.hasOwnProperty.call(finalParams, 'entrypoint_variation')) {
+
+            if (Object.prototype.hasOwnProperty.call(finalParams, 'device_id')) {
+                delete finalParams['device_id'];
+            }
+
+            if (Object.prototype.hasOwnProperty.call(finalParams, 'flow_id')) {
+                delete finalParams['flow_id'];
+            }
+
+            if (Object.prototype.hasOwnProperty.call(finalParams, 'flow_begin_time')) {
+                delete finalParams['flow_begin_time'];
+            }
+        }
+
         // Both utm_source and utm_campaign are considered required, so only pass through referral data if they exist.
         // Alternatively, pass through entrypoint_experiment and entrypoint_variation independently.
         if ((Object.prototype.hasOwnProperty.call(finalParams, 'utm_source') && Object.prototype.hasOwnProperty.call(finalParams, 'utm_campaign')) ||
@@ -127,10 +148,10 @@ if (typeof window.Mozilla === 'undefined') {
             // In principle, experiments should never clobber eachother(!). However, if we have
             // new entrypoint_* parameters then assume they take precedence in the target URL.
             if (Object.prototype.hasOwnProperty.call(data, 'entrypoint_experiment') && Object.prototype.hasOwnProperty.call(data, 'entrypoint_variation')) {
-                for (var j = 0; j < entrypointParams.length; j++) {
-                    var entryPointParam = entrypointParams[j];
-                    if (Object.prototype.hasOwnProperty.call(linkParams, entryPointParam)) {
-                        delete linkParams[entryPointParam];
+                for (var j = 0; j < fxaParams.length; j++) {
+                    var fxaParam = fxaParams[j];
+                    if (Object.prototype.hasOwnProperty.call(linkParams, fxaParam)) {
+                        delete linkParams[fxaParam];
                     }
                 }
             }

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -102,10 +102,18 @@ if (typeof window.Mozilla === 'undefined') {
 
         // applies url to all buttons and adds cta position
         for (var i = 0; i < buttons.length; i++) {
-            var hostName = FxaProductButton.getHostName(buttons[i].href);
+            var href = buttons[i].href;
+            var hostName = FxaProductButton.getHostName(href);
             // check if link is in the FxA referral allowedListDomains.
             if (hostName && allowedList.indexOf(hostName) !== -1) {
-                buttons[i].href += flowParams;
+
+                // Only add flow params if they do not already exist.
+                if (href.indexOf('flow_id') === -1 &&
+                    href.indexOf('flow_begin_time') === -1 &&
+                    href.indexOf('device_id') === -1) {
+
+                    buttons[i].href += flowParams;
+                }
             }
         }
     };

--- a/media/js/products/vpn/download-first-experiment.js
+++ b/media/js/products/vpn/download-first-experiment.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    var href = window.location.href;
+
+    var initTrafficCop = function () {
+        if (href.indexOf('entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=') !== -1) {
+            if (href.indexOf('entrypoint_variation=a') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'a',
+                    'data-ex-name': 'vpn-landing-page-download-first'
+                });
+            } else if (href.indexOf('entrypoint_variation=b') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'b',
+                    'data-ex-name': 'vpn-landing-page-download-first'
+                });
+            }
+        } else {
+            var cop = new Mozilla.TrafficCop({
+                id: 'vpn-landing-page-sub-position-experiment',
+                variations: {
+                    'entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=a': 50,
+                    'entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=b': 50
+                }
+            });
+
+            cop.init();
+        }
+    };
+
+    // Avoid entering automated tests into random experiments.
+    // Experiment targets Windows and macOS only.
+    if (href.indexOf('automation=true') === -1 && window.site && (window.site.platform === 'windows' || window.site.platform === 'osx')) {
+        initTrafficCop();
+    }
+
+})(window.Mozilla);

--- a/media/js/products/vpn/download-first-geo-callback.js
+++ b/media/js/products/vpn/download-first-geo-callback.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+    'use strict';
+
+    window.Mozilla.VPN.onGeoReadyCallback = function(country) {
+
+        // Check that country code exists and meets ISO 2 char format.
+        if (country && (/^[A-Z]{2}$/i).test(country)) {
+
+            // Add country code to download URLs so experiment can differentiate clicks between countries.
+            var downloadLinks = document.querySelectorAll('.js-download-first-url');
+
+            for (var i = 0; i < downloadLinks.length; i++) {
+                var separator = downloadLinks[i].href.indexOf('?') > 0 ? '&' : '?';
+
+                downloadLinks[i].href += separator + 'geo=' + encodeURIComponent(country);
+            }
+        }
+    };
+
+})();

--- a/media/js/products/vpn/geo.js
+++ b/media/js/products/vpn/geo.js
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
 (function() {
     'use strict';
 
@@ -155,6 +159,11 @@
     VPN.showFixedPricing = function() {
         document.body.classList.add('show-vpn-fixed-pricing');
 
+        // support custom callback for geo-location check
+        if (typeof VPN.onGeoReadyCallback === 'function') {
+            VPN.onGeoReadyCallback(VPN.countryCode);
+        }
+
         // initiate FxA flow metrics after subscription URLs have been set.
         if (typeof Mozilla.FxaProductButton !== 'undefined') {
             Mozilla.FxaProductButton.init();
@@ -165,6 +174,11 @@
         document.body.classList.add('show-vpn-variable-pricing');
         VPN.renderScrollToPricingButtons();
         VPN.setSubscriptionButtons();
+
+        // support custom callback for geo-location check
+        if (typeof VPN.onGeoReadyCallback === 'function') {
+            VPN.onGeoReadyCallback(VPN.countryCode);
+        }
 
         // initiate FxA flow metrics after subscription URLs have been set.
         if (typeof Mozilla.FxaProductButton !== 'undefined') {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1555,6 +1555,22 @@
     },
     {
       "files": [
+        "js/base/mozilla-fxa-product-button.js",
+        "js/products/vpn/geo.js",
+        "js/products/vpn/download-first-geo-callback.js",
+        "js/products/vpn/landing.js"
+      ],
+      "name": "vpn-landing-page-download-first-geo-callback"
+    },
+    {
+      "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/products/vpn/download-first-experiment.js"
+      ],
+      "name": "vpn-landing-page-download-first-experiment"
+    },
+    {
+      "files": [
         "js/libs/mozilla-traffic-cop.js",
         "js/products/vpn/sub-position-experiment.js"
       ],

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -85,6 +85,59 @@ describe('fxa-utm-referral.js', function() {
             expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
         });
 
+        it('shoult return FxA flow params if present together with experiment entrypoint params'), function() {
+            var validObj = {
+                'utm_source': 'vpn-client',
+                'utm_content': 'download-first-experiment',
+                'utm_medium': 'referral',
+                'utm_term': 4242,
+                'utm_campaign': 'F100_4242_otherstuff_in_here',
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation',
+                'device_id': 123456789,
+                'flow_id': 987654321,
+                'flow_begin_time': 1234567899
+            };
+
+            var validData = {
+                'utm_source': 'vpn-client',
+                'utm_content': 'download-first-experiment',
+                'utm_medium': 'referral',
+                'utm_term': '4242',
+                'utm_campaign': 'F100_4242_otherstuff_in_here',
+                'entrypoint_experiment': 'test-id',
+                'entrypoint_variation': 'test-variation',
+                'device_id': '123456789',
+                'flow_id': '987654321',
+                'flow_begin_time': '1234567899'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
+        };
+
+        it('shoult not return FxA flow params if experiment entrypoint params are also not present', function() {
+            var validObj = {
+                'utm_source': 'desktop-snippet',
+                'utm_content': 'rel-esr',
+                'utm_medium': 'referral',
+                'utm_term': 4242,
+                'utm_campaign': 'F100_4242_otherstuff_in_here',
+                'device_id': 123456789,
+                'flow_id': 987654321,
+                'flow_begin_time': 1234567899
+            };
+
+            var validData = {
+                'utm_source': 'desktop-snippet',
+                'utm_content': 'rel-esr',
+                'utm_medium': 'referral',
+                'utm_term': '4242',
+                'utm_campaign': 'F100_4242_otherstuff_in_here'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(validObj)).toEqual(validData);
+        });
+
         it('should return entrypoint and utm params if supported source attribute is present', function() {
             var validObj1 = {
                 'source': 'whatsnew88'

--- a/tests/unit/spec/base/mozilla-fxa-product-button.js
+++ b/tests/unit/spec/base/mozilla-fxa-product-button.js
@@ -10,7 +10,8 @@ describe('mozilla-fxa-product-button.js', function() {
     beforeEach(function() {
         var button = '<a class="js-fxa-product-button" href="https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-action="https://accounts.firefox.com/" data-mozillaonline-link="https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign Up to Monitor</a>' +
                      '<a class="js-fxa-product-button" href="https://getpocket.com/ff_signup?s=ffwelcome2&amp;form_type=button&amp;entrypoint=mozilla.org-firefox-welcome-2&amp;utm_source=mozilla.org-firefox-welcome-2&amp;utm_campaign=welcome-2-pocket&amp;utm_medium=referral" data-action="https://accounts.firefox.com/">Activate Pocket</a>' +
-                     '<a class="js-fxa-product-button" href="https://www.mozilla.org/en-US/firefox/accounts/">Learn more</a>';
+                     '<a class="js-fxa-product-button" href="https://www.mozilla.org/en-US/firefox/accounts/">Learn more</a>' +
+                     '<a class="js-fxa-product-button" href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FiJ42WCzZNRSbS?plan=plan_FvPMH5lVx1vhV0&device_id=123456789&flow_begin_time=123456789&flow_id=123456789">Get Mozilla VPN</a>';
 
         var data = {
             'deviceId': '848377ff6e3e4fc982307a316f4ca3d6',
@@ -76,6 +77,20 @@ describe('mozilla-fxa-product-button.js', function() {
         return Mozilla.FxaProductButton.init().then(function() {
             var buttons = document.querySelectorAll('.js-fxa-product-button');
             expect(buttons[2].href).toEqual('https://www.mozilla.org/en-US/firefox/accounts/');
+        });
+    });
+
+    it('should not attach flow parameters if already present', function() {
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
+            callback({
+                'accurate': true,
+                'distribution': undefined,
+            });
+        });
+
+        return Mozilla.FxaProductButton.init().then(function() {
+            var buttons = document.querySelectorAll('.js-fxa-product-button');
+            expect(buttons[3].href).toEqual('https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FiJ42WCzZNRSbS?plan=plan_FvPMH5lVx1vhV0&device_id=123456789&flow_begin_time=123456789&flow_id=123456789');
         });
     });
 


### PR DESCRIPTION
## Description
Adds a "download first" experiment to the VPN landing page with two variations:
  - a) Control
  - b) "Get Mozilla VPN" buttons link directly to a client download page (`/vpn/download`). The pricing/subscription section of the page still links to regular FxA auth flow (`/vpn/subscribe`). 

Experiment targets Windows and macOS only.

To understand the full user flow, you can view the [figma file here](https://www.figma.com/file/Rvu8RsVhTksMs48b5pRlup/Mozilla-VPN---Download-Experiment-Flowchart?node-id=0%3A1).

## Issue / Bugzilla link
#10209

## Testing
**Demo URLs:**

- https://www-demo1.allizom.org/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=a (control)
- https://www-demo1.allizom.org/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=b (download first)

**Testing:**

Targeting:
- [x] Experiment should redirect to a variation when hitting http://localhost:8000/en-US/products/vpn/ (on mac/windows) in a browser with DNT disabled.

Control (US)
- [x] http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=a (verify "Get Mozilla VPN" buttons link to `/vpn/subscribe/`)

Control (DE)
- [x] http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=a&geo=de (verify clicking "Get Mozilla VPN" scrolls to pricing section, and pricing buttons link to `/vpn/subscribe/`)

Variation (US)
- [x] http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=b (verify "Get Mozilla VPN" buttons link to `/vpn/download/`, except link in pricing section which should still link to `/vpn/subscribe/`)

Variation (DE)
- [x] http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=b&geo=de (verify "Get Mozilla VPN" buttons link to `/vpn/download/`, except links in pricing section which should still link to `/vpn/subscribe/`)