### PR TITLE
Fix dead source code links on /firefox/all page (Fix bug 1722760)

### DIFF
--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -46,35 +46,35 @@
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_beta">
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_developer">
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_nightly">
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_esr">
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="android_release">
@@ -210,7 +210,7 @@
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_release', desktop_release_channel_label, desktop_release_platforms, desktop_release_full_builds, 'release') }}
         </section>
@@ -220,7 +220,7 @@
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_beta', desktop_beta_channel_label, desktop_beta_platforms, desktop_beta_full_builds, 'beta') }}
         </section>
@@ -230,7 +230,7 @@
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_developer', desktop_developer_channel_label, desktop_developer_platforms, desktop_developer_full_builds, 'alpha') }}
         </section>
@@ -240,7 +240,7 @@
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_nightly', desktop_nightly_channel_label, desktop_nightly_platforms, desktop_nightly_full_builds, 'nightly') }}
         </section>
@@ -250,7 +250,7 @@
           <ul>
             <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
             <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
 
           {% if desktop_esr_next_version %}

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -570,8 +570,8 @@ redirectpatterns = (
 
     redirect(r'^projects/marketing(/.*)?$', 'https://wiki.mozilla.org/MarketingGuide'),
 
-    # bug 1288647
-    redirect(r'^hacking/?$', 'https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction'),
+    # bug 1288647, 1722760
+    redirect(r'^hacking/?$', 'https://firefox-source-docs.mozilla.org/'),
 
     redirect(r'^(careers|jobs)/?$', 'https://careers.mozilla.org/'),
     redirect(r'^join/?$', 'https://donate.mozilla.org/'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1056,8 +1056,8 @@ URLS = flatten((
 
     url_test('/firefox/{,46.0/,46.0.1/,47.0/,47.0.1/}secondrun', '/firefox/mobile/'),
 
-    # bug 1288647
-    url_test('/hacking', 'https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction'),
+    # bug 1288647, 1722760
+    url_test('/hacking', 'https://firefox-source-docs.mozilla.org/'),
 
     url_test('/{careers,jobs}', 'https://careers.mozilla.org/'),
     url_test('/join', 'https://donate.mozilla.org/'),


### PR DESCRIPTION
## Description

- Fixes broken "source code" links on /firefox/all/ page.
- Updates old `/hacking` redirect.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1722760

## Testing

http://localhost:8000/en-US/firefox/all/