### PR TITLE
Add welcome/page13.ftl to Pontoon config [#10801]

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -201,6 +201,14 @@ locales = [
         "nl",
     ]
 [[paths]]
+    reference = "en/firefox/welcome/page13.ftl"
+    l10n = "{locale}/firefox/welcome/page13.ftl"
+    locales = [
+        "es-ES",
+        "it",
+        "nl",
+    ]
+[[paths]]
     reference = "en/firefox/whatsnew/whatsnew-account.ftl"
     l10n = "{locale}/firefox/whatsnew/whatsnew-account.ftl"
 [[paths]]


### PR DESCRIPTION
## Description
Adds page13.ftl to pontoon.toml for es-ES, it, and nl. Other locales are covered by Smartling.

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/issues/263