### PR TITLE
Remove DNT check from VPN link referral attribution (Fixes #10701)

### DIFF
--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -124,15 +124,8 @@ if (typeof window.Mozilla === 'undefined') {
     UtmUrl.setFxALinkReferralCookie = function (id) {
         var cookiesEnabled =
             typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
-        var dntEnabled =
-            typeof Mozilla.dntEnabled === 'function' && Mozilla.dntEnabled();
 
-        if (
-            id &&
-            cookiesEnabled &&
-            !dntEnabled &&
-            !UtmUrl.hasFxALinkReferralCookie()
-        ) {
+        if (id && cookiesEnabled && !UtmUrl.hasFxALinkReferralCookie()) {
             var date = new Date();
             date.setTime(date.getTime() + 1 * 3600 * 1000); // expiry in 1 hour.
             var expires = date.toUTCString();

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -43,7 +43,6 @@ module.exports = function (config) {
             'media/js/base/stub-attribution.js',
             'media/js/firefox/all/all-downloads-unified.js',
             'media/js/firefox/new/common/thanks.js',
-            'media/js/firefox/new/yandex/show-yandex.js',
             'tests/unit/spec/base/mozilla-banner.js',
             'tests/unit/spec/base/mozilla-run.js',
             'tests/unit/spec/base/core-datalayer-page-id.js',
@@ -68,7 +67,6 @@ module.exports = function (config) {
             'tests/unit/spec/base/stub-attribution.js',
             'tests/unit/spec/firefox/all/all-downloads-unified.js',
             'tests/unit/spec/firefox/new/common/thanks.js',
-            'tests/unit/spec/firefox/new/yandex/show-yandex.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',
                 watched: false,

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -472,19 +472,6 @@ describe('fxa-utm-referral.js', function () {
             );
         });
 
-        it('should not set a referral cookie if DNT is enabled', function () {
-            spyOn(Mozilla, 'dntEnabled').and.returnValue(true);
-            spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
-            spyOn(Mozilla.Cookies, 'setItem');
-            spyOn(Mozilla.UtmUrl, 'hasFxALinkReferralCookie').and.returnValue(
-                false
-            );
-
-            Mozilla.UtmUrl.setFxALinkReferralCookie('navigation');
-
-            expect(Mozilla.Cookies.setItem).not.toHaveBeenCalled();
-        });
-
         it('should not set a referral cookie if one already exists', function () {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);


### PR DESCRIPTION
## Description
Removes DNT check from VPN same-site link attribution check (legal team have given this the OK).

## Issue / Bugzilla link
#10701

## Testing
1. Using Firefox (with DNT enabled), open http://localhost:8000/en-US/
2. Click the "Get Mozilla VPN" link in the top right navigation.
3. Verify that the subscription links in the pricing section conatin `utm_campaign=navigation`