### PR TITLE
NOTICKET: Add paul-mclendahand config to bedrock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,9 @@ testpaths =
     bedrock
     lib
     tests
+
+[tool:paul-mclendahand]
+# Config for use with https://github.com/willkg/paul-mclendahand
+github_user=mozilla
+github_project=bedrock
+main_branch=master


### PR DESCRIPTION
Add config for tooling to make dependabot PRs easier to manage in bulk.

Trivial, but not zero value :)

## Description

https://github.com/willkg/paul-mclendahand makes maintenance-PR handling so much easier than one-by-one

This changeset adds a default config to make it pretty much instant to use after installation.

Note that this addition doesn't specify which remote to use, so we may need to tune this if 'origin' means different things to different contributors.

## Issue / Bugzilla link

No ticket for this one

## Testing

* Pull the branch
* Install (eg `pipx install paul-mclendahand` - see docs for other ways)
* Confirm the config from setup.cfg is picked up - doing `pmac listprs` at your prompt will be enough
