### PR TITLE
Fix bug where a trailing space in the location data attr on a positio…

### DIFF
--- a/bedrock/careers/templates/careers/listings.html
+++ b/bedrock/careers/templates/careers/listings.html
@@ -56,10 +56,15 @@
     </thead>
     <tbody>
     {% for position in positions %}
+      {#
+        When the options list for the Django Form is built, we strip()
+        whitespace from around each option. We need to do the same here
+        to make sure the values can match, else we get filtering 'misses'.
+      #}
       <tr class="position"
-          data-team="{{ position.department }},"
-          data-type="{{ position.position_type }},"
-          data-location="{{ position.location }},">
+          data-team="{{ position.department.strip() }},"
+          data-type="{{ position.position_type.strip() }},"
+          data-location="{{ position.location.strip() }},">
         <td class="title"><a href="{{ position.get_absolute_url() }}">{{ position.title }}</a></td>
         <td class="location">{{ position.job_locations }}</td>
         <td class="name">{{ position.department }}</td>

--- a/media/js/careers/filters.js
+++ b/media/js/careers/filters.js
@@ -144,6 +144,9 @@
         },
 
         filterLocations: function (value) {
+            // Note that filtering is based on a data attr, but the position's
+            // location shown in the HTML may be different to (or contain _more_
+            // items than) the data attribute's value.
             if (!value) return;
 
             var positions =


### PR DESCRIPTION
## Description

This changeset fixes a bug on the /careers/listings/ where a trailing space in the location data attr on a position causes the filtering to skip that role when the appropriate value is selected.

It also adds a comment explaining how the filtering uses a different data source than the overall list of locations shown in the HTML

There are no unit tests, I'm afraid

## Issue / Bugzilla link

Resolves #11073

## Testing

* Go to https://www.mozilla.org/en-US/careers/listings/?location=Remote and you will see that there are no results shown. 
* Clear the filters / go to https://www.mozilla.org/en-US/careers/listings/ and you will see, at the bottom of the page, that there ARE things with 'Remote' as their location. 
* You can also experiment with 'Remote San Francisco Bay Area' as another example of the filtering missing the target.

* Pull this branch and go to http://localhost:8080/en-US/careers/listings/?location=Remote - you will see the Remote-tagged jobs do appear in the filtered list. 
* Repeat for 'Remote San Francisco Bay Area' which will now display a result (even if it's not as directly matching in its labels as you might expect) 

Note: when testing, it's easy to get confused about what results you're seeing based on what filter you are selecting, and how some of the locations displayed in the HTML appear in the filter but others do not. 
The key thing here is that the filtering code is looking at a data attr on each position, but this data attr contains just one value, while the displayed HTML can/does often contain more, and slightly differently expressed, location options.
(I think that's a bigger thing to sort out and will require a chat with the relevant stakeholders to confirm what the ideal behaviour is these days.)
