### PR TITLE
Update number of available servers on VPN /whatsnew page 90 (Fixes #10342)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx90-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx90-eu.html
@@ -53,7 +53,12 @@
           </div>
           <h3 class="mzp-c-picto-heading">{{ ftl('whatsnew90-block-2-heading') }}</h3>
           <div class="mzp-c-picto-body">
-            <p>{{ ftl('whatsnew90-block-2-body') }}</p>
+            {% if ftl_has_messages('whatsnew90-block-2-body-v2') %}
+              <p>{{ ftl('whatsnew90-block-2-body-v2', servers=settings.VPN_CONNECT_SERVERS, countries=settings.VPN_CONNECT_COUNTRIES) }}</p>
+            {% else %}
+              <p>{{ ftl('whatsnew90-block-2-body') }}</p>
+            {% endif %}
+            <p></p>
           </div>
         </div>
       </div>

--- a/l10n/en/firefox/whatsnew/whatsnew-fx90.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-fx90.ftl
@@ -14,7 +14,14 @@ whatsnew90-block-1-heading = Safe & Secure
 whatsnew90-block-1-body = Public wifi is one of the easiest ways for hackers to get to your personal info. { -brand-name-mozilla-vpn } encrypts your network activity and hides your location and IP address.
 
 whatsnew90-block-2-heading = Home is where your VPN is
+
+# Obsolete string
 whatsnew90-block-2-body = Take your entertainment on the road or travel to your entertainment. Connect to 750+ servers in more than 30 countries and stream, play, and surf more securely while staying flexible.
+
+# Variables:
+#   $servers (number) - number of available servers
+#   $countries (number) - number of available countries
+whatsnew90-block-2-body-v2 = Take your entertainment on the road or travel to your entertainment. Connect to { $servers }+ servers in more than { $countries } countries and stream, play, and surf more securely while staying flexible.
 
 whatsnew90-availability-heading = Now available in additional countries including:
 whatsnew90-availability-body = Germany, France, Italy, Spain, Belgium, Austria, Switzerland.


### PR DESCRIPTION
## Description
Small string update for WNP 90 (VPN)

http://localhost:8000/de/firefox/90.0/whatsnew/all/

## Issue / Bugzilla link
#10342

## Testing
This new string won't show up in the page until it's been translated, but it's a small enough change it should hopefully be easy enough to review and trust that it's good.