### PR TITLE
Fix #10780: Add back `Markup` to `gettext` no-op

### DIFF
--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -19,7 +19,7 @@ from jinja2 import Markup
 cache = caches["l10n"]
 
 
-def translate(text, files):
+def translate(text, files=None):
     """
     An almost no-op to avoid triggering the old l10n machinery.
     """
@@ -30,6 +30,9 @@ def gettext(text, *args, **kwargs):
     """
     An almost no-op to avoid triggering the old l10n machinery.
     """
+    text = translate(text)
+    if args:
+        text = text % args
     return text
 
 

--- a/lib/l10n_utils/templatetags/helpers.py
+++ b/lib/l10n_utils/templatetags/helpers.py
@@ -10,6 +10,7 @@ from babel.dates import format_date
 from babel.numbers import format_number
 from django_jinja import library
 
+from lib.l10n_utils.dotlang import translate
 from lib.l10n_utils.translation import get_language
 
 babel_format_locale_map = {
@@ -25,7 +26,7 @@ def gettext(ctx, text):
 
     Once we remove all uses of `_(...)` in templates this can be removed.
     """
-    return text
+    return translate(text)
 
 
 # backward compatible for imports


### PR DESCRIPTION
## Description

This adds back the call to `Markup` to flag the text string as safe to be rendered as HTML.

## Issue / Bugzilla link

Fixes #10780 

## Testing

Ensure that `/about/forums/` links in the text work as expected.