### PR TITLE
Remove old PictoCard code from Firefox Privacy Products JS

### DIFF
--- a/media/js/firefox/privacy/products.js
+++ b/media/js/firefox/privacy/products.js
@@ -33,35 +33,12 @@
                 var protectionReportLinks = document.querySelectorAll(
                     '.js-open-about-protections'
                 );
-                var pictoCardTitles = document.querySelectorAll(
-                    '.privacy-products-etp .mzp-c-card-picto-title'
-                );
 
                 for (var i = 0; i < protectionReportLinks.length; i++) {
                     protectionReportLinks[i].addEventListener(
                         'click',
                         handleOpenProtectionReport,
                         false
-                    );
-                }
-
-                for (var j = 0; j < pictoCardTitles.length; j++) {
-                    // Make picto card titles click and keyboard accessible.
-                    pictoCardTitles[j].setAttribute('role', 'link');
-                    pictoCardTitles[j].setAttribute('tabindex', 0);
-                    pictoCardTitles[j].addEventListener(
-                        'click',
-                        handleOpenProtectionReport,
-                        false
-                    );
-                    pictoCardTitles[j].addEventListener(
-                        'keydown',
-                        function (e) {
-                            if (e.key === 'Enter') {
-                                e.preventDefault();
-                                handleOpenProtectionReport(e);
-                            }
-                        }
                     );
                 }
             });


### PR DESCRIPTION
## Description
This PR removes unused PictoCard code from Firefox Privacy Products JS code:

- [x] Firefox Privacy Products JS code no longer references Picto Cards.

- [x] Firefox Privacy Product page still shows Protection Report when users click on "See what Firefox has blocked for you" while using a Firefox Browser.

## Issue / Bugzilla link
Fixes: #10731 

## Testing
All tests passed.
