### PR TITLE
Update jasmine docs link [NO BUG]

### DIFF
--- a/tests/unit/spec/base/core-datalayer-page-id.js
+++ b/tests/unit/spec/base/core-datalayer-page-id.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/dnt-helper.js
+++ b/tests/unit/spec/base/dnt-helper.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/experiment-utils.js
+++ b/tests/unit/spec/base/experiment-utils.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/mozilla-banner.js
+++ b/tests/unit/spec/base/mozilla-banner.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/mozilla-convert.js
+++ b/tests/unit/spec/base/mozilla-convert.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/mozilla-fxa-form.js
+++ b/tests/unit/spec/base/mozilla-fxa-form.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/mozilla-fxa-link.js
+++ b/tests/unit/spec/base/mozilla-fxa-link.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/mozilla-fxa.js
+++ b/tests/unit/spec/base/mozilla-fxa.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/search-params.js
+++ b/tests/unit/spec/base/search-params.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/send-to-device.js
+++ b/tests/unit/spec/base/send-to-device.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/firefox/all/all-downloads-unified.js
+++ b/tests/unit/spec/firefox/all/all-downloads-unified.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 

--- a/tests/unit/spec/firefox/new/common/thanks.js
+++ b/tests/unit/spec/firefox/new/common/thanks.js
@@ -5,7 +5,7 @@
  */
 
 /* For reference read the Jasmine and Sinon docs
- * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Jasmine docs: https://jasmine.github.io/
  * Sinon docs: http://sinonjs.org/docs/
  */
 


### PR DESCRIPTION
## Description

We have a broken link in JS unit test comments. Needs update to current Jasmine docs.

## Issue / Bugzilla link
NO BUG

## Testing
http://pivotal.github.io/jasmine/ is broken and is replaced everywhere with https://jasmine.github.io/