### PR TITLE
Added comment to string used on /new variant

### DIFF
--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -37,9 +37,9 @@ firefox-desktop-download-blocks-social-trackers = Blocks social trackers
 firefox-desktop-download-os-availability = OS availability
 firefox-desktop-download-in-browser-screenshot = In-browser screenshot tool
 firefox-desktop-download-primary-password = Primary password
-# This will only be used when passed the parameter ?v=fx94 in the URL
+# This will only be used when passed the parameter ?v=fx94 in the URL. Example: https://www-dev.allizom.org/firefox/new/?v=fx94
 firefox-desktop-love-your-life = Love your life online
-# This will only be used when passed the parameter ?v=fx94 in the URL
+# This will only be used when passed the parameter ?v=fx94 in the URL. Example https://www-dev.allizom.org/firefox/new/?v=fx94
 # Color is being used as slang here, means customize here. Alternative: Customize it the way you want...
 firefox-desktop-its-your-internet = It’s your internet. Color it the way you want with thousands of tools, themes and extensions. Firefox is the original alternative browser that puts people before profits.
 

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -37,7 +37,9 @@ firefox-desktop-download-blocks-social-trackers = Blocks social trackers
 firefox-desktop-download-os-availability = OS availability
 firefox-desktop-download-in-browser-screenshot = In-browser screenshot tool
 firefox-desktop-download-primary-password = Primary password
+# This will only be used when passed the parameter ?v=fx94 in the URL
 firefox-desktop-love-your-life = Love your life online
+# This will only be used when passed the parameter ?v=fx94 in the URL
 # Color is being used as slang here, means customize here. Alternative: Customize it the way you want...
 firefox-desktop-its-your-internet = It’s your internet. Color it the way you want with thousands of tools, themes and extensions. Firefox is the original alternative browser that puts people before profits.
 


### PR DESCRIPTION
## Description
Small comment to communicate which strings will only be used in a variant view. In this case it's for https://www-dev.allizom.org/en-US/firefox/new/?v=fx94

