### PR TITLE
Fluent fixes [fix #10474, #10475]

### DIFF
--- a/l10n/en/firefox/browsers/mobile/focus.ftl
+++ b/l10n/en/firefox/browsers/mobile/focus.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-### URL: https://www-dev.allizom.org/firefox/browsers/mobile/android/
+### URL: https://www-dev.allizom.org/firefox/browsers/mobile/focus/
 
 # HTML page title
 mobile-focus-firefox-focus-the-privacy = { -brand-name-firefox-focus }: The privacy browser

--- a/l10n/en/firefox/facebook_container.ftl
+++ b/l10n/en/firefox/facebook_container.ftl
@@ -12,7 +12,7 @@ facebook-container-download-firefox-and-get-the = Download { -brand-name-firefox
 facebook-container-only-available-for-desktop = The { -brand-name-facebook-container } Extension is currently only available for { -brand-name-firefox } for Desktop.
 facebook-container-brand-name-firefox-browser = { -brand-name-firefox-browser }
 # Obsolete string
-facebook-container-firefox-browser = { -brandname-firefox-browser }
+facebook-container-firefox-browser = { -brand-name-firefox-browser }
 
 # Variables:
 #   $link_copy (string) - www.mozilla.org/firefox/new/


### PR DESCRIPTION
## Description
Fixes some minor errors in Fluent files; a misspelled brand ID and a missmatched dev URL.

## Issue / Bugzilla link
#10474 
#10475 
