### PR TITLE
Add pricing offer to VPN hero for wave 1 countries (en only) (Fixes #10286)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -63,6 +63,9 @@
       desc=ftl('vpn-landing-hero-desc')
     ) %}
       <div class="js-vpn-fixed-pricing">
+        {% if LANG.startswith('en') %}
+          <p><strong>{{ settings.VPN_FIXED_MONTHLY_PRICE }}/month - This introductory offer ends soon.</strong></p>
+        {% endif %}
         {% block get_mozilla_vpn_hero %}
           {{ vpn_subscribe_link(
             entrypoint=_utm_source,


### PR DESCRIPTION
## Description
Adds introductory offer to the top of the VPN landing page for wave 1 countries (EN locales only).

localhost:8000/en-US/products/vpn/?geo=us

## Issue / Bugzilla link
#10286

## Testing
- [x] Offer should display when `SWITCH_VPN_VARIABLE_PRICING_WAVE_1=off` in your `.env` file.
- [x] Offer should **not** display when `SWITCH_VPN_VARIABLE_PRICING_WAVE_1=on` in your `.env` file.
- [x] Offer should **not** display for non `en` locales e.g. http://localhost:8000/de/products/vpn/?geo=us
- [x] Offer should **not** display for non wave 1 countries e.g. http://localhost:8000/en-US/products/vpn/?geo=de