### PR TITLE
Issue #10335: Add simplified VPN redirect

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -743,7 +743,7 @@ redirectpatterns = (
 
     # Issue 9984
     redirect(r'^/about/legal/fraud-report/?$', '/about/legal/defend-mozilla-trademarks/'),
-    
+
     # Issue 10335
     redirect(r'^vpn/?$', 'products.vpn.landing'),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -743,4 +743,7 @@ redirectpatterns = (
 
     # Issue 9984
     redirect(r'^/about/legal/fraud-report/?$', '/about/legal/defend-mozilla-trademarks/'),
+    
+    # Issue 10335
+    redirect(r'^vpn/?$', 'products.vpn.landing'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1388,4 +1388,7 @@ URLS = flatten((
     url_test('/firefox/90.0/whatsnew/india/', '/firefox/90.0/whatsnew/'),
     url_test('/firefox/whatsnew/africa/', '/firefox/whatsnew/'),
     url_test('/firefox/whatsnew/india/', '/firefox/whatsnew/'),
+
+    # Issue 10335
+    url_test('/vpn/', '/products/vpn/'),
 ))


### PR DESCRIPTION
## Description
Created a redirect that enables a user to add `/vpn` at the end of the mozorg URL to redirect them directly to `/products/vpn`

## Issue / Bugzilla link
Issue #10335  

## Testing
Ran `py.test -r a tests/redirects` and all tests have passed.