### PR TITLE
Add default bottom margin to VRC images served in Contewntful articles (Fixes #10769)

### DIFF
--- a/media/css/products/vpn/resource-center.scss
+++ b/media/css/products/vpn/resource-center.scss
@@ -123,6 +123,10 @@ $image-path: '/media/protocol/img';
     h3 {
         @include text-title-sm;
     }
+
+    img {
+        margin: 0 0 $spacing-lg;
+    }
 }
 
 .vpn-article-bottom-title {


### PR DESCRIPTION
## Issue / Bugzilla link
#10769

## Testing
http://localhost:8000/en-US/contentful-preview/1dQAhsz5Xnr6IrGwvhnFZp/