### PR TITLE
Add tests to pocket mobile navigation (fixes #11029)

### DIFF
--- a/bedrock/externalpages/templates/externalpages/pocket/base.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/base.html
@@ -45,6 +45,10 @@
   <body>
     <main class="main-container">{% block content %}{% endblock %}</main>
 
+     {% block base_js %}
+      {{ js_bundle('pocket-base') }}
+     {% endblock %}
+
      {% block js %}{% endblock %}
   </body>
 </html>

--- a/bedrock/externalpages/templates/externalpages/pocket/includes/nav.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/includes/nav.html
@@ -8,7 +8,7 @@
 
 <header class="pocket-header">
     <nav class="global-nav-container">
-        <button class="global-nav-mobile-menu-btn inline" aria-labeledby="mobile-menu-icon-title" aria-describedby="mobile-menu-icon-description">
+        <button class="global-nav-mobile-menu-btn inline" aria-labelledby="mobile-menu-icon-title" aria-describedby="mobile-menu-icon-description">
             <svg
                 class="hamburger-btn"
                 aria-labelledby="mobile-menu-icon-description"

--- a/bedrock/externalpages/templates/externalpages/pocket/includes/nav.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/includes/nav.html
@@ -14,7 +14,9 @@
                 aria-labelledby="mobile-menu-icon-description"
                 fill="currentColor"
                 xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24">
+                viewBox="0 0 24 24"
+                width="24px"
+                height="24px">
                 <path
                 fill-rule="evenodd"
                 d="M2 5a1 1 0 011-1h18a1 1 0 110 2H3a1 1 0 01-1-1zM2 12a1 1 0 011-1h18a1 1 0 110 2H3a1 1 0 01-1-1zM2 19a1 1 0 011-1h18a1 1 0 110 2H3a1 1 0 01-1-1z"

--- a/media/css/externalpages/pocket/includes/_mobile-nav.scss
+++ b/media/css/externalpages/pocket/includes/_mobile-nav.scss
@@ -19,11 +19,10 @@ $easing-decelerate: cubic-bezier(0, 0, 0.2, 1);
 .mobile-nav-wrapper {
     background: rgba(26, 26, 26, 0.4) none repeat scroll 0 0;
     bottom: 0;
-    display: none;
+    visibility: hidden;
     left: 0;
     mix-blend-mode: normal;
     opacity: 0;
-    pointer-events: none;
     position: fixed;
     right: 0;
     transition: opacity 150ms $easing-accelerate, transform 75ms $easing-accelerate;
@@ -31,8 +30,7 @@ $easing-decelerate: cubic-bezier(0, 0, 0.2, 1);
     z-index: 20;
 
     &.active {
-        display: block;
-        pointer-events: auto;
+        visibility: visible;
     }
 }
 

--- a/media/js/externalpages/pocket/base.js
+++ b/media/js/externalpages/pocket/base.js
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * General DOM ready handler applied to all pages in base template.
+ */
+(function () {
+    'use strict';
+
+    // The `loaded` class is used mostly as a signal for functional tests to run.
+    window.addEventListener(
+        'load',
+        function () {
+            document.getElementsByTagName('html')[0].classList.add('loaded');
+        },
+        false
+    );
+})();

--- a/media/js/externalpages/pocket/mobile-nav-init.es6.js
+++ b/media/js/externalpages/pocket/mobile-nav-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import init from './mobile-nav.es6';
+
+init();

--- a/media/js/externalpages/pocket/mobile-nav.es6.js
+++ b/media/js/externalpages/pocket/mobile-nav.es6.js
@@ -19,34 +19,34 @@ function detectClickOutside(event) {
     }
 }
 
+function toggleContentWrapperClass(e) {
+    if (e.target === mobileNavWrapper) {
+        contentWrapper.classList.toggle('mobile-nav-open');
+    }
+}
+
 function handleMenuOpen() {
     mobileNavWrapper.classList.add('active');
+    mobileNavWrapper.style.opacity = 1;
+    mobileNav.classList.add('active');
     navOpenBtn.setAttribute('aria-expanded', true);
-    contentWrapper.classList.add('mobile-nav-open');
+
     document.addEventListener('click', detectClickOutside);
     window.addEventListener('keydown', handleKeyDown);
 
-    // move focus to close button when modal is opened, need to use setTimeout to get the animation working correctly
-    setTimeout(function () {
-        mobileNavWrapper.style.opacity = 1;
-        mobileNav.classList.add('active');
-        navCloseBtn.focus();
-    }, 10);
+    navCloseBtn.focus();
 }
 
 function handleMenuClose() {
     mobileNav.classList.remove('active');
-    navOpenBtn.setAttribute('aria-expanded', false);
+    mobileNavWrapper.classList.remove('active');
     mobileNavWrapper.style.opacity = 0;
+    navOpenBtn.setAttribute('aria-expanded', false);
+
     document.removeEventListener('click', detectClickOutside);
     window.removeEventListener('keydown', handleKeyDown);
 
-    // move focus to open button when modal is closed need to use setTimeout to get the animation working correctly
-    setTimeout(function () {
-        mobileNavWrapper.classList.remove('active');
-        contentWrapper.classList.remove('mobile-nav-open');
-        navOpenBtn.focus();
-    }, 250);
+    navOpenBtn.focus();
 }
 
 function handleKeyDown(e) {
@@ -109,6 +109,12 @@ const init = function () {
     // add event listeners
     navOpenBtn.addEventListener('click', handleMenuOpen, false);
     navCloseBtn.addEventListener('click', handleMenuClose, false);
+    // this event is used both for styling and as a test condition
+    mobileNavWrapper.addEventListener(
+        'transitionend',
+        toggleContentWrapperClass,
+        { capture: true }
+    );
 };
 
 export default init;

--- a/media/js/externalpages/pocket/mobile-nav.es6.js
+++ b/media/js/externalpages/pocket/mobile-nav.es6.js
@@ -4,11 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const navOpenBtn = document.querySelector('.global-nav-mobile-menu-btn');
-const mobileNavWrapper = document.querySelector('.mobile-nav-wrapper');
-const mobileNav = document.querySelector('.mobile-nav');
-const navCloseBtn = document.querySelector('.mobile-nav-close-btn');
-const contentWrapper = document.querySelector('body');
+let navOpenBtn;
+let mobileNavWrapper;
+let mobileNav;
+let navCloseBtn;
+let contentWrapper;
 
 const TAB = 9;
 const ESC = 27;
@@ -21,7 +21,7 @@ function detectClickOutside(event) {
 
 function handleMenuOpen() {
     mobileNavWrapper.classList.add('active');
-    mobileNav.setAttribute('aria-expanded', true);
+    navOpenBtn.setAttribute('aria-expanded', true);
     contentWrapper.classList.add('mobile-nav-open');
     document.addEventListener('click', detectClickOutside);
     window.addEventListener('keydown', handleKeyDown);
@@ -36,16 +36,16 @@ function handleMenuOpen() {
 
 function handleMenuClose() {
     mobileNav.classList.remove('active');
-    mobileNav.setAttribute('aria-expanded', false);
+    navOpenBtn.setAttribute('aria-expanded', false);
     mobileNavWrapper.style.opacity = 0;
     document.removeEventListener('click', detectClickOutside);
     window.removeEventListener('keydown', handleKeyDown);
 
-    // move focus to close button when modal is closed need to use setTimeout to get the animation working correctly
+    // move focus to open button when modal is closed need to use setTimeout to get the animation working correctly
     setTimeout(function () {
         mobileNavWrapper.classList.remove('active');
         contentWrapper.classList.remove('mobile-nav-open');
-        navCloseBtn.focus();
+        navOpenBtn.focus();
     }, 250);
 }
 
@@ -82,7 +82,6 @@ function handleKeyDown(e) {
         }
     }
 
-    // function handleForwardTab(){}
     switch (e.keyCode) {
         case TAB:
             if (e.shiftKey) {
@@ -99,5 +98,17 @@ function handleKeyDown(e) {
     }
 }
 
-navOpenBtn.addEventListener('click', handleMenuOpen, false);
-navCloseBtn.addEventListener('click', handleMenuClose, false);
+const init = function () {
+    // set element references
+    navOpenBtn = document.querySelector('.global-nav-mobile-menu-btn');
+    mobileNavWrapper = document.querySelector('.mobile-nav-wrapper');
+    mobileNav = document.querySelector('.mobile-nav');
+    navCloseBtn = document.querySelector('.mobile-nav-close-btn');
+    contentWrapper = document.querySelector('body');
+
+    // add event listeners
+    navOpenBtn.addEventListener('click', handleMenuOpen, false);
+    navCloseBtn.addEventListener('click', handleMenuClose, false);
+};
+
+export default init;

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1514,9 +1514,16 @@
     },
     {
       "files": [
-        "js/externalpages/pocket/mobile-nav.es6.js"
+        "js/externalpages/pocket/mobile-nav.es6.js",
+        "js/externalpages/pocket/mobile-nav-init.es6.js"
       ],
       "name": "pocket-nav"
+    },
+    {
+      "files": [
+        "js/externalpages/pocket/base.js"
+      ],
+      "name": "pocket-base"
     },
     {
       "files": [

--- a/tests/functional/externalpages/pocket/__init__.py
+++ b/tests/functional/externalpages/pocket/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/functional/externalpages/pocket/test_navigation.py
+++ b/tests/functional/externalpages/pocket/test_navigation.py
@@ -24,14 +24,14 @@ def test_mobile_menu(base_url, selenium_mobile):
 
 
 def test_accessible_mobile_menu_open_name(base_url, selenium_mobile):
-    expected_accessible_name = "Open"
     page = AboutPage(selenium_mobile, base_url).open()
     button_label_reference = page.navigation.mobile_menu_open_button.get_attribute("aria-labelledby")
-    assert page.navigation.mobile_menu_open_button.find_element(By.ID, button_label_reference).text == expected_accessible_name
+    string = page.navigation.mobile_menu_open_button.find_element(By.ID, button_label_reference).text
+    assert len(string) > 0
 
 
 def test_accessible_mobile_menu_close_name(base_url, selenium_mobile):
-    expected_accessible_name = "Close the Pocket Mobile Menu"
     page = AboutPage(selenium_mobile, base_url).open()
     page.navigation.open_mobile_menu()
-    assert page.navigation.mobile_menu_close_button.text == expected_accessible_name
+    string = page.navigation.mobile_menu_close_button.text
+    assert len(string) > 0

--- a/tests/functional/externalpages/pocket/test_navigation.py
+++ b/tests/functional/externalpages/pocket/test_navigation.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+from selenium.webdriver.common.by import By
+
+from pages.externalpages.pocket.about import AboutPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_mobile_menu(base_url, selenium_mobile):
+    page = AboutPage(selenium_mobile, base_url).open()
+    assert page.navigation.is_mobile_menu_open_button_displayed
+    page.navigation.open_mobile_menu()
+    assert page.navigation.is_mobile_menu_home_link_displayed
+    assert page.navigation.is_mobile_menu_my_list_link_displayed
+
+    assert page.navigation.is_mobile_menu_close_button_displayed
+    page.navigation.close_mobile_menu()
+    assert not page.navigation.is_mobile_menu_home_link_displayed
+    assert not page.navigation.is_mobile_menu_my_list_link_displayed
+
+
+def test_accessible_mobile_menu_open_name(base_url, selenium_mobile):
+    expected_accessible_name = "Open"
+    page = AboutPage(selenium_mobile, base_url).open()
+    button_label_reference = page.navigation.mobile_menu_open_button.get_attribute("aria-labelledby")
+    assert page.navigation.mobile_menu_open_button.find_element(By.ID, button_label_reference).text == expected_accessible_name
+
+
+def test_accessible_mobile_menu_close_name(base_url, selenium_mobile):
+    expected_accessible_name = "Close the Pocket Mobile Menu"
+    page = AboutPage(selenium_mobile, base_url).open()
+    page.navigation.open_mobile_menu()
+    assert page.navigation.mobile_menu_close_button.text == expected_accessible_name

--- a/tests/functional/externalpages/pocket/test_navigation.py
+++ b/tests/functional/externalpages/pocket/test_navigation.py
@@ -8,6 +8,7 @@ from selenium.webdriver.common.by import By
 from pages.externalpages.pocket.about import AboutPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_mobile_menu(base_url, selenium_mobile):
     page = AboutPage(selenium_mobile, base_url).open()

--- a/tests/functional/externalpages/pocket/test_navigation.py
+++ b/tests/functional/externalpages/pocket/test_navigation.py
@@ -8,7 +8,6 @@ from selenium.webdriver.common.by import By
 from pages.externalpages.pocket.about import AboutPage
 
 
-@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_mobile_menu(base_url, selenium_mobile):
     page = AboutPage(selenium_mobile, base_url).open()

--- a/tests/pages/externalpages/pocket/__init__.py
+++ b/tests/pages/externalpages/pocket/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/externalpages/pocket/about.py
+++ b/tests/pages/externalpages/pocket/about.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from pages.externalpages.pocket.base import BasePage
+
+
+class AboutPage(BasePage):
+
+    _URL_TEMPLATE = "/{locale}/external/pocket/about/"

--- a/tests/pages/externalpages/pocket/base.py
+++ b/tests/pages/externalpages/pocket/base.py
@@ -4,6 +4,7 @@
 
 from pypom import Page, Region
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
 
 
 class BaseRegion(Region):
@@ -21,6 +22,7 @@ class BasePage(Page):
 
         # Dismiss cookie prompt before running tests
         cookie_prompt = self.wait.until(lambda s: s.find_element(By.ID, "onetrust-accept-btn-handler"))
+        self.wait.until(lambda s: expected.element_to_be_clickable(cookie_prompt))
         cookie_prompt.click()
         self.wait.until(lambda s: cookie_prompt.is_displayed() is False)
 

--- a/tests/pages/externalpages/pocket/base.py
+++ b/tests/pages/externalpages/pocket/base.py
@@ -30,7 +30,7 @@ class BasePage(Page):
         accept_cookie_button.click()
 
         self.wait.until(lambda s: cookie_banner.is_displayed() is False)
-        
+
         return self
 
     @property
@@ -48,7 +48,8 @@ class BasePage(Page):
 
         _mobile_menu_open_btn_locator = (By.CLASS_NAME, "global-nav-mobile-menu-btn")
         _mobile_menu_close_btn_locator = (By.CLASS_NAME, "mobile-nav-close-btn")
-        _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav-list")
+        _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav")
+        _mobile_menu_wrapper_locator = (By.CLASS_NAME, "mobile-nav-wrapper")
         _home_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/home?src=navbar"]')
         _my_list_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/my-list?src=navbar"]')
 
@@ -62,12 +63,16 @@ class BasePage(Page):
 
         @property
         def is_mobile_menu_open(self):
-            return self.is_element_displayed(*self._mobile_menu_locator) and self.mobile_menu_open_button.get_attribute("aria-expanded") == "true"
+            return (
+                "active" in self.find_element(*self._mobile_menu_locator).get_attribute("class")
+                and self.mobile_menu_open_button.get_attribute("aria-expanded") == "true"
+            )
 
         @property
         def is_mobile_menu_closed(self):
             return (
-                not self.is_element_displayed(*self._mobile_menu_locator) and self.mobile_menu_open_button.get_attribute("aria-expanded") == "false"
+                "active" not in self.find_element(*self._mobile_menu_wrapper_locator).get_attribute("class")
+                and self.mobile_menu_open_button.get_attribute("aria-expanded") == "false"
             )
 
         @property

--- a/tests/pages/externalpages/pocket/base.py
+++ b/tests/pages/externalpages/pocket/base.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from pypom import Page, Region
+from selenium.webdriver.common.by import By
+
+
+class BaseRegion(Region):
+    pass
+
+
+class BasePage(Page):
+    def __init__(self, selenium, base_url, locale="en-US", **url_kwargs):
+        super(BasePage, self).__init__(selenium, base_url, locale=locale, **url_kwargs)
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.seed_url in s.current_url)
+        el = self.find_element(By.TAG_NAME, "html")
+        self.wait.until(lambda s: "loaded" in el.get_attribute("class"))
+
+        # Dismiss cookie prompt before running tests
+        cookie_prompt = self.wait.until(lambda s: s.find_element(By.ID, "onetrust-accept-btn-handler"))
+        cookie_prompt.click()
+        self.wait.until(lambda s: cookie_prompt.is_displayed() is False)
+
+        return self
+
+    @property
+    def URL_TEMPLATE(self):
+        if "{params}" in self._URL_TEMPLATE:
+            return f"{self._URL_TEMPLATE}&automation=true"
+        else:
+            return f"{self._URL_TEMPLATE}?automation=true"
+
+    @property
+    def navigation(self):
+        return self.Navigation(self)
+
+    class Navigation(BaseRegion):
+
+        _mobile_menu_open_btn_locator = (By.CLASS_NAME, "global-nav-mobile-menu-btn")
+        _mobile_menu_close_btn_locator = (By.CLASS_NAME, "mobile-nav-close-btn")
+        _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav-list")
+        _home_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/home?src=navbar"]')
+        _my_list_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/my-list?src=navbar"]')
+
+        @property
+        def is_mobile_menu_home_link_displayed(self):
+            return self.is_element_displayed(*self._home_mobile_menu_locator)
+
+        @property
+        def is_mobile_menu_my_list_link_displayed(self):
+            return self.is_element_displayed(*self._my_list_mobile_menu_locator)
+
+        @property
+        def is_mobile_menu_open(self):
+            return self.is_element_displayed(*self._mobile_menu_locator) and self.mobile_menu_open_button.get_attribute("aria-expanded") == "true"
+
+        @property
+        def is_mobile_menu_closed(self):
+            return (
+                not self.is_element_displayed(*self._mobile_menu_locator) and self.mobile_menu_open_button.get_attribute("aria-expanded") == "false"
+            )
+
+        @property
+        def is_mobile_menu_open_button_displayed(self):
+            return self.mobile_menu_open_button
+
+        @property
+        def is_mobile_menu_close_button_displayed(self):
+            return self.mobile_menu_close_button
+
+        @property
+        def mobile_menu_open_button(self):
+            return self.find_element(*self._mobile_menu_open_btn_locator)
+
+        @property
+        def mobile_menu_close_button(self):
+            return self.find_element(*self._mobile_menu_close_btn_locator)
+
+        def open_mobile_menu(self):
+            assert not self.is_mobile_menu_open, "Menu is already open"
+            self.mobile_menu_open_button.click()
+            self.wait.until(lambda s: self.is_mobile_menu_open)
+            return self
+
+        def close_mobile_menu(self):
+            assert not self.is_mobile_menu_closed, "Menu is already closed"
+            self.mobile_menu_close_button.click()
+            self.wait.until(lambda s: self.is_mobile_menu_closed)
+            return self

--- a/tests/pages/externalpages/pocket/base.py
+++ b/tests/pages/externalpages/pocket/base.py
@@ -46,6 +46,7 @@ class BasePage(Page):
 
     class Navigation(BaseRegion):
 
+        _content_wrapper_locator = (By.TAG_NAME, "body")
         _mobile_menu_open_btn_locator = (By.CLASS_NAME, "global-nav-mobile-menu-btn")
         _mobile_menu_close_btn_locator = (By.CLASS_NAME, "mobile-nav-close-btn")
         _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav")
@@ -64,14 +65,14 @@ class BasePage(Page):
         @property
         def is_mobile_menu_open(self):
             return (
-                "active" in self.find_element(*self._mobile_menu_locator).get_attribute("class")
+                "mobile-nav-open" in self.find_element(*self._content_wrapper_locator).get_attribute("class")
                 and self.mobile_menu_open_button.get_attribute("aria-expanded") == "true"
             )
 
         @property
         def is_mobile_menu_closed(self):
             return (
-                "active" not in self.find_element(*self._mobile_menu_wrapper_locator).get_attribute("class")
+                "mobile-nav-open" not in self.find_element(*self._content_wrapper_locator).get_attribute("class")
                 and self.mobile_menu_open_button.get_attribute("aria-expanded") == "false"
             )
 

--- a/tests/pages/externalpages/pocket/base.py
+++ b/tests/pages/externalpages/pocket/base.py
@@ -21,11 +21,16 @@ class BasePage(Page):
         self.wait.until(lambda s: "loaded" in el.get_attribute("class"))
 
         # Dismiss cookie prompt before running tests
-        cookie_prompt = self.wait.until(lambda s: s.find_element(By.ID, "onetrust-accept-btn-handler"))
-        self.wait.until(lambda s: expected.element_to_be_clickable(cookie_prompt))
-        cookie_prompt.click()
-        self.wait.until(lambda s: cookie_prompt.is_displayed() is False)
+        self.wait.until(lambda s: expected.presence_of_element_located(s.find_element(By.ID, "onetrust-banner-sdk")))
+        cookie_banner = self.find_element(By.ID, "onetrust-banner-sdk")
+        self.wait.until(lambda s: "animation-name" not in cookie_banner.get_attribute("style"))
 
+        accept_cookie_button = self.find_element(By.ID, "onetrust-accept-btn-handler")
+        self.wait.until(lambda s: expected.element_to_be_clickable(accept_cookie_button))
+        accept_cookie_button.click()
+
+        self.wait.until(lambda s: cookie_banner.is_displayed() is False)
+        
         return self
 
     @property

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -20,6 +20,7 @@ module.exports = function (config) {
             'media/js/base/mozilla-utils.js',
             'media/js/base/mozilla-client.js',
             'media/js/base/search-params.js',
+            'media/js/externalpages/pocket/base.js',
             // end common dependencies.
             'media/js/base/banners/mozilla-banner.js',
             'media/js/base/mozilla-run.js',
@@ -35,6 +36,7 @@ module.exports = function (config) {
             'media/js/base/stub-attribution.js',
             'media/js/firefox/all/all-downloads-unified.js',
             'media/js/firefox/new/common/thanks.js',
+            'media/js/externalpages/pocket/mobile-nav.es6.js',
             'tests/unit/spec/base/core-datalayer-page-id.js',
             'tests/unit/spec/base/core-datalayer.js',
             'tests/unit/spec/base/dnt-helper.js',
@@ -59,6 +61,7 @@ module.exports = function (config) {
             'tests/unit/spec/careers/params.js',
             'tests/unit/spec/firefox/all/all-downloads-unified.js',
             'tests/unit/spec/firefox/new/common/thanks.js',
+            'tests/unit/spec/externalpages/pocket/mobile-nav.es6.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',
                 watched: false,

--- a/tests/unit/spec/externalpages/pocket/mobile-nav.es6.js
+++ b/tests/unit/spec/externalpages/pocket/mobile-nav.es6.js
@@ -1,0 +1,114 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import init from '../../../../../media/js/externalpages/pocket/mobile-nav.es6';
+
+describe('mobile-nav.js', () => {
+    const mobileNav = `<div class="mobile-nav-wrapper" tabindex="-1">
+        <nav class="mobile-nav">
+            <div>
+                <button class="mobile-nav-close-btn"></button>
+            </div>
+            <ul>
+                <li>
+                    <a href="#first">1</a>
+                </li>
+                <li>
+                    <a href="#last">2</a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+    <button class="global-nav-mobile-menu-btn"></button>`;
+
+    const TAB = 9;
+    const ESC = 27;
+
+    beforeEach(function () {
+        jasmine.clock().install();
+        document.body.insertAdjacentHTML('afterbegin', mobileNav);
+        init();
+        const navOpenBtn = document.querySelector(
+            '.global-nav-mobile-menu-btn'
+        );
+        navOpenBtn.click();
+        // need to move past timeout in handleOpenMenu before testing focused element
+        jasmine.clock().tick(500);
+    });
+
+    afterEach(function () {
+        document.querySelector('.mobile-nav-wrapper').remove();
+        document.querySelector('.global-nav-mobile-menu-btn').remove();
+        jasmine.clock().uninstall();
+    });
+
+    it('should move focus onto close button inside the mobile menu when opened', function () {
+        const mobileMenuWrapper = document.querySelector('.mobile-nav-wrapper');
+        expect(document.activeElement).toBe(
+            mobileMenuWrapper.querySelector('.mobile-nav-close-btn')
+        );
+    });
+
+    it('should keep focus in mobile menu while open', function () {
+        const keydownForward = new KeyboardEvent('keydown', {
+            keyCode: TAB
+        });
+        const keydownBackward = new KeyboardEvent('keydown', {
+            keyCode: TAB,
+            shiftKey: true
+        });
+
+        // tab around
+        expect(document.activeElement).toBe(
+            document.querySelector('.mobile-nav-close-btn')
+        );
+        dispatchEvent(keydownBackward);
+        expect(document.activeElement).toBe(
+            document.querySelector('.mobile-nav-wrapper li:last-of-type a')
+        );
+        dispatchEvent(keydownForward);
+        expect(document.activeElement).toBe(
+            document.querySelector('.mobile-nav-close-btn')
+        );
+        dispatchEvent(keydownForward);
+        expect(document.activeElement).toBe(
+            document.querySelector('.mobile-nav-wrapper a')
+        );
+    });
+
+    describe('closing mobile menu', () => {
+        const openButtonClass = 'global-nav-mobile-menu-btn';
+        it('should return focus to open button on close button click', function () {
+            document.querySelector('.mobile-nav-close-btn').click();
+            // need to move past timeout in handleCloseMenu before testing focused element
+            jasmine.clock().tick(500);
+            expect(document.activeElement).toHaveClass(openButtonClass);
+        });
+
+        it('should return focus to open button on ESC keypress', function () {
+            dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    keyCode: ESC
+                })
+            );
+            // need to move past timeout in handleCloseMenu before testing focused element
+            jasmine.clock().tick(500);
+            expect(document.activeElement).toHaveClass(openButtonClass);
+        });
+
+        it('should return focus to open button on outside menu click', function () {
+            document.body.insertAdjacentHTML(
+                'afterbegin',
+                `<div id="test">Just somewhere to click outside the mobile menu</div>`
+            );
+            document.getElementById('test').click();
+            // need to move past timeout in handleCloseMenu before testing focused element
+            jasmine.clock().tick(500);
+            expect(document.activeElement).toHaveClass(openButtonClass);
+            document.getElementById('test').remove();
+        });
+    });
+});


### PR DESCRIPTION
## Description

Introduce Functional and JS Unit tests for new Pocket mobile navigation

Functional:
- open and close menu  
- accessible names are available on open and close buttons

Unit:
- accessible focus management

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11029

## Testing

Run functional test locally: `py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/externalpages/pocket`
`py.test --base-url http://localhost:8000 --driver Chrome --html tests/functional/results.html tests/functional/externalpages/pocket`

successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/449648084

successful test run 2 (after removing timeout): https://gitlab.com/mozmeao/www-config/-/pipelines/451416342

Unit tests should pass in PR CI
