### PR TITLE
Update comment links for external docs (Fixes #10458)

### DIFF
--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -65,7 +65,7 @@ def geolocate(request):
 
     Mimics the responses from the Mozilla Location Service:
 
-    https://mozilla.github.io/ichnaea/api/region.html
+    https://ichnaea.readthedocs.io/en/latest/api/region.html
     """
     country_code = get_country_from_request(request)
     if country_code is None:

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -144,7 +144,7 @@ if (typeof window.Mozilla === 'undefined') {
 
     /**
      * Fetch and validate accepted params from the page URL for FxA referral.
-     * https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters
+     * https://mozilla.github.io/ecosystem-platform/docs/relying-parties/metrics-for-relying-parties#metrics-related-query-parameters
      * @returns {Object} if params are valid, else {null}.
      */
     UtmUrl.getAttributionData = function (params) {


### PR DESCRIPTION
## Description

We had two 404/redirect links in the code comments. This updates those links to directly reach the information source required.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10458

## Testing
The new links should take you to expected pages.
