### PR TITLE
Enable new EU countries on VPN landing page (Fixes #10280)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/templates.html
+++ b/bedrock/products/templates/products/vpn/includes/templates.html
@@ -11,7 +11,11 @@
       </a>
 
       <p class="availability-copy">
-        {{ ftl('vpn-shared-available-countries-v2') }}
+        {% if switch('vpn-variable-pricing-eu-expansion') %}
+          {{ ftl('vpn-shared-available-countries-v3') }}
+        {% else %}
+          {{ ftl('vpn-shared-available-countries-v2') }}
+        {% endif %}
       </p>
     </div>
   </div>

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -20,7 +20,7 @@
 {% set _params = '?utm_source=' ~ _utm_source ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign %}
 
 {% block experiments %}
-  {% if switch('vpn-landing-page-sub-position-experiment') and not switch('vpn-variable-pricing-wave-1') %}
+  {% if switch('vpn-landing-page-sub-position-experiment') and not switch('vpn-variable-pricing-wave-1') and not switch('vpn-variable-pricing-eu-expansion') %}
     {{ js_bundle('vpn-landing-page-sub-position-experiment') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -80,13 +80,19 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, plan=None, class_name=None, l
     if plan in ['12-month', '6-month', 'monthly']:
 
         # Set a default plan ID using page locale. This acts as a fallback should geo-location fail.
-        pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
-        plan_default = pricing_params[plan]['id']
+        cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
+        default_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+        plan_default = default_params['default'][plan]['id']
         plan_attributes = {}
 
         # HTML data-attributes are used by client side JS to set the correct plan ID based on geo.
         for country, attrs in settings.VPN_VARIABLE_PRICING.items():
-            plan_attributes.update({f'data-plan-{country}': attrs[plan]['id']})
+            if 'alt' in attrs and cc in attrs['alt']:
+                plan_id = attrs['alt'][cc][plan]['id']
+            else:
+                plan_id = attrs['default'][plan]['id']
+
+            plan_attributes.update({f'data-plan-{country}': plan_id})
 
     # All other subscription links default to fixed monthly pricing in $US.
     else:
@@ -117,16 +123,19 @@ def vpn_monthly_price(ctx, plan='monthly', lang=None):
         {{ vpn_monthly_price(plan='12-month') }}
     """
 
-    pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
-    default_amount = pricing_params[plan]['price']
-    euro_amount = settings.VPN_VARIABLE_PRICING['de'][plan]['price']
-    usd_amount = settings.VPN_VARIABLE_PRICING['us'][plan]['price']
+    cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
+    default_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+    default_amount = default_params['default'][plan]['price']
+    euro_amount = settings.VPN_VARIABLE_PRICING['de']['default'][plan]['price']
+    usd_amount = settings.VPN_VARIABLE_PRICING['us']['default'][plan]['price']
+    chf_amount = settings.VPN_VARIABLE_PRICING['ch']['default'][plan]['price']
     default_text = ftl('vpn-shared-pricing-monthly', amount=default_amount, ftl_files=FTL_FILES)
 
     # HTML data-attributes are used by client side JS to set the correct display price based on geo.
     attributes = {
         'data-price-usd': ftl('vpn-shared-pricing-monthly', amount=usd_amount, ftl_files=FTL_FILES),
         'data-price-euro': ftl('vpn-shared-pricing-monthly', amount=euro_amount, ftl_files=FTL_FILES),
+        'data-price-chf': ftl('vpn-shared-pricing-monthly', amount=chf_amount, ftl_files=FTL_FILES),
     }
 
     attrs = ' '.join('%s="%s"' % (attr, val) for attr, val in attributes.items())
@@ -153,16 +162,19 @@ def vpn_total_price(ctx, plan='12-month', lang=None):
         {{ vpn_total_price(plan='6-month') }}
     """
 
-    pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
-    default_amount = pricing_params[plan]['total']
-    euro_amount = settings.VPN_VARIABLE_PRICING['de'][plan]['total']
-    usd_amount = settings.VPN_VARIABLE_PRICING['us'][plan]['total']
+    cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
+    pricing_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+    default_amount = pricing_params['default'][plan]['total']
+    euro_amount = settings.VPN_VARIABLE_PRICING['de']['default'][plan]['total']
+    usd_amount = settings.VPN_VARIABLE_PRICING['us']['default'][plan]['total']
+    chf_amount = settings.VPN_VARIABLE_PRICING['ch']['default'][plan]['total']
     default_text = ftl('vpn-shared-pricing-total', amount=default_amount, ftl_files=FTL_FILES)
 
     # HTML data-attributes are used by client side JS to set the correct display price based on geo.
     attributes = {
         'data-price-usd': ftl('vpn-shared-pricing-total', amount=usd_amount, ftl_files=FTL_FILES),
         'data-price-euro': ftl('vpn-shared-pricing-total', amount=euro_amount, ftl_files=FTL_FILES),
+        'data-price-chf': ftl('vpn-shared-pricing-total', amount=chf_amount, ftl_files=FTL_FILES),
     }
 
     attrs = ' '.join('%s="%s"' % (attr, val) for attr, val in attributes.items())
@@ -189,16 +201,19 @@ def vpn_saving(ctx, plan='12-month', lang=None):
         {{ vpn_saving(plan='6-month') }}
     """
 
-    pricing_params = settings.VPN_VARIABLE_PRICING.get(lang, settings.VPN_VARIABLE_PRICING['us'])
-    default_amount = pricing_params[plan]['saving']
-    euro_amount = settings.VPN_VARIABLE_PRICING['de'][plan]['saving']
-    usd_amount = settings.VPN_VARIABLE_PRICING['us'][plan]['saving']
+    cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
+    pricing_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+    default_amount = pricing_params['default'][plan]['saving']
+    euro_amount = settings.VPN_VARIABLE_PRICING['de']['default'][plan]['saving']
+    usd_amount = settings.VPN_VARIABLE_PRICING['us']['default'][plan]['saving']
+    chf_amount = settings.VPN_VARIABLE_PRICING['ch']['default'][plan]['saving']
     default_text = ftl('vpn-shared-pricing-save-percent', percent=default_amount, ftl_files=FTL_FILES)
 
     # HTML data-attributes are used by client side JS to set the correct saving based on geo.
     attributes = {
         'data-price-usd': ftl('vpn-shared-pricing-save-percent', percent=usd_amount, ftl_files=FTL_FILES),
         'data-price-euro': ftl('vpn-shared-pricing-save-percent', percent=euro_amount, ftl_files=FTL_FILES),
+        'data-price-chf': ftl('vpn-shared-pricing-save-percent', percent=chf_amount, ftl_files=FTL_FILES),
     }
 
     attrs = ' '.join('%s="%s"' % (attr, val) for attr, val in attributes.items())

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -42,6 +42,19 @@ def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optio
     return jinja2.Markup(markup)
 
 
+def get_cc(lang):
+    cc = lang.split('-')[1] if lang and '-' in lang else lang
+    cc = cc.lower() if cc else cc
+    return cc
+
+
+def get_default_params(lang):
+    cc = get_cc(lang)
+
+    # Default to US pricing if no matching country/lang code is found.
+    return settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+
+
 @library.global_function
 @jinja2.contextfunction
 def vpn_sign_in_link(ctx, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
@@ -80,8 +93,8 @@ def vpn_subscribe_link(ctx, entrypoint, link_text, plan=None, class_name=None, l
     if plan in ['12-month', '6-month', 'monthly']:
 
         # Set a default plan ID using page locale. This acts as a fallback should geo-location fail.
-        cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
-        default_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+        default_params = get_default_params(lang)
+        cc = get_cc(lang)
         plan_default = default_params['default'][plan]['id']
         plan_attributes = {}
 
@@ -123,8 +136,7 @@ def vpn_monthly_price(ctx, plan='monthly', lang=None):
         {{ vpn_monthly_price(plan='12-month') }}
     """
 
-    cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
-    default_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+    default_params = get_default_params(lang)
     default_amount = default_params['default'][plan]['price']
     euro_amount = settings.VPN_VARIABLE_PRICING['de']['default'][plan]['price']
     usd_amount = settings.VPN_VARIABLE_PRICING['us']['default'][plan]['price']
@@ -162,8 +174,7 @@ def vpn_total_price(ctx, plan='12-month', lang=None):
         {{ vpn_total_price(plan='6-month') }}
     """
 
-    cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
-    pricing_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+    pricing_params = get_default_params(lang)
     default_amount = pricing_params['default'][plan]['total']
     euro_amount = settings.VPN_VARIABLE_PRICING['de']['default'][plan]['total']
     usd_amount = settings.VPN_VARIABLE_PRICING['us']['default'][plan]['total']
@@ -201,8 +212,7 @@ def vpn_saving(ctx, plan='12-month', lang=None):
         {{ vpn_saving(plan='6-month') }}
     """
 
-    cc = lang.split('-')[1].lower() if lang and '-' in lang else lang
-    pricing_params = settings.VPN_VARIABLE_PRICING.get(cc, settings.VPN_VARIABLE_PRICING['us'])
+    pricing_params = get_default_params(lang)
     default_amount = pricing_params['default'][plan]['saving']
     euro_amount = settings.VPN_VARIABLE_PRICING['de']['default'][plan]['saving']
     usd_amount = settings.VPN_VARIABLE_PRICING['us']['default'][plan]['saving']

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -20,19 +20,19 @@ TEST_VPN_PLAN_ID_MATRIX = {
         'de': {
             '12-month': {
                 'id': 'price_1J5JssJNcmPzuWtR616BH4aU',
-                'price': u'Fr. 4.99',
-                'total': u'Fr. 59.88',
-                'saving': 50
+                'price': u'5.99 CHF',
+                'total': u'71.88 CHF',
+                'saving': 45
             },
             '6-month': {
                 'id': 'price_1J5JtWJNcmPzuWtRMd2siphH',
-                'price': u'Fr. 6.99',
-                'total': u'Fr. 41.94',
-                'saving': 30
+                'price': u'7.99 CHF',
+                'total': u'47.94 CHF',
+                'saving': 27
             },
             'monthly': {
                 'id': 'price_1J5Ju3JNcmPzuWtR3GpNYSWj',
-                'price': u'Fr. 9.99',
+                'price': u'10.99 CHF',
                 'total': None,
                 'saving': None
             }
@@ -40,19 +40,19 @@ TEST_VPN_PLAN_ID_MATRIX = {
         'fr': {
             '12-month': {
                 'id': 'price_1J5JunJNcmPzuWtRo9dLxn6M',
-                'price': u'Fr. 4.99',
-                'total': u'Fr. 59.88',
-                'saving': 50
+                'price': u'5.99 CHF',
+                'total': u'71.88 CHF',
+                'saving': 45
             },
             '6-month': {
                 'id': 'price_1J5JvLJNcmPzuWtRayB4d7Ij',
-                'price': u'Fr. 6.99',
-                'total': u'Fr. 41.94',
-                'saving': 30
+                'price': u'7.99 CHF',
+                'total': u'47.94 CHF',
+                'saving': 27
             },
             'monthly': {
                 'id': 'price_1J5JvjJNcmPzuWtR3wwy1dcR',
-                'price': u'Fr. 9.99',
+                'price': u'10.99 CHF',
                 'total': None,
                 'saving': None
             }
@@ -60,19 +60,19 @@ TEST_VPN_PLAN_ID_MATRIX = {
         'it': {
             '12-month': {
                 'id': 'price_1J5JwWJNcmPzuWtRgrx5fjOc',
-                'price': u'Fr. 4.99',
-                'total': u'Fr. 59.88',
-                'saving': 50
+                'price': u'5.99 CHF',
+                'total': u'71.88 CHF',
+                'saving': 45
             },
             '6-month': {
                 'id': 'price_1J5JwvJNcmPzuWtRH2HuhWM5',
-                'price': u'Fr. 6.99',
-                'total': u'Fr. 41.94',
-                'saving': 30
+                'price': u'7.99 CHF',
+                'total': u'47.94 CHF',
+                'saving': 27
             },
             'monthly': {
                 'id': 'price_1J5JxGJNcmPzuWtRrp5e1SUB',
-                'price': u'Fr. 9.99',
+                'price': u'10.99 CHF',
                 'total': None,
                 'saving': None
             }
@@ -488,7 +488,7 @@ class TestVPNMonthlyPrice(TestCase):
         markup = self._render(plan='monthly')
         expected = (
             u'<span class="js-vpn-monthly-price-display" data-price-usd="US$9.99<span>/month</span>" '
-            u'data-price-euro="9,99‎ €<span>/month</span>" data-price-chf="Fr. 9.99<span>/month</span>">'
+            u'data-price-euro="9,99‎ €<span>/month</span>" data-price-chf="10.99 CHF<span>/month</span>">'
             u'US$9.99<span>/month</span></span>')
         self.assertEqual(markup, expected)
 
@@ -497,7 +497,7 @@ class TestVPNMonthlyPrice(TestCase):
         markup = self._render(plan='6-month')
         expected = (
             u'<span class="js-vpn-monthly-price-display" data-price-usd="US$7.99<span>/month</span>" '
-            u'data-price-euro="6,99 €<span>/month</span>" data-price-chf="Fr. 6.99<span>/month</span>">'
+            u'data-price-euro="6,99 €<span>/month</span>" data-price-chf="7.99 CHF<span>/month</span>">'
             u'US$7.99<span>/month</span></span>')
         self.assertEqual(markup, expected)
 
@@ -506,7 +506,7 @@ class TestVPNMonthlyPrice(TestCase):
         markup = self._render(plan='12-month')
         expected = (
             u'<span class="js-vpn-monthly-price-display" data-price-usd="US$4.99<span>/month</span>" '
-            u'data-price-euro="4,99 €<span>/month</span>" data-price-chf="Fr. 4.99<span>/month</span>">'
+            u'data-price-euro="4,99 €<span>/month</span>" data-price-chf="5.99 CHF<span>/month</span>">'
             u'US$4.99<span>/month</span></span>')
         self.assertEqual(markup, expected)
 
@@ -525,7 +525,7 @@ class TestVPNTotalPrice(TestCase):
         markup = self._render(plan='6-month')
         expected = (
             u'<span class="js-vpn-total-price-display" data-price-usd="US$47.94 total" '
-            u'data-price-euro="41,94 € total" data-price-chf="Fr. 41.94 total">US$47.94 total</span>')
+            u'data-price-euro="41,94 € total" data-price-chf="47.94 CHF total">US$47.94 total</span>')
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_total_price(self):
@@ -533,7 +533,7 @@ class TestVPNTotalPrice(TestCase):
         markup = self._render(plan='12-month')
         expected = (
             u'<span class="js-vpn-total-price-display" data-price-usd="US$59.88 total" '
-            u'data-price-euro="59,88 € total" data-price-chf="Fr. 59.88 total">US$59.88 total</span>')
+            u'data-price-euro="59,88 € total" data-price-chf="71.88 CHF total">US$59.88 total</span>')
         self.assertEqual(markup, expected)
 
 
@@ -551,7 +551,7 @@ class TestVPNSaving(TestCase):
         markup = self._render(plan='6-month')
         expected = (
             u'<span class="js-vpn-saving-display" data-price-usd="Save 20%" '
-            u'data-price-euro="Save 30%" data-price-chf="Save 30%">Save 20%</span>')
+            u'data-price-euro="Save 30%" data-price-chf="Save 27%">Save 20%</span>')
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_saving(self):
@@ -559,5 +559,5 @@ class TestVPNSaving(TestCase):
         markup = self._render(plan='12-month')
         expected = (
             u'<span class="js-vpn-saving-display" data-price-usd="Save 50%" '
-            u'data-price-euro="Save 50%" data-price-chf="Save 50%">Save 50%</span>')
+            u'data-price-euro="Save 50%" data-price-chf="Save 45%">Save 50%</span>')
         self.assertEqual(markup, expected)

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -14,57 +14,227 @@ TEST_FXA_ENDPOINT = 'https://accounts.firefox.com/'
 TEST_VPN_ENDPOINT = 'https://vpn.mozilla.org/'
 TEST_VPN_PRODUCT_ID = 'prod_FvnsFHIfezy3ZI'
 TEST_VPN_FIXED_PRICE_MONTHLY_USD = 'plan_FvnxS1j9oFUZ7Y'
-TEST_VPN_VARIABLE_PRICING = {
-    'de': {
-        '12-month': {
-            'id': 'price_1IgwblJNcmPzuWtRynC7dqQa',
-            'price': '4,99 €',
-            'total': '59,88 €'
+
+TEST_VPN_PLAN_ID_MATRIX = {
+    'chf': {
+        'de': {
+            '12-month': {
+                'id': 'price_1J5JssJNcmPzuWtR616BH4aU',
+                'price': u'Fr. 4.99',
+                'total': u'Fr. 59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J5JtWJNcmPzuWtRMd2siphH',
+                'price': u'Fr. 6.99',
+                'total': u'Fr. 41.94',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J5Ju3JNcmPzuWtR3GpNYSWj',
+                'price': u'Fr. 9.99',
+                'total': None,
+                'saving': None
+            }
         },
-        '6-month': {
-            'id': 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
-            'price': '6,99 €',
-            'total': '41,94 €'
+        'fr': {
+            '12-month': {
+                'id': 'price_1J5JunJNcmPzuWtRo9dLxn6M',
+                'price': u'Fr. 4.99',
+                'total': u'Fr. 59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J5JvLJNcmPzuWtRayB4d7Ij',
+                'price': u'Fr. 6.99',
+                'total': u'Fr. 41.94',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J5JvjJNcmPzuWtR3wwy1dcR',
+                'price': u'Fr. 9.99',
+                'total': None,
+                'saving': None
+            }
         },
-        'monthly': {
-            'id': 'price_1IgwZVJNcmPzuWtRg9Wssh2y',
-            'price': '9,99‎ €',
-            'total': None
+        'it': {
+            '12-month': {
+                'id': 'price_1J5JwWJNcmPzuWtRgrx5fjOc',
+                'price': u'Fr. 4.99',
+                'total': u'Fr. 59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J5JwvJNcmPzuWtRH2HuhWM5',
+                'price': u'Fr. 6.99',
+                'total': u'Fr. 41.94',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J5JxGJNcmPzuWtRrp5e1SUB',
+                'price': u'Fr. 9.99',
+                'total': None,
+                'saving': None
+            }
         }
+    },
+    'euro': {
+        'de': {
+            '12-month': {
+                'id': 'price_1IgwblJNcmPzuWtRynC7dqQa',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1IgwZVJNcmPzuWtRg9Wssh2y',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'es': {
+            '12-month': {
+                'id': 'price_1J5JCdJNcmPzuWtRrvQMFLlP',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J5JDFJNcmPzuWtRrC4IeXTs',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J5JDgJNcmPzuWtRqQtIbktk',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'fr': {
+            '12-month': {
+                'id': 'price_1IgnlcJNcmPzuWtRjrNa39W4',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1IgoxGJNcmPzuWtRG7l48EoV',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1IgowHJNcmPzuWtRzD7SgAYb',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'it': {
+            '12-month': {
+                'id': 'price_1J4owvJNcmPzuWtRomVhWQFq',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J5J7eJNcmPzuWtRKdQi4Tkk',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J5J6iJNcmPzuWtRK5zfoguV',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'nl': {
+            '12-month': {
+                'id': 'price_1J5JRGJNcmPzuWtRXwXA84cm',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J5JRmJNcmPzuWtRyFGj0tkN',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J5JSkJNcmPzuWtR54LPH2zi',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        }
+    },
+    'usd': {
+        'en': {
+            '12-month': {
+                'id': 'price_1Iw85dJNcmPzuWtRyhMDdtM7',
+                'price': u'US$4.99',
+                'total': u'US$59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1Iw87cJNcmPzuWtRefuyqsOd',
+                'price': u'US$7.99',
+                'total': u'US$47.94',
+                'saving': 20
+            },
+            'monthly': {
+                'id': 'price_1Iw7qSJNcmPzuWtRMUZpOwLm',
+                'price': u'US$9.99',
+                'total': None,
+                'saving': None
+            }
+        }
+    }
+}
+
+TEST_VPN_VARIABLE_PRICING = {
+    'at': {
+        'default': TEST_VPN_PLAN_ID_MATRIX['euro']['de'],
+    },
+    'be': {
+        'default': TEST_VPN_PLAN_ID_MATRIX['euro']['nl'],
+        'alt': {
+            'fr': TEST_VPN_PLAN_ID_MATRIX['euro']['fr'],
+        }
+    },
+    'ch': {
+        'default': TEST_VPN_PLAN_ID_MATRIX['chf']['de'],
+        'alt': {
+            'fr': TEST_VPN_PLAN_ID_MATRIX['chf']['fr'],
+            'it': TEST_VPN_PLAN_ID_MATRIX['chf']['it'],
+        }
+    },
+    'de': {
+        'default': TEST_VPN_PLAN_ID_MATRIX['euro']['de'],
+    },
+    'es': {
+        'default': TEST_VPN_PLAN_ID_MATRIX['euro']['es'],
     },
     'fr': {
-        '12-month': {
-            'id': 'price_1IgnlcJNcmPzuWtRjrNa39W4',
-            'price': '4,99 €',
-            'total': '59,88 €'
-        },
-        '6-month': {
-            'id': 'price_1IgoxGJNcmPzuWtRG7l48EoV',
-            'price': '6,99 €',
-            'total': '41,94 €'
-        },
-        'monthly': {
-            'id': 'price_1IgowHJNcmPzuWtRzD7SgAYb',
-            'price': '9,99‎ €',
-            'total': None
-        }
+        'default': TEST_VPN_PLAN_ID_MATRIX['euro']['fr'],
+    },
+    'it': {
+        'default': TEST_VPN_PLAN_ID_MATRIX['euro']['it'],
     },
     'us': {
-        '12-month': {
-            'id': 'price_1Iw85dJNcmPzuWtRyhMDdtM7',
-            'price': 'TBD',
-            'total': 'TBD'
-        },
-        '6-month': {
-            'id': 'price_1Iw87cJNcmPzuWtRefuyqsOd',
-            'price': 'TBD',
-            'total': 'TBD'
-        },
-        'monthly': {
-            'id': 'price_1Iw7qSJNcmPzuWtRMUZpOwLm',
-            'price': 'TBD',
-            'total': None
-        }
+        'default': TEST_VPN_PLAN_ID_MATRIX['usd']['en'],
     }
 }
 
@@ -120,8 +290,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
-            u'data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-be="price_1J5JRGJNcmPzuWtRXwXA84cm" '
+            u'data-plan-ch="price_1J5JssJNcmPzuWtR616BH4aU" data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" '
+            u'data-plan-es="price_1J5JCdJNcmPzuWtRrvQMFLlP" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-it="price_1J4owvJNcmPzuWtRomVhWQFq" data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_6_month_en(self):
@@ -137,8 +309,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
-            u'data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-be="price_1J5JRmJNcmPzuWtRyFGj0tkN" '
+            u'data-plan-ch="price_1J5JtWJNcmPzuWtRMd2siphH" data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" '
+            u'data-plan-es="price_1J5JDFJNcmPzuWtRrC4IeXTs" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-it="price_1J5J7eJNcmPzuWtRKdQi4Tkk" data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_monthly_en(self):
@@ -154,8 +328,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
-            u'data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-be="price_1J5JSkJNcmPzuWtR54LPH2zi" '
+            u'data-plan-ch="price_1J5Ju3JNcmPzuWtR3GpNYSWj" data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" '
+            u'data-plan-es="price_1J5JDgJNcmPzuWtRqQtIbktk" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-it="price_1J5J6iJNcmPzuWtRK5zfoguV" data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_12_month_de(self):
@@ -171,8 +347,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
-            u'data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-be="price_1J5JRGJNcmPzuWtRXwXA84cm" '
+            u'data-plan-ch="price_1J5JssJNcmPzuWtR616BH4aU" data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" '
+            u'data-plan-es="price_1J5JCdJNcmPzuWtRrvQMFLlP" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-it="price_1J4owvJNcmPzuWtRomVhWQFq" data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_6_month_de(self):
@@ -188,8 +366,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
-            u'data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-be="price_1J5JRmJNcmPzuWtRyFGj0tkN" '
+            u'data-plan-ch="price_1J5JtWJNcmPzuWtRMd2siphH" data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" '
+            u'data-plan-es="price_1J5JDFJNcmPzuWtRrC4IeXTs" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-it="price_1J5J7eJNcmPzuWtRKdQi4Tkk" data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_monthly_de(self):
@@ -205,8 +385,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
-            u'data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-be="price_1J5JSkJNcmPzuWtR54LPH2zi" '
+            u'data-plan-ch="price_1J5Ju3JNcmPzuWtR3GpNYSWj" data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" '
+            u'data-plan-es="price_1J5JDgJNcmPzuWtRqQtIbktk" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-it="price_1J5J6iJNcmPzuWtRK5zfoguV" data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_12_month_fr(self):
@@ -222,8 +404,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
-            u'data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-be="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-ch="price_1J5JunJNcmPzuWtRo9dLxn6M" data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" '
+            u'data-plan-es="price_1J5JCdJNcmPzuWtRrvQMFLlP" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-it="price_1J4owvJNcmPzuWtRomVhWQFq" data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_6_month_fr(self):
@@ -237,10 +421,11 @@ class TestVPNSubscribeLink(TestCase):
             u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1IgoxGJNcmPzuWtRG7l48EoV'
             u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
-            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
-            u'data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" '
+            u'data-cta-position="primary" data-plan-at="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-be="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-ch="price_1J5JvLJNcmPzuWtRayB4d7Ij" data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" '
+            u'data-plan-es="price_1J5JDFJNcmPzuWtRrC4IeXTs" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-it="price_1J5J7eJNcmPzuWtRKdQi4Tkk" data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
     def test_vpn_subscribe_link_variable_monthly_fr(self):
@@ -256,8 +441,10 @@ class TestVPNSubscribeLink(TestCase):
             u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
             u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
-            u'data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
-            u'data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
+            u'data-plan-at="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-be="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-ch="price_1J5JvjJNcmPzuWtR3wwy1dcR" data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" '
+            u'data-plan-es="price_1J5JDgJNcmPzuWtRqQtIbktk" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-it="price_1J5J6iJNcmPzuWtRK5zfoguV" data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
 
@@ -287,6 +474,7 @@ class TestVPNSignInLink(TestCase):
         self.assertEqual(markup, expected)
 
 
+@override_settings(VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING)
 class TestVPNMonthlyPrice(TestCase):
     rf = RequestFactory()
 
@@ -300,7 +488,8 @@ class TestVPNMonthlyPrice(TestCase):
         markup = self._render(plan='monthly')
         expected = (
             u'<span class="js-vpn-monthly-price-display" data-price-usd="US$9.99<span>/month</span>" '
-            u'data-price-euro="9,99‎ €<span>/month</span>">US$9.99<span>/month</span></span>')
+            u'data-price-euro="9,99‎ €<span>/month</span>" data-price-chf="Fr. 9.99<span>/month</span>">'
+            u'US$9.99<span>/month</span></span>')
         self.assertEqual(markup, expected)
 
     def test_vpn_6_month_price(self):
@@ -308,7 +497,8 @@ class TestVPNMonthlyPrice(TestCase):
         markup = self._render(plan='6-month')
         expected = (
             u'<span class="js-vpn-monthly-price-display" data-price-usd="US$7.99<span>/month</span>" '
-            u'data-price-euro="6,99 €<span>/month</span>">US$7.99<span>/month</span></span>')
+            u'data-price-euro="6,99 €<span>/month</span>" data-price-chf="Fr. 6.99<span>/month</span>">'
+            u'US$7.99<span>/month</span></span>')
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_price(self):
@@ -316,10 +506,12 @@ class TestVPNMonthlyPrice(TestCase):
         markup = self._render(plan='12-month')
         expected = (
             u'<span class="js-vpn-monthly-price-display" data-price-usd="US$4.99<span>/month</span>" '
-            u'data-price-euro="4,99 €<span>/month</span>">US$4.99<span>/month</span></span>')
+            u'data-price-euro="4,99 €<span>/month</span>" data-price-chf="Fr. 4.99<span>/month</span>">'
+            u'US$4.99<span>/month</span></span>')
         self.assertEqual(markup, expected)
 
 
+@override_settings(VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING)
 class TestVPNTotalPrice(TestCase):
     rf = RequestFactory()
 
@@ -333,7 +525,7 @@ class TestVPNTotalPrice(TestCase):
         markup = self._render(plan='6-month')
         expected = (
             u'<span class="js-vpn-total-price-display" data-price-usd="US$47.94 total" '
-            u'data-price-euro="41,94 € total">US$47.94 total</span>')
+            u'data-price-euro="41,94 € total" data-price-chf="Fr. 41.94 total">US$47.94 total</span>')
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_total_price(self):
@@ -341,10 +533,11 @@ class TestVPNTotalPrice(TestCase):
         markup = self._render(plan='12-month')
         expected = (
             u'<span class="js-vpn-total-price-display" data-price-usd="US$59.88 total" '
-            u'data-price-euro="59,88 € total">US$59.88 total</span>')
+            u'data-price-euro="59,88 € total" data-price-chf="Fr. 59.88 total">US$59.88 total</span>')
         self.assertEqual(markup, expected)
 
 
+@override_settings(VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING)
 class TestVPNSaving(TestCase):
     rf = RequestFactory()
 
@@ -358,7 +551,7 @@ class TestVPNSaving(TestCase):
         markup = self._render(plan='6-month')
         expected = (
             u'<span class="js-vpn-saving-display" data-price-usd="Save 20%" '
-            u'data-price-euro="Save 30%">Save 20%</span>')
+            u'data-price-euro="Save 30%" data-price-chf="Save 30%">Save 20%</span>')
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_saving(self):
@@ -366,5 +559,5 @@ class TestVPNSaving(TestCase):
         markup = self._render(plan='12-month')
         expected = (
             u'<span class="js-vpn-saving-display" data-price-usd="Save 50%" '
-            u'data-price-euro="Save 50%">Save 50%</span>')
+            u'data-price-euro="Save 50%" data-price-chf="Save 50%">Save 50%</span>')
         self.assertEqual(markup, expected)

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -447,6 +447,62 @@ class TestVPNSubscribeLink(TestCase):
             u'data-plan-it="price_1J5J6iJNcmPzuWtRK5zfoguV" data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
         self.assertEqual(markup, expected)
 
+    def test_vpn_subscribe_link_variable_12_month_es(self):
+        """Should return expected markup for variable 12-month plan for es-ES"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='12-month', class_name='mzp-c-button', lang='es-ES',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1J5JCdJNcmPzuWtRrvQMFLlP'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-at="price_1IgwblJNcmPzuWtRynC7dqQa" data-plan-be="price_1J5JRGJNcmPzuWtRXwXA84cm" '
+            u'data-plan-ch="price_1J5JssJNcmPzuWtR616BH4aU" data-plan-de="price_1IgwblJNcmPzuWtRynC7dqQa" '
+            u'data-plan-es="price_1J5JCdJNcmPzuWtRrvQMFLlP" data-plan-fr="price_1IgnlcJNcmPzuWtRjrNa39W4" '
+            u'data-plan-it="price_1J4owvJNcmPzuWtRomVhWQFq" data-plan-us="price_1Iw85dJNcmPzuWtRyhMDdtM7">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_6_month_es(self):
+        """Should return expected markup for variable 6-month plan for es-ES"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='6-month', class_name='mzp-c-button', lang='es-ES',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1J5JDFJNcmPzuWtRrC4IeXTs'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" '
+            u'data-cta-position="primary" data-plan-at="price_1IgwaHJNcmPzuWtRuUfSR4l7" data-plan-be="price_1J5JRmJNcmPzuWtRyFGj0tkN" '
+            u'data-plan-ch="price_1J5JtWJNcmPzuWtRMd2siphH" data-plan-de="price_1IgwaHJNcmPzuWtRuUfSR4l7" '
+            u'data-plan-es="price_1J5JDFJNcmPzuWtRrC4IeXTs" data-plan-fr="price_1IgoxGJNcmPzuWtRG7l48EoV" '
+            u'data-plan-it="price_1J5J7eJNcmPzuWtRKdQi4Tkk" data-plan-us="price_1Iw87cJNcmPzuWtRefuyqsOd">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_variable_monthly_es(self):
+        """Should return expected markup for variable monthly plan for es-ES"""
+        markup = self._render(entrypoint='www.mozilla.org-vpn-product-page', link_text='Get Mozilla VPN',
+                              plan='monthly', class_name='mzp-c-button', lang='es-ES',
+                              optional_parameters={'utm_campaign': 'vpn-product-page'},
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN monthly', 'data-cta-type':
+                                                   'fxa-vpn', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FvnsFHIfezy3ZI?plan=price_1J5JDgJNcmPzuWtRqQtIbktk'
+            u'&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page'
+            u'&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button" '
+            u'data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" data-cta-position="primary" '
+            u'data-plan-at="price_1IgwZVJNcmPzuWtRg9Wssh2y" data-plan-be="price_1J5JSkJNcmPzuWtR54LPH2zi" '
+            u'data-plan-ch="price_1J5Ju3JNcmPzuWtR3GpNYSWj" data-plan-de="price_1IgwZVJNcmPzuWtRg9Wssh2y" '
+            u'data-plan-es="price_1J5JDgJNcmPzuWtRqQtIbktk" data-plan-fr="price_1IgowHJNcmPzuWtRzD7SgAYb" '
+            u'data-plan-it="price_1J5J6iJNcmPzuWtRK5zfoguV" data-plan-us="price_1Iw7qSJNcmPzuWtRMUZpOwLm">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)
+
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT, VPN_ENDPOINT=TEST_VPN_ENDPOINT)
 class TestVPNSignInLink(TestCase):

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -25,12 +25,15 @@ def vpn_fixed_price_countries():
 
 
 def vpn_variable_price_countries():
+    countries = settings.VPN_VARIABLE_PRICE_COUNTRY_CODES
+
     if switch('vpn-variable-pricing-wave-1'):
-        countries = settings.VPN_FIXED_PRICE_COUNTRY_CODES + settings.VPN_VARIABLE_PRICE_COUNTRY_CODES
-        return '|%s|' % '|'.join(cc.lower() for cc in countries)
-    else:
-        countries = settings.VPN_VARIABLE_PRICE_COUNTRY_CODES
-        return '|%s|' % '|'.join(cc.lower() for cc in countries)
+        countries.extend(settings.VPN_FIXED_PRICE_COUNTRY_CODES)
+
+    if switch('vpn-variable-pricing-eu-expansion'):
+        countries.extend(settings.VPN_VARIABLE_PRICE_COUNTRY_CODES_EXPANSION)
+
+    return '|%s|' % '|'.join(cc.lower() for cc in countries)
 
 
 @require_safe
@@ -58,10 +61,11 @@ def vpn_landing_page(request):
         'fixed_price_countries': vpn_fixed_price_countries(),
         'fixed_monthly_price': settings.VPN_FIXED_MONTHLY_PRICE,
         'variable_price_countries': vpn_variable_price_countries(),
-        'default_monthly_price': pricing_params['monthly']['price'],
-        'default_6_month_price': pricing_params['6-month']['price'],
-        'default_12_month_price': pricing_params['12-month']['price'],
-        'available_countries': settings.VPN_AVAILABLE_COUNTRIES,
+        'default_monthly_price': pricing_params['default']['monthly']['price'],
+        'default_6_month_price': pricing_params['default']['6-month']['price'],
+        'default_12_month_price': pricing_params['default']['12-month']['price'],
+        'available_countries': (settings.VPN_AVAILABLE_COUNTRIES_EXPANSION if switch('vpn-variable-pricing-eu-expansion') else
+                                settings.VPN_AVAILABLE_COUNTRIES),
         'connect_servers': settings.VPN_CONNECT_SERVERS,
         'connect_countries': settings.VPN_CONNECT_COUNTRIES,
         'connect_devices': settings.VPN_CONNECT_DEVICES,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1298,19 +1298,19 @@ VPN_PLAN_ID_MATRIX = {
         'de': {
             '12-month': {
                 'id': 'price_1J4sAUKb9q6OnNsLfYDKbpdY' if DEV else 'price_1J5JssJNcmPzuWtR616BH4aU',
-                'price': u'Fr. 4.99',
-                'total': u'Fr. 59.88',
-                'saving': 50
+                'price': u'5.99 CHF',
+                'total': u'71.88 CHF',
+                'saving': 45
             },
             '6-month': {
                 'id': 'price_1J4sB1Kb9q6OnNsLD5WQ4N5y' if DEV else 'price_1J5JtWJNcmPzuWtRMd2siphH',
-                'price': u'Fr. 6.99',
-                'total': u'Fr. 41.94',
-                'saving': 30
+                'price': u'7.99 CHF',
+                'total': u'47.94 CHF',
+                'saving': 27
             },
             'monthly': {
                 'id': 'price_1J4sC2Kb9q6OnNsLIgz3DDu8' if DEV else 'price_1J5Ju3JNcmPzuWtR3GpNYSWj',
-                'price': u'Fr. 9.99',
+                'price': u'10.99 CHF',
                 'total': None,
                 'saving': None
             }
@@ -1318,19 +1318,19 @@ VPN_PLAN_ID_MATRIX = {
         'fr': {
             '12-month': {
                 'id': 'price_1J4sM2Kb9q6OnNsLsGLZwTP9' if DEV else 'price_1J5JunJNcmPzuWtRo9dLxn6M',
-                'price': u'Fr. 4.99',
-                'total': u'Fr. 59.88',
-                'saving': 50
+                'price': u'5.99 CHF',
+                'total': u'71.88 CHF',
+                'saving': 45
             },
             '6-month': {
                 'id': 'price_1J4sMWKb9q6OnNsL3eL2v91Q' if DEV else 'price_1J5JvLJNcmPzuWtRayB4d7Ij',
-                'price': u'Fr. 6.99',
-                'total': u'Fr. 41.94',
-                'saving': 30
+                'price': u'7.99 CHF',
+                'total': u'47.94 CHF',
+                'saving': 27
             },
             'monthly': {
                 'id': 'price_1J4sNGKb9q6OnNsLl3OEuKqT' if DEV else 'price_1J5JvjJNcmPzuWtR3wwy1dcR',
-                'price': u'Fr. 9.99',
+                'price': u'10.99 CHF',
                 'total': None,
                 'saving': None
             }
@@ -1338,19 +1338,19 @@ VPN_PLAN_ID_MATRIX = {
         'it': {
             '12-month': {
                 'id': 'price_1J4sWMKb9q6OnNsLkrTo2uUW' if DEV else 'price_1J5JwWJNcmPzuWtRgrx5fjOc',
-                'price': u'Fr. 4.99',
-                'total': u'Fr. 59.88',
-                'saving': 50
+                'price': u'5.99 CHF',
+                'total': u'71.88 CHF',
+                'saving': 45
             },
             '6-month': {
                 'id': 'price_1J4sWsKb9q6OnNsLXBVXh664' if DEV else 'price_1J5JwvJNcmPzuWtRH2HuhWM5',
-                'price': u'Fr. 6.99',
-                'total': u'Fr. 41.94',
-                'saving': 30
+                'price': u'7.99 CHF',
+                'total': u'47.94 CHF',
+                'saving': 27
             },
             'monthly': {
                 'id': 'price_1J4sXWKb9q6OnNsLVoGiXcW5' if DEV else 'price_1J5JxGJNcmPzuWtRrp5e1SUB',
-                'price': u'Fr. 9.99',
+                'price': u'10.99 CHF',
                 'total': None,
                 'saving': None
             }

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1292,67 +1292,231 @@ VPN_FIXED_PRICE_MONTHLY_USD = config('VPN_FIXED_PRICE_MONTHLY_USD',
                                      default='plan_FvPMH5lVx1vhV0'
                                      if DEV else 'plan_FvnxS1j9oFUZ7Y')
 
-# Plan IDs for VPN variable price subscriptions in Euros.
-VPN_VARIABLE_PRICING = {
-    'de': {
-        '12-month': {
-            'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgwblJNcmPzuWtRynC7dqQa',
-            'price': '4,99 €',
-            'total': '59,88 €',
-            'saving': 50
+# VPN variable subscription plan IDs by currency/language.
+VPN_PLAN_ID_MATRIX = {
+    'chf': {
+        'de': {
+            '12-month': {
+                'id': 'price_1J4sAUKb9q6OnNsLfYDKbpdY' if DEV else 'price_1J5JssJNcmPzuWtR616BH4aU',
+                'price': u'Fr. 4.99',
+                'total': u'Fr. 59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J4sB1Kb9q6OnNsLD5WQ4N5y' if DEV else 'price_1J5JtWJNcmPzuWtRMd2siphH',
+                'price': u'Fr. 6.99',
+                'total': u'Fr. 41.94',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J4sC2Kb9q6OnNsLIgz3DDu8' if DEV else 'price_1J5Ju3JNcmPzuWtR3GpNYSWj',
+                'price': u'Fr. 9.99',
+                'total': None,
+                'saving': None
+            }
         },
-        '6-month': {
-            'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
-            'price': '6,99 €',
-            'total': '41,94 €',
-            'saving': 30
+        'fr': {
+            '12-month': {
+                'id': 'price_1J4sM2Kb9q6OnNsLsGLZwTP9' if DEV else 'price_1J5JunJNcmPzuWtRo9dLxn6M',
+                'price': u'Fr. 4.99',
+                'total': u'Fr. 59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J4sMWKb9q6OnNsL3eL2v91Q' if DEV else 'price_1J5JvLJNcmPzuWtRayB4d7Ij',
+                'price': u'Fr. 6.99',
+                'total': u'Fr. 41.94',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J4sNGKb9q6OnNsLl3OEuKqT' if DEV else 'price_1J5JvjJNcmPzuWtR3wwy1dcR',
+                'price': u'Fr. 9.99',
+                'total': None,
+                'saving': None
+            }
         },
-        'monthly': {
-            'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgwZVJNcmPzuWtRg9Wssh2y',
-            'price': '9,99‎ €',
-            'total': None,
-            'saving': None
+        'it': {
+            '12-month': {
+                'id': 'price_1J4sWMKb9q6OnNsLkrTo2uUW' if DEV else 'price_1J5JwWJNcmPzuWtRgrx5fjOc',
+                'price': u'Fr. 4.99',
+                'total': u'Fr. 59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J4sWsKb9q6OnNsLXBVXh664' if DEV else 'price_1J5JwvJNcmPzuWtRH2HuhWM5',
+                'price': u'Fr. 6.99',
+                'total': u'Fr. 41.94',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J4sXWKb9q6OnNsLVoGiXcW5' if DEV else 'price_1J5JxGJNcmPzuWtRrp5e1SUB',
+                'price': u'Fr. 9.99',
+                'total': None,
+                'saving': None
+            }
         }
+    },
+    'euro': {
+        'de': {
+            '12-month': {
+                'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgwblJNcmPzuWtRynC7dqQa',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgwaHJNcmPzuWtRuUfSR4l7',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgwZVJNcmPzuWtRg9Wssh2y',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'es': {
+            '12-month': {
+                'id': 'price_1J4pE7Kb9q6OnNsLnvvyRClI' if DEV else 'price_1J5JCdJNcmPzuWtRrvQMFLlP',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J4pEcKb9q6OnNsLKrjmFqUc' if DEV else 'price_1J5JDFJNcmPzuWtRrC4IeXTs',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J4pFSKb9q6OnNsLEyiFLbvB' if DEV else 'price_1J5JDgJNcmPzuWtRqQtIbktk',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'fr': {
+            '12-month': {
+                'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgnlcJNcmPzuWtRjrNa39W4',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgoxGJNcmPzuWtRG7l48EoV',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgowHJNcmPzuWtRzD7SgAYb',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'it': {
+            '12-month': {
+                'id': 'price_1J4p3CKb9q6OnNsLK2oBxgsV' if DEV else 'price_1J4owvJNcmPzuWtRomVhWQFq',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J4p5rKb9q6OnNsL3uDibRbN' if DEV else 'price_1J5J7eJNcmPzuWtRKdQi4Tkk',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J4p6wKb9q6OnNsLTb6kCDsC' if DEV else 'price_1J5J6iJNcmPzuWtRK5zfoguV',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
+        'nl': {
+            '12-month': {
+                'id': 'price_1J4ryxKb9q6OnNsL3fPF8mxI' if DEV else 'price_1J5JRGJNcmPzuWtRXwXA84cm',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J4rzWKb9q6OnNsLKUR9kmFG' if DEV else 'price_1J5JRmJNcmPzuWtRyFGj0tkN',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1J4s0MKb9q6OnNsLS19LMKBb' if DEV else 'price_1J5JSkJNcmPzuWtR54LPH2zi',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        }
+    },
+    'usd': {
+        'en': {
+            '12-month': {
+                'id': 'price_1J0Y1iKb9q6OnNsLXwdOFgDr' if DEV else 'price_1Iw85dJNcmPzuWtRyhMDdtM7',
+                'price': u'US$4.99',
+                'total': u'US$59.88',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1J0Y12Kb9q6OnNsL4SB2hhmp' if DEV else 'price_1Iw87cJNcmPzuWtRefuyqsOd',
+                'price': u'US$7.99',
+                'total': u'US$47.94',
+                'saving': 20
+            },
+            'monthly': {
+                'id': 'price_1J0owvKb9q6OnNsLExNhEDXm' if DEV else 'price_1Iw7qSJNcmPzuWtRMUZpOwLm',
+                'price': u'US$9.99',
+                'total': None,
+                'saving': None
+            }
+        }
+    }
+}
+
+# Map of country codes to allocated VPN currency/language plan IDs.
+# Each country can support both a default language and (optionally)
+# a set of one or more alternative languages.
+VPN_VARIABLE_PRICING = {
+    'at': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['de'],
+    },
+    'be': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['nl'],
+        'alt': {
+            'de': VPN_PLAN_ID_MATRIX['euro']['de'],
+            'fr': VPN_PLAN_ID_MATRIX['euro']['fr'],
+        }
+    },
+    'ch': {
+        'default': VPN_PLAN_ID_MATRIX['chf']['de'],
+        'alt': {
+            'fr': VPN_PLAN_ID_MATRIX['chf']['fr'],
+            'it': VPN_PLAN_ID_MATRIX['chf']['it'],
+        }
+    },
+    'de': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['de'],
+    },
+    'es': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['es'],
     },
     'fr': {
-        '12-month': {
-            'id': 'price_1IXw5oKb9q6OnNsLPMkWOid7' if DEV else 'price_1IgnlcJNcmPzuWtRjrNa39W4',
-            'price': '4,99 €',
-            'total': '59,88 €',
-            'saving': 50
-        },
-        '6-month': {
-            'id': 'price_1IXw5NKb9q6OnNsLLIyYuhWF' if DEV else 'price_1IgoxGJNcmPzuWtRG7l48EoV',
-            'price': '6,99 €',
-            'total': '41,94 €',
-            'saving': 30
-        },
-        'monthly': {
-            'id': 'price_1IXw4eKb9q6OnNsLqnVP4PvO' if DEV else 'price_1IgowHJNcmPzuWtRzD7SgAYb',
-            'price': '9,99‎ €',
-            'total': None,
-            'saving': None
-        }
+        'default': VPN_PLAN_ID_MATRIX['euro']['fr'],
+    },
+    'it': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['it'],
     },
     'us': {
-        '12-month': {
-            'id': 'price_1J0Y1iKb9q6OnNsLXwdOFgDr' if DEV else 'price_1Iw85dJNcmPzuWtRyhMDdtM7',
-            'price': 'US$4.99',
-            'total': 'US$59.88',
-            'saving': 50
-        },
-        '6-month': {
-            'id': 'price_1J0Y12Kb9q6OnNsL4SB2hhmp' if DEV else 'price_1Iw87cJNcmPzuWtRefuyqsOd',
-            'price': 'US$7.99',
-            'total': 'US$47.94',
-            'saving': 20
-        },
-        'monthly': {
-            'id': 'price_1J0owvKb9q6OnNsLExNhEDXm' if DEV else 'price_1Iw7qSJNcmPzuWtRMUZpOwLm',
-            'price': 'US$9.99',
-            'total': None,
-            'saving': None
-        }
+        'default': VPN_PLAN_ID_MATRIX['usd']['en'],
     }
 }
 
@@ -1391,7 +1555,16 @@ VPN_VARIABLE_PRICE_COUNTRY_CODES = [
     'FR',  # France
 ]
 
+VPN_VARIABLE_PRICE_COUNTRY_CODES_EXPANSION = [
+    'AT',  # Austria
+    'BE',  # Belgium
+    'CH',  # Switzerland
+    'ES',  # Spain
+    'IT',  # Italy
+]
+
 VPN_AVAILABLE_COUNTRIES = 8
+VPN_AVAILABLE_COUNTRIES_EXPANSION = 13
 VPN_CONNECT_SERVERS = 750
 VPN_CONNECT_COUNTRIES = 30
 VPN_CONNECT_DEVICES = 5

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -8,8 +8,14 @@ vpn-shared-product-name = { -brand-name-mozilla-vpn }
 vpn-shared-subscribe-link = Get { -brand-name-mozilla-vpn }
 vpn-shared-waitlist-link = Join the Waitlist
 vpn-shared-sign-in-link = Already a subscriber?
+
+# Outdated string
 vpn-shared-available-countries = We currently offer { -brand-name-mozilla-vpn } in the US, the UK, Canada, New Zealand, Singapore, and Malaysia.
+
+# Outdated string
 vpn-shared-available-countries-v2 = We currently offer { -brand-name-mozilla-vpn } in the US, the UK, Germany, France, Canada, Malaysia, New Zealand, and Singapore.
+
+vpn-shared-available-countries-v3 = We currently offer { -brand-name-mozilla-vpn } in the US, Canada, the UK, Germany, France, Italy, Spain, Belgium, Austria, Switzerland, Malaysia, New Zealand, and Singapore.
 vpn-shared-money-back-guarantee = 30-day money-back guarantee
 
 # This string will be followed by a lockup of press logos for publications that have featured Mozilla VPN.

--- a/media/css/products/vpn/components/block.scss
+++ b/media/css/products/vpn/components/block.scss
@@ -390,7 +390,6 @@ $image-path: '/media/protocol/img';
 
     .vpn-pricing-variable-total {
         @include text-body-md;
-        margin-bottom: 0;
     }
 
     .vpn-pricing-12-months {

--- a/tests/unit/spec/vpn/geo.js
+++ b/tests/unit/spec/vpn/geo.js
@@ -89,7 +89,7 @@ describe('geo.js', function() {
     describe('getAvailability', function() {
 
         var fixedCountries = '|ca|my|nz|sg|gb|gg|im|io|je|uk|vg|as|mp|pr|um|us|vi|';
-        var variableCountries = '|de|fr|';
+        var variableCountries = '|at|be|ch|de|es|fr|it|';
 
         it('should return `fixed-pricce` if matching country code is found', function() {
             expect(Mozilla.VPN.getAvailability('us', fixedCountries, variableCountries)).toEqual('fixed-price');
@@ -97,8 +97,13 @@ describe('geo.js', function() {
         });
 
         it('should return `variable-price` if matching country code is found', function() {
+            expect(Mozilla.VPN.getAvailability('at', fixedCountries, variableCountries)).toEqual('variable-price');
+            expect(Mozilla.VPN.getAvailability('be', fixedCountries, variableCountries)).toEqual('variable-price');
+            expect(Mozilla.VPN.getAvailability('ch', fixedCountries, variableCountries)).toEqual('variable-price');
             expect(Mozilla.VPN.getAvailability('de', fixedCountries, variableCountries)).toEqual('variable-price');
+            expect(Mozilla.VPN.getAvailability('es', fixedCountries, variableCountries)).toEqual('variable-price');
             expect(Mozilla.VPN.getAvailability('fr', fixedCountries, variableCountries)).toEqual('variable-price');
+            expect(Mozilla.VPN.getAvailability('it', fixedCountries, variableCountries)).toEqual('variable-price');
         });
 
         it('should return `not-available` if no matching country code is found', function() {
@@ -142,33 +147,82 @@ describe('geo.js', function() {
             expect(Mozilla.VPN.showJoinWaitList).toHaveBeenCalled();
         });
 
-        it('should fallback to page language if availability is not known', function() {
+        it('should fallback to page language if country is unknown (en-US)', function() {
             Mozilla.VPN.setAvailability('unknown', 'en-US');
             expect(Mozilla.VPN.showFixedPricing).toHaveBeenCalled();
+        });
 
+        it('should fallback to page language if country is unknown (de)', function() {
             Mozilla.VPN.setAvailability('unknown', 'de');
             expect(Mozilla.VPN.showVariablePricing).toHaveBeenCalled();
+        });
 
+        it('should fallback to page language if country is unknown (es-ES)', function() {
+            Mozilla.VPN.setAvailability('unknown', 'es-ES');
+            expect(Mozilla.VPN.showVariablePricing).toHaveBeenCalled();
+        });
+
+        it('should fallback to page language if country is unknown (fr)', function() {
             Mozilla.VPN.setAvailability('unknown', 'fr');
+            expect(Mozilla.VPN.showVariablePricing).toHaveBeenCalled();
+        });
+
+        it('should fallback to page language if country is unknown (it)', function() {
+            Mozilla.VPN.setAvailability('unknown', 'it');
             expect(Mozilla.VPN.showVariablePricing).toHaveBeenCalled();
         });
     });
 
     describe('updateSubscriptionURL', function() {
 
-        it ('should update the subscription plan ID as expected', function() {
+        it('should update the subscription plan ID as expected', function() {
             var result = Mozilla.VPN.updateSubscriptionURL('price_1IgnlcJNcmPzuWtRjrNa39W4', 'https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FiJ42WCzZNRSbS?plan=price_1IgwblJNcmPzuWtRynC7dqQa&entrypoint=www.mozilla.org-vpn-product-page');
             expect(result).toEqual('https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FiJ42WCzZNRSbS?plan=price_1IgnlcJNcmPzuWtRjrNa39W4&entrypoint=www.mozilla.org-vpn-product-page');
         });
 
-        it ('should not change the URL if there is no plan ID', function() {
+        it('should not change the URL if there is no plan ID', function() {
             var result = Mozilla.VPN.updateSubscriptionURL(null, 'https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FiJ42WCzZNRSbS?plan=price_1IgwblJNcmPzuWtRynC7dqQa&entrypoint=www.mozilla.org-vpn-product-page');
             expect(result).toEqual('https://vpn.mozilla.org/r/vpn/subscribe/products/prod_FiJ42WCzZNRSbS?plan=price_1IgwblJNcmPzuWtRynC7dqQa&entrypoint=www.mozilla.org-vpn-product-page');
         });
 
-        it ('should not change the URL if there is no plan query parameter', function() {
+        it('should not change the URL if there is no plan query parameter', function() {
             var result = Mozilla.VPN.updateSubscriptionURL('price_1IgwblJNcmPzuWtRynC7dqQa', 'https://vpn.mozilla.org/r/vpn/subscribe?entrypoint=www.mozilla.org-vpn-product-page');
             expect(result).toEqual('https://vpn.mozilla.org/r/vpn/subscribe?entrypoint=www.mozilla.org-vpn-product-page');
+        });
+    });
+
+    describe('getCurrency', function() {
+        it('should return "euro" for EU countries', function() {
+            expect(Mozilla.VPN.getCurrency('at')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('be')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('de')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('es')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('fr')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('it')).toEqual('euro');
+        });
+
+        it('should return "chf" for Switzerland', function() {
+            expect(Mozilla.VPN.getCurrency('ch')).toEqual('chf');
+        });
+
+        it('should return "usd" for wave 1 countries', function() {
+            expect(Mozilla.VPN.getCurrency('ca')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('my')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('nz')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('sg')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('gb')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('gg')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('im')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('io')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('je')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('uk')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('vg')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('as')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('mp')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('pr')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('um')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('us')).toEqual('usd');
+            expect(Mozilla.VPN.getCurrency('vi')).toEqual('usd');
         });
     });
 


### PR DESCRIPTION
## Description
Enables VPN availability in new EU countries (behind a feature switch)

## Issue / Bugzilla link
#10280

## Testing
Note: this will go through a week of testing by the product QA team prior to launch on www-dev, but I tried to provide some (hopefully) easy to follow steps for reviewing the changes here:

To test this PR please set the following in your `.env` file:

```
SWITCH_VPN_VARIABLE_PRICING_WAVE_1=off
SWITCH_VPN_VARIABLE_PRICING_EU_EXPANSION=on
```
**New countries:**

Page should display variable pricing in Euros:

- [x] http://localhost:8000/en-US/products/vpn/?geo=at (Austria)
- [x] http://localhost:8000/en-US/products/vpn/?geo=be (Belgium)
- [x] http://localhost:8000/en-US/products/vpn/?geo=es (Spain)
- [x] http://localhost:8000/en-US/products/vpn/?geo=it (Italy)

Page should display variable pricing in Swis Francs:

- [x] http://localhost:8000/en-US/products/vpn/?geo=ch (Switzerland)

**Not available:**

- [x] http://localhost:8000/en-US/products/vpn/?geo=pl
   - [x] Page should mention "Available in 13 countries now".
   - [x] Page copy should reference the new additions: Italy, Spain, Belgium, Austria, Switzerland.