### PR TITLE
Bump Django to 2.2.26

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
-Django==2.2.25 \
-    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
-    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
+Django==2.2.26 \
+    --hash=sha256:85e62019366692f1d5afed946ca32fef34c8693edf342ac9d067d75d64faf0ac \
+    --hash=sha256:dfa537267d52c6243a62b32855a744ca83c37c70600aacffbfd98bc5d6d8518f
 sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873


### PR DESCRIPTION

## Description
See release notes https://docs.djangoproject.com/en/dev/releases/2.2.26/

We do use `dictsort`, which is one of the three things amended in this release, so the testing steps below cover the two places where we do, to confirm there's no regression.

Integration tests have been run and [passed](https://gitlab.com/mozmeao/www-config/-/pipelines/441040365)

## Issue / Bugzilla link

No ticket

## Testing

* Set `DEV=False` in your local build.  
* `make run` 
* Visit the homepage and view source. 
* View the list of canonical links in the head. Compare these to the ones in live site. They match.
* View the list of locales in the language picker. Compare these to the ones in live site. They match.