### PR TITLE
Remove google domains from Sentry JS allowList (Fixes #10615)

### DIFF
--- a/media/js/base/sentry.es6.js
+++ b/media/js/base/sentry.es6.js
@@ -25,12 +25,7 @@ if (
                 'https://plugin.ucads.ucweb.com/api/flow/',
                 'Non-Error promise rejection captured with value' // issue 10380
             ],
-            allowUrls: [
-                '/media/js/',
-                'https://www.googletagmanager.com/',
-                'https://www.google-analytics.com/',
-                'https://cdn-3.convertexperiments.com/'
-            ],
+            allowUrls: ['/media/js/', 'https://cdn-3.convertexperiments.com/'],
             beforeSend(event) {
                 try {
                     // https://github.com/getsentry/sentry-javascript/issues/3147


### PR DESCRIPTION
Fixes https://github.com/mozilla/bedrock/issues/10615
