### PR TITLE
Update Fluent file for exp home page [no bug]

### DIFF
--- a/bedrock/exp/views.py
+++ b/bedrock/exp/views.py
@@ -42,7 +42,7 @@ def home_view(request):
     ctx = {
         "donate_params": donate_params,
         "pocket_articles": PocketArticle.objects.all()[:4],
-        "ftl_files": ["mozorg/home-mr1-promo"],
+        "ftl_files": ["mozorg/home-mr2-promo"],
         "active_locales": ["de", "fr", "en-US"],
     }
 


### PR DESCRIPTION
## Description
The /exp home page wasn't referencing the `mozorg/home-mr2-promo` Fluent file and hence was display string IDs instead of the correct text.

## Issue / Bugzilla link
n/a

## Testing
http://localhost:8000/en-US/exp/

The button in the top promo should read "Get the new Firefox" and not show the string ID.