### PR TITLE
Fix split call on dev edition pages [no bug]

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -66,8 +66,8 @@
 
 
 {# Split: https://protocol.mozilla.org/patterns/organisms/split.html #}
-{% macro split(block_class=None, theme_class=None, body_class=None, image_url=None, media_class=None, include_highres_image=False, l10n_image=False, image_alt='', mobile_class=None, media_after=False, media_include=None) -%}
-<section class="mzp-c-split{% if block_class %} {{ block_class }}{% endif %}{% if mobile_class %} {{ mobile_class }}{% endif %}">
+{% macro split(base_el='section', block_id=None, block_class=None, theme_class=None, body_class=None, image_url=None, media_class=None, include_highres_image=False, l10n_image=False, image_alt='', mobile_class=None, media_after=False, media_include=None) -%}
+<{{base_el}}{% if block_id %} id="{{ block_id }}"{% endif %} class="mzp-c-split{% if block_class %} {{ block_class }}{% endif %}{% if mobile_class %} {{ mobile_class }}{% endif %}">
   {% if theme_class %}
   <div class="mzp-c-split-bg {{ theme_class }}">
   {% endif %}
@@ -121,7 +121,7 @@
   {% if theme_class %}
   </div>
   {% endif %}
-</section>
+</{{ base_el }}>
 {%- endmacro %}
 
 

--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -1,7 +1,7 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% call split(
-  id='nextgen',
+  block_id='nextgen',
   image_url='img/firefox/developer/stylo-engine.svg',
   block_class='t-performance'
 ) %}

--- a/bedrock/firefox/templates/firefox/developer/includes/performance.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/performance.html
@@ -1,7 +1,7 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% call split(
-  id='nextgen',
+  block_id='nextgen',
   image_url='img/firefox/developer/stylo-engine.svg',
   block_class='t-performance'
 ) %}


### PR DESCRIPTION
## Description
Restores (and renames) `id` param in the split macro that was lost in a different merge.
Adds a `base_el` param while I'm in here anyway, which defaults to `section` so doesn't actually change anycurrent uses of this macro but gives us future opportunities.

## Testing
The id param was only used in two places.

http://localhost:8000/en-US/firefox/developer/
http://localhost:8000/en-US/firefox/91.0a2/whatsnew/all/