### PR TITLE
fixed outdated link with a new link in privacy

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -76,7 +76,7 @@
   {% if ftl_has_messages('privacy-index-get-involved', 'privacy-index-to-review-and-comment-on-proposed', 'privacy-index-read-more-about-our-ongoing') %}
   <section id="side-involved" class="side-reference">
     <h2 class="side-reference-title">{{ ftl('privacy-index-get-involved') }}</h2>
-    <p>{{ ftl('privacy-index-to-review-and-comment-on-proposed', group='https://groups.google.com/forum/?fromgroups#!forum/mozilla.governance') }}</p>
+    <p>{{ ftl('privacy-index-to-review-and-comment-on-proposed', group='https://groups.google.com/a/mozilla.org/g/governance/') }}</p>
     <p>{{ ftl('privacy-index-read-more-about-our-ongoing', blog='https://blog.mozilla.org/privacy/') }}</p>
   </section>
   {% endif %}

--- a/l10n/en/privacy/index.ftl
+++ b/l10n/en/privacy/index.ftl
@@ -30,7 +30,7 @@ privacy-index-get-involved = Get Involved
 privacy-index-as-an-open-source-project = As an open source project, transparency and openness are an essential part of { -brand-name-mozilla }’s founding principles. Our codebases are open and auditable. Our development work is open. Our bi-annual <a href="{ $report }">Transparency Report</a> also demonstrates our commitment to these principles.
 
 # Variables:
-#   $group (url) - link to https://groups.google.com/forum/?fromgroups#!forum/mozilla.governance
+#   $group (url) - link to https://groups.google.com/a/mozilla.org/g/governance/
 privacy-index-to-review-and-comment-on-proposed = To review and comment on proposed changes to our privacy policies, <a href="{ $group }"> subscribe to { -brand-name-mozilla }’s governance group</a>.
 
 # Variables:


### PR DESCRIPTION
## Description
removed outdated link from Privacy page Index portion and added a new link.

## Issue / Bugzilla link
#10722


