### PR TITLE
Transparency report amendment h1 2021 (Fixes #11095)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2021.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2021.html
@@ -212,7 +212,7 @@
   <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Personal Data Requests</h2>
 
   <div data-accordion-role="tabpanel">
-    <p>In the Reporting Period, we received 3,919 requests.</p>
+    <p>In the Reporting Period, we received 4,199 requests. *</p>
 
     <table class="mzp-u-data-table">
       <thread>
@@ -222,7 +222,7 @@
       <tbody>
         <tr>
           <th scope="row">Mozilla</th>
-          <td>2,323</td>
+          <td>2,603</td>
         </tr>
         <tr>
           <th scope="row">Pocket</th>
@@ -230,6 +230,8 @@
         </tr>
       </tbody>
     </table>
+
+    <p>* This number was corrected on January 7 2022, adding 280 requests for Mozilla that had been omitted because of an error.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Description
Minor update to H1 2021 transparency report due to a data error.

## Issue / Bugzilla link
#11095

## Testing
http://localhost:8000/en-US/about/policy/transparency/jan-jun-2021/
