### PR TITLE
Change recommended VPN plan to 12-months (Fixes #10302)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -18,62 +18,61 @@
     <li class="vpn-feature-list-item">{{ ftl('vpn-shared-money-back-guarantee') }}</li>
   </ul>
 
- <div class="vpn-pricing-variable-plans">
+  <div class="vpn-pricing-variable-plans">
+    {% call vpn_content_block(
+      class_name='vpn-pricing-12-months t-highlight'
+    ) %}
+      <p class="vpn-pricing-variable-plan-tag">{{ ftl('vpn-shared-pricing-recommended-offer') }}</p>
+      <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-12-month') }}</h2>
+      <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='12-month', lang=LANG) }}</h3>
 
-  {% call vpn_content_block(
-    class_name='vpn-pricing-6-months t-highlight'
-  ) %}
-    <p class="vpn-pricing-variable-plan-tag">{{ ftl('vpn-shared-pricing-recommended-offer') }}</p>
-    <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-6-month') }}</h2>
-    <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='6-month', lang=LANG) }}</h3>
+      {{ vpn_subscribe_link(
+        entrypoint=_utm_source,
+        link_text=ftl('vpn-shared-pricing-get-12-month'),
+        plan='12-month',
+        class_name='mzp-c-button mzp-t-xl ',
+        lang=LANG,
+        optional_parameters={
+          'utm_campaign': _utm_campaign
+        },
+        optional_attributes={
+          'data-cta-type': 'fxa-vpn',
+          'data-cta-text': 'Get Mozilla VPN 12-month',
+          'data-cta-position': 'pricing'
+        }
+      ) }}
 
-    {{ vpn_subscribe_link(
-      entrypoint=_utm_source,
-      link_text=ftl('vpn-shared-pricing-get-6-month'),
-      plan='6-month',
-      class_name='mzp-c-button mzp-t-xl ',
-      lang=LANG,
-      optional_parameters={
-        'utm_campaign': _utm_campaign
-      },
-      optional_attributes={
-        'data-cta-type': 'fxa-vpn',
-        'data-cta-text': 'Get Mozilla VPN 6-month',
-        'data-cta-position': 'pricing'
-      }
-    ) }}
+      <p class="refund-policy"><a href="#faq-refunds">{{ ftl('vpn-shared-refund-policy') }}</a></p>
+      <p class="vpn-pricing-variable-saving">{{ vpn_saving(plan='12-month', lang=LANG) }}</p>
+      <p class="vpn-pricing-variable-total">{{ vpn_total_price(plan='12-month', lang=LANG) }}</p>
+    {% endcall %}
 
-    <p class="refund-policy"><a href="#faq-refunds">{{ ftl('vpn-shared-refund-policy') }}</a></p>
-    <p class="vpn-pricing-variable-saving">{{ vpn_saving(plan='6-month', lang=LANG) }}</p>
-    <p class="vpn-pricing-variable-total">{{ vpn_total_price(plan='6-month', lang=LANG) }}</p>
-  {% endcall %}
+    {% call vpn_content_block(
+      class_name='vpn-pricing-6-months'
+    ) %}
+      <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-6-month') }}</h2>
+      <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='6-month', lang=LANG) }}</h3>
 
-   {% call vpn_content_block(
-     class_name='vpn-pricing-12-months'
-   ) %}
-     <h2 class="vpn-content-block-heading">{{ ftl('vpn-shared-pricing-plan-12-month') }}</h2>
-     <h3 class="vpn-content-block-sub-heading">{{ vpn_monthly_price(plan='12-month', lang=LANG) }}</h3>
+      {{ vpn_subscribe_link(
+        entrypoint=_utm_source,
+        link_text=ftl('vpn-shared-pricing-get-6-month'),
+        plan='6-month',
+        class_name='mzp-c-button mzp-t-secondary mzp-t-xl ',
+        lang=LANG,
+        optional_parameters={
+          'utm_campaign': _utm_campaign
+        },
+        optional_attributes={
+          'data-cta-type': 'fxa-vpn',
+          'data-cta-text': 'Get Mozilla VPN 6-month',
+          'data-cta-position': 'pricing'
+        }
+      ) }}
 
-     {{ vpn_subscribe_link(
-       entrypoint=_utm_source,
-       link_text=ftl('vpn-shared-pricing-get-12-month'),
-       plan='12-month',
-       class_name='mzp-c-button mzp-t-secondary mzp-t-xl ',
-       lang=LANG,
-       optional_parameters={
-         'utm_campaign': _utm_campaign
-       },
-       optional_attributes={
-         'data-cta-type': 'fxa-vpn',
-         'data-cta-text': 'Get Mozilla VPN 12-month',
-         'data-cta-position': 'pricing'
-       }
-     ) }}
-
-     <p class="refund-policy"><a href="#faq-refunds">{{ ftl('vpn-shared-refund-policy') }}</a></p>
-     <p class="vpn-pricing-variable-saving">{{ vpn_saving(plan='12-month', lang=LANG) }}</p>
-     <p class="vpn-pricing-variable-total">{{ vpn_total_price(plan='12-month', lang=LANG) }}</p>
-   {% endcall %}
+      <p class="refund-policy"><a href="#faq-refunds">{{ ftl('vpn-shared-refund-policy') }}</a></p>
+      <p class="vpn-pricing-variable-saving">{{ vpn_saving(plan='6-month', lang=LANG) }}</p>
+      <p class="vpn-pricing-variable-total">{{ vpn_total_price(plan='6-month', lang=LANG) }}</p>
+    {% endcall %}
 
    {% call vpn_content_block(
      class_name='vpn-pricing-monthly'

--- a/media/css/products/vpn/components/block.scss
+++ b/media/css/products/vpn/components/block.scss
@@ -421,8 +421,8 @@ $image-path: '/media/protocol/img';
         @supports(display: grid) {
             display: grid;
             grid-column-gap: $spacing-xl * 2;
-            grid-template-areas: 'months-6 months-6'
-                                'months-12 monthly';
+            grid-template-areas: 'months-12 months-12'
+                                 'months-6 monthly';
             grid-template-columns: repeat(2, 1fr);
             grid-template-rows: repeat(2, 1fr);
 
@@ -445,7 +445,7 @@ $image-path: '/media/protocol/img';
 
         @supports(display: grid) {
             grid-column-gap: $spacing-xl;
-            grid-template-areas: 'monthly months-6 months-12';
+            grid-template-areas: 'months-12 months-6 monthly';
             grid-template-columns: repeat(3, 1fr);
             grid-template-rows: none;
         }


### PR DESCRIPTION
## Description
- Update variable pricing section on VPN landing page to recommend 12-month plan vs 6-month (current).

http://localhost:8000/en-US/products/vpn/

## Issue / Bugzilla link
#10302

## Testing
- [x] 12-month plan should be "recommended".
- [x] Ordering on desktop should be "12-month" -> "6-month" -> "monthly" from left to right.
- [x] For RTL languages ordering should be from right to left.
- [x] On small viewports order should be 12 -> 6 -> monthly top to bottom.