### PR TITLE
Removed links in Bedrock linking to research.mozorg

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
@@ -56,17 +56,6 @@
               </a>
             </section>
           </li>
-          <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://research.mozilla.org/webassembly/?{{ utm_params }}" data-link-name="WebAssembly" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
-                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M17.2 27l8.7-4.3c.2-.1.4-.2.5-.4.1-.2.2-.4.2-.6V10.9l-9.3 4.7V27zm-2.4 0V15.6l-9.3-4.7v10.7c0 .4.2.9.6 1l8.7 4.4zM25.1 9l-8.5-4.3c-.2-.1-.3-.1-.5-.1s-.4 0-.5.1L6.9 9l9.1 4.5L25.1 9zm-7.5-6.4l9.3 4.7c.6.3 1.1.7 1.4 1.3.3.6.5 1.2.5 1.8v11.1c0 .7-.2 1.3-.5 1.8-.3.6-.8 1-1.4 1.3l-9.3 4.7c-.5.2-1 .4-1.6.4-.5 0-1.1-.1-1.6-.4l-9.3-4.7c-.6-.2-1.1-.6-1.4-1.2-.3-.6-.5-1.2-.5-1.8V10.4c0-.7.2-1.3.5-1.8.3-.6.8-1 1.4-1.3l9.3-4.7c.5-.2 1-.4 1.6-.4s1.1.2 1.6.4z"></path></svg>
-                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-webassembly') }}</h4>
-              {% if ftl_has_messages('navigation-v2-learn-more-about-the-new') %}
-                <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-more-about-the-new') }}</p>
-              {% endif %}
-              </a>
-            </section>
-          </li>
         </ul>
         <p class="c-menu-category-link"><a href="https://labs.mozilla.org/?{{ utm_params }}" data-link-name="More Mozilla Innovation" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">{{ ftl('navigation-v2-more-mozilla-innovation') }}</a></p>
       </div>

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -112,12 +112,6 @@
             <li>
               <a class="mzp-c-cta-link" rel="external" href="https://vr.mozilla.org/{{ referrals }}">{{ ftl('home-virtual-reality-platform') }}</a>
             </li>
-            <li>
-              <a class="mzp-c-cta-link" rel="external" href="https://research.mozilla.org/servo-engines/{{ referrals }}">{{ _('Servo') }}</a>
-            </li>
-            <li>
-              <a class="mzp-c-cta-link" rel="external" href="https://research.mozilla.org/rust/{{ referrals }}">{{ _('Rust') }}</a>
-            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Description
We're going to be sunsetting most of https://research.mozilla.org, and in this ticket, I remove the traces of content in mozorg that links to the sunsetting website. We'll be keeping the redirects for now, as we will probably keep the site up purely for the publications listed in this page: https://research.mozilla.org/papers-publications/

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10556

## Testing
1. In the rest-of-world homepage, I removed links for:
- Servo
- Rust

2. In the Innovations tab on the navbar, I removed the link to WebAssembly.


