### PR TITLE
Fixup TypeError -> HTTP 500 when certain WNPs for China are loaded

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -675,7 +675,7 @@ class WhatsNewChinaView(WhatsnewView):
     def get_template_names(self):
         template = super().get_template_names()[0]
         if template in self.excluded_templates:
-            template = ["firefox/whatsnew/index-account.html"]
+            template = "firefox/whatsnew/index-account.html"
 
         # return a list to conform with original intention
         return [template]


### PR DESCRIPTION
## Description

Sentry flagged that some pages were blowing up for specific, earlier, versions of FF and a specific locale

This changeset remedies that.

## Issue / Bugzilla link

Fixes #10586

## Testing

Manually tested on the following - you can do the same too!

Failing before fix, working after - 

http://localhost:8080/en-US/firefox/87.0/whatsnew/china/ - compare with https://mozilla.org/en-US/firefox/87.0/whatsnew/china/ for example
http://localhost:8080/en-US/firefox/88.0/whatsnew/china/
http://localhost:8080/en-US/firefox/92.0.1/whatsnew/china/
http://localhost:8080/en-US/firefox/93.0/whatsnew/china/

Working before and after (lots, but a cherry-pick)
http://localhost:8000/en-US/firefox/73.0/whatsnew/china/
http://localhost:8000/en-US/firefox/whatsnew/china/

Unit test for regression protection will follow in a separate fixup



