### PR TITLE
Fix home page promo switch logic

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -58,7 +58,7 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if not switch('firefox-mr1-launch') %}
+  {% if switch('firefox-mr1-launch') %}
     {%- set promos = [
       'mozorg/home/includes/mr1-promo-lalo.html',
       'mozorg/home/includes/mr1-promo-soraya.html',


### PR DESCRIPTION
## Description
Fixes test failure in https://gitlab.com/mozmeao/www-config/-/jobs/1549619134

See https://github.com/mozilla/bedrock/pull/10384/files#r699390512 for context.

## Issue / Bugzilla link
N/A

## Testing
MR1 promo should default to being visible on http://localhost:8000/en-US/