### PR TITLE
Allow bpython (used by ./manage.py) to write its history file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,12 @@ COPY ./tests ./tests
 RUN bin/run-sync-all.sh
 
 RUN chown webdev.webdev -R .
+
+# for bpython
+RUN mkdir /home/webdev/
+RUN touch /home/webdev/.pythonhist
+RUN chown -R webdev /home/webdev/
+
 USER webdev
 
 # build args


### PR DESCRIPTION
## Description

Before, bpython would complain it couldn't write to /home/webdev/.pythonhist because it and the parent dir did not exist. 

Adding both with the appropriate permissions seems the smallest change to make the history work, and reduce the noise in the shell, but if we don't like this, I can dig into adding a config file in bedrock and mounting that in the container

## Issue / Bugzilla link

No ticket

## Testing

Pull, `make build`, then `make shell`, then `./manage.py shell` and write some Python, confirming that the up-arrow history now works and doesn't pepper the terminal with `Error occurred while writing to file /home/webdev/.pythonhist (No such file or directory)`

