### PR TITLE
Add paths to vendor.toml

### DIFF
--- a/l10n/configs/vendor.toml
+++ b/l10n/configs/vendor.toml
@@ -13,6 +13,10 @@ locales = [
     "ms",
 ]
 
+[[paths]]
+    reference = "en/*.ftl"
+    l10n = "{locale}/*.ftl"
+
 ## Examples:
 
 # [[paths]]


### PR DESCRIPTION
I don't think there's anything actually using this file, but that's what I use to parse strings in Transvision (which, at the moment, it's missing all these locales).

The file doesn't make a lot of sense in its current form, as it lists locales but doesn't apply to any resource.

CC @peiying2 