### PR TITLE
Fix welcome page footer links in dark mode [fix #10836]

### DIFF
--- a/media/css/firefox/welcome11.scss
+++ b/media/css/firefox/welcome11.scss
@@ -126,19 +126,18 @@ $image-path: '/media/protocol/img';
     }
 
     .c-footer {
+        @include white-links;
         background: $color-dark-gray-60;
         color: $color-white;
 
-        a:link,
-        a:visited,
-        a:hover,
-        a:focus,
-        a:active {
-            color: $color-white;
-        }
-
         .c-footer-sections {
             border-color: $color-dark-gray-30;
+
+            a:hover,
+            a:focus,
+            a:active {
+                text-decoration: underline;
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Updated footer link styles for dark mode.

## Issue / Bugzilla link
#10836 
https://bugzilla.mozilla.org/show_bug.cgi?id=1743408

## Testing
http://localhost:8000/firefox/welcome/11/