### PR TITLE
Update Adjust links on EN WNP96 [#11070]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx96-en-qr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx96-en-qr.html
@@ -21,9 +21,6 @@
   {{ css_bundle('firefox_whatsnew_96_en_mobile') }}
 {% endblock %}
 
-{% set android_url = firefox_adjust_url('android', 'whatsnew-96-v2-qr') %}
-{% set ios_url = firefox_adjust_url('ios', 'whatsnew-96-v2-qr') %}
-
 {% block site_header %}{% endblock %}
 
 {% block wnp_content %}
@@ -40,10 +37,10 @@
     <div class="mobile-download-buttons-wrapper">
       <ul class="mobile-download-buttons">
         <li class="android">
-          {{ google_play_button(href=android_url, id='playStoreLink-primary') }}
+          {{ google_play_button(href='https://app.adjust.com/8abpl22?redirect=https://play.google.com/store/apps/details?id=org.mozilla.firefox&campaign=www.mozilla.org&adgroup=whatsnew-96-v2-qr', id='playStoreLink-primary') }}
         </li>
         <li class="ios">
-          <a id="appStoreLink-primary" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+          <a id="appStoreLink-primary" href="https://app.adjust.com/5jpoe35?redirect=https://itunes.apple.com/us/app/firefox-private-safe-browser/id989804926&campaign=www.mozilla.org&adgroup=whatsnew-96-v2-qr" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
           </a>
         </li>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx96-en-s2d.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx96-en-s2d.html
@@ -27,14 +27,11 @@
 {% endif %}
 {% endblock %}
 
-{% if variant %}
+{% if variant == '1' %}
   {% set creative = 'whatsnew-96-v1-s2d' %}
 {% else %}
   {% set creative = 'whatsnew-96' %}
 {% endif %}
-
-{% set android_url = firefox_adjust_url('android', creative) %}
-{% set ios_url = firefox_adjust_url('ios', creative) %}
 
 {% block site_header %}{% endblock %}
 
@@ -52,10 +49,10 @@
     <div class="mobile-download-buttons-wrapper">
       <ul class="mobile-download-buttons">
         <li class="android">
-          {{ google_play_button(href=android_url, id='playStoreLink-primary') }}
+          {{ google_play_button(href='https://app.adjust.com/b4dabjm?redirect=https://play.google.com/store/apps/details?id=org.mozilla.firefox&campaign=www.mozilla.org&adgroup=' + creative, id='playStoreLink-primary') }}
         </li>
         <li class="ios">
-          <a id="appStoreLink-primary" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+          <a id="appStoreLink-primary" href="https://app.adjust.com/fokjl4u?redirect=https://itunes.apple.com/us/app/firefox-private-safe-browser/id989804926&campaign=www.mozilla.org&adgroup={{ creative }}" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
           </a>
         </li>


### PR DESCRIPTION
## Description
We've generated custom Adjust links for the app store badges instead of using the standard global link. This updates WNP96 to use the new URLs.

## Issue / Bugzilla link
#11070 

## Testing
http://localhost:8000/en-US/firefox/96.0/whatsnew/?v=1
http://localhost:8000/en-US/firefox/96.0/whatsnew/?v=2

[Google Doc with the custom links](https://docs.google.com/document/d/1rw_bsL_S7CYHXStoRxivxMzWZ35YQzve0PvGSHGfzMA/edit). The bit to look for in each URL is the 7-digit code right after app.adjust.com.

v1, Android = `b4dabjm`
v1, Apple = `fokjl4u`
v2, Android = `8abpl22`
v2, Apple = `5jpoe35`