### PR TITLE
Update ESLint rules for bedrock (Fixes #10527)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,69 @@ module.exports = {
     extends: [
         'plugin:json/recommended'
     ],
+    rules: {
+        // Require strict mode directive in top level functions
+        // https://eslint.org/docs/rules/strict
+        'strict': ['error', 'function'],
+
+        // This option sets a specific tab width for your code
+        // https://eslint.org/docs/rules/indent
+        'indent': ['error', 4],
+
+        // Disallow mixed 'LF' and 'CRLF' as linebreaks
+        // https://eslint.org/docs/rules/linebreak-style
+        'linebreak-style': ['error', 'unix'],
+
+        // Specify whether double or single quotes should be used
+        'quotes': ['error', 'single'],
+
+        // Require or disallow use of semicolons instead of ASI
+        'semi': ['error', 'always'],
+
+        // Enforce location of semicolons
+        // https://eslint.org/docs/rules/semi-style
+        'semi-style': ['error', 'last'],
+
+        // Require camel case names
+        // https://eslint.org/docs/rules/camelcase
+        'camelcase': ['error', { 'properties': 'always' }],
+
+        // Use type-safe equality operators
+        // https://eslint.org/docs/rules/eqeqeq
+        'eqeqeq': ['error', 'always'],
+
+        // Treat var statements as if they were block scoped
+        // https://eslint.org/docs/rules/block-scoped-var
+        'block-scoped-var': 'error',
+
+        // Require newlines around variable declarations
+        // https://eslint.org/docs/rules/one-var-declaration-per-line
+        'one-var-declaration-per-line': ['error', 'always'],
+
+        // Require constructor names to begin with a capital letter
+        // https://eslint.org/docs/rules/new-cap
+        'new-cap': 'error',
+
+        // Disallow Use of alert, confirm, prompt
+        // https://eslint.org/docs/rules/no-alert
+        'no-alert': 'error',
+
+        // Disallow eval()
+        // https://eslint.org/docs/rules/no-eval
+        'no-eval': 'error',
+
+        // Disallow empty functions
+        // https://eslint.org/docs/rules/no-empty-function
+        'no-empty-function': 'error',
+
+        // Require radix parameter
+        // https://eslint.org/docs/rules/radix
+        'radix': 'error',
+
+        // Disallow the use of `console`
+        // https://eslint.org/docs/rules/no-console
+        'no-console': 'error'
+    },
     /**
      * A set of overrides for JavaScript assets where we support ES2015+.
      * */
@@ -20,6 +83,15 @@ module.exports = {
             },
             parserOptions: {
                 'sourceType': 'module'
+            },
+            rules: {
+                // Require `let` or `const` instead of `var`
+                // https://eslint.org/docs/rules/no-var
+                'no-var': 'error',
+
+                // Require `const` declarations for variables that are never reassigned after declared
+                // https://eslint.org/docs/rules/prefer-const
+                'prefer-const': 'error'
             }
         },
         {

--- a/media/js/base/mozilla-convert.js
+++ b/media/js/base/mozilla-convert.js
@@ -87,11 +87,13 @@ if (typeof window.Mozilla === 'undefined') {
             return false;
 
         } catch(e) {
+            /* eslint-disable no-console */
             // log errors thrown in the console to make debugging easier.
             if ('console' in window && typeof console.error === 'function') {
                 console.error(e);
             }
             return false;
+            /* eslint-enable no-console */
         }
     };
 

--- a/media/js/base/sentry.es6.js
+++ b/media/js/base/sentry.es6.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 import * as Sentry from '@sentry/browser';
 
 // Respect Do Not Track
@@ -30,7 +28,7 @@ if (typeof window.Mozilla.dntEnabled === 'function' && !window.Mozilla.dntEnable
             beforeSend(event) {
                 try {
                     // https://github.com/getsentry/sentry-javascript/issues/3147
-                    if (event.exception.values[0].stacktrace.frames[0].filename === `<anonymous>`) {
+                    if (event.exception.values[0].stacktrace.frames[0].filename === '<anonymous>') {
                         return null;
                     }
                 } catch (e) {}

--- a/media/js/firefox/whatsnew/whatsnew-88-en.js
+++ b/media/js/firefox/whatsnew/whatsnew-88-en.js
@@ -7,7 +7,6 @@
 
     var jingle = function(){
         button.style.fontStyle = 'italic';
-        console.log('jingle');
         var audio = new Audio(button.dataset.audio);
         audio.play();
     };

--- a/media/js/foundation/annual-report-2019.es6.js
+++ b/media/js/foundation/annual-report-2019.es6.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 // Lazyload images
 window.Mozilla.LazyLoad.init();
 
@@ -97,7 +95,7 @@ function getCurrentModalIndex() {
 
 function updateModalArticle(index) {
     const modalContent = document.querySelector('.mzp-u-modal-content.mzp-c-modal-overlay-contents');
-    let newArticleId = articleArray[index].getAttribute('data-modal-id');
+    const newArticleId = articleArray[index].getAttribute('data-modal-id');
     const newModalContent = document.querySelector(`[data-modal-parent="${newArticleId}"]`).cloneNode(true);
     const currentModalContent = modalContent.firstElementChild;
 


### PR DESCRIPTION
## Description
Updates bedrock ESLint rules for both ES5 and ES2017+ JS files.

Feel free to make other suggestions? https://eslint.org/docs/rules/

## Issue / Bugzilla link
#10527

## Testing
- `npm run lint`