### PR TITLE
Fix navigation links on /pocket/about/ (Fixes #11030)

### DIFF
--- a/media/css/externalpages/pocket/includes/_nav.scss
+++ b/media/css/externalpages/pocket/includes/_nav.scss
@@ -185,12 +185,8 @@ $image-path: '/media/img/externalpages/pocket';
         display: none;
     }
 
-    &:active {
+    &:active::before {
         display: none;
-
-        &::before {
-            display: none;
-        }
     }
 
     &.selected::after {


### PR DESCRIPTION
## Description
For some reason `active` links were being set as `display: none`. I'm guessing the original intent was to remove some pseudo class styling?

## Issue / Bugzilla link
#11030

## Testing
http://localhost:8000/en-US/external/pocket/about/