### PR TITLE
Update Twitter social links for DE/FR (fix bug 1740912)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -67,14 +67,14 @@
         <section class="c-footer-section-social">
           <h5 class="c-footer-heading">{{ ftl('footer-follow-mozilla') }}</h5>
           <ul class="c-footer-list-social">
-            <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
-            <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>
+            <li><a class="twitter" href="{{ mozilla_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
+            <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>
           </ul>
 
           <h5 class="c-footer-heading">{{ ftl('footer-follow-firefox') }}</h5>
           <ul class="c-footer-list-social">
             <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('footer-twitter') }}<span> (@firefox)</span></a></li>
-            <li><a class="instagram" href="{{ firefox_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
+            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
             <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-name="YouTube (@firefoxchannel)">{{ ftl('footer-youtube') }}<span> (@firefoxchannel)</span></a></li>
           </ul>
         </section>

--- a/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
+++ b/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
@@ -14,10 +14,10 @@
   "founder": "Mitchell Baker",
   "sameAs": [
     "https://www.wikidata.org/wiki/Q169925",
-    "https://twitter.com/mozilla",
+    "{{ mozilla_twitter_url() }}",
     "https://www.facebook.com/mozilla",
     "https://github.com/mozilla",
-    "https://www.instagram.com/mozilla/",
+    "{{ mozilla_instagram_url() }}",
     "https://www.youtube.com/user/Mozilla",
     "https://{{ lang_short() }}.wikipedia.org/wiki/Mozilla_Corporation",
     "https://www.linkedin.com/company/mozilla-corporation"

--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -51,7 +51,7 @@
           <h4>{{ _('Find us online') }}</h4>
           <ul class="mzp-u-list-styled">
             <li><a href="https://facebook.com/mozilla" hreflang="en-US" rel="external">{{ _('Facebook') }}</a></li>
-            <li><a href="https://twitter.com/mozilla" hreflang="en-US" rel="external">{{ _('Twitter') }}</a></li>
+            <li><a href="{{ mozilla_twitter_url() }}" rel="external">{{ _('Twitter') }}</a></li>
             <li><a href="{{ url('mozorg.about.forums.forums') }}">{{ _('Forums &amp; e-mail lists') }}</a></li>
           </ul>
         </div>

--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -144,7 +144,7 @@
         </li>
 
         <li class="contribute-mission-card">
-          <a href="https://twitter.com/mozilla">
+          <a href="{{ mozilla_twitter_url() }}">
             <h3 class="contribute-mission-follow-icon">{{ ftl('contribute-follow-mozilla') }}</h3>
             <p>{{ ftl('contribute-opportunities') }}</p>
           </a>

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -447,7 +447,40 @@ def firefox_twitter_url(ctx):
 
 @library.global_function
 @jinja2.contextfunction
-def firefox_instagram_url(ctx):
+def mozilla_twitter_url(ctx):
+    """Output a link to Twitter taking locales into account.
+
+    Uses the locale from the current request. Checks to see if we have
+    a Twitter account that match this locale, returns the localized account
+    url or falls back to the US account url if not.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ mozilla_twitter_url() }}
+
+    For en-US this would output:
+
+        https://twitter.com/mozilla
+
+    For DE this would output:
+
+        https://twitter.com/mozilla_germany
+
+    """
+    locale = getattr(ctx["request"], "locale", "en-US")
+    if locale not in settings.MOZILLA_TWITTER_ACCOUNTS:
+        locale = "en-US"
+
+    return settings.MOZILLA_TWITTER_ACCOUNTS[locale]
+
+
+@library.global_function
+@jinja2.contextfunction
+def mozilla_instagram_url(ctx):
     """Output a link to Instagram taking locales into account.
 
     Uses the locale from the current request. Checks to see if we have
@@ -460,11 +493,11 @@ def firefox_instagram_url(ctx):
     In Template
     -----------
 
-        {{ firefox_instagram_url() }}
+        {{ mozilla_instagram_url() }}
 
     For en-US this would output:
 
-        https://www.instagram.com/firefox/
+        https://www.instagram.com/mozilla/
 
     For DE this would output:
 
@@ -472,10 +505,10 @@ def firefox_instagram_url(ctx):
 
     """
     locale = getattr(ctx["request"], "locale", "en-US")
-    if locale not in settings.FIREFOX_INSTAGRAM_ACCOUNTS:
+    if locale not in settings.MOZILLA_INSTAGRAM_ACCOUNTS:
         locale = "en-US"
 
-    return settings.FIREFOX_INSTAGRAM_ACCOUNTS[locale]
+    return settings.MOZILLA_INSTAGRAM_ACCOUNTS[locale]
 
 
 @library.filter

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -37,17 +37,6 @@ TEST_DONATE_PARAMS = {
     "es-MX": {"currency": "eur", "presets": "100,50,25,15", "default": "15"},
 }
 
-TEST_FIREFOX_TWITTER_ACCOUNTS = {
-    "en-US": "https://twitter.com/firefox",
-    "es-ES": "https://twitter.com/firefox_es",
-    "pt-BR": "https://twitter.com/firefoxbrasil",
-}
-
-TEST_FIREFOX_INSTAGRAM_ACCOUNTS = {
-    "de": "https://www.instagram.com/unfcktheinternet/",
-    "en-US": "https://www.instagram.com/firefox/",
-}
-
 TEST_FXA_ENDPOINT = "https://accounts.firefox.com/"
 TEST_FXA_MOZILLAONLINE_ENDPOINT = "https://accounts.firefox.com.cn/"
 
@@ -379,7 +368,6 @@ class TestDonateUrl(TestCase):
         )
 
 
-@override_settings(FIREFOX_TWITTER_ACCOUNTS=TEST_FIREFOX_TWITTER_ACCOUNTS)
 class TestFirefoxTwitterUrl(TestCase):
     rf = RequestFactory()
 
@@ -412,30 +400,61 @@ class TestFirefoxTwitterUrl(TestCase):
         assert self._render("pt-PT") == "https://twitter.com/firefox"
 
 
-@override_settings(FIREFOX_INSTAGRAM_ACCOUNTS=TEST_FIREFOX_INSTAGRAM_ACCOUNTS)
-class TestFirefoxInstagramUrl(TestCase):
+class TestMozillaTwitterUrl(TestCase):
     rf = RequestFactory()
 
     def _render(self, locale):
         req = self.rf.get("/")
         req.locale = locale
-        return render("{{ firefox_instagram_url() }}", {"request": req})
+        return render("{{ mozilla_twitter_url() }}", {"request": req})
 
-    def test_firefox_twitter_url_no_locale(self):
+    def test_mozilla_twitter_url_no_locale(self):
         """No locale, fallback to default account"""
-        assert self._render("") == "https://www.instagram.com/firefox/"
+        assert self._render("") == "https://twitter.com/mozilla"
 
-    def test_firefox_twitter_url_english(self):
+    def test_mozilla_twitter_url_english(self):
         """en-US locale, default account"""
-        assert self._render("en-US") == "https://www.instagram.com/firefox/"
+        assert self._render("en-US") == "https://twitter.com/mozilla"
 
-    def test_firefox_twitter_url_spanish(self):
+    def test_mozilla_twitter_url_french(self):
+        """fr locale, a local account"""
+        assert self._render("fr") == "https://twitter.com/mozilla_france"
+
+    def test_mozilla_twitter_url_german(self):
+        """de locale, a local account"""
+        assert self._render("de") == "https://twitter.com/mozilla_germany"
+
+    def test_mozilla_twitter_url_other_locale(self):
+        """No account for locale, fallback to default account"""
+        assert self._render("es-AR") == "https://twitter.com/mozilla"
+        assert self._render("es-CL") == "https://twitter.com/mozilla"
+        assert self._render("es-MX") == "https://twitter.com/mozilla"
+        assert self._render("pt-PT") == "https://twitter.com/mozilla"
+
+
+class TestMozillaInstagramUrl(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale):
+        req = self.rf.get("/")
+        req.locale = locale
+        return render("{{ mozilla_instagram_url() }}", {"request": req})
+
+    def test_mozilla_instagram_url_no_locale(self):
+        """No locale, fallback to default account"""
+        assert self._render("") == "https://www.instagram.com/mozilla/"
+
+    def test_mozilla_instagram_url_english(self):
+        """en-US locale, default account"""
+        assert self._render("en-US") == "https://www.instagram.com/mozilla/"
+
+    def test_mozilla_instagram_url_german(self):
         """de locale, a local account"""
         assert self._render("de") == "https://www.instagram.com/unfcktheinternet/"
 
-    def test_firefox_twitter_url_other_locale(self):
+    def test_mozilla_instagram_url_other_locale(self):
         """No account for locale, fallback to default account"""
-        assert self._render("es-AR") == "https://www.instagram.com/firefox/"
+        assert self._render("es-AR") == "https://www.instagram.com/mozilla/"
 
 
 @override_settings(STATIC_URL="/media/")

--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -64,7 +64,7 @@
         </ul>
 
         <ul class="social-links">
-          <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
+          <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
           <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
           <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
           <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -920,17 +920,22 @@ DONATE_PARAMS = {
 
 # Official Firefox Twitter accounts
 FIREFOX_TWITTER_ACCOUNTS = {
-    "de": "https://twitter.com/firefox_DE",
     "en-US": "https://twitter.com/firefox",
     "es-ES": "https://twitter.com/firefox_es",
-    "fr": "https://twitter.com/firefox_FR",
     "pt-BR": "https://twitter.com/firefoxbrasil",
 }
 
+# Official Mozilla Twitter accounts
+MOZILLA_TWITTER_ACCOUNTS = {
+    "en-US": "https://twitter.com/mozilla",
+    "de": "https://twitter.com/mozilla_germany",
+    "fr": "https://twitter.com/mozilla_france",
+}
+
 # Official Firefox Instagram accounts
-FIREFOX_INSTAGRAM_ACCOUNTS = {
+MOZILLA_INSTAGRAM_ACCOUNTS = {
+    "en-US": "https://www.instagram.com/mozilla/",
     "de": "https://www.instagram.com/unfcktheinternet/",
-    "en-US": "https://www.instagram.com/firefox/",
 }
 
 # Firefox Accounts product links


### PR DESCRIPTION
## Description
The German / French Twitter social accounts have been re-branded / renamed using Mozilla instead of Firefox. This PR updates the footer links, as well as a few other places.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1740912

## Testing
Scroll to the footer on the following pages:

- [x] http://localhost:8000/de/ should link to https://twitter.com/mozilla_germany under `@Mozilla folgen`.
- [x] http://localhost:8000/de/ should link to https://twitter.com/firefox under `@Firefox folgen` (since the German specific account no longer exists).
- [x] http://localhost:8000/de/ should link to https://www.instagram.com/unfcktheinternet/ under `@Mozilla folgen` (since this is now a Mozilla branded account).
- [x] http://localhost:8000/de/ should link to https://www.instagram.com/firefox/ under `@Firefox folgen` (since the German Firefox specific account no longer exists).
- [x] http://localhost:8000/fr/ footer should link to https://twitter.com/mozilla_france under `Suivre @Mozilla`.
- [x] http://localhost:8000/fr/should link to https://twitter.com/firefox under `Suivre @Firefox` (since the French specific account no longer exists).