### PR TITLE
Remove MR1 banner from homepage

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contentful-homepage.html
+++ b/bedrock/mozorg/templates/mozorg/contentful-homepage.html
@@ -78,27 +78,6 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if switch('firefox-mr1-launch') %}
-    {%- set promos = [
-      'mozorg/home/includes/mr1-promo-lalo.html',
-      'mozorg/home/includes/mr1-promo-soraya.html',
-      'mozorg/home/includes/mr1-promo-gary.html',
-      'mozorg/home/includes/mr1-promo-ryan.html'
-    ] -%}
-    {% include promos|random() %}
-  {% else %}
-    {% call hero(
-      title='Firefox products are designed to protect your privacy',
-      class='privacy-promise-hero mzp-has-image mzp-t-dark mzp-t-firefox',
-      image_url='img/firefox/privacy/promise/privacy-hero.png',
-      include_highres_image=True,
-      include_cta=True,
-      heading_level=2
-    ) %}
-      <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product">Learn more</a>
-    {% endcall %}
-  {% endif %}
-
   {% include 'includes/contentful/all.html' %}
 <div class="mzp-l-content">
   <aside class="mzp-c-newsletter">


### PR DESCRIPTION
## Description
We're going to be promoting VPN to the top of mozorg until Nov 2nd (MR2 release). For now, I've removed the MR1 banner and promos to be replaced by VPN, which will be done via Contentful by Dan.

## Issue / Bugzilla link
#10560 

## Testing
This will only be done for the `en` locale.
http://localhost:8000/en-US/ 
