### PR TITLE
Supress JS errors thrown when YouTube is blocked (Fixes #10202)

### DIFF
--- a/media/js/firefox/features/picture-in-picture.js
+++ b/media/js/firefox/features/picture-in-picture.js
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* global YT */
 /* eslint no-unused-vars: [2, { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
 
 // YouTube API hook has to be in global scope
@@ -38,7 +37,12 @@ window.onYouTubeIframeAPIReady = function () {
         var videoId = videoLink.getAttribute('data-id');
         var title = videoLink.getAttribute('data-video-title');
 
-        new YT.Player(videoLink, {
+        // return early if youtube API fails to load or is blocked.
+        if (typeof window.YT === 'undefined') {
+            return;
+        }
+
+        new window.YT.Player(videoLink, {
             width: 500,
             height: 281,
             videoId: videoId,
@@ -60,13 +64,13 @@ window.onYouTubeIframeAPIReady = function () {
             var state;
 
             switch (event.data) {
-                case YT.PlayerState.PLAYING:
+                case window.YT.PlayerState.PLAYING:
                     state = 'video play';
                     break;
-                case YT.PlayerState.PAUSED:
+                case window.YT.PlayerState.PAUSED:
                     state = 'video paused';
                     break;
-                case YT.PlayerState.ENDED:
+                case window.YT.PlayerState.ENDED:
                     state = 'video complete';
                     break;
             }

--- a/media/js/firefox/features/tips/tips-youtube.js
+++ b/media/js/firefox/features/tips/tips-youtube.js
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* global YT */
 /* eslint no-unused-vars: [2, { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
 
 // YouTube API hook has to be in global scope, ugh.
@@ -54,7 +53,12 @@ window.onYouTubeIframeAPIReady = function () {
         );
         var videoId = videoLink.getAttribute('data-id');
 
-        player = new YT.Player(videoLink, {
+        // if youtube API fails or is blocked, try redirecting to youtube.com
+        if (typeof window.YT === 'undefined') {
+            window.location.href = 'https://www.youtube.com/watch?v=' + videoId;
+        }
+
+        player = new window.YT.Player(videoLink, {
             width: 640,
             height: 360,
             videoId: videoId,
@@ -76,13 +80,13 @@ window.onYouTubeIframeAPIReady = function () {
             var state;
 
             switch (event.data) {
-                case YT.PlayerState.PLAYING:
+                case window.YT.PlayerState.PLAYING:
                     state = 'video play';
                     break;
-                case YT.PlayerState.PAUSED:
+                case window.YT.PlayerState.PAUSED:
                     state = 'video paused';
                     break;
-                case YT.PlayerState.ENDED:
+                case window.YT.PlayerState.ENDED:
                     state = 'video complete';
                     break;
             }

--- a/media/js/mozorg/home/youtube.js
+++ b/media/js/mozorg/home/youtube.js
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/* global YT */
 /* eslint no-unused-vars: [2, { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
 
 // YouTube API hook has to be in global scope, ugh.
@@ -54,7 +53,12 @@ window.onYouTubeIframeAPIReady = function () {
         );
         var videoId = videoLink.getAttribute('data-id');
 
-        player = new YT.Player(videoLink, {
+        // if youtube API fails or is blocked, try redirecting to youtube.com
+        if (typeof window.YT === 'undefined') {
+            window.location.href = 'https://www.youtube.com/watch?v=' + videoId;
+        }
+
+        player = new window.YT.Player(videoLink, {
             width: 640,
             height: 360,
             videoId: videoId,
@@ -76,13 +80,13 @@ window.onYouTubeIframeAPIReady = function () {
             var state;
 
             switch (event.data) {
-                case YT.PlayerState.PLAYING:
+                case window.YT.PlayerState.PLAYING:
                     state = 'video play';
                     break;
-                case YT.PlayerState.PAUSED:
+                case window.YT.PlayerState.PAUSED:
                     state = 'video paused';
                     break;
-                case YT.PlayerState.ENDED:
+                case window.YT.PlayerState.ENDED:
                     state = 'video complete';
                     break;
             }


### PR DESCRIPTION
## Description
There's not really much we can do if people block YouTube, or their script / API fails. This PR will supress frequent errors like https://sentry.prod.mozaws.net/operations/bedrock-prod/issues/10909431/

In some cases I've tried to redirect people to youtube.com, where there's a chance they might have more luck.

## Issue / Bugzilla link
#10202

## Testing
- http://localhost:8000/en-US/firefox/features/tips/
- http://localhost:8000/en-US/firefox/features/picture-in-picture/
- http://localhost:8000/en-US/