### PR TITLE
Add GA custom dimension for AMO experiments (Fixes #10175)

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -58,6 +58,19 @@
     if (typeof Mozilla.Utils !== 'undefined') {
         Mozilla.Utils.onDocumentReady(function() {
             initCoreDataLayer();
+
+            // Add GA custom dimension for AMO experiments (Issue 10175).
+            if (typeof window._SearchParams !== 'undefined') {
+                var params = new window._SearchParams().params;
+                var validParams = analytics.getAMOExperiment(params);
+
+                if (validParams) {
+                    dataLayer.push({
+                        'data-ex-name': validParams['experiment'],
+                        'data-ex-variant': validParams['variation']
+                    });
+                }
+            }
         });
     }
 

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -80,6 +80,27 @@ if (typeof window.Mozilla.Analytics === 'undefined') {
         }
     };
 
+    analytics.getAMOExperiment = function(params) {
+        var allowedExperiment = /^\d{8}_amo_.[\w/.%-]{1,50}$/; // should match the format YYYYMMDD_amo_experiment_name.
+        var allowedVariation = /^[\w/.%-]{1,50}$/; // allow alpha numeric & common URL encoded chars.
+
+        if (Object.prototype.hasOwnProperty.call(params, 'experiment') &&
+            Object.prototype.hasOwnProperty.call(params, 'variation')) {
+
+            var experiment = decodeURIComponent(params['experiment']);
+            var variation = decodeURIComponent(params['variation']);
+
+            if ((allowedExperiment).test(experiment) && (allowedVariation).test(variation)) {
+                return {
+                    'experiment': experiment,
+                    'variation': variation
+                };
+            }
+        }
+
+        return null;
+    };
+
     /** Returns an object containing GA-formatted FxA details
     * The specs for this are a combination of:
     * - https://bugzilla.mozilla.org/show_bug.cgi?id=1457024#c33

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1340,9 +1340,10 @@
     {
       "files": [
         "js/libs/jquery-3.5.1.min.js",
+        "js/base/class-list-polyfill.js",
+        "js/base/search-params.js",
         "js/base/mozilla-utils.js",
         "js/base/mozilla-client.js",
-        "js/base/class-list-polyfill.js",
         "js/base/mozilla-run.js",
         "protocol/js/protocol-supports.js",
         "protocol/js/protocol-utils.js",
@@ -1357,7 +1358,6 @@
         "js/base/base-page-init.js",
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
-        "js/base/search-params.js",
         "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-link.js",
         "js/base/mozilla-fxa-link-init.js",

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -120,6 +120,53 @@ describe('core-datalayer.js', function() {
         });
     });
 
+    describe('getAMOExperiment', function() {
+        it('should return true when experiment and variation params are well formatted', function() {
+            var params = {
+                'experiment': '20210708_amo_experiment_name',
+                'variation': 'variation_1_name'
+            };
+            expect(Mozilla.Analytics.getAMOExperiment(params)).toEqual(params);
+        });
+
+        it('should return falsy when experiment and variation params are not specific to amo', function() {
+            var params = {
+                'experiment': 'some_other_experiment',
+                'variation': 'variation_1_name'
+            };
+            expect(Mozilla.Analytics.getAMOExperiment(params)).toBeFalsy();
+        });
+
+        it('should return falsy when experiment and variation params contain dangerous characters', function() {
+            var params = {
+                'experiment': '20210708_amo_"><h1>hello</h1>',
+                'variation': '<script>alert("test");</script>'
+            };
+            expect(Mozilla.Analytics.getAMOExperiment(params)).toBeFalsy();
+
+            var params2 = {
+                'experiment': '20210708_amo_%22%3E%3Ch1%3Ehello%3C%2Fh1%3E',
+                'variation': '%3Cscript%3Ealert%28%22test%22%29%3B%3C%2Fscript%3E'
+            };
+            expect(Mozilla.Analytics.getAMOExperiment(params2)).toBeFalsy();
+        });
+
+        it('should return falsy if parameters values are more than 50 chars', function() {
+            var params = {
+                'experiment': '20210708_amo_experiment_name',
+                'variation': 'a_very_very_very_very_very_long_experiment_variation_name_much_much_much_more_than_50_chars'
+            };
+            expect(Mozilla.Analytics.getAMOExperiment(params)).toBeFalsy();
+
+            var params2 = {
+                'experiment': '20210708_amo_a_very_very_very_long_experiment_name_much_much_much_much_more_than_50_chars',
+                'variation': 'variation_1_name'
+            };
+            expect(Mozilla.Analytics.getAMOExperiment(params2)).toBeFalsy();
+        });
+
+    });
+
     describe('formatFxaDetails', function() {
 
         it('will correctly format FxA data returned from UITour', function() {


### PR DESCRIPTION
## Description
For URLs that contain `experiment` and `variation` parameters, both of which match validation specific to AMO experiments, add a `dataLayer.push()` event to register then experiment as a custom dimension in GA.

http://localhost:8000/en-US/?experiment=20210708_amo_experiment_name&variation=variation_1_name

## Issue / Bugzilla link
#10175

## Testing
1.) Open the above URL.
2.) Open web console
3.) In the console enter `window.dataLayer` and hit enter.
4.) Verify that the array contains an abject with `{ "data-ex-name": "20210708_amo_experiment_name", "data-ex-variant": "variation_1_name" }`