### PR TITLE
Add Relay wordmark to Contentful home CSS

### DIFF
--- a/media/css/contentful/firefox/c-logo.scss
+++ b/media/css/contentful/firefox/c-logo.scss
@@ -21,6 +21,7 @@ $brand-theme: 'firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-relay';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
@@ -33,4 +34,5 @@ $brand-theme: 'firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
 

--- a/media/css/contentful/general.scss
+++ b/media/css/contentful/general.scss
@@ -30,6 +30,7 @@ $brand-theme: 'firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-relay';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
@@ -42,6 +43,7 @@ $brand-theme: 'firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
 
 
 .mzp-u-center {

--- a/media/css/contentful/mozilla/c-logo.scss
+++ b/media/css/contentful/mozilla/c-logo.scss
@@ -21,6 +21,7 @@ $brand-theme: 'mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-relay';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
@@ -33,4 +34,5 @@ $brand-theme: 'mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
 

--- a/media/css/mozorg/home/home-contentful-en.scss
+++ b/media/css/mozorg/home/home-contentful-en.scss
@@ -11,8 +11,5 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
 @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
 
 @import 'includes/home-base-en';


### PR DESCRIPTION
## Description

Add relay product class to Contentful logo styles. `firefox/c-logo` is already imported into Contentful pages, so we do not need to individually import brand wordmarks.

**Note**: we should probably discuss why this logo partial is always imported: https://github.com/mozilla/bedrock/blob/master/bedrock/contentful/templates/includes/contentful/css.html#L14

## Issue / Bugzilla link
No issue, follow up for https://github.com/mozilla/bedrock/issues/10661

## Testing

You'll need to update npm dependencies to access the latest Protocol version (with Relay assets).
Check http://localhost:8000/en-US/contentful-preview/01i30zNjYwlPkmcAoc1hy0/ has Relay logo in the Hero component.
