### PR TITLE
Add sphinx-copybutton for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,10 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx_copybutton']
+
+# Remove prompt for copy button clipboard
+copybutton_prompt_text = "$ "
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -103,3 +103,6 @@ fluent.pygments==0.1.0 \
 fluent.syntax==0.17.0 \
     --hash=sha256:ac3db2f77d62b032fdf1f17ef5c390b7801a9e9fb58d41eca3825c0d47b88d79 \
     --hash=sha256:e26be470aeebe4badd84f7bb0b648414e0f2ef95d26e5336d634af99e402ea61
+sphinx-copybutton==0.4.0 \
+    --hash=sha256:4340d33c169dac6dd82dce2c83333412aa786a42dd01a81a8decac3b130dc8b0 \
+    --hash=sha256:8daed13a87afd5013c3a9af3575cc4d5bec052075ccd3db243f895c07a689386


### PR DESCRIPTION
## Description

Add copy button to code snippets in bedrock docs

## Issue / Bugzilla link

## Testing

Docker: in root folder, run `make docs`
Local: in docs folder, run `make html`

You should see a small clipboard icon when you hover over a code section. If you click, you should be able to copy the code (minus the prompt) to your terminal.
