### PR TITLE
Added new VPN fluent variables for hyphens

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-vpn-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-vpn-en.html
@@ -67,7 +67,7 @@
 
           {{ vpn_subscribe_link(
             entrypoint=_utm_source,
-            link_text=ftl('vpn-shared-pricing-get-12-month'),
+            link_text=ftl('vpn-shared-pricing-get-12-month-v2', fallback='vpn-shared-pricing-get-12-month'),
             plan='12-month',
             class_name='mzp-c-button mzp-t-xl ',
             lang=LANG,
@@ -93,7 +93,7 @@
 
           {{ vpn_subscribe_link(
             entrypoint=_utm_source,
-            link_text=ftl('vpn-shared-pricing-get-6-month'),
+            link_text=ftl('vpn-shared-pricing-get-6-month-v2', fallback='vpn-shared-pricing-get-6-month'),
             plan='6-month',
             class_name='mzp-c-button mzp-t-secondary mzp-t-xl ',
             lang=LANG,

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-vpn-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx92-vpn-fr.html
@@ -67,7 +67,7 @@
 
           {{ vpn_subscribe_link(
             entrypoint=_utm_source,
-            link_text=ftl('vpn-shared-pricing-get-12-month'),
+            link_text=ftl('vpn-shared-pricing-get-12-month-v2', fallback='vpn-shared-pricing-get-12-month'),
             plan='12-month',
             class_name='mzp-c-button mzp-t-xl ',
             lang=LANG,
@@ -93,7 +93,7 @@
 
           {{ vpn_subscribe_link(
             entrypoint=_utm_source,
-            link_text=ftl('vpn-shared-pricing-get-6-month'),
+            link_text=ftl('vpn-shared-pricing-get-6-month-v2', fallback='vpn-shared-pricing-get-6-month'),
             plan='6-month',
             class_name='mzp-c-button mzp-t-secondary mzp-t-xl ',
             lang=LANG,

--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -28,7 +28,7 @@
 
       {{ vpn_subscribe_link(
         entrypoint=_utm_source,
-        link_text=ftl('vpn-shared-pricing-get-12-month'),
+        link_text=ftl('vpn-shared-pricing-get-12-month-v2', fallback='vpn-shared-pricing-get-12-month'),
         plan='12-month',
         class_name='mzp-c-button mzp-t-xl ',
         lang=LANG,
@@ -55,7 +55,7 @@
 
       {{ vpn_subscribe_link(
         entrypoint=_utm_source,
-        link_text=ftl('vpn-shared-pricing-get-6-month'),
+        link_text=ftl('vpn-shared-pricing-get-6-month-v2', fallback='vpn-shared-pricing-get-6-month'),
         plan='6-month',
         class_name='mzp-c-button mzp-t-secondary mzp-t-xl ',
         lang=LANG,

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -96,8 +96,12 @@ vpn-shared-pricing-plan-monthly = Monthly
 #   $amount (string) - a string containing the monthly subscription price together with the appropriate currency symbol e.g. 'US$4.99' or '6,99 €'.
 vpn-shared-pricing-monthly = { $amount }<span>/month</span>
 
-vpn-shared-pricing-get-6-month = Get 6-month plan
-vpn-shared-pricing-get-12-month = Get 12-month plan
+# Outdated string
+vpn-shared-pricing-get-6-month = Get 6 month plan
+vpn-shared-pricing-get-12-month = Get 12 month plan
+
+vpn-shared-pricing-get-6-month-v2 = Get 6-month plan
+vpn-shared-pricing-get-12-month-v2 = Get 12-month plan
 vpn-shared-pricing-get-monthly = Get monthly plan
 
 # Variables:

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -98,6 +98,8 @@ vpn-shared-pricing-monthly = { $amount }<span>/month</span>
 
 # Outdated string
 vpn-shared-pricing-get-6-month = Get 6 month plan
+
+# Outdated string
 vpn-shared-pricing-get-12-month = Get 12 month plan
 
 vpn-shared-pricing-get-6-month-v2 = Get 6-month plan


### PR DESCRIPTION
## Description
Had to create new Fluent strings (added `-v2`) and undo changes from previous PR: https://github.com/mozilla/bedrock/pull/10503. 
Updated the variable throughout some pages and created a fallback.

## Issue / Bugzilla link
#10503 

## Testing
http://localhost:8000/en-US/products/vpn/
http://localhost:8000/en-US/firefox/92.0/whatsnew/en/
http://localhost:8000/fr/firefox/92.0/whatsnew/france/ (since it's a translated page, the hyphens won't show up for now. I'm not sure how the French do it with hyphens, but code has been updated on this page in case the French do hyphens in this context as well)
