### PR TITLE
10778: Add support for VRC pages to sitemap

### DIFF
--- a/bedrock/contentful/constants.py
+++ b/bedrock/contentful/constants.py
@@ -34,3 +34,5 @@ ACTION_UNPUBLISH = "unpublish"
 ACTION_CREATE = "create"
 ACTION_SAVE = "save"
 ACTION_AUTO_SAVE = "auto_save"
+
+VRC_ROOT_PATH = "/products/vpn/resource-center/"

--- a/bedrock/sitemaps/tests/test_utils.py
+++ b/bedrock/sitemaps/tests/test_utils.py
@@ -36,11 +36,11 @@ def test__get_vrc_urls(dummy_vrc_pages):
     # TODO: support different locales
     output = _get_vrc_urls()
     assert output == {
-        "/products/vpn/resource-center/test-slug-0": ["en-US"],
-        "/products/vpn/resource-center/test-slug-1": ["en-US"],
-        "/products/vpn/resource-center/test-slug-2": ["en-US"],
-        "/products/vpn/resource-center/test-slug-3": ["en-US"],
-        "/products/vpn/resource-center/test-slug-4": ["en-US"],
+        "/products/vpn/resource-center/test-slug-0/": ["en-US"],
+        "/products/vpn/resource-center/test-slug-1/": ["en-US"],
+        "/products/vpn/resource-center/test-slug-2/": ["en-US"],
+        "/products/vpn/resource-center/test-slug-3/": ["en-US"],
+        "/products/vpn/resource-center/test-slug-4/": ["en-US"],
         "/products/vpn/resource-center/": ["en-US"],
     }
 

--- a/bedrock/sitemaps/tests/test_utils.py
+++ b/bedrock/sitemaps/tests/test_utils.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest.mock import patch
+
+import pytest
+
+from bedrock.contentful.constants import (
+    CONTENT_CLASSIFICATION_VPN,
+    CONTENT_TYPE_PAGE_RESOURCE_CENTER,
+)
+from bedrock.contentful.models import ContentfulEntry
+from bedrock.sitemaps.utils import _get_vrc_urls, get_contentful_urls, update_sitemaps
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def dummy_vrc_pages():
+    # No content, just the bare data we need
+    for idx in range(5):
+        ContentfulEntry.objects.create(
+            contentful_id=f"DUMMY-{idx}",
+            slug=f"test-slug-{idx}",
+            # TODO: support different locales
+            locale="en-US",
+            content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
+            classification=CONTENT_CLASSIFICATION_VPN,
+            data={},
+            data_hash="dummy",
+        )
+
+
+def test__get_vrc_urls(dummy_vrc_pages):
+    # TODO: support different locales
+    output = _get_vrc_urls()
+    assert output == {
+        "/products/vpn/resource-center/test-slug-0": ["en-US"],
+        "/products/vpn/resource-center/test-slug-1": ["en-US"],
+        "/products/vpn/resource-center/test-slug-2": ["en-US"],
+        "/products/vpn/resource-center/test-slug-3": ["en-US"],
+        "/products/vpn/resource-center/test-slug-4": ["en-US"],
+        "/products/vpn/resource-center/": ["en-US"],
+    }
+
+
+def test__get_vrc_urls__no_content():
+    # If there are no VRC pages in the DB, don't even show the listing page
+    output = _get_vrc_urls()
+    assert output == {}
+
+
+@patch("bedrock.sitemaps.utils._get_vrc_urls")
+def test_get_contentful_urls(mock__get_vrc_urls):
+    mock__get_vrc_urls.return_value = {"vrc-urls": "dummy-here"}
+
+    output = get_contentful_urls()
+    assert output == {"vrc-urls": "dummy-here"}
+    mock__get_vrc_urls.assert_called_once_with()
+
+
+@patch("bedrock.sitemaps.utils.get_static_urls")
+@patch("bedrock.sitemaps.utils.get_release_notes_urls")
+@patch("bedrock.sitemaps.utils.get_security_urls")
+@patch("bedrock.sitemaps.utils.get_contentful_urls")
+@patch("bedrock.sitemaps.utils.output_json")
+def test_update_sitemaps(
+    mock_output_json,
+    mock_get_contentful_urls,
+    mock_get_security_urls,
+    mock_get_release_notes_urls,
+    mock_get_static_urls,
+):
+    "Light check to ensure we've not added _new_ things we haven't added tests for"
+
+    mock_get_contentful_urls.return_value = {"contentful": "dummy"}
+    mock_get_security_urls.return_value = {"security": "dummy"}
+    mock_get_release_notes_urls.return_value = {"release_notes": "dummy"}
+    mock_get_static_urls.return_value = {"static_urls": "dummy"}
+
+    update_sitemaps()
+    expected = {
+        "contentful": "dummy",
+        "security": "dummy",
+        "release_notes": "dummy",
+        "static_urls": "dummy",
+    }
+
+    mock_output_json.assert_called_once_with(expected)

--- a/bedrock/sitemaps/tests/test_utils.py
+++ b/bedrock/sitemaps/tests/test_utils.py
@@ -41,12 +41,10 @@ def test__get_vrc_urls(dummy_vrc_pages):
         "/products/vpn/resource-center/test-slug-2/": ["en-US"],
         "/products/vpn/resource-center/test-slug-3/": ["en-US"],
         "/products/vpn/resource-center/test-slug-4/": ["en-US"],
-        "/products/vpn/resource-center/": ["en-US"],
     }
 
 
 def test__get_vrc_urls__no_content():
-    # If there are no VRC pages in the DB, don't even show the listing page
     output = _get_vrc_urls()
     assert output == {}
 

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -158,6 +158,8 @@ def get_static_urls():
 
 
 def _get_vrc_urls():
+    # URLs for individual VRC articles - the listing/landing page is declared
+    # separately in bedrock/products/urls.py so we don't need to include it here
 
     urls = defaultdict(list)
 
@@ -167,10 +169,6 @@ def _get_vrc_urls():
     ):
         _path = f"{VRC_ROOT_PATH}{entry.slug}/"
         urls[_path].append(entry.locale)  # In the future one, slug may support multiple locales
-
-    if urls:
-        # We only show the VRC listing page if there are VRC articles in the DB
-        urls[VRC_ROOT_PATH] = ["en-US"]  # TODO: support more locales
 
     return urls
 

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -165,7 +165,7 @@ def _get_vrc_urls():
         content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
         classification=CONTENT_CLASSIFICATION_VPN,
     ):
-        _path = f"{VRC_ROOT_PATH}{entry.slug}"
+        _path = f"{VRC_ROOT_PATH}{entry.slug}/"
         urls[_path].append(entry.locale)  # In the future one, slug may support multiple locales
 
     if urls:

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import json
 import re
+from collections import defaultdict
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -12,6 +13,12 @@ from django.urls import resolvers
 
 from mock import patch
 
+from bedrock.contentful.constants import (
+    CONTENT_CLASSIFICATION_VPN,
+    CONTENT_TYPE_PAGE_RESOURCE_CENTER,
+    VRC_ROOT_PATH,
+)
+from bedrock.contentful.models import ContentfulEntry
 from bedrock.releasenotes.models import ProductRelease
 from bedrock.security.models import SecurityAdvisory
 
@@ -150,10 +157,35 @@ def get_static_urls():
     return urls
 
 
+def _get_vrc_urls():
+
+    urls = defaultdict(list)
+
+    for entry in ContentfulEntry.objects.filter(
+        content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
+        classification=CONTENT_CLASSIFICATION_VPN,
+    ):
+        _path = f"{VRC_ROOT_PATH}{entry.slug}"
+        urls[_path].append(entry.locale)  # In the future one, slug may support multiple locales
+
+    if urls:
+        # We only show the VRC listing page if there are VRC articles in the DB
+        urls[VRC_ROOT_PATH] = ["en-US"]  # TODO: support more locales
+
+    return urls
+
+
+def get_contentful_urls():
+    urls = {}
+    urls.update(_get_vrc_urls())
+    return urls
+
+
 def update_sitemaps():
     urls = get_static_urls()
     urls.update(get_release_notes_urls())
     urls.update(get_security_urls())
+    urls.update(get_contentful_urls())
     # Output static files
     output_json(urls)
 


### PR DESCRIPTION
## Description

This changeset adds support for showing the VPN-specific resource center pages authored in Contentful in the sitemap, plus the index/landing page for the VPN Resource Center iff there are any articles available in the DB

TBC how one sees the results of the sitemap - that hasn't been manually checked yet

## Issue / Bugzilla link

Resolves #10778 (assuming it needs no extra work/wiring)

## Testing

```
make shell
./manage.py update_contentful --force  # to ensure you have VRC pages in your local DB
./manage.py update_sitemaps  # to regen the sitemap-powering JSON file
```
then inspect `root_files/sitemaps.json` to confirm the VRC pages are in there - they should be towards the very end of the file
