### PR TITLE
10711: Update Contentful sync to delete absent pages from sqlite

### DIFF
--- a/bedrock/contentful/constants.py
+++ b/bedrock/contentful/constants.py
@@ -25,3 +25,12 @@ CONTENT_TYPE_PAGE_GENERAL = "pageGeneral"
 CONTENT_CLASSIFICATION_VPN = "VPN"  # Matches string in Contenful for VPN as `product`
 
 ARTICLE_CATEGORY_LABEL = "category"  # for URL-param filtering
+
+ACTION_DELETE = "delete"
+ACTION_ARCHIVE = "archive"
+ACTION_UNARCHIVE = "unarchive"
+ACTION_PUBLISH = "publish"
+ACTION_UNPUBLISH = "unpublish"
+ACTION_CREATE = "create"
+ACTION_SAVE = "save"
+ACTION_AUTO_SAVE = "auto_save"

--- a/bedrock/contentful/tests/test_commands.py
+++ b/bedrock/contentful/tests/test_commands.py
@@ -3,10 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from typing import List, Tuple
 from unittest import mock
 
@@ -15,10 +11,21 @@ from django.test import override_settings
 
 import pytest
 
+from bedrock.contentful.constants import (
+    ACTION_ARCHIVE,
+    ACTION_AUTO_SAVE,
+    ACTION_CREATE,
+    ACTION_DELETE,
+    ACTION_PUBLISH,
+    ACTION_SAVE,
+    ACTION_UNARCHIVE,
+    ACTION_UNPUBLISH,
+)
 from bedrock.contentful.management.commands.update_contentful import (
     MAX_MESSAGES_PER_QUEUE_POLL,
     Command as UpdateContentfulCommand,
 )
+from bedrock.contentful.models import ContentfulEntry
 
 
 @pytest.fixture
@@ -51,7 +58,7 @@ def test_handle__no_contentful_configuration_results_in_pass_but_no_exception(
         ):
             command_instance.refresh = mock.Mock(
                 name="mock_refresh",
-                return_value=(True, 0, 0, 0),
+                return_value=(True, 0, 0, 0, 0),
             )
             command_instance.handle(quiet=True, force=False)
 
@@ -67,23 +74,35 @@ def test_handle__no_contentful_configuration_results_in_pass_but_no_exception(
     (
         (
             "ContentManagement.Entry.create,123abcdef123abcdef,abcdefabcdefabcdef",
-            "create",
+            ACTION_CREATE,
         ),
         (
             "ContentManagement.Entry.publish,123abcdef123abcdef,abcdefabcdefabcdef",
-            "publish",
+            ACTION_PUBLISH,
+        ),
+        (
+            "ContentManagement.Entry.unpublish,123abcdef123abcdef,abcdefabcdefabcdef",
+            ACTION_UNPUBLISH,
+        ),
+        (
+            "ContentManagement.Entry.archive,123abcdef123abcdef,abcdefabcdefabcdef",
+            ACTION_ARCHIVE,
         ),
         (
             "ContentManagement.Entry.unarchive,123abcdef123abcdef,abcdefabcdefabcdef",
-            "unarchive",
+            ACTION_UNARCHIVE,
         ),
         (
             "ContentManagement.Entry.save,123abcdef123abcdef,abcdefabcdefabcdef",
-            "save",
+            ACTION_SAVE,
         ),
         (
             "ContentManagement.Entry.auto_save,123abcdef123abcdef,abcdefabcdefabcdef",
-            "auto_save",
+            ACTION_AUTO_SAVE,
+        ),
+        (
+            "ContentManagement.Entry.delete,123abcdef123abcdef,abcdefabcdefabcdef",
+            ACTION_DELETE,
         ),
         (
             "ContentManagement.Entry,123abcdef123abcdef,abcdefabcdefabcdef",
@@ -167,31 +186,81 @@ def _establish_mock_queue(batched_messages: List[List]) -> Tuple[mock.Mock, mock
 @pytest.mark.parametrize(
     "message_actions_sequence",
     (
-        # One message in the queue
-        ["auto_save"],
-        ["create"],
-        ["publish"],
-        ["save"],
-        ["unarchive"],
-        # Multiple messages in the queue
-        ["delete", "auto_save", "delete"],
-        ["delete", "unpublish", "create"],
-        ["publish", "unpublish", "unpublish"],
-        ["publish", "publish", "publish", "publish"],
+        # In Dev mode, all Contentful actions apart from `create` are ones which
+        # should trigger polling the queue
+        [ACTION_AUTO_SAVE],
+        [ACTION_SAVE],
+        [ACTION_ARCHIVE],
+        [ACTION_UNARCHIVE],
+        [ACTION_PUBLISH],
+        [ACTION_UNPUBLISH],
+        [ACTION_DELETE],
+        [ACTION_DELETE, ACTION_AUTO_SAVE, ACTION_PUBLISH],
+        ["dummy_for_test", ACTION_AUTO_SAVE, "dummy_for_test"],
+        ["dummy_for_test", "dummy_for_test", ACTION_PUBLISH],
+        [ACTION_PUBLISH, "dummy_for_test", "dummy_for_test"],
     ),
     ids=[
         "single auto-save message",
-        "single create message",
-        "single publish message",
         "single save message",
+        "single archive message",
         "single unarchive message",
+        "single publish message",
+        "single unpublish message",
+        "single delete message",
+        "multiple messages, all are triggers",
+        "multiple messages with fake extra non-trigger states, go-signal is in middle",
+        "multiple messages with fake extra non-trigger states, go-signal is last",
+        "multiple messages with fake extra non-trigger states, go-signal is first",
+    ],
+)
+def test_update_contentful__queue_has_viable_messages__viable_message_found__dev_mode(
+    mock_boto_3,
+    message_actions_sequence,
+    command_instance,
+):
+    messages_for_queue = _build_mock_messages(message_actions_sequence)
+    mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
+
+    mock_boto_3.resource.return_value = mock_sqs
+
+    assert command_instance._queue_has_viable_messages() is True
+    mock_queue.purge.assert_called_once()
+
+
+@override_settings(
+    CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
+    DEV=False,
+)
+@mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
+@pytest.mark.parametrize(
+    "message_actions_sequence",
+    (
+        # One message in the queue
+        [ACTION_PUBLISH],
+        [ACTION_UNPUBLISH],
+        [ACTION_ARCHIVE],
+        [ACTION_UNARCHIVE],
+        [ACTION_DELETE],
+        # Multiple messages in the queue
+        [ACTION_AUTO_SAVE, ACTION_DELETE, ACTION_AUTO_SAVE],
+        [ACTION_SAVE, ACTION_AUTO_SAVE, ACTION_PUBLISH],
+        [ACTION_ARCHIVE, ACTION_AUTO_SAVE, ACTION_AUTO_SAVE],
+        [ACTION_ARCHIVE, ACTION_PUBLISH, ACTION_DELETE, ACTION_UNPUBLISH, ACTION_UNARCHIVE],
+    ),
+    ids=[
+        "single publish message",
+        "single unpublish message",
+        "single archive message",
+        "single unarchive message",
+        "single delete message",
         "multiple messages, go-signal is in middle",
         "multiple messages, go-signal is last",
         "multiple messages, go-signal is first",
         "multiple messages, all are go-signals",
     ],
 )
-def test_update_contentful__queue_has_viable_messages__viable_message_found(
+def test_update_contentful__queue_has_viable_messages__viable_message_found__prod_mode(
     mock_boto_3,
     message_actions_sequence,
     command_instance,
@@ -214,24 +283,61 @@ def test_update_contentful__queue_has_viable_messages__viable_message_found(
     "message_actions_sequence",
     (
         # One message in the queue
-        ["delete"],
-        ["unpublish"],
-        ["archive"],
+        [ACTION_CREATE],
         # Multiple messages in the queue
-        ["delete", "archive", "delete"],
+        [ACTION_CREATE, ACTION_CREATE, ACTION_CREATE],
     ),
     ids=[
-        "single delete message",
-        "single unpublish message",
-        "single archive message",
-        "multiple messages",
+        "single create message",
+        "multiple create messages",
     ],
 )
-def test_update_contentful__queue_has_viable_messages__no_viable_message_found(
+def test_update_contentful__queue_has_viable_messages__no_viable_message_found__dev_mode(
     mock_boto_3,
     message_actions_sequence,
     command_instance,
 ):
+    # Create is the only message that will not trigger a contenful poll in Dev
+    assert settings.DEV is True
+    messages_for_queue = _build_mock_messages(message_actions_sequence)
+    mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
+
+    mock_boto_3.resource.return_value = mock_sqs
+
+    assert command_instance._queue_has_viable_messages() is False
+    mock_queue.purge.assert_not_called()
+
+
+@override_settings(
+    CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
+    DEV=False,
+)
+@mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
+@pytest.mark.parametrize(
+    "message_actions_sequence",
+    (
+        # One message in the queue
+        [ACTION_SAVE],
+        [ACTION_AUTO_SAVE],
+        [ACTION_CREATE],
+        # Multiple messages in the queue
+        [ACTION_AUTO_SAVE, ACTION_SAVE, ACTION_CREATE],
+    ),
+    ids=[
+        "single save message",
+        "single auto-save message",
+        "single create message",
+        "multiple messages",
+    ],
+)
+def test_update_contentful__queue_has_viable_messages__no_viable_message_found__prod_mode(
+    mock_boto_3,
+    message_actions_sequence,
+    command_instance,
+):
+    # In prod mode we don't want creation or draft editing to trigger a
+    # re-poll of the API because it's unnecessary.
+    assert settings.DEV is False
     messages_for_queue = _build_mock_messages(message_actions_sequence)
     mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
 
@@ -262,10 +368,10 @@ def test_queue_has_viable_messages__no_sqs_configured(
 @pytest.mark.parametrize(
     "message_actions_sequence",
     (
-        ["delete"] * 10 + ["publish"],
-        ["delete"] * 9 + ["publish"],
-        ["delete"] * 8 + ["publish"],
-        ["delete"] * 56 + ["publish"],
+        [ACTION_CREATE] * 10 + [ACTION_PUBLISH],
+        [ACTION_CREATE] * 9 + [ACTION_PUBLISH],
+        [ACTION_CREATE] * 8 + [ACTION_PUBLISH],
+        [ACTION_CREATE] * 56 + [ACTION_PUBLISH],
     ),
     ids=[
         "Eleven messages",
@@ -280,7 +386,8 @@ def test_update_contentful__iteration_through_message_batch_thresholds(
     command_instance,
 ):
     # ie, show we handle less and more than 10 messages in the queue.
-    # Only the last message in each test case is viable
+    # Only the last message in each test case is viable, because
+    # ACTION_CREATE should not trigger anything in Dev or Prod
     messages_for_queue = _build_mock_messages(message_actions_sequence)
     mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
 
@@ -311,9 +418,9 @@ def test_update_contentful__queue_has_viable_messages__no_messages(
 @pytest.mark.parametrize(
     "must_force,has_viable_messages,expected",
     (
-        (False, False, (False, -1, -1, -1)),
-        (True, False, (True, 1, 2, 0)),
-        (False, True, (True, 1, 2, 0)),
+        (False, False, (False, -1, -1, -1, -1)),
+        (True, False, (True, 3, 2, 1, 0)),
+        (False, True, (True, 3, 2, 1, 0)),
     ),
     ids=(
         "Not forced, no viable messages in queue",
@@ -335,8 +442,9 @@ def test_update_contentful__refresh(
     command_instance._refresh_from_contentful = mock.Mock(
         name="_refresh_from_contentful",
         return_value=(
-            1,  # 'added'
+            3,  # 'added'
             2,  # 'updated'
+            1,  # 'deleted'
             0,  # 'errors'
         ),
     )
@@ -345,3 +453,32 @@ def test_update_contentful__refresh(
 
     retval = command_instance.refresh()
     assert retval == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "total_to_create, contentful_ids_synced, expected_deletion_count",
+    (
+        (3, ["entry_1", "entry_2", "entry_3"], 0),
+        (3, ["entry_1", "entry_2"], 1),
+        (5, ["entry_2", "entry_3", "entry_4"], 2),
+        (3, [], 3),
+    ),
+    ids=[
+        "All ids attempted, so none deleted",
+        "First two ids attempted, so one deleted",
+        "Middle three of five ids attempted,, so two deleted",
+        "No ids attempted, so all deleted",
+    ],
+)
+def test_update_contentful__detect_and_delete_absent_entries(
+    total_to_create,
+    contentful_ids_synced,
+    expected_deletion_count,
+    command_instance,
+):
+    for idx in range(total_to_create):
+        ContentfulEntry.objects.create(contentful_id=f"entry_{idx+1}")
+
+    retval = command_instance._detect_and_delete_absent_entries(contentful_ids_synced)
+    assert retval == expected_deletion_count


### PR DESCRIPTION
## Description

This changeset adds support for mirroring the removal of a page in Contentful in Bedrock's sqlite database.

The main behavioural changes are:

* The "archive", "unpublish" and "delete" events now trigger an API poll, whereas before they did not
* The "create" event of a page no longer counts as a 'go signal' for an API poll (and probably shouldn't have been in the first instance)
* We continue to ask the API for all the pages it knows of (for the relevant environment + API key combination), so we get a list of page IDs which we attempt to sync. After that attempt, we then query sqlite and look for any ContentfulEntry records we hold that were NOT in the list of IDs we just tried to sync -- and we delete those entries. This approach means that even if a sync for a particular page fails, we won't delete the page from sqlite -- this is safer than tracking 'sucessful ids' and deleteing all pages that are not in that successful set.

The sync still has slightly different behaviour on Dev than in Prod, in that Dev will act upon more states than Prod, because Dev can and will show draft pages as a way of previewing them.

## Issue / Bugzilla link

Resolves mozilla/bedrock#10711

## Testing

This is trickier to test on Prod, but on Dev:

* Use the sandbox environment by putting `CONTENTFUL_ENVIRONMENT=sandbox` in your .env
* Sync down everything with `make shell` then `./manage.py update_contentful`
* Create a new a VRC page that's obviously yours for testing and publish it
* Re-sync from contenful and confirm that it appears at http://localhost:8080/en-US/products/vpn/resource-center/ - open the specific article in a new tab, too
* Unpublish the page and re-sync -- it will remain visible because you're in DEV mode
* Archive the page and re-sync - it will disappear from your local build
* Unarchive the page (you may have to change the view in Contentful to find it to archive) and re-sync - it will reappear in your local build whether it's published or not
* Delete the page and re-sync - it will disappear from your local build

There are unit tests to confirm the changes to the SQS message checking.





