### PR TITLE
Remove unrelated JS bundle from safe-passwords page (Fixes #10717)

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/passwords.html
+++ b/bedrock/firefox/templates/firefox/privacy/passwords.html
@@ -103,10 +103,4 @@
   </article>
 </div>
 
-
-
-{% endblock %}
-
-{% block js %}
-  {{ js_bundle('firefox-privacy-products') }}
 {% endblock %}


### PR DESCRIPTION
## Description
I can't see any reason why this page needs this bundle.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10717

## Testing
http://localhost:8000/en-US/firefox/privacy/safe-passwords/