### PR TITLE
Fix #10434: Add country_code to the context for all pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV PYTHONUNBUFFERED=1
 ENV PATH="/venv/bin:$PATH"
 
 COPY docker/bin/apt-install /usr/local/bin/
-RUN apt-install gettext build-essential libxml2-dev libxslt1-dev libxslt1.1 libmaxminddb0 libmaxminddb-dev
+RUN apt-install gettext build-essential libxml2-dev libxslt1-dev libxslt1.1
 RUN python -m venv /venv
 
 COPY requirements/base.txt requirements/prod.txt ./requirements/
@@ -61,7 +61,7 @@ EXPOSE 8000
 CMD ["./bin/run.sh"]
 
 COPY docker/bin/apt-install /usr/local/bin/
-RUN apt-install gettext libxslt1.1 git libmaxminddb0
+RUN apt-install gettext libxslt1.1 git
 
 # copy in Python environment
 COPY --from=python-builder /venv /venv

--- a/bedrock/base/context_processors.py
+++ b/bedrock/base/context_processors.py
@@ -1,15 +1,18 @@
-# from bedrock.base
-
 from django.conf import settings
 
+from bedrock.base.geo import get_country_from_request
 from lib.l10n_utils import translation
+
+
+def geo(request):
+    return {'country_code': get_country_from_request(request)}
 
 
 def i18n(request):
     return {
         'LANGUAGES': settings.LANGUAGES,
-        'LANG': (settings.LANGUAGE_URL_MAP.get(translation.get_language()) or
-                 translation.get_language()),
+        'LANG': (settings.LANGUAGE_URL_MAP.get(
+                 translation.get_language()) or translation.get_language()),
         'DIR': 'rtl' if translation.get_language_bidi() else 'ltr',
     }
 

--- a/bedrock/base/geo.py
+++ b/bedrock/base/geo.py
@@ -4,72 +4,32 @@
 
 from django.conf import settings
 
-try:
-    import maxminddb
-except ImportError:
-    maxminddb = None
+from product_details import product_details
 
 
-GEO = None
+def valid_country_code(country):
+    codes = product_details.get_regions('en-US').keys()
+    if country and country.lower() in codes:
+        return country.upper()
 
 
-def _get_geo_client():
-    global GEO
-    if GEO is None and maxminddb is not None:
-        try:
-            GEO = maxminddb.open_database(settings.MAXMIND_DB_PATH)
-        except (maxminddb.InvalidDatabaseError, OSError, IOError):
-            GEO = False
-
-    return GEO
+def get_country_from_param(request):
+    is_prod = request.get_host() == 'www.mozilla.org'
+    country_code = valid_country_code(request.GET.get('geo'))
+    return country_code if not is_prod else None
 
 
-def get_country_from_ip(ip_addr):
-    """Return country info for the given IP Address."""
-    geo = _get_geo_client()
-    if not geo and settings.DEV:
-        return settings.MAXMIND_DEFAULT_COUNTRY.upper()
+def get_country_from_header(request):
+    """Return an uppercase 2 letter country code retrieved from the request header."""
+    country_code = valid_country_code(request.META.get('HTTP_CF_IPCOUNTRY'))
+    if not country_code and settings.DEV:
+        country_code = settings.DEV_GEO_COUNTRY_CODE
 
-    if geo and ip_addr:
-        try:
-            data = geo.get(ip_addr)
-        except ValueError:
-            data = None
-
-        if data:
-            country = data.get('country', data.get('registered_country'))
-            if country:
-                return country['iso_code'].upper()
-
-    return None
-
-
-def get_country_from_request_header(request):
-    """Return an uppercase 2 letter country code retrieved from request headers."""
-    country_code = request.META.get('HTTP_CF_IPCOUNTRY', 'XX')
-    if country_code == 'XX' or len(country_code) != 2:
-        if settings.DEV:
-            country_code = settings.DEV_GEO_COUNTRY_CODE
-        else:
-            return None
-
-    return country_code.upper()
-
-
-def get_country_from_maxmind(request):
-    ip_addr = request.META.get('HTTP_X_FORWARDED_FOR', '')
-    if ',' in ip_addr:
-        ip_addr = ip_addr.split(',', 1)[0]
-
-    return get_country_from_ip(ip_addr.strip())
+    return country_code
 
 
 def get_country_from_request(request):
-    """Return country info for the given request data."""
-    country = get_country_from_request_header(request)
-    source = 'cdn'
-    if country is None:
-        country = get_country_from_maxmind(request)
-        source = 'local'
-
-    return country, source
+    """Return a country code from either the request geo param or header from CDN"""
+    param_code = get_country_from_param(request)
+    header_code = get_country_from_header(request)
+    return param_code or header_code

--- a/bedrock/base/templates/cron-health-check.html
+++ b/bedrock/base/templates/cron-health-check.html
@@ -94,12 +94,6 @@
         <td><a href="{{ server_info.db_file_url }}">{{ server_info.db_file_name }}</a></td>
       </tr>
       {% endif %}
-      {% if server_info.geo_last_update %}
-        <tr>
-          <td>GeoIP DB Last Updated</td>
-          <td>{{ server_info.geo_last_update }}</td>
-        </tr>
-      {% endif %}
     </tbody>
   </table>
 

--- a/bedrock/base/tests/test_geo.py
+++ b/bedrock/base/tests/test_geo.py
@@ -1,104 +1,42 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from django.test import RequestFactory
-from django.test.utils import override_settings
+from django.test import override_settings, TestCase, RequestFactory
 
-from mock import patch
-
-from bedrock.base import geo
-from bedrock.mozorg.tests import TestCase
+from bedrock.base.geo import get_country_from_request
 
 
-@patch("bedrock.base.geo._get_geo_client")
 class TestGeo(TestCase):
-    # real output from a real maxmind db
-    good_geo_data = {
-        "continent": {
-            "code": "NA",
-            "geoname_id": 6255149,
-            "names": {
-                "de": "Nordamerika",
-                "en": "North America",
-                "es": "Norteamérica",
-                "fr": "Amérique du Nord",
-                "ja": "北アメリカ",
-                "pt-BR": "América do Norte",
-                "ru": "Северная Америка",
-                "zh-CN": "北美洲",
-            },
-        },
-        "country": {
-            "geoname_id": 6252001,
-            "iso_code": "US",
-            "names": {
-                "de": "USA",
-                "en": "United States",
-                "es": "Estados Unidos",
-                "fr": "États-Unis",
-                "ja": "アメリカ合衆国",
-                "pt-BR": "Estados Unidos",
-                "ru": "США",
-                "zh-CN": "美国",
-            },
-        },
-        "registered_country": {
-            "geoname_id": 6252001,
-            "iso_code": "US",
-            "names": {
-                "de": "USA",
-                "en": "United States",
-                "es": "Estados Unidos",
-                "fr": "États-Unis",
-                "ja": "アメリカ合衆国",
-                "pt-BR": "Estados Unidos",
-                "ru": "США",
-                "zh-CN": "美国",
-            },
-        },
-    }
+    def setUp(self):
+        self.factory = RequestFactory()
 
-    def test_get_country_by_ip(self, geo_mock):
-        geo_mock.return_value.get.return_value = self.good_geo_data
-        self.assertEqual(geo.get_country_from_ip('1.1.1.1'), 'US')
-        geo_mock.return_value.get.assert_called_with('1.1.1.1')
+    def test_geo_header(self):
+        """Country code from request header should work"""
+        req = self.factory.get('/', HTTP_CF_IPCOUNTRY='de')
+        assert get_country_from_request(req) == 'DE'
 
-    def test_get_country_by_ip_default(self, geo_mock):
-        """Geo failure should return default country."""
-        geo_mock.return_value.get.return_value = None
-        self.assertIsNone(geo.get_country_from_ip('1.1.1.1'))
-        geo_mock.return_value.get.assert_called_with('1.1.1.1')
+    @override_settings(DEV=False)
+    def test_geo_no_header(self):
+        """Country code when header absent should be None"""
+        req = self.factory.get('/')
+        assert get_country_from_request(req) is None
 
-        geo_mock.reset_mock()
-        geo_mock.return_value.get.side_effect = ValueError
-        self.assertIsNone(geo.get_country_from_ip('1.1.1.1'))
-        geo_mock.return_value.get.assert_called_with('1.1.1.1')
+    def test_geo_param(self):
+        """Country code from header should be overridden by query param
+           for pre-prod domains."""
+        req = self.factory.get('/', data={'geo': 'fr'}, HTTP_CF_IPCOUNTRY='de')
+        assert get_country_from_request(req) == 'FR'
 
-    def test_get_country_by_ip_bad_data(self, geo_mock):
-        """Bad data from geo should return None."""
-        geo_mock.return_value.get.return_value = {'fred': 'flintstone'}
-        self.assertIsNone(geo.get_country_from_ip('1.1.1.1'))
-        geo_mock.return_value.get.assert_called_with('1.1.1.1')
+        # should use header if at prod domain
+        req = self.factory.get('/', data={'geo': 'fr'},
+                               HTTP_CF_IPCOUNTRY='de',
+                               HTTP_HOST='www.mozilla.org')
+        assert get_country_from_request(req) == 'DE'
 
-    @override_settings(DEV=True, MAXMIND_DEFAULT_COUNTRY='XX')
-    def test_get_country_by_ip_dev_mode(self, geo_mock):
-        geo_mock.return_value = None
-        assert geo.get_country_from_ip('1.1.1.1') == 'XX'
+    @override_settings(DEV=False)
+    def test_invalid_geo_param(self):
+        req = self.factory.get('/', data={'geo': 'france'}, HTTP_CF_IPCOUNTRY='de')
+        assert get_country_from_request(req) == 'DE'
 
-    def test_get_country_from_maxmind(self, geo_mock):
-        geo_mock.return_value.get.return_value = self.good_geo_data
-        req = RequestFactory().get('/', HTTP_X_FORWARDED_FOR='192.168.1.2, 192.168.8.8')
-        self.assertEqual(geo.get_country_from_maxmind(req), 'US')
-        geo_mock.return_value.get.assert_called_with('192.168.1.2')
+        req = self.factory.get('/', data={'geo': ''}, HTTP_CF_IPCOUNTRY='de')
+        assert get_country_from_request(req) == 'DE'
 
-    def test_get_country_from_maxmind_single_ip(self, geo_mock):
-        geo_mock.return_value.get.return_value = self.good_geo_data
-        req = RequestFactory().get('/', HTTP_X_FORWARDED_FOR='192.168.8.8')
-        self.assertEqual(geo.get_country_from_maxmind(req), 'US')
-        geo_mock.return_value.get.assert_called_with('192.168.8.8')
-
-    def test_get_country_from_maxmind_no_header(self, geo_mock):
-        geo_mock.return_value.get.return_value = self.good_geo_data
-        req = RequestFactory().get('/')
-        self.assertEqual(geo.get_country_from_maxmind(req), None)
-        geo_mock.return_value.get.assert_not_called()
+        req = self.factory.get('/', data={'geo': 'france'})
+        assert get_country_from_request(req) is None

--- a/bedrock/base/tests/test_views.py
+++ b/bedrock/base/tests/test_views.py
@@ -4,23 +4,21 @@ from unittest.mock import patch
 from django.test import TestCase, RequestFactory
 from django.test import override_settings
 
-from bedrock.base.views import geolocate, GeoRedirectView
+from bedrock.base.views import geolocate, GeoRedirectView, GeoTemplateView
 
 
 class TestGeolocate(TestCase):
     def get_country(self, country):
         with patch('bedrock.base.views.get_country_from_request') as geo_mock:
-            geo_mock.return_value = country, 'local'
+            geo_mock.return_value = country
             rf = RequestFactory()
             req = rf.get('/')
             resp = geolocate(req)
             return json.loads(resp.content)
 
     def test_geo_returns(self):
-        self.assertDictEqual(self.get_country('US'), {'country_code': 'US',
-                                                      'data_source': 'local'})
-        self.assertDictEqual(self.get_country('FR'), {'country_code': 'FR',
-                                                      'data_source': 'local'})
+        self.assertDictEqual(self.get_country('US'), {'country_code': 'US'})
+        self.assertDictEqual(self.get_country('FR'), {'country_code': 'FR'})
         self.assertDictEqual(self.get_country(None), {
             "error": {
                 "errors": [{
@@ -47,7 +45,7 @@ geo_view = GeoRedirectView.as_view(
 class TestGeoRedirectView(TestCase):
     def get_response(self, country):
         with patch('bedrock.base.views.get_country_from_request') as geo_mock:
-            geo_mock.return_value = country, 'local'
+            geo_mock.return_value = country
             rf = RequestFactory()
             req = rf.get('/')
             return geo_view(req)
@@ -78,3 +76,35 @@ class TestGeoRedirectView(TestCase):
         resp = self.get_response('42')
         assert resp.status_code == 302
         assert resp['location'] == 'https://abide.dude'
+
+
+geo_template_view = GeoTemplateView.as_view(
+    geo_template_names={
+        'DE': 'firefox-klar.html',
+        'GB': 'firefox-focus.html',
+    },
+    template_name='firefox-mobile.html',
+)
+
+
+class TestGeoTemplateView(TestCase):
+    def get_template(self, country):
+        with patch('bedrock.firefox.views.l10n_utils.render') as render_mock:
+            with patch('bedrock.base.views.get_country_from_request') as geo_mock:
+                geo_mock.return_value = country
+                rf = RequestFactory()
+                req = rf.get('/')
+                geo_template_view(req)
+                return render_mock.call_args[0][1][0]
+
+    def test_country_template(self):
+        template = self.get_template('DE')
+        assert template == 'firefox-klar.html'
+
+    def test_default_template(self):
+        template = self.get_template('US')
+        assert template == 'firefox-mobile.html'
+
+    def test_no_country(self):
+        template = self.get_template(None)
+        assert template == 'firefox-mobile.html'

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -188,7 +188,7 @@ UUID_REGEX = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a
 def set_country(request, token):
     """Allow a user to set their country"""
     initial = {}
-    countrycode, _ = get_country_from_request(request)
+    countrycode = get_country_from_request(request)
     if countrycode:
         initial['country'] = countrycode.lower()
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -290,11 +290,8 @@ FEED_CACHE = 3900
 # 30 min during dev and 10 min in prod
 DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', parser=int)
 
-# Maxmind Database
 # country code for /country-code.json to return in dev mode
 DEV_GEO_COUNTRY_CODE = config('DEV_GEO_COUNTRY_CODE', default='US')
-MAXMIND_DB_PATH = config('MAXMIND_DB_PATH', default=path('geoip', 'GeoIP2-Country.mmdb'))
-MAXMIND_DEFAULT_COUNTRY = config('MAXMIND_DEFAULT_COUNTRY', default=DEV_GEO_COUNTRY_CODE)
 
 # Paths that don't require a locale code in the URL.
 # matches the first url component (e.g. mozilla.org/gameon/)
@@ -610,6 +607,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'bedrock.base.context_processors.i18n',
                 'bedrock.base.context_processors.globals',
+                'bedrock.base.context_processors.geo',
                 'bedrock.mozorg.context_processors.canonical_path',
                 'bedrock.mozorg.context_processors.contrib_numbers',
                 'bedrock.mozorg.context_processors.current_year',

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -39,5 +39,3 @@ greenlet==0.4.15 \
     --hash=sha256:d97b0661e1aead761f0ded3b769044bb00ed5d33e1ec865e891a8b128bf7c656
 newrelic==4.4.1.104 \
     --hash=sha256:eb60752a2c2a9904ea1eaf6b25dfbe8181e02fca9c11f895c13469057971b343
-maxminddb==1.5.4 \
-    --hash=sha256:f4d28823d9ca23323d113dc7af8db2087aa4f657fafc64ff8f7a8afda871425b


### PR DESCRIPTION
Allows for a query param to override the country (e.g. `?geo=de`).

Also removes the old Maxmind stuff since we're unlikely to use that again, and add a GeoTemplateView class to make it easy to switch template based on request country. Adds docs for all of this as well.