### PR TITLE
Update Impressum page (Fixes #10483)

### DIFF
--- a/bedrock/legal/templates/legal/impressum.html
+++ b/bedrock/legal/templates/legal/impressum.html
@@ -16,20 +16,23 @@
 
   <h2>Sitz der Gesellschaft:</h2>
   <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-    <span itemprop="streetAddress">331 E. Evelyn Avenue</span>
-    <span itemprop="addressLocality">Mountain View</span>,
+    <span itemprop="streetAddress">Harrison Street Suite 175</span>
+    <span itemprop="addressLocality">San Francisco</span>,
     <abbr itemprop="addressRegion" title="California">CA</abbr>
-    <span itemprop="postalCode">94041</span>
+    <span itemprop="postalCode">94105</span>
     <span itemprop="addressCountry">USA</span>
   </p>
 
   <h2>Vertretungsberechtigte Personen:</h2>
   <ul class="mzp-u-list-styled">
     <li itemscope itemtype="http://schema.org/Person">
-      <span itemprop="name">Roxi Wen</a>
+      <span itemprop="name">Jeff Garver</span>
     </li>
     <li itemscope itemtype="http://schema.org/Person">
-      <span itemprop="name">Amy Keating</a>
+      <span itemprop="name">Frank Huang</span>
+    </li>
+    <li itemscope itemtype="http://schema.org/Person">
+      <span itemprop="name">Mitchell Baker</span>
     </li>
   </ul>
 


### PR DESCRIPTION
## Description
Address and director updates to hardcoded page only available for `de` locale

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10483

## Testing
http://localhost:8000/de/about/legal/impressum/