### PR TITLE
Update Windows platform string on VPN waitlist page (Fixes #10819)

### DIFF
--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -68,7 +68,7 @@
             <li>
               <label class="mzp-u-inline">
                 <input type="checkbox" id="platforms-windows" name="platforms" value="windows">
-                {{ ftl('vpn-landing-invite-platform-windows-10') }}
+                {{ ftl('vpn-landing-invite-platform-windows', fallback='vpn-landing-invite-platform-windows-10') }}
               </label>
             </li>
             <li>

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -189,7 +189,12 @@ vpn-landing-invite-email-placeholder = yourname@example.com
 vpn-landing-invite-country-label = What country do you live in?
 vpn-landing-invite-language-label = Select your preferred language.
 vpn-landing-invite-platform-label = Which platforms are you interested in?
+
+vpn-landing-invite-platform-windows = { -brand-name-windows } 10/11
+
+# Outdated string
 vpn-landing-invite-platform-windows-10 = { -brand-name-windows } 10
+
 vpn-landing-invite-platform-ios = { -brand-name-ios }
 vpn-landing-invite-platform-android = { -brand-name-android }
 vpn-landing-invite-platform-mac = { -brand-name-mac-short }


### PR DESCRIPTION
## Description
Updates platform interest string to include Windows 11.

## Issue / Bugzilla link
#10819

## Testing
http://localhost:8000/en-US/products/vpn/invite/
