### PR TITLE
Fix legacy home page billboard spacing [fix #10273]

### DIFF
--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -22,7 +22,11 @@ $image-path: '/media/protocol/img';
 //* -------------------------------------------------------------------------- */
 // Billboard
 .mzp-c-billboard {
-    margin-top: 0;
+    margin-top: get-theme('v-grid-xl');
+
+    @media #{$mq-md} {
+        margin-top: 0;
+    }
 }
 
 // offset image override


### PR DESCRIPTION
## Description
The billboard has a negative top margin to create the "pop-out" effect on the dino image, but that was causing content overlap at smaller screen sizes. This compensates for that by adding some generous margin on the container.

## Issue / Bugzilla link
#10273 

## Testing
http://localhost:8000/es-ES/