### PR TITLE
10690: Fix leak of MPL comment into newsletter management form

### DIFF
--- a/bedrock/newsletter/templates/newsletter/forms/simple_radio_select.html
+++ b/bedrock/newsletter/templates/newsletter/forms/simple_radio_select.html
@@ -1,8 +1,10 @@
-{#
+{# SKIP LICENSE INSERTION #}
+
+{% comment %}
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#}
+{% endcomment %}
 
 {% for group, options, index in widget.optgroups %}{% if group %}
 <h5>{{ group }}</h5>{% endif %}{% for option in options %}

--- a/bedrock/newsletter/templates/newsletter/forms/tabular_radio_select.html
+++ b/bedrock/newsletter/templates/newsletter/forms/tabular_radio_select.html
@@ -1,8 +1,10 @@
-{#
+{# SKIP LICENSE INSERTION #}
+
+{% comment %}
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#}
+{% endcomment %}
 
 {% for group, options, index in widget.optgroups %}{% for option in options %}
     <td>{% include option.template_name with widget=option %}</td>{% endfor %}{% endfor %}


### PR DESCRIPTION
## Description

This changeset stops the newsletter preferences form at /newsletter/existing/<hash>/ from showing a reference to MPL2.0, which was leaking from a template partial being used to render the form.

Two templates have been updated, one of which was clearly leaking. The other was updated for consistency and belt-and-braces safety

The key issue was that the template had a Jinja2-style comment, which was not being skipped because the standard Django form renderer was being used.

Switching to a jinja2 renderer did not work, so instead the fix has been to swap the comment style to be Django Template Language style AND also add a magic string so that the pre-commit hook does not think that the templates in question lack the licence text.

BEFORE

<img width="606" alt="Screenshot 2021-11-04 at 16 32 09" src="https://user-images.githubusercontent.com/101457/140380161-c5ee60b6-cd8a-4464-aea6-2b148580b624.png">


AFTER

<img width="1413" alt="Screenshot 2021-11-04 at 16 03 10" src="https://user-images.githubusercontent.com/101457/140380212-dc054892-e968-4df4-81f7-c710aa150232.png">



## Issue / Bugzilla link

Fixes #10690  

## Testing

* Go to  /newsletter/existing/<hash>/ (replacing hash with the test value - DM me or pmac if you need it)
* Confirm there is no MPL leak as per screenshots
* Confirm can still save/update email preferences