### PR TITLE
Nightly /whatsnew page show incorrect content to users in France (Fixes #10422)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-fr.html
@@ -1,0 +1,5 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/whatsnew/index-account.html" %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -556,7 +556,7 @@ class TestWhatsNew92France(TestCase):
         req.locale = 'fr'
         self.view(req, version='92.0')
         template = render_mock.call_args[0][1]
-        assert template == ['firefox/whatsnew/index-account.html']
+        assert template == ['firefox/whatsnew/whatsnew-fx92-fr.html']
 
     @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING='True')
     def test_fx_92_0_0_vpn_fr(self, render_mock):
@@ -566,6 +566,15 @@ class TestWhatsNew92France(TestCase):
         self.view(req, version='92.0')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx92-vpn-fr.html']
+
+    @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING='True')
+    def test_fx_94_0_a1_fr(self, render_mock):
+        """Should use Nightly /whatsnew template for 94.0.a1"""
+        req = self.rf.get('/firefox/whatsnew/france/')
+        req.locale = 'fr'
+        self.view(req, version='94.0a1')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/nightly/whatsnew.html']
 
 
 @patch('bedrock.firefox.views.l10n_utils.render', return_value=HttpResponse())

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -544,6 +544,7 @@ class WhatsnewView(L10nTemplateView):
         'firefox/whatsnew/whatsnew-fx91-de.html': ['firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx92-en.html': ['firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx92-de.html': ['firefox/whatsnew/whatsnew'],
+        'firefox/whatsnew/whatsnew-fx92-fr.html': ['firefox/whatsnew/whatsnew-account', 'firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx92-vpn-en.html': ['firefox/whatsnew/whatsnew', 'products/vpn/shared'],
         'firefox/whatsnew/whatsnew-fx92-vpn-fr.html': ['firefox/whatsnew/whatsnew', 'products/vpn/shared'],
     }
@@ -623,6 +624,8 @@ class WhatsnewView(L10nTemplateView):
             template = 'firefox/whatsnew/whatsnew-fx92-en.html'
         elif version.startswith('92.') and locale == 'de':
             template = 'firefox/whatsnew/whatsnew-fx92-de.html'
+        elif version.startswith('92.') and locale == 'fr':
+            template = 'firefox/whatsnew/whatsnew-fx92-fr.html'
         elif version.startswith('91.') and locale.startswith('en-'):
             template = 'firefox/whatsnew/whatsnew-fx91-en.html'
         elif version.startswith('91.') and locale == 'de':
@@ -682,9 +685,8 @@ class WhatsNewEnglishView(WhatsnewView):
 class WhatsNewFranceView(WhatsnewView):
     def get_template_names(self):
         template = super().get_template_names()
-        locale = l10n_utils.get_locale(self.request)
-        if switch('firefox-whatsnew-92-vpn-pricing'):
-            template = ['firefox/whatsnew/whatsnew-fx92-vpn-fr.html'] if locale == 'fr' else ['firefox/whatsnew/index-account.html']
+        if switch('firefox-whatsnew-92-vpn-pricing') and template == ['firefox/whatsnew/whatsnew-fx92-fr.html']:
+            template = ['firefox/whatsnew/whatsnew-fx92-vpn-fr.html']
 
         return template
 


### PR DESCRIPTION
## Description
Fixes /whatsnew page display logic for `WhatsNewFranceView`

## Issue / Bugzilla link
#10422

## Testing
- http://localhost:8000/fr/firefox/94.0a1/whatsnew/france/ should display Nightly /whatsnew page
- http://localhost:8000/fr/firefox/92.0/whatsnew/france/ should displaye VPN page for release channel.
