### PR TITLE
Add a timeout to cron tasks, to avoid a long-running blockage

### DIFF
--- a/bin/cron.py
+++ b/bin/cron.py
@@ -44,15 +44,18 @@ DEAD_MANS_SNITCH_URL = config("DEAD_MANS_SNITCH_URL", default="")
 MANAGE = str(ROOT_PATH / "manage.py")
 HEALTH_FILE_BASE = f"{DATA_PATH}/last-run"
 
-TIMEOUT = 60 * 9
+# The jobs are run every five minutes, so should all normally complete within that
+# timeframe. If they don't (eg, they've hung), we set a timeout just before then,
+# so that they are killed and we will try again.
+TIMEOUT_SECS = 290  # Just shy of five minutes.
 
 
 def set_updated_time(name):
-    check_call("touch {}-{}".format(HEALTH_FILE_BASE, name), shell=True, timeout=TIMEOUT)
+    check_call("touch {}-{}".format(HEALTH_FILE_BASE, name), shell=True, timeout=TIMEOUT_SECS)
 
 
 def call_command(command):
-    check_call("python {0} {1}".format(MANAGE, command), shell=True, timeout=TIMEOUT)
+    check_call("python {0} {1}".format(MANAGE, command), shell=True, timeout=TIMEOUT_SECS)
 
 
 class scheduled_job:
@@ -109,9 +112,9 @@ def schedule_database_jobs():
         if time_since > 21600:  # 6 hours
             command += " --all"
 
-        check_call(command, shell=True, timeout=TIMEOUT)
+        check_call(command, shell=True, timeout=TIMEOUT_SECS)
         if not LOCAL_DB_UPDATE:
-            check_call("python bin/run-db-upload.py", shell=True, timeout=TIMEOUT)
+            check_call("python bin/run-db-upload.py", shell=True, timeout=TIMEOUT_SECS)
 
         if command.endswith("--all"):
             # must set this after command run so that it won't update
@@ -134,7 +137,7 @@ def schedule_file_jobs():
             if DB_DOWNLOAD_IGNORE_GIT:
                 command += " --ignore-git"
 
-            check_call(command, shell=True, timeout=TIMEOUT)
+            check_call(command, shell=True, timeout=TIMEOUT_SECS)
 
 
 def main(args):

--- a/bin/cron.py
+++ b/bin/cron.py
@@ -53,7 +53,7 @@ HEALTH_FILE_BASE = f"{DATA_PATH}/last-run"
 TIMEOUT_SECS = 290  # Just shy of five minutes.
 
 
-sentry_dsn = config("SENTRY_DSN")
+sentry_dsn = config("SENTRY_DSN", raise_error=False)
 if sentry_dsn:
     # Set up Sentry logging if we can.
     sentry_logging = LoggingIntegration(

--- a/bin/cron.py
+++ b/bin/cron.py
@@ -44,13 +44,15 @@ DEAD_MANS_SNITCH_URL = config("DEAD_MANS_SNITCH_URL", default="")
 MANAGE = str(ROOT_PATH / "manage.py")
 HEALTH_FILE_BASE = f"{DATA_PATH}/last-run"
 
+TIMEOUT = 60 * 9
+
 
 def set_updated_time(name):
-    check_call("touch {}-{}".format(HEALTH_FILE_BASE, name), shell=True)
+    check_call("touch {}-{}".format(HEALTH_FILE_BASE, name), shell=True, timeout=TIMEOUT)
 
 
 def call_command(command):
-    check_call("python {0} {1}".format(MANAGE, command), shell=True)
+    check_call("python {0} {1}".format(MANAGE, command), shell=True, timeout=TIMEOUT)
 
 
 class scheduled_job:
@@ -107,9 +109,9 @@ def schedule_database_jobs():
         if time_since > 21600:  # 6 hours
             command += " --all"
 
-        check_call(command, shell=True)
+        check_call(command, shell=True, timeout=TIMEOUT)
         if not LOCAL_DB_UPDATE:
-            check_call("python bin/run-db-upload.py", shell=True)
+            check_call("python bin/run-db-upload.py", shell=True, timeout=TIMEOUT)
 
         if command.endswith("--all"):
             # must set this after command run so that it won't update
@@ -132,7 +134,7 @@ def schedule_file_jobs():
             if DB_DOWNLOAD_IGNORE_GIT:
                 command += " --ignore-git"
 
-            check_call(command, shell=True)
+            check_call(command, shell=True, timeout=TIMEOUT)
 
 
 def main(args):


### PR DESCRIPTION
## Description

This was suggested by @duallain following a minor problem where a scheduled sync
task stalled/failed during an infrastructure outage and just hung. Adding a
timeout should avoid this happening again.

~Nine minutes is a gut-feel for a reasonable time, allowing for long-running syncs, but maybe we can go with less - 4 mins?~

## Issue / Bugzilla link

Resolves #11038

## Testing

Tricky to test - suggestions welcome!