### PR TITLE
Deal with warning during test collection of bedrock/utils 

### DIFF
--- a/bedrock/utils/tests/test_decorators.py
+++ b/bedrock/utils/tests/test_decorators.py
@@ -10,12 +10,12 @@ from bedrock.utils.management.decorators import alert_sentry_on_exception
 
 
 @alert_sentry_on_exception
-class TestCommandWithException(BaseCommand):
+class _TestCommandWithException(BaseCommand):
     def handle(self, *args, **options):
         raise Exception("This is a test")
 
 
-class TestCommandWithoutException(BaseCommand):
+class _TestCommandWithoutException(BaseCommand):
     def foo(self):
         # just for mocking in tests
         pass
@@ -30,7 +30,7 @@ def test_sentry_alerting_base_command__exception_raised(mock_capture_exception):
     assert not mock_capture_exception.called
 
     try:
-        TestCommandWithException().handle()
+        _TestCommandWithException().handle()
         assert False, "Expected an exception to have been raised"
     except Exception as ex:
         # The same exception raised should have been passed to Sentry
@@ -42,7 +42,7 @@ def test_sentry_alerting_base_command__no_exception_raised(mock_capture_exceptio
 
     assert not mock_capture_exception.called
 
-    command = TestCommandWithoutException()
+    command = _TestCommandWithoutException()
     command.foo = Mock()
     command.handle()
 


### PR DESCRIPTION
## Description
A clash between test auto-discovery (find something beginning with "Test") and a dummy/utility class created for testing the relevant decorator was causing pytest to raise warning.

Renaming the dummy classes solves the issue. Note that no tests were being skipped - the dummy classes being skipped were not actual test cases, so we didn't have a gap.

## Issue / Bugzilla link

Resolves #11103 

## Testing

Run `pytest bedrock/utils -vv` and see that the relevant tests mentioned in the diff are still run, while the warnings are now gone. (There are 13 tests in total in `bedrock/utils`)