### PR TITLE
Create cross-site Firefox download attribution page (Fixes #10520)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/thanks_direct.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks_direct.html
@@ -1,0 +1,14 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "firefox/new/basic/thanks.html" %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {{ js_bundle('firefox_new_pixel') }}
+  {% endif %}
+  {{ js_bundle('firefox_new_thanks_direct') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks_direct.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks_direct.html
@@ -10,5 +10,5 @@
   {% if switch('tracking-pixel') %}
     {{ js_bundle('firefox_new_pixel') }}
   {% endif %}
-  {{ js_bundle('firefox_new_thanks_amo_exp') }}
+  {{ js_bundle('firefox_new_thanks_direct') }}
 {% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -499,25 +499,27 @@ class TestFirefoxNew(TestCase):
         assert resp.status_code == 301
         assert resp["location"].endswith("/firefox/download/thanks/?scene=2&dude=abides")
 
-    # begin AMO experiment - issue 10207
+    # begin /thanks?s=direct URL - issue 10520
 
-    @patch.dict(os.environ, SWITCH_NEW_REDESIGN="True")
-    def test_thanks_amo_experiment_en(self, render_mock):
-        req = RequestFactory().get("/firefox/download/thanks/?xv=amo")
+    @patch.object(views, "ftl_file_is_active", lambda *x: True)
+    def test_thanks_desktop_direct(self, render_mock):
+        req = RequestFactory().get("/firefox/download/thanks/?s=direct")
         req.locale = "en-US"
         view = views.DownloadThanksView.as_view()
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/new/desktop/thanks-amo-exp.html"]
+        assert template == ["firefox/new/desktop/thanks_direct.html"]
 
-    @patch.dict(os.environ, SWITCH_NEW_REDESIGN="True")
-    def test_thanks_amo_experiment_locales(self, render_mock):
-        req = RequestFactory().get("/firefox/download/thanks/?xv=amo")
-        req.locale = "de"
+    @patch.object(views, "ftl_file_is_active", lambda *x: False)
+    def test_thanks_basic_direct(self, render_mock):
+        req = RequestFactory().get("/firefox/download/thanks/?s=direct")
+        req.locale = "el"
         view = views.DownloadThanksView.as_view()
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/new/desktop/thanks.html"]
+        assert template == ["firefox/new/basic/thanks_direct.html"]
+
+    # end /thanks?s=direct URL - issue 10520
 
     # begin yandex - issue 5635 & 10607
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -605,8 +605,9 @@ class WhatsnewView(L10nTemplateView):
 class DownloadThanksView(L10nTemplateView):
     ftl_files_map = {
         "firefox/new/basic/thanks.html": ["firefox/new/download"],
+        "firefox/new/basic/thanks_direct.html": ["firefox/new/download"],
         "firefox/new/desktop/thanks.html": ["firefox/new/desktop"],
-        "firefox/new/desktop/thanks-amo-exp.html": ["firefox/new/desktop"],
+        "firefox/new/desktop/thanks_direct.html": ["firefox/new/desktop"],
     }
     activation_files = [
         "firefox/new/download",
@@ -630,15 +631,18 @@ class DownloadThanksView(L10nTemplateView):
 
     def get_template_names(self):
         experience = self.request.GET.get("xv", None)
-        locale = l10n_utils.get_locale(self.request)
+        source = self.request.GET.get("s", None)
 
         if ftl_file_is_active("firefox/new/desktop") and experience != "basic":
-            if locale == "en-US" and experience == "amo":
-                template = "firefox/new/desktop/thanks-amo-exp.html"
+            if source == "direct":
+                template = "firefox/new/desktop/thanks_direct.html"
             else:
                 template = "firefox/new/desktop/thanks.html"
         else:
-            template = "firefox/new/basic/thanks.html"
+            if source == "direct":
+                template = "firefox/new/basic/thanks_direct.html"
+            else:
+                template = "firefox/new/basic/thanks.html"
 
         return [template]
 

--- a/media/js/firefox/new/common/thanks-direct.js
+++ b/media/js/firefox/new/common/thanks-direct.js
@@ -52,7 +52,7 @@
         // Fire GA event to log attribution success
         window.dataLayer.push({
             event: 'non-interaction',
-            eAction: 'amo-exp-attribution',
+            eAction: 'direct-attribution',
             eLabel: 'success'
         });
 
@@ -70,7 +70,7 @@
         // Fire GA event to log attribution timeout
         window.dataLayer.push({
             event: 'non-interaction',
-            eAction: 'amo-exp-attribution',
+            eAction: 'direct-attribution',
             eLabel: 'timeout'
         });
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1112,9 +1112,9 @@
     {
       "files": [
         "js/firefox/new/common/thanks.js",
-        "js/firefox/new/common/thanks-amo-exp.js"
+        "js/firefox/new/common/thanks-direct.js"
       ],
-      "name": "firefox_new_thanks_amo_exp"
+      "name": "firefox_new_thanks_direct"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds special `?s=direct` URL parameter to `/firefox/download/thanks/` for cross-site attribution of direct downloads.

## Issue / Bugzilla link
#10520

## Testing
Note: needs testing on a Windows device / VM:

1. Open a new private tab and load https://www-demo1.allizom.org/firefox/download/thanks/?s=direct
2. Wait for the download to begin.
3. Verify that the download was initiated with both `attribution_code` and `attribution_sig` query parameters in the URL (you can hover over the "Try downloading again" link to easily copy/view the URL).

Example: https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US&attribution_code=c291cmNlPShub3Qgc2V0KSZtZWRpdW09KGRpcmVjdCkmY2FtcGFpZ249KG5vdCBzZXQpJmNvbnRlbnQ9KG5vdCBzZXQpJmV4cGVyaW1lbnQ9KG5vdCBzZXQpJnZhcmlhdGlvbj0obm90IHNldCkmdWE9Y2hyb21lJnZpc2l0X2lkPTEwNzg5NjA0MzAuMTYzNzY2MTkxMQ..&attribution_sig=4219d06b734ba4c5d0da4f56a22d80d6271ed34929b790656434600d8765c4a2

4. Repeat steps 1-3 for the URL https://www-demo1.allizom.org/firefox/download/thanks/?s=direct&xv=basic
5.  Validate that both URLs work normally for non-Windows devices and simply trigger the download without the attribution params.