### PR TITLE
Break up common.js bundle (Fixes #9321)

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -116,7 +116,9 @@
 
     {% block site_js %}
       <!--[if !IE]><!-->
-        {{ js_bundle('common') }}
+        {{ js_bundle('lib') }}
+        {{ js_bundle('ui') }}
+        {{ js_bundle('data') }}
       <!--<![endif]-->
 
       <!--[if IE]>

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1344,11 +1344,17 @@
       "files": [
         "js/libs/classlist.js",
         "js/base/search-params.js",
+        "js/base/uitour-lib.js",
+        "js/base/mozilla-run.js",
         "js/base/mozilla-utils.js",
         "js/base/mozilla-client.js",
-        "js/base/mozilla-run.js",
         "protocol/js/protocol-supports.js",
-        "protocol/js/protocol-utils.js",
+        "protocol/js/protocol-utils.js"
+      ],
+      "name": "lib"
+    },
+    {
+      "files": [
         "js/base/protocol/protocol-menu.js",
         "js/base/protocol/protocol-navigation.js",
         "js/base/protocol/init-navigation.js",
@@ -1357,16 +1363,20 @@
         "protocol/js/protocol-details.js",
         "js/base/protocol/protocol-footer.js",
         "js/base/protocol/protocol-sub-navigation.js",
-        "js/base/base-page-init.js",
-        "js/base/core-datalayer.js",
-        "js/base/core-datalayer-init.js",
-        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-link.js",
         "js/base/mozilla-fxa-link-init.js",
+        "js/base/base-page-init.js"
+      ],
+      "name": "ui"
+    },
+    {
+      "files": [
+        "js/base/core-datalayer.js",
+        "js/base/core-datalayer-init.js",
         "js/base/fxa-utm-referral.js",
         "js/base/fxa-utm-referral-init.js"
       ],
-      "name": "common"
+      "name": "data"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Splits up `common.js` into three separate bundles with more distinct responsibilities:

- `lib.js` (libraries, utilities, polyfills).
- `ui.js` (global components etc).
- `data.js` (analytics and referrals).

Happy to bikeshed the naming if others have ideas or suggestions.

## Issue / Bugzilla link
#9321

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/350097824