### PR TITLE
Add sqlite3 to devapp image, so we can run manage.py dbshell in local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ FROM app-base AS devapp
 
 CMD ["./bin/run-tests.sh"]
 
-RUN apt-install make
+RUN apt-install make sqlite3
 COPY requirements/base.txt requirements/dev.txt requirements/migration.txt requirements/docs.txt ./requirements/
 RUN pip install --no-cache-dir -r requirements/dev.txt
 RUN pip install --no-cache-dir -r requirements/docs.txt


### PR DESCRIPTION
## Description

This changeset enables us to run `manage.py dbshell` in the app container for the devapp (but not production)

## Issue / Bugzilla link

No ticket

## Testing

```
you@host:$ make shell

webdev@df9f9ff07135:/app$ ./manage.py dbshell

sqlite> select count(*) from releasenotes_productrelease;
```
