### PR TITLE
Aligned the Newsletter section on Contentful home page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contentful-homepage.html
+++ b/bedrock/mozorg/templates/mozorg/contentful-homepage.html
@@ -100,7 +100,7 @@
   {% endif %}
 
   {% include 'includes/contentful/all.html' %}
-
+<div class="mzp-l-content">
   <aside class="mzp-c-newsletter">
     <div class="mzp-c-newsletter-image">
       {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
@@ -117,7 +117,7 @@
       )}}
     </div>
   </aside>
-
+</div>
 </main>
 
 {% call download_banner_secondary(


### PR DESCRIPTION
## Description 

The newsletter section on the Contentful home page is now inside `mzp-l-content` container and correctly aligned after fixing this issue.

## Issue / Bugzilla link

#10521

## Final Result

Here is the screenshot of my changes

![Screenshot from 2021-09-29 20-40-43](https://user-images.githubusercontent.com/73520373/135297365-745ba9e1-0252-4b5e-8998-01d493486e80.png)



