### PR TITLE
Add Relay logo to Products page

### DIFF
--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -107,6 +107,12 @@
               {{ ftl('firefox-home-pocket') }}
             </a>
           </li>
+          <li>
+            <a class="mzp-c-cta-link" href="https://relay.firefox.com/{{ promo_referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Relay">
+              <img alt="" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" height="40" width="40"><br>
+              {{ ftl('firefox-home-relay') }}
+            </a>
+          </li>
         </ul>
       </div>
     </div>
@@ -228,6 +234,12 @@
                 <a class="mzp-c-cta-link" href="https://getpocket.com{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket">
                   <img alt="" src="{{ static('img/logos/pocket/logo.svg') }}" height="40" width="40"><br>
                   {{ ftl('firefox-home-pocket') }}
+                </a>
+              </li>
+              <li>
+                <a class="mzp-c-cta-link" href="https://relay.firefox.com/{{ promo_referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Relay">
+                  <img alt="" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" height="40" width="40"><br>
+                  {{ ftl('firefox-home-relay') }}
                 </a>
               </li>
             </ul>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -108,7 +108,7 @@
             </a>
           </li>
           <li>
-            <a class="mzp-c-cta-link" href="https://relay.firefox.com/{{ promo_referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Relay">
+            <a class="mzp-c-cta-link" href="https://relay.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Relay">
               <img alt="" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" height="40" width="40"><br>
               {{ ftl('firefox-home-relay') }}
             </a>
@@ -237,7 +237,7 @@
                 </a>
               </li>
               <li>
-                <a class="mzp-c-cta-link" href="https://relay.firefox.com/{{ promo_referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Relay">
+                <a class="mzp-c-cta-link" href="https://relay.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Relay">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" height="40" width="40"><br>
                   {{ ftl('firefox-home-relay') }}
                 </a>

--- a/l10n/en/firefox/home.ftl
+++ b/l10n/en/firefox/home.ftl
@@ -52,7 +52,7 @@ firefox-home-send = { -brand-name-send }
 firefox-home-mozilla = { -brand-name-mozilla }
 firefox-home-pocket = { -brand-name-pocket }
 firefox-home-mozilla-vpn = { -brand-name-mozilla-vpn }
-firefox-home-relay = { -brand-name-relay}
+firefox-home-relay = { -brand-name-relay }
 
 ## The strings below are visually hidden in the page and replaced by logo wordmark images. They are still important for a11y and SEO.
 

--- a/l10n/en/firefox/home.ftl
+++ b/l10n/en/firefox/home.ftl
@@ -52,6 +52,7 @@ firefox-home-send = { -brand-name-send }
 firefox-home-mozilla = { -brand-name-mozilla }
 firefox-home-pocket = { -brand-name-pocket }
 firefox-home-mozilla-vpn = { -brand-name-mozilla-vpn }
+firefox-home-relay = { -brand-name-relay}
 
 ## The strings below are visually hidden in the page and replaced by logo wordmark images. They are still important for a11y and SEO.
 


### PR DESCRIPTION
## Description
Adding Firefox Relay logo to the products page:
- Under 'Family of Products' section
- Bottom products section 

<img width="716" alt="Screen Shot 2021-11-04 at 4 46 30 PM" src="https://user-images.githubusercontent.com/42309026/140417431-da2869e1-ddd8-446c-b7b8-bb95cdd1d1a0.png">


<img width="841" alt="Screen Shot 2021-11-04 at 4 46 46 PM" src="https://user-images.githubusercontent.com/42309026/140417456-fc43fafb-64e8-4d39-be29-6845e23499bc.png">

## Issue / Bugzilla link
#10698 
## Testing
http://localhost:8000/en-US/firefox/