### PR TITLE
Add locale `sco` per community request

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -84,6 +84,7 @@ locales = [
     "rm",
     "ro",
     "ru",
+    "sco",
     "si",
     "sk",
     "sl",


### PR DESCRIPTION
`sco` is for Scots, which is localized for Firefox and ready for Beta. There are links in the product that take users to mozilla.org.

## Description

## Issue / Bugzilla link

## Testing
