### PR TITLE
Fix docs syntax [no bug]

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -209,8 +209,7 @@ credits, release notes, localizations, legal-docs etc::
 
     $ bin/bootstrap.sh
 
-**Next, you need to have `Node.js <https://nodejs.org/>`_ and `npm <https://www.npmjs.com/>`_ installed**.
-The node dependencies for running the site can be installed with ``npm install``::
+**Install the node dependencies to run the site**. This will only work if you already have `Node.js <https://nodejs.org/>`_ and `npm <https://www.npmjs.com/>`_ installed::
 
     $ npm install
 


### PR DESCRIPTION
## Description

rST doesn't seem to like links nested in bold. 

<img width="732" alt="Screen Shot 2022-02-18 at 12 04 22 PM" src="https://user-images.githubusercontent.com/19650432/154695669-6a7c8cf4-65e3-4a9a-940e-165b4a9dc430.png">

I rearranged the copy a bit to adjust the syntax. 
<img width="721" alt="Screen Shot 2022-02-18 at 1 58 01 PM" src="https://user-images.githubusercontent.com/19650432/154696186-4bce90de-1ab0-4547-b23d-efbc94538767.png">

Does the instruction still make sense?
