### PR TITLE
Fixed Error-message colour on newsletter error

### DIFF
--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -48,7 +48,15 @@ $image-path: '/media/protocol/img';
 }
 
 // style classes automatically added by python to match Protocol form error styles
-.errorlist,
+.errorlist {
+    @include white-links;
+    background-color: $form-red;
+    border-radius: $field-border-radius;
+    color: $color-white;
+    padding: $spacing-sm;
+    margin-bottom: $spacing-xl;
+}
+
 .error-msg {
     @include light-links;
     background-color: $form-red;


### PR DESCRIPTION
## Description
Changed Error-message colour on newsletter error as per accessibility standards.

## Issue / Bugzilla link
#11016

## Testing
![mozillaerror](https://user-images.githubusercontent.com/73520373/148506997-43852d02-66d0-45f8-9c87-73b31714f921.png)
