### PR TITLE
fix bug 10255. Hide overflow to fix RTL issues /ar/firefox/developer/

### DIFF
--- a/media/css/firefox/developer/includes/intro.scss
+++ b/media/css/firefox/developer/includes/intro.scss
@@ -43,6 +43,7 @@
     background-size: auto 420px;
     height: 420px;
     position: relative;
+    overflow: hidden;
 
     img {
         bottom: 0;


### PR DESCRIPTION
## Description
This PR fixes a RTL issue /ar/firefox/developer/ at small viewport sizes where the imagery would breaks out of the viewport causing horizontal scroll on the page.

Example: https://www.mozilla.org/ar/firefox/developer/

## Issue / Bugzilla link

Fixes #10255 

## Testing

I tested it on my computer by running bedrock via Docker.
<img width="728" alt="Screen Shot 2021-10-12 at 4 14 40 PM" src="https://user-images.githubusercontent.com/53121061/137023314-0ec5d9e3-1c51-4c05-98e7-316206e0a48e.png">


