### PR TITLE
More string fixes for mobile pages [fix #10477]

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
@@ -117,7 +117,7 @@
       </tbody>
     </table>
 
-    <p class="compare-content">{{ ftl('mobile-compare-at-a-minimum') }}</p>
+    <p class="compare-content">{{ ftl('mobile-compare-at-a-minimum-v2', fallback='mobile-compare-at-a-minimum') }}</p>
 
     <p class="compare-content">{{ ftl('mobile-compare-another-mobile-feature') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -111,7 +111,7 @@
     theme_class='mzp-t-background-alt'
   ) %}
     <h3>{{ ftl('mobile-ios-get-more-firefox') }}</h3>
-    <p>{{ ftl('mobile-ios-add-firefox-across') }}</p>
+    <p>{{ ftl('mobile-ios-add-firefox-across-v2', fallback='mobile-ios-add-firefox-across') }}</p>
   {% endcall %}
 
   {% call split(

--- a/l10n/en/firefox/browsers/mobile/compare.ftl
+++ b/l10n/en/firefox/browsers/mobile/compare.ftl
@@ -13,6 +13,9 @@ mobile-compare-who-makes-the = Who makes the best mobile browser? We’ll compar
 mobile-compare-since-your-mobile = Since your mobile browser is your lifeline to information wherever you are, speed, security, privacy and ease-of-use are the keys to a good experience. So which one is the best mobile browser? Let’s compare the top players — and see which one best suits your needs.
 
 mobile-compare-which-mobile-browser = Which mobile browser keeps things confidential?
+mobile-compare-at-a-minimum-v2 = At a minimum, your mobile browser should provide some version of “private browsing mode,” which automatically deletes your history and search history. In this area, all five of the browsers compared here score points.
+
+# Obsolete string
 mobile-compare-at-a-minimum = At a minimum, your mobile browser should provide some version of “private browsing mode,” which automatically deletes your history and search history. In this area, all seven of the browsers compared here score points.
 mobile-compare-another-mobile-feature = Another mobile feature that should be a given is the ability to prevent websites and companies from tracking your browsing and shopping data — even in normal browsing mode.
 mobile-compare-blocking-thirdparty-trackers = Blocking third-party trackers isn’t just important for privacy — it also helps pages load much faster, without those pieces of code attaching themselves and slowing your browser down.

--- a/l10n/en/firefox/browsers/mobile/ios.ftl
+++ b/l10n/en/firefox/browsers/mobile/ios.ftl
@@ -31,6 +31,9 @@ mobile-ios-your-browsing-history = Your browsing history is history
 mobile-ios-if-you-want = If you want, you can easily select to go online and search in private browsing mode. And when you close private browsing mode, your browsing history and any cookies are automatically erased from your device.
 
 mobile-ios-get-more-firefox = Get more { -brand-name-firefox } in your life
+mobile-ios-add-firefox-across-v2 = Add { -brand-name-firefox } across your devices for secure, seamless browsing. Sync your devices to take your favorite bookmarks, saved logins, passwords and browsing history wherever you go. Plus, send open tabs between your phone and desktop to pick up where you left off.
+
+# Obsolete string
 mobile-ios-add-firefox-across = Add { -brand-name-firefox } across your devices for secure, seamless browsing. { -brand-name-sync } your devices to take your favorite bookmarks, saved logins, passwords and browsing history wherever you go. Plus, send open tabs between your phone and desktop to pick up where you left off.
 
 mobile-ios-find-it-all = Find it all faster

--- a/l10n/en/firefox/facebook_container.ftl
+++ b/l10n/en/firefox/facebook_container.ftl
@@ -11,8 +11,6 @@ facebook-container-get-the-facebook-container = Get the { -brand-name-facebook-c
 facebook-container-download-firefox-and-get-the = Download { -brand-name-firefox } and get the { -brand-name-facebook-container } Extension
 facebook-container-only-available-for-desktop = The { -brand-name-facebook-container } Extension is currently only available for { -brand-name-firefox } for Desktop.
 facebook-container-brand-name-firefox-browser = { -brand-name-firefox-browser }
-# Obsolete string
-facebook-container-firefox-browser = { -brand-name-firefox-browser }
 
 # Variables:
 #   $link_copy (string) - www.mozilla.org/firefox/new/


### PR DESCRIPTION
## Description
Fixes a string on the iOS page, one on the compare page, and deletes an obsolete string (see https://github.com/mozilla-l10n/www-l10n/pull/230#issuecomment-922107952)

## Issue / Bugzilla link
#10477 
#10482 
https://github.com/mozilla-l10n/www-l10n/pull/230

