### PR TITLE
Update module owners in the Access Policy page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
@@ -78,11 +78,11 @@ This is the lowest level of access. It allows someone to check in to the <a href
 <table class="mzp-u-data-table">
   <tr>
     <td><a href="http://hg.mozilla.org/projects/nss/">projects/nss</a></td>
-    <td>Wan-Teh Chang</td>
+    <td>Benjamin Beurdouche</td>
   </tr>
   <tr>
     <td><a href="http://hg.mozilla.org/projects/nspr/">projects/nspr</a></td>
-    <td>Wan-Teh Chang</td>
+    <td>Kai Engert</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Description
Update module owners in the Access Policy page.
See https://wiki.mozilla.org/Modules/All for the current owners