### PR TITLE
Make update commands alert to sentry on exceptions

### DIFF
--- a/bedrock/base/management/commands/update_www_config.py
+++ b/bedrock/base/management/commands/update_www_config.py
@@ -11,6 +11,7 @@ from envcat import get_env_vars
 
 from bedrock.base.models import ConfigValue
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
 def get_config_file_name(app_name=None):
@@ -37,6 +38,7 @@ def refresh_db_values():
     return count
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/contentcards/management/commands/update_content_cards.py
+++ b/bedrock/contentcards/management/commands/update_content_cards.py
@@ -7,8 +7,10 @@ from django.core.management.base import BaseCommand
 
 from bedrock.contentcards.models import ContentCard
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/contentful/management/commands/update_contentful.py
+++ b/bedrock/contentful/management/commands/update_contentful.py
@@ -29,6 +29,7 @@ from bedrock.contentful.constants import (
     MAX_MESSAGES_PER_QUEUE_POLL,
 )
 from bedrock.contentful.models import ContentfulEntry
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
 def data_hash(data: Dict) -> str:
@@ -36,6 +37,7 @@ def data_hash(data: Dict) -> str:
     return sha256(str_data.encode("utf8")).hexdigest()
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     rf = RequestFactory()
 
@@ -61,7 +63,7 @@ class Command(BaseCommand):
         if not self.quiet:
             print(msg)
 
-    def handle(self, *args, **options) -> None:
+    def handle(self, *args, **options):
         self.quiet = options["quiet"]
         self.force = options["force"]
         if settings.CONTENTFUL_SPACE_ID and settings.CONTENTFUL_SPACE_KEY:

--- a/bedrock/externalfiles/management/commands/update_externalfiles.py
+++ b/bedrock/externalfiles/management/commands/update_externalfiles.py
@@ -7,8 +7,10 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.module_loading import import_string
 
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/legal_docs/management/commands/update_legal_docs.py
+++ b/bedrock/legal_docs/management/commands/update_legal_docs.py
@@ -9,8 +9,10 @@ import requests
 
 from bedrock.legal_docs.models import LegalDoc
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/mozorg/management/commands/update_product_details_files.py
+++ b/bedrock/mozorg/management/commands/update_product_details_files.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from product_details.storage import PDDatabaseStorage, PDFileStorage
 
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 FIREFOX_VERSION_KEYS = (
     "FIREFOX_NIGHTLY",
@@ -23,6 +24,7 @@ FIREFOX_VERSION_KEYS = (
 )
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def __init__(self, stdout=None, stderr=None, no_color=False):
         self.file_storage = PDFileStorage(json_dir=settings.PROD_DETAILS_TEST_DIR)

--- a/bedrock/newsletter/management/commands/update_newsletter_data.py
+++ b/bedrock/newsletter/management/commands/update_newsletter_data.py
@@ -7,8 +7,10 @@ from django.core.management.base import BaseCommand, CommandError
 import basket
 
 from bedrock.newsletter.models import Newsletter
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/pocketfeed/management/commands/update_pocketfeed.py
+++ b/bedrock/pocketfeed/management/commands/update_pocketfeed.py
@@ -6,8 +6,10 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from bedrock.pocketfeed.models import PocketArticle
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/releasenotes/management/commands/update_release_notes.py
+++ b/bedrock/releasenotes/management/commands/update_release_notes.py
@@ -7,8 +7,10 @@ from django.core.management.base import BaseCommand
 
 from bedrock.releasenotes.models import ProductRelease
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),

--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -25,6 +25,7 @@ from bedrock.security.utils import (
 )
 from bedrock.utils.git import GitRepo
 from bedrock.utils.management.cron_command import CronCommand
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 ADVISORIES_REPO = settings.MOFO_SECURITY_ADVISORIES_REPO
 ADVISORIES_PATH = settings.MOFO_SECURITY_ADVISORIES_PATH
@@ -217,6 +218,7 @@ def delete_orphaned_products():
     return num_products
 
 
+@alert_sentry_on_exception
 class Command(CronCommand):
     help = "Refresh database of MoFo Security Advisories."
     lock_key = "update_security_advisories"

--- a/bedrock/sitemaps/management/commands/update_sitemaps_data.py
+++ b/bedrock/sitemaps/management/commands/update_sitemaps_data.py
@@ -8,8 +8,10 @@ from django.core.management.base import BaseCommand
 
 from bedrock.sitemaps.models import SitemapURL
 from bedrock.utils.git import GitRepo
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     help = "Clones or updates sitemaps info from github"
 

--- a/bedrock/utils/management/cron_command.py
+++ b/bedrock/utils/management/cron_command.py
@@ -14,8 +14,6 @@ from contextlib import contextmanager
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
 
-from bedrock.utils.management.decorators import alert_sentry_on_exception
-
 
 @contextmanager
 def cache_lock(lock_key):
@@ -36,7 +34,6 @@ def cache_lock(lock_key):
         yield False
 
 
-@alert_sentry_on_exception
 class CronCommand(BaseCommand):
     lock_key = "cron-command"
 

--- a/bedrock/utils/management/cron_command.py
+++ b/bedrock/utils/management/cron_command.py
@@ -14,6 +14,8 @@ from contextlib import contextmanager
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
 
+from bedrock.utils.management.decorators import alert_sentry_on_exception
+
 
 @contextmanager
 def cache_lock(lock_key):
@@ -34,6 +36,7 @@ def cache_lock(lock_key):
         yield False
 
 
+@alert_sentry_on_exception
 class CronCommand(BaseCommand):
     lock_key = "cron-command"
 

--- a/bedrock/utils/management/decorators.py
+++ b/bedrock/utils/management/decorators.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from sentry_sdk import capture_exception
+
+
+def alert_sentry_on_exception(cls):
+    """Custom decorator for management commands that ensure failures
+    anywhere in the main handle() call get to Sentry.
+
+    Usage:
+
+        @alert_sentry_on_exception
+        class MyTestManagementCommand(BaseCommand):
+            ...
+    """
+
+    def _handle(cls, *args, **kwargs):
+        try:
+            cls.old_handle(*args, **kwargs)
+        except Exception as ex:
+            capture_exception(ex)
+            # We DO want the exception to bubble up, because a calling script
+            # will want to check the exit code
+            raise
+
+    cls.old_handle = cls.handle  # Will fail hard if the subclass lacks handle(), but that's good
+    cls.handle = _handle
+
+    return cls

--- a/bedrock/utils/tests/test_decorators.py
+++ b/bedrock/utils/tests/test_decorators.py
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest.mock import Mock, patch
+
+from django.core.management.base import BaseCommand
+
+from bedrock.utils.management.decorators import alert_sentry_on_exception
+
+
+@alert_sentry_on_exception
+class TestCommandWithException(BaseCommand):
+    def handle(self, *args, **options):
+        raise Exception("This is a test")
+
+
+class TestCommandWithoutException(BaseCommand):
+    def foo(self):
+        # just for mocking in tests
+        pass
+
+    def handle(self, *args, **options):
+        self.foo()
+
+
+@patch("bedrock.utils.management.decorators.capture_exception")
+def test_sentry_alerting_base_command__exception_raised(mock_capture_exception):
+
+    assert not mock_capture_exception.called
+
+    try:
+        TestCommandWithException().handle()
+        assert False, "Expected an exception to have been raised"
+    except Exception as ex:
+        # The same exception raised should have been passed to Sentry
+        mock_capture_exception.assert_called_once_with(ex)
+
+
+@patch("bedrock.utils.management.decorators.capture_exception")
+def test_sentry_alerting_base_command__no_exception_raised(mock_capture_exception):
+
+    assert not mock_capture_exception.called
+
+    command = TestCommandWithoutException()
+    command.foo = Mock()
+    command.handle()
+
+    assert not mock_capture_exception.called
+    assert command.foo.call_count == 1

--- a/bedrock/wordpress/management/commands/update_wordpress.py
+++ b/bedrock/wordpress/management/commands/update_wordpress.py
@@ -5,9 +5,11 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from bedrock.utils.management.decorators import alert_sentry_on_exception
 from bedrock.wordpress.models import BlogPost
 
 
+@alert_sentry_on_exception
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", default=False, help="If no error occurs, swallow all output."),


### PR DESCRIPTION
## Description

This is part of [a broader epic](https://github.com/mozilla/bedrock/issues/10627) about making the DB update script a bit more resilient and its results more visible

This changeset adds a way for us to have management commmands raise exceptions upon failure, but still capture that info in Sentry, in a fairly unobstrusive way, via a class decorator

## Issue / Bugzilla link

Resolves #10813 

## Testing

* Add the SENTRY_DSN from Dev to your .env and restart your local stack
* In one of the relevant management commands (eg `update_contentful`) raise an Exception high in the _handle() command
* Confirm the exception is shown in your console AND also gets sent to sentry - eg https://sentry.prod.mozaws.net/operations/bedrock-dev/issues/15307834/?referrer=alert_email  
