### PR TITLE
Upgrade NodeJS Docker image to 14 (Fixes #10464)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
   test_js:
     docker:
-      - image: "circleci/node:12-browsers"
+      - image: "circleci/node:14-browsers"
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ########
 # assets builder and dev server
 #
-FROM node:12-slim AS assets
+FROM node:14-slim AS assets
 
 ENV PATH=/app/node_modules/.bin:$PATH
 WORKDIR /app


### PR DESCRIPTION
## Description
Bump Node to 14 for both the main Docker image and in CircleCI

## Issue / Bugzilla link
#10464

## Testing
- `make build` and then `make run`