### PR TITLE
Fix 500 error for missing macro on /ru/firefox/new/ (Fixed #10605)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download_yandex.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download_yandex.html
@@ -1,3 +1,5 @@
+{% from "macros-protocol.html" import call_out_compact with context %}
+
 {% extends "firefox/new/desktop/download.html" %}
 
 {% block extrahead %}


### PR DESCRIPTION
## Description
Looks like a macro removed in https://github.com/mozilla/bedrock/pull/10541 was still required for this special template.

## Issue / Bugzilla link
#10605

## Testing
http://localhost:8000/ru/firefox/new/
http://localhost:8000/ru/firefox/new/?geo=ru