### PR TITLE
Fix trailing slash for platform urls [no bug]

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -132,9 +132,9 @@ urlpatterns = (
     page("firefox/switch", "firefox/switch.html", ftl_files=["firefox/switch"]),
     page("firefox/pocket", "firefox/pocket.html"),
     # Issue 6604, SEO firefox/new pages
-    path("firefox/linux", views.PlatformViewLinux.as_view(), name="firefox.linux"),
-    path("firefox/mac", views.PlatformViewMac.as_view(), name="firefox.mac"),
-    path("firefox/windows", views.PlatformViewWindows.as_view(), name="firefox.windows"),
+    path("firefox/linux/", views.PlatformViewLinux.as_view(), name="firefox.linux"),
+    path("firefox/mac/", views.PlatformViewMac.as_view(), name="firefox.mac"),
+    path("firefox/windows/", views.PlatformViewWindows.as_view(), name="firefox.windows"),
     page(
         "firefox/browsers/compare",
         "firefox/browsers/compare/index.html",

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -104,14 +104,14 @@ urlpatterns = (
     page("moss/secure-open-source", "mozorg/moss/secure-open-source.html"),
     path("robots.txt", views.Robots.as_view(), name="robots.txt"),
     # namespaces
-    path("2004/em-rdf/", views.namespaces, {"namespace": "em-rdf"}),
-    path("2005/app-update/", views.namespaces, {"namespace": "update"}),
-    path("2006/addons-blocklist/", views.namespaces, {"namespace": "addons-bl"}),
+    path("2004/em-rdf", views.namespaces, {"namespace": "em-rdf"}),
+    path("2005/app-update", views.namespaces, {"namespace": "update"}),
+    path("2006/addons-blocklist", views.namespaces, {"namespace": "addons-bl"}),
     path("2006/browser/search/", views.namespaces, {"namespace": "mozsearch"}),
     path("keymaster/gatekeeper/there.is.only.xul", views.namespaces, {"namespace": "xul"}),
-    path("microsummaries/0.1/", views.namespaces, {"namespace": "microsummaries"}),
-    path("projects/xforms/2005/type/", views.namespaces, {"namespace": "xforms-type"}),
-    path("xbl/", views.namespaces, {"namespace": "xbl"}),
+    path("microsummaries/0.1", views.namespaces, {"namespace": "microsummaries"}),
+    path("projects/xforms/2005/type", views.namespaces, {"namespace": "xforms-type"}),
+    path("xbl", views.namespaces, {"namespace": "xbl"}),
     page("locales", "mozorg/locales.html"),
 )
 

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -104,14 +104,14 @@ urlpatterns = (
     page("moss/secure-open-source", "mozorg/moss/secure-open-source.html"),
     path("robots.txt", views.Robots.as_view(), name="robots.txt"),
     # namespaces
-    path("2004/em-rdf", views.namespaces, {"namespace": "em-rdf"}),
-    path("2005/app-update", views.namespaces, {"namespace": "update"}),
-    path("2006/addons-blocklist", views.namespaces, {"namespace": "addons-bl"}),
+    path("2004/em-rdf/", views.namespaces, {"namespace": "em-rdf"}),
+    path("2005/app-update/", views.namespaces, {"namespace": "update"}),
+    path("2006/addons-blocklist/", views.namespaces, {"namespace": "addons-bl"}),
     path("2006/browser/search/", views.namespaces, {"namespace": "mozsearch"}),
     path("keymaster/gatekeeper/there.is.only.xul", views.namespaces, {"namespace": "xul"}),
-    path("microsummaries/0.1", views.namespaces, {"namespace": "microsummaries"}),
-    path("projects/xforms/2005/type", views.namespaces, {"namespace": "xforms-type"}),
-    path("xbl", views.namespaces, {"namespace": "xbl"}),
+    path("microsummaries/0.1/", views.namespaces, {"namespace": "microsummaries"}),
+    path("projects/xforms/2005/type/", views.namespaces, {"namespace": "xforms-type"}),
+    path("xbl/", views.namespaces, {"namespace": "xbl"}),
     page("locales", "mozorg/locales.html"),
 )
 


### PR DESCRIPTION
## Description

Started seeing functional test failures after https://github.com/mozilla/bedrock/pull/11047
https://gitlab.com/mozmeao/www-config/-/pipelines/431529045

Platform pages 404 with a trailing slash before the ?automation=true param:
http://localhost:8000/en-US/firefox/windows/?automation=true is 404
http://localhost:8000/en-US/firefox/windows?automation=true is fine 

Urls using the new `path` helper should have trailing slashes 

## Issue / Bugzilla link
no bug

## Testing
Functional tests should pass and
http://localhost:8000/en-US/firefox/windows/?automation=true should be working

Successful test run:
https://gitlab.com/mozmeao/www-config/-/pipelines/431817259
