### PR TITLE
Support CloudFront geo header

### DIFF
--- a/bedrock/base/geo.py
+++ b/bedrock/base/geo.py
@@ -21,7 +21,8 @@ def get_country_from_param(request):
 
 def get_country_from_header(request):
     """Return an uppercase 2 letter country code retrieved from the request header."""
-    country_code = valid_country_code(request.META.get("HTTP_CF_IPCOUNTRY"))
+    country_code = request.META.get("HTTP_CLOUDFRONT_VIEWER_COUNTRY", request.META.get("HTTP_CF_IPCOUNTRY"))
+    country_code = valid_country_code(country_code)
     if not country_code and settings.DEV:
         country_code = settings.DEV_GEO_COUNTRY_CODE
 


### PR DESCRIPTION
In addition to supporting the CloudFlare header, we should add support for the CloudFront one so that we can more easily switch CDN providers should we need to.

https://aws.amazon.com/blogs/networking-and-content-delivery/leverage-amazon-cloudfront-geolocation-headers-for-state-level-geo-targeting/