### PR TITLE
Issue #10341 Remove deprecated Picto Card components

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -56,7 +56,7 @@
     ) %}
       <ul>
         <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>
-        <li><a class="mzp-c-cta-link" href="https://support.mozilla.org/en-US/kb/contributors-guide-writing-good-bug">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
+        <li><a class="mzp-c-cta-link" href="https://support.mozilla.org/kb/contributors-guide-writing-good-bug">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
       </ul>
       {% endcall %}
     </aside>

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -46,30 +46,13 @@
 
   {% block channels %}{% endblock %}
 
-  <!-- picto card // to be removed-->
-  {% call picto_card(
-    title=ftl('firefox-channel-see-something-that-isnt-working'),
-    heading_level=2,
-    class='bugzilla',
-    base_el='section',
-    custom_desc=True) %}
-
-  <ul>
-    <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>
-    <li><a class="mzp-c-cta-link" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
-  </ul>
-  {% endcall %}
-
-  <!-- picto to replace picto_card above -->
-
 <ul class="mzp-t-picto-center">
   {% call picto(
     image_url='img/icons/warning.svg',
     heading_level=2,
-    image_width=56,
+    image_width=44,
     title=ftl('firefox-channel-see-something-that-isnt-working'),
     body=True,
-    class='bugzilla'
     ) %}
 
     <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -56,7 +56,7 @@
     ) %}
       <ul>
         <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>
-        <li><a class="mzp-c-cta-link" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
+        <li><a class="mzp-c-cta-link" href="https://support.mozilla.org/en-US/kb/contributors-guide-writing-good-bug">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
       </ul>
       {% endcall %}
     </aside>

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% from "macros-protocol.html" import hero, feature_card, call_out_compact, picto_card with context %}
+{% from "macros-protocol.html" import hero, feature_card, call_out_compact, picto_card, picto with context %}
 
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}
 
@@ -46,6 +46,7 @@
 
   {% block channels %}{% endblock %}
 
+  <!-- picto card // to be removed-->
   {% call picto_card(
     title=ftl('firefox-channel-see-something-that-isnt-working'),
     heading_level=2,
@@ -58,6 +59,23 @@
     <li><a class="mzp-c-cta-link" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
   </ul>
   {% endcall %}
+
+  <!-- picto to replace picto_card above -->
+
+<ul class="mzp-t-picto-center">
+  {% call picto(
+    image_url='img/icons/warning.svg',
+    heading_level=2,
+    image_width=56,
+    title=ftl('firefox-channel-see-something-that-isnt-working'),
+    body=True,
+    class='bugzilla'
+    ) %}
+
+    <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>
+    <li><a class="mzp-c-cta-link" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
+    {% endcall %}
+  </ul>
 
   <section class="t-newsletter">
     <div class="mzp-l-content">

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% from "macros-protocol.html" import hero, feature_card, call_out_compact, picto_card, picto with context %}
+{% from "macros-protocol.html" import hero, feature_card, call_out_compact, picto with context %}
 
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}
 
@@ -46,7 +46,7 @@
 
   {% block channels %}{% endblock %}
 
-<ul class="mzp-t-picto-center">
+  <aside class='mzp-t-picto-center'>
   {% call picto(
     image_url='img/icons/warning.svg',
     heading_level=2,
@@ -54,11 +54,12 @@
     title=ftl('firefox-channel-see-something-that-isnt-working'),
     body=True,
     ) %}
-
-    <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>
-    <li><a class="mzp-c-cta-link" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
-    {% endcall %}
-  </ul>
+      <ul>
+        <li><a class="mzp-c-cta-link" href="https://bugzilla.mozilla.org/enter_bug.cgi">{{ ftl('firefox-channel-file-a-bug-now') }}</a></li>
+        <li><a class="mzp-c-cta-link" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ ftl('firefox-channel-tips-for-filing-a-bug') }}</a></li>
+      </ul>
+      {% endcall %}
+    </aside>
 
   <section class="t-newsletter">
     <div class="mzp-l-content">

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -46,7 +46,7 @@
 
   {% block channels %}{% endblock %}
 
-  <aside class='mzp-t-picto-center'>
+  <aside class="mzp-t-picto-center">
   {% call picto(
     image_url='img/icons/warning.svg',
     heading_level=2,

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -44,6 +44,7 @@
           heading_level=3,
           body=True,
           image_url='img/firefox/firstrun/test.png',
+          base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-find-and-file-bugs') }}</p>
           <a href="https://quality.mozilla.org/get-involved/" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start testing">{{ ftl('nightly-firstrun-start-testing') }}</a>
@@ -54,6 +55,7 @@
           heading_level=3,
           body=True,
           image_url='img/firefox/firstrun/code.png',
+          base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-file-bugs-and-work') }}</p>
           <a href="https://firefox-source-docs.mozilla.org/contributing/contributing_to_mozilla.html" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start coding">{{ ftl('nightly-firstrun-start-coding') }}</a>
@@ -64,6 +66,7 @@
            heading_level=3,
           body=True,
           image_url='img/firefox/firstrun/localize.png',
+          base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-make-firefox-available') }}</p>
           <a href="{{ ftl('nightly-firstrun-contribute-link') }}" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start localizing">{{ ftl('nightly-firstrun-start-localizing') }}</a>

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import hero, picto_card, picto with context %}
+{% from "macros-protocol.html" import hero, picto with context %}
 
 {% extends "/firefox/base/base-protocol.html" %}
 
@@ -38,7 +38,7 @@
   <section class="contribute">
     <div class="mzp-l-content">
       <h2 class="contribute-title">{{ ftl('nightly-firstrun-choose-an-area') }}</h2>
-      <ul class="mzp-t-dark mzp-l-columns mzp-t-columns-three">
+      <ul class="mzp-l-card-third mzp-t-dark mzp-l-columns mzp-t-columns-three mzp-t-picto-center">
         {% call picto(
           title=ftl('nightly-firstrun-test'),
           heading_level=3,
@@ -63,7 +63,7 @@
           title=ftl('nightly-firstrun-localize'),
            heading_level=3,
           body=True,
-          image_url='img/firefox/firstrun/code.png',
+          image_url='img/firefox/firstrun/localize.png',
         ) %}
           <p>{{ ftl('nightly-firstrun-make-firefox-available') }}</p>
           <a href="{{ ftl('nightly-firstrun-contribute-link') }}" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start localizing">{{ ftl('nightly-firstrun-start-localizing') }}</a>

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import hero, picto_card with context %}
+{% from "macros-protocol.html" import hero, picto_card, picto with context %}
 
 {% extends "/firefox/base/base-protocol.html" %}
 
@@ -38,32 +38,32 @@
   <section class="contribute">
     <div class="mzp-l-content">
       <h2 class="contribute-title">{{ ftl('nightly-firstrun-choose-an-area') }}</h2>
-      <ul class="mzp-l-card-third mzp-t-dark">
-        {% call picto_card(
+      <ul class="mzp-t-dark mzp-l-columns mzp-t-columns-three">
+        {% call picto(
           title=ftl('nightly-firstrun-test'),
-          class='test',
           heading_level=3,
-          custom_desc=True
+          body=True,
+          image_url='img/firefox/firstrun/test.png',
         ) %}
           <p>{{ ftl('nightly-firstrun-find-and-file-bugs') }}</p>
           <a href="https://quality.mozilla.org/get-involved/" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start testing">{{ ftl('nightly-firstrun-start-testing') }}</a>
         {% endcall %}
 
-        {% call picto_card(
+        {% call picto(
           title=ftl('nightly-firstrun-code'),
-          class='code',
           heading_level=3,
-          custom_desc=True
+          body=True,
+          image_url='img/firefox/firstrun/code.png',
         ) %}
           <p>{{ ftl('nightly-firstrun-file-bugs-and-work') }}</p>
           <a href="https://firefox-source-docs.mozilla.org/contributing/contributing_to_mozilla.html" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start coding">{{ ftl('nightly-firstrun-start-coding') }}</a>
         {% endcall %}
 
-        {% call picto_card(
+        {% call picto(
           title=ftl('nightly-firstrun-localize'),
-          class='localize',
-          heading_level=3,
-          custom_desc=True
+           heading_level=3,
+          body=True,
+          image_url='img/firefox/firstrun/code.png',
         ) %}
           <p>{{ ftl('nightly-firstrun-make-firefox-available') }}</p>
           <a href="{{ ftl('nightly-firstrun-contribute-link') }}" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start localizing">{{ ftl('nightly-firstrun-start-localizing') }}</a>

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -92,7 +92,8 @@
         title=ftl('firefox-privacy-hub-why-trust-firefox'),
         body=True,
         image_url='img/icons/mountain-purple.svg',
-        image_width=150
+        image_width=150,
+        base_el='li'
       ) %}
         <p>
           {{ ftl('firefox-privacy-hub-because-we-put-people-first',
@@ -105,7 +106,8 @@
         title=ftl('firefox-privacy-hub-your-privacy-by-the-product'),
         body=True,
         image_url='img/icons/privacy-shield.svg',
-        image_width=150
+        image_width=150,
+        base_el='li'
       ) %}
         <p>{{ ftl('firefox-privacy-hub-firefox-products-work-differently') }}</p>
         <p><a href="{{ url('firefox.privacy.products') }}">{{ ftl('firefox-privacy-hub-learn-about-our-products') }}</a></p>

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import call_out, feature_card, hero, picto_card, hero with context %}
+{% from "macros-protocol.html" import call_out, feature_card, hero, picto, hero with context %}
 
 {% extends "firefox/privacy/base.html" %}
 
@@ -86,12 +86,13 @@
     {% endcall %}
   </div>
 
-  <div class="privacy-promise-learn-more">
-    <ul class="mzp-l-content mzp-l-card-half">
-      {% call picto_card(
+  <div class="privacy-promise-learn-more mzp-l-content">
+      <ul class=" mzp-l-columns mzp-t-columns-two mzp-t-picto-center">
+      {% call picto(
         title=ftl('firefox-privacy-hub-why-trust-firefox'),
-        class='trust',
-        custom_desc=True
+        body=True,
+        image_url='img/icons/mountain-purple.svg',
+        image_width=150
       ) %}
         <p>
           {{ ftl('firefox-privacy-hub-because-we-put-people-first',
@@ -100,14 +101,16 @@
         <p><a href="{{ url('mozorg.mission') }}">{{ ftl('firefox-privacy-hub-learn-more-about-our-mission') }}</a></p>
       {% endcall %}
 
-      {% call picto_card(
+      {% call picto(
         title=ftl('firefox-privacy-hub-your-privacy-by-the-product'),
-        class='privacy',
-        custom_desc=True
+        body=True,
+        image_url='img/icons/privacy-shield.svg',
+        image_width=150
       ) %}
         <p>{{ ftl('firefox-privacy-hub-firefox-products-work-differently') }}</p>
         <p><a href="{{ url('firefox.privacy.products') }}">{{ ftl('firefox-privacy-hub-learn-about-our-products') }}</a></p>
       {% endcall %}
     </ul>
   </div>
+
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -86,8 +86,8 @@
     {% endcall %}
   </div>
 
-  <div class="privacy-promise-learn-more mzp-l-content">
-      <ul class=" mzp-l-columns mzp-t-columns-two mzp-t-picto-center">
+  <div class="privacy-promise-learn-more">
+      <ul class="mzp-l-content mzp-l-columns mzp-t-columns-two mzp-t-picto-center">
       {% call picto(
         title=ftl('firefox-privacy-hub-why-trust-firefox'),
         body=True,

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import card, picto_card with context %}
+{% from "macros-protocol.html" import card, picto with context %}
 
 {% extends "mozorg/moss/base.html" %}
 
@@ -42,17 +42,17 @@
   <div class="t-medium">
     <div class="mzp-l-content">
       <h2 class="moss-section-heading">{{ _('Award Tracks') }}</h2>
-
       <p>{{ _('MOSS awards are available in multiple tracks:') }}</p>
     </div>
   </div>
-
-  <ul class="mzp-l-content mzp-l-card-third moss-tracks-list">
-    {% call picto_card(
+  <div class="mzp-l-content">
+  <ul class="mzp-l-columns mzp-t-columns-three mzp-t-picto-center moss-tracks-list">
+    {% call picto(
       title=_('Track I: Foundational Technology'),
-      class='foundational-technology',
-      heading_level=3,
-      custom_desc=True
+    heading_level=3,
+      image_url='img/mozorg/moss/foundational-technology.svg',
+      image_width=200,
+      body=True
     ) %}
       <p>{{ _('The Foundational Technology track supports open source projects that Mozilla relies on, either as an embedded part of our products or as part of our everyday work.') }}</p>
       <div class="moss-track-cta">
@@ -61,11 +61,12 @@
       </div>
     {% endcall %}
 
-    {% call picto_card(
+    {% call picto(
       title=_('Track II: Mission Partners'),
-      class='mission-partners',
       heading_level=3,
-      custom_desc=True
+      image_url='img/mozorg/moss/mission-partners.svg',
+      image_width=200,
+      body=True
     ) %}
       <p>{{ _('The Mission Partners track supports open source projects that significantly advance Mozilla’s mission.') }}</p>
       <div class="moss-track-cta">
@@ -74,11 +75,12 @@
       </div>
     {% endcall %}
 
-    {% call picto_card(
+    {% call picto(
       title=_('Track III: Secure Open Source Fund'),
-      class='fund',
       heading_level=3,
-      custom_desc=True
+       image_url='img/mozorg/moss/secure-open-source.svg',
+      image_width=200,
+      body=True
     ) %}
       <p>{{ _('The Secure Open Source (“SOS”) track supports security audits for widely used open source software projects as well as the remedial work needed to rectify the problems found.') }}</p>
       <div class="moss-track-cta">
@@ -87,7 +89,9 @@
       </div>
     {% endcall %}
   </ul>
+  </div>
 </section>
+
 
 <div class="t-medium">
   <section class="mzp-l-content moss-section">

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -49,10 +49,11 @@
   <ul class="mzp-l-columns mzp-t-columns-three mzp-t-picto-center moss-tracks-list">
     {% call picto(
       title=_('Track I: Foundational Technology'),
-    heading_level=3,
+      heading_level=3,
       image_url='img/mozorg/moss/foundational-technology.svg',
       image_width=200,
-      body=True
+      body=True,
+      base_el='li'
     ) %}
       <p>{{ _('The Foundational Technology track supports open source projects that Mozilla relies on, either as an embedded part of our products or as part of our everyday work.') }}</p>
       <div class="moss-track-cta">
@@ -66,7 +67,8 @@
       heading_level=3,
       image_url='img/mozorg/moss/mission-partners.svg',
       image_width=200,
-      body=True
+      body=True,
+      base_el='li'
     ) %}
       <p>{{ _('The Mission Partners track supports open source projects that significantly advance Mozilla’s mission.') }}</p>
       <div class="moss-track-cta">
@@ -78,9 +80,10 @@
     {% call picto(
       title=_('Track III: Secure Open Source Fund'),
       heading_level=3,
-       image_url='img/mozorg/moss/secure-open-source.svg',
+      image_url='img/mozorg/moss/secure-open-source.svg',
       image_width=200,
-      body=True
+      body=True,
+      base_el='li'
     ) %}
       <p>{{ _('The Secure Open Source (“SOS”) track supports security audits for widely used open source software projects as well as the remedial work needed to rectify the problems found.') }}</p>
       <div class="moss-track-cta">

--- a/media/css/firefox/channel.scss
+++ b/media/css/firefox/channel.scss
@@ -7,7 +7,7 @@ $image-path: '/media/protocol/img';
 
 @import '../../protocol/css/includes/lib';
 @import '../../protocol/css/components/hero';
-@import '../../protocol/css/components/picto-card';
+@import '../../protocol/css/components/picto';
 @import '../protocol/components/sub-navigation';
 @import '../../protocol/css/components/newsletter-form';
 @import '../../protocol/css/components/call-out';
@@ -30,17 +30,6 @@ $image-path: '/media/protocol/img';
 
     .mzp-c-hero-desc {
         margin: 0;
-    }
-}
-
-//* -------------------------------------------------------------------------- */
-// Picto Card
-
-.bugzilla .mzp-c-card-picto-content {
-    max-width: none;
-
-    &:before {
-        background: transparent url('/media/img/icons/warning.svg') no-repeat center;
     }
 }
 

--- a/media/css/firefox/firstrun/nightly.scss
+++ b/media/css/firefox/firstrun/nightly.scss
@@ -7,6 +7,7 @@ $image-path: '/media/protocol/img';
 
 @import '../../../protocol/css/includes/lib';
 @import '../../../protocol/css/components/picto-card';
+@import '../../../protocol/css/components/picto';
 @import '../../../protocol/css/components/hero';
 @import '../../../protocol/css/templates/card-layout';
 
@@ -59,15 +60,7 @@ main {
         color: $color-white;
     }
 
-    .test .mzp-c-card-picto-content::before {
-        background-image: url('/media/img/firefox/firstrun/test.png');
-    }
-    .code .mzp-c-card-picto-content::before {
-        background-image: url('/media/img/firefox/firstrun/code.png');
-    }
-    .localize .mzp-c-card-picto-content::before {
-        background-image: url('/media/img/firefox/firstrun/localize.png');
-    }
+
 }
 
 .locale-specific {

--- a/media/css/firefox/firstrun/nightly.scss
+++ b/media/css/firefox/firstrun/nightly.scss
@@ -79,7 +79,6 @@ main {
     margin-bottom: $layout-md;
     @media #{$mq-md} {
         margin-bottom: 0;
-        padding: 48px;
-        padding-bottom: 0;
+        padding: $spacing-2xl $spacing-2xl 0;
     }
 }

--- a/media/css/firefox/firstrun/nightly.scss
+++ b/media/css/firefox/firstrun/nightly.scss
@@ -8,6 +8,7 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/includes/lib';
 @import '../../../protocol/css/components/picto-card';
 @import '../../../protocol/css/components/picto';
+@import '../../../protocol/css/templates/multi-column';
 @import '../../../protocol/css/components/hero';
 @import '../../../protocol/css/templates/card-layout';
 
@@ -59,8 +60,6 @@ main {
     .mzp-c-card-picto-desc p {
         color: $color-white;
     }
-
-
 }
 
 .locale-specific {
@@ -73,5 +72,14 @@ main {
     h5,
     h6 {
         @include text-title-sm;
+    }
+}
+
+.mzp-l-columns .mzp-c-picto {
+    margin-bottom: $layout-md;
+    @media #{$mq-md} {
+        margin-bottom: 0;
+        padding: 48px;
+        padding-bottom: 0;
     }
 }

--- a/media/css/firefox/privacy/promise.scss
+++ b/media/css/firefox/privacy/promise.scss
@@ -94,11 +94,15 @@ $image-path: '/media/protocol/img';
 /* -------------------------------------------------------------------------- */
 // Picto Cards
 
+.mzp-l-columns .mzp-c-picto {
+    margin-bottom: $layout-md;
+    @media #{$mq-md} {
+        margin-bottom: 0;
+        padding: $spacing-2xl $spacing-2xl 0;
+    }
+}
+
 .privacy-promise-learn-more {
     background-color: $color-marketing-gray-10;
-
-    .mzp-c-card-picto-content {
-        max-width: 500px;
-    }
 }
 

--- a/media/css/firefox/privacy/promise.scss
+++ b/media/css/firefox/privacy/promise.scss
@@ -6,6 +6,8 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/picto';
+@import '../../../protocol/css/templates/multi-column';
 
 
 /* -------------------------------------------------------------------------- */

--- a/media/css/firefox/privacy/promise.scss
+++ b/media/css/firefox/privacy/promise.scss
@@ -100,33 +100,5 @@ $image-path: '/media/protocol/img';
     .mzp-c-card-picto-content {
         max-width: 500px;
     }
-
-    // Custom Overrides pending https://github.com/mozilla/protocol/issues/382
-    .mzp-c-card-picto {
-
-        .mzp-c-card-picto-content {
-            padding-top: 113px + $spacing-lg;
-
-            &:before {
-                background-color: transparent;
-                background-repeat: no-repeat;
-            }
-        }
-
-        &.trust .mzp-c-card-picto-content:before {
-            background-image: url('/media/img/icons/mountain-purple.svg');
-            height: 113px;
-            margin-left: -76px;
-            width: 153px;
-        }
-
-        &.privacy .mzp-c-card-picto-content:before {
-            background-image: url('/media/img/icons/privacy-shield.svg');
-            height: 113px;
-            margin-left: -73px;
-            width: 146px;
-        }
-    }
 }
-
 

--- a/media/css/mozorg/moss.scss
+++ b/media/css/mozorg/moss.scss
@@ -7,7 +7,8 @@ $image-path: '/media/protocol/img';
 
 @import '../../protocol/css/includes/lib';
 @import '../../protocol/css/components/newsletter-form';
-@import '../../protocol/css/components/picto-card';
+@import '../../protocol/css/components/picto';
+@import '../../protocol/css/templates/multi-column';
 @import '../../protocol/css/templates/card-layout';
 
 /* -------------------------------------------------------------------------- */
@@ -117,59 +118,24 @@ $image-path: '/media/protocol/img';
 /* -------------------------------------------------------------------------- */
 // Picto cards
 
-.mzp-c-card-picto {
-    padding: 0;
-
-    .mzp-c-card-picto-content {
-        padding-top: 220px;
-    }
-
-    .mzp-c-card-picto-content:before {
-        background-color: transparent;
-        background-repeat: no-repeat;
-        height: 200px;
-        margin-left: -100px;
-        width: 200px;
-    }
-
-    &.foundational-technology .mzp-c-card-picto-content:before {
-        @include background-size(200px 200px);
-        background-image: url('/media/img/mozorg/moss/foundational-technology.svg');
-    }
-
-    &.mission-partners .mzp-c-card-picto-content:before {
-        @include background-size(200px 193px);
-        background-image: url('/media/img/mozorg/moss/mission-partners.svg');
-    }
-
-    &.fund .mzp-c-card-picto-content:before {
-        @include background-size(200px 172px);
-        background-image: url('/media/img/mozorg/moss/secure-open-source.svg');
-    }
-}
-
 // Vertically align buttons in moss tracks lists.
 @supports(display: flex) {
     @media #{$mq-md} {
         .moss-tracks-list {
             display: flex;
 
-            .mzp-c-card-picto {
+            .mzp-c-picto {
                 align-items: stretch;
                 display: flex;
+                flex-direction: column;
                 flex: 1;
             }
 
-            .mzp-c-card-picto-content {
-                display: flex;
-                flex-direction: column;
-            }
-
-            .mzp-c-card-picto-title {
+            .mzp-c-picto-heading {
                 flex-grow: 1;
             }
 
-            .mzp-c-card-picto-desc {
+            .mzp-c-picto-body {
                 display: flex;
                 flex-direction: column;
                 flex-grow: 2;


### PR DESCRIPTION
## Description
This PR mainly addressed replacing the old Picto Card component with the new Picto component in Protocol.

## Issue / Bugzilla link
#10341 

## Testing
http://localhost:8000/en-US/firefox/channel/desktop/
http://localhost:8000/en-US/firefox/nightly/firstrun/
http://localhost:8000/en-US/firefox/privacy/
http://localhost:8000/en-US/moss






