### PR TITLE
fixing of non-functional stylesheet URL from credits page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/credits.html
+++ b/bedrock/mozorg/templates/mozorg/credits.html
@@ -12,7 +12,6 @@
   {% block page_css %}
     {{ css_bundle('credits') }}
   {% endblock %}
-  <link rel="stylesheet" href="chrome://global/skin/about.css" type="text/css">
 </head>
 
 <body id="aboutPageContainer" class="aboutPageWideContainer">

--- a/media/css/mozorg/credits.scss
+++ b/media/css/mozorg/credits.scss
@@ -1,15 +1,50 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 html {
-    background-color: #fff;
+    background: -moz-dialog;
+    color: -moz-dialogtext;
+    padding: 0 1em;
+    font: message-box;
+    line-height: 1.6em;
 }
 
 body {
-    color: #000;
+    position: relative;
+    min-width: 330px;
+    max-width: 50em;
+    margin: 4em auto;
+    padding-inline-start: 30px;
+}
+
+.about-page-wide-container {
+    max-width: 80%;
 }
 
 h1 {
-    text-align: center;
+    font-weight: lighter;
+    font-size: 2.4em;
+}
+
+img {
+    border: 0;
+}
+
+ul {
+    margin: 0;
+    margin-inline-start: 1.5em;
+    padding: 0;
+}
+
+ul > li {
+    margin-top: 0.5em;
+}
+
+th {
+    padding: 0 5px;
+}
+
+td {
+    padding: 0 5px;
 }


### PR DESCRIPTION
## Description
Removed non-functional stylesheet URL from credits page and added those rules to credits.scss

## Issue / Bugzilla link
#11197

### Success Criteria

- [x]  Link to about: removed from bedrock/mozorg/templates/mozorg/credits.html
- [x]  The CSS from the last version of the Firefox-hosted about.css is used in the credits CSS bundle in bedrock