### PR TITLE
Add VPN promo banner [fix #11026]

### DIFF
--- a/bedrock/base/templates/includes/banners/vpn-promo.html
+++ b/bedrock/base/templates/includes/banners/vpn-promo.html
@@ -1,0 +1,51 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<aside class="c-banner hide-from-legacy-ie" id="vpn-promo-banner">
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+    <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>
+    <div class="mzp-l-content">
+      <div class="c-banner-main">
+        <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-vpn">Mozilla VPN</div>
+
+        <div class="c-banner-content">
+          <h2 class="c-banner-title">
+          {% if LANG == 'de' %}
+            Der einfache Weg zu mehr Online-Privatsphäre
+          {% elif LANG == 'fr' %}
+            Un moyen simple de renforcer votre confidentialité en ligne
+          {% else %}
+            An easy way to take your online privacy up a notch
+          {% endif %}
+          </h2>
+          {% if LANG.startswith('en-') %}
+          <p>Mozilla VPN blurs your personal info for next-level security.</p>
+          {% endif %}
+        </div>
+
+        <div class="c-cta">
+        {% if LANG == 'de' %}
+        {% set link_text = 'Hol dir jetzt Mozilla VPN' %}
+        {% elif LANG == 'fr' %}
+        {% set link_text = 'Installer Mozilla VPN' %}
+        {% else %}
+        {% set link_text = 'Get Mozilla VPN' %}
+        {% endif %}
+        {{ vpn_product_referral_link(
+            referral_id='vpn-promo-banner',
+            link_text=link_text,
+            page_anchor='#pricing',
+            class_name='mzp-t-secondary',
+            optional_attributes= {
+                'data-cta-text' : 'Get Mozilla VPN',
+                'data-cta-type' : 'link',
+                'data-cta-position' : 'banner',
+            }
+        ) }}
+        </div>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -16,7 +16,7 @@
           referral_id='navigation',
           page_anchor='#pricing',
           link_text=ftl('navigation-v2-get-mozilla-vpn'),
-          class_name='mzp-t-secondary mzp-t-md',
+          class_name='mzp-t-product mzp-t-secondary mzp-t-md',
           optional_attributes= {
             'data-cta-text' : 'Get Mozilla VPN',
             'data-cta-type' : 'button',

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -9,6 +9,7 @@
 {% from "macros-protocol.html" import call_out, call_out_compact, split with context %}
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
+{% set show_vpn_promo_banner = switch('vpn-promo-banner', ['en-US', 'en-CA', 'en-GB', 'de', 'fr']) %}
 
 {% block page_title %}{{ ftl('firefox-home-firefox-protect-your') }}{% endblock %}
 
@@ -33,6 +34,10 @@
 
   {% if show_firefox_app_store_banner %}
     {{ css_bundle('firefox-app-store-banner') }}
+  {% endif %}
+
+  {% if show_vpn_promo_banner %}
+    {{ css_bundle('vpn-promo-banner') }}
   {% endif %}
 {% endblock %}
 
@@ -66,6 +71,10 @@
 {% endblock %}
 
 {% block page_banner %}
+  {% if show_vpn_promo_banner %}
+    {% include 'includes/banners/vpn-promo.html' %}
+  {% endif %}
+
   {% if show_firefox_app_store_banner %}
     {% include 'includes/banners/mobile/firefox-app-store.html' %}
   {% endif %}
@@ -272,6 +281,10 @@
 
   {% if show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}
+  {% endif %}
+
+  {% if show_vpn_promo_banner %}
+    {{ js_bundle('vpn-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-contentful.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-contentful.html
@@ -13,8 +13,10 @@
 {% block page_title %}{{ _('Internet for people, not profit') }}{% endblock %}
 {% block page_desc %}{{ _('Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.') }}{% endblock %}
 
-{% set show_pocket_banner = switch('pocket-banner', ['en-US', 'en-CA', 'en-GB', 'de']) %}
 {% set show_fundraising_banner = switch('fundraising-banner-eoy2021') and donate_params and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
+{% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
+{% set show_pocket_banner = switch('pocket-banner', ['en-US', 'en-CA', 'en-GB', 'de']) %}
+{% set show_vpn_promo_banner = switch('vpn-promo-banner', ['en-US', 'en-CA', 'en-GB', 'de']) %}
 
 {% block page_css %}
   {% include 'includes/contentful/css.html' %}
@@ -24,6 +26,8 @@
     {{ css_bundle('fundraising-banner') }}
   {% elif show_pocket_banner %}
     {{ css_bundle('pocket-banner') }}
+  {% elif show_vpn_promo_banner %}
+    {{ css_bundle('vpn-promo-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ css_bundle('firefox-app-store-banner') }}
   {% endif %}
@@ -38,6 +42,8 @@
     {% include 'includes/banners/fundraiser.html' %}
   {% elif show_pocket_banner %}
     {% include 'includes/banners/pocket.html' %}
+  {% elif show_vpn_promo_banner %}
+    {% include 'includes/banners/vpn-promo.html' %}
   {% elif show_firefox_app_store_banner %}
     {% include 'includes/banners/mobile/firefox-app-store.html' %}
   {% endif %}
@@ -118,6 +124,8 @@
     {{ js_bundle('fundraising-banner') }}
   {% elif show_pocket_banner %}
     {{ js_bundle('pocket-banner') }}
+  {% elif show_vpn_promo_banner %}
+    {{ js_bundle('vpn-promo-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}
   {% endif %}

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -15,6 +15,8 @@
 {% set show_pocket_banner = switch('pocket-banner') %}
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 {% set show_fundraising_banner = switch('fundraising-banner-eoy2021') and donate_params and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
+{% set show_vpn_promo_banner = switch('vpn-promo-banner') %}
+
 
 {% block page_css %}
   {{ css_bundle('home-eu') }}
@@ -27,6 +29,8 @@
     {{ css_bundle('fundraising-banner') }}
   {% elif show_pocket_banner %}
     {{ css_bundle('pocket-banner') }}
+  {% elif show_vpn_promo_banner %}
+    {{ css_bundle('vpn-promo-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ css_bundle('firefox-app-store-banner') }}
   {% endif %}
@@ -37,6 +41,8 @@
     {% include 'includes/banners/fundraiser.html' %}
   {% elif show_pocket_banner %}
     {% include 'includes/banners/pocket.html' %}
+  {% elif show_vpn_promo_banner %}
+    {% include 'includes/banners/vpn-promo.html' %}
   {% elif show_firefox_app_store_banner %}
     {% include 'includes/banners/mobile/firefox-app-store.html' %}
   {% endif %}
@@ -156,6 +162,8 @@
     {{ js_bundle('fundraising-banner') }}
   {% elif show_pocket_banner %}
     {{ js_bundle('pocket-banner') }}
+  {% elif show_vpn_promo_banner %}
+    {{ js_bundle('vpn-promo-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}
   {% endif %}

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -14,6 +14,7 @@
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 {% set show_fundraising_banner = switch('fundraising-banner-eoy2021') and donate_params and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}
+{% set show_vpn_promo_banner = switch('vpn-promo-banner') %}
 
 {% block page_css %}
   {{ css_bundle('home-eu') }}
@@ -24,6 +25,8 @@
 
   {% if show_fundraising_banner %}
     {{ css_bundle('fundraising-banner') }}
+  {% elif show_vpn_promo_banner %}
+    {{ css_bundle('vpn-promo-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ css_bundle('firefox-app-store-banner') }}
   {% endif %}
@@ -32,6 +35,8 @@
 {% block page_banner %}
   {% if show_fundraising_banner %}
     {% include 'includes/banners/fundraiser.html' %}
+  {% elif show_vpn_promo_banner %}
+    {% include 'includes/banners/vpn-promo.html' %}
   {% elif show_firefox_app_store_banner %}
     {% include 'includes/banners/mobile/firefox-app-store.html' %}
   {% endif %}
@@ -148,6 +153,8 @@
 
   {% if show_fundraising_banner %}
     {{ js_bundle('fundraising-banner') }}
+  {% elif show_vpn_promo_banner %}
+    {{ js_bundle('vpn-promo-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}
   {% endif %}

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -196,7 +196,7 @@ def vpn_product_referral_link(ctx, referral_id="", page_anchor="", link_text=Non
     """
 
     href = reverse("products.vpn.landing")
-    css_class = "mzp-c-button mzp-t-product js-fxa-product-referral-link"
+    css_class = "mzp-c-button js-fxa-product-referral-link"
     attrs = f'data-referral-id="{referral_id}" '
 
     if optional_attributes:

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -871,12 +871,12 @@ class TestVPNProductReferralLink(TestCase):
             referral_id="navigation",
             page_anchor="#pricing",
             link_text="Get Mozilla VPN",
-            class_name="mzp-t-secondary mzp-t-md",
+            class_name="mzp-t-product mzp-t-secondary mzp-t-md",
             optional_attributes={"data-cta-text": "Get Mozilla VPN", "data-cta-type": "button"},
         )
         expected = (
-            '<a href="/en-US/products/vpn/#pricing" class="mzp-c-button mzp-t-product '
-            'js-fxa-product-referral-link mzp-t-secondary mzp-t-md" data-referral-id="navigation" '
+            '<a href="/en-US/products/vpn/#pricing" class="mzp-c-button js-fxa-product-referral-link '
+            'mzp-t-product mzp-t-secondary mzp-t-md" data-referral-id="navigation" '
             'data-cta-text="Get Mozilla VPN" data-cta-type="button">Get Mozilla VPN</a>'
         )
         self.assertEqual(markup, expected)

--- a/media/css/base/banners/vpn-promo.scss
+++ b/media/css/base/banners/vpn-promo.scss
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+$brand-theme: 'mozilla';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+
+#vpn-promo-banner {
+    &.c-banner {
+        @include clearfix;
+        background: #c4c6fc;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.25) inset;
+        color: $color-ink-80;
+        position: relative;
+        z-index: 3;
+
+        .mzp-l-content {
+            padding-top: $spacing-lg;
+            padding-bottom: $spacing-lg;
+        }
+
+        // hide by default if JS is available to avoid flicker
+        // (if visitor previously dismissed)
+        .js & {
+            display: none;
+        }
+
+        // conditional class used to display the banner.
+        &.c-banner-is-visible {
+            display: block;
+        }
+    }
+
+    .mzp-c-wordmark {
+        width: 140px;
+    }
+
+    .c-banner-content {
+        @include bidi(((padding-right, $spacing-lg, 0), (padding-left, 0, $spacing-lg),)); // make room for the close button
+    }
+
+    .c-banner-title {
+        @include font-size(24px);
+    }
+
+    @media #{$mq-md} {
+        .c-banner-main {
+            display: flex;
+            align-items: center;
+        }
+
+        .mzp-c-wordmark {
+            @include bidi(((margin-right, $spacing-xl, 0), (margin-left, 0, $spacing-xl),));
+            margin-bottom: 0;
+        }
+
+        .c-banner-title {
+            margin: 0;
+            padding: 0;
+        }
+
+        .c-banner-content p {
+            margin-bottom: 0;
+        }
+
+        .c-cta {
+            line-height: 0;
+            min-width: 180px;
+            padding: 0 $spacing-2xl;
+        }
+    }
+
+    // Close button
+    .c-banner-close {
+        @include background-size(20px 20px);
+        @include bidi((
+            (right, $spacing-sm, auto),
+            (left, auto, $spacing-sm),
+        ));
+        @include image-replaced;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
+        border: none;
+        cursor: pointer;
+        display: none;
+        height: 42px;
+        min-width: 0;
+        padding: 0;
+        position: absolute;
+        top: $spacing-sm;
+        width: 42px;
+        z-index: 1;
+
+        &:hover,
+        &:focus {
+            @include transition(transform 100ms ease-in-out);
+            @include transform(scale(1.1));
+        }
+
+        &:focus {
+            outline: 1px dotted $color-white;
+        }
+
+        // hide the 'Close' text
+        span {
+            @include visually-hidden;
+        }
+
+        // only display when JS is available
+        .js & {
+            display: block;
+        }
+    }
+}

--- a/media/js/base/banners/vpn-promo-banner-init.js
+++ b/media/js/base/banners/vpn-promo-banner-init.js
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    function onLoad() {
+        window.Mozilla.Banner.init('vpn-promo-banner', true);
+    }
+
+    window.Mozilla.run(onLoad);
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -258,6 +258,12 @@
     },
     {
       "files": [
+        "css/base/banners/vpn-promo.scss"
+      ],
+      "name": "vpn-promo-banner"
+    },
+    {
+      "files": [
         "css/base/banners/firefox-app-store.scss"
       ],
       "name": "firefox-app-store-banner"
@@ -1207,6 +1213,13 @@
         "js/base/banners/pocket-banner-init.js"
       ],
       "name": "pocket-banner"
+    },
+    {
+      "files": [
+        "js/base/banners/mozilla-banner.js",
+        "js/base/banners/vpn-promo-banner-init.js"
+      ],
+      "name": "vpn-promo-banner"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds a top-of-page banner to the home page and main /firefox page, in English, French, and German.

## Issue / Bugzilla link
#11026 

## Testing
In your .env file set:
```
SWITCH_FUNDRAISING_BANNER_EOY2021=False
SWITCH_POCKET_BANNER=False
SWITCH_VPN_PROMO_BANNER=True
```
http://localhost:8000/en-US/ (also en-GB and en-CA)
http://localhost:8000/en-US/firefox/ (also en-GB and en-CA)
http://localhost:8000/de/
http://localhost:8000/de/firefox/
http://localhost:8000/fr/
http://localhost:8000/fr/firefox/