### PR TITLE
Return whatsnew template as a list in China view [fix #10584]

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -677,7 +677,8 @@ class WhatsNewChinaView(WhatsnewView):
         if template in self.excluded_templates:
             template = ["firefox/whatsnew/index-account.html"]
 
-        return template
+        # return a list to conform with original intention
+        return [template]
 
 
 class DownloadThanksView(L10nTemplateView):


### PR DESCRIPTION
## Description
WNPs shown through the China view were missing the Fluent files and showing string IDs. Updating the China view to return the template as a list matches the original whatsnew view and keeps all its Fluent map references.

Currently broken in prod so we should try to get it fixed quick.

## Issue / Bugzilla link
#10584 

## Testing
Beta: http://localhost:8000/en-US/firefox/94.0b3/whatsnew/china/
Dev: http://localhost:8000/en-US/firefox/94.0a2/whatsnew/china/
Nightly: http://localhost:8000/en-US/firefox/95.0a1/whatsnew/china/