### PR TITLE
Implement attribution flow for VPN subscription referrals (Fixes #10409)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -9,16 +9,18 @@
         {{ download_firefox_thanks(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_class='mzp-t-secondary mzp-t-md', download_location='nav') }}
       {% endif %}
       {% if not hide_nav_get_vpn_button %}
-      <div class="c-navigation-fxa-cta-container">
-        <a
-          href="{{ url('products.vpn.landing') }}#pricing"
-          class="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-md"
-          data-cta-text="Get Mozilla VPN"
-          data-cta-type="button"
-          data-cta-position="navigation"
-        >
-          {{ ftl('navigation-v2-get-mozilla-vpn') }}
-        </a>
+      <div class="c-navigation-vpn-cta-container">
+        {{ vpn_product_referral_link(
+          referral_id='navigation',
+          page_anchor='#pricing',
+          link_text=ftl('navigation-v2-get-mozilla-vpn'),
+          class_name='mzp-t-secondary mzp-t-md',
+          optional_attributes= {
+            'data-cta-text' : 'Get Mozilla VPN',
+            'data-cta-type' : 'button',
+            'data-cta-position' : 'navigation'
+          }
+        ) }}
       </div>
       {% endif %}
     {% else %}

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -7,6 +7,7 @@ import jinja2
 from django.conf import settings
 from django_jinja import library
 
+from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils.fluent import ftl
 
 FTL_FILES = ['products/vpn/shared']
@@ -223,5 +224,35 @@ def vpn_saving(ctx, plan='12-month', lang=None):
     markup = (f'<span class="js-vpn-saving-display" {attrs}>'
               f'{default_text}'
               f'</span>')
+
+    return jinja2.Markup(markup)
+
+
+@library.global_function
+@jinja2.contextfunction
+def vpn_product_referral_link(ctx, referral_id='', page_anchor='', link_text=None, class_name=None, optional_attributes=None):
+    """
+    Render link to the /products/vpn/ landing page with referral attribution markup
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ vpn_product_referral_link(referral_id='navigation', link_text='Get Mozilla VPN') }}
+    """
+
+    href = reverse('products.vpn.landing')
+    css_class = 'mzp-c-button mzp-t-product js-fxa-product-referral-link'
+    attrs = f'data-referral-id="{referral_id}" '
+
+    if optional_attributes:
+        attrs += ' '.join('%s="%s"' % (attr, val) for attr, val in optional_attributes.items())
+
+    if class_name:
+        css_class += f' {class_name}'
+
+    markup = (f'<a href="{href}{page_anchor}" class="{css_class}" {attrs}>{link_text}</a>')
 
     return jinja2.Markup(markup)

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -601,3 +601,27 @@ class TestVPNSaving(TestCase):
             u'<span class="js-vpn-saving-display" data-price-usd="Save 50%" '
             u'data-price-euro="Save 50%" data-price-chf="Save 45%">Save 50%</span>')
         self.assertEqual(markup, expected)
+
+
+class TestVPNProductReferralLink(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, referral_id, page_anchor, link_text, class_name, optional_attributes):
+        with self.activate('en-US'):
+            req = self.rf.get('/')
+            req.locale = 'en-US'
+            return render("{{{{ vpn_product_referral_link('{0}', '{1}', '{2}', '{3}', {4}) }}}}".format(
+                        referral_id, page_anchor, link_text, class_name, optional_attributes),
+                        {'request': req})
+
+    def test_vpn_product_referral_link(self):
+        """Should return expected markup"""
+        markup = self._render(referral_id='navigation', page_anchor='#pricing',
+                              link_text='Get Mozilla VPN', class_name='mzp-t-secondary mzp-t-md',
+                              optional_attributes={'data-cta-text': 'Get Mozilla VPN',
+                                                   'data-cta-type': 'button'})
+        expected = (
+            u'<a href="/en-US/products/vpn/#pricing" class="mzp-c-button mzp-t-product '
+            u'js-fxa-product-referral-link mzp-t-secondary mzp-t-md" data-referral-id="navigation" '
+            u'data-cta-text="Get Mozilla VPN" data-cta-type="button">Get Mozilla VPN</a>')
+        self.assertEqual(markup, expected)

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -242,12 +242,75 @@ The ``vpn_subscribe_link`` helper has an additional ``plan`` parameter to suppor
 |    plan                    | Subscription plan ID. Defaults to 12-month plan.                                                                       | '12-month'                                               | '12-month', '6-month', or 'monthly'                                                                    |
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 
+Tracking Same-Site Links for Mozilla VPN
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Often we promote Mozilla VPN on different pages via the use of same-site referral
+links to the product landing page. For example, we display a "Get Mozilla VPN"
+button in the main navigation that links to the ``/products/vpn/`` landing page.
+
+In scenarios such as this we want to understand how many people click the link in the
+navigation and go on to signup / subscribe to VPN. To achieve this, we have some
+additional logic in ``fxa-utm-referral.js`` that will check for a specific cookie
+that gets set when someone clicks a specific referral link.
+
+To create a Mozilla VPN referral link, you can use the ``vpn_product_referral_link`` helper:
+
+.. code-block:: jinja
+
+    {{ vpn_product_referral_link(
+        referral_id='navigation',
+        link_text='Get Mozilla VPN',
+        class_name='mzp-t-secondary mzp-t-md',
+        page_anchor='#pricing',
+        optional_attributes= {
+            'data-cta-text' : 'Get Mozilla VPN',
+            'data-cta-type' : 'button',
+            'data-cta-position' : 'navigation',
+        }
+    ) }}
+
+The helper supports the following parameters:
+
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    Parameter name          |                                                       Definition                                                       |                          Format                          |                                                Example                                                 |
++============================+========================================================================================================================+==========================================================+========================================================================================================+
+|    referral_id*            | The ID for the referring page / component. This serves as a value for 'utm_campaign'.                                  | String                                                   | 'navigation'                                                                                           |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    link_text*              | The link copy to be used in the call to action.                                                                        | Localizable string                                       | 'Get Mozilla VPN'                                                                                      |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    class_name              | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'mzp-t-secondary mzp-t-md'                                                                             |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    page_anchor             | An optional page anchor for the link destination.                                                                      | String                                                   | '#pricing'                                                                                             |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optiona_attributes      | An dictionary of key value pairs containing additional data attributes to include in the button.                       | Dictionary                                               | {'data-cta-text': 'Get Mozilla VPN', 'data-cta-type': 'button', 'data-cta-position': 'navigation'}     |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+
+When someone clicks the link a cookie gets set with a 1 hour expiry. The
+``fxa-utm-referral.js`` script will then check for the existence of this
+cookie on page load and update the product landing page subscription links
+with utm parameters that attribute where the click came from.
+
+For example, a referral cookie with the ID ``navigation`` would result
+in the following utm parameters being set:
+
+  - ``utm_source=www.mozilla.org``.
+  - ``utm_campaign=navigation``.
+  - ``utm_medium=referral``.
+
+.. Note::
+
+    The above attribution will only be applied if there are not already
+    utm parameters on the product landing page URL. We will also respect
+    privacy and only set the cookie if DNT is disabled.
+
 
 Link Metrics
 ------------
 
-When using any of the FxA or VPN link/button helpers, a templates's respective JavaScript
-bundle should also include the following dependencies:
+When using any of the FxA or VPN helpers that link directly to FxA,
+a templates's respective JavaScript bundle should also include the following
+dependencies:
 
 .. code-block:: text
 

--- a/media/css/protocol/components/_navigation-ie.scss
+++ b/media/css/protocol/components/_navigation-ie.scss
@@ -59,7 +59,7 @@ $image-path: '/media/protocol/img';
         }
 
         // hide FxA button
-        .c-navigation-fxa-cta-container {
+        .c-navigation-vpn-cta-container {
             display: none;
         }
     }

--- a/media/css/protocol/components/_navigation.scss
+++ b/media/css/protocol/components/_navigation.scss
@@ -238,7 +238,7 @@ html.other {
 
 // Global FxA CTA
 .c-navigation {
-    .c-navigation-fxa-cta-container {
+    .c-navigation-vpn-cta-container {
         display: none;
     }
 }
@@ -249,20 +249,8 @@ html.is-firefox .c-navigation {
         display: none;
     }
 
-    .c-navigation-fxa-cta-container {
+    .c-navigation-vpn-cta-container {
         display: block;
-    }
-}
-
-// ... but not on mobile platforms
-html.is-firefox.ios .c-navigation,
-html.is-firefox.android .c-navigation {
-    .mzp-c-button-download-container {
-        display: block;
-    }
-
-    .c-navigation-fxa-cta-container {
-        display: none;
     }
 }
 

--- a/media/js/base/mozilla-cookie-helper.js
+++ b/media/js/base/mozilla-cookie-helper.js
@@ -70,7 +70,6 @@ Mozilla.Cookies = {
             else {
                 return 'lax';
             }
-            
         }
         vSamesite = checkSameSite(vSamesite);
 

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -73,7 +73,7 @@ class BasePage(ScrollElementIntoView, Page):
         _developer_edition_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-name="Firefox Developer Edition"]')
         _manifesto_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-name="Mozilla Manifesto"]')
         _firefox_download_button_locator = (By.CSS_SELECTOR, '#protocol-nav-download-firefox > .download-link')
-        _mozilla_vpn_button_locator = (By.CSS_SELECTOR, '[data-cta-text="Get Mozilla VPN"]')
+        _mozilla_vpn_button_locator = (By.CSS_SELECTOR, '.c-navigation-vpn-cta-container > [data-cta-text="Get Mozilla VPN"]')
 
         @property
         def is_firefox_download_button_displayed(self):


### PR DESCRIPTION
## Description
- Adds a new VPN product referral link helper.
- Implements helper in navigation CTA button for VPN.

## Issue / Bugzilla link
#10409

## Testing
To test use a Firefox browser with DNT disabled:

1.) Open http://localhost:8000/en-US/
2.) Click on the "Get Mozilla VPN" CTA button in the main navigation.
3.) Once on http://localhost:8000/en-US/products/vpn/#pricing, verify that each subscription link contains:
  - `utm_source=www.mozilla.org`
  - `utm_medium=referral`
  - `utm_campaign=navigation`

Demo link: https://www-demo1.allizom.org/en-US/