### PR TITLE
Enable firefox/welcome/10 for L10n (Fixes #10708)

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page10.html
+++ b/bedrock/firefox/templates/firefox/welcome/page10.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/welcome/base.html" %}
 
-{% block page_title %}Firefox protects your browsing. Mozilla VPN protects you everywhere{% endblock %}
+{% block page_title %}{{ ftl('welcome-page10-page-title') }}{% endblock %}
 
 {% block page_image %}{{ static('img/products/vpn/common/social-share.png') }}{% endblock %}
 
@@ -27,11 +27,11 @@
     <div class="mzp-l-content mzp-t-content-md">
       <img class="c-main-image" src="{{ static('protocol/img/logos/mozilla/vpn/logo-flat.svg') }}" width="90" alt="">
 
-      <h1 class="c-main-title">Firefox protects your browsing. <strong>Mozilla VPN</strong> protects you everywhere.</h1>
-      <p class="c-main-tagline">Mozilla VPN (Virtual Private Network) protects your entire internet connection on your computer, your tablet, and even your phone. For even more security, it comes with a 30-day money back guarantee.</p>
+      <h1 class="c-main-title">{{ ftl('welcome-page10-main-heading') }}</h1>
+      <p class="c-main-tagline">{{ ftl('welcome-page10-main-description') }}</p>
 
       <div class="c-main-cta">
-        <a href="{{ url('products.vpn.landing') }}{{ source }}#pricing" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Get Mozilla VPN" data-cta-type="button">Get Mozilla VPN</a>
+        <a href="{{ url('products.vpn.landing') }}{{ source }}#pricing" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Get Mozilla VPN" data-cta-type="button">{{ ftl('welcome-page10-get-mozilla-vpn') }}</a>
       </div>
     </div>
   </section>
@@ -46,9 +46,9 @@
         <div class="mzp-c-picto-image">
           {% include 'firefox/welcome/includes/page10/laptop.svg' %}
         </div>
-        <h3 class="mzp-c-picto-title">It’s fast, very fast</h3>
+        <h3 class="mzp-c-picto-title">{{ ftl('welcome-page10-very-fast') }}</h3>
         <div class="mzp-c-picto-body">
-          <p>Our WireGuard® powered servers are built for speed so you can stream, download, and game as usual.</p>
+          <p>{{ ftl('welcome-page10-wireguard-powered') }}</p>
         </div>
       </div>
 
@@ -56,9 +56,9 @@
         <div class="mzp-c-picto-image">
           {% include 'firefox/welcome/includes/page10/mobile.svg' %}
         </div>
-        <h3 class="mzp-c-picto-title">Internet without a trace</h3>
+        <h3 class="mzp-c-picto-title">{{ ftl('welcome-page10-without-trace') }}</h3>
         <div class="mzp-c-picto-body">
-          <p>We never log, track, or share your network data — your online activity won’t leave a footprint on our VPN servers.</p>
+          <p>{{ ftl('welcome-page10-never-log') }}</p>
         </div>
       </div>
     </div>
@@ -70,7 +70,7 @@
 <p>
   <strong>
     <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
-      Why am I seeing this?
+      {{ ftl('welcome-page10-why-see-this') }}
     </a>
   </strong>
 </p>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -124,7 +124,7 @@ urlpatterns = (
         name="firefox.welcome.page8",
     ),
     page("firefox/welcome/9", "firefox/welcome/page9.html", active_locales=["de", "fr"]),
-    page("firefox/welcome/10", "firefox/welcome/page10.html"),
+    page("firefox/welcome/10", "firefox/welcome/page10.html", ftl_files=["firefox/welcome/page10"]),
     page("firefox/switch", "firefox/switch.html", ftl_files=["firefox/switch"]),
     page("firefox/pocket", "firefox/pocket.html"),
     # Issue 6604, SEO firefox/new pages

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -164,8 +164,34 @@ locales = [
     reference = "en/firefox/set-as-default/**/*.ftl"
     l10n = "{locale}/firefox/set-as-default/**/*.ftl"
 [[paths]]
-    reference = "en/firefox/welcome/**/*.ftl"
-    l10n = "{locale}/firefox/welcome/**/*.ftl"
+    reference = "en/firefox/welcome/page1.ftl"
+    l10n = "{locale}/firefox/welcome/page1.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page2.ftl"
+    l10n = "{locale}/firefox/welcome/page2.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page3.ftl"
+    l10n = "{locale}/firefox/welcome/page3.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page4.ftl"
+    l10n = "{locale}/firefox/welcome/page4.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page6.ftl"
+    l10n = "{locale}/firefox/welcome/page6.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page7.ftl"
+    l10n = "{locale}/firefox/welcome/page7.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page8.ftl"
+    l10n = "{locale}/firefox/welcome/page8.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/page10.ftl"
+    l10n = "{locale}/firefox/welcome/page10.ftl"
+    locales = [
+        "es-ES",
+        "it",
+        "nl",
+    ]
 [[paths]]
     reference = "en/firefox/whatsnew/whatsnew-account.ftl"
     l10n = "{locale}/firefox/whatsnew/whatsnew-account.ftl"

--- a/l10n/en/firefox/welcome/page10.ftl
+++ b/l10n/en/firefox/welcome/page10.ftl
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/10/
+
+# HTML page title
+welcome-page10-page-title = { -brand-name-firefox } protects your browsing. { -brand-name-mozilla-vpn } protects you everywhere
+
+# The strong tag wraps a product name that gets highlighted in color for emphasis.
+welcome-page10-main-heading = { -brand-name-firefox } protects your browsing. <strong>{ -brand-name-mozilla-vpn }</strong> protects you everywhere.
+
+welcome-page10-main-description = { -brand-name-mozilla-vpn } (Virtual Private Network) protects your entire internet connection on your computer, your tablet, and even your phone. For even more security, it comes with a 30-day money back guarantee.
+
+welcome-page10-get-mozilla-vpn = Get { -brand-name-mozilla-vpn }
+
+welcome-page10-very-fast = It’s fast, very fast
+
+welcome-page10-wireguard-powered = Our { -brand-name-wireguard }® powered servers are built for speed so you can stream, download, and game as usual.
+
+welcome-page10-without-trace = Internet without a trace
+
+welcome-page10-never-log = We never log, track, or share your network data — your online activity won’t leave a footprint on our VPN servers.
+
+welcome-page10-why-see-this = Why am I seeing this?


### PR DESCRIPTION
## Description
Exposes string for welcome/10 in Pontoon for locales `es-ES`, `it`, `nl`.

## Issue / Bugzilla link
#10708

## Testing
http://localhost:8000/en-US/firefox/welcome/10/