### PR TITLE
Code /privacy and add cookies scripts (Fixes #10762)

### DIFF
--- a/bedrock/externalpages/templates/externalpages/pocket/base.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/base.html
@@ -27,7 +27,16 @@
       <meta property="og:site_name" content="Pocket" />
       <link rel="icon" type="image/png" sizes="196x196" href="{% block page_favicon_large %}{{ static('img/favicons/pocket/favicon-196x196.png') }}{% endblock %}">
       <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicons/pocket/favicon.ico') }}{% endblock %}">
-    {% endblock shared_meta %}
+      {% endblock shared_meta %}
+      <!-- OneTrust Cookies Consent Notice start for getpocket.com -->
+      <script type="text/javascript" src="https://cdn.cookielaw.org/consent/a7ff9c31-9f59-421f-9a8e-49b11a3eb24e/OtAutoBlock.js"></script>
+      <script type="text/javascript" src="https://cdn.cookielaw.org/consent/a7ff9c31-9f59-421f-9a8e-49b11a3eb24e/otSDKStub.js" charset="UTF-8"data-domain-script="a7ff9c31-9f59-421f-9a8e-49b11a3eb24e"></script>
+      <script type="text/javascript">
+        function OptanonWrapper() {}
+      </script>
+      <!-- end OneTrust Cookies Consent Notice -->
+      {# Cookie Helper #}
+      <script src="{{ static('js/base/mozilla-cookie-helper.js') }}"></script>
 
     {% block pocket_css %}{% endblock  %}
 

--- a/bedrock/externalpages/templates/externalpages/pocket/includes/footer.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/includes/footer.html
@@ -87,7 +87,7 @@
               <span>© 2021 Read It Later, Inc.</span>
               <a href="https://getpocket.com/privacy?src=footer_v2">Privacy policy</a>
               <a href="https://getpocket.com/tos?src=footer_v2">Terms of service</a>
-              <button id="ot-sdk-btn" class="cookie-show-settings">Cookie preferences</button>
+              <button id="ot-sdk-btn" class="ot-sdk-show-settings">Cookie preferences</button>
             </div>
           </div>
           <ul class="pocket-footer-socials">

--- a/bedrock/externalpages/templates/externalpages/pocket/privacy.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/privacy.html
@@ -33,10 +33,10 @@
         <li><a href="#transfer">Transfer of Information</a></li>
         <li><a href="#keeping">Keeping Information</a></li>
         <li><a href="#security">Security</a></li>
-        <li><a href="">Phishing</a></li>
-        <li><a href="">Managing My Privacy and Email Settings</a></li>
-        <li><a href="">Amendments to Policy</a></li>
-        <li><a href="">Contact</a></li>
+        <li><a href="#phishing">Phishing</a></li>
+        <li><a href="#manage">Managing My Privacy and Email Settings</a></li>
+        <li><a href="#policy">Amendments to Policy</a></li>
+        <li><a href="#contact">Contact</a></li>
       </ul>
     </section>
 
@@ -79,7 +79,7 @@
       <p>We also have a legitimate business interest to operate and improve our services such as saving articles, videos, or other content to Pocket and making such content and recommendations available to you at a later time on any device that you use to access the Pocket Technologies. We also use non-identifying, aggregated information to analyze the manner in which the Pocket Technologies are used, which also allows us to improve our services. The aggregated information we use includes the manner in which articles, videos, or content has been accessed, saved and shared. We may use aggregated information to offer a list of top sites or content, to make recommendations to our users, to report on usage and trends, to improve the products and services that we offer, or to develop new products and services.</p>
     </section>
 
-    <section id="#sharing">
+    <section id="sharing">
       <h2>Sharing of Information</h2>
       <p>Except as set forth below, we do not share any personally identifiable information unless you expressly agree that we may do so.</p>
       <h3>Public content</h3>
@@ -96,7 +96,7 @@
     </section>
 
     <section id="keeping">
-      <h2>keeping information</h2>
+      <h2>Keeping information</h2>
       <p>We will keep your information only for as long as we need it to provide you services, manage our business or as required by law or contract.</p>
     </section>
 

--- a/bedrock/externalpages/templates/externalpages/pocket/privacy.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/privacy.html
@@ -41,19 +41,19 @@
     </section>
 
     <section id="user">
-      <h2>USER ACCOUNTS AND COLLECTION OF INFORMATION</h2>
+      <h2>User accounts and collection of information</h2>
       <p>You are not required to create a user account or provide any personal information in order to visit the Pocket website. You are required to create a user account, however, to use our application. During registration, you are required to provide a name, password and valid email address.</p>
       <p>If you choose to share any articles, videos, or other content with another person, we will ask you to provide a valid email address for that person. We may also ask you to provide your username and password for third party websites in order to access the articles and information published on such sites. We also collect information if you contact us for support or help, submit an application or otherwise communicate with us. The information which you supply to us enables us to customize and enhance the services we provide to you. In addition, it helps us communicate with you about our news, events, promotions and new products.</p>
       <p>If you choose to subscribe to our paid subscription service, our third party payment processors will collect and handle your credit card and related payment information. Such third party processors’ use of your personal information is governed by their respective privacy policies.</p>
     </section>
 
     <section id="collection">
-      <h2>COLLECTION OF INFORMATION AS PART OF USING POCKET SERVICE</h2>
+      <h2>Collection of information as part of using pocket service</h2>
       <p>In addition to the information that you provide to us when you register for a user account, we collect information about the URLs, titles and content of the web pages and other information you save to Pocket. The types of information we collect includes your browser type, device type, time zone, language, and other information related to the manner in which you access the Pocket Technologies. If you are on a mobile device, we collect the advertising identifiers provided by Apple on iOS and by Google on Android. You can change this identifier in your device settings. We also collect information about your use of the Pocket Technologies so that we can provide our services. For example, as a part of providing Pocket’s syncing features, we sync information about the items that you save and view within Pocket so that your list, tags, scroll position, and other account and usage information may be synced across all of your devices.</p>
     </section>
 
     <section id="cookies">
-      <h2>USE OF COOKIES AND ANALYTICS</h2>
+      <h2>Use of cookies and analytics</h2>
       <h3 class="cookies-subheading">Types and Purposes</h3>
       <p>We use cookies and analytics tools for the following purposes:</p>
       <ul>
@@ -74,12 +74,13 @@
     </section>
 
     <section id="info">
-      <h2>USE OF INFORMATION</h2>
+      <h2>Use of information</h2>
       <p>We use your personal information to respond to your requests and perform our contract with you. We may do this, for example, by using your contact information to respond to your inquiries, to provide customer support and to supply any products or services you have requested. In addition, if you choose to use the Pocket Technologies to share content with another person, we will use the recipient's email address or user account information to provide that service, but we will not use that email address for any other purpose.</p>
       <p>We also have a legitimate business interest to operate and improve our services such as saving articles, videos, or other content to Pocket and making such content and recommendations available to you at a later time on any device that you use to access the Pocket Technologies. We also use non-identifying, aggregated information to analyze the manner in which the Pocket Technologies are used, which also allows us to improve our services. The aggregated information we use includes the manner in which articles, videos, or content has been accessed, saved and shared. We may use aggregated information to offer a list of top sites or content, to make recommendations to our users, to report on usage and trends, to improve the products and services that we offer, or to develop new products and services.</p>
     </section>
+
     <section id="#sharing">
-      <h2>SHARING OF INFORMATION</h2>
+      <h2>Sharing of Information</h2>
       <p>Except as set forth below, we do not share any personally identifiable information unless you expressly agree that we may do so.</p>
       <h3>Public content</h3>
       <p>If you choose to make the content you save publicly available, we may share that information with others in accordance with the options you select. In addition, if you choose to use the Pocket Technologies to share articles, videos, or other content with another person, we will send an email on your behalf to that person with a link to the content that you have chosen to share.</p>
@@ -95,33 +96,33 @@
     </section>
 
     <section id="keeping">
-      <h2>KEEPING INFORMATION</h2>
+      <h2>keeping information</h2>
       <p>We will keep your information only for as long as we need it to provide you services, manage our business or as required by law or contract.</p>
     </section>
 
     <section id="transfer">
-      <h2>TRANSFER OF INFORMATION</h2>
+      <h2>Transfer of Information</h2>
       <p>We're a global organization and our computers are in several different places around the world. We also use service providers whose computers may also be in various countries. This means that your information might end up on one of those computers in another country, and that country may have a different level of data protection regulation than yours. By giving us information, you consent to this kind of transfer of your information. No matter what country your information is in, we comply with applicable law and will also abide by the commitments we make in this privacy policy.</p>
     </section>
 
     <section id="security">
-      <h2>SECURITY</h2>
+      <h2>Security</h2>
       <p>We have agreements with third parties and have adopted other security measures in place to protect against the loss, misuse and/or unauthorized alteration of the information under our control or under the control of our service providers. Your personally identifiable information is protected by utilizing both online and offline security methods, including firewalls, passwords and restricted physical access to the places where your information is stored. Although we use industry standard practices to protect your privacy, we do not promise, and you should not expect, that your personal information or private communications will always remain free from security issues. In the event of a security breach involving your personal information, we will make any legally required disclosures to you in the most expedient time possible and without unreasonable delay, consistent with the legitimate interests of law enforcement, or any measures necessary to determine the scope of the breach and restore the reasonable integrity of the data system.</p>
     </section>
 
     <section id="phishing">
-      <h2>PHISHING</h2>
+      <h2>Phishing</h2>
       <p>Identity theft and the practice currently known as "phishing" are of great concern to Pocket. Safeguarding information to help protect you from identity theft is a top priority. We do not and will not, at any time, request your username, password, credit card information or national identification number in an unsolicited e-mail or telephone communication. For more information about phishing, visit the Federal Trade Commission’s website.</p>
     </section>
 
     <section id="manage">
-      <h2>MANAGING MY PRIVACY AND EMAIL SETTINGS</h2>
-      <p>You can access, correct, or delete your personal information and export your data from your Pocket Profile. You can also view and control which third party services, if any, you want to connect to your Pocket account. These settings are at: https://getpocket.com/options</p>
+      <h2>Managing my privacy and email settings</h2>
+      <p>You can access, correct, or delete your personal information and export your data from your Pocket Profile. You can also view and control which third party services, if any, you want to connect to your Pocket account. These settings are at: <a href="https://getpocket.com/options">https://getpocket.com/options</a></p>
       <p>As part of our default settings to share saved and recommended content, we send emails to our users. You may opt-out of receiving these, and updates on our service and your use, by using the unsubscribe feature on any of our email correspondence or from your account settings. We will try to communicate with you only according to your instructions, although it may take some time to process your request.</p>
     </section>
 
     <section id="policy">
-      <h2>AMENDMENTS TO POLICY</h2>
+      <h2>Amendments to policy</h2>
       <p>Please note this Privacy Policy will change from time to time. We may amend this Privacy Policy at any time by posting the amended terms on our Website that you can access at getpocket.com or through the options or help menu of the Pocket application. All amended terms shall automatically be effective thirty (30) days after they are initially posted on the Website. If we make any material changes to our Privacy Policy that affect user information already stored in our database, we will post a prominent notice on our Website notifying users that our Privacy Policy has changed. Our use of your information shall be governed by the terms and conditions of our Privacy Policy in effect when you first use our application or thirty (30) after the terms are changed, as explained above.</p>
       <p>If you have questions about any of the provisions described above, please contact us at <a href="mailto:privacy@getpocket.com">privacy@getpocket.com</a> or at the street address listed above.</p>
     </section>

--- a/bedrock/externalpages/templates/externalpages/pocket/privacy.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/privacy.html
@@ -1,0 +1,142 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "externalpages/pocket/base.html" %}
+
+{% from "macros-protocol.html" import split with context %}
+
+{% block pocket_css %}
+{{ css_bundle('pocket-privacy') }}
+{% endblock %}
+
+{% block page_title %}Privacy{% endblock page_title %}
+
+{% block content %}
+  {% include 'externalpages/pocket/includes/nav.html' %}
+  <div class="mzp-l-content mzp-t-content-xl pocket-privacy-wrapper">
+    <section>
+      <h1>Privacy Policy</h1>
+      <h2 class="date-heading">Posted October 11, 2021</h2>
+      <p>This notice describes the Privacy Policy that applies to all information collected or submitted when you install or use the Pocket application or any of the other proprietary software applications or services we provide, and when you visit our website (all of which are referred to collectively herein as the "Pocket Technologies"). The Pocket Technologies are owned and licensed by Mozilla Corporation (referred to herein as "we," "us," "our," "Mozilla"), and are operated by Mozilla's business unit known as "Pocket," which has developed applications and services for use in connection with a variety of devices and platforms, including without limitation, Windows, Mac, iPhone, iPad, Kindle Fire, Android, BlackBerry, Windows phone, Chrome, Safari, Firefox and other mobile devices and computers.</p>
+      <p>We understand your concerns about privacy. We want you to understand what types of information we collect and what may happen to that information if you install the Pocket application, visit the Pocket Website or use any of the Pocket Technologies.</p>
+      <p>Our Privacy Policy includes the following provisions, and you can jump to each by selecting the links below:</p>
+      <ul>
+        <li><a href="#user">User Accounts and Collection of Information</a></li>
+        <li><a href="#collection">Collection of Information as Part of Using Pocket Service</a></li>
+        <li><a href="#cookies">Use of Cookies and Analytics</a></li>
+        <li><a href="#info">Use of Information</a></li>
+        <li><a href="#sharing">Sharing of Information</a></li>
+        <li><a href="#keeping">Keeping Information</a></li>
+        <li><a href="#transfer">Transfer of Information</a></li>
+        <li><a href="#keeping">Keeping Information</a></li>
+        <li><a href="#security">Security</a></li>
+        <li><a href="">Phishing</a></li>
+        <li><a href="">Managing My Privacy and Email Settings</a></li>
+        <li><a href="">Amendments to Policy</a></li>
+        <li><a href="">Contact</a></li>
+      </ul>
+    </section>
+
+    <section id="user">
+      <h2>USER ACCOUNTS AND COLLECTION OF INFORMATION</h2>
+      <p>You are not required to create a user account or provide any personal information in order to visit the Pocket website. You are required to create a user account, however, to use our application. During registration, you are required to provide a name, password and valid email address.</p>
+      <p>If you choose to share any articles, videos, or other content with another person, we will ask you to provide a valid email address for that person. We may also ask you to provide your username and password for third party websites in order to access the articles and information published on such sites. We also collect information if you contact us for support or help, submit an application or otherwise communicate with us. The information which you supply to us enables us to customize and enhance the services we provide to you. In addition, it helps us communicate with you about our news, events, promotions and new products.</p>
+      <p>If you choose to subscribe to our paid subscription service, our third party payment processors will collect and handle your credit card and related payment information. Such third party processors’ use of your personal information is governed by their respective privacy policies.</p>
+    </section>
+
+    <section id="collection">
+      <h2>COLLECTION OF INFORMATION AS PART OF USING POCKET SERVICE</h2>
+      <p>In addition to the information that you provide to us when you register for a user account, we collect information about the URLs, titles and content of the web pages and other information you save to Pocket. The types of information we collect includes your browser type, device type, time zone, language, and other information related to the manner in which you access the Pocket Technologies. If you are on a mobile device, we collect the advertising identifiers provided by Apple on iOS and by Google on Android. You can change this identifier in your device settings. We also collect information about your use of the Pocket Technologies so that we can provide our services. For example, as a part of providing Pocket’s syncing features, we sync information about the items that you save and view within Pocket so that your list, tags, scroll position, and other account and usage information may be synced across all of your devices.</p>
+    </section>
+
+    <section id="cookies">
+      <h2>USE OF COOKIES AND ANALYTICS</h2>
+      <h3 class="cookies-subheading">Types and Purposes</h3>
+      <p>We use cookies and analytics tools for the following purposes:</p>
+      <ul>
+        <li>Necessary: These cookies are necessary for our website to function and to support our business. They cannot be switched off. For example, we use them to manage your login state, and our ad partners use them to display ads and measure impressions and clicks. You can set your browser to block or alert you about these cookies, but this may cause parts of the site to not work properly. These cookies do not store any personally identifiable information and unless Personalized Advertising Cookies are enabled, ads are non-personalized.</li>
+        <li>Analytics: We place these cookies on your device to help us understand how users engage with our website and product, and to remember your account preferences and language settings. For example, we use Google Analytics and other tools to understand which Pocket webpages are popular. We also use pixels in our emails in order to collect usage information.</li>
+        <li>Personalized Advertising: Some Pocket web pages have ads. If you choose, Pocket ad partners will place advertising cookies on your device to personalize the ads you see here and on other websites. If you play a YouTube video on Pocket, YouTube may place cookies on your device which can be used for personalization.</li>
+      </ul>
+      <h3 class="cookies-subheading">Your choices</h3>
+      <ul>
+        <li>Cookie Preference tool: By default, Pocket sets necessary and analytics cookies, and disables personalized advertising cookies. You can manage these cookies from this <button id="ot-sdk-btn" class="ot-sdk-show-settings">Cookie Prefrences</button> tool. <a href="https://help.getpocket.com/article/1163-pocket-website-cookies-faq">Learn more</a>.</li>
+        <li>Your browser: Your browser preferences menu can help you manage cookies and prevent cross-site tracking.</li>
+        <li>Google’s Analytics opt-out: Install the <a href="https://tools.google.com/dlpage/gaoptout">Google Analytics Opt-out Browser Add-on</a>, which prohibits data transmission to Google Analytics.</li>
+        <li>External opt-out tools: Some third- party organizations provide ways of opting out of personalized advertising delivered by participating companies. For information about how to opt-out, you can visit these organizations’ websites: <a href="https://optout.networkadvertising.org/?c=1">Network Advertising Initiative’s opt-out tools</a>, the <a href="https://optout.aboutads.info/?c=2&lang=EN">Digital Advertising Initiative’s Browser Check tool</a>, and the <a href="https://www.youronlinechoices.com/uk/your-ad-choices">European Interactive Digital Advertising Alliance Your Ad Choices</a>.</li>
+        <li>Your Right to Opt-Out of the Sale of Personal Information: Pocket does not share or sell your personal information. If you enable personalized advertising on Pocket, we allow advertisers to personalize your ads on Pocket and this may be considered a sale of your information under California’s privacy law. You can opt-out by navigating to your Cookie Preference tool → Personalized Advertising Cookies and toggling to “disabled”.</li>
+      </ul>
+      <p>In addition to the methods described above, we may also collect information using cookies or other technologies when you access our website or use Pocket Technologies. You may decline our cookies if your browser permits, although in that case you may not be able to use certain features, you may be required to enter your password more frequently during a session, and you may be unable to install or use certain Pocket Technologies. Cookies and other technologies make our Pocket Technologies easier to use and help us customize and personalize the services we provide based on your interests and activities.</p>
+      <p>We may also use "pixel tags," "web beacons," "clear GIFs" or similar means (individually or collectively "Pixel Tags") in connection with emails that we send to our users in order to collect usage data. We use Pixel Tags, other technologies and the information we collect to count users who have visited certain pages on our Website, to deliver branded services and to help determine the effectiveness of promotional or advertising campaigns.</p>
+    </section>
+
+    <section id="info">
+      <h2>USE OF INFORMATION</h2>
+      <p>We use your personal information to respond to your requests and perform our contract with you. We may do this, for example, by using your contact information to respond to your inquiries, to provide customer support and to supply any products or services you have requested. In addition, if you choose to use the Pocket Technologies to share content with another person, we will use the recipient's email address or user account information to provide that service, but we will not use that email address for any other purpose.</p>
+      <p>We also have a legitimate business interest to operate and improve our services such as saving articles, videos, or other content to Pocket and making such content and recommendations available to you at a later time on any device that you use to access the Pocket Technologies. We also use non-identifying, aggregated information to analyze the manner in which the Pocket Technologies are used, which also allows us to improve our services. The aggregated information we use includes the manner in which articles, videos, or content has been accessed, saved and shared. We may use aggregated information to offer a list of top sites or content, to make recommendations to our users, to report on usage and trends, to improve the products and services that we offer, or to develop new products and services.</p>
+    </section>
+    <section id="#sharing">
+      <h2>SHARING OF INFORMATION</h2>
+      <p>Except as set forth below, we do not share any personally identifiable information unless you expressly agree that we may do so.</p>
+      <h3>Public content</h3>
+      <p>If you choose to make the content you save publicly available, we may share that information with others in accordance with the options you select. In addition, if you choose to use the Pocket Technologies to share articles, videos, or other content with another person, we will send an email on your behalf to that person with a link to the content that you have chosen to share.</p>
+      <h3>Aggregate data</h3>
+      <p>We also share aggregated, non-personal data and related usage information, which does not contain any personal information which can identify you or any other individual user, with third parties, including content providers, website operators, advertisers and publishers. For example, we may share with a content provider a list of the most saved articles to Pocket based on an analysis of aggregated, anonymous user data, but we would not share with such content provider any personal information regarding such users.</p>
+      <h3>Links to other sites and apps</h3>
+      <p>If you choose to, you may connect your Pocket account to third-party applications to enable additional features like saving from your favorite apps or other unique features third-party developers have created. We have set up controls in the Pocket application so that you can control the information that is shared with third-party providers of products and services. For example, you may be informed that another app that you use wants to connect to your Pocket account. In some cases, such apps will request access to certain data in your Pocket account, such as your Pocket list or your preferred topics, sites and authors (which we have developed based on the content you have saved to Pocket), so that they can customize their services. Before such access is provided, however, you will be asked to authorize the sharing of any such information. Although the Pocket Technologies may be used in conjunction with third-party products and services, we are not affiliated with, and have no control over, such third parties. Except as otherwise expressly included in this Privacy Policy, this document only addresses the use and disclosure of information we collect from you and we encourage you to check the privacy policy of each third-party provider of products or services that you choose to connect your Pocket account to.</p>
+      <h3>Working with third parties</h3>
+      <p>We may work with trusted third parties to facilitate one or more aspects of the products,services, or features that we provide to you, and we may provide some of your personal information directly to these third parties. For example, as discussed above, we may use a third party payment processor to process payments for our paid subscription service. We may also share limited aggregated data with our advertising partners (read more in the “Aggregate data” section above). These parties are subject to confidentiality agreements with us and other legal restrictions that prohibit their use of the information we provide to them for any other purpose other than those discussed above, unless you have explicitly agreed or given your prior permission to them for additional uses. If you use the "Listen" feature, we may share the content of the article with a third party service in order to read the article aloud.</p>
+      <h3>Sharing as required by law or asset sale</h3>
+      <p>In the event that we or certain of our assets are acquired, user information may be included among the transferred assets.</p>
+      <p>Although we strive to protect the personal information of our users, we will release personal information if required by law or in the good-faith belief that such action is necessary. We follow the law whenever we receive requests about you from a government or related to a lawsuit. We will notify you when we are asked to hand over your personally identifiable information in this way unless we are legally prohibited from doing so. When we receive requests like this, we will only release your personally identifiable information if we have a good faith belief that disclosure is necessary or appropriate under applicable law. Nothing in this policy is intended to limit any legal defenses or objections that you may have to a third party's request to disclose your information.</p>
+    </section>
+
+    <section id="keeping">
+      <h2>KEEPING INFORMATION</h2>
+      <p>We will keep your information only for as long as we need it to provide you services, manage our business or as required by law or contract.</p>
+    </section>
+
+    <section id="transfer">
+      <h2>TRANSFER OF INFORMATION</h2>
+      <p>We're a global organization and our computers are in several different places around the world. We also use service providers whose computers may also be in various countries. This means that your information might end up on one of those computers in another country, and that country may have a different level of data protection regulation than yours. By giving us information, you consent to this kind of transfer of your information. No matter what country your information is in, we comply with applicable law and will also abide by the commitments we make in this privacy policy.</p>
+    </section>
+
+    <section id="security">
+      <h2>SECURITY</h2>
+      <p>We have agreements with third parties and have adopted other security measures in place to protect against the loss, misuse and/or unauthorized alteration of the information under our control or under the control of our service providers. Your personally identifiable information is protected by utilizing both online and offline security methods, including firewalls, passwords and restricted physical access to the places where your information is stored. Although we use industry standard practices to protect your privacy, we do not promise, and you should not expect, that your personal information or private communications will always remain free from security issues. In the event of a security breach involving your personal information, we will make any legally required disclosures to you in the most expedient time possible and without unreasonable delay, consistent with the legitimate interests of law enforcement, or any measures necessary to determine the scope of the breach and restore the reasonable integrity of the data system.</p>
+    </section>
+
+    <section id="phishing">
+      <h2>PHISHING</h2>
+      <p>Identity theft and the practice currently known as "phishing" are of great concern to Pocket. Safeguarding information to help protect you from identity theft is a top priority. We do not and will not, at any time, request your username, password, credit card information or national identification number in an unsolicited e-mail or telephone communication. For more information about phishing, visit the Federal Trade Commission’s website.</p>
+    </section>
+
+    <section id="manage">
+      <h2>MANAGING MY PRIVACY AND EMAIL SETTINGS</h2>
+      <p>You can access, correct, or delete your personal information and export your data from your Pocket Profile. You can also view and control which third party services, if any, you want to connect to your Pocket account. These settings are at: https://getpocket.com/options</p>
+      <p>As part of our default settings to share saved and recommended content, we send emails to our users. You may opt-out of receiving these, and updates on our service and your use, by using the unsubscribe feature on any of our email correspondence or from your account settings. We will try to communicate with you only according to your instructions, although it may take some time to process your request.</p>
+    </section>
+
+    <section id="policy">
+      <h2>AMENDMENTS TO POLICY</h2>
+      <p>Please note this Privacy Policy will change from time to time. We may amend this Privacy Policy at any time by posting the amended terms on our Website that you can access at getpocket.com or through the options or help menu of the Pocket application. All amended terms shall automatically be effective thirty (30) days after they are initially posted on the Website. If we make any material changes to our Privacy Policy that affect user information already stored in our database, we will post a prominent notice on our Website notifying users that our Privacy Policy has changed. Our use of your information shall be governed by the terms and conditions of our Privacy Policy in effect when you first use our application or thirty (30) after the terms are changed, as explained above.</p>
+      <p>If you have questions about any of the provisions described above, please contact us at <a href="mailto:privacy@getpocket.com">privacy@getpocket.com</a> or at the street address listed above.</p>
+    </section>
+
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>If you have questions or concerns regarding this Privacy Policy, you should contact us at <a href="mailto:privacy@getpocket.com">privacy@getpocket.com</a> or <a href="https://help.getpocket.com/contact">https://help.getpocket.com/contact</a>. Alternatively, you may contact us at:</p>
+       <address class="contact-info-body-text address">
+        Mozilla Corporation/Pocket Business Unit <br/>
+        2 Harrison Street, Suite 175 <br/>
+        San Francisco, CA 94105 <br/>
+        <a href="tel:4156926111" aria-label="4 1 5. 6 9 2. 6 1 1 1.">415-692-6111</a>
+    </address>
+    <p>Europeans who believe a privacy complaint is unresolved have the right to lodge a complaint with the supervisory authority of their Member State.</p>
+    </section>
+  </div>
+  {% include 'externalpages/pocket/includes/footer.html' %}
+{% endblock %}

--- a/bedrock/externalpages/urls.py
+++ b/bedrock/externalpages/urls.py
@@ -18,4 +18,5 @@ urlpatterns = (
     page("pocket/firefox/new_tab_learn_more", "externalpages/pocket/firefox/new-tab-learn-more.html"),
     page("pocket/get-inspired", "externalpages/pocket/get-inspired.html"),
     page("pocket/jobs", "externalpages/pocket/jobs.html"),
+    page("pocket/privacy", "externalpages/pocket/privacy.html"),
 )

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1149,7 +1149,7 @@ CSP_IMG_SRC = CSP_DEFAULT_SRC + [
     "cdn-3.convertexperiments.com",
     "logs.convertexperiments.com",
     "images.ctfassets.net",
-    "cdn.cookielaw.org"
+    "cdn.cookielaw.org",
 ]
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
@@ -1167,13 +1167,13 @@ CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + [
     "data.track.convertexperiments.com",
     "1003350.track.convertexperiments.com",
     "1003343.track.convertexperiments.com",
-    "cdn.cookielaw.org"
+    "cdn.cookielaw.org",
 ]
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
     "app.convert.com",
-    "cdn.cookielaw.org"
+    "cdn.cookielaw.org",
 ]
 CSP_CHILD_SRC = CSP_DEFAULT_SRC + [
     "www.googletagmanager.com",
@@ -1184,7 +1184,7 @@ CSP_CHILD_SRC = CSP_DEFAULT_SRC + [
     "accounts.firefox.com",
     "accounts.firefox.com.cn",
     "www.youtube.com",
-    "cdn.cookielaw.org"
+    "cdn.cookielaw.org",
 ]
 CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "www.googletagmanager.com",

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1173,6 +1173,7 @@ CSP_STYLE_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
     "app.convert.com",
+    "cdn.cookielaw.org"
 ]
 CSP_CHILD_SRC = CSP_DEFAULT_SRC + [
     "www.googletagmanager.com",
@@ -1183,6 +1184,7 @@ CSP_CHILD_SRC = CSP_DEFAULT_SRC + [
     "accounts.firefox.com",
     "accounts.firefox.com.cn",
     "www.youtube.com",
+    "cdn.cookielaw.org"
 ]
 CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "www.googletagmanager.com",

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1173,7 +1173,6 @@ CSP_STYLE_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
     "app.convert.com",
-    "cdn.cookielaw.org",
 ]
 CSP_CHILD_SRC = CSP_DEFAULT_SRC + [
     "www.googletagmanager.com",
@@ -1184,7 +1183,6 @@ CSP_CHILD_SRC = CSP_DEFAULT_SRC + [
     "accounts.firefox.com",
     "accounts.firefox.com.cn",
     "www.youtube.com",
-    "cdn.cookielaw.org",
 ]
 CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "www.googletagmanager.com",

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1149,6 +1149,7 @@ CSP_IMG_SRC = CSP_DEFAULT_SRC + [
     "cdn-3.convertexperiments.com",
     "logs.convertexperiments.com",
     "images.ctfassets.net",
+    "cdn.cookielaw.org"
 ]
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
@@ -1166,6 +1167,7 @@ CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + [
     "data.track.convertexperiments.com",
     "1003350.track.convertexperiments.com",
     "1003343.track.convertexperiments.com",
+    "cdn.cookielaw.org"
 ]
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
@@ -1189,6 +1191,8 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "1003350.metrics.convertexperiments.com",
     "1003343.metrics.convertexperiments.com",
     "sentry.prod.mozaws.net",
+    "cdn.cookielaw.org",
+    "privacyportal.onetrust.com",
     FXA_ENDPOINT,
     FXA_ENDPOINT_MOZILLAONLINE,
 ]

--- a/media/css/externalpages/pocket/components/privacy.scss
+++ b/media/css/externalpages/pocket/components/privacy.scss
@@ -24,6 +24,11 @@
     h2 {
         @include text-title-2xs;
         font-weight: 600;
+        margin-top: $spacing-2xl;
+
+        &:not(.date-heading) {
+            text-transform: uppercase;
+        }
     }
 
     h3 {
@@ -38,6 +43,10 @@
     }
 
     p {
+        color: $color-text-secondary;
+    }
+
+    address {
         color: $color-text-secondary;
     }
 

--- a/media/css/externalpages/pocket/components/privacy.scss
+++ b/media/css/externalpages/pocket/components/privacy.scss
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import '../utils/variables';
+@import '../includes/nav';
+@import '../includes/footer';
+
+@import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
+
+.pocket-privacy-wrapper {
+    font-family: $font-sans;
+
+    section {
+        max-width: 745px;
+    }
+
+    h1 {
+        @include text-title-md;
+        font-weight: 600;
+        margin-top: 0;
+    }
+
+    h2 {
+        @include text-title-2xs;
+        font-weight: 600;
+    }
+
+    h3 {
+        @include text-body-lg;
+        font-weight: 600;
+    }
+
+    .date-heading {
+        @include text-title-2xs;
+        font-style: italic;
+        font-weight: 600;
+    }
+
+    p {
+        color: $color-text-secondary;
+    }
+
+    ul {
+        padding-left: $layout-xs;
+
+        li {
+            color: $color-text-secondary;
+            list-style: inherit;
+        }
+    }
+
+    a {
+        color: $color-text-secondary;
+
+        &:hover {
+            color: $color-action-primary;
+        }
+    }
+
+    .cookies-subheading {
+        @include text-body-md;
+        color: $color-text-secondary;
+        font-weight: 700;
+    }
+
+    button {
+        @include text-body-md;
+        background: transparent;
+        border: none;
+        color: $color-text-secondary;
+        font-family: $font-sans;
+        padding: 0;
+        text-decoration: underline;
+    }
+}

--- a/media/css/externalpages/pocket/includes/_footer.scss
+++ b/media/css/externalpages/pocket/includes/_footer.scss
@@ -233,7 +233,7 @@ $pocket-image-path: '/media/img/externalpages/pocket';
     }
 }
 
-.cookie-show-settings {
+.ot-sdk-show-settings {
     background: transparent;
     color: $color-text-primary;
     text-decoration: underline;

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1011,6 +1011,13 @@
     },
     {
       "files": [
+        "css/externalpages/pocket/style.scss",
+        "css/externalpages/pocket/components/privacy.scss"
+      ],
+      "name": "pocket-privacy"
+    },
+    {
+      "files": [
         "css/careers/protocol.min.scss",
         "css/careers/protocol-extra.min.scss",
         "css/careers/careers.scss",


### PR DESCRIPTION
## Description
Coded the /privacy page and also added the scripts for the cookie helper that getpocket.com uses
## Issue / Bugzilla link
#10762
## Testing
http://localhost:8000/external/pocket/privacy