### PR TITLE
Attach FxA flow params to VPN subscription links (Fixes #10663)

### DIFF
--- a/media/js/products/vpn/landing.js
+++ b/media/js/products/vpn/landing.js
@@ -25,6 +25,15 @@
 (function () {
     'use strict';
 
+    // initiate FxA flow metrics after subscription URLs have been set.
+    if (typeof Mozilla.FxaProductButton !== 'undefined') {
+        Mozilla.FxaProductButton.init();
+    }
+})();
+
+(function () {
+    'use strict';
+
     function openFaqItem(id) {
         var faq = document.getElementById(id);
 


### PR DESCRIPTION
## Description
This was accidentally removed in https://github.com/mozilla/bedrock/pull/10608/ when `geo.js` was deleted.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10663

## Testing
http://localhost:8000/en-US/products/vpn/

It looks like https://stable.dev.lcip.org/ is currently down right now, which makes it a little hard to test locally. But hopefully this is a simple enough fix that the code can be reviewed with enough confidence to validate later once this merges?