### PR TITLE
Add Fluent config for VPN content pages [#10224]

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -284,3 +284,6 @@ locales = [
 [[paths]]
     reference = "en/products/vpn/shared.ftl"
     l10n = "{locale}/products/vpn/shared.ftl"
+[[paths]]
+    reference = "en/products/vpn/more/*.ftl"
+    l10n = "{locale}/products/vpn/more/*.ftl"


### PR DESCRIPTION
## Description
Adds the new VPN content pages added in https://github.com/mozilla/bedrock/pull/10339 to pontoon.toml
