### PR TITLE
Delete redundant Fluent files for WNP 80 and 81 [no bug]

### DIFF
--- a/l10n/en-US/firefox/whatsnew/whatsnew-fx80.ftl
+++ b/l10n/en-US/firefox/whatsnew/whatsnew-fx80.ftl
@@ -1,7 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-### URL: https://www-dev.allizom.org/firefox/80.0/whatsnew/all/
-
-whatsnew80-our-latest-version = Our latest version of { -brand-name-firefox } features lightning-fast page loads and a clean new design that makes it easier to get more things done, more quickly.

--- a/l10n/en-US/firefox/whatsnew/whatsnew-fx81.ftl
+++ b/l10n/en-US/firefox/whatsnew/whatsnew-fx81.ftl
@@ -1,7 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-whatsnew81-our-latest-for-android-has = Our latest for { -brand-name-android } has lots of fun, smart and even weirdo features – like a moveable search bar. Because we’re an independent browser. We care about your thumbs.
-whatsnew81-make-firefox-your-everyday = No more phoning it in with { -brand-name-safari }
-


### PR DESCRIPTION
## Description
For some reason these two files started showing up in www-l10n PRs from automation. They're en-US only, and the pages they correspond to were deleted a while back so they can safely be removed.

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/241
