### PR TITLE
Check for double-encoded RTAMO attribution data (Fixes #10524)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -336,8 +336,29 @@ if (typeof window.Mozilla === 'undefined') {
 
     StubAttribution.hasValidData = function(data) {
         if (typeof data.utm_content === 'string' && typeof data.referrer === 'string') {
-            // If RTAMO data does not originate from AMO, drop attribution (Issue 10337).
-            if ((/^rta:/).test(decodeURIComponent(data.utm_content)) && data.referrer.indexOf('https://addons.mozilla.org') === -1) {
+            var content = data.utm_content;
+            var charLimit = 150;
+
+            // If utm_content is unusually long, return false early.
+            if (content.length > charLimit) {
+                return false;
+            }
+
+            // Attribution data can be double encoded
+            while (content.includes('%')) {
+                try {
+                    var result = decodeURIComponent(content);
+                    if (result === content) {
+                        break;
+                    }
+                    content = result;
+                } catch (e) {
+                    break;
+                }
+            }
+
+            // If RTAMO data does not originate from AMO, drop attribution (Issues 10337, 10524).
+            if ((/^rta:/).test(content) && data.referrer.indexOf('https://addons.mozilla.org') === -1) {
                 return false;
             }
         }

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -181,6 +181,48 @@ describe('stub-attribution.js', function() {
             /* eslint-enable camelcase */
 
             expect(Mozilla.StubAttribution.hasValidData(data)).toBeTruthy();
+
+            /* eslint-disable camelcase */
+            const data2 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'amo-fx-cta-607454',
+                utm_content: 'rta:dUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
+                referrer: 'https://addons.mozilla.org/',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data2)).toBeTruthy();
+
+            /* eslint-disable camelcase */
+            const data3 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
+                referrer: 'https://addons.mozilla.org/',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data3)).toBeTruthy();
+
+            /* eslint-disable camelcase */
+            const data4 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
+                referrer: 'https://addons.mozilla.org/',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data4)).toBeTruthy();
         });
 
         it('should return false for RTAMO data that does not have AMO as the referrer', function() {
@@ -197,6 +239,78 @@ describe('stub-attribution.js', function() {
             /* eslint-enable camelcase */
 
             expect(Mozilla.StubAttribution.hasValidData(data)).toBeFalsy();
+
+            /* eslint-disable camelcase */
+            const data2 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: 'rta:cm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
+                referrer: 'https://example.com/',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data2)).toBeFalsy();
+
+            /* eslint-disable camelcase */
+            const data3 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
+                referrer: 'https://example.com/',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data3)).toBeFalsy();
+
+            /* eslint-disable camelcase */
+            const data4 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
+                referrer: '',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data4)).toBeFalsy();
+        });
+
+        it('should return false if utm_content is too long', function() {
+            /* eslint-disable camelcase */
+            const data1 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: `rta%${'25'.repeat(58)}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
+                referrer: '',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data1)).toBeFalsy();
+
+            /* eslint-disable camelcase */
+            const data2 = {
+                utm_source: 'addons.mozilla.org',
+                utm_medium: 'referral',
+                utm_campaign: 'non-fx-button',
+                utm_content: `rta%${'25'.repeat(58)}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
+                referrer: 'https://addons.mozilla.org/',
+                ua: 'chrome',
+                visit_id: GA_VISIT_ID
+            };
+            /* eslint-enable camelcase */
+
+            expect(Mozilla.StubAttribution.hasValidData(data2)).toBeFalsy();
         });
 
         it('should return false for RTAMO data if referrer is not set', function() {


### PR DESCRIPTION
## Description
Handles double-encoded attribution data when validating RTAMO referrals.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10524