### PR TITLE
11106: Disable logging of DisallowedHost to reduce log noise

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1089,8 +1089,21 @@ LOGGING = {
     "formatters": {
         "verbose": {"format": "%(levelname)s %(asctime)s %(module)s %(message)s"},
     },
-    "handlers": {"console": {"class": "logging.StreamHandler", "stream": sys.stdout, "formatter": "verbose"}},
+    "handlers": {
+        "null": {
+            "class": "logging.NullHandler",
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+            "formatter": "verbose",
+        },
+    },
     "loggers": {
+        "django.security.DisallowedHost": {  # NB: this exception changes base in Django 4
+            "handlers": ["null"],
+            "propagate": False,
+        },
         "django.db.backends": {
             "level": "ERROR",
             "handlers": ["console"],


### PR DESCRIPTION
## Description

`DisallowedHost` will still return a 400, but we won't get Sentry being filled with them

## Issue / Bugzilla link

#11106

## Testing

Local test-drive and CI passing should be enough. Integration tests have been pre-run https://gitlab.com/mozmeao/bedrock/-/pipelines/449752340
