### PR TITLE
Use a separate switch name for French VPN WNP 92 (Issue #10450)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-fr.html
@@ -2,4 +2,4 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "firefox/whatsnew/index-account.html" %}
+{% extends "firefox/whatsnew/whatsnew-fx90-eu.html" %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -549,16 +549,16 @@ class TestWhatsNew92France(TestCase):
         self.view = fx_views.WhatsNewFranceView.as_view()
         self.rf = RequestFactory(HTTP_USER_AGENT='Firefox')
 
-    @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING='False')
+    @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING_FR='False')
     def test_fx_92_0_0_fr(self, render_mock):
-        """Should use standard whatsnew template for 92.0 in French when VPN switch is OFF"""
+        """Should use whatsnew-fx92-fr template for 92.0 in French when VPN switch is OFF"""
         req = self.rf.get('/firefox/whatsnew/france/')
         req.locale = 'fr'
         self.view(req, version='92.0')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx92-fr.html']
 
-    @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING='True')
+    @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING_FR='True')
     def test_fx_92_0_0_vpn_fr(self, render_mock):
         """Should use whatsnew-fx92-vpn-fr template for 92.0 in French when VPN switch is ON"""
         req = self.rf.get('/firefox/whatsnew/france/')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -544,7 +544,7 @@ class WhatsnewView(L10nTemplateView):
         'firefox/whatsnew/whatsnew-fx91-de.html': ['firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx92-en.html': ['firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx92-de.html': ['firefox/whatsnew/whatsnew'],
-        'firefox/whatsnew/whatsnew-fx92-fr.html': ['firefox/whatsnew/whatsnew-account', 'firefox/whatsnew/whatsnew'],
+        'firefox/whatsnew/whatsnew-fx92-fr.html': ['firefox/whatsnew/whatsnew-fx90.ftl', 'firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/whatsnew-fx92-vpn-en.html': ['firefox/whatsnew/whatsnew', 'products/vpn/shared'],
         'firefox/whatsnew/whatsnew-fx92-vpn-fr.html': ['firefox/whatsnew/whatsnew', 'products/vpn/shared'],
     }
@@ -685,7 +685,7 @@ class WhatsNewEnglishView(WhatsnewView):
 class WhatsNewFranceView(WhatsnewView):
     def get_template_names(self):
         template = super().get_template_names()
-        if switch('firefox-whatsnew-92-vpn-pricing') and template == ['firefox/whatsnew/whatsnew-fx92-fr.html']:
+        if switch('firefox-whatsnew-92-vpn-pricing-fr') and template == ['firefox/whatsnew/whatsnew-fx92-fr.html']:
             template = ['firefox/whatsnew/whatsnew-fx92-vpn-fr.html']
 
         return template


### PR DESCRIPTION
## Description
- Adds a new switch name for France WNP that can be toggle on/off independently of English WNP.
- Adds a prior VPN WNP template as a fallback for France.

## Issue / Bugzilla link
#10450

## Testing
- [x] http://localhost:8000/fr/firefox/92.0/whatsnew/france/ should display VPN page with variable pricing options when `SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING_FR=on` in your `.env` file.
- [x] http://localhost:8000/fr/firefox/92.0/whatsnew/france/  should display VPN page with a single CTA button when `SWITCH_FIREFOX_WHATSNEW_92_VPN_PRICING_FR=off` in your `.env` file.