### PR TITLE
cdn cache geo redirects

### DIFF
--- a/bedrock/base/tests/test_views.py
+++ b/bedrock/base/tests/test_views.py
@@ -56,31 +56,25 @@ class TestGeoRedirectView(TestCase):
         resp = self.get_response('CA')
         assert resp.status_code == 302
         assert resp['location'] == '/firefox/new/'
-        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'
 
         resp = self.get_response('US')
         assert resp.status_code == 302
         assert resp['location'] == '/firefox/'
-        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'
 
     def test_other_country(self):
         resp = self.get_response('DE')
         assert resp.status_code == 302
         assert resp['location'] == 'https://abide.dude'
-        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'
 
         resp = self.get_response('JA')
         assert resp.status_code == 302
         assert resp['location'] == 'https://abide.dude'
-        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'
 
     def test_invalid_country(self):
         resp = self.get_response('dude')
         assert resp.status_code == 302
         assert resp['location'] == 'https://abide.dude'
-        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'
 
         resp = self.get_response('42')
         assert resp.status_code == 302
         assert resp['location'] == 'https://abide.dude'
-        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'

--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -9,7 +9,6 @@ import timeago
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import render
-from django.utils.decorators import method_decorator
 from django.views.generic import RedirectView
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
@@ -19,7 +18,6 @@ from bedrock.base.geo import get_country_from_request
 from bedrock.utils import git
 
 
-@method_decorator(never_cache, name='dispatch')
 class GeoRedirectView(RedirectView):
     # dict of country codes to full URLs or URL names
     geo_urls = None
@@ -40,7 +38,6 @@ class GeoRedirectView(RedirectView):
 
 
 @require_safe
-@never_cache
 def geolocate(request):
     """Return the country code provided by our CDN
 

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -139,5 +139,4 @@ urlpatterns = (
 if settings.DEV:
     urlpatterns += (
         path('contentful-preview/<content_id>/', views.ContentfulPreviewView.as_view()),
-        path('cdn-geo-test/', views.cdn_geo_test_view),
     )

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django.http import JsonResponse
 from django.shortcuts import render as django_render
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
@@ -14,7 +13,6 @@ from commonware.decorators import xframe_allow
 from lib import l10n_utils
 from lib.l10n_utils import L10nTemplateView
 
-from bedrock.base.geo import get_country_from_request_header
 from bedrock.base.waffle import switch
 from bedrock.contentcards.models import get_page_content_cards
 from bedrock.contentful.api import ContentfulPage
@@ -184,9 +182,3 @@ class ContentfulPreviewView(L10nTemplateView):
                                  template,
                                  context,
                                  **response_kwargs)
-
-
-def cdn_geo_test_view(request):
-    return JsonResponse({
-        'country_code': get_country_from_request_header(request)
-    })

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -185,7 +185,6 @@ UUID_REGEX = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a
                         re.IGNORECASE)
 
 
-@never_cache
 def set_country(request, token):
     """Allow a user to set their country"""
     initial = {}


### PR DESCRIPTION
- Remove the CDN geo test page
- Remove the no-cache headers from views that use Geo
