### PR TITLE
Make MR2 home promo styles more specific [#10620]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -18,6 +18,7 @@
 {% block body_id %}home{% endblock %}
 
 {% set referrals="?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage" %}
+{% set show_mr2_promo = switch('homepage-mr2-promo') and ftl_has_messages('home-mr2-promo-title', 'home-mr2-promo-cta') %}
 
 {% block extra_meta %}
 <!-- validates bing webmaster tools -->
@@ -33,7 +34,7 @@
     {{ css_bundle('fundraising-banner') }}
   {% endif %}
 
-  {% if switch('homepage-mr2-promo') %}
+  {% if show_mr2_promo %}
     {{ css_bundle('home-mr2-promo') }}
   {% else %}
     {{ css_bundle('home-mr1-promo') }}
@@ -48,7 +49,7 @@
 
 {% block content %}
 <main role="main">
-  {% if switch('homepage-mr2-promo') and ftl_has_messages('home-mr2-promo-title', 'home-mr2-promo-cta') %}
+  {% if show_mr2_promo %}
     {% include 'mozorg/home/includes/mr2-promo.html' %}
   {% elif ftl_has_messages('home-promo-title-lalo', 'home-promo-title-soraya', 'home-promo-title-gary', 'home-promo-title-ryan') %}
     {%- set promos = [

--- a/bedrock/mozorg/templates/mozorg/home/includes/mr2-promo-eu.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/mr2-promo-eu.html
@@ -14,7 +14,7 @@
 {% call split(
   image_url=image,
   include_highres_image=True,
-  block_class='home-hero mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md',
+  block_class='mr2-home-hero mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md',
   body_class=None,
   media_class='mzp-l-split-h-center mzp-l-split-v-center',
   media_after=True,

--- a/bedrock/mozorg/templates/mozorg/home/includes/mr2-promo.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/mr2-promo.html
@@ -9,7 +9,7 @@
 {% call split(
   image_url='img/home/2021/mr2-watercolor.png',
   include_highres_image=True,
-  block_class='home-hero mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md',
+  block_class='mr2-home-hero mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md',
   body_class=None,
   media_class='mzp-l-split-h-center mzp-l-split-v-center',
   media_after=True,

--- a/media/css/mozorg/home/home-mr2-promo.scss
+++ b/media/css/mozorg/home/home-mr2-promo.scss
@@ -9,50 +9,49 @@ $image-path: '/media/protocol/img';
 
 
 // Firefox MR2 promo
-.c-fxpromo-title {
-    @include font-firefox;
-    @include text-title-xl;
-    color: $color-ink-60;
-    margin-bottom: .25em;
-    text-align: center;
-
-    br {
-        display: none;
-    }
-}
-
-[lang^='en'] .c-fxpromo-title {
-    @include text-title-2xl;
-}
-
-.c-fxpromo-tagline {
-    @include font-firefox;
-    @include text-title-sm;
-    color: $color-ink-60;
-    margin-bottom: 1em;
-}
-
-
-@media #{$mq-md} {
-    .mzp-c-split-container .mzp-c-split-body {
-        @include bidi(((padding-left, get-theme('h-grid-sm'), padding-right, get-theme('h-grid-sm')),));
-    }
-
+.mr2-home-hero {
     .c-fxpromo-title {
-        @include bidi((
-            (text-align, left, right),
-            (margin-left, -$spacing-xs, 0),
-            (margin-right, 0, -$spacing-xs),
-        ));
+        @include font-firefox;
+        @include text-title-xl;
+        color: $color-ink-60;
+        margin-bottom: .25em;
+        text-align: center;
 
         br {
-            display: block;
+            display: none;
+        }
+
+        [lang^='en'] & {
+            @include text-title-2xl;
         }
     }
-}
 
-@media #{$mq-lg} {
-    .mzp-c-split.home-hero {
+    .c-fxpromo-tagline {
+        @include font-firefox;
+        @include text-title-sm;
+        color: $color-ink-60;
+        margin-bottom: 1em;
+    }
+
+    @media #{$mq-md} {
+        .mzp-c-split-body {
+            @include bidi(((padding-left, get-theme('h-grid-sm'), padding-right, get-theme('h-grid-sm')),));
+        }
+
+        .c-fxpromo-title {
+            @include bidi((
+                (text-align, left, right),
+                (margin-left, -$spacing-xs, 0),
+                (margin-right, 0, -$spacing-xs),
+            ));
+
+            br {
+                display: block;
+            }
+        }
+    }
+
+    @media #{$mq-lg} {
         padding-top: $layout-lg;
         padding-bottom: $layout-lg;
 
@@ -60,20 +59,20 @@ $image-path: '/media/protocol/img';
             margin-top: -$layout-md;
             margin-bottom: -$layout-md;
         }
+
+        .mzp-c-split-body {
+            @include bidi(((padding-left, get-theme('h-grid-md'), padding-right, get-theme('h-grid-md')),));
+        }
+
+        [lang^='en'] & .c-fxpromo-title {
+            @include font-size(100px);
+            line-height: .85;
+        }
     }
 
-    .mzp-c-split-container .mzp-c-split-body {
-        @include bidi(((padding-left, get-theme('h-grid-md'), padding-right, get-theme('h-grid-md')),));
-    }
-
-    [lang^='en'] .c-fxpromo-title {
-        @include font-size(100px);
-        line-height: .85;
-    }
-}
-
-@media #{$mq-xl} {
-    [lang^='en'] .c-fxpromo-title {
-        @include font-size(140px);
+    @media #{$mq-xl} {
+        [lang^='en'] & .c-fxpromo-title {
+            @include font-size(140px);
+        }
     }
 }


### PR DESCRIPTION
## Description
While looking at the Contentful preview I realized some of my styling for the MR2 promo was applying some padding to other instances of the Split component. This updates the promo styles to be more specific to just the promo so they won't mess with any other Splits on the same page.

## Testing
http://localhost:8000/en-US/
http://localhost:8000/fr/
http://localhost:8000/de/
http://localhost:8000/es-ES/