### PR TITLE
Remove Low subdomain wildcard

### DIFF
--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -63,10 +63,10 @@
         <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
       </tr>
       <tr>
-        <th scope="row">Domain Takeovers<sup>8</sup></th>
+        <th scope="row">Domain Takeovers<sup>7</sup></th>
         <td>$5000</td>
         <td>$2000</td>
-        <td>$500<sup>5</sup>/$200<sup>6</sup></td>
+        <td>$500<sup>5</sup></td>
       </tr>
       <tr>
         <th scope="row">XSS (minor)</th>
@@ -81,7 +81,7 @@
         <td>--</td>
       </tr>
       <tr>
-        <th scope="row">Clickjacking<sup>7</sup></th>
+        <th scope="row">Clickjacking<sup>6</sup></th>
         <td>$1000</td>
         <td>$500</td>
         <td>--</td>
@@ -101,7 +101,6 @@
     <li>Significant actions only, such as changing email/passwords, deleting accounts, etc.</li>
     <li>Must be able to conduct significant action (i.e., not defacement, phishing, cookie injection, etc.)</li>
     <li>For *.mozilla.org, *.mozilla.com, *.mozilla.net, and *.firefox.com.</li>
-    <li>For all other domains excluding *.ngrok.io, *.s3.amazonaws.com, and similar domains used only for development or logging.</li>
     <li>Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty</li>
     <li>Requires a proof of concept to be eligible</li>
   </ol>


### PR DESCRIPTION
This removes the lowest tier of bug bounty rewards for subdomain takeovers and restricts payments to only eligible properties and properties which are hanging off *.mozilla.org, *.mozilla.com, *.mozilla.net, or *.firefox.com.
