### PR TITLE
10575: Update git-blame-ignore-revs for this issues's crucial commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,4 +8,4 @@
 ab38b080abbff26e6968ced9267f3c576bb9e5fa
 
 # Allow Black to reformat migrations
-329890d484ff62fc05d6ca764801f56a6baaf748
+5f3865dbee447c51c0e32a168ac7dbd8e4026358


### PR DESCRIPTION
## Description

Skips the history from the main work done in for #10575 to make git archaeology easier in the future

## Issue / Bugzilla link

## Testing

* git-blame any migration file (they were all touched by black, I think, but 0003_halloffamer.py def was) and confirm there is no sign of my commit to apply Black