### PR TITLE
Fix Contentful CTAs (fixes #10661, #10662)

### DIFF
--- a/bedrock/contentful/templates/includes/contentful/cta.html
+++ b/bedrock/contentful/templates/includes/contentful/cta.html
@@ -7,8 +7,14 @@
 {% set utm_source = request.page_info.utm_source %}
 {% set utm_campaign = request.page_info.utm_campaign %}
 {% set utm_content = label.replace(' ', '-') %}
+{% set referral = '?utm_source=' + utm_source + '&utm_medium=referral&utm_campaign=' + utm_campaign %}
 
 {% if action == 'Download Firefox' %}
+
+  <!-- TODO: unique dom_ID -->
+  {{ download_firefox_thanks(dom_id='download-button-primary', download_location=location, alt_copy=label, button_class=button_class) }}
+
+{% elif action == 'Explore Firefox' %}
 
   <a href="{{ url('firefox.browsers.index') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
 
@@ -24,8 +30,7 @@
 
 {% elif action == 'Get Pocket' %}
 
-    {% set referral = '?utm_source=' + utm_source + '&utm_medium=referral&utm_campaign=' + utm_campaign %}
-    <a href="https://getpocket.com/{{ referral|safe }}" class="mzp-c-button {{ button_class }}" rel="external noopener" data-cta-type="link" data-cta-text="{{ cta_text }}">{{ label }}</a>
+  <a href="https://getpocket.com/{{ referral|safe }}" class="mzp-c-button {{ button_class }}" rel="external noopener" data-cta-type="link" data-cta-text="{{ cta_text }}">{{ label }}</a>
 
 {% elif action == 'Get Mozilla VPN' %}
 
@@ -33,7 +38,6 @@
 
 {% elif action == 'Try Relay' %}
 
-  {% set referral = '?utm_source=' + utm_source + '&utm_medium=referral&utm_campaign=' + utm_campaign %}
   <a href="https://relay.firefox.com/{{ referral|safe }}" class="mzp-c-button {{ button_class }}" rel="external noopener" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
 
 {% endif %}

--- a/bedrock/contentful/templates/includes/contentful/cta.html
+++ b/bedrock/contentful/templates/includes/contentful/cta.html
@@ -10,8 +10,7 @@
 
 {% if action == 'Download Firefox' %}
 
-  <!-- TODO: unique dom_ID -->
-  {{ download_firefox_thanks(dom_id='download-button-primary', download_location=location, alt_copy=label, button_class=button_class) }}
+  <a href="{{ url('firefox.browsers.index') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
 
 {% elif action == 'Create a Firefox Account' %}
 
@@ -31,6 +30,11 @@
 {% elif action == 'Get Mozilla VPN' %}
 
   <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
+
+{% elif action == 'Try Relay' %}
+
+  {% set referral = '?utm_source=' + utm_source + '&utm_medium=referral&utm_campaign=' + utm_campaign %}
+  <a href="https://relay.firefox.com/{{ referral|safe }}" class="mzp-c-button {{ button_class }}" rel="external noopener" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
 
 {% endif %}
 

--- a/bedrock/contentful/templates/includes/contentful/cta.html
+++ b/bedrock/contentful/templates/includes/contentful/cta.html
@@ -12,11 +12,11 @@
 {% if action == 'Download Firefox' %}
 
   <!-- TODO: unique dom_ID -->
-  {{ download_firefox_thanks(dom_id='download-button-primary', download_location=location, alt_copy=label, button_class=button_class) }}
+  {{ download_firefox_thanks(dom_id='download-button-primary', alt_copy=label, button_class=button_class) }}
 
 {% elif action == 'Explore Firefox' %}
 
-  <a href="{{ url('firefox.browsers.index') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
+  <a href="{{ url('firefox.browsers.index') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link">{{ label }}</a>
 
 {% elif action == 'Create a Firefox Account' %}
 
@@ -25,7 +25,7 @@
     button_text=label,
     class_name=button_class,
     optional_parameters={'utm_campaign': utm_campaign, 'utm_content': 'firefox-sync-' + utm_content },
-    optional_attributes={'data-cta-text': cta_text, 'data-cta-type': 'fxa-sync', 'data-cta-position': location}
+    optional_attributes={'data-cta-text': cta_text, 'data-cta-type': 'fxa-sync'}
   ) }}
 
 {% elif action == 'Get Pocket' %}
@@ -34,11 +34,11 @@
 
 {% elif action == 'Get Mozilla VPN' %}
 
-  <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
+  <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button {{ button_class }}" data-cta-text="{{ cta_text }}" data-cta-type="link">{{ label }}</a>
 
 {% elif action == 'Try Relay' %}
 
-  <a href="https://relay.firefox.com/{{ referral|safe }}" class="mzp-c-button {{ button_class }}" rel="external noopener" data-cta-text="{{ cta_text }}" data-cta-type="link" data-cta-position="{{ location }}">{{ label }}</a>
+  <a href="https://relay.firefox.com/{{ referral|safe }}" class="mzp-c-button {{ button_class }}" rel="external noopener" data-cta-text="{{ cta_text }}" data-cta-type="link">{{ label }}</a>
 
 {% endif %}
 


### PR DESCRIPTION
## Description

We need a Relay option in bedrock to match Contentful CTA buttons. ~We also want to change the Download Firefox CTA link to: /firefox/browsers~

[UPDATE](https://github.com/mozilla/bedrock/issues/10662#issuecomment-957970219): we want a new option to "Explore Firefox" which leads to /firefox/browers, "Download Firefox" action will not change

UPDATE 2 (see comments below): We are removing the analytics for location as that value is waiting on a Contentful content model update

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10661
https://github.com/mozilla/bedrock/issues/10662

## Testing
~set `.env` to use:
`CONTENTFUL_ENVIRONMENT=maureen-2021-11-02`~
All changes were made in Master env, so you do not need to specify a CONTENTFUL_ENVIRONMENT to test (as long as you have your CONTENTFUL_KEY)

http://localhost:8000/en-US/contentful-preview/01i30zNjYwlPkmcAoc1hy0/
~*If you get an error on this link, ask pmac for access to maureen-2021-11-02 on your Contentful key~

For FIREFOX BROWSERS
CTA link should take you to http://localhost:8000/en-US/firefox/browsers

For FIREFOX RELAY
<img width="866" alt="Screen Shot 2021-11-02 at 1 26 44 PM" src="https://user-images.githubusercontent.com/19650432/139856129-c564c25a-0733-4b69-87ea-3deaeaf573b7.png">


CTA link should be: https://relay.firefox.com/?utm_source=www.mozilla.org-home&utm_medium=referral&utm_campaign=home
CTA button color should be BLUE

ℹ️ Firefox Relay has the correct wordmark class but the logo doesn't exist in Protocol yet. There is a [PR](https://github.com/mozilla/protocol/pull/739) to address this. Once published and updated in Bedrock, the Relay wordmark will show in this component