### PR TITLE
Remove sticky nav if user prefers reduced motion

### DIFF
--- a/media/js/base/protocol/protocol-navigation.js
+++ b/media/js/base/protocol/protocol-navigation.js
@@ -232,13 +232,20 @@
          * If there are multiple navigation organisms on a single page,
          * assume only the first (and hence top-most) instance can and
          * will be sticky.
+         *
+         * Do not init sticky navigation if user prefers reduced motion
          */
-        _navElem = document.querySelector('.c-navigation');
 
-        if (_navElem && _navElem.classList.contains('mzp-is-sticky')) {
-            if (Navigation.supportsSticky()) {
-                Navigation.initSticky();
-            }
+        _navElem = document.querySelector('.c-navigation');
+        var _navIsSticky =
+            _navElem &&
+            _navElem.classList.contains('mzp-is-sticky') &&
+            Navigation.supportsSticky();
+
+        if (_navIsSticky && matchMedia('(prefers-reduced-motion)').matches) {
+            _navElem.classList.remove('mzp-is-sticky');
+        } else if (_navIsSticky) {
+            Navigation.initSticky();
         }
     };
 


### PR DESCRIPTION
## Description

We want to remove sticky behaviour from the nav for users who prefer reduced motion.

## Issue / Bugzilla link
https://github.com/mozilla/protocol/issues/733

We landed a fix in Protocol, but will not be backporting this nav because a redesign is coming, so we will make the bedrock-specific fix too: https://github.com/mozilla/protocol/pull/734#issuecomment-943839063

## Testing

You'll have to toggle your preference for reduced motion according to your user agent: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences

http://localhost:8000/en-US/

When you prefer reduced motion, the nav should be static.
When you do not prefer reduced motion, the nav should be sticky with animations to scroll in and out of view on page scroll (current behaviour all the time on https://www.mozilla.org/en-US/).
