### PR TITLE
Remove obsolete sanity markers from functional tests

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -214,28 +214,6 @@ be enough to cover our most critical pages where legacy browser support is impor
 You can run smoke tests only by adding ``-m smoke`` when running the test suite on the
 command line.
 
-Sanity tests
-~~~~~~~~~~~~
-
-Sanity tests behave in much the same way as smoke tests, but will also run against Internet
-Explorer 9, which is a browser that does not receive 1st class CSS/JS support (except on
-certain download pages such as /firefox/new/). The number of sanity tests we run should be
-small and cover only a handful key of pages.
-
-.. code-block:: python
-
-    import pytest
-
-    @pytest.mark.sanity
-    @pytest.mark.smoke
-    @pytest.mark.nondestructive
-    def test_download_button_displayed(base_url, selenium):
-        page = DownloadPage(selenium, base_url, params='').open()
-        assert page.is_download_button_displayed
-
-You can run sanity tests only by adding ``-m sanity`` when running the test suite on the
-command line.
-
 Waits and Expected Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -8,7 +8,6 @@ from pages.firefox.new.download import DownloadPage
 
 
 @pytest.mark.smoke
-@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
     page = DownloadPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_installer_help.py
+++ b/tests/functional/firefox/test_installer_help.py
@@ -7,7 +7,6 @@ import pytest
 from pages.firefox.installer_help import InstallerHelpPage
 
 
-@pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_displayed(base_url, selenium):

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -9,7 +9,6 @@ from pages.home import HomePage
 
 @pytest.mark.skip(reason="MR2 promo temporarily hides standard CTA (Issue 10653")
 @pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
-@pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize("locale", ["de", "fr"])
@@ -29,7 +28,6 @@ def test_primary_accounts_button_is_displayed(locale, base_url, selenium):
 
 
 @pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
-@pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize("locale", ["en-US", "de", "fr"])


### PR DESCRIPTION
Since https://github.com/mozmeao/www-config/pull/429 we're no longer running functional tests using IE9 against deployed code, since this old browser is now a bit too much of a challenge to run the SSL certs we use in our deployment environments.

Instead, we have a new set of CDN tests that were added in https://github.com/mozilla/bedrock/pull/11129, which will at least make sure the site is accessible in old browsers such as legacy IE.

This PR removes references to the now obsolete `sanity` marker in functional browser tests.
