### PR TITLE
FIx home page lazyloading [no bug]

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -231,16 +231,17 @@
 {%- endmacro %}
 
 {# Feature Card: https://protocol.mozilla.org/patterns/molecules/feature-card.html #}
-{% macro feature_card_media(image_url, include_highres_image=False, l10n_image=False) %}
+{% macro feature_card_media(image_url, include_highres_image=False, l10n_image=False, lazy_loading=False) %}
 <div class="mzp-c-card-feature-media-wrapper">
   <div class="mzp-c-card-feature-media">
+    {% set loading = 'lazy' if lazy_loading else 'eager' %}
     {% if include_highres_image %}
-      {{ high_res_img(image_url, {'alt': '', 'l10n': l10n_image}) }}
+      {{ high_res_img(image_url, {'alt': '', 'l10n': l10n_image, 'loading': loading}) }}
     {% else %}
       {% if l10n_image %}
-        <img src="{{ l10n_img(image_url) }}" alt="">
+        <img src="{{ l10n_img(image_url) }}" alt="" loading="{{ loading }}">
       {% else %}
-        <img src="{{ static(image_url) }}" alt="">
+        <img src="{{ static(image_url) }}" alt="" loading="{{ loading }}">
       {% endif %}
     {% endif %}
   </div>
@@ -249,10 +250,10 @@
 
 
 {# Feature Card: https://protocol.mozilla.org/patterns/molecules/feature-card.html #}
-{% macro feature_card(title, ga_title, image_url, class=None, link_url=None, link_cta=None, include_highres_image=False, l10n_image=False, aspect_ratio=None, heading_level=2, media_after=False) -%}
+{% macro feature_card(title, ga_title, image_url, class=None, link_url=None, link_cta=None, include_highres_image=False, l10n_image=False, aspect_ratio=None, heading_level=2, media_after=False, lazy_loading=False) -%}
 <section class="mzp-c-card-feature {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if class %}{{ class }}{% endif %}">
   {% if not media_after %}
-    {{ feature_card_media(image_url, include_highres_image, l10n_image) }}
+    {{ feature_card_media(image_url, include_highres_image, l10n_image, lazy_loading) }}
   {% endif %}
   <div class="mzp-c-card-feature-content">
     <div class="mzp-c-card-feature-content-container">
@@ -268,7 +269,7 @@
     </div>
   </div>
   {% if media_after %}
-    {{ feature_card_media(image_url, include_highres_image, l10n_image) }}
+    {{ feature_card_media(image_url, include_highres_image, l10n_image, lazy_loading) }}
   {% endif %}
 </section>
 {%- endmacro %}

--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+    'use strict';
+
+    // Lazyload images
+    Mozilla.LazyLoad.init();
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1206,8 +1206,10 @@
       "files": [
         "protocol/js/protocol-modal.js",
         "protocol/js/protocol-newsletter.js",
+        "js/base/mozilla-lazy-load.js",
         "js/newsletter/form-protocol.js",
-        "js/mozorg/home/youtube.js"
+        "js/mozorg/home/youtube.js",
+        "js/mozorg/home/home.js"
       ],
       "name": "home"
     },


### PR DESCRIPTION
## Description
Card images on the old (non-Contentful) home page were failing to load because the lazyloading script was moved/renamed in https://github.com/mozilla/bedrock/commit/8beef7541e079c73446ab71e56b49e1215b1eed2. This restores the JS for the old home page but shouldn't interfere with Contentful.

## Testing
http://localhost:8000/