### PR TITLE
Update VPN variation to include months

### DIFF
--- a/bedrock/products/templates/products/vpn/variations/cta-b.html
+++ b/bedrock/products/templates/products/vpn/variations/cta-b.html
@@ -7,7 +7,7 @@
 {% block hero_cta_change %}
 
 <div class="vpn-pricing-offer">
-  {% set price = 'Get Mozilla VPN for ' + vpn_monthly_price(plan='12-month', lang=LANG) %}
+  {% set price = 'Get Mozilla VPN for ' + vpn_monthly_price(plan='12-month', lang=LANG) + '*' %}
 
   {{ vpn_subscribe_link(
     entrypoint=_utm_source,
@@ -25,7 +25,7 @@
     }
     ) }}
     <p>
-      <a href="#pricing" data-cta-type="button"data-cta-position="primary"data-cta-text="Scroll to pricing">View all pricing plans</a>
+     *For a 12-month plan. <a href="#pricing" data-cta-type="button"data-cta-position="primary"data-cta-text="Scroll to pricing">View all pricing plans</a>
     </p>
 </div>
 

--- a/bedrock/products/templates/products/vpn/variations/cta-b.html
+++ b/bedrock/products/templates/products/vpn/variations/cta-b.html
@@ -25,7 +25,7 @@
     }
     ) }}
     <p>
-     *For a 12-month plan. <a href="#pricing" data-cta-type="button"data-cta-position="primary"data-cta-text="Scroll to pricing">View all pricing plans</a>
+     *For a 12-month plan. <a href="#pricing" data-cta-type="button" data-cta-position="primary" data-cta-text="Scroll to pricing">View all pricing plans</a>
     </p>
 </div>
 

--- a/media/js/products/vpn/cta-change-experiment.js
+++ b/media/js/products/vpn/cta-change-experiment.js
@@ -34,7 +34,7 @@
     };
 
     // Avoid entering automated tests into random experiments.
-    if (href.indexOf('automation=true') === -1) {
+    if (href.indexOf('automation=true') === -1 && href.indexOf('utm_medium=cpc') === -1) {
         initTrafficCop();
     }
 


### PR DESCRIPTION
## Description
An extra add-on to the VPN CTA variation ticket. This ticket is to reflect Dan's comment in https://github.com/mozilla/bedrock/pull/10436#issuecomment-918392872. It is to make sure the end user understands that the top CTA for the VPN page reflects that the $4.99/month plan is, in fact, a 12-month plan.

Changes include:
- adding an asterisks to the end of the button text
- including "*For a 12 month plan." to the copy below the button.
- setting up test to not trigger when the URL contains "utm_medium=cpc"


## Issue / Bugzilla link
Extension of this PR: #10436
Original issue: #10404 

## Testing
http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-page-cta-change&entrypoint_variation=b

<img width="559" alt="Screen Shot 2021-09-15 at 10 09 50 AM" src="https://user-images.githubusercontent.com/42309026/133449111-07fbf5f1-ecfd-470a-bf8b-9f24e6eafc12.png">

