### PR TITLE
Fix pocket banner link:visited style [no bug]

### DIFF
--- a/media/css/base/banners/pocket.scss
+++ b/media/css/base/banners/pocket.scss
@@ -41,7 +41,8 @@ $close-btn-space: calc(1rem + (2 * #{$spacing-lg}));
     }
 
     // protocol overrides
-    a:link {
+    a:link,
+    a:visited {
         color: $color-text-primary;
     }
 


### PR DESCRIPTION
## Description

Noticed on https://www-dev.allizom.org/en-CA/
If you visit the CTA button link and return, the text is white and cannot be seen. (or use dev tools to set visited state)


<img width="578" alt="Screen Shot 2021-12-01 at 4 07 31 PM" src="https://user-images.githubusercontent.com/19650432/144270066-eb5273bf-2e9e-4baf-812b-c9e4ac4fb9c7.png">
This PR adds `a:visited` to the pocket banner link text styling

## Issue / Bugzilla link

## Testing
http://localhost:8000/en-US/

Open dev tools and target the Pocket banner CTA. Set state to visited. You should still see link text
<img width="609" alt="Screen Shot 2021-12-01 at 4 07 40 PM" src="https://user-images.githubusercontent.com/19650432/144270081-1764162d-946e-49ec-ab20-fb0bd8b11862.png">
.
