### PR TITLE
Use image description for alt text in Contentful (Fixes #10787)

### DIFF
--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -335,7 +335,7 @@ class AssetBlockRenderer(BaseBlockRenderer):
         return self.IMAGE_HTML.format(
             src=_get_image_url(asset, 688),
             src_highres=_get_image_url(asset, 1376),
-            alt=asset.title,
+            alt=asset.description,
         )
 
 


### PR DESCRIPTION
## Description
Use image description fields for `<img>` alt text instead of title fields.

## Issue / Bugzilla link
#10787

## Testing
Note: if you already have these pages in the DB locally, you may need to run `./manage.py update_contentful --force` to see the changes.

http://localhost:8000/en-US/products/vpn/resource-center/what-is-an-ip-address/

- [ ] Images that have a description should use that copy for `alt` text.
- [ ] Images that have no description should render as `alt=""`.