### PR TITLE
vendor.toml: parse also subfolders

### DIFF
--- a/l10n/configs/vendor.toml
+++ b/l10n/configs/vendor.toml
@@ -14,8 +14,8 @@ locales = [
 ]
 
 [[paths]]
-    reference = "en/*.ftl"
-    l10n = "{locale}/*.ftl"
+    reference = "en/**/*.ftl"
+    l10n = "{locale}/**/*.ftl"
 
 ## Examples:
 


### PR DESCRIPTION
I was naive when copying from `pontoon.toml`, and didn't realize this would analyze only the files in the root, and ignore subfolders.