### PR TITLE
Fix spacing issue on VRC landing page (Fixes #10777)

### DIFF
--- a/bedrock/products/templates/products/vpn/resource-center/landing.html
+++ b/bedrock/products/templates/products/vpn/resource-center/landing.html
@@ -46,7 +46,7 @@
   </div>
   {% call split (
     image_url="img/products/vpn/resource-center/resource_center_split_1.svg",
-    block_class='resource-center-split mzp-t-split-nospace mzp-t-content-lg mzp-l-split-center-on-sm-md',
+    block_class='resource-center-split mzp-t-content-lg mzp-l-split-center-on-sm-md',
     media_class='resource-center-split-media',
   ) %}
     <h1 class="resource-center-wordmark">{{ ftl('vpn-resource-center-mozilla-vpn') }}</h1>


### PR DESCRIPTION
## Description
Fixes missing spacing around "Start protecting your identity today" section.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10777

## Testing
http://localhost:8000/en-US/products/vpn/resource-center/