### PR TITLE
Fix VPN devices variables [fix #10883]

### DIFF
--- a/bedrock/products/templates/products/vpn/platforms/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/linux.html
@@ -112,7 +112,7 @@
       image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
       class_name='vpn-content-media-left-half'
     ) %}
-      <p>{{ ftl('vpn-linux-devices-copy') }}</p>
+      <p>{{ ftl('vpn-linux-devices-copy', devices=vpn_devices) }}</p>
     {% endcall %}
 
     {% call vpn_content_media(

--- a/bedrock/products/templates/products/vpn/platforms/mac.html
+++ b/bedrock/products/templates/products/vpn/platforms/mac.html
@@ -111,7 +111,7 @@
       image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
       class_name='vpn-content-media-left-half'
     ) %}
-      <p>{{ ftl('vpn-mac-devices-copy') }}</p>
+      <p>{{ ftl('vpn-mac-devices-copy', devices=vpn_devices) }}</p>
     {% endcall %}
 
     {% call vpn_content_media(


### PR DESCRIPTION
## Description
A few strings had undefined variables.

## Issue / Bugzilla link
#10883 

## Testing
Check body copy under "Protect 5 devices with one subscription" on both the Mac and Linux pages. These were the only ones I could find.

http://localhost:8000/products/vpn/desktop/mac/
http://localhost:8000/products/vpn/desktop/linux/