### PR TITLE
Reinstate ESLint default rule set (#10527)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,11 @@
 module.exports = {
     env: {
-        'jasmine': true,
-        'commonjs': true
+        'browser': true,
+        'commonjs': true,
+        'jasmine': true
     },
     extends: [
+        'eslint:recommended',
         'plugin:json/recommended'
     ],
     rules: {

--- a/media/js/base/sentry.es6.js
+++ b/media/js/base/sentry.es6.js
@@ -31,7 +31,9 @@ if (typeof window.Mozilla.dntEnabled === 'function' && !window.Mozilla.dntEnable
                     if (event.exception.values[0].stacktrace.frames[0].filename === '<anonymous>') {
                         return null;
                     }
-                } catch (e) {}
+                } catch (e) {
+                    // do nothing.
+                }
 
                 return event;
             }


### PR DESCRIPTION
## Description
This got accidentally removed when I updated to the latest version.

## Issue / Bugzilla link
#10527

## Testing
`npm run lint`