### PR TITLE
Fall back to locale-based country if user data country is invalid

### DIFF
--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -146,8 +146,8 @@ class ManageSubscriptionsForm(forms.Form):
                              required=False)
 
     def __init__(self, locale, *args, **kwargs):
-        regions = product_details.get_regions(locale)
-        regions = sorted(iter(regions.items()), key=itemgetter(1))
+        regions_dict = product_details.get_regions(locale)
+        regions = sorted(iter(regions_dict.items()), key=itemgetter(1))
         lang_choices = get_lang_choices()
         languages = [x[0] for x in lang_choices]
 
@@ -161,6 +161,9 @@ class ManageSubscriptionsForm(forms.Form):
         # Get initial - work with a copy so we're not modifying the
         # data that was passed to us
         initial = kwargs.get('initial', {}).copy()
+        if 'country' in initial and initial['country'] not in regions_dict:
+            # clear the initial country if it's not in the list
+            del initial['country']
         if not initial.get('country', None):
             initial['country'] = country
         if not initial.get('lang', None):

--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -100,6 +100,29 @@ class TestManageSubscriptionsForm(TestCase):
                                        })
         self.assertEqual('pt', form.initial['lang'])
 
+    def test_bad_country(self):
+        """Handle their country preference if it's not valid"""
+        # Suppose their selected country in CTMS is one we don't recognize
+        # at all.  Use the country from their locale instead.
+        locale = "pt-BR"
+        form = ManageSubscriptionsForm(locale=locale,
+                                       initial={
+                                           'lang': 'zz',
+                                           'country': 'Spain',
+                                       })
+        self.assertEqual('br', form.initial['country'])
+
+    def test_no_country(self):
+        """Handle their country preference if it's not set"""
+        # Suppose they have no selected country in CTMS.
+        # Use the country from their locale instead.
+        locale = "en-US"
+        form = ManageSubscriptionsForm(locale=locale,
+                                       initial={
+                                           'lang': 'zz',
+                                       })
+        self.assertEqual('us', form.initial['country'])
+
 
 @mock.patch('bedrock.newsletter.utils.get_newsletters', newsletters_mock)
 class TestNewsletterForm(TestCase):


### PR DESCRIPTION
For the newsletter/existing/<token>/ form (email preferences) it would
select the first country in the list if the country from the user data
was an invalid selection in the list. e.g. if the data said "Spain"
instead of "ES". This change makes the form default to the best country
based on the locale of the page.
