### PR TITLE
Ensure x-backend-server header appears in all responses

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -473,6 +473,7 @@ BASIC_AUTH_CREDS = config('BASIC_AUTH_CREDS', default='')
 MIDDLEWARE = [
     'allow_cidr.middleware.AllowCIDRMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'bedrock.mozorg.middleware.HostnameMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'bedrock.mozorg.middleware.VaryNoCacheMiddleware',
@@ -481,7 +482,6 @@ MIDDLEWARE = [
     'bedrock.redirects.middleware.RedirectsMiddleware',
     'bedrock.base.middleware.LocaleURLMiddleware',
     'bedrock.mozorg.middleware.ClacksOverheadMiddleware',
-    'bedrock.mozorg.middleware.HostnameMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'bedrock.mozorg.middleware.CacheMiddleware',


### PR DESCRIPTION
To accomplish this we simply move the middleware closer to the front
of the list of MIDDLEWARE so that it is not skipped for redirects.
