### PR TITLE
Update 2FA references

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/passwords.html
+++ b/bedrock/firefox/templates/firefox/privacy/passwords.html
@@ -92,7 +92,7 @@
     {% set url_sumo_2fa = 'href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication" rel="external noopener"' %}
     <p>{{ ftl('privacy-passwords-your-firefox-account', url_sumo_2fa=url_sumo_2fa) }}</p>
     <img src="{{ static('img/firefox/privacy/passwords/accounts.png') }}" alt="" height="811" width="738">
-    {% set url_2fa = 'href="https://twofactorauth.org" rel="external noopener"' %}
+    {% set url_2fa = 'href="https://2fa.directory" rel="external noopener"' %}
     <p>{{ ftl('privacy-passwords-2fa-provides-much', url_2fa=url_2fa) }}</p>
 
     <h2>{{ ftl('privacy-passwords-strong-diverse-and') }}</h2>

--- a/l10n/en/firefox/privacy/passwords.ftl
+++ b/l10n/en/firefox/privacy/passwords.ftl
@@ -61,8 +61,8 @@ privacy-passwords-2fa-is-a = 2FA is a great way to level-up your security. When 
 #   $url_sumo_2fa (string) - link to https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication with additional attributes for analytics
 privacy-passwords-your-firefox-account = Your { -brand-name-firefox } account, for instance, can be protected with 2FA, <a { $url_sumo_2fa }>which you can learn more about here</a>.
 
-#   $url_2fa (string) - link to https://twofactorauth.org with additional attributes for analytics
-privacy-passwords-2fa-provides-much = 2FA provides much better security than passwords alone, but not every website supports it. You can find a list of websites that support 2FA at <a { $url_2fa }>https://twofactorauth.org</a>, as well as a list of sites that don’t support 2FA and ways you can ask them to add support.
+#   $url_2fa (string) - link to https://2fa.directory with additional attributes for analytics
+privacy-passwords-2fa-provides-much = 2FA provides much better security than passwords alone, but not every website supports it. You can find a list of websites that support 2FA at <a { $url_2fa }>https://2fa.directory</a>, as well as a list of sites that don’t support 2FA and ways you can ask them to add support.
 privacy-passwords-strong-diverse-and = Strong, diverse, and multi-factor
 privacy-passwords-for-better-or = For better or worse, we’re going to be using passwords to protect our online accounts for the foreseeable future. Use passwords that are <strong>strong</strong> and <strong>different for each site</strong>, and use a <strong>password manager</strong> to help you remember them safely. Set <strong>long, random answers</strong> for security questions (even if they’re not the truth). And <strong>use two-factor authentication</strong> on any site that supports it.
 


### PR DESCRIPTION
## Description
This PR updates the twofactorauth.org references to [https://2fa.directory](https://2fa.directory) in firefox/privacy/safe-passwords/

## Issue / Bugzilla link
#10137

## Testing
Docker/ local machine