### PR TITLE
Fix SOM2020 typo

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2020/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2020/index.html
@@ -76,7 +76,7 @@
       {{ card(
         title='Mark Surman',
         ga_title='Mark Surman',
-        tag_label='Steeting Committee',
+        tag_label='Steering Committee',
         desc='President and Executive Director',
         class='has-modal',
         attributes='data-modal-id="mark-surman-letter"',
@@ -87,7 +87,7 @@
       {{ card(
         title='Angela Plohman & Eric Muhlheim',
         ga_title='Angela Plohman & Eric Muhlheim',
-        tag_label='Steeting Committee',
+        tag_label='Steering Committee',
         desc='Executive Vice President & Chief Financial Officer',
         class='has-modal',
         attributes='data-modal-id="angela-eric-letter"',


### PR DESCRIPTION
## Description
There was a typo on the leadership cards -- fixed `Steeting Committee` to be `Steering Committee`

## Issue / Bugzilla link

## Testing
http://localhost:8000/en-US/foundation/annualreport/2020/
