### PR TITLE
Refactor DB update script to be more resilient and also ping a new DMS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ EXPOSE 8000
 CMD ["./bin/run.sh"]
 
 COPY docker/bin/apt-install /usr/local/bin/
-RUN apt-install gettext libxslt1.1 git
+RUN apt-install gettext libxslt1.1 git curl
 
 # copy in Python environment
 COPY --from=python-builder /venv /venv

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1100,7 +1100,9 @@ FIREFOX_MOBILE_SYSREQ_URL = "https://support.mozilla.org/kb/will-firefox-work-my
 
 MOZILLA_LOCATION_SERVICES_KEY = "a9b98c12-d9d5-4015-a2db-63536c26dc14"
 
-DEAD_MANS_SNITCH_URL = config("DEAD_MANS_SNITCH_URL", default="")
+DEAD_MANS_SNITCH_URL = config("DEAD_MANS_SNITCH_URL", default="")  # see cron.py
+# There is also a DB_UPDATE_SCRIPT_DMS_URL defined in env vars, which is called directly from
+# the bash script bin/run-db-update.sh
 
 # Sentry config for Backend and Frontend
 SENTRY_DSN = config("SENTRY_DSN", default="")

--- a/bin/run-db-update.sh
+++ b/bin/run-db-update.sh
@@ -3,7 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set -ex
+# We deliberately don't set -e here because we don't want a failure to block subsequent tasks
+set -x
 
 # run all jobs
 ALL=false
@@ -24,19 +25,34 @@ while [[ $# -ge 1 ]]; do
     shift # past argument or value
 done
 
-python manage.py update_product_details_files
-python manage.py update_security_advisories --quiet
-#python manage.py update_wordpress --quiet
-python manage.py update_release_notes --quiet
-python manage.py update_content_cards --quiet
-python manage.py update_contentful --quiet
-python manage.py update_externalfiles --quiet
-python manage.py update_newsletter_data --quiet
-python manage.py update_www_config --quiet
-python manage.py update_legal_docs --quiet
-python manage.py update_sitemaps_data --quiet
+failure_detected=false
+
+# Please ensure all new command calls are suffixed with || failure_detected=true
+
+python manage.py update_product_details_files || failure_detected=true
+python manage.py update_security_advisories --quiet || failure_detected=true
+#python manage.py update_wordpress --quiet || failure_detected=true
+python manage.py update_release_notes --quiet || failure_detected=true
+python manage.py update_content_cards --quiet || failure_detected=true
+python manage.py update_contentful --quiet || failure_detected=true
+python manage.py update_externalfiles --quiet || failure_detected=true
+python manage.py update_newsletter_data --quiet || failure_detected=true
+python manage.py update_www_config --quiet || failure_detected=true
+python manage.py update_legal_docs --quiet || failure_detected=true
+python manage.py update_sitemaps_data --quiet || failure_detected=true
 
 if [[ "$AUTH" == true ]]; then
     # jobs that require some auth. don't run these during build.
-    python manage.py update_pocketfeed --quiet
+    python manage.py update_pocketfeed --quiet || failure_detected=true
+fi
+
+# If all is well, ping DMS to avoid an alert being raised.
+if [[ $failure_detected == false ]]; then
+    echo "No failures detected across all update scripts"
+    if [[ -n "${DB_UPDATE_SCRIPT_DMS_URL}" ]]; then
+        curl "${DB_UPDATE_SCRIPT_DMS_URL}"
+        echo "Pinged snitch"
+    fi
+else
+    echo "WARNING: Failure detected during update scripts - snitch not pinged"
 fi


### PR DESCRIPTION
## Description

This changeset updates the bin/run-db-update.sh script to be more resilient to errors and ping a new Dead Man's Snitch IFF we have successful completion of all update tasks.

Specifically:

* Changed script mode to allow continue execution even if one of the management 
commands has a non-zero exit value
* Sets a sentinel to true if we encounter a problem during one of those 
management commands
* If the sentinel is false AND we have a specific, new, DMS url 
configured, ping it to confirm the update script went without problem. 
NOT pinging it will trigger an alert within MEAO circles once the snitch is active

Note that the new DMS snitch URL will come from the environment, but is 
not loaded in as a Django setting. Three new env-specific ones have been set up via [www-config](https://github.com/mozmeao/www-config/pull/417)

## Issue / Bugzilla link

Resolves #10814

## Testing

* set DB_UPDATE_SCRIPT_DMS_URL=http://example.com/test/ in your env (or a DMS URL if you have a pet one you use for testing
* stop and restart your Docker app server

* `make shell`
* `./bin/run-db-update.sh` -- this should run through and then try to ping the DMS url. If you used the example.com one, above, you'll see the HTML of that in our output

* Now, make one or more of the management commands break, by raising an Exception at the top of its `handle()` method.
* Re-run the script (no need to bounce Docker)
* Note the output shows a failure was detected and the snitch URL is not pinged