### PR TITLE
Removed incorrect email for academic question on contact page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -29,7 +29,6 @@
         <li><a href="{{ donate_url('contact_us_page') }}">{{ _('I want to donate to Mozilla') }}</a></li>
         <li><a href="{{ url('foundation.trademarks.policy') }}">{{ _('I have questions about using Mozilla’s trademarks') }}</a></li>
         <li><a href="{{ url('legal.fraud-report') }}">{{ _('I’d like to report misuse of a Mozilla trademark') }}</a></li>
-        <li><a href="mailto:research_requests@mozilla.com">{{ _('I need information for an academic paper') }}</a></li>
         <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines">{{ _('I want to hold an event in a Mozilla space') }}</a></li>
         <li><a href="https://bugzilla.mozilla.org/form.dev-engagement-event">{{ _('I want Mozilla to sponsor my event') }}</a></li>
         <li><a href="mailto:trademark-permissions@mozilla.com">{{ _('I’d like permission to use a Mozilla logo') }}</a></li>


### PR DESCRIPTION
## Description

Remove this email from Contact page for academic question part and now it will redirect to contact page.

## Issue / Bugzilla link

#10329 

