### PR TITLE
Update VPN landing paging to reflect support for Windows 11 (Fixes #10633)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -247,11 +247,7 @@
 
       <ul class="vpn-faq-item-detail mzp-u-list-styled">
         <li>
-          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-windows-v2') %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-windows-v2', url=url('products.vpn.platforms.windows')) }}
-          {% else %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-windows') }}
-          {% endif %}
+          {{ ftl('vpn-landing-faq-compatibility-question-desc-windows-v3', fallback='vpn-landing-faq-compatibility-question-desc-windows-v2', url=url('products.vpn.platforms.windows')) }}
         </li>
         <li>
           {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-mac-v3') %}

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -103,10 +103,12 @@ vpn-landing-faq-compatibility-question-desc = { -brand-name-mozilla-vpn } is com
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/windows/
-vpn-landing-faq-compatibility-question-desc-windows-v2 = <a href="{ $url }">{ -brand-name-windows }</a> 10 (64-bit only)
+vpn-landing-faq-compatibility-question-desc-windows-v3 = <a href="{ $url }">{ -brand-name-windows }</a> 10/11 (64-bit only)
 
 # Outdated string
-vpn-landing-faq-compatibility-question-desc-windows = { -brand-name-windows } 10 (64-bit only)
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/windows/
+vpn-landing-faq-compatibility-question-desc-windows-v2 = <a href="{ $url }">{ -brand-name-windows }</a> 10 (64-bit only)
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/mac/


### PR DESCRIPTION
## Description
Updates supported devices copy for windows in page FAQ.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10633

## Testing

http://localhost:8000/en-US/products/vpn/#faq-compatibility