### PR TITLE
Remove unused cookie helper 404 script (#11123)

### DIFF
--- a/bedrock/externalpages/templates/externalpages/pocket/base.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/base.html
@@ -35,8 +35,6 @@
         function OptanonWrapper() {}
       </script>
       <!-- end OneTrust Cookies Consent Notice -->
-      {# Cookie Helper #}
-      <script src="{{ static('js/base/mozilla-cookie-helper.js') }}"></script>
 
     {% block pocket_css %}{% endblock  %}
 


### PR DESCRIPTION
This script doesn't seem (?) to be used by any Pocket pages currently, so this PR removes the 404 request for now. We can always figure out the best way to include it when there's a requirement for it in the future.
