### PR TITLE
Move VPN pricing component position (Fixes #10321)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -97,6 +97,14 @@
       <p>{{ ftl('vpn-landing-privacy-desc') }}</p>
     {% endcall %}
 
+    {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+    <div id="pricing" class="mzp-is-anchor-link">
+      {% include 'products/vpn/includes/pricing-fixed.html' %}
+      {% include 'products/vpn/includes/pricing-variable.html' %}
+    </div>
+
+    {% include 'products/vpn/includes/featured-press.html' %}
+
     {% call vpn_content_media(
       heading=ftl('vpn-landing-fast-secure-heading'),
       image_url='img/products/vpn/landing/vpn-cntwell-02.png',
@@ -160,14 +168,6 @@
 
     <div class="js-target-secondary-cta"></div>
     {% endcall %}
-
-    {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
-    <div id="pricing" class="mzp-is-anchor-link">
-      {% include 'products/vpn/includes/pricing-fixed.html' %}
-      {% include 'products/vpn/includes/pricing-variable.html' %}
-    </div>
-
-    {% include 'products/vpn/includes/featured-press.html' %}
   </div>
 
   <section id="faq" class="vpn-faq mzp-l-content mzp-t-content-lg">

--- a/media/css/products/vpn/components/block.scss
+++ b/media/css/products/vpn/components/block.scss
@@ -295,7 +295,7 @@ $image-path: '/media/protocol/img';
 // Pricing Blocks
 
 .vpn-fixed-pricing-block {
-    margin-bottom: $layout-xl;
+    margin: $layout-xl 0;
     text-align: center;
 
     .vpn-content-block-heading span {
@@ -309,7 +309,7 @@ $image-path: '/media/protocol/img';
 
     @media #{$mq-md} {
         @include bidi(((text-align, left, right),));
-        margin-bottom: $layout-2xl;
+        margin: $layout-2xl 0;
     }
 
     @media #{$mq-lg} {
@@ -321,6 +321,7 @@ $image-path: '/media/protocol/img';
 
 .vpn-variable-pricing-block {
     text-align: center;
+    margin-top: $layout-xl;
 
     .vpn-pricing-variable-heading {
         @include text-title-md;
@@ -330,6 +331,10 @@ $image-path: '/media/protocol/img';
     .vpn-pricing-variable-sub-heading {
         @include text-title-xs;
         margin: $spacing-xl auto $spacing-2xl;
+    }
+
+    @media #{$mq-md} {
+        margin-top: $layout-2xl;
     }
 }
 


### PR DESCRIPTION
## Description
Moves VPN pricing component from bottom of page to up underneath the "One tap to privacy" section.

## Issue / Bugzilla link
#10321