### PR TITLE
Limit RTAMO attribution to AMO referrals (Fixes #10337)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -334,6 +334,16 @@ if (typeof window.Mozilla === 'undefined') {
         return data;
     };
 
+    StubAttribution.hasValidData = function(data) {
+        if (typeof data.utm_content === 'string' && typeof data.referrer === 'string') {
+            // If RTAMO data does not originate from AMO, drop attribution (Issue 10337).
+            if ((/^rta:/).test(decodeURIComponent(data.utm_content)) && data.referrer.indexOf('https://addons.mozilla.org') === -1) {
+                return false;
+            }
+        }
+        return true;
+    };
+
     /**
      * Determine if the current page is scene2 of /firefox/new/.
      * This is needed as scene2 auto-initiates the download. There is little point
@@ -410,7 +420,7 @@ if (typeof window.Mozilla === 'undefined') {
             StubAttribution.waitForGoogleAnalytics(function() {
                 data = StubAttribution.getAttributionData();
 
-                if (data && StubAttribution.withinAttributionRate()) {
+                if (data && StubAttribution.withinAttributionRate() && StubAttribution.hasValidData(data)) {
                     StubAttribution.requestAuthentication(data);
                 }
             });


### PR DESCRIPTION
## Description
- If `utm_content` contains valid RTAMO data, and `referrer` is **not** AMO, then drop attribution data.

## Issue / Bugzilla link
#10337

## Testing
Validate that no attribution cookie is created when hitting a RTAMO link directly (i.e. the referrer is not AMO):

1. On a Windows device using Chrome, open a new Incognito Window and visit https://www-demo2.allizom.org/en-US/firefox/new/?utm_source=addons.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button&utm_content=rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20
2. Open Developer Tools and select the Application tab.
3. In the Storage panel on the left, open the Cookie menu and select www-demo2.
4. Validate that there are no `moz-stub-attribution-code` and `moz-stub-attribution-sig` cookies created.