### PR TITLE
Avoid duplicates when generating list of VRC categories based on available data

### DIFF
--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -38,7 +38,7 @@ urlpatterns = (
     ),
     path(
         "vpn/resource-center/<slug:slug>/",
-        views.resource_center_detail_view,
+        views.resource_center_article_view,
         name="products.vpn.resource-center.article",
     ),
 )

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -189,7 +189,7 @@ def resource_center_landing_view(request):
     )
 
 
-def resource_center_detail_view(request, slug):
+def resource_center_article_view(request, slug):
     """Individual detail pages for the VPN Resource Center"""
 
     template_name = "products/vpn/resource-center/article.html"

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -112,17 +112,19 @@ def _build_category_list(entry_list):
     # category_list = [
     #   {"name": "Cat1", "url": "/full/path/to/category"}, ...
     # ]
+    categories_seen = set()
     category_list = []
     root_url = reverse("products.vpn.resource-center.landing")
     for entry in entry_list:
         category = entry.category
-        if category:
+        if category and category not in categories_seen:
             category_list.append(
                 {
                     "name": category,
                     "url": f"{root_url}?{ARTICLE_CATEGORY_LABEL}={quote_plus(category)}",
                 }
             )
+            categories_seen.add(category)
 
     category_list = sorted(category_list, key=lambda x: x["name"])
     return category_list


### PR DESCRIPTION


## Description

While we're not yet using/revealing any categories in the VRC, we have code that provides a list of them for filtering. This code was not avoiding duplicates, so this changeset remedies that, via TDD.

There were different ways to approach this, but the separate tracking set of 'seen' categories seemed the simplest.

This changeset also renames a view to match the template it renders (`detail -> article`)

## Issue / Bugzilla link

Resolves #10744 

## Testing

Not straightfoward to test at the mo, because the categories are not revealed in the template, but reviewing the tests should be enough
