### PR TITLE
Update links to point to FxA staging when Dev=True (#10670)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -936,7 +936,7 @@ FIREFOX_INSTAGRAM_ACCOUNTS = {
 
 # Firefox Accounts product links
 # ***This URL *MUST* end in a traling slash!***
-FXA_ENDPOINT = config("FXA_ENDPOINT", default="https://stable.dev.lcip.org/" if DEV else "https://accounts.firefox.com/")
+FXA_ENDPOINT = config("FXA_ENDPOINT", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
 
 FXA_ENDPOINT_MOZILLAONLINE = config("FXA_ENDPOINT_MOZILLAONLINE", default="https://accounts.firefox.com.cn/")
 

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -415,7 +415,7 @@ Set the following in your local ``.env`` file:
 
 .. code-block:: text
 
-    FXA_ENDPOINT=https://stable.dev.lcip.org/
+    FXA_ENDPOINT=https://accounts.stage.mozaws.net/
 
 For Mozilla VPN links you can also set:
 
@@ -429,18 +429,6 @@ For Mozilla VPN links you can also set:
     The above values for staging are already set by default when ``Dev=True``,
     which will also apply to demo servers. You may only need to configure
     your ``.env`` file if you wish to change a setting to something else.
-
-**Local and demo server testing:**
-
-Follow the `instructions`_ provided by the FxA team. These instructions will launch a
-new Firefox instance with the necessary config already set. In the new instance of
-Firefox:
-
-#. Navigate to the page containing the Firefox Accounts CTA.
-#. If testing locally, be sure to use ``127.0.0.1`` instead of ``localhost``
-
-.. _instructions: https://github.com/vladikoff/fxa-dev-launcher#basic-usage-example-in-os-x
-
 
 Google Analytics Guidelines
 ---------------------------

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -20,8 +20,6 @@ if (typeof window.Mozilla === 'undefined') {
         'https://accounts.stage.mozaws.net/',
         'https://monitor.firefox.com/',
         'https://getpocket.com/',
-        'https://latest.dev.lcip.org/',
-        'https://stable.dev.lcip.org/',
         'https://vpn.mozilla.org/',
         'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/',
         'https://guardian-dev.herokuapp.com/'

--- a/media/js/base/mozilla-fxa-link.js
+++ b/media/js/base/mozilla-fxa-link.js
@@ -17,8 +17,6 @@ if (typeof window.Mozilla === 'undefined') {
     var allowedList = [
         'https://accounts.firefox.com/',
         'https://accounts.stage.mozaws.net/',
-        'https://latest.dev.lcip.org/',
-        'https://stable.dev.lcip.org/',
         'https://accounts.firefox.com.cn/'
     ];
 

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -20,7 +20,6 @@ if (typeof window.Mozilla === 'undefined') {
         'https://accounts.stage.mozaws.net/',
         'https://getpocket.com/',
         'https://guardian-dev.herokuapp.com/',
-        'https://latest.dev.lcip.org/',
         'https://monitor.firefox.com/',
         'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/',
         'https://vpn.mozilla.org/'


### PR DESCRIPTION
## Description
- Update FxA links to point to https://accounts.stage.mozaws.net/ when `Dev=True`.
- Remove references to deprecated https://stable.dev.lcip.org/ and https://latest.dev.lcip.org/ domains.

Note: this does not yet fix the CORS error mentioned in the issue. We'll need some help from the FxA team with this part, but that doesn't need to hold up changing the links.

## Issue / Bugzilla link
#10670

## Testing
1. Using a **non-Firefox browser**, open http://localhost:8000/en-US/firefox/ (with `Dev=True` in your `.env` file).
2. Scroll to the bottom of the page and click the "Join Firefox" button.
3. Verify that the link navigates to https://accounts.stage.mozaws.net/