### PR TITLE
Contentful: Card components font size is too big (Fixes #10444)

### DIFF
--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -67,6 +67,8 @@
           {% for card_data in entry.cards -%}
             {% if card_data.component == 'large_card' %}
               {% set size_class = 'mzp-c-card-large' %}
+            {% elif entry.layout_class == 'mzp-l-card-quarter' %}
+              {% set size_class = 'mzp-c-card-extra-small' %}
             {% else %}
               {% set size_class = 'mzp-c-card-medium' %}
             {% endif %}


### PR DESCRIPTION
## Description
Assume that 4-card layout should always use the `mzp-c-card-extra-small` component class.


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10444

## Testing
http://localhost:8000/en-US/
