### PR TITLE
Update Mozilla DMB link on history page [no bug]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/history.html
+++ b/bedrock/mozorg/templates/mozorg/about/history.html
@@ -76,7 +76,7 @@
   <ul>
     <li><a href="https://wiki.mozilla.org/Historical_Documents">{{ ftl('history-mozilla-bookmarks') }}</a></li>
     <li><a href="https://wiki.mozilla.org/Timeline">{{ ftl('history-timeline-of-mozilla-project') }}</a></li>
-    <li><a href="http://mozillamemory.org/index.php">{{ ftl('history-mozilla-digital-memory-bank') }}</a></li>
+    <li><a href="https://mozillamemory.org/">{{ ftl('history-mozilla-digital-memory-bank') }}</a></li>
     <li>
       {{ ftl('history-the-history-of-firefox-and', link="https://www.foxkeh.com/downloads/") }}
     </li>


### PR DESCRIPTION
## Description
Reported via Slack. The history page at `/about/history/` features an external link to `http://mozillamemory.org/index.php` which is now a 404. It looks like that site updated to no longer resolve the `index.php` part, and they've also enabled HTTPS. This just updates the link.

## Testing
http://localhost:8000/about/history/ the link is at the bottom labeled "Mozilla Digital Memory Bank"