### PR TITLE
Fix hover state on join modal for firefox/new (Fixes #9866)

### DIFF
--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -1396,6 +1396,20 @@ button.mzp-c-cta-link {
 
     .join-firefox-button {
         margin-bottom: $spacing-lg;
+
+        // Overriding visited link styling from Protocol
+        // https://github.com/mozilla/bedrock/issues/9866
+        // https://github.com/mozilla/protocol/issues/758
+        &:link,
+        &:visited {
+            color: $color-white;
+
+            &:hover,
+            &:active,
+            &:focus {
+                color: $color-white;
+            }
+        }
     }
 
     .mzp-c-button,


### PR DESCRIPTION
## Description
Fixes button color contrast issue on /firefox/new/ page.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9866

## Testing
1. Test in a **Firefox** browser that's **not** signed into a Firefox Account.
2. Open http://localhost:8000/en-US/firefox/new/
3. Click "Download Firefox" and wait for the modal to open.

- [x] Verify that the "Get More From Firefox" button text color is correct (you may need to click the link once and then repeat to see the visited link styles).