### PR TITLE
Issue #10287: Do not show Developer section in release notes for dot releases

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -231,8 +231,14 @@
         {% endif %}
       {% endfor %}
 
-      {# The Developer section is always visible with a MDN link #}
+      {# The Developer section is always visible with a MDN link except for dot releases #}
+      {% set dot_release = release.channel == 'Release' and release.version_obj|string != release.major_version + '.0' -%}
+      {% set devtools_notes = release_notes|selectattr('tag', 'equalto', 'Developer')|list|length > 1 %}
+
       {% for note in release_notes if note.tag == "Developer" %}
+        {% if dot_release and not devtools_notes %}
+          {% continue %}
+        {% endif %}
         {% if loop.first %}
           <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
             <div class="mzp-l-sidebar">


### PR DESCRIPTION
## Description
- Do not display the Developer section for dot releases on the Release channel
- Keep displaying it on other release notes (major release, beta, nightly, esr)
- Display the Developer section for a dot release if one of the fixes included has a note tagged with `Developer` in nucleus

## Issue / Bugzilla link
Issue #10287

## Testing
These release notes should have a Developer section:
- https://www.mozilla.org/en-US/firefox/89.0/releasenotes/ 
- https://www.mozilla.org/en-US/firefox/beta/notes/
- https://www.mozilla.org/en-US/firefox/nightly/notes/
- https://www.mozilla.org/en-US/firefox/78.10.0/releasenotes/

Most dot releases shouldn't have a developer section:
- https://www.mozilla.org/en-US/firefox/85.0.2/releasenotes/

Only dot releases with a note which has the Developer tag should have a Developer section;
- https://www.mozilla.org/en-US/firefox/65.0.1/releasenotes/