### PR TITLE
Add promo ftl file to /exp/ home page

### DIFF
--- a/bedrock/exp/views.py
+++ b/bedrock/exp/views.py
@@ -44,6 +44,7 @@ def home_view(request):
     ctx = {
         'donate_params': donate_params,
         'pocket_articles': PocketArticle.objects.all()[:4],
+        'ftl_files': ['mozorg/home-mr1-promo'],
         'active_locales': ['de', 'fr', 'en-US']
     }
 


### PR DESCRIPTION
## Description
There's no traffic going to this experimental page, but I noticided the MR1 promo strings weren't showing up correctly.

## Issue / Bugzilla link
N/A

## Testing
http://localhost:8000/en-US/exp/