### PR TITLE
Added Documentation section under Make it Run (fixes #10452)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -234,6 +234,29 @@ image first:
 
     $ make build-prod run-prod
 
+Documentation
+-------------
+
+This is a great place for coders and non-coders alike to contribute! Please note most of the documentation is currently in `reStructuredText <https://bashtage.github.io/sphinx-material/basics.html>`_ but we also support `Markdown <https://www.markdownguide.org/>`_ files.
+
+If you see a typo or similarly small change, you can use the "Edit in GitHub" link to propose a fix through GitHub. Note: you will not see your change directly committed to the master branch. You will commit the change to a separate branch so it can be reviewed by a staff member before merging to master.
+
+If you want to make a bigger change or `find a Documentation issue on the repo <https://github.com/mozilla/bedrock/labels/Documentation>`_, it is best to edit and preview locally before submitting a pull request. You can do this with Docker or Local installations. Run the commands from your root folder. They will build documentation and start a live server to auto-update any changes you make to a documentation file.
+
+Docker: 
+
+.. code-block:: bash
+
+    $ make docs
+
+Local:
+
+.. code-block:: bash
+
+    $ pip install -r requirements/docs.txt
+    $ make livedocs
+
+
 Localization
 ============
 


### PR DESCRIPTION
## Description

Added a Documentation section under "Installing Bedrock > Make it run".

## Issue / Bugzilla link

#10452

## Testing

![Screenshot 2021-09-14 at 19-13-43 Installing Bedrock — mozilla org 1 0 documentation](https://user-images.githubusercontent.com/73520373/133269608-807ce7ff-4a25-452b-82b0-ab907b952c29.png)

