### PR TITLE
Remove duplicate CSS/JS bundles from Contentful home page (Fixes #10470)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contentful-homepage.html
+++ b/bedrock/mozorg/templates/mozorg/contentful-homepage.html
@@ -38,7 +38,7 @@
 
 {% block page_css %}
   {% include 'includes/contentful/css.html' %}
-  {{ css_bundle('home-en') }}
+  {{ css_bundle('home-contentful-en') }}
   {{ css_bundle('home-mr1-promo') }}
 
   {% if switch('fundraising-banner-eoy2020') %}
@@ -140,8 +140,8 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('home') }}
   {% include 'includes/contentful/js.html' %}
+  {{ js_bundle('home-contentful') }}
 
   {% if switch('fundraising-banner-eoy2020') %}
     {{ js_bundle('fundraising-banner') }}

--- a/media/css/mozorg/home/home-contentful-en.scss
+++ b/media/css/mozorg/home/home-contentful-en.scss
@@ -11,10 +11,8 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
 @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/components/split';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 
 @import 'includes/home-base-en';

--- a/media/css/mozorg/home/includes/_home-base-en.scss
+++ b/media/css/mozorg/home/includes/_home-base-en.scss
@@ -2,11 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
 .main-page-heading {
     @include visually-hidden;
 }

--- a/media/css/mozorg/home/includes/_home-base-en.scss
+++ b/media/css/mozorg/home/includes/_home-base-en.scss
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.main-page-heading {
+    @include visually-hidden;
+}
+
+/* -------------------------------------------------------------------------- */
+// Split container
+
+.mzp-c-split.mzp-t-dark {
+    background-color: $color-ink-80;
+
+    .mzp-c-split-media {
+        max-width: 400px;
+    }
+
+    .mzp-c-split-container {
+        @media #{$mq-lg} {
+            padding-bottom: 0;
+            box-sizing: content-box;
+            padding-top: $spacing-2xl;
+        }
+    }
+}
+
+.mzp-c-split-body {
+    padding: $spacing-lg;
+
+    .mzp-u-title-lg {
+        @include font-firefox;
+    }
+}
+/* -------------------------------------------------------------------------- */
+// Custom card styles for lazy-loaded images.
+
+.mzp-c-card {
+    .lazy-image-container .mzp-c-card-image {
+        opacity: 1;
+        transition: opacity 0.3s;
+    }
+
+    .lazy-image-container .mzp-c-card-image[data-src] {
+        opacity: 0;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+// Pocket highlights section.
+
+.pocket {
+
+    .mzp-l-content {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
+    .section-heading {
+        @include text-title-xs;
+        margin-bottom: $spacing-sm;
+    }
+
+    .tagline {
+        color: #676767;
+
+        a:link,
+        a:visited {
+            color: inherit;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: #000;
+        }
+    }
+
+    @media #{$mq-md} {
+        margin-bottom: 0;
+        padding-top: $spacing-lg;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Secondary Download CTA (page bottom)
+
+.c-secondary-cta {
+    background-color: $color-ink-80;
+    color: $color-white;
+    overflow: hidden;
+    position: relative;
+    text-align: center;
+    z-index: 2;
+
+    p {
+        margin-bottom: 0;
+    }
+}
+
+.c-secondary-cta-title {
+    @include at2x('#{$image-path}/logos/firefox/browser/logo-sm.png', 40px, 40px);
+    @include text-title-sm;
+    background-position: center 35px;
+    background-repeat: no-repeat;
+    margin-bottom: $spacing-sm;
+    padding-top: 90px;
+}
+
+.c-secondary-cta-button {
+    margin-bottom: $spacing-lg;
+    margin-top: $spacing-xl;
+}
+
+@media #{$mq-lg} {
+    .c-secondary-cta {
+        @include bidi(((text-align, left, right),));
+        background-image: url('/media/img/home/2018/shield.svg'), url('/media/img/home/2018/bg-secondary.svg');
+        background-position: calc(50vw + 100px) 120px, 50vw 0;
+        background-repeat: no-repeat;
+        padding: $layout-xs 0 $layout-sm 0;
+    }
+
+    .c-secondary-cta-content {
+        max-width: 48%;
+    }
+
+    .c-secondary-cta-title {
+        @include font-firefox;
+        background-position: left 35px;
+    }
+}
+
+@media #{$mq-xl} {
+    .c-secondary-cta {
+        background-position: calc(50vw + 30px) 120px, 45vw 0;
+    }
+}
+
+
+
+//* -------------------------------------------------------------------------- */
+// Secondary FxA CTA (page bottom)
+
+
+.fxaccount-secondary-cta.mzp-t-dark {
+    background-color: $color-ink-80;
+}
+
+.fxaccount-secondary-cta.mzp-t-product-firefox {
+
+    .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/firefox/logo-md.png', 64px, 64px);
+    }
+
+    .mzp-c-call-out-title {
+        @include font-firefox;
+        @include text-title-xs;
+        margin-bottom: 0;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// YouTube iframe responsive in modal.
+
+.ytcontainer-video {
+    max-width: 100%;
+
+    .video-container {
+        height: 0;
+        margin-bottom: $spacing-lg;
+        overflow: hidden;
+        padding-bottom: 56.25%;
+        position: relative;
+        width: 100%;
+    }
+
+    iframe {
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top:0;
+        width: 100%;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Conditional content
+
+// Hide Firefox Account CTAs by default; show download unless we know otherwise.
+.fxaccount-secondary-cta {
+    display: none;
+}
+
+// Hide download CTAs for people already using Firefox; promote Firefox Accounts instead.
+.is-firefox {
+    .download-firefox-secondary-cta {
+        display: none;
+    }
+
+    .fxaccount-secondary-cta {
+        display: block;
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -246,6 +246,12 @@
     },
     {
       "files": [
+        "css/mozorg/home/home-contentful-en.scss"
+      ],
+      "name": "home-contentful-en"
+    },
+    {
+      "files": [
         "css/base/banners/fundraiser.scss"
       ],
       "name": "fundraising-banner"
@@ -1257,6 +1263,15 @@
         "js/mozorg/home/home.js"
       ],
       "name": "home"
+    },
+    {
+      "files": [
+        "protocol/js/protocol-modal.js",
+        "protocol/js/protocol-newsletter.js",
+        "js/newsletter/form-protocol.js",
+        "js/mozorg/home/youtube.js"
+      ],
+      "name": "home-contentful"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Removes duplicate front-end assets from Contentful home page:
- `protocol/css/components/split.scss`
- `protocol/css/templates/card-layout.scss`
- `js/base/mozilla-lazy-load.js`

## Issue / Bugzilla link
#10470

## Testing
- [x] Contentful homepage no longer contain duplicate bundles.
- [x] Non-Contentful home page should look the same and not be effected by the changes.