### PR TITLE
Remove duplicated </main> tag

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contentful-homepage.html
+++ b/bedrock/mozorg/templates/mozorg/contentful-homepage.html
@@ -107,7 +107,6 @@
       </div>
     </aside>
   </div>
-</main>
 
 {% call download_banner_secondary(
   title=_('Privacy over profit'),


### PR DESCRIPTION
## Description

While in the neighbourhood I spotted we had two tags closing `<main>` on the contentful-powered homepage

Deleting the first of the two

## Issue / Bugzilla link

No ticket

## Testing

* Pull this branch and visit the contentful-powered `en` homepage - confirm visually OK
* View source and paste it into validator.w3.org and confirm no warning of "Stray end tag `main`" (which you can see on https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2F)