### PR TITLE
Avoid using extend for VPN country lists (#10280)

### DIFF
--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -28,10 +28,10 @@ def vpn_variable_price_countries():
     countries = settings.VPN_VARIABLE_PRICE_COUNTRY_CODES
 
     if switch('vpn-variable-pricing-wave-1'):
-        countries.extend(settings.VPN_FIXED_PRICE_COUNTRY_CODES)
+        countries = countries + settings.VPN_FIXED_PRICE_COUNTRY_CODES
 
     if switch('vpn-variable-pricing-eu-expansion'):
-        countries.extend(settings.VPN_VARIABLE_PRICE_COUNTRY_CODES_EXPANSION)
+        countries = countries + settings.VPN_VARIABLE_PRICE_COUNTRY_CODES_EXPANSION
 
     return '|%s|' % '|'.join(cc.lower() for cc in countries)
 


### PR DESCRIPTION
@pmac r?

I noticed that with `extend()` the country lists we're growing exponentially on each page refresh. I don't quite understand why exactly (my guess is something to do with the setting file acting differently?). Good thing is this is still behind a feature switch.

This PR seems to fix the issue?