### PR TITLE
Add missing meta descriptions to Pocket pages (Fixes #11039)

### DIFF
--- a/bedrock/externalpages/templates/externalpages/pocket/about.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/about.html
@@ -8,6 +8,8 @@
 
 {% block page_title %}About Us{% endblock %}
 
+{% block page_desc %}Pocket empowers people to keep their minds focused, stimulated, and nourished. We’re powered by a community of interesting people with curious minds.{% endblock %}
+
 {% block pocket_css %}
   {{ css_bundle('pocket-about') }}
 {% endblock  %}

--- a/bedrock/externalpages/templates/externalpages/pocket/add.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/add.html
@@ -8,7 +8,7 @@
 
 {% from "macros-protocol.html" import split with context %}
 
-{% block page_title %} How to Save {% endblock %}
+{% block page_title %}How to Save{% endblock %}
 
 {% block pocket_css %}
   {{ css_bundle('pocket-add') }}

--- a/bedrock/externalpages/templates/externalpages/pocket/android.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/android.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-android.jpg' %}
 
-{% block page_title %} Pocket for Android {% endblock %}
+{% block page_title %}Pocket for Android{% endblock %}
 
-{% block page_desc %} View your list on your Android device. Download the free Pocket app from Google Play. {% endblock %}
+{% block page_desc %}View your list on your Android device. Download the free Pocket app from Google Play.{% endblock %}
 
-{% block page_cta %} Get the app {% endblock %}
+{% block page_cta %}Get the app{% endblock %}
 
 {% block page_url %}https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro{% endblock %}

--- a/bedrock/externalpages/templates/externalpages/pocket/base.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/base.html
@@ -9,7 +9,7 @@
     {% block shared_meta %}
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-      <meta name="description" content="{% block page_desc%}pocket_desc{% endblock %}"/>
+      <meta name="description" content="{% block page_desc %}When you find something you want to view later, put it in Pocket.{% endblock %}"/>
       <meta name="x-pocket-override-excerpt" content="{% block pocket_override %}{{ self.page_desc()}}{% endblock %}"/>
       <meta itemprop="name" content="{{ self.page_title() }} | Pocket" />
       <meta itemprop="description" content="{{ self.page_desc()}}"/>

--- a/bedrock/externalpages/templates/externalpages/pocket/chrome.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/chrome.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-chrome.jpg' %}
 
-{% block page_title %} Pocket for Chrome {% endblock %}
+{% block page_title %}Pocket for Chrome{% endblock %}
 
-{% block page_desc %} Installing the Pocket browser extension installs buttons that let you save items with one click. {% endblock %}
+{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
 
-{% block page_cta %} Install {% endblock %}
+{% block page_cta %}Install{% endblock %}
 
 {% block page_url %}https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj{% endblock %}

--- a/bedrock/externalpages/templates/externalpages/pocket/edge.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/edge.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-edge.jpg' %}
 
-{% block page_title %} Pocket for Edge {% endblock %}
+{% block page_title %}Pocket for Edge{% endblock %}
 
-{% block page_desc %} Installing the Pocket browser extension installs buttons that let you save items with one click. {% endblock %}
+{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
 
-{% block page_cta %} Install {% endblock %}
+{% block page_cta %}Install{% endblock %}
 
 {% block page_url %}https://microsoftedge.microsoft.com/addons/detail/save-to-pocket/jicacccodjjgmghnmekophahpmddeemd?source=sfw{% endblock %}

--- a/bedrock/externalpages/templates/externalpages/pocket/ios.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/ios.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-ios.jpg' %}
 
-{% block page_title %} Pocket for iOS {% endblock %}
+{% block page_title %}Pocket for iOS{% endblock %}
 
-{% block page_desc %} View your list on your iPhone or iPad. Download the free Pocket app for iOS from the App Store. {% endblock %}
+{% block page_desc %}View your list on your iPhone or iPad. Download the free Pocket app for iOS from the App Store.{% endblock %}
 
-{% block page_cta %} Get the app {% endblock %}
+{% block page_cta %}Get the app{% endblock %}
 
 {% block page_url %}https://apps.apple.com/app/read-it-later-pro/id309601447{% endblock %}

--- a/bedrock/externalpages/templates/externalpages/pocket/opera.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/opera.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-opera.jpg' %}
 
-{% block page_title %} Pocket for Opera {% endblock %}
+{% block page_title %}Pocket for Opera{% endblock %}
 
-{% block page_desc %} Installing the Pocket browser extension installs buttons that let you save items with one click. {% endblock %}
+{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
 
-{% block page_cta %} Install {% endblock %}
+{% block page_cta %}Install{% endblock %}
 
 {% block page_url %}https://addons.opera.com/en/extensions/details/pocket-formerly-read-it-later/?display=en{% endblock %}

--- a/bedrock/externalpages/templates/externalpages/pocket/safari.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/safari.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-safari.jpg' %}
 
-{% block page_title %} Pocket for Safari {% endblock %}
+{% block page_title %}Pocket for Safari{% endblock %}
 
-{% block page_desc %} Installing the Pocket browser extension installs buttons that let you save items with one click. {% endblock %}
+{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
 
-{% block page_cta %} Download {% endblock %}
+{% block page_cta %}Download{% endblock %}
 
 {% block page_url %}https://apps.apple.com/us/app/save-to-pocket/id1477385213?ls=1&mt=12{% endblock %}

--- a/bedrock/externalpages/templates/externalpages/pocket/welcome.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/welcome.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/externalpages/pocket/welcome-bookmarklet.jpg' %}
 
-{% block page_title %} Pocket for Your Browser {% endblock %}
+{% block page_title %}Pocket for Your Browser{% endblock %}
 
-{% block page_desc %} When browsing the web, simply push this button in your Bookmarks Bar to add pages to your Pocket list. {% endblock %}
+{% block page_desc %}When browsing the web, simply push this button in your Bookmarks Bar to add pages to your Pocket list.{% endblock %}
 
-{% block page_cta %} Log in {% endblock %}
+{% block page_cta %}Log in{% endblock %}
 
 {% block page_url %}https://getpocket.com/login/{% endblock %}


### PR DESCRIPTION
## Description
Added a default meta description in the base Pocket template (taken from the [home page](https://getpocket.com/en/)), as well as a missing description on the `/about` page. There are still some URLs such as `/add` and `/contact-info` that don't yet have a description (even in prod), but for now at least they can default to something.

## Issue / Bugzilla link
#11039

## Testing
http://localhost:8000/en-US/external/pocket/about/