### PR TITLE
Fix youtube_id on contentful cards (Fixes #10442)

### DIFF
--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -81,7 +81,7 @@
               image_url=card_data.image_url,
               aspect_ratio=card_data.aspect_ratio,
               link_url=card_data.link,
-              youtube_id=card_data.youtube,
+              youtube_id=card_data.youtube_id,
             ) }}
 
           {% endfor %}


### PR DESCRIPTION
## Description

Contentful cards had misnamed youtube attribute so the style and functionality for cards with youtube links was missing. This fixes that typo.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/10442

## Testing

Running locally, ensure you have the latest DB data: `bin/run-db-download.py --force`
~.env file must have Contentful homepage switch on: `SWITCH_CONTENTFUL_HOMEPAGE_EN=on`~ (all switches are on by default as long as you are in dev mode)
http://localhost:8000/en-US/

The large card (new look for Firefox) should behave like the one in production:https://www.mozilla.org/en-US/
- has play icon by video tag
- has play icon over thumbnail
- opens modal
- has learn more link to new page