### PR TITLE
Remove jQuery as a dependency from stub-attribution.js (Fixes #7524)

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -124,12 +124,14 @@
       <![endif]-->
     {% endblock %}
 
+    <!--[if !lte IE 7]><!-->
     {# Bug 1279291 #}
     {% block stub_attribution %}
       {% if settings.STUB_ATTRIBUTION_RATE %}
         {{ js_bundle('stub-attribution') }}
       {% endif %}
     {% endblock %}
+    <!--<![endif]-->
 
     <!--[if !IE]><!-->
     {% block js %}{% endblock %}


### PR DESCRIPTION
## Description
- Removes old jQuery calls from stub-attribution script.
- Prevent the script from running on IE6/7 via conditional comment.
- Add custom success / timeout callbacks that might be useful for https://github.com/mozilla/bedrock/issues/10207
- Update tests.

## Issue / Bugzilla link
#7524

## Testing
To test this use **Chrome on a Windows VM**:

1. Open https://www-demo2.allizom.org/en-US/?utm_source=test&utm_campaign=test
2. Click "Download Firefox" in the navigation on the top right.
3. Hold down the shift key and click the "Try downloading again" link to open the download URL in a new tab.
4. Copy the download URL using command + C
5. Open https://www.base64decode.org/
6. Paste the download link in the text field, and then remove everything except the value of the `attribution_code` param (this is the only bit we need to test).
7. Click "Decode".
8. Verify the following:
  - [x] Both `source` and `campaign` have the value `test`.
  - [x] The `ua` value should be `chrome` (assuming you tested in Chrome).
  - [x] The `visit_id` value should be a random number (your GA visit ID).
  - [x] Everything else should be `(not set)`.