### PR TITLE
More docs improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ help:
 	@echo "  test          - run tests against local files"
 	@echo "  test-image    - run tests against files in docker image"
 	@echo "  test-cdn      - run CDN tests against TEST_DOMAIN"
-	@echo "  docs          - generate Sphinx HTML documentation"
+	@echo "  docs          - generate Sphinx HTML documentation with server and live reload using Docker"
 	@echo "  livedocs      - generate Sphinx HTML documentation with server and live reload"
+	@echo "  build-docs    - generate Sphinx HTML documentation using Docker"
 	@echo "  build-ci      - build docker images for use in our CI pipeline"
 	@echo "  test-ci       - run tests against files in docker image built by CI"
 
@@ -106,6 +107,9 @@ test-image: .docker-build
 	${DC} run test-image
 
 docs: .docker-build-pull
+	${DC} up docs
+
+build-docs: .docker-build-pull
 	${DC} run app make -C docs/ clean html
 
 livedocs:
@@ -129,4 +133,4 @@ build-ci: .docker-build-pull
 test-ci: .docker-build-ci
 	${DC_CI} run test-image
 
-.PHONY: all clean build pull docs livedocs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod build-prod test-cdn
+.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod build-prod test-cdn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,8 @@ services:
   release-local:
     image: mozmeao/bedrock:${GIT_COMMIT:-latest}
     env_file: .env
+    environment:
+      RUN_SUPERVISOR: "true"
     ports:
       - "8000:8000"
     volumes:
@@ -95,6 +97,15 @@ services:
       - ./wsgi/:/app/wsgi:delegated
       - ./locale/:/app/locale:delegated
       - ./l10n/:/app/l10n:delegated
+
+  docs:
+    image: mozmeao/bedrock_test:${GIT_COMMIT:-latest}
+    platform: linux/amd64
+    command: sphinx-autobuild "docs" "docs/_build/html" --host 0.0.0.0 --port 8100
+    ports:
+      - "8100:8100"
+    volumes:
+      - ./docs/:/app/docs:delegated
 
   builder:
     build:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,7 +47,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" --open-browser $(SPHINXOPTS) $(O)
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" --port 8100 --open-browser --delay 1 $(SPHINXOPTS) $(O)
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -315,6 +315,7 @@ define URLs per country as well as a default for everyone else.
         }
         default_url = 'app.everyone-else'
 
+
 In this example people in Canada would go to the URL that Django returns using `reverse()`
 (i.e. the name of the URL) and everyone else would go to the `app.everyone-else` URL. You
 may also use full URLs instead of URL names if you want to. It will look for strings that

--- a/docs/contentful.rst
+++ b/docs/contentful.rst
@@ -4,9 +4,9 @@
 
 .. _contentful:
 
-===========
+======================
 Contentful Integration
-===========
+======================
 
 Overview
 --------
@@ -28,7 +28,7 @@ correspond to components in our design system. The smallest create little bits o
 like buttons. The larger ones group together several entries for the smaller components
 into a bigger component or an entire page.
 
-For example: The _Page: General_ model allows editors to include a hero entry, body
+For example: The *Page: General* model allows editors to include a hero entry, body
 entry, and callout entry. The callout layout entry, in turn, includes a CTA
 entry.
 
@@ -173,7 +173,7 @@ display image to a regular card entry. The large card must still be included in 
 Layout: 5 Cards.
 
 ✏️ Component
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 We're using this term pretty loosely. It corresponds roughly to a Protocol atom,
 molecule, or organism.
@@ -195,28 +195,28 @@ however, they don't have a specific layout wrapper either. They can go in any en
 has a body field that is configured as rich text (picto, split, multi column text...)
 
 Adding a new ✏️ Component
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Example: Picto
 
-#. Create the content model in Contentful
-_Follow the naming conventions._
-You may need two models if you are configuring layout separately.
-#. Add the new content model to the list of allowed references in other content models
-(ATM this is just the "content" reference field on pages).
-#. In bedrock create CSS and JS entries in static-bundles for the new component.
-#. In api.py write a def for the component
-#. In api.py add the component name, def, and bundles to the CONTENT_TYPE_MAP
-#. Find or add the macro to macros-protocol
-#. Import the macro into all.html and add a call to it in the entries loop
+#. Create the content model in Contentful.
 
+   * *Follow the naming conventions*.
+   * You may need two models if you are configuring layout separately.
+
+#. Add the new content model to the list of allowed references in other content models (ATM this is just the "content" reference field on pages).
+#. In bedrock create CSS and JS entries in static-bundles for the new component.
+#. In api.py write a def for the component.
+#. In api.py add the component name, def, and bundles to the CONTENT_TYPE_MAP.
+#. Find or add the macro to macros-protocol.
+#. Import the macro into all.html and add a call to it in the entries loop.
 
 .. note::
 
-    Tips:
-    - can't define defaults in Contentful, so set those in your Python def
-    - for any optional fields make sure you check the field exists before referencing the
-    content
+  Tips:
+
+  * can't define defaults in Contentful, so set those in your Python def.
+  * for any optional fields make sure you check the field exists before referencing the content.
 
 
 Adding a new ♟ Component
@@ -224,19 +224,20 @@ Adding a new ♟ Component
 
 Example: Wordmark.
 
-#. Create the content model in Contentful
-_Follow the naming conventions._
-#. Add the new content model to rich text fields (like split and text)
-#. In bedrock include the CSS in the Sass file for any component which may use it.
-(yeah, this is not ideal, hopefully we will have better control in the future)
-#. Add a def to api.py to render the piece (like _make_wordmark)
+#. Create the content model in Contentful.
+
+   * *Follow the naming conventions*.
+
+#. Add the new content model to rich text fields (like split and text).
+#. In bedrock include the CSS in the Sass file for any component which may use it (yeah, this is not ideal, hopefully we will have better control in the future).
+#. Add a def to api.py to render the piece (like ``_make_wordmark``).
 
 .. note::
 
-    Tips:
-    - can't define defaults in Contentful, so set those in your Python def
-    - for any optional fields make sure you check the field exists before referencing the
-    content
+  Tips:
+
+  * can't define defaults in Contentful, so set those in your Python def.
+  * for any optional fields make sure you check the field exists before referencing the content.
 
 Adding a rich text field in a component
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Contents
    redirects
    javascript-libs
    newsletters
+   contentful
    content-cards
    banners
    uitour

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -233,8 +233,8 @@ image first:
 .. code-block:: bash
 
     $ make build-prod run-prod
-Localization
 
+Localization
 ============
 
 Localization (or L10n) files were fetched by the `bootstrap.sh` command your ran earlier and are

--- a/docs/javascript-libs.rst
+++ b/docs/javascript-libs.rst
@@ -11,4 +11,8 @@ JavaScript Libraries
 Mozilla Image Lazy Loader
 -------------------------
 
-:ref:`mozilla-lazy-load.js<mozillalazyload>`
+
+.. toctree::
+   :maxdepth: 2
+
+   mozilla-lazy-load


### PR DESCRIPTION
Followup from #10437:

- Fix docs formating errors and warnings from Sphinx
- Change the `make docs` command to start an auto-build-reload server using Docker:
  * `make docs` does this using Docker
  * `make livedocs` does this locally
  * `make build-docs` just builds the docs using Docker
