### PR TITLE
Fix pocket collections url (fixes #10853)

### DIFF
--- a/bedrock/base/templates/includes/banners/pocket.html
+++ b/bedrock/base/templates/includes/banners/pocket.html
@@ -9,10 +9,12 @@
  {% block banner_id %}pocket-banner{% endblock %}
 
  {% if LANG.startswith('en') %}
+  {% set pocket_page = '/collections' %}
   {% set pocket_campaign = 'best-of-us' %}
   {% set pocket_title = 'The top articles of the year are here' %}
   {% set pocket_button = 'Read Pocket\'s Best of 2021' %}
  {% elif LANG == 'de'%}
+  {% set pocket_page = '/de/collections' %}
   {% set pocket_campaign = 'best-of-de' %}
   {% set pocket_title = 'Die meistgelesenen Artikel des Jahres warten auf dich' %}
   {% set pocket_button = 'Jetzt die Pocket Best of 2021 lesen' %}
@@ -22,7 +24,7 @@
 
  {% block banner_content %}
   <a
-    href="https://getpocket.com/collections?utm_source=mozilla.org&utm_campaign={{ pocket_campaign }}"
+    href="https://getpocket.com{{ pocket_page }}?utm_source=mozilla.org&utm_campaign={{ pocket_campaign }}"
     rel="external noopener"
     class="mzp-c-button mzp-t-md"
     data-cta-type="button"


### PR DESCRIPTION
## Description
We want to include the language in Pocket Collections URL so users end up on the correctly translated page

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10853

## Testing
http://localhost:8000/de/
Click Pocket Banner Best Of button
Should go to Pocket's DE collections page
https://getpocket.com/de/collections?utm_source=mozilla.org&utm_campaign=best-of-de

http://localhost:8000/en
Click Pocket Banner Best Of button
Should go to Pocket's EN collections page
https://getpocket.com/collections?utm_source=mozilla.org&utm_campaign=best-of-us