### PR TITLE
Add linkable targets to the principles on the Manifesto page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -83,47 +83,47 @@
 
     <div class="mzp-l-content mzp-t-content-lg">
       <section id="sec-principles">
-        <header class="principles-header">
+        <header class="principles-header" id="principles">
           <h2 class="principles-head">{{ ftl('manifesto-our-10-principles') }}</h2>
         </header>
-        <ol id="principles">
-          <li class="principle">
+        <ol>
+          <li class="principle" id="principles-01">
             <h3 class="principle-number">{{ principle_number_01 }}</h3>
             <p class="principle-desc">{{ principle_text_01 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-02">
             <h3 class="principle-number">{{ principle_number_02 }}</h3>
             <p class="principle-desc">{{ principle_text_02 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-03">
             <h3 class="principle-number">{{ principle_number_03 }}</h3>
             <p class="principle-desc">{{ principle_text_03 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-04">
             <h3 class="principle-number">{{ principle_number_04 }}</h3>
             <p class="principle-desc">{{ principle_text_04 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-05">
             <h3 class="principle-number">{{ principle_number_05 }}</h3>
             <p class="principle-desc">{{ principle_text_05 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-06">
             <h3 class="principle-number">{{ principle_number_06 }}</h3>
             <p class="principle-desc">{{ principle_text_06 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-07">
             <h3 class="principle-number">{{ principle_number_07 }}</h3>
             <p class="principle-desc">{{ principle_text_07 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-08">
             <h3 class="principle-number">{{ principle_number_08 }}</h3>
             <p class="principle-desc">{{ principle_text_08 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-09">
             <h3 class="principle-number">{{ principle_number_09 }}</h3>
             <p class="principle-desc">{{ principle_text_09 }}</p>
           </li>
-          <li class="principle">
+          <li class="principle" id="principles-10">
             <h3 class="principle-number">{{ principle_number_10 }}</h3>
             <p class="principle-desc">{{ principle_text_10 }}</p>
           </li>


### PR DESCRIPTION
## Description
Add linkable targets to the principles on the Manifesto page - added an id to each individual principle and move the id #principles to the header for the principles section so it is viewable when navigating from a different page.
## Issue / Bugzilla link
#10408 
## Testing
localhost:8000en-US/about/manifesto/#principles