### PR TITLE
Don’t show sticky promo for reduced motion [fix #10324]

### DIFF
--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -32,11 +32,12 @@
     }
 
     function onLoad(){
-        // Check if promo exists on the page or if smaller than tablet.
+        // Check if promo exists on the page, or if smaller than tablet, or if user prefers reduced motion.
+        var matchMediaNoMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         var matchMediaDesktop = window.matchMedia('(min-width: 768px)').matches;
         var promo = document.querySelector('.mzp-c-sticky-promo');
 
-        if (!promo || !matchMediaDesktop) {
+        if (!promo || !matchMediaDesktop || matchMediaNoMotion) {
             return;
         }
 


### PR DESCRIPTION
## Description
Sticky elements can be troublesome for people who prefer reduced motion. This adds a matchMedia check and doesn't trigger the sticky promo if it matches `prefers-reduced-motion: reduce`.

## Issue / Bugzilla link
#10324 

## Testing
http://localhost:8000/firefox/
http://localhost:8000/firefox/browsers/

On a Mac, open System Preferences > Accessibility > Display and check "Reduce motion"

The sticky promo should **not** appear when reduced motion is preferred, and should only appear when there's no preference.

The preference can also be emulated via devtools in [Chrome](https://umaar.com/dev-tips/211-media-query-simulation/) and [Edge](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/accessibility/reduced-motion-simulation) but it's a bit hard to get to (alas, not in Firefox devtools yet).