### PR TITLE
10886: Update Contentful sync to allow non-Prod environments to treat saved/draft content as worth syncing.

### DIFF
--- a/bedrock/contentful/management/commands/update_contentful.py
+++ b/bedrock/contentful/management/commands/update_contentful.py
@@ -178,12 +178,8 @@ class Command(BaseCommand):
             ACTION_SAVE,
         }
 
-        if settings.APP_NAME in [
+        if settings.APP_NAME != "bedrock-prod":
             # See settings.base.get_app_name()
-            "bedrock",  # Default, returned for local dev
-            "bedrock-dev",
-            "bedrock-stage",
-        ]:
             GO_ACTIONS = GO_ACTIONS.union(EXTRA_PREVIEW_API_GO_ACTIONS)
 
         if not settings.CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID:

--- a/bedrock/contentful/management/commands/update_contentful.py
+++ b/bedrock/contentful/management/commands/update_contentful.py
@@ -150,10 +150,10 @@ class Command(BaseCommand):
 
         What action types count as a 'go' signal?
 
-        * auto_save -> YES if on Dev (ie, preview mode)
-        * create -> NO - not on prod or on DEV
+        * auto_save -> YES if using preview mode (ie on Dev/Stage)
+        * create -> NO, NEVER - not on Prod, Stage or Dev
         * publish -> YES
-        * save -> YES if on Dev (ie, preview mode)
+        * save -> YES if using preview mode
         * unarchive -> YES
         * archive -> YES (and we'll remove the page from bedrock's DB as well)
         * unpublish  -> YES (as above)
@@ -178,7 +178,12 @@ class Command(BaseCommand):
             ACTION_SAVE,
         }
 
-        if not settings.PROD:
+        if settings.APP_NAME in [
+            # See settings.base.get_app_name()
+            "bedrock",  # Default, returned for local dev
+            "bedrock-dev",
+            "bedrock-stage",
+        ]:
             GO_ACTIONS = GO_ACTIONS.union(EXTRA_PREVIEW_API_GO_ACTIONS)
 
         if not settings.CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID:

--- a/bedrock/contentful/management/commands/update_contentful.py
+++ b/bedrock/contentful/management/commands/update_contentful.py
@@ -171,13 +171,15 @@ class Command(BaseCommand):
             ACTION_UNPUBLISH,
             ACTION_DELETE,
         }
-        EXTRA_DEV_GO_ACTIONS = {
+        EXTRA_PREVIEW_API_GO_ACTIONS = {
+            # Sites that are using the preview API key (Dev and Stage) act upon
+            # two more state changes
             ACTION_AUTO_SAVE,
             ACTION_SAVE,
         }
 
-        if settings.DEV:
-            GO_ACTIONS = GO_ACTIONS.union(EXTRA_DEV_GO_ACTIONS)
+        if not settings.PROD:
+            GO_ACTIONS = GO_ACTIONS.union(EXTRA_PREVIEW_API_GO_ACTIONS)
 
         if not settings.CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID:
             self.log(

--- a/bedrock/contentful/tests/test_commands.py
+++ b/bedrock/contentful/tests/test_commands.py
@@ -180,7 +180,7 @@ def _establish_mock_queue(batched_messages: List[List]) -> Tuple[mock.Mock, mock
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    DEV=True,
+    APP_NAME="bedrock-dev",
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(
@@ -276,7 +276,7 @@ def test_update_contentful__queue_has_viable_messages__viable_message_found__pro
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    DEV=True,
+    APP_NAME="bedrock-dev",
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(
@@ -298,7 +298,7 @@ def test_update_contentful__queue_has_viable_messages__no_viable_message_found__
     command_instance,
 ):
     # Create is the only message that will not trigger a contenful poll in Dev
-    assert settings.DEV is True
+    assert settings.APP_NAME == "bedrock-dev"
     messages_for_queue = _build_mock_messages(message_actions_sequence)
     mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
 
@@ -310,7 +310,7 @@ def test_update_contentful__queue_has_viable_messages__no_viable_message_found__
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    PROD=True,
+    APP_NAME="bedrock-prod",
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(
@@ -337,7 +337,7 @@ def test_update_contentful__queue_has_viable_messages__no_viable_message_found__
 ):
     # In prod mode we don't want creation or draft editing to trigger a
     # re-poll of the API because it's unnecessary.
-    assert settings.PROD is True
+    assert settings.APP_NAME == "bedrock-prod"
     messages_for_queue = _build_mock_messages(message_actions_sequence)
     mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
 
@@ -387,7 +387,7 @@ def test_update_contentful__iteration_through_message_batch_thresholds(
 ):
     # ie, show we handle less and more than 10 messages in the queue.
     # Only the last message in each test case is viable, because
-    # ACTION_CREATE should not trigger anything in Dev or Prod
+    # ACTION_CREATE should NOT trigger anything in Dev, Stage or Prod
     messages_for_queue = _build_mock_messages(message_actions_sequence)
     mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
 
@@ -399,7 +399,7 @@ def test_update_contentful__iteration_through_message_batch_thresholds(
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    DEV=True,
+    APP_NAME="bedrock-dev",
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 def test_update_contentful__queue_has_viable_messages__no_messages(

--- a/bedrock/contentful/tests/test_commands.py
+++ b/bedrock/contentful/tests/test_commands.py
@@ -230,7 +230,7 @@ def test_update_contentful__queue_has_viable_messages__viable_message_found__dev
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    DEV=False,
+    APP_NAME="bedrock-prod",
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(
@@ -362,7 +362,7 @@ def test_queue_has_viable_messages__no_sqs_configured(
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    PROD=False,
+    APP_NAME="bedrock-dev",
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(

--- a/bedrock/contentful/tests/test_commands.py
+++ b/bedrock/contentful/tests/test_commands.py
@@ -310,7 +310,7 @@ def test_update_contentful__queue_has_viable_messages__no_viable_message_found__
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    DEV=False,
+    PROD=True,
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(
@@ -337,7 +337,7 @@ def test_update_contentful__queue_has_viable_messages__no_viable_message_found__
 ):
     # In prod mode we don't want creation or draft editing to trigger a
     # re-poll of the API because it's unnecessary.
-    assert settings.DEV is False
+    assert settings.PROD is True
     messages_for_queue = _build_mock_messages(message_actions_sequence)
     mock_sqs, mock_queue = _establish_mock_queue(messages_for_queue)
 
@@ -362,7 +362,7 @@ def test_queue_has_viable_messages__no_sqs_configured(
 
 @override_settings(
     CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID="dummy",
-    DEV=True,
+    PROD=False,
 )
 @mock.patch("bedrock.contentful.management.commands.update_contentful.boto3")
 @pytest.mark.parametrize(

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -37,9 +37,16 @@ def data_path(*args):
     return abspath(str(DATA_PATH.joinpath(*args)))
 
 
-# Is this a dev instance?
+# Is this a development-mode deployment where we might have
+# extra behaviour/helpers/URLs enabled? (eg, local dev or demo)
+# (Don't infer that this specifically means our Dev _deployment_
+# - it doesn't. You can use APP_NAME, below, to get that)
 DEV = config("DEV", parser=bool, default="false")
+
+# Is this particular deployment running in _production-like_ mode?
+# (This will include the Dev and Staging deployments, for instance)
 PROD = config("PROD", parser=bool, default="false")
+
 DEBUG = config("DEBUG", parser=bool, default="false")
 DATABASES = {
     "default": {

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -503,7 +503,8 @@ def get_app_name(hostname):
 
     The hostname in our deployments will be in the form `bedrock-{version}-{type}-{random-ID}`
     where {version} is "dev", "stage", or "prod", and {type} is the process type
-    (e.g. "web" or "clock"). Everywhere else it won't be in this form and will return None.
+    (e.g. "web" or "clock"). Everywhere else the hostname won't be in this form and
+    this helper will just return a default string.
     """
     if hostname.startswith("bedrock-"):
         app_mode = hostname.split("-")[1]


### PR DESCRIPTION
## Description

This doesn't affect prod behaviour, but we have had to swap from checking 'is this dev' to 'is this NOT prod', 
rather than introduce a new settings.STAGING variable

~NB BLOCKED by PR 280 in the infra repo, which needs to be merged first to avoid errors on staging~

## Issue / Bugzilla link

Resolves #10886

## Testing

Tricky to test - let's DM about it
