### PR TITLE
AMO attribution experiment template (Fixes #10207)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/thanks-amo-exp.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks-amo-exp.html
@@ -1,0 +1,12 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/desktop/thanks.html" %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {{ js_bundle('firefox_new_pixel') }}
+  {% endif %}
+  {{ js_bundle('firefox_new_thanks_amo_exp') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -519,7 +519,27 @@ class TestFirefoxNew(TestCase):
             '/firefox/download/thanks/?scene=2&dude=abides'
         )
 
-    # yandex - issue 5635
+    # begin AMO experiment - issue 10207
+
+    @patch.dict(os.environ, SWITCH_NEW_REDESIGN='True')
+    def test_thanks_amo_experiment_en(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=amo')
+        req.locale = 'en-US'
+        view = views.DownloadThanksView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/new/desktop/thanks-amo-exp.html']
+
+    @patch.dict(os.environ, SWITCH_NEW_REDESIGN='True')
+    def test_thanks_amo_experiment_locales(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=amo')
+        req.locale = 'de'
+        view = views.DownloadThanksView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/new/desktop/thanks.html']
+
+    # begin yandex - issue 5635
 
     @patch.dict(os.environ, SWITCH_FIREFOX_YANDEX='True')
     def test_yandex_download(self, render_mock):
@@ -559,6 +579,8 @@ class TestFirefoxNew(TestCase):
         view(req)
         template = render_mock.call_args[0][1]
         assert template == ['firefox/new/desktop/download.html']
+
+    # end yandex - issue 5635
 
     @patch.dict(os.environ, EXP_CONFIG_FX_NEW='de:100')
     def test_experiment_redirect(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -684,6 +684,7 @@ class DownloadThanksView(L10nTemplateView):
     ftl_files_map = {
         'firefox/new/basic/thanks.html': ['firefox/new/download'],
         'firefox/new/desktop/thanks.html': ['firefox/new/desktop'],
+        'firefox/new/desktop/thanks-amo-exp.html': ['firefox/new/desktop'],
     }
     activation_files = [
         'firefox/new/download',
@@ -691,7 +692,7 @@ class DownloadThanksView(L10nTemplateView):
     ]
 
     # place expected ?v= values in this list
-    variations = ['a', 'b', 'c']
+    variations = []
 
     def get_context_data(self, **kwargs):
         ctx = super(DownloadThanksView, self).get_context_data(**kwargs)
@@ -707,9 +708,13 @@ class DownloadThanksView(L10nTemplateView):
 
     def get_template_names(self):
         experience = self.request.GET.get('xv', None)
+        locale = l10n_utils.get_locale(self.request)
 
         if ftl_file_is_active('firefox/new/desktop') and experience != 'basic':
-            template = 'firefox/new/desktop/thanks.html'
+            if locale == 'en-US' and experience == 'amo':
+                template = 'firefox/new/desktop/thanks-amo-exp.html'
+            else:
+                template = 'firefox/new/desktop/thanks.html'
         else:
             template = 'firefox/new/basic/thanks.html'
 

--- a/media/js/firefox/new/common/thanks-amo-exp.js
+++ b/media/js/firefox/new/common/thanks-amo-exp.js
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var timeout;
+    var requestComplete = false;
+
+    function beginFirefoxDownload() {
+        var directDownloadLink = document.getElementById('direct-download-link');
+        var downloadURL;
+
+        // Only auto-start the download if a supported platform is detected.
+        if (Mozilla.DownloadThanks.shouldAutoDownload(window.site.platform) && typeof Mozilla.Utils !== 'undefined') {
+            downloadURL = Mozilla.DownloadThanks.getDownloadURL(window.site);
+
+            if (downloadURL) {
+                // Pull download link from the download button and add to the 'Try downloading again' link.
+                // Make sure the 'Try downloading again' link is well formatted! (issue 9615)
+                if (directDownloadLink && directDownloadLink.href) {
+                    directDownloadLink.href = downloadURL;
+                }
+
+                // Start the platform-detected download a second after DOM ready event.
+                // We don't rely on the window load event as we have third-party tracking pixels.
+                Mozilla.Utils.onDocumentReady(function() {
+                    setTimeout(function() {
+                        window.location.href = downloadURL;
+                    }, 1000);
+                });
+            }
+        }
+    }
+
+    function onSuccess() {
+        // Make sure we only initiate the download once!
+        clearTimeout(timeout);
+        if (requestComplete) {
+            return;
+        }
+        requestComplete = true;
+
+        // Fire GA event to log attribution success
+        window.dataLayer.push({
+            'event': 'non-interaction',
+            'eAction': 'amo-exp-attribution',
+            'eLabel': 'success'
+        });
+
+        beginFirefoxDownload();
+    }
+
+    function onTimeout() {
+        // Make sure we only initiate the download once!
+        clearTimeout(timeout);
+        if (requestComplete) {
+            return;
+        }
+        requestComplete = true;
+
+        // Fire GA event to log attribution timeout
+        window.dataLayer.push({
+            'event': 'non-interaction',
+            'eAction': 'amo-exp-attribution',
+            'eLabel': 'timeout'
+        });
+
+        beginFirefoxDownload();
+    }
+
+    /**
+     * If visitor already has a cookie, or does not meet the typical requirements fo
+     * stub attribution, then we can start the download as normal. If requirements *are*
+     * met and the visitor does *not* have a cookie, then attempt to make the attribution
+     * call before starting the download.
+     */
+    if (typeof Mozilla.StubAttribution !== 'undefined' &&
+        Mozilla.StubAttribution.meetsRequirements() &&
+        !Mozilla.StubAttribution.hasCookie()) {
+
+        // Wait for GA to load so that we can pass along visit ID.
+        Mozilla.StubAttribution.waitForGoogleAnalytics(function() {
+            var data = Mozilla.StubAttribution.getAttributionData();
+
+            if (data && Mozilla.StubAttribution.withinAttributionRate()) {
+                Mozilla.StubAttribution.successCallback = onSuccess;
+                Mozilla.StubAttribution.timeoutCallback = onTimeout;
+                // We don't want to delay the download indefinitely for a stub attribution call,
+                // so we only wait up to an additional 2 seconds (on top of GA) before downloading.
+                timeout = setTimeout(onTimeout, 2000);
+                Mozilla.StubAttribution.requestAuthentication(data);
+            } else {
+                beginFirefoxDownload();
+            }
+        });
+    } else {
+        beginFirefoxDownload();
+    }
+
+    // Bug 1354334 - add a hint for test automation that page has loaded.
+    document.getElementsByTagName('html')[0].classList.add('download-ready');
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -993,6 +993,13 @@
     },
     {
       "files": [
+        "js/firefox/new/common/thanks.js",
+        "js/firefox/new/common/thanks-amo-exp.js"
+      ],
+      "name": "firefox_new_thanks_amo_exp"
+    },
+    {
+      "files": [
         "js/firefox/new/yandex/show-yandex.js",
         "js/firefox/new/yandex/show-yandex-init.js"
       ],


### PR DESCRIPTION
## Description
Adds an experiment template for the AMO team at the following URL:

http://localhost:8000/en-US/firefox/download/thanks/?xv=amo

This will help the AMO team understand the impact on installs if they link directly to `/download/thanks/` instead of `/firefox/new/` from AMO pages. The template contains some custom stub attribution logic that will delay the Firefox download (!) if someone lands on the page directly and does not already have a stub attribution cookie.

Obviously this is something we've been cautious about doing be default, but in the confines of an experiment we met and agreed the risk was low enough to test.

~**Note:** this PR relies on some logic added in https://github.com/mozilla/bedrock/pull/10216, so **please review that PR first**.~

## Issue / Bugzilla link
#10207

## Testing
This is up on demo2 for testing:

1.) On a Windows device/VM, open a **new Ingognito window** in Chrome.
2.) Open https://www-demo2.allizom.org/en-US/firefox/download/thanks/?xv=amo&utm_source=test&utm_campaign=test
3.) Wait for the Firefox download to being.
4.) Right click on the "Try downloading again" link and select "copy link address".
5.) Paste the link somewhere so you can inspect it.

The link should contain the following params:
- [x] `attribution_code`
- [x] `attribution_sig`