### PR TITLE
9575: Expand backend FF100 coverage

### DIFF
--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -15,7 +15,10 @@ PROD_DETAILS_DIR = os.path.join(TEST_DATA_DIR, "product_details_json")
 
 
 GOOD_PLATS = {"Windows": {}, "OS X": {}, "Linux": {}}
-GOOD_BUILDS = {
+
+# In the run-up to FF100, these tests support both two-digit and
+# three-digit major version numbers
+GOOD_BUILDS__TWO_DIGITS = {
     "en-US": {
         "25.0": GOOD_PLATS,  # current release
         "26.0b2": GOOD_PLATS,
@@ -24,27 +27,50 @@ GOOD_BUILDS = {
     "de": {"25.0": GOOD_PLATS},
     "fr": {"24.0": GOOD_PLATS},  # prev release
 }
-GOOD_VERSIONS = {
+GOOD_BUILDS__THREE_DIGITS = {
+    "en-US": {
+        "125.0": GOOD_PLATS,  # current release
+        "126.0b2": GOOD_PLATS,
+        "127.0a1": GOOD_PLATS,
+    },
+    "de": {"125.0": GOOD_PLATS},
+    "fr": {"124.0": GOOD_PLATS},  # prev release
+}
+
+GOOD_VERSIONS__TWO_DIGITS = {
     "LATEST_FIREFOX_VERSION": "25.0",
     "LATEST_FIREFOX_DEVEL_VERSION": "26.0b2",
     "FIREFOX_DEVEDITION": "26.0b2",
     "FIREFOX_AURORA": "",
     "FIREFOX_ESR": "24.1.0esr",
 }
-GOOD_VERSIONS_NO_DEV = {
+GOOD_VERSIONS__THREE_DIGITS = {
+    "LATEST_FIREFOX_VERSION": "125.0",
+    "LATEST_FIREFOX_DEVEL_VERSION": "126.0b2",
+    "FIREFOX_DEVEDITION": "126.0b2",
+    "FIREFOX_AURORA": "",
+    "FIREFOX_ESR": "124.1.0esr",
+}
+GOOD_VERSIONS__TWO_DIGITS_NO_DEV = {
     "LATEST_FIREFOX_VERSION": "25.0",
     "LATEST_FIREFOX_DEVEL_VERSION": "26.0b2",
     "FIREFOX_AURORA": "",
     "FIREFOX_ESR": "24.1.0esr",
 }
+GOOD_VERSIONS__THREE_DIGITS_NO_DEV = {
+    "LATEST_FIREFOX_VERSION": "125.0",
+    "LATEST_FIREFOX_DEVEL_VERSION": "126.0b2",
+    "FIREFOX_AURORA": "",
+    "FIREFOX_ESR": "124.1.0esr",
+}
 
 
-class PatchFirefoxDesktopMixin:
-    firefox_desktop_versions = GOOD_VERSIONS
+class PatchFirefoxDesktopTwoDigitsMixin:
+    firefox_desktop_versions = GOOD_VERSIONS__TWO_DIGITS
 
     def setUp(self):
         self.firefox_desktop = FirefoxDesktop(json_dir=PROD_DETAILS_DIR)
-        self.p1 = patch.object(self.firefox_desktop, "firefox_primary_builds", GOOD_BUILDS)
+        self.p1 = patch.object(self.firefox_desktop, "firefox_primary_builds", GOOD_BUILDS__TWO_DIGITS)
         self.p2 = patch.object(self.firefox_desktop, "firefox_beta_builds", {})
         self.p3 = patch.object(self.firefox_desktop, "firefox_versions", self.firefox_desktop_versions)
         self.p1.start()
@@ -56,12 +82,39 @@ class PatchFirefoxDesktopMixin:
         self.p2.stop()
         self.p3.stop()
 
+    def _patch_if_necessary(self, expected):
+        # no patching needed for two-digit version numbers
+        return expected
 
-class TestLatestBuilds(PatchFirefoxDesktopMixin, TestCase):
-    def test_latest_builds(self):
+
+class PatchFirefoxDesktopThreeDigitsMixin:
+    firefox_desktop_versions = GOOD_VERSIONS__THREE_DIGITS
+
+    def setUp(self):
+        self.firefox_desktop = FirefoxDesktop(json_dir=PROD_DETAILS_DIR)
+        self.p1 = patch.object(self.firefox_desktop, "firefox_primary_builds", GOOD_BUILDS__THREE_DIGITS)
+        self.p2 = patch.object(self.firefox_desktop, "firefox_beta_builds", {})
+        self.p3 = patch.object(self.firefox_desktop, "firefox_versions", self.firefox_desktop_versions)
+        self.p1.start()
+        self.p2.start()
+        self.p3.start()
+
+    def tearDown(self):
+        self.p1.stop()
+        self.p2.stop()
+        self.p3.stop()
+
+    def _patch_if_necessary(self, expected):
+        # Patching is needed for three-digit version numbers
+        return f"1{expected}"
+
+
+class _TestLatestBuildsBase:
+    def test_latest_builds(self, expected="25.0"):
         """Should return platforms if localized build does exist."""
         result = self.firefox_desktop.latest_builds("de", "release")
-        self.assertEqual(result[0], "25.0")
+        expected = self._patch_if_necessary(expected)
+        self.assertEqual(result[0], expected)
         self.assertIs(result[1], GOOD_PLATS)
 
     def test_latest_builds_is_none_if_no_build(self):
@@ -69,26 +122,44 @@ class TestLatestBuilds(PatchFirefoxDesktopMixin, TestCase):
         result = self.firefox_desktop.latest_builds("fr", "release")
         self.assertIsNone(result)
 
-    def test_latest_builds_channels(self):
+    def test_latest_builds_channels(self, expected="26.0b2"):
         """Should work with all channels."""
+        expected = self._patch_if_necessary(expected)
         result = self.firefox_desktop.latest_builds("en-US", "beta")
-        self.assertEqual(result[0], "26.0b2")
+        self.assertEqual(result[0], expected)
         self.assertIs(result[1], GOOD_PLATS)
 
         result = self.firefox_desktop.latest_builds("en-US", "alpha")
-        self.assertEqual(result[0], "26.0b2")
+        self.assertEqual(result[0], expected)
         self.assertIs(result[1], GOOD_PLATS)
 
 
-class TestLatestBuildsNoDevEdition(PatchFirefoxDesktopMixin, TestCase):
+class TestLatestBuildsTwoDigits(
+    PatchFirefoxDesktopTwoDigitsMixin,
+    _TestLatestBuildsBase,
+    TestCase,
+):
+    pass
+
+
+class TestLatestBuildsThreeDigits(
+    PatchFirefoxDesktopThreeDigitsMixin,
+    _TestLatestBuildsBase,
+    TestCase,
+):
+    pass
+
+
+class _TestLatestBuildsBaseNoDevEditionBase:
     """Should get same results as above and not blow up"""
 
-    firefox_desktop_versions = GOOD_VERSIONS_NO_DEV
+    firefox_desktop_versions = GOOD_VERSIONS__TWO_DIGITS_NO_DEV
 
-    def test_latest_builds(self):
+    def test_latest_builds(self, expected="25.0"):
         """Should return platforms if localized build does exist."""
+        expected = self._patch_if_necessary(expected)
         result = self.firefox_desktop.latest_builds("de", "release")
-        self.assertEqual(result[0], "25.0")
+        self.assertEqual(result[0], expected)
         self.assertIs(result[1], GOOD_PLATS)
 
     def test_latest_builds_is_none_if_no_build(self):
@@ -96,18 +167,35 @@ class TestLatestBuildsNoDevEdition(PatchFirefoxDesktopMixin, TestCase):
         result = self.firefox_desktop.latest_builds("fr", "release")
         self.assertIsNone(result)
 
-    def test_latest_builds_channels(self):
+    def test_latest_builds_channels(self, expected="26.0b2"):
         """Should work with all channels."""
+        expected = self._patch_if_necessary(expected)
         result = self.firefox_desktop.latest_builds("en-US", "beta")
-        self.assertEqual(result[0], "26.0b2")
+        self.assertEqual(result[0], expected)
         self.assertIs(result[1], GOOD_PLATS)
 
         result = self.firefox_desktop.latest_builds("en-US", "alpha")
-        self.assertEqual(result[0], "26.0b2")
+        self.assertEqual(result[0], expected)
         self.assertIs(result[1], GOOD_PLATS)
 
 
-class TestFirefoxDesktop(TestCase):
+class TestLatestBuildsNoDevEditionTwoDigits(
+    PatchFirefoxDesktopTwoDigitsMixin,
+    _TestLatestBuildsBaseNoDevEditionBase,
+    TestCase,
+):
+    pass
+
+
+class TestLatestBuildsNoDevEditionThreeDigits(
+    PatchFirefoxDesktopThreeDigitsMixin,
+    _TestLatestBuildsBaseNoDevEditionBase,
+    TestCase,
+):
+    pass
+
+
+class TestFirefoxDesktopBase(TestCase):
     pd_cache = caches["product-details"]
 
     def setUp(self):

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -899,21 +899,25 @@ class TestFirefoxAndroid(TestCase):
 
     def test_latest_release_version(self):
         """latest_version should return the latest release version."""
-        with patch.object(
-            self.firefox_android._storage,
-            "data",
-            Mock(return_value=dict(version="22.0.1")),
-        ):
-            assert self.firefox_android.latest_version("release") == "22.0.1"
+        for version in ["22.0.1", "100.0.1", "122.0.1"]:
+            with self.subTest(version=version):
+                with patch.object(
+                    self.firefox_android._storage,
+                    "data",
+                    Mock(return_value=dict(version=version)),
+                ):
+                    assert self.firefox_android.latest_version("release") == version
 
     def test_latest_beta_version(self):
         """latest_version should return the latest beta version."""
-        with patch.object(
-            self.firefox_android._storage,
-            "data",
-            Mock(return_value=dict(beta_version="23.0")),
-        ):
-            assert self.firefox_android.latest_version("beta") == "23.0"
+        for version in ["23.0.1", "101.0.1", "123.0.1"]:
+            with self.subTest(version=version):
+                with patch.object(
+                    self.firefox_android._storage,
+                    "data",
+                    Mock(return_value=dict(beta_version=version)),
+                ):
+                    assert self.firefox_android.latest_version("beta") == version
 
     def test_get_download_url_nightly(self):
         """
@@ -1023,3 +1027,25 @@ class TestFirefoxIos(TestCase):
     def test_latest_beta_version(self):
         """latest_version should return the latest beta version."""
         assert self.firefox_ios.latest_version("beta") == "6.0"
+
+
+class TestFirefox100Ios(TestCase):
+    def setUp(self):
+        self.firefox_ios = FirefoxIOS(json_dir=PROD_DETAILS_DIR)
+        self.patcher = patch.object(
+            self.firefox_ios._storage,
+            "data",
+            Mock(return_value=dict(ios_version="100.0", ios_beta_version="101.0")),
+        )
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_latest_release_version(self):
+        """latest_version should return the latest release version."""
+        assert self.firefox_ios.latest_version("release") == "100.0"
+
+    def test_latest_beta_version(self):
+        """latest_version should return the latest beta version."""
+        assert self.firefox_ios.latest_version("beta") == "101.0"

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -41,13 +41,34 @@ class TestReleaseModel(TestCase):
         models.ProductRelease.objects.refresh()
         release_cache.clear()
 
+    def _add_in_ff100(self):
+        # TODO: remove once FF100 data is properly in the dataset
+        last = models.ProductRelease.objects.filter(channel="Release").last()
+        last.pk = None
+        last.version = "100.0a1"
+        last.save()
+        last.refresh_from_db()
+        assert last.pk is not None
+
     def test_release_major_version(self):
         rel = models.get_release("firefox", "57.0a1")
         assert rel.major_version == "57"
 
+    def test_release_major_version__ff100(self):
+        self._add_in_ff100()
+        rel = models.get_release("firefox", "100.0a1")
+        assert rel.major_version == "100"
+
     def test_get_bug_search_url(self):
         rel = models.get_release("firefox", "57.0a1")
         assert "=Firefox%2057&" in rel.get_bug_search_url()
+        rel.bug_search_url = "custom url"
+        assert "custom url" == rel.get_bug_search_url()
+
+    def test_get_bug_search_url__ff100(self):
+        self._add_in_ff100()
+        rel = models.get_release("firefox", "100.0a1")
+        assert "=Firefox%20100&" in rel.get_bug_search_url()
         rel.bug_search_url = "custom url"
         assert "custom url" == rel.get_bug_search_url()
 

--- a/bedrock/releasenotes/tests/test_views.py
+++ b/bedrock/releasenotes/tests/test_views.py
@@ -2,9 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from unittest.mock import patch
+
 import pytest
 
-from bedrock.releasenotes.views import show_android_sys_req
+from bedrock.releasenotes.views import releases_index, show_android_sys_req
 
 
 @pytest.mark.parametrize(
@@ -39,3 +41,124 @@ from bedrock.releasenotes.views import show_android_sys_req
 )
 def test_show_android_sys_req(version_string, expected):
     assert show_android_sys_req(version_string) == expected
+
+
+@patch("bedrock.firefox.views.l10n_utils.render")
+def test_releases_index(render_mock, rf):
+    """Spot checks, incl confirmation that FF100 will not cause a hiccup"""
+
+    # Dates are from https://wiki.mozilla.org/Release_Management/Calendar but
+    # these are here just for testing/dummy purposes
+    mock_major_releases_val = {
+        "3.6": "2010-01-21",
+        "33.0": "2014-10-14",
+        "33.1": "2014-11-10",
+        "96.0": "2022-01-11",
+        "100.0": "2022-05-03",
+        "101.0": "2022-05-31",
+    }
+    mock_minor_releases_val = {
+        "3.6.2": "2010-03-22",
+        "3.6.3": "2010-04-01",
+        "3.6.4": "2010-06-22",
+        "3.6.6": "2010-06-26",
+        "3.6.7": "2010-07-20",
+        "3.6.8": "2010-07-23",
+        "3.6.9": "2010-09-07",
+        "3.6.10": "2010-09-15",
+        "3.6.11": "2010-10-19",
+        "3.6.12": "2010-10-27",
+        "3.6.13": "2010-12-09",
+        "3.6.14": "2011-03-01",
+        "3.6.15": "2011-03-04",
+        "3.6.16": "2011-03-22",
+        "33.0.1": "2014-10-24",
+        "33.0.2": "2014-10-28",
+        "33.0.3": "2014-11-06",
+        "33.1.1": "2014-11-14",
+        "96.5": "2022-01-11",  # 100% fake/test
+        "100.1": "2022-05-03",  # 100% fake/test
+        "100.2": "2022-05-03",  # 100% fake/test
+        "101.2": "2022-05-31",  # 100% fake/test
+    }
+
+    request = rf.get("/")
+
+    with patch("bedrock.releasenotes.views.firefox_desktop") as mock_firefox_desktop:
+
+        mock_firefox_desktop.firefox_history_major_releases = mock_major_releases_val
+        mock_firefox_desktop.firefox_history_stability_releases = mock_minor_releases_val
+
+        releases_index(request, "Firefox")
+
+    expected_data = {
+        "releases": [
+            (101.0, {"major": "101.0", "minor": ["101.2"]}),
+            (
+                100.0,
+                {
+                    "major": "100.0",
+                    "minor": ["100.1", "100.2"],
+                },
+            ),
+            (
+                96.0,
+                {
+                    "major": "96.0",
+                    "minor": ["96.5"],
+                },
+            ),
+            (
+                33.1,
+                {
+                    "major": "33.1",
+                    "minor": ["33.1.1"],
+                },
+            ),
+            (
+                33.0,
+                {
+                    "major": "33.0",
+                    "minor": ["33.0.1", "33.0.2", "33.0.3"],
+                },
+            ),
+            (
+                3.6,
+                {
+                    "major": "3.6",
+                    "minor": [
+                        "3.6.2",
+                        "3.6.3",
+                        "3.6.4",
+                        "3.6.6",
+                        "3.6.7",
+                        "3.6.8",
+                        "3.6.9",
+                        "3.6.10",
+                        "3.6.11",
+                        "3.6.12",
+                        "3.6.13",
+                        "3.6.14",
+                        "3.6.15",
+                        "3.6.16",
+                    ],
+                },
+            ),
+        ],
+    }
+    render_mock.assert_called_once_with(
+        request,
+        "firefox/releases/index.html",
+        expected_data,
+    )
+
+
+@patch("bedrock.firefox.views.l10n_utils.render")
+def test_releases_index__product_other_than_firefox(render_mock, rf):
+    request = rf.get("/")
+    releases_index(request, "someproduct")
+    render_mock.assert_called_once_with(
+        request,
+        "someproduct/releases/index.html",
+        {"releases": []},
+    )

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -163,6 +163,8 @@ def latest_sysreq(request, product="firefox", platform=None, channel=None):
 
 def releases_index(request, product):
     releases = {}
+    major_releases = []
+
     if product == "Firefox":
         major_releases = firefox_desktop.firefox_history_major_releases
         minor_releases = firefox_desktop.firefox_history_stability_releases


### PR DESCRIPTION
## Description

This changeset expands test coverage for code that deals with specific version numbers, and confirms it handles three-digit version numbers without problem.

## Issue / Bugzilla link

Contributes to #9575

## Testing

Reviewing the tests and ensuring CI is green should be enough here