### PR TITLE
Add new supported countries to VPN landing page (Fixes #11213)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -90,7 +90,7 @@
     </a>
 
     <p class="availability-copy">
-      {{ ftl('vpn-shared-available-countries-v4', fallback='vpn-shared-available-countries-v3') }}
+      {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
     </p>
   {% endif %}
 {%- endmacro %}

--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -90,7 +90,11 @@
     </a>
 
     <p class="availability-copy">
-      {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
+      {% if switch('vpn_wave_v') %}
+        {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
+      {% else %}
+        {{ ftl('vpn-shared-available-countries-v4') }}
+      {% endif %}
     </p>
   {% endif %}
 {%- endmacro %}

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -81,7 +81,7 @@
               </a>
 
               <p class="availability-copy">
-                {{ ftl('vpn-shared-available-countries-v4', fallback='vpn-shared-available-countries-v3') }}
+                {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
               </p>
             </div>
             <div class="l-column-last">
@@ -152,7 +152,7 @@
         </a>
 
         <p class="availability-copy">
-          {{ ftl('vpn-shared-available-countries-v4', fallback='vpn-shared-available-countries-v3') }}
+          {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
         </p>
       {% endcall %}
     {% endif %}

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -81,7 +81,11 @@
               </a>
 
               <p class="availability-copy">
-                {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
+                {% if switch('vpn_wave_v') %}
+                  {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
+                {% else %}
+                  {{ ftl('vpn-shared-available-countries-v4') }}
+                {% endif %}
               </p>
             </div>
             <div class="l-column-last">
@@ -152,7 +156,11 @@
         </a>
 
         <p class="availability-copy">
-          {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
+          {% if switch('vpn_wave_v') %}
+            {{ ftl('vpn-shared-available-countries-v5', fallback='vpn-shared-available-countries-v4') }}
+          {% else %}
+            {{ ftl('vpn-shared-available-countries-v4') }}
+          {% endif %}
         </p>
       {% endcall %}
     {% endif %}

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -36,7 +36,7 @@ TEST_VPN_PLAN_ID_MATRIX = {
         "de": {
             "12-month": {"id": "price_1IgwblJNcmPzuWtRynC7dqQa", "price": "4,99 €", "total": "59,88 €", "saving": 50},
             "6-month": {"id": "price_1IgwaHJNcmPzuWtRuUfSR4l7", "price": "6,99 €", "total": "41,94 €", "saving": 30},
-            "monthly": {"id": "price_1IgwZVJNcmPzuWtRg9Wssh2y", "price": "9,99‎ €", "total": None, "saving": None},
+            "monthly": {"id": "price_1IgwZVJNcmPzuWtRg9Wssh2y", "price": "9,99 €", "total": None, "saving": None},
         },
         "en": {
             "12-month": {
@@ -53,7 +53,7 @@ TEST_VPN_PLAN_ID_MATRIX = {
             },
             "monthly": {
                 "id": "price_1JcdsSJNcmPzuWtRGF9Y5TMJ",
-                "price": "9,99‎ €",
+                "price": "9,99 €",
                 "total": None,
                 "saving": None,
             },
@@ -61,22 +61,22 @@ TEST_VPN_PLAN_ID_MATRIX = {
         "es": {
             "12-month": {"id": "price_1J5JCdJNcmPzuWtRrvQMFLlP", "price": "4,99 €", "total": "59,88 €", "saving": 50},
             "6-month": {"id": "price_1J5JDFJNcmPzuWtRrC4IeXTs", "price": "6,99 €", "total": "41,94 €", "saving": 30},
-            "monthly": {"id": "price_1J5JDgJNcmPzuWtRqQtIbktk", "price": "9,99‎ €", "total": None, "saving": None},
+            "monthly": {"id": "price_1J5JDgJNcmPzuWtRqQtIbktk", "price": "9,99 €", "total": None, "saving": None},
         },
         "fr": {
             "12-month": {"id": "price_1IgnlcJNcmPzuWtRjrNa39W4", "price": "4,99 €", "total": "59,88 €", "saving": 50},
             "6-month": {"id": "price_1IgoxGJNcmPzuWtRG7l48EoV", "price": "6,99 €", "total": "41,94 €", "saving": 30},
-            "monthly": {"id": "price_1IgowHJNcmPzuWtRzD7SgAYb", "price": "9,99‎ €", "total": None, "saving": None},
+            "monthly": {"id": "price_1IgowHJNcmPzuWtRzD7SgAYb", "price": "9,99 €", "total": None, "saving": None},
         },
         "it": {
             "12-month": {"id": "price_1J4owvJNcmPzuWtRomVhWQFq", "price": "4,99 €", "total": "59,88 €", "saving": 50},
             "6-month": {"id": "price_1J5J7eJNcmPzuWtRKdQi4Tkk", "price": "6,99 €", "total": "41,94 €", "saving": 30},
-            "monthly": {"id": "price_1J5J6iJNcmPzuWtRK5zfoguV", "price": "9,99‎ €", "total": None, "saving": None},
+            "monthly": {"id": "price_1J5J6iJNcmPzuWtRK5zfoguV", "price": "9,99 €", "total": None, "saving": None},
         },
         "nl": {
             "12-month": {"id": "price_1J5JRGJNcmPzuWtRXwXA84cm", "price": "4,99 €", "total": "59,88 €", "saving": 50},
             "6-month": {"id": "price_1J5JRmJNcmPzuWtRyFGj0tkN", "price": "6,99 €", "total": "41,94 €", "saving": 30},
-            "monthly": {"id": "price_1J5JSkJNcmPzuWtR54LPH2zi", "price": "9,99‎ €", "total": None, "saving": None},
+            "monthly": {"id": "price_1J5JSkJNcmPzuWtR54LPH2zi", "price": "9,99 €", "total": None, "saving": None},
         },
     },
     "usd": {
@@ -108,6 +108,9 @@ TEST_VPN_VARIABLE_PRICING = {
     "ES": {
         "default": TEST_VPN_PLAN_ID_MATRIX["euro"]["es"],
     },
+    "FI": {
+        "default": TEST_VPN_PLAN_ID_MATRIX["euro"]["en"],
+    },
     "FR": {
         "default": TEST_VPN_PLAN_ID_MATRIX["euro"]["fr"],
     },
@@ -119,6 +122,9 @@ TEST_VPN_VARIABLE_PRICING = {
     },
     "NL": {
         "default": TEST_VPN_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    "SE": {
+        "default": TEST_VPN_PLAN_ID_MATRIX["euro"]["en"],
     },
     "US": {
         "default": TEST_VPN_PLAN_ID_MATRIX["usd"]["en"],
@@ -665,6 +671,60 @@ class TestVPNSubscribeLink(TestCase):
         )
         self.assertIn("?plan=price_1J5JSkJNcmPzuWtR54LPH2zi", markup)
 
+    def test_vpn_subscribe_link_variable_12_month_se_en(self):
+        """Should contain expected 12-month plan ID (SE / en-US)"""
+        markup = self._render(
+            plan="12-month",
+            country_code="SE",
+            lang="en-US",
+        )
+        self.assertIn("?plan=price_1JcdvBJNcmPzuWtROLbEH9d2", markup)
+
+    def test_vpn_subscribe_link_variable_6_month_se_en(self):
+        """Should contain expected 16-month plan ID (SE / en-US)"""
+        markup = self._render(
+            plan="6-month",
+            country_code="SE",
+            lang="en-US",
+        )
+        self.assertIn("?plan=price_1Jcdu8JNcmPzuWtRK6u5TUoZ", markup)
+
+    def test_vpn_subscribe_link_variable_monthly_se_en(self):
+        """Should contain expected monthly plan ID (SE / en-US)"""
+        markup = self._render(
+            plan="monthly",
+            country_code="SE",
+            lang="en-US",
+        )
+        self.assertIn("?plan=price_1JcdsSJNcmPzuWtRGF9Y5TMJ", markup)
+
+    def test_vpn_subscribe_link_variable_12_month_fi_en(self):
+        """Should contain expected 12-month plan ID (FI / en-US)"""
+        markup = self._render(
+            plan="12-month",
+            country_code="FI",
+            lang="en-US",
+        )
+        self.assertIn("?plan=price_1JcdvBJNcmPzuWtROLbEH9d2", markup)
+
+    def test_vpn_subscribe_link_variable_6_month_fi_en(self):
+        """Should contain expected 16-month plan ID (FI / en-US)"""
+        markup = self._render(
+            plan="6-month",
+            country_code="FI",
+            lang="en-US",
+        )
+        self.assertIn("?plan=price_1Jcdu8JNcmPzuWtRK6u5TUoZ", markup)
+
+    def test_vpn_subscribe_link_variable_monthly_fi_en(self):
+        """Should contain expected monthly plan ID (FI / en-US)"""
+        markup = self._render(
+            plan="monthly",
+            country_code="FI",
+            lang="en-US",
+        )
+        self.assertIn("?plan=price_1JcdsSJNcmPzuWtRGF9Y5TMJ", markup)
+
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT, VPN_ENDPOINT=TEST_VPN_ENDPOINT)
 class TestVPNDownloadLink(TestCase):
@@ -715,7 +775,7 @@ class TestVPNMonthlyPrice(TestCase):
     def test_vpn_monthly_price_euro(self):
         """Should return expected markup"""
         markup = self._render(plan="monthly", country_code="DE", lang="de")
-        expected = '<span class="vpn-monthly-price-display">9,99‎ €<span>/month</span></span>'
+        expected = '<span class="vpn-monthly-price-display">9,99 €<span>/month</span></span>'
         self.assertEqual(markup, expected)
 
     def test_vpn_monthly_price_chf(self):

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -14,6 +14,7 @@ import basket.errors
 from sentry_sdk import capture_exception
 
 from bedrock.base.geo import get_country_from_request
+from bedrock.base.waffle import switch
 from bedrock.contentful.constants import (
     ARTICLE_CATEGORY_LABEL,
     CONTENT_CLASSIFICATION_VPN,
@@ -29,18 +30,26 @@ from lib.l10n_utils.fluent import ftl
 
 def vpn_available(request):
     country = get_country_from_request(request)
+    country_list = settings.VPN_COUNTRY_CODES
 
-    return country in settings.VPN_COUNTRY_CODES
+    if switch("vpn-wave-v"):
+        country_list = settings.VPN_COUNTRY_CODES + settings.VPN_COUNTRY_CODES_WAVE_V
+
+    return country in country_list
 
 
 @require_safe
 def vpn_landing_page(request):
     template_name = "products/vpn/landing.html"
     ftl_files = ["products/vpn/landing", "products/vpn/shared"]
+    available_countries = settings.VPN_AVAILABLE_COUNTRIES
+
+    if switch("vpn-wave-v"):
+        available_countries = settings.VPN_AVAILABLE_COUNTRIES_WAVE_V
 
     context = {
         "vpn_available": vpn_available(request),
-        "available_countries": settings.VPN_AVAILABLE_COUNTRIES,
+        "available_countries": available_countries,
         "connect_servers": settings.VPN_CONNECT_SERVERS,
         "connect_countries": settings.VPN_CONNECT_COUNTRIES,
         "connect_devices": settings.VPN_CONNECT_DEVICES,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1358,7 +1358,7 @@ VPN_PLAN_ID_MATRIX = {
             },
             "monthly": {
                 "id": "price_1IXw4eKb9q6OnNsLqnVP4PvO" if DEV else "price_1IgwZVJNcmPzuWtRg9Wssh2y",
-                "price": "9,99‎ €",
+                "price": "9,99 €",
                 "total": None,
                 "saving": None,
             },
@@ -1378,7 +1378,7 @@ VPN_PLAN_ID_MATRIX = {
             },
             "monthly": {
                 "id": "price_1Jcu7uKb9q6OnNsLG4JAAXuw" if DEV else "price_1JcdsSJNcmPzuWtRGF9Y5TMJ",
-                "price": "9,99‎ €",
+                "price": "9,99 €",
                 "total": None,
                 "saving": None,
             },
@@ -1398,7 +1398,7 @@ VPN_PLAN_ID_MATRIX = {
             },
             "monthly": {
                 "id": "price_1J4pFSKb9q6OnNsLEyiFLbvB" if DEV else "price_1J5JDgJNcmPzuWtRqQtIbktk",
-                "price": "9,99‎ €",
+                "price": "9,99 €",
                 "total": None,
                 "saving": None,
             },
@@ -1418,7 +1418,7 @@ VPN_PLAN_ID_MATRIX = {
             },
             "monthly": {
                 "id": "price_1IXw4eKb9q6OnNsLqnVP4PvO" if DEV else "price_1IgowHJNcmPzuWtRzD7SgAYb",
-                "price": "9,99‎ €",
+                "price": "9,99 €",
                 "total": None,
                 "saving": None,
             },
@@ -1438,7 +1438,7 @@ VPN_PLAN_ID_MATRIX = {
             },
             "monthly": {
                 "id": "price_1J4p6wKb9q6OnNsLTb6kCDsC" if DEV else "price_1J5J6iJNcmPzuWtRK5zfoguV",
-                "price": "9,99‎ €",
+                "price": "9,99 €",
                 "total": None,
                 "saving": None,
             },
@@ -1511,6 +1511,9 @@ VPN_VARIABLE_PRICING = {
     "ES": {
         "default": VPN_PLAN_ID_MATRIX["euro"]["es"],
     },
+    "FI": {
+        "default": VPN_PLAN_ID_MATRIX["euro"]["en"],
+    },
     "FR": {
         "default": VPN_PLAN_ID_MATRIX["euro"]["fr"],
     },
@@ -1522,6 +1525,9 @@ VPN_VARIABLE_PRICING = {
     },
     "NL": {
         "default": VPN_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    "SE": {
+        "default": VPN_PLAN_ID_MATRIX["euro"]["en"],
     },
     "US": {
         "default": VPN_PLAN_ID_MATRIX["usd"]["en"],
@@ -1563,6 +1569,12 @@ VPN_COUNTRY_CODES = [
     "IE",  # Ireland
     "NL",  # Netherlands
 ]
+
+VPN_COUNTRY_CODES_WAVE_V = [
+    "SE",  # Sweden
+    "FI",  # Finland
+]
+VPN_AVAILABLE_COUNTRIES_WAVE_V = 17
 
 VPN_AVAILABLE_COUNTRIES = 15
 VPN_CONNECT_SERVERS = 400

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -10,9 +10,9 @@ vpn-shared-waitlist-link = Join the Waitlist
 vpn-shared-sign-in-link = Already a subscriber?
 
 # Outdated string
-vpn-shared-available-countries-v3 = We currently offer { -brand-name-mozilla-vpn } in the US, Canada, the UK, Germany, France, Italy, Spain, Belgium, Austria, Switzerland, Malaysia, New Zealand, and Singapore.
-
 vpn-shared-available-countries-v4 = We currently offer { -brand-name-mozilla-vpn } in Austria, Belgium, Canada, France, Germany, Ireland, Italy, Malaysia, the Netherlands, New Zealand, Singapore, Spain, Switzerland, the UK, and the US.
+
+vpn-shared-available-countries-v5 = We currently offer { -brand-name-mozilla-vpn } in Austria, Belgium, Canada, Finland, France, Germany, Ireland, Italy, Malaysia, the Netherlands, New Zealand, Singapore, Spain, Sweden, Switzerland, the UK, and the US.
 
 # This is a standalone string that is typically displayed underneath a "Get Mozilla VPN" button.
 vpn-shared-money-back-guarantee = 30-day money-back guarantee


### PR DESCRIPTION
## Description
Adds 2 new supported countries to the VPN landing page behind `SWITCH_VPN_WAVE_V`

## Issue / Bugzilla link
#11213

## Testing

`SWITCH_VPN_WAVE_V=on`

- [x] http://localhost:8000/en-US/products/vpn/?geo=se should display pricing in Euros (clicking through to payment will be in English).
- [x] http://localhost:8000/en-US/products/vpn/?geo=fi should display pricing in Euros (clicking through to payment will be in English).
- [x] http://localhost:8000/en-US/products/vpn/?geo=cn should list the two new countries in availability copy.
- [x] http://localhost:8000/en-US/products/vpn/?geo=cn should mention "Available in 17 countries now. More regions coming soon".


`SWITCH_VPN_WAVE_V=off`

- [x] http://localhost:8000/en-US/products/vpn/?geo=se should display waitlist
- [x] http://localhost:8000/en-US/products/vpn/?geo=fi should display waitlist
- [x] http://localhost:8000/en-US/products/vpn/?geo=cn should not list the two new countries in availability copy.
- [x] http://localhost:8000/en-US/products/vpn/?geo=cn should mention "Available in 15 countries now. More regions coming soon".