### PR TITLE
Fix string ID on Android page [fix #10510]

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -83,7 +83,7 @@
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-android-one-tap-to') }}</h3>
-    <p>{{ ftl('mobile-android-got-a-big') }}</p>
+    <p>{{ ftl('mobile-android-get-to-private') }}</p>
   {% endcall %}
 
   {% call split(


### PR DESCRIPTION
## Description
Had the same string twice on the page. The dangers of copy-paste. 🤦 

## Issue / Bugzilla link
#10510 

## Testing
http://localhost:8000/firefox/browsers/mobile/android/