### PR TITLE
Contentful homepage 500 error missing staticfiles entry (Fixes #10460)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contentful-homepage.html
+++ b/bedrock/mozorg/templates/mozorg/contentful-homepage.html
@@ -143,12 +143,9 @@
   {{ js_bundle('home') }}
   {% include 'includes/contentful/js.html' %}
 
-  {% if switch('firefox-daylight-promo-banner') and not switch('fundraising-banner-eoy2020') %}
-    {{ js_bundle('daylight-promo-banner') }}
-  {% elif switch('fundraising-banner-eoy2020') %}
+  {% if switch('fundraising-banner-eoy2020') %}
     {{ js_bundle('fundraising-banner') }}
   {% endif %}
-
 {% endblock %}
 
 {% block structured_data %}


### PR DESCRIPTION
## Description

Fixes https://sentry.prod.mozaws.net/operations/bedrock-demos/issues/13118973/

```
Missing staticfiles manifest entry for 'js/daylight-promo-banner.js'
```

## Issue / Bugzilla link
#10460
