### PR TITLE
Add analytics params to VPN download experiment links (Fixes #10247)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/footer-download-exp.html
+++ b/bedrock/products/templates/products/vpn/includes/footer-download-exp.html
@@ -8,7 +8,7 @@
   class_name='vpn-footer-subscribe'
 ) %}
   <div class="js-vpn-fixed-pricing">
-    <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="secondary">
+    <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-fxa-product-button js-download-first-url" data-action="{{ settings.FXA_ENDPOINT }}" href="{{ settings.VPN_ENDPOINT }}vpn/download?{{ _download_params }}&data_cta_position=secondary" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="secondary">
       {{ ftl('vpn-shared-subscribe-link') }}
     </a>
 

--- a/bedrock/products/templates/products/vpn/variants/download-b.html
+++ b/bedrock/products/templates/products/vpn/variants/download-b.html
@@ -6,10 +6,12 @@
 
 {% block body_class %}mozilla-vpn-landing-download-first{% endblock %}
 
+{% set _download_params = 'entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page' %}
+
 {% macro vpn_nav_download(link_text, alt_link_text, sign_in_link_text, utm_source, utm_campaign) -%}
   <div class="vpn-nav-cta">
     <span class="js-vpn-fixed-pricing">
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="navigation">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-md js-fxa-cta-link js-fxa-product-button js-download-first-url" data-action="{{ settings.FXA_ENDPOINT }}" href="{{ settings.VPN_ENDPOINT }}vpn/download?{{ _download_params }}&data_cta_position=navigation" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="navigation">
         {{ link_text }}
       </a>
     </span>
@@ -47,19 +49,21 @@
 {% endblock %}
 
 {% block get_mozilla_vpn_hero %}
-  <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="primary">
+  <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-fxa-product-button js-download-first-url" data-action="{{ settings.FXA_ENDPOINT }}" href="{{ settings.VPN_ENDPOINT }}vpn/download?{{ _download_params }}&data_cta_position=primary" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="primary">
     {{ ftl('vpn-shared-subscribe-link') }}
   </a>
 {% endblock %}
 
 {% block get_mozilla_vpn_connect %}
-  <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-download-first-url" href="{{ settings.VPN_ENDPOINT }}vpn/download" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="secondary">
+  <a class="mzp-c-button mzp-t-xl js-fxa-cta-link js-fxa-product-button js-download-first-url" data-action="{{ settings.FXA_ENDPOINT }}" href="{{ settings.VPN_ENDPOINT }}vpn/download?{{ _download_params }}&data_cta_position=secondary" data-cta-type="button" data-cta-text="Download VPN Client" data-cta-position="secondary">
     {{ ftl('vpn-shared-subscribe-link') }}
   </a>
 {% endblock %}
 
 {% block footer_subscribe %}
-  {% include 'products/vpn/includes/footer-download-exp.html' %}
+  {% with _download_params = _download_params %}
+    {% include 'products/vpn/includes/footer-download-exp.html' %}
+  {% endwith %}
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
## Description
Adds default analytics params to variation b of download experiment.

http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-download-first&entrypoint_variation=b

## Issue / Bugzilla link
#10247

## Testing
Setup: make sure to set `FXA_ENDPOINT=https://stable.dev.lcip.org/` in your `.env`.

"Get Mozilla VPN" links that point to `vpn/download` should now also contain:
- [x] default utm parameters
- [x] `data_cta_position` param
- [x] fxa `device_id`, `flow_id` and `flow_begin_time` params.