### PR TITLE
Fixed hyperlink rendering in error message of recovery page. Closes #10691

### DIFF
--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -40,7 +40,13 @@
           <label for="id_email" class="mzp-c-field-label">
             {{ ftl('newsletters-your-email-address') }}
             {% if form.email.errors %}
-              <em class="mzp-c-fieldnote">{{ form.email.errors }}</em>
+              <em class="mzp-c-fieldnote">
+                <ul class="errorlist">
+                {% for error in form.email.errors %}
+                  <li> {{ error|safe }} </li>
+                {% endfor %}
+                </ul>
+              </em>
             {% endif %}
           </label>
           {{ field_with_attrs(form.email, class='mzp-c-field-control'|safe) }}


### PR DESCRIPTION
Fixed hyperlink rendering in error message of recovery page. Closes #10691

## Description
Fixed the hyperlink rendering error in the error message produced on submitting an email id that does not occur in the newsletter system.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10691

## Testing
Enter an email id that does not occur in the newsletter system.  [localhost:8080/en-US/newsletter/recovery](http://localhost:8080/en-US/newsletter/recovery/)
![Screenshot (87)](https://user-images.githubusercontent.com/24841841/145727398-e422ed1b-44db-4cd3-b335-00e735aad53f.png)

