### PR TITLE
Add service=guardian-vpn param to VPN metrics-flow and FxA links (Fixes #10811)

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -25,7 +25,7 @@ def _vpn_get_available_plans(country_code, lang):
 
 def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
     separator = "&" if "?" in product_url else "?"
-    href = f"{product_url}{separator}entrypoint={entrypoint}&form_type=button&utm_source={entrypoint}&utm_medium=referral"
+    href = f"{product_url}{separator}entrypoint={entrypoint}&form_type=button&service=guardian-vpn&utm_source={entrypoint}&utm_medium=referral"
 
     if optional_parameters:
         params = "&".join("%s=%s" % (param, val) for param, val in optional_parameters.items())

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -172,7 +172,7 @@ class TestVPNSubscribeLink(TestCase):
         )
         expected = (
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7'
-            "&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page"
+            "&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=guardian-vpn&utm_source=www.mozilla.org-vpn-product-page"
             '&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-vpn-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" '
             'data-cta-position="primary">Get Mozilla VPN</a>'
@@ -190,7 +190,7 @@ class TestVPNSubscribeLink(TestCase):
         )
         expected = (
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw87cJNcmPzuWtRefuyqsOd'
-            "&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page"
+            "&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=guardian-vpn&utm_source=www.mozilla.org-vpn-product-page"
             '&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-vpn-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" '
             'data-cta-position="primary">Get Mozilla VPN</a>'
@@ -208,7 +208,7 @@ class TestVPNSubscribeLink(TestCase):
         )
         expected = (
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw7qSJNcmPzuWtRMUZpOwLm'
-            "&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&utm_source=www.mozilla.org-vpn-product-page"
+            "&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=guardian-vpn&utm_source=www.mozilla.org-vpn-product-page"
             '&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-vpn-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Mozilla VPN monthly" data-cta-type="fxa-vpn" '
             'data-cta-position="primary">Get Mozilla VPN</a>'
@@ -689,7 +689,7 @@ class TestVPNDownloadLink(TestCase):
         )
         expected = (
             '<a href="https://vpn.mozilla.org/vpn/download?entrypoint=www.mozilla.org-vpn-product-page'
-            "&form_type=button&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral"
+            "&form_type=button&service=guardian-vpn&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral"
             '&utm_campaign=vpn-product-page&data_cta_position=navigation" data-action="https://accounts.firefox.com/" '
             'class="js-vpn-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '
             'data-cta-type="fxa-vpn" data-cta-position="navigation">Already a Subscriber?</a>'

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -55,6 +55,12 @@ if (typeof window.Mozilla === 'undefined') {
 
         // add required params to the token fetch request
         metricsURL += '?form_type=' + params.form_type;
+
+        // add service identifier for VPN (issue #10811)
+        if (params.service) {
+            metricsURL += '&service=' + params.service;
+        }
+
         metricsURL += '&entrypoint=' + params.entrypoint;
         metricsURL += '&utm_source=' + params.utm_source;
 

--- a/tests/unit/spec/base/mozilla-fxa-product-button.js
+++ b/tests/unit/spec/base/mozilla-fxa-product-button.js
@@ -13,7 +13,7 @@ describe('mozilla-fxa-product-button.js', function () {
     'use strict';
 
     beforeEach(function () {
-        const button = `<a class="js-fxa-product-button" href="https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-action="https://accounts.firefox.com/" data-mozillaonline-link="https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign Up to Monitor</a>
+        const button = `<a class="js-fxa-product-button" href="https://accounts.firefox.com/signup?form_type=button&service=test&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-action="https://accounts.firefox.com/" data-mozillaonline-link="https://accounts.firefox.com.cn/signup?form_type=button&service=test&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign Up to Monitor</a>
              <a class="js-fxa-product-button" href="https://getpocket.com/ff_signup?s=ffwelcome2&amp;form_type=button&amp;entrypoint=mozilla.org-firefox-welcome-2&amp;utm_source=mozilla.org-firefox-welcome-2&amp;utm_campaign=welcome-2-pocket&amp;utm_medium=referral" data-action="https://accounts.firefox.com/">Activate Pocket</a>
              <a class="js-fxa-product-button" href="https://www.mozilla.org/en-US/firefox/accounts/">Learn more</a>
              <a class="js-fxa-product-button" href="https://accounts.firefox.com/subscriptions/products/prod_FiJ42WCzZNRSbS?plan=plan_FvPMH5lVx1vhV0&device_id=123456789&flow_begin_time=123456789&flow_id=123456789">Get Mozilla VPN</a>`;
@@ -55,7 +55,7 @@ describe('mozilla-fxa-product-button.js', function () {
         return Mozilla.FxaProductButton.init().then(() => {
             expect(window.fetch).toHaveBeenCalledTimes(1);
             expect(window.fetch).toHaveBeenCalledWith(
-                'https://accounts.firefox.com/metrics-flow?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60&utm_medium=referral'
+                'https://accounts.firefox.com/metrics-flow?form_type=button&service=test&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60&utm_medium=referral'
             );
         });
     });
@@ -71,7 +71,7 @@ describe('mozilla-fxa-product-button.js', function () {
         return Mozilla.FxaProductButton.init().then(() => {
             const buttons = document.querySelectorAll('.js-fxa-product-button');
             expect(buttons[0].href).toEqual(
-                'https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+                'https://accounts.firefox.com/signup?form_type=button&service=test&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
             );
             expect(buttons[1].href).toEqual(
                 'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
@@ -122,13 +122,19 @@ describe('mozilla-fxa-product-button.js', function () {
         return Mozilla.FxaProductButton.init().then(() => {
             const buttons = document.querySelectorAll('.js-fxa-product-button');
             expect(window.fetch).toHaveBeenCalledWith(
-                'https://accounts.firefox.com.cn/metrics-flow?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60&utm_medium=referral'
+                'https://accounts.firefox.com.cn/metrics-flow?form_type=button&service=test&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60&utm_medium=referral'
             );
             expect(buttons[0].href).toEqual(
-                'https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+                'https://accounts.firefox.com.cn/signup?form_type=button&service=test&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
             );
             expect(buttons[1].href).toEqual(
                 'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral'
+            );
+            expect(buttons[2].href).toEqual(
+                'https://www.mozilla.org/en-US/firefox/accounts/'
+            );
+            expect(buttons[3].href).toEqual(
+                'https://accounts.firefox.com/subscriptions/products/prod_FiJ42WCzZNRSbS?plan=plan_FvPMH5lVx1vhV0&device_id=123456789&flow_begin_time=123456789&flow_id=123456789'
             );
         });
     });


### PR DESCRIPTION
## Description
Adds `service=guardian-vpn` param to VPN auth URLs to make querying easier for data science teams.

## Issue / Bugzilla link
#10811

## Testing
http://localhost:8000/en-US/products/vpn/

- [x] Param should be present in all subscription button links.
- [x] Param should be present in metrics-flow API request on page load.
- [x] Param should be present in "Already a subscriber" link in navigation.