### PR TITLE
Update Hero components with Split

### DIFF
--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -105,7 +105,7 @@
       block_class='mzp-l-split-center-on-sm-md'
     ) %}
 
-    <h1> {{ ftl('lockwise-firefox-lockwise') }} </h1>
+    <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
     <p class="mzp-u-title-md">{{ ftl('lockwise-take-your-passwords-everywhere') }}</p>
     <p>{{ ftl('lockwise-securely-access-the-passwords') }}</p>
 

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button with context %}
-{% from "macros-protocol.html" import hero, split, picto with context %}
+{% from "macros-protocol.html" import split, picto with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -58,46 +58,6 @@
       {% set _img = 'img/firefox/lockwise/en.png'%}
     {% endif %}
 
-    <!-- {% call hero(
-      title=ftl('lockwise-firefox-lockwise'),
-      tagline=ftl('lockwise-take-your-passwords-everywhere'),
-      desc=ftl('lockwise-securely-access-the-passwords'),
-      class='mzp-c-hero mzp-has-image lockwise-hero',
-      image_url= _img,
-      include_cta=True,
-      heading_level=1,
-    ) %}
-
-      <div class="mobile-download-buttons">
-        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
-      </div>
-      <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden" >
-        <div class="mzp-c-button-download-container">
-          <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
-          <a href="https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.5-alpha/lockwise-signed.xpi" class="mzp-c-button mzp-t-product" data-cta-type="lockwise-install" data-cta-position="primary">
-            {{ ftl('lockwise-install-for-firefox') }}
-          </a>
-        </div>
-      </div>
-      <div class="mzp-c-hero-cta add-on-download for-firefox-70-and-above hidden" >
-        <div class="mzp-c-button-download-container">
-          <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
-          <button class="mzp-c-button mzp-t-product" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="primary">{{ ftl('lockwise-open-in-firefox') }} </button>
-        </div>
-      </div>
-      <div class="mzp-c-hero-cta add-on-download for-non-firefox-users hidden" >
-        <div class="mzp-c-button-download-container">
-          <p>{{ ftl('lockwise-only-in-the-firefox-browser') }}</p>
-          {{ download_firefox(alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}
-        </div>
-      </div>
-
-    {% endcall %} -->
-
-    <!-- split -->
     {% call split(
       image_url= _img,
       media_after=True,
@@ -105,7 +65,7 @@
       block_class='mzp-l-split-center-on-sm-md'
     ) %}
 
-    <h1 class="mzp-c-wordmark mzp-t-wordmark-lg mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
+    <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
     <p class="mzp-u-title-md">{{ ftl('lockwise-take-your-passwords-everywhere') }}</p>
     <p>{{ ftl('lockwise-securely-access-the-passwords') }}</p>
 

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button with context %}
-{% from "macros-protocol.html" import hero, picto with context %}
+{% from "macros-protocol.html" import hero, split, picto with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -62,7 +62,7 @@
       image_url= _img,
       media_after=True,
       media_class='mzp-l-split-h-center',
-      block_class='mzp-l-split-center-on-sm-md'
+      block_class='mzp-l-split-center-on-sm-md '
     ) %}
 
     <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
@@ -75,7 +75,7 @@
         </a>
         {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
-      <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden" >
+      <div class="add-on-download for-firefox-69-and-below hidden" >
         <div class="mzp-c-button-download-container">
           <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
           <a href="https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.5-alpha/lockwise-signed.xpi" class="mzp-c-button mzp-t-product" data-cta-type="lockwise-install" data-cta-position="primary">
@@ -83,13 +83,13 @@
           </a>
         </div>
       </div>
-      <div class="mzp-c-hero-cta add-on-download for-firefox-70-and-above hidden" >
+      <div class="add-on-download for-firefox-70-and-above hidden" >
         <div class="mzp-c-button-download-container">
           <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
           <button class="mzp-c-button mzp-t-product" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="primary">{{ ftl('lockwise-open-in-firefox') }} </button>
         </div>
       </div>
-      <div class="mzp-c-hero-cta add-on-download for-non-firefox-users hidden" >
+      <div class="add-on-download for-non-firefox-users hidden" >
         <div class="mzp-c-button-download-container">
           <p>{{ ftl('lockwise-only-in-the-firefox-browser') }}</p>
           {{ download_firefox(alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -58,7 +58,7 @@
       {% set _img = 'img/firefox/lockwise/en.png'%}
     {% endif %}
 
-    {% call hero(
+    <!-- {% call hero(
       title=ftl('lockwise-firefox-lockwise'),
       tagline=ftl('lockwise-take-your-passwords-everywhere'),
       desc=ftl('lockwise-securely-access-the-passwords'),
@@ -95,7 +95,7 @@
         </div>
       </div>
 
-    {% endcall %}
+    {% endcall %} -->
 
     <!-- split -->
     {% call split(
@@ -105,7 +105,7 @@
       block_class='mzp-l-split-center-on-sm-md'
     ) %}
 
-    <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
+    <h1 class="mzp-c-wordmark mzp-t-wordmark-lg mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
     <p class="mzp-u-title-md">{{ ftl('lockwise-take-your-passwords-everywhere') }}</p>
     <p>{{ ftl('lockwise-securely-access-the-passwords') }}</p>
 

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -57,6 +57,7 @@
     {% else %}
       {% set _img = 'img/firefox/lockwise/en.png'%}
     {% endif %}
+
     {% call hero(
       title=ftl('lockwise-firefox-lockwise'),
       tagline=ftl('lockwise-take-your-passwords-everywhere'),
@@ -94,6 +95,46 @@
         </div>
       </div>
 
+    {% endcall %}
+
+    <!-- split -->
+    {% call split(
+      image_url= _img,
+      media_after=True,
+      media_class='mzp-l-split-h-center',
+      block_class='mzp-l-split-center-on-sm-md'
+    ) %}
+
+    <h1> {{ ftl('lockwise-firefox-lockwise') }} </h1>
+    <p class="mzp-u-title-md">{{ ftl('lockwise-take-your-passwords-everywhere') }}</p>
+    <p>{{ ftl('lockwise-securely-access-the-passwords') }}</p>
+
+      <div class="mobile-download-buttons">
+        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+        </a>
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+      </div>
+      <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden" >
+        <div class="mzp-c-button-download-container">
+          <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
+          <a href="https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.5-alpha/lockwise-signed.xpi" class="mzp-c-button mzp-t-product" data-cta-type="lockwise-install" data-cta-position="primary">
+            {{ ftl('lockwise-install-for-firefox') }}
+          </a>
+        </div>
+      </div>
+      <div class="mzp-c-hero-cta add-on-download for-firefox-70-and-above hidden" >
+        <div class="mzp-c-button-download-container">
+          <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
+          <button class="mzp-c-button mzp-t-product" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="primary">{{ ftl('lockwise-open-in-firefox') }} </button>
+        </div>
+      </div>
+      <div class="mzp-c-hero-cta add-on-download for-non-firefox-users hidden" >
+        <div class="mzp-c-button-download-container">
+          <p>{{ ftl('lockwise-only-in-the-firefox-browser') }}</p>
+          {{ download_firefox(alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}
+        </div>
+      </div>
     {% endcall %}
 
     <section class="mzp-t-dark">

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -66,7 +66,7 @@
     ) %}
 
     <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-lockwise"> {{ ftl('lockwise-firefox-lockwise') }} </h1>
-    <p class="mzp-u-title-md">{{ ftl('lockwise-take-your-passwords-everywhere') }}</p>
+    <h2 class="mzp-u-title-md">{{ ftl('lockwise-take-your-passwords-everywhere') }}</h2>
     <p>{{ ftl('lockwise-securely-access-the-passwords') }}</p>
 
       <div class="mobile-download-buttons">

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -24,12 +24,11 @@
       media_class='mzp-l-split-h-center',
       block_class='mzp-l-split-center-on-sm-md'
     ) %}
-      <div
-       class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">
+      <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">
         Firefox Browser
       </div>
-      <h1>{{ ftl('switch-switch-from-chrome') }}</h1>
-      <p>{{ ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description') }}</p>
+      <h1 class="mzp-u-title-xl">{{ ftl('switch-switch-from-chrome') }}</h1>
+      <p class="mzp-u-body-md">{{ ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description') }}</p>
     {% endcall %}
 
   <section class="c-steps mzp-l-content">

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% from "macros-protocol.html" import hero, split with context %}
+{% from "macros-protocol.html" import split with context %}
 
 {% block page_title %}{{ ftl('switch-switch-from-chrome') }}{% endblock %}
 {% block page_desc %}{{ ftl('switch-switching-to-firefox-is-fast-updated', fallback='switch-switching-to-firefox-is-fast') }}{% endblock %}
@@ -17,16 +17,6 @@
 
 {% block content %}
 <main>
-  {% call hero(
-    title=ftl('switch-switch-from-chrome'),
-    desc=ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description'),
-    class='mzp-has-image mzp-t-product-firefox t-switch',
-    include_cta=False,
-    heading_level=1
-  ) %}
-  {% endcall %}
-
-  <!-- new split -->
   {% call split(
       image_url='img/firefox/switch/switch.png',
       include_highres_image=True,

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -22,7 +22,7 @@
       include_highres_image=True,
       media_after=True,
       media_class='mzp-l-split-h-center',
-      block_class='mzp-l-split-center-on-sm-md'
+      block_class='mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md'
     ) %}
       <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">
         Firefox Browser

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% from "macros-protocol.html" import hero, picto_card with context %}
+{% from "macros-protocol.html" import hero, split with context %}
 
 {% block page_title %}{{ ftl('switch-switch-from-chrome') }}{% endblock %}
 {% block page_desc %}{{ ftl('switch-switching-to-firefox-is-fast-updated', fallback='switch-switching-to-firefox-is-fast') }}{% endblock %}
@@ -25,6 +25,22 @@
     heading_level=1
   ) %}
   {% endcall %}
+
+  <!-- new split -->
+  {% call split(
+      image_url='img/firefox/switch/switch.png',
+      include_highres_image=True,
+      media_after=True,
+      media_class='mzp-l-split-h-center',
+      block_class='mzp-l-split-center-on-sm-md'
+    ) %}
+      <div
+       class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">
+        Firefox Browser
+      </div>
+      <h1>{{ ftl('switch-switch-from-chrome') }}</h1>
+      <p>{{ ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description') }}</p>
+    {% endcall %}
 
   <section class="c-steps mzp-l-content">
     <ol class="c-steps-list">

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -28,7 +28,7 @@
         Firefox Browser
       </div>
       <h1 class="mzp-u-title-xl">{{ ftl('switch-switch-from-chrome') }}</h1>
-      <p class="mzp-u-body-md">{{ ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description') }}</p>
+      <p>{{ ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description') }}</p>
     {% endcall %}
 
   <section class="c-steps mzp-l-content">

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -58,7 +58,7 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if switch('firefox-mr1-launch') %}
+  {% if not switch('firefox-mr1-launch') %}
     {%- set promos = [
       'mozorg/home/includes/mr1-promo-lalo.html',
       'mozorg/home/includes/mr1-promo-soraya.html',
@@ -72,8 +72,7 @@
       include_highres_image=True,
       media_after=True,
       media_class='mzp-l-split-h-center',
-      block_class='mzp-t-split-nospace mzp-l-split-center-on-sm-md mzp-t-dark mzp-t-firefox',
-      theme_class=''
+      block_class='mzp-t-split-nospace mzp-l-split-center-on-sm-md mzp-t-dark mzp-t-firefox mzp-l-split-hide-media-on-sm-md'
     ) %}
       <h2 class="mzp-u-title-lg">Firefox products are designed to protect your privacy</h2>
       <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -58,7 +58,7 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if switch('firefox-mr1-launch') %}
+  {% if not switch('firefox-mr1-launch') %}
     {%- set promos = [
       'mozorg/home/includes/mr1-promo-lalo.html',
       'mozorg/home/includes/mr1-promo-soraya.html',
@@ -67,12 +67,23 @@
     ] -%}
     {% include promos|random() %}
   {% else %}
+    {% call hero(
+      title='Firefox products are designed to protect your privacy',
+      class='privacy-promise-hero mzp-has-image mzp-t-dark mzp-t-firefox',
+      image_url='img/firefox/privacy/promise/privacy-hero.png',
+      include_highres_image=True,
+      include_cta=True,
+      heading_level=2
+    ) %}
+      <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>
+    {% endcall %}
     {% call split(
       image_url='img/firefox/privacy/promise/privacy-hero.png',
       include_highres_image=True,
       media_after=True,
       media_class='mzp-l-split-h-center',
-      block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-t-dark mzp-t-firefox',
+      block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md',
+      theme_class='mzp-t-dark mzp-t-firefox'
     ) %}
       <h2>Firefox products are designed to protect your privacy</h2>
       <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import hero, split, billboard, card, call_out_compact, content_card with context %}
+{% from "macros-protocol.html" import split, billboard, card, call_out_compact, content_card with context %}
 {% from "mozorg/home/includes/macros.html" import download_banner, download_banner_secondary, fxa_banner %}
 
 {% extends "base-protocol-mozilla.html" %}
@@ -58,7 +58,7 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if not switch('firefox-mr1-launch') %}
+  {% if switch('firefox-mr1-launch') %}
     {%- set promos = [
       'mozorg/home/includes/mr1-promo-lalo.html',
       'mozorg/home/includes/mr1-promo-soraya.html',
@@ -67,25 +67,15 @@
     ] -%}
     {% include promos|random() %}
   {% else %}
-    {% call hero(
-      title='Firefox products are designed to protect your privacy',
-      class='privacy-promise-hero mzp-has-image mzp-t-dark mzp-t-firefox',
-      image_url='img/firefox/privacy/promise/privacy-hero.png',
-      include_highres_image=True,
-      include_cta=True,
-      heading_level=2
-    ) %}
-      <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>
-    {% endcall %}
     {% call split(
       image_url='img/firefox/privacy/promise/privacy-hero.png',
       include_highres_image=True,
       media_after=True,
       media_class='mzp-l-split-h-center',
-      block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md',
-      theme_class='mzp-t-dark mzp-t-firefox'
+      block_class='mzp-t-split-nospace mzp-l-split-center-on-sm-md mzp-t-dark mzp-t-firefox',
+      theme_class=''
     ) %}
-      <h2>Firefox products are designed to protect your privacy</h2>
+      <h2 class="mzp-u-title-lg">Firefox products are designed to protect your privacy</h2>
       <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>
     {% endcall %}
   {% endif %}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -67,14 +67,14 @@
     ] -%}
     {% include promos|random() %}
   {% else %}
-    {% call hero(
-      title='Firefox products are designed to protect your privacy',
-      class='privacy-promise-hero mzp-has-image mzp-t-dark mzp-t-firefox',
+    {% call split(
       image_url='img/firefox/privacy/promise/privacy-hero.png',
       include_highres_image=True,
-      include_cta=True,
-      heading_level=2
+      media_after=True,
+      media_class='mzp-l-split-h-center',
+      block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-t-dark mzp-t-firefox',
     ) %}
+      <h2>Firefox products are designed to protect your privacy</h2>
       <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>
     {% endcall %}
   {% endif %}

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '../../../protocol/css/includes/lib';
-@import '../../../protocol/css/components/hero';
 @import '../../../protocol/css/components/picto';
 @import '../../../protocol/css/components/split';
 @import '../../../protocol/css/templates/card-layout';
@@ -14,27 +13,42 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/components/logos/wordmark';
 @import '../../../protocol/css/components/logos/wordmark-product-lockwise';
 
+// split
+.mzp-c-split-container {
+
+    p {
+        font-size: 18px;
+    }
+
+    @media #{$mq-lg} {
+        box-sizing: content-box;
+    }
+}
+
+.mzp-c-split-body .mzp-u-title-md {
+    @include font-base;
+    font-size: 38px;
+}
+
+@media #{$mq-lg} {
+
+    .mzp-c-split-body .mzp-u-title-md {
+         font-size: 38px;
+     }
+}
+
+.mzp-c-split-container .mzp-c-split-media {
+    @media #{$mq-lg} {
+        width: 460px;
+    }
+}
 
 .add-on-download p {
     margin: $spacing-sm;
 }
 
-.card-header {
-    text-align: center;
-}
-
 .ios-button {
     text-decoration: none;
-}
-
-.links {
-    margin: $layout-xl auto;
-    text-align: center;
-
-    li {
-        display: inline-block;
-        margin: 0 $spacing-md;
-    }
 }
 
 .mobile-download-buttons {
@@ -45,55 +59,18 @@ $image-path: '/media/protocol/img';
     @include text-body-lg;
 }
 
-.mzp-c-hero-desc {
-    margin-bottom: $spacing-lg;
-}
-
-// h1 {
-//     @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-sm.png', auto, 100%);
-//     background-position: center;
-//     @include image-replaced;
-//     background-repeat: no-repeat;
-//     margin-bottom: $spacing-md;
-// }
-
 @media #{$mq-sm} {
     .mobile-download-buttons {
         margin-bottom: $spacing-lg;
     }
 }
 
-// @media #{$mq-md} {
-//     h1 {
-//         @include bidi(((background-position, top left, top right),));
-//         @include background-size(auto 48px);
-//     }
-// }
+.links {
+    margin: $layout-xl auto;
+    text-align: center;
 
-@media #{$mq-lg} {
-
-    .mzp-c-hero-image img {
-        margin: 0 $layout-lg;
+    li {
+        display: inline-block;
+        margin: 0 $spacing-md;
     }
-}
-
-
-// split
-.mzp-c-split-body {
-
-    p {
-        font-size: 18px;
-    }
-
-    .mzp-u-title-md {
-        @include font-base;
-        font-size: 28px;
-    }
-}
-
- @media #{$mq-lg} {
-
-     .mzp-u-title-md {
-         font-size: 38px;
-     }
 }

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -8,6 +8,7 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/includes/lib';
 @import '../../../protocol/css/components/hero';
 @import '../../../protocol/css/components/picto';
+@import '../../../protocol/css/components/split';
 @import '../../../protocol/css/templates/card-layout';
 @import '../../../protocol/css/templates/multi-column';
 

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -11,9 +11,8 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/components/split';
 @import '../../../protocol/css/templates/card-layout';
 @import '../../../protocol/css/templates/multi-column';
+@import '../../../protocol/css/components/logos/wordmark';
 @import '../../../protocol/css/components/logos/wordmark-product-lockwise';
-
-
 
 
 .add-on-download p {
@@ -64,12 +63,12 @@ $image-path: '/media/protocol/img';
     }
 }
 
-@media #{$mq-md} {
-    h1 {
-        @include bidi(((background-position, top left, top right),));
-        @include background-size(auto 48px);
-    }
-}
+// @media #{$mq-md} {
+//     h1 {
+//         @include bidi(((background-position, top left, top right),));
+//         @include background-size(auto 48px);
+//     }
+// }
 
 @media #{$mq-lg} {
 

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -14,6 +14,11 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/components/logos/wordmark-product-lockwise';
 
 // split
+
+.mzp-c-split {
+    padding: $spacing-2xl;
+}
+
 .mzp-c-split-container {
 
     p {

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -44,7 +44,7 @@ $image-path: '/media/protocol/img';
 
 .mzp-c-split-container .mzp-c-split-media {
     @media #{$mq-lg} {
-        width: 460px;
+       max-width: 460px;
     }
 }
 

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -74,3 +74,24 @@ h1 {
         margin: 0 $layout-lg;
     }
 }
+
+
+// split
+.mzp-c-split-body {
+
+    p {
+        font-size: 16px;
+    }
+
+    .mzp-u-title-md {
+        @include font-base;
+        font-size: 28px;
+    }
+}
+
+ @media #{$mq-lg} {
+
+     .mzp-u-title-md {
+         font-size: 38px;
+     }
+}

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -16,13 +16,16 @@ $image-path: '/media/protocol/img';
 // split
 
 .mzp-c-split {
-    padding: $spacing-2xl;
+
+    @media #{$mq-lg} {
+        padding: $spacing-2xl;
+    }
 }
 
 .mzp-c-split-container {
 
     p {
-        font-size: 18px;
+        @include text-body-lg;
     }
 
     @media #{$mq-lg} {
@@ -30,21 +33,25 @@ $image-path: '/media/protocol/img';
     }
 }
 
-.mzp-c-split-body .mzp-u-title-md {
-    @include font-base;
-    font-size: 38px;
+.mzp-c-split-body .mzp-c-wordmark {
+    margin: 0 auto;
+    margin-bottom: $spacing-lg;
+
+    @media #{$mq-lg} {
+        margin-left: 0;
+    }
 }
 
-@media #{$mq-lg} {
-
-    .mzp-c-split-body .mzp-u-title-md {
-         font-size: 38px;
-     }
+.mzp-c-split-body .mzp-u-title-md {
+    @include font-base;
+    font-weight: normal;
+    margin-bottom: $spacing-2xl;
+    color: $color-marketing-gray-80;
 }
 
 .mzp-c-split-container .mzp-c-split-media {
     @media #{$mq-lg} {
-       max-width: 460px;
+       width: 460px;
     }
 }
 

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -11,6 +11,9 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/components/split';
 @import '../../../protocol/css/templates/card-layout';
 @import '../../../protocol/css/templates/multi-column';
+@import '../../../protocol/css/components/logos/wordmark-product-lockwise';
+
+
 
 
 .add-on-download p {
@@ -47,13 +50,13 @@ $image-path: '/media/protocol/img';
     margin-bottom: $spacing-lg;
 }
 
-h1 {
-    @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-sm.png', auto, 100%);
-    background-position: center;
-    @include image-replaced;
-    background-repeat: no-repeat;
-    margin-bottom: $spacing-md;
-}
+// h1 {
+//     @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-sm.png', auto, 100%);
+//     background-position: center;
+//     @include image-replaced;
+//     background-repeat: no-repeat;
+//     margin-bottom: $spacing-md;
+// }
 
 @media #{$mq-sm} {
     .mobile-download-buttons {
@@ -80,7 +83,7 @@ h1 {
 .mzp-c-split-body {
 
     p {
-        font-size: 16px;
+        font-size: 18px;
     }
 
     .mzp-u-title-md {

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -11,7 +11,7 @@ $image-path: '/media/protocol/img';
 
 
 .mzp-c-split {
-    overflow: visible;
+    overflow-x: hidden;
     height: 100%;
 }
 
@@ -34,7 +34,8 @@ $image-path: '/media/protocol/img';
     position: relative;
     z-index: 1;
 
-     @media #{$mq-lg} {
+
+    @media #{$mq-lg} {
         &:before {
             background-image: url('/media/img/firefox/switch/bg.svg');
             background-position: 300px bottom 100px left;

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -6,6 +6,9 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 @import '../../protocol/css/includes/lib';
 @import '../../protocol/css/components/hero';
+@import '../../protocol/css/components/split';
+@import '../../protocol/css/components/logos/wordmark';
+@import '../../protocol/css/components/logos/wordmark-product-firefox';
 
 
 .t-switch.mzp-c-hero {
@@ -44,6 +47,30 @@ $image-path: '/media/protocol/img';
                 }
             }
         }
+    }
+}
+
+// Split
+
+.mzp-c-split-container {
+    box-sizing: content-box;
+}
+
+
+.mzp-c-split-media {
+    position: relative;
+    &::before {
+        position: absolute;
+        content: '';
+        top: 0;
+        width: 50%;
+        left: 50%;
+        background-position: 14px center, top left;
+        background-size: 592px 302px, auto 100%;
+        background-image: url("/media/img/firefox/switch/bg.svg");
+        background-repeat: no-repeat;
+        // background-position: center;
+        // background-size: cover;
     }
 }
 

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -5,7 +5,6 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 @import '../../protocol/css/includes/lib';
-@import '../../protocol/css/components/hero';
 @import '../../protocol/css/components/split';
 @import '../../protocol/css/components/logos/wordmark';
 @import '../../protocol/css/components/logos/wordmark-product-firefox';
@@ -52,25 +51,41 @@ $image-path: '/media/protocol/img';
 
 // Split
 
+.mzp-c-split {
+    // padding: 0;
+    overflow: visible;
+    height: 100%;
+}
+
 .mzp-c-split-container {
-    box-sizing: content-box;
+
+    @media #{$mq-lg} {
+        box-sizing: content-box;
+    }
 }
 
 
 .mzp-c-split-media {
     position: relative;
-    &::before {
-        position: absolute;
-        content: '';
-        top: 0;
-        width: 50%;
-        left: 50%;
-        background-position: 14px center, top left;
-        background-size: 592px 302px, auto 100%;
-        background-image: url("/media/img/firefox/switch/bg.svg");
-        background-repeat: no-repeat;
-        // background-position: center;
-        // background-size: cover;
+    z-index: 1;
+
+     @media #{$mq-lg} {
+        &:before {
+            background-image: url('/media/img/firefox/switch/bg.svg');
+            background-position: 14px center, bottom left;
+            background-size: cover;
+            background-repeat: no-repeat;
+            bottom: 0;
+            top: -100%;
+            content: '';
+            display: block;
+            left: 0;
+            right: 0;
+            position: absolute;
+            width: 1000px;
+            height: 1000px;
+            z-index: -1;
+        }
     }
 }
 

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -10,49 +10,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/logos/wordmark-product-firefox';
 
 
-.t-switch.mzp-c-hero {
-
-    &.mzp-t-product-firefox .mzp-c-hero-title {
-        @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-sm.png', auto, 48px);
-        padding-top: $layout-md + 48px;
-    }
-
-    @media #{$mq-md} {
-        &:before {
-            background-image: url('/media/img/firefox/switch/switch.png'), url('/media/img/firefox/switch/bg.svg');
-            background-position: 14px center, top left;
-            background-size: 592px 302px, auto 100%;
-            background-repeat: no-repeat;
-            bottom: 0;
-            content: '';
-            display: block;
-            left: 50%;
-            position: absolute;
-            top: 0;
-            width: 50%;
-
-            html[dir=rtl] & {
-                background-image: url('/media/img/firefox/switch/switch-rtl.png'), url('/media/img/firefox/switch/bg-rtl.svg');
-                background-position: right center, top right;
-                right: 50%;
-                left: auto;
-            }
-
-            @media #{$mq-high-res} {
-                background-image: url('/media/img/firefox/switch/switch-high-res.png'), url('/media/img/firefox/switch/bg.svg');
-
-                html[dir=rtl] & {
-                    background-image: url('/media/img/firefox/switch/switch-rtl-high-res.png'), url('/media/img/firefox/switch/bg-rtl.svg');
-                }
-            }
-        }
-    }
-}
-
-// Split
-
 .mzp-c-split {
-    // padding: 0;
     overflow: visible;
     height: 100%;
 }
@@ -64,6 +22,13 @@ $image-path: '/media/protocol/img';
     }
 }
 
+.mzp-t-product-firefox {
+    margin: 0 auto $spacing-md;
+
+    @media #{$mq-lg} {
+        margin: 0 0 $spacing-lg;
+    }
+}
 
 .mzp-c-split-media {
     position: relative;
@@ -72,20 +37,26 @@ $image-path: '/media/protocol/img';
      @media #{$mq-lg} {
         &:before {
             background-image: url('/media/img/firefox/switch/bg.svg');
-            background-position: 14px center, bottom left;
-            background-size: cover;
+            background-position: 300px bottom 100px left;
+            background-size: auto 100%;
             background-repeat: no-repeat;
             bottom: 0;
-            top: -100%;
+            top: -160px;
             content: '';
             display: block;
-            left: 0;
+            left: -50px;
             right: 0;
             position: absolute;
             width: 1000px;
-            height: 1000px;
+            height: 600px;
             z-index: -1;
         }
+    }
+}
+
+.mzp-c-split-body {
+    p {
+        @include text-body-lg;
     }
 }
 

--- a/media/css/mozorg/home/home-en.scss
+++ b/media/css/mozorg/home/home-en.scss
@@ -9,7 +9,6 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/includes/fonts/metropolis';
 @import '../../../protocol/css/components/billboard';
 @import '../../../protocol/css/components/call-out';
-@import '../../../protocol/css/components/hero';
 @import '../../../protocol/css/components/modal';
 @import '../../../protocol/css/components/newsletter-form';
 @import '../../../protocol/css/components/split';
@@ -22,30 +21,26 @@ $image-path: '/media/protocol/img';
     @include visually-hidden;
 }
 
-// Split container styles
+/* -------------------------------------------------------------------------- */
+// Split container
+
 .mzp-c-split.mzp-t-dark {
     background-color: $color-ink-80;
-}
 
- .mzp-c-split-container {
-    padding: $spacing-2xl;
-    @media #{$mq-lg} {
-        box-sizing: content-box;
-        padding-top: $spacing-2xl;
+    .mzp-c-split-media {
+        max-width: 400px;
+    }
+
+    .mzp-c-split-container {
+        padding-top: $spacing-lg;
+        padding-bottom: 0;
+        @media #{$mq-lg} {
+            padding-bottom: 0;
+            box-sizing: content-box;
+            padding-top: $spacing-2xl;
+        }
     }
 }
-
-.mzp-c-split-media {
-    max-width: 500px;
-}
-
-.mzp-c-split-body {
-
-    h2 {
-        @include font-firefox;
-    }
-}
-
 /* -------------------------------------------------------------------------- */
 // Custom card styles for lazy-loaded images.
 

--- a/media/css/mozorg/home/home-en.scss
+++ b/media/css/mozorg/home/home-en.scss
@@ -22,59 +22,33 @@ $image-path: '/media/protocol/img';
     @include visually-hidden;
 }
 
-//* -------------------------------------------------------------------------- */
-// Primary CTA (page top)
-
-.privacy-promise-hero.mzp-c-hero.mzp-t-dark {
+// Split container styles
+.mzp-c-split {
     background-color: $color-ink-80;
-    overflow: hidden;
-    padding-bottom: 0;
-    text-align: left;
+}
 
-    .mzp-c-hero-title {
-        @include font-firefox;
-        @include font-size(32px);
-    }
+.mzp-c-split-bg.mzp-t-dark {
+    background-color: $color-ink-80;
+}
 
-    .mzp-c-hero-body {
-        max-width: none;
-    }
-
-    .privacy-promise-hero-desc {
-        @include text-body-lg;
-        margin-bottom: 0;
-    }
-
-    .mzp-c-hero-image {
-        display: none;
-    }
-
-    @media #{$mq-md} {
-        .privacy-promise-hero-desc {
-            margin-bottom: $spacing-lg;
-        }
-
-        .mzp-c-hero-image {
-            display: block;
-            height: 100%;
-            margin: 0;
-
-            img {
-                @include bidi(((left, $spacing-xl, right, auto),));
-            }
-        }
-    }
+.mzp-c-split-container {
 
     @media #{$mq-lg} {
-        padding-bottom: $spacing-lg;
-
-        .mzp-c-hero-title {
-            @include font-size(48px);
-        }
+        box-sizing: content-box;
+        padding-top: $spacing-2xl;
     }
 }
 
+.mzp-c-split-media {
+    max-width: 500px;
+}
 
+.mzp-c-split-body {
+
+    h2 {
+        @include font-firefox;
+    }
+}
 
 /* -------------------------------------------------------------------------- */
 // Custom card styles for lazy-loaded images.

--- a/media/css/mozorg/home/home-en.scss
+++ b/media/css/mozorg/home/home-en.scss
@@ -23,16 +23,12 @@ $image-path: '/media/protocol/img';
 }
 
 // Split container styles
-.mzp-c-split {
+.mzp-c-split.mzp-t-dark {
     background-color: $color-ink-80;
 }
 
-.mzp-c-split-bg.mzp-t-dark {
-    background-color: $color-ink-80;
-}
-
-.mzp-c-split-container {
-
+ .mzp-c-split-container {
+    padding: $spacing-2xl;
     @media #{$mq-lg} {
         box-sizing: content-box;
         padding-top: $spacing-2xl;

--- a/media/css/mozorg/home/home-en.scss
+++ b/media/css/mozorg/home/home-en.scss
@@ -32,13 +32,19 @@ $image-path: '/media/protocol/img';
     }
 
     .mzp-c-split-container {
-        padding-top: $spacing-lg;
-        padding-bottom: 0;
         @media #{$mq-lg} {
             padding-bottom: 0;
             box-sizing: content-box;
             padding-top: $spacing-2xl;
         }
+    }
+}
+
+.mzp-c-split-body {
+    padding: $spacing-lg;
+
+    .mzp-u-title-lg {
+        @include font-firefox;
     }
 }
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Description
Replacing the soon-to-be deprecated [Hero](https://protocol.mozilla.org/patterns/organisms/hero.html) components in some pages with the new [Split](https://protocol.mozilla.org/patterns/organisms/split.html) component.

## Issue / Bugzilla link
#10341 

## Testing
http://localhost:8000/firefox/lockwise/
http://localhost:8000/firefox/switch/
http://localhost:8000/en-US/

