### PR TITLE
Add hyphens to VPN plans buttons

### DIFF
--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -93,8 +93,8 @@ vpn-shared-pricing-plan-monthly = Monthly
 #   $amount (string) - a string containing the monthly subscription price together with the appropriate currency symbol e.g. 'US$4.99' or '6,99 €'.
 vpn-shared-pricing-monthly = { $amount }<span>/month</span>
 
-vpn-shared-pricing-get-6-month = Get 6 month plan
-vpn-shared-pricing-get-12-month = Get 12 month plan
+vpn-shared-pricing-get-6-month = Get 6-month plan
+vpn-shared-pricing-get-12-month = Get 12-month plan
 vpn-shared-pricing-get-monthly = Get monthly plan
 
 # Variables:


### PR DESCRIPTION
## Description
Added hyphens on the buttons for the 12-month and 6-month plans on the VPN page.

## Issue / Bugzilla link
#10441 

## Testing
http://localhost:8000/en-US/products/vpn/