### PR TITLE
10593: Add support for an optional frontend-specific Sentry DSN

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -7,7 +7,7 @@
 {% set_lang_files "main" %}
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% block html_attrs %}{% endblock %} {% if settings.SENTRY_DSN %}data-sentry-dsn="{{ settings.SENTRY_DSN }}"{% endif %}>
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% block html_attrs %}{% endblock %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 
@@ -112,7 +112,7 @@
 
     {# Issue 8444 #}
     {% block sentry_client %}
-      {% if settings.SENTRY_DSN and switch('sentry-js') %}
+      {% if settings.SENTRY_FRONTEND_DSN and switch('sentry-js') %}
         <!--[if !IE]><!-->
           {{ js_bundle('sentry') }}
         <!--<![endif]-->

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1116,6 +1116,7 @@ MOZILLA_LOCATION_SERVICES_KEY = "a9b98c12-d9d5-4015-a2db-63536c26dc14"
 
 DEAD_MANS_SNITCH_URL = config("DEAD_MANS_SNITCH_URL", default="")
 
+# Sentry config for Backend and Frontend
 SENTRY_DSN = config("SENTRY_DSN", default="")
 if SENTRY_DSN:
     sentry_sdk.init(
@@ -1124,6 +1125,13 @@ if SENTRY_DSN:
         server_name=".".join(x for x in [APP_NAME, CLUSTER_NAME] if x),
         integrations=[DjangoIntegration()],
     )
+
+# Frontend uses the same DSN as backend by default, but we'll
+# specify a separate one for FE use in Production only
+SENTRY_FRONTEND_DSN = config(
+    "SENTRY_FRONTEND_DSN",
+    default=SENTRY_DSN,
+)
 
 # Django-CSP
 CSP_DEFAULT_SRC = ["'self'", "*.mozilla.net", "*.mozilla.org", "*.mozilla.com"]


### PR DESCRIPTION
## Description

In some situations/environments we want to separate out backend and frontend sentry alerts, to make spotting relevant issues easier.

This changeset adds support for a frontend-specific DSN, which will default to be the same DSN as the existing one, which wil remain in use for the backend.

We can add the FE DSN config to specific environments only (eg Production) and leave all other envs using the same DSN for both FE and BE.

**This changeset will also need a config/secrets change, but it can be released beforehand as it's non-breaking** That change is PRed here https://github.com/mozmeao/www-config/pull/409

## Issue / Bugzilla link

#10593  


## Testing

1. Check out the branch
2. Load http://localhost:8080 and view source. Search for `data-sentry-dsn` and you will have no matches
3. In your `.env` set a `SENTRY_DSN` value (only) for now -- eg see the one from `app.json`, which is for the demo environments
4. Restart your server, reload http://localhost:8080 and view source. `data-sentry-dsn`will now be set as an attribute on the `html` node and it will have the value you set as `SENTRY_DSN`, showing the fallback to the main DSN works.
5. In your `.env` set a `SENTRY_FRONTEND_DSN` value -- this can be a dummy string or the SENTRY_DSN string with a prefix on it.
6. Restart your server, reload http://localhost:8080 and view source. `data-sentry-dsn` will now have the value you set for`SENTRY_FRONTEND_DSN`, showing we can have a custom DSN for the frontend



