### PR TITLE
Replace lockwise logo with vpn on /firefox (Fixes #10299)

### DIFF
--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -234,9 +234,9 @@
                 </a>
               </li>
               <li>
-                <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" data-cta-type="link" data-cta-text="Lockwise">
-                  <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
-                  {{ ftl('firefox-home-lockwise') }}
+                <a class="mzp-c-cta-link" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Mozilla VPN">
+                  <img alt="" src="{{ static('protocol/img/logos/mozilla/vpn/logo-flat-white.svg') }}" height="40" width="40"><br>
+                  {{ ftl('firefox-home-mozilla-vpn') }}
                 </a>
               </li>
               <li>


### PR DESCRIPTION
## Description

We want to replace Lockwise logo link with Mozilla VPN logo link in bottom section above footer on /firefox.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10299

## Testing

http://localhost:8000/en-US/firefox/
Scroll down to section above footer. You should see the correct logos (no lockwise, white VPN logo instead)
![correct-logo](https://user-images.githubusercontent.com/19650432/125531077-93ab2c10-81c1-4182-856d-f33a1bfa5e1a.png)

If you inspect VPN logo, text should be "Mozilla VPN"
If you click VPN logo, you should go to VPN product page: http://localhost:8000/en-US/products/vpn/

