### PR TITLE
Add basket docs link [no bug]

### DIFF
--- a/docs/newsletters.rst
+++ b/docs/newsletters.rst
@@ -109,7 +109,7 @@ Configuration
 -------------
 
 Currently, information about the available newsletters is configured in
-Basket. See Basket for more information.
+Basket. `See Basket for more information <https://basket.readthedocs.io/>`_.
 
 Footer signup
 -------------


### PR DESCRIPTION
## Description

We have a line on [Bedrock's newsletter docs](https://bedrock.readthedocs.io/en/latest/newsletters.html#configuration) to see Basket for more information. This adds a link to the Basket docs homepage to find that information.

## Issue / Bugzilla link
no bug

## Testing
Does this link make sense? Should it go directly to the Newsletter API docs or the github repo instead?