### PR TITLE
Remove deprecated picto cards [#10500]

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -291,7 +291,7 @@
 
 
 {# Picto: https://protocol.mozilla.org/patterns/molecules/picto.html #}
-{% macro picto(title=None, class=None, heading_level=3, base_el='div', body=False, image_url=None, image_width=64, include_highres_image=False, l10n_image=False, lazy_loading=False) -%}
+{% macro picto(title=None, class=None, heading_level=3, base_el='div', body=False, image_url='', image_width=64, include_highres_image=False, l10n_image=False, lazy_loading=False) -%}
 <{{ base_el }} class="mzp-c-picto{% if class %} {{ class }}{% endif %}">
   {% set loading = 'lazy' if lazy_loading else 'eager' %}
   {% if include_highres_image %}

--- a/bedrock/firefox/templates/firefox/new/basic/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_download.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button with context %}
-{% from "macros-protocol.html" import hero, picto_card with context %}
+{% from "macros-protocol.html" import hero with context %}
 
 {% extends "firefox/new/basic/base.html" %}
 

--- a/bedrock/firefox/templates/firefox/new/basic/base_platform.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_platform.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/new/basic/base_download.html" %}
 
+{% from "macros-protocol.html" import picto with context %}
+
 {% block experiments %}{% endblock %}
 
 {# This template can render with EITHER 'firefox/new/download.ftl' OR 'firefox/new/platform.ftl' active
@@ -25,11 +27,35 @@
 
 {% block features %}
   {% if ftl_file_is_active('firefox/new/platform') %}
-    <section class="features t-platform">
-      <ul class="mzp-l-card-third mzp-l-content">
-        {{ picto_card(title=card1_title, desc=card1_desc, class=card1_class) }}
-        {{ picto_card(title=card2_title, desc=card2_desc, class=card2_class) }}
-        {{ picto_card(title=card3_title, desc=card3_desc, class=card3_class) }}
+    <section class="features">
+      <ul class="mzp-l-content mzp-l-columns mzp-t-columns-three">
+        {% call picto(
+          title=card1_title,
+          image_url=card1_image_url,
+          body=True,
+          base_el='li',
+          class=card1_class
+        ) %}
+          {{ card1_desc }}
+        {% endcall%}
+        {% call picto(
+          title=card2_title,
+          image_url=card2_image_url,
+          body=True,
+          base_el='li',
+          class=card2_class
+        ) %}
+          {{ card2_desc }}
+        {% endcall%}
+        {% call picto(
+          title=card3_title,
+          image_url=card3_image_url,
+          body=True,
+          base_el='li',
+          class=card3_class
+        ) %}
+          {{ card3_desc }}
+        {% endcall%}
       </ul>
     </section>
   {% endif %}

--- a/bedrock/firefox/templates/firefox/new/basic/download_linux.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_linux.html
@@ -21,14 +21,17 @@
 {# cards #}
 {% set card1_title = ftl('new-platform-privacy-more-than') %}
 {% set card1_desc = ftl('new-platform-your-life-your-business') %}
+{% set card1_image_url  = 'img/firefox/new/platform/icon-private.svg' %}
 {% set card1_class = 'private' %}
 
 {% set card2_title = ftl('new-platform-2x-faster') %}
 {% set card2_desc = ftl('new-platform-speed-meet-security') %}
+{% set card2_image_url  = 'img/firefox/new/platform/icon-faster.svg' %}
 {% set card2_class = 'faster' %}
 
 {% set card3_title = ftl('new-platform-open-source') %}
 {% set card3_desc = ftl('new-platform-look-under-the-hood') %}
+{% set card3_image_url  = 'img/firefox/new/platform/icon-opensource.svg' %}
 {% set card3_class = 'open-source' %}
 
 {% block structured_data %}

--- a/bedrock/firefox/templates/firefox/new/basic/download_mac.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_mac.html
@@ -21,14 +21,17 @@
 {# cards #}
 {% set card1_title = ftl('new-platform-privacy-comes-first') %}
 {% set card1_desc = ftl('new-platform-firefox-doesnt-spy') %}
+{% set card1_image_url = 'img/firefox/new/platform/icon-private.svg' %}
 {% set card1_class = 'private' %}
 
 {% set card2_title = ftl('new-platform-2x-faster') %}
 {% set card2_desc = ftl('new-platform-get-speed-and-security') %}
+{% set card2_image_url = 'img/firefox/new/platform/icon-faster.svg' %}
 {% set card2_class = 'faster' %}
 
 {% set card3_title = ftl('new-platform-block-trackers') %}
 {% set card3_desc = ftl('new-platform-be-the-master-of-your') %}
+{% set card3_image_url = 'img/firefox/new/platform/icon-blocker.svg' %}
 {% set card3_class = 'blocker' %}
 
 {% block structured_data %}

--- a/bedrock/firefox/templates/firefox/new/basic/download_windows.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_windows.html
@@ -21,14 +21,17 @@
 {# cards #}
 {% set card1_title = ftl('new-platform-2x-faster') %}
 {% set card1_desc = ftl('new-platform-firefox-moves-fast') %}
+{% set card1_image_url = 'img/firefox/new/platform/icon-faster.svg' %}
 {% set card1_class = 'faster' %}
 
 {% set card2_title = ftl('new-platform-common-sense-privacy') %}
 {% set card2_desc = ftl('new-platform-live-your-life') %}
+{% set card1_image_url = 'img/firefox/new/platform/icon-private.svg' %}
 {% set card2_class = 'private' %}
 
 {% set card3_title = ftl('new-platform-seamless-setup') %}
 {% set card3_desc = ftl('new-platform-easy-migration') %}
+{% set card1_image_url = 'img/firefox/new/platform/icon-seamless.svg' %}
 {% set card3_class = 'seamless' %}
 
 {% block structured_data %}

--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import call_out, picto_card with context %}
-
 {% extends "firefox/new/basic/base.html" %}
 
 {# FxA automated tests use this attribute to verify the page #}

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -3,7 +3,6 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
-{% from "macros-protocol.html" import hero, picto_card, call_out_compact with context %}
 
 {% extends "firefox/new/desktop/base.html" %}
 

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import call_out, picto_card with context %}
-
 {% extends "firefox/new/desktop/base.html" %}
 
 {# FxA automated tests use this attribute to verify the page #}

--- a/bedrock/foundation/templates/foundation/reimagine-open.html
+++ b/bedrock/foundation/templates/foundation/reimagine-open.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import feature_card, picto_card with context %}
-
 {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}The Future of the Open Web — White Paper{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros-protocol.html" import hero, billboard, picto_card with context %}
+{% from "macros-protocol.html" import hero, billboard, picto with context %}
 
 {% extends "base-protocol-mozilla.html" %}
 
@@ -41,6 +41,7 @@
 
 {% block content %}
 <main role="main">
+testing
   {% if ftl_has_messages('home-promo-title-lalo', 'home-promo-title-soraya', 'home-promo-title-gary', 'home-promo-title-ryan') %}
     {%- set promos = [
       'mozorg/home/includes/mr1-promo-lalo.html',
@@ -123,44 +124,41 @@
       </div>
     </section>
 
-    <section class="mzp-l-card-third">
-      <ul>
-        <li>
-          {% call picto_card(
-          custom_desc=True,
-          class='extensions') %}
+    <section>
+      <ul class="mzp-l-content mzp-l-columns mzp-t-columns-three">
+          {% call picto(
+            image_url='img/home/externals-sprite.png',
+            body=True,
+            base_el='li',
+            class='extensions')
+          %}
           <a class="mzp-c-cta-link" rel="external" href="https://addons.mozilla.org/{{ referrals }}">
-            <h2 class="mzp-c-card-picto-title">{{ ftl('home-extensions') }}</h2>
+            <h2>{{ ftl('home-extensions') }}</h2>
           </a>
-          <p class="mzp-c-card-picto-desc">
-            {{ ftl('home-personalize-firefox-with-your') }}
-          </p>
+          <p>{{ ftl('home-personalize-firefox-with-your') }}</p>
           {% endcall %}
-        </li>
-        <li>
-          {% call picto_card(
-          custom_desc=True,
+
+          {% call picto(
+          image_url='img/home/externals-sprite.png',
+          body=True,
+          base_el='li',
           class='careers') %}
           <a class="mzp-c-cta-link" rel="external" href="https://careers.mozilla.org/{{ referrals }}">
-            <h2 class="mzp-c-card-picto-title">{{ ftl('home-careers') }}</h2>
+            <h2>{{ ftl('home-careers') }}</h2>
           </a>
-          <p class="mzp-c-card-picto-desc">
-            {{ ftl('home-learn-about-the-benefits-of') }}
-          </p>
+          <p>{{ ftl('home-learn-about-the-benefits-of') }}</p>
           {% endcall %}
-        </li>
-        <li>
-          {% call picto_card(
-          custom_desc=True,
+
+          {% call picto(
+          image_url='img/home/externals-sprite.png',
+          body=True,
+          base_el='li',
           class='help') %}
           <a class="mzp-c-cta-link" rel="external" href="https://support.mozilla.org/{{ referrals }}">
-            <h2 class="mzp-c-card-picto-title">{{ ftl('home-need-help') }}</h2>
+            <h2>{{ ftl('home-need-help') }}</h2>
           </a>
-          <p class="mzp-c-card-picto-desc">
-            {{ ftl('home-get-answers-to-your-questions') }}
-          </p>
+          <p>{{ ftl('home-get-answers-to-your-questions') }} </p>
           {% endcall %}
-        </li>
       </ul>
     </section>
 

--- a/media/css/firefox/new/basic/platform.scss
+++ b/media/css/firefox/new/basic/platform.scss
@@ -6,46 +6,5 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/picto-card';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
-
-
-.t-platform .mzp-c-card-picto-content {
-    padding-top: 96px + $layout-sm;
-
-    &::before {
-        @include background-size(96px 96px);
-        background-color: transparent;
-        background-position: top left;
-        background-repeat: no-repeat;
-        height: 96px;
-        margin-left: -48px;
-        width: 96px;
-    }
-}
-
-.mzp-c-card-picto-content::before {
-    .blocker & {
-        background-image: url('/media/img/firefox/new/platform/icon-blocker.svg');
-    }
-
-    .faster & {
-        background-image: url('/media/img/firefox/new/platform/icon-faster.svg');
-    }
-
-    .lighter & {
-        background-image: url('/media/img/firefox/new/platform/icon-lighter.svg');
-    }
-
-    .open-source & {
-        background-image: url('/media/img/firefox/new/platform/icon-opensource.svg');
-    }
-
-    .private & {
-        background-image: url('/media/img/firefox/new/platform/icon-private.svg');
-    }
-
-    .seamless & {
-        background-image: url('/media/img/firefox/new/platform/icon-seamless.svg');
-    }
-}
+@import '~@mozilla-protocol/core/protocol/css/components/picto';
+@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -10,8 +10,8 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
 @import '~@mozilla-protocol/core/protocol/css/components/billboard';
 @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
-@import '~@mozilla-protocol/core/protocol/css/components/picto-card';
+@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
+@import '~@mozilla-protocol/core/protocol/css/components/picto';
 
 .mzp-c-hero .c-primary-cta-title {
     @include font-firefox;
@@ -35,48 +35,6 @@ $image-path: '/media/protocol/img';
         padding: $spacing-lg $spacing-sm;
     }
 }
-
-//* -------------------------------------------------------------------------- */
-// Picto Cards
-
-// Picto card custom icon sizes.
-// These should be standardized into a `large` icon size.
-// https://github.com/mozilla/protocol/issues/382
-
-.mzp-c-card-picto .mzp-c-card-picto-content {
-    padding-top: 140px;
-
-    &:before {
-        background-color: transparent;
-        background-position: top left;
-        background-repeat: no-repeat;
-        height: 100px;
-        margin-left: -52px;
-        width: 100px;
-    }
-
-    @media #{$mq-lg} {
-        .mzp-c-card-picto-title {
-            @include text-title-sm;
-            margin-bottom: $spacing-xl;
-        }
-    }
-}
-
-.extensions .mzp-c-card-picto-content::before {
-    @include at2x('/media/img/home/externals-sprite.png', 100px, 300px);
-}
-
-.careers .mzp-c-card-picto-content::before {
-    @include at2x('/media/img/home/externals-sprite.png', 100px, 300px);
-    background-position: left -100px;
-}
-
-.help .mzp-c-card-picto-content::before {
-    @include at2x('/media/img/home/externals-sprite.png', 100px, 300px);
-    background-position: left -200px;
-}
-
 
 //* -------------------------------------------------------------------------- */
 // Two column section


### PR DESCRIPTION
## Description

We are still deciding the best component to use to replace centered hero components, but we have a picto_card replacement in [picto](https://protocol.mozilla.org/patterns/molecules/picto.html) so we can clean up those remaining components. There should be no more picto_card references in bedrock and we can remove the picto_card macro.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10500

## Testing
TBA
