### PR TITLE
Expose Fluent strings for WNP 90 (Issue #10270)

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -169,8 +169,33 @@ locales = [
     reference = "en/firefox/welcome/**/*.ftl"
     l10n = "{locale}/firefox/welcome/**/*.ftl"
 [[paths]]
-    reference = "en/firefox/whatsnew/**/*.ftl"
-    l10n = "{locale}/firefox/whatsnew/**/*.ftl"
+    reference = "en/firefox/whatsnew/whatsnew-account.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-account.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-fx79.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-fx79.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-fx80.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-fx80.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-fx81.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-fx81.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-fx90.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-fx90.ftl"
+    locales = [
+        "de",
+        "fr",
+        "it",
+        "nl",
+        "es-ES"
+    ]
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-s2d.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-s2d.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew.ftl"
 [[paths]]
     reference = "en/mozorg/contribute.ftl"
     l10n = "{locale}/mozorg/contribute.ftl"

--- a/l10n/en/firefox/whatsnew/whatsnew-fx90.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-fx90.ftl
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/90.0/whatsnew/all/ ('de', 'fr', 'it', 'nl', 'es-ES')
+
+# Line break (<br>) is for visual formatting only.
+whatsnew90-main-heading = Online anywhere. <br>Protected everywhere.
+
+whatsnew90-main-body = From coffee shop to campsite, train station to beach — public wifi is convenient, but not always secure. { -brand-name-mozilla-vpn } protects your internet connection and identity no matter where you are.
+whatsnew90-main-cta = Get { -brand-name-mozilla-vpn }
+
+whatsnew90-block-1-heading = Safe & Secure
+whatsnew90-block-1-body = Public wifi is one of the easiest ways for hackers to get to your personal info. { -brand-name-mozilla-vpn } encrypts your network activity and hides your location and IP address.
+
+whatsnew90-block-2-heading = Home is where your VPN is
+whatsnew90-block-2-body = Take your entertainment on the road or travel to your entertainment. Connect to 750+ servers in more than 30 countries and stream, play, and surf more securely while staying flexible.
+
+whatsnew90-availability-heading = Now available in additional countries including:
+whatsnew90-availability-body = Germany, France, Italy, Spain, Belgium, Austria, Switzerland.
+
+whatsnew90-press-logos-heading = Featured in


### PR DESCRIPTION
## Description
Exposes `whatsnew-fx90.ftl` in Pontoon for locales "de", "fr", "it", "nl", and "es-ES".

The EU team want to get this in ahead of https://github.com/mozilla/bedrock/pull/10295 to give the community as much time as possible to translate.

## Issue / Bugzilla link
#10270

## Testing
- [ ] Check for typos?
- [ ] Did I miss any files in the config changes?