### PR TITLE
Update VPN Already a subscriber? link url (Fixes #10535)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -95,9 +95,8 @@
   {% endif %}
 {%- endmacro %}
 
-{% macro vpn_nav_cta(link_text, alt_link_text, sign_in_link_text, utm_source, utm_campaign) -%}
+{% macro vpn_nav_cta(link_text, alt_link_text, download_link_text, utm_source, utm_campaign) -%}
   <div class="vpn-nav-cta">
-
     {% if vpn_available %}
       <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="#pricing" data-cta-type="button" data-cta-text="Scroll to pricing" data-cta-position="navigation">
         {{ ftl('vpn-shared-subscribe-link') }}
@@ -108,9 +107,9 @@
       </a>
     {% endif %}
 
-    {{ vpn_sign_in_link(
+    {{ vpn_download_link(
         entrypoint=utm_source,
-        link_text=sign_in_link_text,
+        link_text=download_link_text,
         class_name='mzp-c-cta-link',
         optional_parameters={
           'utm_campaign': utm_campaign

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -28,7 +28,7 @@
     custom_nav_cta=vpn_nav_cta(
       link_text=ftl('vpn-shared-subscribe-link'),
       alt_link_text=ftl('vpn-shared-waitlist-link'),
-      sign_in_link_text=ftl('vpn-shared-sign-in-link'),
+      download_link_text=ftl('vpn-shared-sign-in-link'),
       utm_source=_utm_source,
       utm_campaign=_utm_campaign,
     )
@@ -43,13 +43,6 @@
 
 {% block content %}
 <main>
-  {# error message for visitors who try to sign-in without a subscription (issue 10002) #}
-  {% if sub_not_found %}
-    <div class="mzp-c-notification-bar mzp-t-error">
-      <p>{{ ftl('vpn-landing-sub-not-found') }}</p>
-    </div>
-  {% endif %}
-
   {% block hero %}
     {% call vpn_hero(
       heading=ftl('vpn-shared-product-name'),

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -53,9 +53,9 @@ def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optio
 
 @library.global_function
 @jinja2.contextfunction
-def vpn_sign_in_link(ctx, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
+def vpn_download_link(ctx, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
     """
-    Render a vpn.mozilla.org sign-in link with required params for FxA authentication.
+    Render a vpn.mozilla.org download link with required params for product referrals.
 
     Examples
     ========
@@ -63,9 +63,9 @@ def vpn_sign_in_link(ctx, entrypoint, link_text, class_name=None, optional_param
     In Template
     -----------
 
-        {{ vpn_sign_in_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Sign In') }}
+        {{ vpn_download_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Already a subscriber?') }}
     """
-    product_url = f"{settings.VPN_ENDPOINT}oauth/init"
+    product_url = f"{settings.VPN_ENDPOINT}vpn/download"
 
     return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)
 

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -667,32 +667,32 @@ class TestVPNSubscribeLink(TestCase):
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT, VPN_ENDPOINT=TEST_VPN_ENDPOINT)
-class TestVPNSignInLink(TestCase):
+class TestVPNDownloadLink(TestCase):
     rf = RequestFactory()
 
     def _render(self, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
         req = self.rf.get("/")
         req.locale = "en-US"
         return render(
-            f"{{{{ vpn_sign_in_link('{entrypoint}', '{link_text}', '{class_name}', {optional_parameters}, {optional_attributes}) }}}}",
+            f"{{{{ vpn_download_link('{entrypoint}', '{link_text}', '{class_name}', {optional_parameters}, {optional_attributes}) }}}}",
             {"request": req},
         )
 
-    def test_vpn_sign_in_link(self):
+    def test_download_in_link(self):
         """Should return expected markup"""
         markup = self._render(
             entrypoint="www.mozilla.org-vpn-product-page",
-            link_text="Sign In",
+            link_text="Already a Subscriber?",
             class_name="mzp-c-cta-link",
             optional_parameters={"utm_campaign": "vpn-product-page"},
             optional_attributes={"data-cta-text": "VPN Sign In", "data-cta-type": "fxa-vpn", "data-cta-position": "navigation"},
         )
         expected = (
-            '<a href="https://vpn.mozilla.org/oauth/init?entrypoint=www.mozilla.org-vpn-product-page'
+            '<a href="https://vpn.mozilla.org/vpn/download?entrypoint=www.mozilla.org-vpn-product-page'
             "&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral"
             '&utm_campaign=vpn-product-page&data_cta_position=navigation" data-action="https://accounts.firefox.com/" '
             'class="js-vpn-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '
-            'data-cta-type="fxa-vpn" data-cta-position="navigation">Sign In</a>'
+            'data-cta-type="fxa-vpn" data-cta-position="navigation">Already a Subscriber?</a>'
         )
         self.assertEqual(markup, expected)
 

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -27,13 +27,6 @@ def vpn_available(request):
 def vpn_landing_page(request):
     template_name = "products/vpn/landing.html"
     ftl_files = ["products/vpn/landing", "products/vpn/shared"]
-    sub_not_found = request.GET.get("vpn-sub-not-found", None)
-
-    # error message for visitors who try to sign-in without a subscription (issue 10002)
-    if sub_not_found == "true":
-        sub_not_found = True
-    else:
-        sub_not_found = False
 
     context = {
         "vpn_available": vpn_available(request),
@@ -41,7 +34,6 @@ def vpn_landing_page(request):
         "connect_servers": settings.VPN_CONNECT_SERVERS,
         "connect_countries": settings.VPN_CONNECT_COUNTRIES,
         "connect_devices": settings.VPN_CONNECT_DEVICES,
-        "sub_not_found": sub_not_found,
     }
 
     return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -193,15 +193,15 @@ all support the same standard parameters:
 Mozilla VPN Links
 -----------------
 
-Use the ``vpn_sign_in_link`` helper to create a sign-in link to https://vpn.mozilla.org/ via a
-Firefox Accounts auth flow.
+Use the ``vpn_download_link`` helper to create a link to https://vpn.mozilla.org/vpn/download/
+with FxA metrics params attached.
 
 Usage
 ~~~~~
 
 .. code-block:: jinja
 
-    {{ vpn_sign_in_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Sign In') }}
+    {{ vpn_download_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Already a subscriber?') }}
 
 Use the ``vpn_subscribe_link`` helpers to create a VPN subscription link via a
 Firefox Accounts auth flow.

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -168,9 +168,6 @@ vpn-landing-faq-manage-subscription-question-desc = If you’re already subscrib
 
 vpn-landing-faq-link = See more FAQs
 
-# message shown to visitors who try to sign-in without an active subscription.
-vpn-landing-sub-not-found = Oops! It looks like you haven’t subscribed yet.
-
 ## Invite page https://www-dev.allizom.org/products/vpn/invite/
 
 vpn-landing-invite-page-title = Join the Waitlist: { -brand-name-mozilla-vpn }

--- a/media/css/products/vpn/landing.scss
+++ b/media/css/products/vpn/landing.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/inline-list';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 //* -------------------------------------------------------------------------- */
 // Smooth Scroll


### PR DESCRIPTION
## Description
- Update "Already a subscriber?" link in VPN page nav to point to https://vpn.mozilla.org/vpn/download/
- Remove superfluous "vpn-sub-not-found" notification.

http://localhost:8000/en-US/products/vpn/

## Issue / Bugzilla link
#10535

## Testing
- [x] Clicking "Already a subscriber?" link in the nav should navigate to `/vpn/download/`.