### PR TITLE
Downgrade pytest-selenium and selenium to avoid regression in integration tests

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -145,14 +145,15 @@ pytest-django==4.5.2 \
 pytest-html==3.1.1 \
     --hash=sha256:3ee1cf319c913d19fe53aeb0bc400e7b0bc2dbeb477553733db1dad12eb75ee3 \
     --hash=sha256:b7f82f123936a3f4d2950bc993c2c1ca09ce262c9ae12f9ac763a2401380b455
-pytest-selenium==2.0.1 \
-    --hash=sha256:a0008e6dce7c68501369c1c543420f5906ffada493d4ff0c5d9d5ccdf4022203 \
-    --hash=sha256:fd632e0b657be6360f6319445eb0f475872d488b67634f791561851d55e390b1
+pytest-selenium==1.17.0 \
+    --hash=sha256:caf049839d12297e01f0521a968e44ae854f4eca1afd80b28f6a2510df02c883 \
+    --hash=sha256:e8034ebabc3b55fad57bfb97e7b0b2137532dbc65f33706e1ce1ed8e547caa1a
 pytest-variables==1.9.0 \
     --hash=sha256:ccf4afcd70de1f5f18b4463758a19f24647a9def1805f675e80db851c9e00ac0 \
     --hash=sha256:f79851e4c92a94c93d3f1d02377b5ac97cc8800392e87d108d2cbfda774ecc2a
-selenium==4.1.0 \
-    --hash=sha256:27e7b64df961d609f3d57237caa0df123abbbe22d038f2ec9e332fb90ec1a939
+selenium==3.141.0 \
+    --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
+    --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
 pytest-rerunfailures==10.2 \
     --hash=sha256:9e1e1bad51e07642c5bbab809fc1d4ec8eebcb7de86f90f1a26e6ef9de446697 \
     --hash=sha256:d31d8e828dfd39363ad99cd390187bf506c7a433a89f15c3126c7d16ab723fe2


### PR DESCRIPTION
## Description
This changeset reverts only the pytest-selenium and selenium dependency upgrades from 6ce73dfac to reverse a regression. Updating Selenium will involve some code changes too, which we can do later.

This should bring `master` back to health

## Issue / Bugzilla link

No ticket

## Testing

CI passing is good. Integration tests have been pre-run at https://gitlab.com/mozmeao/www-config/-/pipelines/452352630 -- note that all the core/automatic ones are green, but some of the optional ones may not be, but don't need to be green
