### PR TITLE
Fixed footer links

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -54,9 +54,9 @@
           <ul class="c-footer-list">
             <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-name="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
             <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-type="footer" data-link-name="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-type="footer" data-link-name="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') }}#beta" data-link-type="footer" data-link-name="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
             <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly">{{ ftl('footer-nightly') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
             <li><a href="{{ url('firefox.enterprise.index') }}" data-link-type="footer" data-link-name="Firefox for Enterprise">{{ ftl('footer-enterprise') }}</a></li>
             <li><a href="https://developer.mozilla.org/docs/Tools/?{{ utm_params }}&utm_content=developers" data-link-type="footer" data-link-name="Tools">{{ ftl('footer-tools') }}</a></li>
           </ul>


### PR DESCRIPTION
## Description
Fixed footer links for Android Nightly / Beta which were incorrect and going to desktop links instead of android.

## Issue / Bugzilla link
#10622

