### PR TITLE
Update EN WNP96 send-to-device form [#11070]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/fx96-en/s2d.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/fx96-en/s2d.html
@@ -9,8 +9,7 @@
 <div class="mzp-c-emphasis-box">
   <h3>Get Firefox for mobile</h3>
 {% if show_send_to_device %}
-  <p>Email yourself a download link</p>
-  {{ send_to_device(include_title=False, message_set='fx-whatsnew-96', spinner_color='#ccc;', class='vertical', id='send-to-device') }}
+  {{ send_to_device(include_title=False, input_label='Email yourself a download link', message_set='fx-whatsnew-96', spinner_color='#ccc;', class='vertical', id='send-to-device') }}
 {% else %}
   <p>Scan the QR code to get started</p>
   <div class="qr-code-wrapper">


### PR DESCRIPTION
## Description
Minor tweak to the device widget to save space. Removed the extra line of copy and used it for the form label.

## Issue / Bugzilla link
#11070 

## Testing
http://localhost:8000/en-US/firefox/96.0/whatsnew/