### PR TITLE
Check translation status when showing MR2 copy on /new (Fixes #10724|

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -44,6 +44,8 @@
 
 {% block content %}
 
+{% set show_mr2_browser_promo = switch("browser-mr2-promo") and variant == 'fx94' and ftl_has_messages('firefox-desktop-love-your-life', 'firefox-desktop-its-your-internet') %}
+
 <main role="main" class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
 
   {# Show unsupported notification to IE 6/7 visitors on Windows XP/Vista #}
@@ -55,7 +57,7 @@
     <div class="c-block-container">
       <div class="c-block-body">
         <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox') }}</h1>
-        {% if switch("browser-mr2-promo") and variation == 'fx94' %}
+        {% if show_mr2_browser_promo %}
           <h2 class="mzp-has-zap-7">{{ ftl('firefox-desktop-love-your-life') }}</h2>
           <p>{{ ftl('firefox-desktop-its-your-internet') }}</p>
         {% else %}
@@ -71,7 +73,7 @@
         </div>
       </div>
       <div class="c-block-media l-v-center">
-        {% if switch("browser-mr2-promo") and variation == 'fx94' %}
+        {% if show_mr2_browser_promo %}
           {{ high_res_img('img/firefox/new/desktop/hero-MR2.png', {'width': '572', 'height': '517', 'alt': '', 'loading': 'lazy', 'class': 'c-block-media-img' }) }}
         {% else %}
           <div class="c-block-img">

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -78,7 +78,7 @@ urlpatterns = (
     page("firefox/mobile/get-app", "firefox/mobile/get-app.html", ftl_files=["firefox/mobile"]),
     url("^firefox/send-to-device-post/$", views.send_to_device_ajax, name="firefox.send-to-device-post"),
     page("firefox/unsupported-systems", "firefox/unsupported-systems.html"),
-    url(r"^firefox/new/$", views.NewView.as_view(template_context_variations=["fx94"]), name="firefox.new"),
+    url(r"^firefox/new/$", views.NewView.as_view(), name="firefox.new"),
     url(r"^firefox/download/thanks/$", views.DownloadThanksView.as_view(), name="firefox.download.thanks"),
     page("firefox/nightly/firstrun", "firefox/nightly/firstrun.html", ftl_files=["firefox/nightly/firstrun"]),
     url(r"^firefox/installer-help/$", views.InstallerHelpView.as_view(), name="firefox.installer-help"),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -40,7 +40,6 @@ from bedrock.firefox.forms import SendToDeviceWidgetForm
 from bedrock.newsletter.forms import NewsletterFooterForm
 from bedrock.products.forms import VPNWaitlistForm
 from bedrock.releasenotes import version_re
-from bedrock.utils.views import VariationMixin
 from lib import l10n_utils
 from lib.l10n_utils import L10nTemplateView
 from lib.l10n_utils.dotlang import get_translations_native_names
@@ -645,7 +644,7 @@ class DownloadThanksView(L10nTemplateView):
         return [template]
 
 
-class NewView(VariationMixin, L10nTemplateView):
+class NewView(L10nTemplateView):
     ftl_files_map = {
         "firefox/new/basic/base_download.html": ["firefox/new/download"],
         "firefox/new/desktop/download.html": ["firefox/new/desktop"],
@@ -657,7 +656,7 @@ class NewView(VariationMixin, L10nTemplateView):
     ]
 
     # place expected ?v= values in this list
-    variations = ["a", "b"]
+    variations = ["a", "b", "fx94"]
 
     def get(self, *args, **kwargs):
         # Remove legacy query parameters (Bug 1236791)

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -41,7 +41,7 @@ firefox-desktop-download-primary-password = Primary password
 firefox-desktop-love-your-life = Love your life online
 # This will only be used when passed the parameter ?v=fx94 in the URL. Example https://www-dev.allizom.org/firefox/new/?v=fx94
 # Color is being used as slang here, means customize here. Alternative: Customize it the way you want...
-firefox-desktop-its-your-internet = It’s your internet. Color it the way you want with thousands of tools, themes and extensions. Firefox is the original alternative browser that puts people before profits.
+firefox-desktop-its-your-internet = It’s your internet. Color it the way you want with thousands of tools, themes and extensions. { -brand-name-firefox } is the original alternative browser that puts people before profits.
 
 # Obsolete string
 firefox-desktop-download-master-password = Master password


### PR DESCRIPTION
## Description
- Fixes bug where English copy is shown on non-English pages.

## Issue / Bugzilla link
 #10724

## Testing
- [ ] http://localhost:8000/en-US/firefox/new/?v=fx94 shows MR2 copy
- [ ] http://localhost:8000/de/firefox/new/?v=fx94 shows regular copy