### PR TITLE
Add variation for get-app email basket id (fixes #11206)

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -27,6 +27,12 @@
   {% endwith %}
 {% endblock %}
 
+{% if variation == 'mfm' %}
+  {% set message_set = 'fx-mobile-download-desktop-experiment' %}
+{% else %}
+  {% set message_set = 'fx-mobile-download-desktop' %}
+{% endif %}
+
 {% block content %}
 <main role="main" class="mzp-l-content mzp-t-content-md mzp-t-firefox">
   <section>
@@ -34,7 +40,7 @@
     <h1>{{ ftl('firefox-mobile-get-firefox-mobile') }}</h1>
     {% if show_send_to_device %}
       <p>{{ ftl('firefox-mobile-send-a-download-link-to-your') }}</p>
-      {{ send_to_device(include_title=False, message_set='fx-mobile-download-desktop', class='vertical') }}
+      {{ send_to_device(include_title=False, message_set=message_set, class='vertical') }}
     {% else %}
       <p>{{ ftl('firefox-mobile-scan-the-qr-code-to-get-started') }}</p>
       <div class="qr-code-wrapper">

--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -18,8 +18,6 @@
 {% block page_og_desc %}{{ ftl('firefox-mobile-check-out-firefox-again-its') }}{% endblock %}
 
 {% set show_send_to_device = LANG in settings.SEND_TO_DEVICE_LOCALES %}
-{% set android_url = firefox_adjust_url('android', 'mobile-get-app-page') %}
-{% set ios_url = firefox_adjust_url('ios', 'mobile-get-app-page') %}
 
 {% block site_header %}
   {% with hide_nav_download_button=True %}
@@ -29,8 +27,12 @@
 
 {% if variation == 'mfm' %}
   {% set message_set = 'fx-mobile-download-desktop-experiment' %}
+  {% set android_url = 'https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-and&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F' %}
+  {% set ios_url = 'https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-ios&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F' %}
 {% else %}
   {% set message_set = 'fx-mobile-download-desktop' %}
+  {% set android_url = firefox_adjust_url('android', 'mobile-get-app-page') %}
+  {% set ios_url = firefox_adjust_url('ios', 'mobile-get-app-page') %}
 {% endif %}
 
 {% block content %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -450,6 +450,22 @@ class TestSendToDeviceView(TestCase):
             lang="en-US",
         )
 
+    # issue #11206
+    def test_fx_mobile_download_desktop_experiment_email(self):
+        resp_data = self._request(
+            {
+                "s2d-email": "dude@example.com",
+                "message-set": "fx-mobile-download-desktop-experiment",
+            }
+        )
+        assert resp_data["success"]
+        self.mock_subscribe.assert_called_with(
+            "dude@example.com",
+            views.SEND_TO_DEVICE_MESSAGE_SETS["fx-mobile-download-desktop-experiment"]["email"]["all"],
+            source_url=None,
+            lang="en-US",
+        )
+
 
 @override_settings(DEV=False)
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -74,7 +74,11 @@ urlpatterns = (
         name="firefox.features.tips",
     ),
     path("firefox/ios/testflight/", views.ios_testflight, name="firefox.ios.testflight"),
-    page("firefox/mobile/get-app", "firefox/mobile/get-app.html", ftl_files=["firefox/mobile"]),
+    path(
+        "firefox/mobile/get-app/",
+        VariationTemplateView.as_view(template_name="firefox/mobile/get-app.html", template_context_variations=["mfm"], ftl_files=["firefox/mobile"]),
+        name="firefox.mobile.get-app",
+    ),
     path("firefox/send-to-device-post/", views.send_to_device_ajax, name="firefox.send-to-device-post"),
     page("firefox/unsupported-systems", "firefox/unsupported-systems.html"),
     path("firefox/new/", views.NewView.as_view(), name="firefox.new"),

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -991,7 +991,7 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
     },
     "fx-mobile-download-desktop-experiment": {
         "email": {
-            "all": "2560328",
+            "all": "download-firefox-mobile-reco-exp",
         }
     },
     "fx-whatsnew": {

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -989,6 +989,11 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
             "all": "download-firefox-mobile-reco",
         }
     },
+    "fx-mobile-download-desktop-experiment": {
+        "email": {
+            "all": "2560328",
+        }
+    },
     "fx-whatsnew": {
         "email": {
             "all": "download-firefox-mobile-whatsnew",


### PR DESCRIPTION
## Description
Add variation context to get-app template to set the `message_set` param for `send_to_device`
This message should correspond to basket ID `download-firefox-mobile-reco-exp` in bedrock settings

We also need new adjust links on the `?v=mfm` variation
Google Play Store: https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-and&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F
App Store: https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-ios&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F 

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11206

## Testing
<img width="1280" alt="Screen Shot 2022-02-18 at 3 46 01 PM" src="https://user-images.githubusercontent.com/19650432/154715826-059aa72a-71d9-48c7-80d7-2047979fd873.png">

should have regular message_set: `fx-mobile-download-desktop`
http://localhost:8000/en-US/firefox/mobile/get-app/ 
should have experiment message_set: `fx-mobile-download-desktop-experiment`
http://localhost:8000/en-US/firefox/mobile/get-app/?v=mfm

entering `success@example.com` in either email field should show success message
entering `failure@example.com` in either email field should show failure message
