### PR TITLE
Fix error thrown by isFirefoxUpToDate when no version number is found (Fixes #10582)

### DIFF
--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -230,7 +230,15 @@ if (typeof window.Mozilla === 'undefined') {
         var versions = isESR
             ? html.getAttribute('data-esr-versions').split(' ')
             : [html.getAttribute('data-latest-firefox')];
-        var userVerArr = userVer.match(/^(\d+(?:\.\d+){1,2})/)[1].split('.');
+        var userVerArr = userVer.match(/^(\d+(?:\.\d+){1,2})/);
+
+        if (userVerArr && userVerArr.length > 0) {
+            userVerArr = userVerArr[1].split('.');
+        } else {
+            // if there's no version in the UA string, assume out of date (issue 10582)
+            return false;
+        }
+
         var isUpToDate = false;
 
         // Sort product details version so we compare the newer version first

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -43,7 +43,6 @@ module.exports = function (config) {
             'media/js/base/stub-attribution.js',
             'media/js/firefox/all/all-downloads-unified.js',
             'media/js/firefox/new/common/thanks.js',
-            'media/js/firefox/new/yandex/show-yandex.js',
             'tests/unit/spec/base/mozilla-banner.js',
             'tests/unit/spec/base/mozilla-run.js',
             'tests/unit/spec/base/core-datalayer-page-id.js',
@@ -68,7 +67,6 @@ module.exports = function (config) {
             'tests/unit/spec/base/stub-attribution.js',
             'tests/unit/spec/firefox/all/all-downloads-unified.js',
             'tests/unit/spec/firefox/new/common/thanks.js',
-            'tests/unit/spec/firefox/new/yandex/show-yandex.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',
                 watched: false,

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -32,7 +32,9 @@ describe('mozilla-client.js', function () {
             fxos: {
                 mobile: 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0',
                 tablet: 'Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0'
-            }
+            },
+            modified:
+                'Mozilla/5.0 (Windows; U; ; de; rv:1.9.2.6) Gecko/20100625 Firefox/ Anonymisiert durch AlMiSoft Browser-Anonymisierer 37324401'
         },
         // Other Gecko browsers
         camino: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 Camino/2.1 (like Firefox/3.6.24)',
@@ -362,6 +364,10 @@ describe('mozilla-client.js', function () {
             test(uas.safari).toEqual('0');
             test(uas.ie).toEqual('0');
         });
+
+        it('should return 0 for modified Firefox UA strings without a version number', function () {
+            test(uas.firefox.modified).toEqual('0');
+        });
     });
 
     describe('_getFirefoxMajorVersion', function () {
@@ -460,6 +466,10 @@ describe('mozilla-client.js', function () {
             test(false, false, '40.0.2').toBeFalsy();
             test(true, true, '31.7.0').toBeFalsy();
             test(false, true, '31.7.0').toBeFalsy();
+        });
+
+        it('should consider outdated if user version is not found', function () {
+            test(true, false, '0').toBeFalsy();
         });
     });
 


### PR DESCRIPTION
## Description
Fixes JS error when Firefox user agents do not contain a version number (e.g. modified through an extension)

## Issue / Bugzilla link
#10582

## Testing
Hopefully the additional unit test should provide enough coverage / confidence.