### PR TITLE
Use UA detection to serve 64bit builds Firefox Beta on Windows (Fixes #10194)

### DIFF
--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -102,6 +102,15 @@ ul.download-list {
     display: block !important;
 }
 
+// 64-bit UA detection for Firefox Beta on Windows (issue #10194)
+.windows.x86.x64 .download-button-beta .os_win {
+    display: none !important;
+}
+
+.windows.x86.x64 .download-button-beta .os_win64 {
+    display: block !important;
+}
+
 .android .download-button-desktop,
 .ios .download-button-desktop,
 .no-js .download-button {


### PR DESCRIPTION
## Description
- Serve Windows 64bit Firefox Beta installer on /channel page for matching user agents.

## Issue / Bugzilla link
#10194

## Testing
Local: http://localhost:8000/en-US/firefox/channel/desktop/
Demo: https://www-demo1.allizom.org/en-US/firefox/channel/desktop/

- [x] On a Windows 64bit OS, clicking the download button for Firefox Beta should load https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=win64&lang=en-US