### PR TITLE
Quick fix to handle WP posts having no tags data returned

### DIFF
--- a/bedrock/wordpress/api.py
+++ b/bedrock/wordpress/api.py
@@ -64,7 +64,7 @@ def complete_posts_data(blog_slug, posts):
 
 
 def get_feed_tags(feed_id):
-    tags = get_wp_data(feed_id, "tags")
+    tags = get_wp_data(feed_id, "tags") or []
     return {t["id"]: t["slug"] for t in tags}
 
 


### PR DESCRIPTION
## Description

Quick fix for occasional blow-up https://sentry.prod.mozaws.net/operations/bedrock-demos/issues/17944644/?referrer=alert_email

## Issue / Bugzilla link
Noticket

## Testing
Eyeballing is enough here, and we can see it recover on Dev