### PR TITLE
Replace the MDN link by Firefox's docs

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -52,7 +52,7 @@
       </section>
 
       <section class="mzp-c-card contribute-card">
-        <a class="mzp-c-card-block-link contribute-card-wrapper" href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction/{{ utm_params }}">
+        <a class="mzp-c-card-block-link contribute-card-wrapper" href="https://firefox-source-docs.mozilla.org/contributing/contributing_to_mozilla.html{{ utm_params }}">
           <div class="mzp-c-card-media-wrapper">
             <picture>
               <source srcset="{{ static('img/contribute/contribute-card-contribute.png') }}" media="(max-width: 480px)">


### PR DESCRIPTION
## Description

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1714434
https://github.com/mozilla/bedrock/issues/10244
