### PR TITLE
Add helper to determine whether to run experiments (Fixes #10559)

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -278,9 +278,32 @@ A/B Test PRs that might have useful code to reuse
 - https://github.com/mozilla/bedrock/pull/5492/files
 - https://github.com/mozilla/bedrock/pull/5499/files
 
-Excluding automated tests from experiments
-------------------------------------------
+Avoiding experiment collisions
+------------------------------
 
-Automated functional tests include a `automation=true` parameter in their URLs. So
-for whichever kind of experimental redirect you're performing, automated tests can
-be excluded from the audience criteria by checking for existance of said parameter.
+To ensure that Traffic Cop doesn't overwrite data from any other externally
+controlled experiments (for example Ad campaign tests, or in-product Firefox
+experiments), you can use the experiment-utils helper to decide whether or
+not Traffic Cop should initiate.
+
+.. code-block:: javascript
+
+    var isApprovedToRun = require('../../base/experiment-utils.es6.js').isApprovedToRun; // relative path
+
+    if (isApprovedToRun()) {
+        var cop = new Mozilla.TrafficCop({
+            id: 'experiment-name',
+            variations: {
+                'entrypoint_experiment=experiment-name&entrypoint_variation=a': 10,
+                'entrypoint_experiment=experiment-name&entrypoint_variation=b': 10
+            }
+        });
+
+        cop.init();
+    }
+
+The ``isApprovedToRun()`` function will check the page URL's query parameters
+against a list of well-known experimental params, and return ``false`` if
+any of those params are found. It will also check for some other cases where
+we do not want to run experiments, such as if the page is being opened in
+an automated testing environment.

--- a/media/js/base/experiment-utils.es6.js
+++ b/media/js/base/experiment-utils.es6.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const knownExperimentalParams = [
+    'automation=true', // Automated functional tests
+    'entrypoint_experiment=', // Firefox Accounts experiments
+    'entrypoint_variation=',
+    'experiment=', // Stub attribution experiments
+    'variation=',
+    'utm_medium=cpc', // Ad campaign tests
+    'utm_source=firefox-browser' // Firefox in-product tests
+];
+
+/**
+ * Check given URL against a list of well-know experemental query parameters.
+ * Issue #10559
+ * @param {String} params - query params, defaults to window.location.search.
+ * @returns {Boolean} - return false if match is found.
+ */
+function isApprovedToRun(params) {
+    let queryString =
+        typeof params === 'string' ? params : window.location.search || null;
+
+    if (queryString) {
+        queryString = decodeURIComponent(queryString);
+
+        return knownExperimentalParams.every((param) => {
+            return queryString.indexOf(param) === -1;
+        });
+    }
+
+    return true;
+}
+
+module.exports = {
+    isApprovedToRun
+};

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -22,6 +22,7 @@ module.exports = function (config) {
             'media/js/base/core-datalayer-page-id.js',
             'media/js/base/core-datalayer.js',
             'media/js/base/dnt-helper.js',
+            'media/js/base/experiment-utils.es6.js',
             'media/js/base/fxa-utm-referral.js',
             'media/js/base/mozilla-convert.js',
             'media/js/base/mozilla-fxa.js',
@@ -43,6 +44,7 @@ module.exports = function (config) {
             'tests/unit/spec/base/core-datalayer-page-id.js',
             'tests/unit/spec/base/core-datalayer.js',
             'tests/unit/spec/base/dnt-helper.js',
+            'tests/unit/spec/base/experiment-utils.js',
             'tests/unit/spec/base/fxa-utm-referral.js',
             'tests/unit/spec/base/mozilla-convert.js',
             'tests/unit/spec/base/mozilla-client.js',
@@ -76,7 +78,8 @@ module.exports = function (config) {
         ],
 
         preprocessors: {
-            'media/js/**/*.js': ['webpack', 'sourcemap']
+            'media/js/**/*.js': ['webpack', 'sourcemap'],
+            'tests/unit/**/*.js': ['webpack', 'sourcemap']
         },
 
         webpack: {

--- a/tests/unit/spec/base/experiment-utils.js
+++ b/tests/unit/spec/base/experiment-utils.js
@@ -1,0 +1,38 @@
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+describe('experiment-utils.es6.js', function () {
+    'use strict';
+
+    describe('isApprovedToRun', function () {
+        it('should return true if experimental params are not found in the page URL', function () {
+            const isApprovedToRun =
+                require('../../../../media/js/base/experiment-utils.es6.js').isApprovedToRun;
+            expect(
+                isApprovedToRun('?utm_source=test&utm_campaign=test')
+            ).toBeTruthy();
+
+            expect(isApprovedToRun('')).toBeTruthy();
+        });
+
+        it('should return false if experimental params are found in the page URL', function () {
+            const isApprovedToRun =
+                require('../../../../media/js/base/experiment-utils.es6.js').isApprovedToRun;
+            expect(isApprovedToRun('?utm_medium=cpc')).toBeFalsy();
+
+            expect(isApprovedToRun('?utm_source=firefox-browser')).toBeFalsy();
+
+            expect(
+                isApprovedToRun(
+                    '?entrypoint_experiment=test&entrypoint_variation=a'
+                )
+            ).toBeFalsy();
+
+            expect(isApprovedToRun('?experiment=test&variation=a')).toBeFalsy();
+
+            expect(isApprovedToRun('?automation=true')).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
## Description
Adds an `isApprovedToRun()` utility helper for Traffic Cop experiments.

## Issue / Bugzilla link
#10559

## Testing
You can test this out on [cta-change-experiment.js](https://github.com/mozilla/bedrock/blob/master/media/js/products/vpn/cta-change-experiment.js) as an example.

- [x] The Traffic Cop experiment should not initiate when matching parameter is found in the page URL.