### PR TITLE
Use Split on Firefox Products page, fix layout [#10341]

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -57,12 +57,12 @@
 
 {% block content %}
 <main role="main">
-
   {% call split(
     image_url='img/firefox/browsers/hero.jpg',
     include_highres_image=True,
-    block_class='c-landing-banner mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
-    media_class='mzp-l-split-media-overflow'
+    block_class='c-landing-banner mzp-l-split-center-on-sm-md',
+    media_class='mzp-l-split-media-overflow',
+    media_after=True
   ) %}
     <h1 class="mzp-has-zap-11">{{ ftl('firefox-browsers-get-the-browsers-strong') }}</h1>
     <p>{{ ftl('firefox-browsers-get-the-privacy-you-deserve') }}</p>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
-{% from "macros-protocol.html" import hero, feature_card with context %}
+{% from "macros-protocol.html" import split, feature_card with context %}
 
 {% block page_title %}{{ ftl('firefox-products-firefox-is-more-than-a-browser') }}{% endblock %}
 {% block page_desc %}{{ ftl('firefox-products-its-a-whole-family-of-products') }}{% endblock %}
@@ -34,18 +34,15 @@
 
 {% block content %}
 <main role="main">
-
-  <div class="c-block has-media-hide t-products">
-    <div class="c-block-container">
-      <div class="c-block-body l-v-center">
-        <h1 class="mzp-has-zap-14">{{ ftl('firefox-products-firefox-is-more-than-a-browser-emphasis') }}</h1>
-        <p>{{ ftl('firefox-products-its-a-whole-family-of-products') }}</p>
-      </div>
-      <div class="c-block-media l-fit-flush-top l-constrain-width">
-        {{ high_res_img('img/firefox/products/hero.jpg', {'alt': '', 'class': 'c-block-media-img', 'width': '670', 'height': '464'}) }}
-      </div>
-    </div>
-  </div>
+  {% call split(
+    image_url='img/firefox/products/hero.jpg',
+    include_highres_image=True,
+    block_class='c-landing-banner t-products mzp-l-split-center-on-sm-md',
+    media_class='mzp-l-split-media-overflow',
+  ) %}
+    <h1 class="mzp-has-zap-14">{{ ftl('firefox-products-firefox-is-more-than-a-browser-emphasis') }}</h1>
+    <p>{{ ftl('firefox-products-its-a-whole-family-of-products') }}</p>
+  {% endcall %}
 
   <div class="mzp-l-content c-landing-grid">
     <div class="c-landing-grid-item">

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -107,6 +107,10 @@ main .mzp-l-content {
     p {
         @include text-body-lg;
     }
+
+    &.t-products {
+        padding-top: 0;
+    }
 }
 
 //* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Description
When we updated the Browsers page in https://github.com/mozilla/bedrock/commit/346aace714ff65b0410d256ec875e896b47f6b83 I failed to notice that the Products page uses the same style sheet, so some styling was broken. This updates the Products page and makes a few other minor tweaks.

This is currently broken in production (pushed only yesterday) so we should try to fix this ASAP.

## Testing
http://localhost:8000/firefox/products/