### PR TITLE
Lint external Pocket .scss files (Fixes #10841)

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -36,8 +36,5 @@
             }
         ]
     },
-    "ignoreFiles": [
-        "media/css/libs/**/*",
-        "media/css/externalpages/pocket/**/*"
-    ]
+    "ignoreFiles": ["media/css/libs/**/*"]
 }

--- a/bedrock/externalpages/urls.py
+++ b/bedrock/externalpages/urls.py
@@ -13,5 +13,4 @@ urlpatterns = (
     page("pocket/safari", "externalpages/pocket/safari.html"),
     page("pocket/opera", "externalpages/pocket/opera.html"),
     page("pocket/edge", "externalpages/pocket/edge.html"),
-    page("pocket/safari", "externalpages/pocket/safari.html"),
 )

--- a/media/css/externalpages/pocket/components/_about.scss
+++ b/media/css/externalpages/pocket/components/_about.scss
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 @import '../utils/variables';
 @import './nav';
 @import './footer';
 
 $image-path: '/media/img/externalpages/pocket';
-
 
 .intro-wrapper {
     background-color: #95d5d2;
@@ -18,7 +16,7 @@ $image-path: '/media/img/externalpages/pocket';
 }
 
 .about-section {
-    font-family: $fontSans;
+    font-family: $font-sans;
     position: relative;
     max-width: 1128px;
     box-sizing: content-box;
@@ -26,8 +24,8 @@ $image-path: '/media/img/externalpages/pocket';
     margin-left: auto;
     margin-right: auto;
 
-    &:before {
-        content: "";
+    &::before {
+        content: '';
         position: absolute;
     }
 
@@ -37,7 +35,7 @@ $image-path: '/media/img/externalpages/pocket';
         z-index: 2;
 
         .about-section-heading {
-            font-family: $fontSansAlt;
+            font-family: $font-sans-alt;
             font-weight: 500;
             margin-top: 0;
             margin-bottom: 8px;
@@ -45,7 +43,7 @@ $image-path: '/media/img/externalpages/pocket';
         }
 
         .about-section-body {
-            font-family: $fontSans;
+            font-family: $font-sans;
             margin: 0 0 24px;
             font-size: 1rem;
         }
@@ -68,7 +66,7 @@ $image-path: '/media/img/externalpages/pocket';
         margin: 0 auto;
         padding: 40px 16px 118vw;
 
-        &:before {
+        &::before {
             background: url('#{$image-path}/people-enjoying-content-md.svg') no-repeat 100% 0 / contain;
             width: 200vw;
             height: 134vw;
@@ -85,11 +83,10 @@ $image-path: '/media/img/externalpages/pocket';
             font-size: 14px;
         }
 
-
         @media ($mq-md) {
-            padding: 104px 40px 496px 40px;
+            padding: 104px 40px 496px;
 
-            &:before {
+            &::before {
                 right: calc(50% - 656px);
                 width: 1176px;
                 height: 875px;
@@ -102,9 +99,9 @@ $image-path: '/media/img/externalpages/pocket';
         }
 
         @media ($mq-lg) {
-            padding: 128px 40px 352px 40px;
+            padding: 128px 40px 352px;
 
-            &:before {
+            &::before {
                 background-image: url('#{$image-path}/people-enjoying-content-lg.svg');
                 top: 40px;
                 right: calc(50% - 872px);
@@ -115,7 +112,6 @@ $image-path: '/media/img/externalpages/pocket';
             .about-section-heading {
                 font-size: 48px;
             }
-
         }
     }
 
@@ -123,7 +119,7 @@ $image-path: '/media/img/externalpages/pocket';
         margin-top: 64px;
         margin-bottom: 304px;
 
-        &:before {
+        &::before {
             background: url('#{$image-path}/swirly-saving-xs.svg') no-repeat 100% 0 / contain;
             bottom: -540px;
             height: 845px;
@@ -136,7 +132,7 @@ $image-path: '/media/img/externalpages/pocket';
             margin-top: 80px;
             margin-bottom: 490px;
 
-            &:before {
+            &::before {
                 background-image: url('#{$image-path}/swirly-saving-sm.svg');
                 height: 845px;
                 right: -195px;
@@ -149,7 +145,7 @@ $image-path: '/media/img/externalpages/pocket';
             margin-top: 175px;
             margin-bottom: 608px;
 
-            &:before {
+            &::before {
                 background-image: url('#{$image-path}/swirly-saving-lg.svg');
                 height: 750px;
                 right: -90px;
@@ -164,7 +160,7 @@ $image-path: '/media/img/externalpages/pocket';
         justify-content: flex-end;
         padding-bottom: 656px;
 
-        &:before {
+        &::before {
             background: url('#{$image-path}/rainbow-hand-gem-sm.svg') no-repeat 100% 0 / contain;
             bottom: 110px;
             height: 590px;
@@ -176,7 +172,7 @@ $image-path: '/media/img/externalpages/pocket';
         @media (min-width: 599px) {
             padding-bottom: 720px;
 
-            &:before {
+            &::before {
                 bottom: 109px;
                 height: 643px;
                 right: calc(50% - 320px);
@@ -188,7 +184,8 @@ $image-path: '/media/img/externalpages/pocket';
             display: flex;
             justify-content: flex-end;
             padding-bottom: 320px;
-            &:before {
+
+            &::before {
                 height: 872px;
                 right: 345px;
                 top: -80px;
@@ -201,7 +198,7 @@ $image-path: '/media/img/externalpages/pocket';
         @media ($mq-lg) {
             padding-bottom: 544px;
 
-            &:before {
+            &::before {
                 height: 982px;
                 right: 50%;
                 top: -240px;
@@ -213,7 +210,7 @@ $image-path: '/media/img/externalpages/pocket';
     &.fourth {
         padding-bottom: 668px;
 
-        &:before {
+        &::before {
             background: url('#{$image-path}/floating-content-md.svg') no-repeat 100% / contain;
             height: 212vw;
             bottom: 80px;
@@ -224,7 +221,7 @@ $image-path: '/media/img/externalpages/pocket';
         @media (min-width: 599px) {
             padding-bottom: 1020px;
 
-            &:before {
+            &::before {
                 bottom: 16px;
                 right: -96px;
             }
@@ -233,7 +230,7 @@ $image-path: '/media/img/externalpages/pocket';
         @media ($mq-md) {
             padding-bottom: 272px;
 
-            &:before {
+            &::before {
                 background-image: url('#{$image-path}/floating-content-lg.svg');
                 height: 1175px;
                 left: 57.5%;
@@ -246,7 +243,7 @@ $image-path: '/media/img/externalpages/pocket';
         @media ($mq-lg) {
             padding-bottom: 384px;
 
-            &:before {
+            &::before {
                 top: -448px;
                 width: 848px;
             }
@@ -256,7 +253,7 @@ $image-path: '/media/img/externalpages/pocket';
     &.fifth {
         padding-bottom: 181vw;
 
-        &:before {
+        &::before {
             background: url('#{$image-path}/sunny-content-md.svg') no-repeat 100% 0 / contain;
             bottom: -29vw;
             height: 242vw;
@@ -270,7 +267,7 @@ $image-path: '/media/img/externalpages/pocket';
             justify-content: flex-end;
             padding-bottom: 520px;
 
-            &:before {
+            &::before {
                 background-image: url('#{$image-path}/sunny-content-lg.svg');
                 height: 1192px;
                 right: calc(50% - 144px);
@@ -282,7 +279,7 @@ $image-path: '/media/img/externalpages/pocket';
         @media ($mq-lg) {
             padding-bottom: 672px;
 
-            &:before {
+            &::before {
                 height: 1228px;
                 top: -310px;
                 width: 1136px;
@@ -296,7 +293,7 @@ $image-path: '/media/img/externalpages/pocket';
     padding: 0 20px;
 
     .about-cta-heading {
-        font-family: $fontSansAlt;
+        font-family: $font-sans-alt;
         font-size: 28px;
         font-weight: 500;
         margin-bottom: 32px;
@@ -345,7 +342,7 @@ $image-path: '/media/img/externalpages/pocket';
     .about-cta-body {
         max-width: 416px;
         text-align: center;
-        margin-left:auto;
+        margin-left: auto;
         margin-right: auto;
     }
 }

--- a/media/css/externalpages/pocket/components/_add.scss
+++ b/media/css/externalpages/pocket/components/_add.scss
@@ -26,7 +26,7 @@ $image-path: '/media/img/externalpages/pocket';
 }
 
 .rarrow::after {
-    content: " ›";
+    content: ' ›';
 }
 
 .add-header {
@@ -39,6 +39,7 @@ $image-path: '/media/img/externalpages/pocket';
 
     &__context {
         display: flex;
+
         &-image {
             width: 60%;
 
@@ -80,6 +81,7 @@ $image-path: '/media/img/externalpages/pocket';
                 width: 100%;
             }
         }
+
         &-stores {
             display: flex;
             align-items: flex-start;
@@ -143,45 +145,43 @@ $image-path: '/media/img/externalpages/pocket';
     }
 }
 
-        .add-save__context-apps {
-            width: 45%;
+.add-save__context-apps { /* stylelint-disable-line selector-class-pattern */
+    width: 45%;
 
-            .app-types {
-                display: flex;
-                align-items: flex-start;
-                justify-content: flex-start;
+    .app-types {
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-start;
 
-                .app-board {
-                    display: flex;
-                    flex-wrap: wrap;
-                    padding: 0;
-                    width: 60%;
+        .app-board {
+            display: flex;
+            flex-wrap: wrap;
+            padding: 0;
+            width: 60%;
 
-                    &__icon {
-                        height: $layout-lg;
-                        margin: $spacing-sm;
-                        width: $layout-lg;
+            &__icon {
+                height: $layout-lg;
+                margin: $spacing-sm;
+                width: $layout-lg;
 
-                            img {
-                            height: 100%;
-                            width: 100%;
-                        }
-                    }
-                }
-
-                .social-apps {
-                    display: flex;
-                    flex-direction: column;
-                    align-items: flex-start;
-                    justify-content: flex-start;
-                    padding: 0;
-                    margin-left: $spacing-lg;
-
-                    li {
-                        margin: $spacing-sm;
-                    }
+                img {
+                    height: 100%;
+                    width: 100%;
                 }
             }
         }
 
+        .social-apps {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: flex-start;
+            padding: 0;
+            margin-left: $spacing-lg;
 
+            li {
+                margin: $spacing-sm;
+            }
+        }
+    }
+}

--- a/media/css/externalpages/pocket/components/_footer.scss
+++ b/media/css/externalpages/pocket/components/_footer.scss
@@ -84,7 +84,7 @@ $pocket-image-path: '/media/img/externalpages/pocket';
 
         .pocket-footer-heading {
             width: 100%;
-            font-family: $fontSans;
+            font-family: $font-sans;
             font-weight: 600;
             font-size: 19px;
             line-height: 24px;
@@ -95,10 +95,10 @@ $pocket-image-path: '/media/img/externalpages/pocket';
         .pocket-footer-list {
             list-style: none;
             padding: 0;
-            margin: 0 0 24px 0;
+            margin: 0 0 24px;
 
             li {
-                font-family: $fontSans;
+                font-family: $font-sans;
                 font-size: 16px;
                 margin-bottom: 12px;
                 font-weight: 400;
@@ -161,7 +161,7 @@ $pocket-image-path: '/media/img/externalpages/pocket';
 .pocket-footer-secondary {
     margin-top: 40px;
     color: $color-text-primary;
-    font-family: $fontSans;
+    font-family: $font-sans;
     border-top: 1px solid $color-divider;
     padding: 24px 0;
     display: flex;
@@ -190,7 +190,6 @@ $pocket-image-path: '/media/img/externalpages/pocket';
     }
 }
 
-
 .pocket-footer-socials {
     display: flex;
     margin: 0;
@@ -206,7 +205,6 @@ $pocket-image-path: '/media/img/externalpages/pocket';
             display: block;
             height: 20px;
             width: 20px;
-
 
             &.twitter {
                 background-image: url('/media/img/externalpages/pocket/platform-footer/twitter-logo.svg');

--- a/media/css/externalpages/pocket/components/_nav.scss
+++ b/media/css/externalpages/pocket/components/_nav.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import "../utils/variables";
+@import '../utils/variables';
 
 $image-path: '/media/img/externalpages/pocket';
 
@@ -65,8 +65,8 @@ $image-path: '/media/img/externalpages/pocket';
     &:focus {
         outline: none;
 
-        &:before {
-            content: "";
+        &::before {
+            content: '';
             display: block;
             position: absolute;
             top: -2px;
@@ -78,7 +78,8 @@ $image-path: '/media/img/externalpages/pocket';
         }
     }
 
-    &:active:before, &:hover:before {
+    &:active::before,
+    &:hover::before {
         display: none;
     }
 
@@ -97,9 +98,9 @@ $image-path: '/media/img/externalpages/pocket';
     @media ($mq-md) {
         margin-right: 56px;
 
-         &:hover {
+        &:hover {
             cursor: pointer;
-         }
+        }
     }
 
     @media ($mq-lg) {
@@ -155,8 +156,8 @@ $image-path: '/media/img/externalpages/pocket';
     &:focus {
         outline: 0;
 
-        &:before {
-            content: "";
+        &::before {
+            content: '';
             display: block;
             box-sizing: border-box;
             position: absolute;
@@ -169,20 +170,20 @@ $image-path: '/media/img/externalpages/pocket';
         }
     }
 
-    &:hover:before {
+    &:hover::before {
         display: none;
     }
 
     &:active {
         display: none;
 
-        &:before {
+        &::before {
             display: none;
         }
     }
 
-    &.selected:after {
-        content: "";
+    &.selected::after {
+        content: '';
         display: block;
         position: absolute;
         bottom: 0;
@@ -192,7 +193,7 @@ $image-path: '/media/img/externalpages/pocket';
         background-color: $color-action-primary;
     }
 
-    &.selected:active:after {
+    &.selected:active::after {
         background-color: $color-action-primary-hover;
     }
 }
@@ -208,13 +209,12 @@ $image-path: '/media/img/externalpages/pocket';
     color: $color-text-primary;
 
     &:focus,
-    &:focus,
     &:active {
         color: $color-action-primary;
         outline: 0;
 
-        &:before {
-            content: "";
+        &::before {
+            content: '';
             display: block;
             box-sizing: border-box;
             position: absolute;
@@ -231,7 +231,8 @@ $image-path: '/media/img/externalpages/pocket';
         text-decoration: none;
     }
 
-    &:hover:before, &:active:before {
+    &:hover::before,
+    &:active::before {
         display: none;
     }
 
@@ -240,7 +241,6 @@ $image-path: '/media/img/externalpages/pocket';
     }
 
     &.signup-link {
-        border: none;
         border-radius: 4px;
         padding: 12px;
         transition: all 0.15s ease-out;
@@ -252,7 +252,6 @@ $image-path: '/media/img/externalpages/pocket';
             background-color: $color-text-primary;
             color: #f2f2f2;
         }
-
     }
 
     @media ($mq-md) {
@@ -275,8 +274,4 @@ $image-path: '/media/img/externalpages/pocket';
         margin-top: -4px;
         display: none;
     }
-
 }
-
-
-

--- a/media/css/externalpages/pocket/components/_platform-footer.scss
+++ b/media/css/externalpages/pocket/components/_platform-footer.scss
@@ -9,7 +9,7 @@ $image-path: '/media/protocol/img';
 .platform-footer {
     border-top: 1px solid #cacaca;
     background-color: $color-light-gray-05;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     padding-top: $spacing-xl;
 
     &__navigation {
@@ -63,7 +63,7 @@ $image-path: '/media/protocol/img';
     }
 }
 
-.platform-footer__navigation--social-media {
+.platform-footer__navigation--social-media { /* stylelint-disable-line selector-class-pattern */
     padding: 0 $spacing-md;
 
     &__wrapper {
@@ -80,7 +80,6 @@ $image-path: '/media/protocol/img';
         margin: 0;
         padding: 0;
         display: flex;
-
 
         &-item {
             margin-right: $spacing-xs;

--- a/media/css/externalpages/pocket/components/_platform-nav.scss
+++ b/media/css/externalpages/pocket/components/_platform-nav.scss
@@ -4,9 +4,8 @@
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
-
 .pocket-header.platform {
-    box-shadow: 0 0 5px rgba(0, 0, 0, .15);
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.15);
     border-bottom-color: #c8c8c8;
 }
 
@@ -40,7 +39,6 @@
         }
     }
 
-
     &__navigation {
         display: flex;
         justify-content: flex-end;
@@ -49,7 +47,6 @@
         white-space: nowrap;
 
         &--list {
-            display: flex;
             margin: 0;
             padding: 0;
             list-style-type: none;
@@ -63,7 +60,7 @@
                 &--link {
                     @include text-body-sm;
                     border-top: 6px solid transparent;
-                    font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
+                    font-family: proxima-nova, 'Helvetica Neue', Helvetica, Arial, sans-serif;
                     font-weight: 700;
                     padding: $spacing-lg 21px;
                     text-decoration: none;
@@ -83,8 +80,6 @@
                     padding: $spacing-lg $spacing-md;
                 }
             }
-
         }
     }
-
 }

--- a/media/css/externalpages/pocket/components/_platforms.scss
+++ b/media/css/externalpages/pocket/components/_platforms.scss
@@ -2,44 +2,45 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import "../utils/variables";
-@import "./platform-footer";
-@import "./platform-nav";
-$image-path: "/media/img/externalpages/pocket";
+@import '../utils/variables';
+@import './platform-footer';
+@import './platform-nav';
 
-@import "~@mozilla-protocol/core/protocol/css/includes/lib";
-@import "~@mozilla-protocol/core/protocol/css/components/split";
-@import "~@mozilla-protocol/core/protocol/css/components/button";
+$image-path: '/media/img/externalpages/pocket';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/split';
+@import '~@mozilla-protocol/core/protocol/css/components/button';
 
 .platform {
     background-color: $color-background-grey;
 
-        .mzp-c-split-container {
-            background: $color-white;
-            border-radius: 10px;
-            border: 1px solid $color-divider;
-            padding-bottom: $spacing-lg;
+    .mzp-c-split-container {
+        background: $color-white;
+        border-radius: 10px;
+        border: 1px solid $color-divider;
+        padding-bottom: $spacing-lg;
 
-            @media #{$mq-md} {
-                padding-bottom: 0;
-            }
+        @media #{$mq-md} {
+            padding-bottom: 0;
+        }
 
-                h1 {
-                    @include text-title-sm;
-                }
+        h1 {
+            @include text-title-sm;
+        }
 
-                p {
-                    @include text-body-xl;
-                    color: $color-text-grey;
-                }
+        p {
+            @include text-body-xl;
+            color: $color-text-grey;
+        }
 
-                .mzp-c-button {
-                    background-color: $color-button-red;
-                    border: 0;
+        .mzp-c-button {
+            background-color: $color-button-red;
+            border: 0;
 
-                    &:hover {
-                        color: $color-white;
-                    }
-                }
+            &:hover {
+                color: $color-white;
             }
         }
+    }
+}

--- a/media/css/externalpages/pocket/style.scss
+++ b/media/css/externalpages/pocket/style.scss
@@ -2,22 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 // @import '~@mozilla-protocol/core/protocol/css/base/elements';
 
 @import 'utils/variables';
 @import 'utils/fonts';
 @import 'utils/tokens';
 
-
 *,
-:after,
-:before {
-  box-sizing: border-box;
+::after,
+::before {
+    box-sizing: border-box;
 }
+
 html {
-  font-family: sans-serif;
-  line-height: 1.15;
+    font-family: sans-serif;
+    line-height: 1.15;
+    font-size: 16px;
 }
 
 article,
@@ -30,18 +30,24 @@ hgroup,
 main,
 nav,
 section {
-  display: block;
-}
-
-html {
-  font-size: 16px;
+    display: block;
 }
 
 body {
     margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-      "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
-      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        Roboto,
+        'Helvetica Neue',
+        Arial,
+        'Noto Sans',
+        sans-serif,
+        'Apple Color Emoji',
+        'Segoe UI Emoji',
+        'Segoe UI Symbol',
+        'Noto Color Emoji';
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.5;
@@ -53,5 +59,3 @@ body {
 button:not(:disabled) {
     cursor: pointer;
 }
-
-

--- a/media/css/externalpages/pocket/utils/_fonts.scss
+++ b/media/css/externalpages/pocket/utils/_fonts.scss
@@ -1,32 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 @font-face {
     font-family: 'Blanco OSF';
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Regular.801a4e20a7d0a0d7920f60e192e46c48.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Regular.801a4e20a7d0a0d7920f60e192e46c48.woff'),
         url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Regular.7d5a8216b7607638e81feb748552a702.woff2');
 }
 
 @font-face {
-    font-family: "Blanco OSF";
+    font-family: 'Blanco OSF';
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Bold.400a57e32ac2790629d4fa0211b45f99.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Bold.400a57e32ac2790629d4fa0211b45f99.woff'),
         url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Bold.5597c92771d64715fcfc7af63ba976e9.woff2');
 }
 
 @font-face {
-    font-family: "Blanco OSF";
+    font-family: 'Blanco OSF';
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Italic.8ddad49f8497468d243c64648470f585.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Italic.8ddad49f8497468d243c64648470f585.woff'),
         url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Italic.5e84440eca9d20d6c8311bd3bd6af473.woff2');
 }
 
 @font-face {
-    font-family: "Blanco OSF";
+    font-family: 'Blanco OSF';
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-BoldItalic.cc63bcbdd7ca611875f1b415dba418e8.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-BoldItalic.cc63bcbdd7ca611875f1b415dba418e8.woff'),
         url('https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-BoldItalic.45e2653f7bf12f75c2f9e8cef5e95e64.woff2');
 }
 
@@ -34,7 +42,8 @@
     font-family: Doyle;
     font-weight: 400;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Doyle-Regular.ae81b3ac3456aa8ce04266ce44168298.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Doyle-Regular.ae81b3ac3456aa8ce04266ce44168298.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Doyle-Regular.96ab1443bd74e896395776fc10e78857.woff2');
 }
 
@@ -43,15 +52,17 @@
     font-weight: 400;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Doyle-RegularItalic.38a8e4befe6a34b235bd18e9e2d04e16.woff'),
-        url("https://assets.getpocket.com/web-ui/assets/Doyle-RegularItalic.e7af5c11daccb053aa0244f7a3e74ebf.woff2");
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Doyle-RegularItalic.38a8e4befe6a34b235bd18e9e2d04e16.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Doyle-RegularItalic.e7af5c11daccb053aa0244f7a3e74ebf.woff2');
 }
 
 @font-face {
     font-family: Doyle;
     font-weight: 500;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Doyle-Medium.c09a60519e560b51048e9efa13159e15.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Doyle-Medium.c09a60519e560b51048e9efa13159e15.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Doyle-Medium.eb6ee0eb205e8467cb3b0e61191217b2.woff2');
 }
 
@@ -60,295 +71,334 @@
     font-weight: 500;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Doyle-MediumItalic.e092e31b43186ff6e57b52b6aa4e684d.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Doyle-MediumItalic.e092e31b43186ff6e57b52b6aa4e684d.woff'),
         url('https://assets.getpocket.com/web-ui/assets/assets/Doyle-MediumItalic.10520e4820b03f63912a9b52ba5aae7a.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 100;
-    src: url('https://assets.getpocket.com/web-ui/assets/assets/Graphik-Thin-Web.8a7b553d6f07fa6774d6cc3f566f3817.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/assets/Graphik-Thin-Web.8a7b553d6f07fa6774d6cc3f566f3817.woff'),
         url('https://assets.getpocket.com/web-ui/assets/assets/Graphik-Thin-Web.f68162edaf17e6d6222ab9da5ee6a3ee.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 100;
     font-style: italic;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-ThinItalic-Web.d8fc643e1ca78c2047bbf1818f898877.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-ThinItalic-Web.d8fc643e1ca78c2047bbf1818f898877.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-ThinItalic-Web.0d830398baa16b5b118e9c3a72544630.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 200;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Extralight-Web.2692a605d0a1873eab0c6c436516b3cc.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Extralight-Web.2692a605d0a1873eab0c6c436516b3cc.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Extralight-Web.3e7d8320e82a4ac557bffb30f49a7dd2.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 200;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-ExtralightItalic-Web.8d878c5ddd91785ae4ce02bcbc3611a5.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-ExtralightItalic-Web.8d878c5ddd91785ae4ce02bcbc3611a5.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-ExtralightItalic-Web.e2021e99b9b03e623fb707081f647e11.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 300;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Light-Web.da8be9aa3a2d638310d7300574c9ca4f.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Light-Web.da8be9aa3a2d638310d7300574c9ca4f.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Light-Web.4389379ad479dec8e9013bda556ef683.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 300;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-LightItalic-Web.6c489a038da4053727bb9d59843d55fa.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-LightItalic-Web.6c489a038da4053727bb9d59843d55fa.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-LightItalic-Web.65c8f8e7f2f448733fe4393d0967fa8b.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 400;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Regular-Web.f4517c893c366f67105eb10713c09aa8.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Regular-Web.f4517c893c366f67105eb10713c09aa8.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Regular-Web.e05a3b2ff4a3813954bcf8bdb83f9804.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 400;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-RegularItalic-Web.499cfc7bd3673043171850abe04dd21e.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-RegularItalic-Web.499cfc7bd3673043171850abe04dd21e.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-RegularItalic-Web.d12ea36eea34954d9fd7dee0ac29640c.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 500;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Medium-Web.31a8dbe17cf69cda402e9b565d1bb595.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Medium-Web.31a8dbe17cf69cda402e9b565d1bb595.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Medium-Web.c28abeb53c5265642e173cb1f81e8091.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 500;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-MediumItalic-Web.e849270d3445a26ebdc0e311f5c09a68.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-MediumItalic-Web.e849270d3445a26ebdc0e311f5c09a68.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-MediumItalic-Web.e983ce64531b413c98468b4d6c8a13da.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 600;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Semibold-Web.f9e768566f6ba55e507f398522df32a7.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Semibold-Web.f9e768566f6ba55e507f398522df32a7.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Semibold-Web.1e9ac78e3efd08db3b5db4380e3a1e6f.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 600;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-SemiboldItalic-Web.034a80f088b241a85c8a8481e842d724.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-SemiboldItalic-Web.034a80f088b241a85c8a8481e842d724.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-SemiboldItalic-Web.876e8402cf5eabe6b470184b3a9a99f9.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Bold-Web.8aec411232046eb045b0222303d906c1.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Bold-Web.8aec411232046eb045b0222303d906c1.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Bold-Web.f9055a490bbbea456422bc02fde65dbd.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 700;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-BoldItalic-Web.5408dfb7fbe6369580c51d784814839a.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-BoldItalic-Web.5408dfb7fbe6369580c51d784814839a.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-BoldItalic-Web.97ee2ed109056dd42d1c56779c9f17ad.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 800;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Black-Web.5bedb5668c86ae2a1f8b7e04ffa54c0b.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Black-Web.5bedb5668c86ae2a1f8b7e04ffa54c0b.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Black-Web.a525aba1cce162a75f23ba5232bafe71.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 800;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-BlackItalic-Web.8148e65b1be4dad9cc97b417e6bfe300.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-BlackItalic-Web.8148e65b1be4dad9cc97b417e6bfe300.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-BlackItalic-Web.e417d4a1935480005c401445a708b71c.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 900;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-Super-Web.8d212593853c895eb75469ee506caa56.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-Super-Web.8d212593853c895eb75469ee506caa56.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-Super-Web.f16672fba11f8f3c5422665538f11733.woff2');
 }
 
 @font-face {
-    font-family: "Graphik Web";
+    font-family: 'Graphik Web';
     font-weight: 900;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Graphik-SuperItalic-Web.142c0ac5636d8f50e906a646df05e722.woff'),
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Graphik-SuperItalic-Web.142c0ac5636d8f50e906a646df05e722.woff'),
         url('https://assets.getpocket.com/web-ui/assets/Graphik-SuperItalic-Web.bf26f31b291983c02f78313e9b32c394.woff2');
 }
 
 @font-face {
     font-family: IdealSans;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Book_Web.7d16617ee3afbae04aad0840190a4fa2.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Book_Web.8ceb4de0789288847af513bd51c5818a.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Book_Web.7d16617ee3afbae04aad0840190a4fa2.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Book_Web.8ceb4de0789288847af513bd51c5818a.woff2');
+}
+@font-face {
     font-family: IdealSans;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Semibold_Web.ab443439365d14e4d3f33b96ace4cf3d.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Semibold_Web.b23b3824fab9ab4dc8006a6f24423b0f.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Semibold_Web.ab443439365d14e4d3f33b96ace4cf3d.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Semibold_Web.b23b3824fab9ab4dc8006a6f24423b0f.woff2');
+}
+@font-face {
     font-family: IdealSans;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-BookItalic_Web.086c41cbfa1e131056192654defa325c.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-BookItalic_Web.e3cf9a006e02acd2311610854754c42b.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-BookItalic_Web.086c41cbfa1e131056192654defa325c.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-BookItalic_Web.e3cf9a006e02acd2311610854754c42b.woff2');
+}
+@font-face {
     font-family: IdealSans;
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-SemiboldItalic_Web.3e33dacd17e8b971382f9075f200fdf5.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-SemiboldItalic_Web.3e33dacd17e8b971382f9075f200fdf5.woff');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-SemiboldItalic_Web.3e33dacd17e8b971382f9075f200fdf5.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/IdealSansSSm-SemiboldItalic_Web.3e33dacd17e8b971382f9075f200fdf5.woff');
+}
+@font-face {
     font-family: Inter;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Inter-Regular.ec3ea472a86202b82f0e82988267ba8c.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Inter-Regular.bcdeb499f86c03ab9093fe49b5c795ae.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Inter-Regular.ec3ea472a86202b82f0e82988267ba8c.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Inter-Regular.bcdeb499f86c03ab9093fe49b5c795ae.woff2');
+}
+@font-face {
     font-family: Inter;
     font-weight: 700;
-    src: url('https://assets.getpocket.com/web-ui/assets/Inter-Bold.c9c89216b48bee4d8727bf39d948b125.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Inter-Bold.fe38e3f307fcbac1a801c0c38dff56ef.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Inter-Bold.c9c89216b48bee4d8727bf39d948b125.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Inter-Bold.fe38e3f307fcbac1a801c0c38dff56ef.woff2');
+}
+@font-face {
     font-family: Inter;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Inter-Italic.62e6973fbd89e3696a41b670146a3eb6.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Inter-Italic.2b168e564b4ccdcac9e17b648d9f41b0.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Inter-Italic.62e6973fbd89e3696a41b670146a3eb6.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Inter-Italic.2b168e564b4ccdcac9e17b648d9f41b0.woff2');
+}
+@font-face {
     font-family: Inter;
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Inter-BoldItalic.ca06b9e049b5e736fd9b8a1cec2bf1c6.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Inter-BoldItalic.6d8374eb1ad9557adf0daf03048adcc9.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Inter-BoldItalic.ca06b9e049b5e736fd9b8a1cec2bf1c6.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Inter-BoldItalic.6d8374eb1ad9557adf0daf03048adcc9.woff2');
+}
+@font-face {
     font-family: Sentinel;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Sentinel-Book_Web.44e095f96c68683ddccf21786f2c7aab.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Sentinel-Book_Web.2a0c49d105a76fdcf8843ae4912732d5.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-Book_Web.44e095f96c68683ddccf21786f2c7aab.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-Book_Web.2a0c49d105a76fdcf8843ae4912732d5.woff2');
+}
+@font-face {
     font-family: Sentinel;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Sentinel-Semibold_Web.0a5a95311f7575d29340624e24d7b308.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Sentinel-Semibold_Web.f3cd3775fc8ca441f3694632cdce03da.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-Semibold_Web.0a5a95311f7575d29340624e24d7b308.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-Semibold_Web.f3cd3775fc8ca441f3694632cdce03da.woff2');
+}
+@font-face {
     font-family: Sentinel;
     font-style: italic;
-    src: url('https://assets.getpocket.com/web-ui/assets/Sentinel-BookItalic_Web.d92befc476196bc9cd4ceda25b5b0705.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Sentinel-BookItalic_Web.9f137203ba87748d9f8a9239729b065a.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-BookItalic_Web.d92befc476196bc9cd4ceda25b5b0705.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-BookItalic_Web.9f137203ba87748d9f8a9239729b065a.woff2');
+}
+@font-face {
     font-family: Sentinel;
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Sentinel-SemiboldItalic_Web.d6370a31cd7fafab460bb19e460ff8c3.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Sentinel-SemiboldItalic_Web.434b7971453df9b22c5cdf4c60f994e2.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-SemiboldItalic_Web.d6370a31cd7fafab460bb19e460ff8c3.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Sentinel-SemiboldItalic_Web.434b7971453df9b22c5cdf4c60f994e2.woff2');
+}
+@font-face {
     font-family: Tiempos;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Regular.ce3a6e174a1e93d77aa9744e668b6733.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Regular.bf6dfa623745f8f9be2c9306dd445f99.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Regular.ce3a6e174a1e93d77aa9744e668b6733.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Regular.bf6dfa623745f8f9be2c9306dd445f99.woff2');
+}
+@font-face {
     font-family: Tiempos;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Semibold.f9ff40092ce7976601c8b42edcba5b16.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Semibold.7e0dadfec14fed4ca5dd26b8ff3b7265.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Semibold.f9ff40092ce7976601c8b42edcba5b16.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Semibold.7e0dadfec14fed4ca5dd26b8ff3b7265.woff2');
+}
+@font-face {
     font-family: Tiempos;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-RegularItalic.779e2322119af37d52245221c0873971.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-RegularItalic.c7b3f3d417c54b9cf7eb7026b9eff8af.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-RegularItalic.779e2322119af37d52245221c0873971.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-RegularItalic.c7b3f3d417c54b9cf7eb7026b9eff8af.woff2');
+}
+@font-face {
     font-family: Tiempos;
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-SemiboldItalic.2dd1ab0682adf8353a47dfe043bf3aa7.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-SemiboldItalic.694d22d08e25711bb9f3ceb9b78f1e7f.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-SemiboldItalic.2dd1ab0682adf8353a47dfe043bf3aa7.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-SemiboldItalic.694d22d08e25711bb9f3ceb9b78f1e7f.woff2');
+}
+@font-face {
     font-family: Whitney;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Whitney-Book_Web.7ce7eaa9b3b0e084228e832d3a440e95.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Whitney-Book_Web.98aad5d22b5244dd121c379f3cea2230.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-Book_Web.7ce7eaa9b3b0e084228e832d3a440e95.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-Book_Web.98aad5d22b5244dd121c379f3cea2230.woff2');
+}
+@font-face {
     font-family: Whitney;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Whitney-Semibld_Web.3bc0fd121a947285c427fe52e380c55f.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Whitney-Semibld_Web.de2dee03c81082edf5341031656ea505.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-Semibld_Web.3bc0fd121a947285c427fe52e380c55f.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-Semibld_Web.de2dee03c81082edf5341031656ea505.woff2');
+}
+@font-face {
     font-family: Whitney;
     font-style: italic;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Whitney-BookItal_Web.5980b2b10590f7740928bc375997f593.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Whitney-BookItal_Web.80efdde5b097eda872e1754487ce68fc.woff2');
-  }
-  @font-face {
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-BookItal_Web.5980b2b10590f7740928bc375997f593.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-BookItal_Web.80efdde5b097eda872e1754487ce68fc.woff2');
+}
+@font-face {
     font-family: Whitney;
     font-style: italic;
     font-weight: 700;
     font-display: swap;
-    src: url('https://assets.getpocket.com/web-ui/assets/Whitney-SemibldItal_Web.b39a835ee55228424c846aec4093f6b9.woff'),
-      url('https://assets.getpocket.com/web-ui/assets/Whitney-SemibldItal_Web.fdd7d75fa8fa59d56cc3c402c5bccb55.woff2');
-  }
+    src:
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-SemibldItal_Web.b39a835ee55228424c846aec4093f6b9.woff'),
+        url('https://assets.getpocket.com/web-ui/assets/Whitney-SemibldItal_Web.fdd7d75fa8fa59d56cc3c402c5bccb55.woff2');
+}

--- a/media/css/externalpages/pocket/utils/_tokens.scss
+++ b/media/css/externalpages/pocket/utils/_tokens.scss
@@ -3,16 +3,17 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 .main-container {
-  overflow: hidden;
+    overflow: hidden;
 
-  .about-section a {
-    color: $color-action-primary;
-    text-decoration: underline;
-    transition: color 0.1s ease-out;
-    &:hover {
-        color: $color-action-primary-hover;
+    .about-section a {
+        color: $color-action-primary;
+        text-decoration: underline;
+        transition: color 0.1s ease-out;
+
+        &:hover {
+            color: $color-action-primary-hover;
+        }
     }
-  }
 }
 
 .red-btn {
@@ -20,17 +21,17 @@
     text-decoration: none;
     font-weight: 700;
     background-color: $color-button-red;
-    background-image: linear-gradient(180deg,#ee5f64 0,#d3505a);
+    background-image: linear-gradient(180deg, #ee5f64 0, #d3505a);
     border-radius: 4px;
     border: 1px solid $color-button-red;
-    box-shadow: inset 0 1px 1px hsla(0,0%,100%,.4);
+    box-shadow: inset 0 1px 1px hsla(0deg, 0%, 100%, 0.4);
     padding: 11px 45px;
     text-align: center;
-    text-shadow: 0 -1px 0 rgba(142,4,17,.5);
+    text-shadow: 0 -1px 0 rgba(142, 4, 17, 0.5);
     transition: background-image 0.2s;
 
     &:hover {
-       background-image: linear-gradient(120deg,#ee5f64 0,#d3505a);
+        background-image: linear-gradient(120deg, #ee5f64 0, #d3505a);
     }
 }
 

--- a/media/css/externalpages/pocket/utils/_variables.scss
+++ b/media/css/externalpages/pocket/utils/_variables.scss
@@ -2,31 +2,26 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$color-white:#fff;
+$color-white: #fff;
 $color-divider: #d9d9d9;
 $color-action-primary: #008078;
 $color-action-primary-hover: #004d48;
 $color-text-primary: #1a1a1a;
 $color-text-secondary: #666;
 $color-text-grey: #555;
-$color-text-dark-grey: #333333;
+$color-text-dark-grey: #333;
 $color-button-red: #e7132f;
 $color-text-cyan: #5dcfca;
-$color-background-grey:#f0f0f0;
-
+$color-background-grey: #f0f0f0;
 $box-shadow-sm: 0 2px 12px rgba(0, 0, 0, 0.08);
-
-
 $mq-md: 'min-width: 720px';
 $mq-lg: 'min-width: 1024px';
-
-$spacing025: .25em;
-$spacing075: .75em;
-$spacing050: .5em;
+$spacing025: 0.25em;
+$spacing075: 0.75em;
+$spacing050: 0.5em;
 $spacing100: 1em;
 $spacing150: 1.5em;
-
-$size025: .25rem;
+$size025: 0.25rem;
 $size100: 1rem;
 $size125: 1.25rem;
 $size150: 1.5rem;
@@ -34,9 +29,7 @@ $size200: 2rem;
 $size250: 2.5rem;
 $size300: 3rem;
 $size400: 4rem;
-
-$fontSize100: 1rem;
-
-$fontSerif: "Blanco OSF", Garamond, Times, Serif;
-$fontSans: "Graphik Web", "Helvetica Neue", Helvetica, Arial, Sans-Serif;
-$fontSansAlt: "Doyle", Garamond, Times, Serif;
+$font-size100: 1rem;
+$font-serif: 'Blanco OSF', garamond, times, serif;
+$font-sans: 'Graphik Web', 'Helvetica Neue', helvetica, arial, sans-serif;
+$font-sans-alt: 'Doyle', garamond, times, serif;


### PR DESCRIPTION
## Description
There's still more work to do here until this matches conventions we use in the rest of bedrock (e.g. removing BEM selector syntax), but this is the minimal set of changes needed to start linting these files.

## Issue / Bugzilla link
#10841

## Testing
- http://localhost:8000/en-US/external/pocket/about/
- http://localhost:8000/en-US/external/pocket/add/
- http://localhost:8000/en-US/external/pocket/android/
- http://localhost:8000/en-US/external/pocket/ios/
- http://localhost:8000/en-US/external/pocket/chrome/
- http://localhost:8000/en-US/external/pocket/safari/
- http://localhost:8000/en-US/external/pocket/opera/
- http://localhost:8000/en-US/external/pocket/edge/