### PR TITLE
Fix pocket utm campaign [no bug]

### DIFF
--- a/bedrock/base/templates/includes/banners/pocket.html
+++ b/bedrock/base/templates/includes/banners/pocket.html
@@ -9,11 +9,11 @@
  {% block banner_id %}pocket-banner{% endblock %}
 
  {% if LANG.startswith('en') %}
-  {% set pocket_lang = '-en' %}
+  {% set pocket_campaign = 'best-of-us' %}
   {% set pocket_title = 'The top articles of the year are here' %}
   {% set pocket_button = 'Read Pocket\'s Best of 2021' %}
  {% elif LANG == 'de'%}
-  {% set pocket_lang = '-de' %}
+  {% set pocket_campaign = 'best-of-de' %}
   {% set pocket_title = 'Die meistgelesenen Artikel des Jahres warten auf dich' %}
   {% set pocket_button = 'Jetzt die Pocket Best of 2021 lesen' %}
  {% endif %}
@@ -22,7 +22,7 @@
 
  {% block banner_content %}
   <a
-    href="https://getpocket.com/collections?utm_source=mozilla.org&utm_campaign=best-of{{ pocket_lang }}"
+    href="https://getpocket.com/collections?utm_source=mozilla.org&utm_campaign={{ pocket_campaign }}"
     rel="external noopener"
     class="mzp-c-button mzp-t-md"
     data-cta-type="button"


### PR DESCRIPTION
## Description

Fix en utm campaign param to 'best-of-us'
https://github.com/mozilla/bedrock/pull/10846#discussion_r760454176

## Issue / Bugzilla link

## Testing
http://localhost:8000/de/
http://localhost:8000/en-US/

CTA should have appropriate utm campaign value
