### PR TITLE
Add snowplow to pocket (fixes #11171)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@
 exclude: >
   (?x)^(
     docs
-    | bedrock/settings
     | node_modules
     | assets
     | static

--- a/bedrock/externalpages/templates/externalpages/pocket/base.html
+++ b/bedrock/externalpages/templates/externalpages/pocket/base.html
@@ -43,8 +43,8 @@
   <body>
     <main class="main-container">{% block content %}{% endblock %}</main>
 
-     {% block base_js %}
-      {{ js_bundle('pocket-base') }}
+     {% block site_js %}
+      {{ js_bundle('pocket-site') }}
      {% endblock %}
 
      {% block js %}{% endblock %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1199,6 +1199,7 @@ CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + [
     "1003350.track.convertexperiments.com",
     "1003343.track.convertexperiments.com",
     "cdn.cookielaw.org",
+    "assets.getpocket.com",  # allow Pocket Snowplow analytics
 ]
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + [
     # TODO fix things so that we don't need this
@@ -1225,6 +1226,8 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "cdn.cookielaw.org",
     "privacyportal.onetrust.com",
     FXA_ENDPOINT,
+    "com-getpocket-prod1.mini.snplow.net",  # Dev Pocket Snowplow
+    "getpocket.com",  # Prod Pocket Snowplow
 ]
 CSP_REPORT_ONLY = config("CSP_REPORT_ONLY", default="false", parser=bool)
 CSP_REPORT_URI = config("CSP_REPORT_URI", default="") or None

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -932,9 +932,9 @@ MOZILLA_INSTAGRAM_ACCOUNTS = {
 FXA_ENDPOINT = config("FXA_ENDPOINT", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
 
 # Google Play and Apple App Store settings
-from .appstores import GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE  # noqa
-from .appstores import GOOGLE_PLAY_FIREFOX_LINK_UTMS  # noqa
-from .appstores import (
+from .appstores import GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE  # noqa: E402, F401
+from .appstores import GOOGLE_PLAY_FIREFOX_LINK_UTMS  # noqa: E402, F401
+from .appstores import (  # noqa: E402, F401
     ADJUST_FIREFOX_URL,
     ADJUST_FOCUS_URL,
     ADJUST_KLAR_URL,
@@ -1226,9 +1226,10 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "cdn.cookielaw.org",
     "privacyportal.onetrust.com",
     FXA_ENDPOINT,
-    "com-getpocket-prod1.mini.snplow.net",  # Dev Pocket Snowplow
-    "getpocket.com",  # Prod Pocket Snowplow
+    "getpocket.com",  # Pocket Snowplow
 ]
+if DEV:
+    CSP_CONNECT_SRC.append("com-getpocket-prod1.mini.snplow.net")
 CSP_REPORT_ONLY = config("CSP_REPORT_ONLY", default="false", parser=bool)
 CSP_REPORT_URI = config("CSP_REPORT_URI", default="") or None
 

--- a/media/js/externalpages/pocket/snowplow.es6.js
+++ b/media/js/externalpages/pocket/snowplow.es6.js
@@ -1,0 +1,78 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* global snowplow */
+
+(function () {
+    const isProduction = !window.location.host.includes('localhost');
+    const SNOWPLOW_URL = `https://assets.getpocket.com/web-utilities/public/static/${
+        isProduction ? 'te' : 'sp'
+    }.js`;
+    function getUserData() {
+        const data = {
+            hashed_user_id: Mozilla.Cookies.getItem('a95b4b6'),
+            hashed_guid: Mozilla.Cookies.getItem('sess_guid')
+        };
+        Object.keys(data).forEach((key) => {
+            if (data[key] === null) {
+                delete data[key];
+            }
+        });
+        if (Object.keys(data).length) {
+            return data;
+        } else {
+            return null;
+        }
+    }
+    // https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/loading/
+    (function (p, l, o, w, i, n, g) {
+        if (!p[i]) {
+            p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || [];
+            p.GlobalSnowplowNamespace.push(i);
+            p[i] = function () {
+                (p[i].q = p[i].q || []).push(arguments);
+            };
+            p[i].q = p[i].q || [];
+            n = l.createElement(o);
+            g = l.getElementsByTagName(o)[0];
+            n.async = 1;
+            n.src = w;
+            g.parentNode.insertBefore(n, g);
+        }
+    })(window, document, 'script', SNOWPLOW_URL, 'snowplow');
+    const connectorUrl = isProduction
+        ? 'getpocket.com'
+        : 'com-getpocket-prod1.mini.snplow.net';
+    const appId = isProduction ? 'pocket-web-mktg' : 'pocket-web-mktg-dev';
+    // https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/initialization-options/
+    snowplow('newTracker', 'sp', connectorUrl, {
+        appId,
+        platform: 'web',
+        eventMethod: 'beacon',
+        respectDoNotTrack: false,
+        contexts: {
+            webPage: true,
+            performanceTiming: true
+        }
+    });
+    const data = getUserData();
+    if (data) {
+        snowplow('addGlobalContexts', [
+            {
+                schema: `iglu:com.pocket/user/jsonschema/1-0-0`,
+                data
+            }
+        ]);
+    }
+    snowplow(
+        'enableActivityTracking',
+        10, // heartbeat delay
+        10 // heartbeat interval
+    );
+    snowplow('enableLinkClickTracking');
+    snowplow('enableFormTracking');
+    snowplow('trackPageView');
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1521,9 +1521,11 @@
     },
     {
       "files": [
-        "js/externalpages/pocket/base.js"
+        "js/externalpages/pocket/base.js",
+        "js/base/mozilla-cookie-helper.js",
+        "js/externalpages/pocket/snowplow.es6.js"
       ],
-      "name": "pocket-base"
+      "name": "pocket-site"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Part of Pocket to Bedrock Pocket migration: we need to preserve the [Snowplow Analytics script](https://github.com/mozmeao/pocket-marketing-pages/blob/master/content/marketing-assets/js/snowplow.js)

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11171

## Testing
NOTE:
You'll get CORS errors similar to the ones from [pocket repo](https://github.com/mozmeao/pocket-marketing-pages) if you run master locally
<img width="987" alt="cors" src="https://user-images.githubusercontent.com/19650432/151034897-503db98c-6431-4777-b99f-332c0877ea6a.png">
This is fine once in production on [getpocket.com](https://getpocket.com/en/)

http://localhost:8000/en-US/external/pocket/about/
Should load the "se" dev script on localhost.
In Storage > Cookies, there should be a long lasting ID cookie to persist across sessions and a short session cookie.
 
<img width="663" alt="cookies" src="https://user-images.githubusercontent.com/19650432/151017259-f0fdbe08-3e06-44e6-9dc0-eb7e88148de2.png">




