### PR TITLE
Add media_after param to split macro (fixes #10367)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -66,17 +66,30 @@
 
 
 {# Split: https://protocol.mozilla.org/patterns/organisms/split.html #}
-{% macro split(id=None, block_class=None, theme_class=None, body_class=None, image_url=None, media_class=None, include_highres_image=False, l10n_image=False, image_alt='') -%}
+{% macro split(id=None, block_class=None, theme_class=None, body_class=None, image_url=None, media_class=None, include_highres_image=False, l10n_image=False, image_alt='', media_after=False) -%}
 
 <section {% if id %}id="{{ id }}"{% endif %} class="mzp-c-split{% if block_class %} {{ block_class }}{% endif %}">
   {% if theme_class %}
   <div class="mzp-c-split-bg {{ theme_class }}">
   {% endif %}
   <div class="mzp-c-split-container">
+    {% if image_url and not media_after %}
+    <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
+      {% if include_highres_image %}
+        {{ high_res_img(image_url, {'alt': image_alt, 'l10n': l10n_image, 'class': 'mzp-c-split-media-asset'}) }}
+      {% else %}
+        {% if l10n_image %}
+          <img class="mzp-c-split-media-asset" src="{{ l10n_img(image_url) }}" alt="{{ image_alt }}">
+        {% else %}
+          <img class="mzp-c-split-media-asset" src="{{ static(image_url) }}" alt="{{ image_alt }}">
+        {% endif %}
+      {% endif %}
+    </div>
+    {% endif %}
     <div class="mzp-c-split-body{% if body_class %} {{ body_class }}{% endif %}">
       {{ caller() }}
     </div>
-    {% if image_url %}
+    {% if image_url and media_after %}
     <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
       {% if include_highres_image %}
         {{ high_res_img(image_url, {'alt': image_alt, 'l10n': l10n_image, 'class': 'mzp-c-split-media-asset'}) }}

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -39,6 +39,7 @@
   {% call split(
     image_url='img/firefox/browsers/quantum/browser.jpg',
     include_highres_image=True,
+    media_after=True
   ) %}
   <div class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></div>
   <h1 class="mzp-u-title-xl">{{ ftl('browsers-chromebook-get-firefox-browser') }}</h1>

--- a/bedrock/firefox/templates/firefox/browsers/quantum.html
+++ b/bedrock/firefox/templates/firefox/browsers/quantum.html
@@ -18,6 +18,7 @@
 {% call split(
     image_url='img/firefox/browsers/quantum/browser.jpg',
     include_highres_image=True,
+    media_after=True
   ) %}
   <div class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></div>
   <h1 class="mzp-u-title-xl">{{ ftl('the-latest-firefox') }}</h1>

--- a/bedrock/firefox/templates/firefox/developer/includes/nightly.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/nightly.html
@@ -3,7 +3,8 @@
 {% call split(
   image_url='img/firefox/developer/browser-nightly.png',
   include_highres_image=True,
-  block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md'
+  block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md',
+  media_after=True
 ) %}
   <h2>{{ ftl('firefox-developer-want-to-be-on-the-cutting-edge') }}</h2>
   <p>{{ ftl('firefox-developer-firefox-nightly-receives') }}</p>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -82,7 +82,8 @@
     {% call split(
       image_url='img/firefox/developer/browser.png',
       include_highres_image=True,
-      block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md'
+      block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md',
+      media_after=True
     ) %}
       <h2>{{ ftl('firefox-developer-download-the-firefox-browser') }}</h2>
       {{ download_firefox('alpha', platform='desktop', dom_id='footer-download', download_location='footer cta') }}

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -26,6 +26,7 @@
     block_class='mzp-t-split-nospace',
     theme_class='mzp-t-background-alt',
     media_class='mzp-l-split-h-center',
+    media_after=True
   ) %}
   <h1 class="mzp-u-title-lg">{{ _('Build Security') }}</h1>
   <p>{{ _('How are you protecting customer data?') }}</p>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -26,6 +26,7 @@
     block_class='mzp-t-split-nospace',
     theme_class='mzp-t-background-alt',
     media_class='mzp-l-split-h-center',
+    media_after=True
   ) %}
   <h1 class="mzp-u-title-lg">{{ _('Engage Users') }}</h1>
   <p>{{ _('Do your customers know your data practices?') }}</p>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
@@ -25,6 +25,7 @@
     block_class='mzp-t-split-nospace',
     theme_class='mzp-t-background-alt',
     media_class='mzp-l-split-h-center',
+    media_after=True
   ) %}
   <h1 class="mzp-u-title-lg">{{ self.page_title() }}</h1>
   <p>{{ _('Staying lean and being smart about how you collect data can build trust with your users and ultimately help grow your business.') }}</p>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -26,6 +26,7 @@
     block_class='mzp-t-split-nospace',
     theme_class='mzp-t-background-alt',
     media_class='mzp-l-split-h-center',
+    media_after=True
   ) %}
   <h1 class="mzp-u-title-lg">{{ _('Stay Lean') }}</h1>
   <p>{{ _('Do I need this data to provide the value I’m trying to deliver?') }}</p>

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -95,6 +95,7 @@
       include_highres_image=True,
       block_class='mzp-l-split-pop',
       media_class='mzp-l-split-media-constrain-height',
+      media_after=True
     ) %}
     <h3 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-vpn">Mozilla VPN</h3>
     <h4 class="mzp-u-title-md">Protection for your whole device, on every device</h4>
@@ -109,6 +110,7 @@
         include_highres_image=True,
         block_class='mzp-l-split-reversed mzp-l-split-pop',
         media_class='mzp-l-split-media-constrain-height',
+        media_after=True
       ) %}
       <h3 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-pocket">Pocket</h3>
       <h4 class="mzp-u-title-md">Welcome to the web, sunny side up</h4>


### PR DESCRIPTION
## Description

Most of the deprecated components we want to upgrade to use Split stack media before text. In the bedrock split macro, we always set media second, but the Protocol component can handle either source order. This PR updates the bedrock macro to add a media_after param and sets the stack order as media first by default.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10367

## Testing

The following should stack media after text:
http://localhost:8000/en-US/
http://localhost:8000/en-US/firefox/browsers/quantum/
http://localhost:8000/en-US/firefox/browsers/chromebook/
http://localhost:8000/en-US/about/policy/lean-data/
http://localhost:8000/en-US/about/policy/lean-data/stay-lean/
http://localhost:8000/en-US/about/policy/lean-data/build-security/
http://localhost:8000/en-US/about/policy/lean-data/engage-users/
http://localhost:8000/en-US/firefox/developer/ (bottom dark theme section: Download the Firefox browser made for developers)

The following should stack media before text (sample urls, complete list is quite long now):
http://localhost:8000/en-US/firefox/developer/ (near top light theme section: The browser made for developers)
http://localhost:8000/en-US/firefox/features/bookmarks/
