### PR TITLE
Remove unused strings on download and Android pages

### DIFF
--- a/l10n/en/firefox/browsers/mobile/android.ftl
+++ b/l10n/en/firefox/browsers/mobile/android.ftl
@@ -54,7 +54,6 @@ mobile-android-mozilla-exists-to = { -brand-name-mozilla } exists to build the I
 
 # 'Shortcut' is US slang, means a quicker way of doing or acheiving something. Being used here as a verb to mean "Take a shortcut..." Alternative is 'Get there faster with Firefox for Android'
 mobile-android-short-cut-the-internet = Shortcut the internet with { -brand-name-firefox } for { -brand-name-android }
-mobile-android-get-there-faster = Get there faster with { -brand-name-firefox } for { -brand-name-android }
 mobile-android-see-all-your-open-tabs = See all your open tabs, recent searches and favorite sites all in one place with { -brand-name-firefox } browser for { -brand-name-android }.
 mobile-android-own-your-home = Own your home screen
 mobile-android-get-to-the-parts = Get to the parts of the internet you care about faster. Choose to see all your open tabs, recent searches, bookmarks and favorite sites all in one place.

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -40,9 +40,6 @@ firefox-desktop-download-primary-password = Primary password
 firefox-desktop-love-your-life = Love your life online
 # Color is being used as slang here, means customize here. Alternative: Customize it the way you want...
 firefox-desktop-its-your-internet = It’s your internet. Color it the way you want with thousands of tools, themes and extensions. Firefox is the original alternative browser that puts people before profits.
-firefox-desktop-choose-your-color = Choose your color
-firefox-desktop-personalize-your-experience = Personalize your experience  with new colorways
-
 
 # Obsolete string
 firefox-desktop-download-master-password = Master password


### PR DESCRIPTION
## Description
Some strings were recently added that ended up not being used in the templates. Removing them so localizers won't need to bother.

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/243#discussion_r738815199
https://github.com/mozilla/bedrock/pull/10644#discussion_r739763136

## Testing
http://localhost:8000/firefox/new/
http://localhost:8000/firefox/browsers/mobile/android/