### PR TITLE
Stop showing hard-coded English vpn/more pages to locales (Fixes #11017)

### DIFF
--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -27,9 +27,9 @@ urlpatterns = (
         "vpn/more/when-to-use-a-vpn", "products/vpn/more/when-to-use.html", ftl_files=["products/vpn/more/when-to-use-a-vpn", "products/vpn/shared"]
     ),
     # VPN pages for Product team (issue #10388)
-    page("vpn/more/why-mozilla-vpn", "products/vpn/more/why-mozilla-vpn.html", ftl_files=["products/vpn/shared"]),
-    page("vpn/more/do-i-need-a-vpn", "products/vpn/more/do-i-need.html", ftl_files=["products/vpn/shared"]),
-    page("vpn/more/what-is-a-vpn-v2", "products/vpn/more/what-is-a-vpn-v2.html", ftl_files=["products/vpn/shared"]),
+    page("vpn/more/why-mozilla-vpn", "products/vpn/more/why-mozilla-vpn.html", ftl_files=["products/vpn/shared"], active_locales=["en-US"]),
+    page("vpn/more/do-i-need-a-vpn", "products/vpn/more/do-i-need.html", ftl_files=["products/vpn/shared"], active_locales=["en-US"]),
+    page("vpn/more/what-is-a-vpn-v2", "products/vpn/more/what-is-a-vpn-v2.html", ftl_files=["products/vpn/shared"], active_locales=["en-US"]),
     # VPN Resource Center
     path(
         "vpn/resource-center/",


### PR DESCRIPTION
## Description
Fixes untranslated VPN pages.

## Issue / Bugzilla link

## Testing
The following URLs should be viewable using `en-US` only:

- http://localhost:8000/en-US/products/vpn/more/do-i-need-a-vpn/
- http://localhost:8000/en-US/products/vpn/more/what-is-a-vpn-v2/
- http://localhost:8000/en-US/products/vpn/more/why-mozilla-vpn/