### PR TITLE
Center wordmarks on mobile (fixes #10666)

### DIFF
--- a/media/css/contentful/mozilla/c-hero.scss
+++ b/media/css/contentful/mozilla/c-hero.scss
@@ -8,3 +8,12 @@ $brand-theme: 'mozilla';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
+
+// issue 10666
+@media screen and (max-width: #{$screen-md}) {
+    .mzp-c-hero .mzp-c-wordmark {
+        margin-right: auto;
+        margin-left: auto;
+        background-position: top center;
+    }
+}


### PR DESCRIPTION
## Description
Center wordmarks for Contentful homepage hero components. A stop-gap fix until we resolve the underlying Protocol issue: https://github.com/mozilla/protocol/issues/718

The Hero component has [mobile centering for logos only](https://github.com/mozilla/protocol/blob/main/src/assets/sass/protocol/components/_hero.scss#L22). We added the wordmark for Contentful Hero but since the Protocol component is deprecated, we won't be updating Hero in Protocol. It's a Mozilla only fix because we should not be using the Contentful Hero component on new pages.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10666

## Testing
http://localhost:8000/en-US/

At mobile view size, Hero wordmarks in the Featured Mozilla Products section should be centered.
Above that view size, the wordmarks should be left-aligned or right-aligned (depending on dir attribute)
