### PR TITLE
Fix JS error parsing malformed utm values (Fixes #10897)

### DIFF
--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -178,9 +178,13 @@ if (typeof window.Mozilla === 'undefined') {
         for (var i = 0; i < acceptedParams.length; i++) {
             var acceptedParam = acceptedParams[i];
             if (Object.prototype.hasOwnProperty.call(params, acceptedParam)) {
-                var foundParam = decodeURIComponent(params[acceptedParam]);
-                if (allowedChars.test(foundParam)) {
-                    finalParams[acceptedParam] = foundParam;
+                try {
+                    var foundParam = decodeURIComponent(params[acceptedParam]);
+                    if (allowedChars.test(foundParam)) {
+                        finalParams[acceptedParam] = foundParam;
+                    }
+                } catch (e) {
+                    // silently drop malformed parameter values (issue #10897)
                 }
             }
         }

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -318,6 +318,23 @@ describe('fxa-utm-referral.js', function () {
                 encodedSource
             );
         });
+
+        it('should drop any malformed parameter values', function () {
+            const encodedData = {
+                utm_source: 'email',
+                utm_campaign: 'fxa',
+                utm_content: 'uns_footer%'
+            };
+
+            const encodedSource = {
+                utm_source: 'email',
+                utm_campaign: 'fxa'
+            };
+
+            expect(Mozilla.UtmUrl.getAttributionData(encodedData)).toEqual(
+                encodedSource
+            );
+        });
     });
 
     describe('appendToDownloadURL', function () {


### PR DESCRIPTION
## Description
Prevents malformed utm parameter values throwing an error when parsing attribution data.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10897

## Testing
Test URL: http://localhost:8000/en-US/products/vpn/?utm_source=test&utm_campaign=test&utm_contant=uns_footer%

- [ ] Page should not throw a JS error in the console.
- [ ] Both `utm_source` and `utm_campaign` should still be passed through to the subscription links in-page.
- [ ] `utm_content` should be dropped from inclusion, since the value is malformed.