### PR TITLE
Change redirects to careers.m.o to temporary

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -188,7 +188,7 @@ redirectpatterns = (
     # bug 957637
     redirect(r"^sopa/?", "https://blog.mozilla.org/blog/2012/01/19/firefox-users-engage-congress-sopa-strike-stats/"),
     # bug 924687
-    redirect(r"^opportunities(?:/|/index\.html)?$", "https://careers.mozilla.org/"),
+    redirect(r"^opportunities(?:/|/index\.html)?$", "https://careers.mozilla.org/", permanent=False),
     # bug 818321
     redirect(r"^projects/security/tld-idn-policy-list\.html$", "https://wiki.mozilla.org/IDN_Display_Algorithm"),
     redirect(r"^projects/security/membership-policy\.html$", "/about/governance/policies/security-group/membership/"),
@@ -299,7 +299,7 @@ redirectpatterns = (
     redirect(r"^about/bookmarks\.html$", "https://wiki.mozilla.org/Historical_Documents"),
     redirect(r"^about/timeline\.html$", "https://wiki.mozilla.org/Timeline"),
     # bug 1016400
-    redirect(r"^about/careers\.html$", "https://careers.mozilla.org/"),
+    redirect(r"^about/careers\.html$", "https://careers.mozilla.org/", permanent=False),
     # bug 861243 and bug 869489
     redirect(r"^about/manifesto\.html$", "/about/manifesto/"),
     redirect(r"^about/manifesto\.(.*)\.html$", "/{}/about/manifesto/", locale_prefix=False),
@@ -393,7 +393,7 @@ redirectpatterns = (
     redirect(r"^projects/marketing(/.*)?$", "https://wiki.mozilla.org/MarketingGuide"),
     # bug 1288647, 1722760
     redirect(r"^hacking/?$", "https://firefox-source-docs.mozilla.org/"),
-    redirect(r"^(careers|jobs)/?$", "https://careers.mozilla.org/"),
+    redirect(r"^(careers|jobs)/?$", "https://careers.mozilla.org/", permanent=False),
     redirect(r"^join/?$", "https://donate.mozilla.org/"),
     # Bug 1262593
     redirect(r"^unix/remote\.html$", "http://www-archive.mozilla.org/unix/remote.html"),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -514,7 +514,7 @@ URLS = flatten(
             "http://website-archive.mozilla.org/www.mozilla.org/fennec_releasenotes/projects/fennec/is/a/pretty/fox.html",
         ),
         # bug 924687
-        url_test("/opportunities{,/,/index.html}", "https://careers.mozilla.org/"),
+        url_test("/opportunities{,/,/index.html}", "https://careers.mozilla.org/", status_code=302),
         # bug 884933
         url_test("/{m,{firefox/,}mobile}/platforms/", "https://support.mozilla.org/kb/will-firefox-work-my-mobile-device"),
         url_test("/m/", "/firefox/new/"),
@@ -698,7 +698,7 @@ URLS = flatten(
         url_test("/about/bookmarks.html", "https://wiki.mozilla.org/Historical_Documents"),
         url_test("/about/timeline.html", "https://wiki.mozilla.org/Timeline"),
         # bug 1016400
-        url_test("/about/careers.html", "https://careers.mozilla.org/"),
+        url_test("/about/careers.html", "https://careers.mozilla.org/", status_code=302),
         # bug 861243 and bug 869489
         url_test("/about/manifesto.html", "/about/manifesto/"),
         url_test("/about/manifesto.{de,pt-BR}.html", "/{de,pt-BR}/about/manifesto/"),
@@ -887,7 +887,7 @@ URLS = flatten(
         url_test("/firefox/{,46.0/,46.0.1/,47.0/,47.0.1/}secondrun", "/firefox/browsers/mobile/"),
         # bug 1288647, 1722760
         url_test("/hacking", "https://firefox-source-docs.mozilla.org/"),
-        url_test("/{careers,jobs}", "https://careers.mozilla.org/"),
+        url_test("/{careers,jobs}", "https://careers.mozilla.org/", status_code=302),
         url_test("/join", "https://donate.mozilla.org/"),
         # Bug 1293539
         url_test("/firefox/{48.0,48.0.1,49.0a1,49.0a2}/tour", "https://support.mozilla.org/kb/get-started-firefox-overview-main-features"),


### PR DESCRIPTION
This will help when we need to change these redirects to point to
/careers/ in the future.
