### PR TITLE
Output warning on missing image not issue 500 error

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import urllib.parse
 
 from django.conf import settings
@@ -15,6 +16,7 @@ from bedrock.utils import expand_locale_groups
 
 CSS_TEMPLATE = '<link href="%s" rel="stylesheet" type="text/css" />'
 JS_TEMPLATE = '<script type="text/javascript" src="%s" charset="utf-8"></script>'
+log = logging.getLogger(__name__)
 
 
 @library.global_function
@@ -107,7 +109,11 @@ def static(path):
     if settings.DEBUG and path.startswith('/'):
         raise ValueError('Static paths must not begin with a slash')
 
-    return staticfiles_storage.url(path)
+    try:
+        return staticfiles_storage.url(path)
+    except ValueError as e:
+        log.warning(str(e))
+        return path
 
 
 @library.global_function


### PR DESCRIPTION
We saw [this error in Sentry](https://sentry.prod.mozaws.net/operations/bedrock-dev/issues/13026476/?query=is%3Aunresolved) when Contentful failed to upload an image. This will cause a warning to be output to the logs, but not break the whole page when an image can't be found by the static assets system.

This is more than just a contentful issue, and we should ensure that outputting a log warning is enough, but I believe we can all agree that a broken image on a page is superior to a broken page. 