### PR TITLE
Add request country code to healthz-cron page

### DIFF
--- a/bedrock/base/templates/cron-health-check.html
+++ b/bedrock/base/templates/cron-health-check.html
@@ -70,6 +70,10 @@
         <td>Hostname</td>
         <td>{{ server_info.name }}</td>
       </tr>
+      <tr>
+        <td>Request Country</td>
+        <td>{{ country_code }}</td>
+      </tr>
       {% if server_info.git_sha %}
       <tr>
         <td>Bedrock Git SHA</td>


### PR DESCRIPTION
With the removal of the country-code.json endpoint in #10719 we need
another easy way to see from which country bedrock thinks the request is
coming. It's available in the html tag on every page, but this makes it
even easier and more human readable.
