### PR TITLE
Update android-sys-req helper for FF100+

### DIFF
--- a/bedrock/releasenotes/tests/test_views.py
+++ b/bedrock/releasenotes/tests/test_views.py
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from bedrock.releasenotes.views import show_android_sys_req
+
+
+@pytest.mark.parametrize(
+    "version_string, expected",
+    (
+        (None, False),
+        ("", False),
+        ("test", False),
+        ("0", False),
+        ("45", False),
+        ("45.0", False),
+        ("45.1.1", False),
+        ("45.0a1", False),
+        ("45.0a2", False),
+        ("46", True),
+        ("46.0", True),
+        ("46.1.1", True),
+        ("46.0a1", True),
+        ("46.0a2", True),
+        ("47", True),
+        ("100", True),
+        ("100.0", True),
+        ("100.1.1", True),
+        ("100.0a1", True),
+        ("100.0a2", True),
+        ("102", True),
+        ("102.0", True),
+        ("102.1.1", True),
+        ("102.0a1", True),
+        ("102.0a2", True),
+    ),
+)
+def test_show_android_sys_req(version_string, expected):
+    assert show_android_sys_req(version_string) == expected

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -59,10 +59,11 @@ def get_download_url(release):
 
 
 def show_android_sys_req(version):
-    match = re.match(r"\d{1,2}", version)
-    if match:
-        num_version = int(match.group(0))
-        return num_version >= 46
+    if version:
+        match = re.match(r"\d{1,3}", version)
+        if match:
+            num_version = int(match.group(0))
+            return num_version >= 46
 
     return False
 


### PR DESCRIPTION
## Description
System requirement pages for Android releases exist from 46.0 and upward. This changeset makes sure that it the relevant check works for FF100 and above

## Issue / Bugzilla link

#9575

## Testing
Unit tests passing should be enough - not sure how to trigger this directly, without actual release notes for 100 yet, but I think the scope of the change is tested well enough
