### PR TITLE
Update to Protocol 16.0.0

### DIFF
--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -57,9 +57,9 @@ LAYOUT_CLASS = {
 }
 THEME_CLASS = {
     "Light": "",
-    "Light (alternative)": "mzp-t-background-alt",
+    "Light (alternative)": "mzp-t-background-secondary",
     "Dark": "mzp-t-dark",
-    "Dark (alternative)": "mzp-t-dark mzp-t-background-alt",
+    "Dark (alternative)": "mzp-t-dark mzp-t-background-secondary",
 }
 COLUMN_CLASS = {
     "1": "",

--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -79,7 +79,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/android/fast-and-private.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-android-fast-and-private') }}</h3>
     <p>{{ ftl('mobile-android-firefox-for-android') }}</p>
@@ -96,7 +96,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/android/search-your-own-way.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-android-search-your-own') }}</h3>
     <p>{{ ftl('mobile-android-got-a-big') }}</p>
@@ -113,7 +113,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/android/easily-organize-your-tabs.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     {% if switch("browser-mr2-promo") %}
       <h3>{{ ftl('mobile-android-own-your-home', fallback='mobile-android-easily-organize-your') }}</h3>
@@ -135,7 +135,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/android/pick-up-where-you-left-off.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-android-pick-up-where') }}</h3>
     <p>{{ ftl('mobile-android-go-from-your') }}</p>
@@ -152,7 +152,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/android/pin-videos-to-your-screen.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-android-pin-videos-to') }}</h3>
     <p>{{ ftl('mobile-android-pop-videos-out') }}</p>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
@@ -89,7 +89,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/focus/disappear-your-history.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-focus-delete-your-history', fallback='mobile-focus-disappear-your-history') }}</h3>
     <p>{{ ftl('mobile-focus-easily-erase-your') }}</p>
@@ -106,7 +106,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/focus/tracking-protection.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-focus-tracking-protection') }}</h3>
     <p>{{ ftl('mobile-focus-firefox-focus-blocks') }}</p>
@@ -123,7 +123,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/focus/see-it-all-faster.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-focus-see-it-all') }}</h3>
     <p>{{ ftl('mobile-focus-focus-removes-trackers-v2', fallback='mobile-focus-focus-removes-trackers') }}</p>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -88,7 +88,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/ios/make-firefox-your-default-browser.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-ios-make-firefox-your') }}</h3>
     <p>{{ ftl('mobile-ios-now-iphone-and') }}</p>
@@ -105,7 +105,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/ios/stay-private-online.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-ios-stay-private-online') }}</h3>
     <p>{{ ftl('mobile-ios-firefox-gives-you') }}</p>
@@ -122,7 +122,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/ios/get-more-firefox-in-your-life.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     <h3>{{ ftl('mobile-ios-get-more-firefox') }}</h3>
     <p>{{ ftl('mobile-ios-add-firefox-across-v2', fallback='mobile-ios-add-firefox-across') }}</p>
@@ -139,7 +139,7 @@
   {% call split(
     image_url='img/firefox/browsers/mobile/ios/keep-tabs-on-all-those-tabs.svg',
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt'
+    theme_class='mzp-t-background-secondary'
   ) %}
     {% if switch("browser-mr2-promo") %}
       <h3>{{ ftl('mobile-ios-own-your-home', fallback='mobile-ios-keep-tabs-on') }}</h3>

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -166,7 +166,7 @@
     </ul>
   </section>
 
-  <section class="secondary-content mzp-t-background-alt">
+  <section class="secondary-content mzp-t-background-secondary">
     <div class="mzp-l-content">
       <h2 class="mzp-c-section-heading">{{ ftl('features-index-from-the-company')}}</h2>
 

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -104,7 +104,7 @@
       {% call split(
         image_url='img/firefox/mobile/protocol/account.svg',
         block_class='mzp-l-split-reversed mzp-t-split-nospace',
-        theme_class='mzp-t-background-alt',
+        theme_class='mzp-t-background-secondary',
         media_class='mzp-l-split-h-center',
       ) %}
         <h2>{{ ftl('firefox-mobile-discover-products-that-keep') }}</h2>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -101,7 +101,7 @@
 {% call split(
   block_id='fake-news',
   image_url='img/firefox/privacy/book/privacy-callouts.png',
-  theme_class='mzp-t-dark mzp-t-background-alt',
+  theme_class='mzp-t-dark mzp-t-background-secondary',
   block_class='mzp-t-split-nospace',
   media_class='mzp-l-split-v-start',
   loading='lazy',
@@ -349,7 +349,7 @@
   block_id='trackers',
   image_url='img/firefox/privacy/book/privacy-target.png',
   block_class='mzp-t-split-nospace',
-  theme_class='mzp-t-dark mzp-t-background-alt',
+  theme_class='mzp-t-dark mzp-t-background-secondary',
   loading='lazy',
 ) %}
   <h3>{{ ftl('privacy-book-friendly-reminder-what') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -26,7 +26,7 @@
     image_url='img/mozorg/about/lean-data/build-security-hero.png',
     include_highres_image=True,
     block_class='mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt',
+    theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True
   ) %}
@@ -105,7 +105,7 @@
 </section>
 
 
-<section class="principles-other mzp-t-background-alt">
+<section class="principles-other mzp-t-background-secondary">
   <div class="mzp-l-content mzp-t-content-lg mzp-l-card-half">
 
     <div class="mzp-c-card mzp-has-aspect-1-1">

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -26,7 +26,7 @@
     image_url='img/mozorg/about/lean-data/engage-users-hero.png',
     include_highres_image=True,
     block_class='mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt',
+    theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True
   ) %}
@@ -128,7 +128,7 @@
   </div>
 </section>
 
-<section class="principles-other mzp-t-background-alt">
+<section class="principles-other mzp-t-background-secondary">
   <div class="mzp-l-content mzp-t-content-lg mzp-l-card-half">
 
     <div class="mzp-c-card mzp-has-aspect-1-1">

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
@@ -25,7 +25,7 @@
     image_url='img/mozorg/about/lean-data/lean-data-hero.png',
     include_highres_image=True,
     block_class='mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt',
+    theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True
   ) %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -26,7 +26,7 @@
     image_url='img/mozorg/about/lean-data/stay-lean-hero.png',
     include_highres_image=True,
     block_class='mzp-t-split-nospace',
-    theme_class='mzp-t-background-alt',
+    theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True
   ) %}
@@ -108,7 +108,7 @@
   </ul>
 </section>
 
-<section class="principles-other mzp-t-background-alt">
+<section class="principles-other mzp-t-background-secondary">
   <div class="mzp-l-content mzp-t-content-lg mzp-l-card-half">
 
     <div class="mzp-c-card mzp-has-aspect-1-1">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,9 +1015,9 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
     },
     "@mozilla-protocol/core": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-15.1.0.tgz",
-      "integrity": "sha512-ZGgld5xDlHcs9oXB1XMDB1jlPYVwBVwolRZjV+sjx/Ip+N0A+YSQH4iUzlAu0AopbPO9iW8p8cxMZhsdIix/Aw=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-16.0.0.tgz",
+      "integrity": "sha512-2eICrBcKvm9GpKy7yv90YIVbR/iscyVpjfaeMt+n25lj0svNknDBPmQJR0njgOemzEr8IFdnqL8oj0+JhMGj8g=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
-    "@mozilla-protocol/core": "15.1.0",
+    "@mozilla-protocol/core": "16.0.0",
     "@sentry/browser": "^6.12.0",
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
## Description
Updates to the latest Protocol, which includes the new breadcrumb component and renames previous "alt" theme variables/classes to "secondary"

## Testing
Run `npm install` or `make build` locally to get latest dependencies.
Make sure I didn't miss any instances of the old names.

Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/406631275