### PR TITLE
Fix send-to-device JS error if there's no form in the template (#7673)

### DIFF
--- a/media/js/base/send-to-device.js
+++ b/media/js/base/send-to-device.js
@@ -20,6 +20,12 @@ if (typeof window.Mozilla === 'undefined') {
         this.formTimeout = null;
 
         this.widget = document.getElementById(this.formId);
+
+        // If there's no widget on the page, do nothing.
+        if (!this.widget) {
+            return;
+        }
+
         this.form = this.widget.querySelector('.send-to-device-form');
         this.formFields = this.form.querySelector('.send-to-device-form-fields');
         this.input = this.formFields.querySelector('.send-to-device-input');


### PR DESCRIPTION
## Description

Fixes https://sentry.prod.mozaws.net/operations/bedrock-prod/?query=is%3Aunresolved+this.widget+is+null

This error occurs because some locales don't have a send-to-device widget in the template, and the JS expects it to be there.

## Issue / Bugzilla link
#7673

## Testing
- [ ] http://localhost:8000/el/firefox/mobile/get-app/ should no longer throw a JS error
- [ ] http://localhost:8000/en-US/firefox/mobile/get-app/ should still have a functional send-to-device widget.