### PR TITLE
Fix text a11y on /about and convert em to px

### DIFF
--- a/media/css/externalpages/pocket/components/_about.scss
+++ b/media/css/externalpages/pocket/components/_about.scss
@@ -31,7 +31,8 @@ $image-path: '/media/img/externalpages/pocket';
 
     .about-section-text-wrapper {
         color: $color-text-primary;
-        z-index: 1;
+        position: inherit;
+        z-index: 2;
 
         .about-section-heading {
             font-family: $fontSansAlt;

--- a/media/css/externalpages/pocket/components/_nav.scss
+++ b/media/css/externalpages/pocket/components/_nav.scss
@@ -45,7 +45,7 @@ $image-path: '/media/img/externalpages/pocket';
         height: 24px;
         margin-bottom: -2px;
         display: inline-block;
-        margin-top: -0.25em;
+        margin-top: -4px;
         vertical-align: middle;
     }
 
@@ -269,7 +269,7 @@ $image-path: '/media/img/externalpages/pocket';
     }
 
     @media ($mq-md) {
-        margin-top: -0.25em;
+        margin-top: -4px;
         display: none;
     }
 


### PR DESCRIPTION
## Description
Had an issue where the text elements on the about page were not able to be highlighted, which presented an a11y issue [Related slack thread](https://mozilla.slack.com/archives/C02F3V74CJV/p1635793459023300) and [w3 doc](https://www.w3.org/dpub/IG/wiki/Accessibility_When_Users_Select_and_Highlight_Text)

Also converted remaining `em` units to `px` in the styles for the global navigation

## Issue / Bugzilla link
#10211
## Testing
external/pocket/about