### PR TITLE
Add redirects for /turningred and /truecolors

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -539,4 +539,16 @@ redirectpatterns = (
     redirect(r"^/about/legal/fraud-report/?$", "/about/legal/defend-mozilla-trademarks/"),
     # Issue 10335
     redirect(r"^vpn/?$", "products.vpn.landing"),
+    # Issue 11204
+    redirect(
+        r"^(truecolors|turningred)/?$",
+        "https://truecolors.firefox.com/",
+        merge_query=True,
+        query={
+            "utm_campaign": "firefox-disney-us",
+            "utm_medium": "web",
+            "utm_source": "redirect",
+            "utm_content": "mozilla.org-turningred",
+        },
+    ),
 )

--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -192,6 +192,10 @@ def redirect(
         else:
             view_decorators.extend(decorators)
 
+    if query:
+        # prevent updating in place
+        query = query.copy()
+
     def _view(request, *args, **kwargs):
         # don't want to have 'None' in substitutions
         kwargs = {k: v or "" for k, v in kwargs.items()}
@@ -222,10 +226,9 @@ def redirect(
         if query:
             if merge_query:
                 req_query = parse_qs(request.META.get("QUERY_STRING", ""))
-                req_query.update(query)
-                querystring = urlencode(req_query, doseq=True)
-            else:
-                querystring = urlencode(query, doseq=True)
+                query.update(req_query)
+
+            querystring = urlencode(query, doseq=True)
         elif query is None:
             querystring = request.META.get("QUERY_STRING", "")
         else:

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1175,5 +1175,26 @@ URLS = flatten(
         url_test("/exp/", "/"),
         # issue 11092
         url_test("/about/legal/terms/vpn/", "/about/legal/terms/mozilla-vpn/"),
+        # Issue 11204
+        url_test(
+            "/{truecolors,turningred}/",
+            "https://truecolors.firefox.com/",
+            query={
+                "utm_campaign": "firefox-disney-us",
+                "utm_medium": "web",
+                "utm_source": "redirect",
+                "utm_content": "mozilla.org-turningred",
+            },
+        ),
+        url_test(
+            "/{truecolors,turningred}/?utm_source=dude",
+            "https://truecolors.firefox.com/",
+            query={
+                "utm_campaign": "firefox-disney-us",
+                "utm_medium": "web",
+                "utm_source": "dude",
+                "utm_content": "mozilla.org-turningred",
+            },
+        ),
     )
 )


### PR DESCRIPTION
Include default query params if none are incoming with the request, otherwise forward the ones from the request.

Fix #11204