### PR TITLE
VPN Wave IV country expansion (Fixes #10498)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/templates.html
+++ b/bedrock/products/templates/products/vpn/includes/templates.html
@@ -11,7 +11,11 @@
       </a>
 
       <p class="availability-copy">
-        {{ ftl('vpn-shared-available-countries-v3') }}
+        {% if switch('vpn-launch-wave-iv') %}
+          {{ ftl('vpn-shared-available-countries-v4') }}
+        {% else %}
+          {{ ftl('vpn-shared-available-countries-v3') }}
+        {% endif %}
       </p>
     </div>
   </div>

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -102,7 +102,11 @@
           </a>
 
           <p class="availability-copy">
-            {{ ftl('vpn-shared-available-countries-v3') }}
+            {% if switch('vpn-launch-wave-iv') %}
+              {{ ftl('vpn-shared-available-countries-v4') }}
+            {% else %}
+              {{ ftl('vpn-shared-available-countries-v3') }}
+            {% endif %}
           </p>
         </div>
         <div class="l-column-last">
@@ -174,7 +178,11 @@
       </a>
 
       <p class="availability-copy">
-        {{ ftl('vpn-shared-available-countries-v3') }}
+        {% if switch('vpn-launch-wave-iv') %}
+          {{ ftl('vpn-shared-available-countries-v4') }}
+        {% else %}
+          {{ ftl('vpn-shared-available-countries-v3') }}
+        {% endif %}
       </p>
     {% endcall %}
   </div>

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST, require_safe
 
+from bedrock.base.waffle import switch
 from bedrock.newsletter.views import general_error, invalid_email_address
 from bedrock.products.forms import VPNWaitlistForm
 from lib import l10n_utils
@@ -16,7 +17,10 @@ from lib.l10n_utils.fluent import ftl
 
 
 def vpn_country_codes():
-    countries = settings.VPN_COUNTRY_CODES
+    if switch('vpn-launch-wave-iv'):
+        countries = settings.VPN_COUNTRY_CODES + settings.VPN_COUNTRY_CODES_WAVE_IV
+    else:
+        countries = settings.VPN_COUNTRY_CODES
     return '|%s|' % '|'.join(cc.lower() for cc in countries)
 
 
@@ -48,12 +52,17 @@ def vpn_landing_page(request):
     else:
         sub_not_found = False
 
+    if switch('vpn-launch-wave-iv'):
+        available_countries = settings.VPN_AVAILABLE_COUNTRIES_WAVE_IV
+    else:
+        available_countries = settings.VPN_AVAILABLE_COUNTRIES
+
     context = {
         'country_codes': vpn_country_codes(),
         'default_monthly_price': pricing_params['default']['monthly']['price'],
         'default_6_month_price': pricing_params['default']['6-month']['price'],
         'default_12_month_price': pricing_params['default']['12-month']['price'],
-        'available_countries': settings.VPN_AVAILABLE_COUNTRIES,
+        'available_countries': available_countries,
         'connect_servers': settings.VPN_CONNECT_SERVERS,
         'connect_countries': settings.VPN_CONNECT_COUNTRIES,
         'connect_devices': settings.VPN_CONNECT_DEVICES,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1383,6 +1383,26 @@ VPN_PLAN_ID_MATRIX = {
                 'saving': None
             }
         },
+        'en': {
+            '12-month': {
+                'id': 'price_1JcuArKb9q6OnNsLXAnkCSUE' if DEV else 'price_1JcdvBJNcmPzuWtROLbEH9d2',
+                'price': u'4,99 €',
+                'total': u'59,88 €',
+                'saving': 50
+            },
+            '6-month': {
+                'id': 'price_1JcuADKb9q6OnNsLGNIwLcdA' if DEV else 'price_1Jcdu8JNcmPzuWtRK6u5TUoZ',
+                'price': u'6,99 €',
+                'total': u'41,94 €',
+                'saving': 30
+            },
+            'monthly': {
+                'id': 'price_1Jcu7uKb9q6OnNsLG4JAAXuw' if DEV else 'price_1JcdsSJNcmPzuWtRGF9Y5TMJ',
+                'price': u'9,99‎ €',
+                'total': None,
+                'saving': None
+            }
+        },
         'es': {
             '12-month': {
                 'id': 'price_1J4pE7Kb9q6OnNsLnvvyRClI' if DEV else 'price_1J5JCdJNcmPzuWtRrvQMFLlP',
@@ -1518,8 +1538,14 @@ VPN_VARIABLE_PRICING = {
     'fr': {
         'default': VPN_PLAN_ID_MATRIX['euro']['fr'],
     },
+    'ie': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['en'],
+    },
     'it': {
         'default': VPN_PLAN_ID_MATRIX['euro']['it'],
+    },
+    'nl': {
+        'default': VPN_PLAN_ID_MATRIX['euro']['nl'],
     },
     'us': {
         'default': VPN_PLAN_ID_MATRIX['usd']['en'],
@@ -1559,7 +1585,13 @@ VPN_COUNTRY_CODES = [
     'IT',  # Italy
 ]
 
+VPN_COUNTRY_CODES_WAVE_IV = [
+    'IE',  # Ireland
+    'NL',  # Netherlands
+]
+
 VPN_AVAILABLE_COUNTRIES = 13
+VPN_AVAILABLE_COUNTRIES_WAVE_IV = 15
 VPN_CONNECT_SERVERS = 400
 VPN_CONNECT_COUNTRIES = 30
 VPN_CONNECT_DEVICES = 5

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -15,7 +15,10 @@ vpn-shared-available-countries = We currently offer { -brand-name-mozilla-vpn } 
 # Outdated string
 vpn-shared-available-countries-v2 = We currently offer { -brand-name-mozilla-vpn } in the US, the UK, Germany, France, Canada, Malaysia, New Zealand, and Singapore.
 
+# Outdated string
 vpn-shared-available-countries-v3 = We currently offer { -brand-name-mozilla-vpn } in the US, Canada, the UK, Germany, France, Italy, Spain, Belgium, Austria, Switzerland, Malaysia, New Zealand, and Singapore.
+
+vpn-shared-available-countries-v4 = We currently offer { -brand-name-mozilla-vpn } in Austria, Belgium, Canada, France, Germany, Ireland, Italy, Malaysia, the Netherlands, New Zealand, Singapore, Spain, Switzerland, the UK, and the US.
 
 # This is a standalone string that is typically displayed underneath a "Get Mozilla VPN" button.
 vpn-shared-money-back-guarantee = 30-day money-back guarantee

--- a/media/js/products/vpn/geo.js
+++ b/media/js/products/vpn/geo.js
@@ -16,7 +16,7 @@ if (typeof window.Mozilla === 'undefined') {
     var _requestComplete = false;
 
     // Euro pricing
-    var EURO_COUNTRIES = ['at', 'be', 'de', 'es', 'fr', 'it'];
+    var EURO_COUNTRIES = ['at', 'be', 'de', 'es', 'fr', 'ie', 'it', 'nl'];
 
     // Swiss Francs (CHF) pricing
     var CHF_COUNTRIES = ['ch'];

--- a/tests/unit/spec/vpn/geo.js
+++ b/tests/unit/spec/vpn/geo.js
@@ -88,7 +88,7 @@ describe('geo.js', function() {
 
     describe('getAvailability', function() {
 
-        const availableCountries = '|ca|my|nz|sg|gb|gg|im|io|je|uk|vg|as|mp|pr|um|us|vi|at|be|ch|de|es|fr|it|';
+        const availableCountries = '|ca|my|nz|sg|gb|gg|im|io|je|uk|vg|as|mp|pr|um|us|vi|at|be|ch|de|es|fr|it|ie|nl|';
 
         it('should return `available` if matching country code is found', function() {
             expect(Mozilla.VPN.getAvailability('us', availableCountries)).toEqual('available');
@@ -100,6 +100,8 @@ describe('geo.js', function() {
             expect(Mozilla.VPN.getAvailability('es', availableCountries)).toEqual('available');
             expect(Mozilla.VPN.getAvailability('fr', availableCountries)).toEqual('available');
             expect(Mozilla.VPN.getAvailability('it', availableCountries)).toEqual('available');
+            expect(Mozilla.VPN.getAvailability('ie', availableCountries)).toEqual('available');
+            expect(Mozilla.VPN.getAvailability('nl', availableCountries)).toEqual('available');
         });
 
         it('should return `not-available` if no matching country code is found', function() {
@@ -168,6 +170,8 @@ describe('geo.js', function() {
             expect(Mozilla.VPN.getCurrency('es')).toEqual('euro');
             expect(Mozilla.VPN.getCurrency('fr')).toEqual('euro');
             expect(Mozilla.VPN.getCurrency('it')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('ie')).toEqual('euro');
+            expect(Mozilla.VPN.getCurrency('nl')).toEqual('euro');
         });
 
         it('should return "chf" for Switzerland', function() {


### PR DESCRIPTION
## Description
- Add 2 new countries to the VPN country list, behind the switch `SWITCH_VPN_LAUNCH_WAVE_IV`.
- Add new plan IDs for English/Euros.
- Update country list strings for landing page copy.

## Issue / Bugzilla link
#10498

## Testing

When `SWITCH_VPN_LAUNCH_WAVE_IV=on`:

- [ ] http://localhost:8000/en-US/products/vpn/?geo=ie should display pricing in Euros.
- [ ] http://localhost:8000/en-US/products/vpn/?geo=nl should display pricing in Euros.
- [ ] http://localhost:8000/en-US/products/vpn/?geo=pl should display waitlist buttons with updated country list copy.

When `SWITCH_VPN_LAUNCH_WAVE_IV=off`

- [ ] http://localhost:8000/en-US/products/vpn/?geo=ie should display waitlist buttons with current country list copy.
- [ ] http://localhost:8000/en-US/products/vpn/?geo=nl should display waitlist buttons with current country list copy.