### PR TITLE
Update VPN guarantee copy (Fixes #10696)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -82,7 +82,7 @@
     {{ ftl('vpn-shared-subscribe-link') }}
     </a>
     <p class="guarantee-copy">
-      {{ ftl('vpn-shared-money-back-guarantee') }}
+      <a href="#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
     </p>
   {% else %}
     <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="{{ position }}">

--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -17,7 +17,7 @@
     <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-encrypt') }}</li>
     <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-bandwidth') }}</li>
     <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-activity') }}</li>
-    <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-guarantee', fallback='vpn-shared-money-back-guarantee') }}</li>
+    <li class="vpn-feature-list-item vpn-features-guarantee">{{ ftl('vpn-shared-features-guarantee', fallback='vpn-shared-money-back-guarantee') }}</li>
   </ul>
 
   <div class="vpn-pricing-variable-plans">

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -137,7 +137,7 @@
         </a>
 
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       {% endcall %}
     {% else %}
@@ -261,7 +261,12 @@
       <summary class="vpn-faq-item-heading">
         <h3>{{ ftl('vpn-landing-faq-refund-question-heading') }}</h3>
       </summary>
-      <p class="vpn-faq-item-detail">{{ ftl('vpn-landing-faq-refund-question-desc') }}</p>
+      {% if ftl_has_messages('vpn-landing-faq-refund-question-desc-v2', 'vpn-landing-faq-refund-question-additional-desc') %}
+        <p class="vpn-faq-item-detail">{{ ftl('vpn-landing-faq-refund-question-desc-v2') }}</p>
+        <p class="vpn-faq-item-detail">{{ ftl('vpn-landing-faq-refund-question-additional-desc') }}</p>
+      {% else %}
+        <p class="vpn-faq-item-detail">{{ ftl('vpn-landing-faq-refund-question-desc') }}</p>
+      {% endif %}
     </details>
 
     <details id="faq-subscriptions" class="vpn-faq-item mzp-is-anchor-link">

--- a/bedrock/products/templates/products/vpn/more/base-article.html
+++ b/bedrock/products/templates/products/vpn/more/base-article.html
@@ -34,7 +34,7 @@
     <div class="vpn-hero-cta">
       <p><a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}#pricing">{{ ftl('vpn-shared-subscribe-link') }}</a></p>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     </div>
     {% endcall %}
@@ -54,7 +54,7 @@
       <h3 class="vpn-content-well-title">{{ ftl('vpn-shared-subscribe-link') }}</h3>
       <div class="vpn-content-well-desc">
         <p><a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}#pricing">{{ ftl('vpn-shared-platform-cta-button') }}</a></p>
-        <p class="guarantee-copy">{{ ftl('vpn-shared-money-back-guarantee') }}</p>
+        <p class="guarantee-copy"><a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a></p>
       </div>
     {% endcall %}
   </div>

--- a/bedrock/products/templates/products/vpn/platforms/android.html
+++ b/bedrock/products/templates/products/vpn/platforms/android.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -138,7 +138,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/bedrock/products/templates/products/vpn/platforms/desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/desktop.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -138,7 +138,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/bedrock/products/templates/products/vpn/platforms/ios.html
+++ b/bedrock/products/templates/products/vpn/platforms/ios.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -138,7 +138,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/bedrock/products/templates/products/vpn/platforms/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/linux.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -138,7 +138,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/bedrock/products/templates/products/vpn/platforms/mac.html
+++ b/bedrock/products/templates/products/vpn/platforms/mac.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -137,7 +137,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/bedrock/products/templates/products/vpn/platforms/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/mobile.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -138,7 +138,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/bedrock/products/templates/products/vpn/platforms/windows.html
+++ b/bedrock/products/templates/products/vpn/platforms/windows.html
@@ -52,7 +52,7 @@
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
+        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
       </p>
     {% endcall %}
   {% endblock %}
@@ -137,7 +137,7 @@
       <div class="vpn-content-well-desc">
         <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
         <p class="guarantee-copy">
-          {{ ftl('vpn-shared-money-back-guarantee') }}
+          <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
         </p>
       </div>
     {% endcall %}

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -159,7 +159,14 @@ vpn-landing-faq-compatibility-question-desc-linux-v2 = <a href="{ $url }">{ -bra
 vpn-landing-faq-compatibility-question-desc-linux = { -brand-name-linux } ({ -brand-name-ubuntu }-only)
 
 vpn-landing-faq-refund-question-heading = What is { -brand-name-mozilla-vpn }’s refund policy?
+
+vpn-landing-faq-refund-question-desc-v2 = The first time you subscribe to { -brand-name-mozilla-vpn } through { -brand-name-mozilla }’s website, if you cancel your account within the first 30 days, you may request a refund and { -brand-name-mozilla } will refund your first subscription term.
+
+vpn-landing-faq-refund-question-additional-desc = If you purchase your subscription through in-app purchase from the { -brand-name-apple } { -brand-name-app-store } or the { -brand-name-google-play } Store, your payment is subject to the terms and conditions of the { -brand-name-app-store }. You must direct any billing and refund inquiries for such purchases to { -brand-name-apple } or { -brand-name-google }, as appropriate.
+
+# Outdated string
 vpn-landing-faq-refund-question-desc = You can get your money back within 30 days of purchasing your subscription. Contact us and submit the refund request by tapping the “Get Help” button in Settings on your { -brand-name-mozilla-vpn } app.
+
 vpn-landing-faq-manage-subscription-question-heading = How do I manage my subscription?
 
 # Variables:

--- a/media/css/products/vpn/common.scss
+++ b/media/css/products/vpn/common.scss
@@ -35,6 +35,34 @@ $image-path: '/media/protocol/img';
         top: 2px;
         width: 16px;
     }
+
+    &:after {
+        @include bidi((
+            (padding-left, .1em, padding-right, 0),
+        ));
+        content: '*';
+    }
+
+    a:link,
+    a:visited {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover,
+        &:active,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
+}
+
+.vpn-features-guarantee {
+    &:after {
+        @include bidi((
+            (padding-left, .1em, padding-right, 0),
+        ));
+        content: '*';
+    }
 }
 
 .refund-policy {

--- a/media/css/products/vpn/landing.scss
+++ b/media/css/products/vpn/landing.scss
@@ -94,6 +94,15 @@ html {
     }
 }
 
+#faq-refunds .vpn-faq-item-heading h3 {
+    &:before {
+        @include bidi((
+            (padding-right, .1em, padding-left, 0),
+        ));
+        content: '*';
+    }
+}
+
 .vpn-faq-item-detail {
     @include bidi((
         (padding-right, $spacing-xl, padding-left, 0),


### PR DESCRIPTION
## Description
- Updates VPN 30-day money back guarantee copy, across all VPN web pages that mention it.
- Updates FAQ copy to highlight that this is only available through subscriptions on the website.

## Issue / Bugzilla link
#10696

## Testing
- http://localhost:8000/en-US/products/vpn/
- http://localhost:8000/en-US/products/vpn/more/what-is-a-vpn/
- http://localhost:8000/en-US/products/vpn/more/what-is-an-ip-address/
- http://localhost:8000/en-US/products/vpn/more/when-to-use-a-vpn/
- http://localhost:8000/en-US/products/vpn/more/vpn-or-proxy/
- http://localhost:8000/en-US/products/vpn/mobile/
- http://localhost:8000/en-US/products/vpn/desktop/
- http://localhost:8000/en-US/products/vpn/desktop/mac/
- http://localhost:8000/en-US/products/vpn/desktop/windows/
- http://localhost:8000/en-US/products/vpn/desktop/linux/
- http://localhost:8000/en-US/products/vpn/mobile/ios/
- http://localhost:8000/en-US/products/vpn/mobile/android/