### PR TITLE
Add Transparency Report for H2 2021 (Fixes #11214)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,7 @@
 <nav class="prev-reports-nav">
   <h3>Previous Reports</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2021') }}">January-June 2021</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2020') }}">July-December 2020</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2020') }}">January-June 2020</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2019') }}">July-December 2019</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -15,7 +15,7 @@
     </li>
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2021') }}">January-June 2021 Report</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2021') }}">July-December 2021 Report</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2021.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2021.html
@@ -1,0 +1,270 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}Transparency Report - July-December 2021{% endblock %}
+
+{% block report_title %}
+<h1>Transparency Report <span>Reporting Period: July 1, 2021 to December 31, 2021</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for User Data</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received the following.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Legal Processes</th>
+          <th scope="col">Received</th>
+          <th scope="col">User Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">Search Warrants</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">Subpoenas</a>
+          </th>
+          <td>3</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">Court Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">Wiretap Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">Pen Register Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">Emergency Requests</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">National Security Requests</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>0-249</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p id="footnote-1">
+        We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for Content Removal</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received no government requests for content removal from our services.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Requesting Country</th>
+          <th scope="col">Requests Received</th>
+          <th scope="col">Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">N/A</th>
+          <td>0</td>
+          <td>N/A</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Copyright</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>3</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Trademark</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 9 Trademark Takedown Notices and 1 Counter Notices.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>8</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="personal-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Personal Data Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 5,684 requests.</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Received</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Mozilla</th>
+          <td>3,755</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>1,929</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Supplement</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>Legislative Reform</h3>
+    <p>During the course of this reporting period, Mozilla continued its efforts to defend privacy and security on the open web. In the United States, we <a href="https://blog.mozilla.org/netpolicy/files/2021/11/Mozillas-Comments-to-CCPA-Consultation-November-2021-6.pdf">submitted comments</a> in response to the <strong>California Privacy Protection Agency</strong>’s Invitation for Preliminary Comments on Proposed Rulemaking Under the California Privacy Rights Act (CPRA).</p>
+    <p>In Europe, we engaged on the <a href="https://blog.mozilla.org/netpolicy/2021/11/04/mozilla-publishes-position-paper-on-the-eu-digital-identity-framework/">problematic</a> provisions around web security  present in the EU’s recently-proposed <a href="https://ec.europa.eu/commission/presscorner/detail/en/IP_21_2663">draft law</a> on Digital ID and Authentication (<strong>eIDAS</strong>). In support of deploying limitations on the use of third-party cookies for pervasive web tracking, we <a href="https://blog.mozilla.org/netpolicy/2021/12/17/privacy-sandbox-cma-dec2021/">contributed</a> to the UK's Competition and Markets Authority (CMA) second round of consultations on Google’s Commitments to the Chrome <strong>Privacy Sandbox</strong>. We also submitted <a href="https://blog.mozilla.org/netpolicy/2021/11/29/mozilla-files-comments-on-uk-data-protection-consultation/">comments</a> to the public consultation on reforming the <strong>UK's data protection regime</strong> post Brexit. On encryption, we also helped push back against a concerning <strong>Belgium Data Retention</strong> proposal that would likely impact encrypted services and possibly mandate greater metadata collection for all online communication providers.</p>
+    <p>In the African continent, we continued to advocate for strong data protection practices in the region while also serving as the trusted entity to <a href="https://www.rapdp.org/en/node/98">coordinate and manage</a> pooled resources for technical and operational support to assist the <a href="https://www.rapdp.org/">Africa Network of Data Protection Authorities</a>. We also developed a curriculum for Lean Data Practices for startups in the Africa region and have held a <a href="https://event.webinarjam.com/register/135/2zmv8i8z">webinar</a> on <strong>Lean Data Practice</strong>, in collaboration with AfriLabs, to promote our philosophy on how to apply privacy, security, and transparency to  products and practices. We also assisted the <a href="https://www.nepad.org/">African Union Development Agency (NEPAD)</a> in advocating for the African Union Cyber Security and Personal data Protection Convention, 2014. In India, we <a href="https://www.thehindu.com/sci-tech/technology/industry-concerned-over-inclusion-of-non-personal-data-expanded-localisation-mandates-jpc-report/article37985361.ece">engaged</a> on the Joint Parliamentary Committee report on <strong>India’s data protection law</strong> with the goal of pushing for stronger privacy protections and a more independent data protection authority.</p>
+
+    <h3>Voluntary Threat Indicators & Data Disclosures</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Type of Disclosure</th>
+          <th scope="col">Number of Disclosures</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">Cybersecurity Threat Indicator</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            Other <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-specific-user' }}">Specific User</a> Data Disclosure
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -76,6 +76,7 @@ urlpatterns = (
     page("about/policy/transparency/jan-jun-2020", "mozorg/about/policy/transparency/jan-jun-2020.html"),
     page("about/policy/transparency/jul-dec-2020", "mozorg/about/policy/transparency/jul-dec-2020.html"),
     page("about/policy/transparency/jan-jun-2021", "mozorg/about/policy/transparency/jan-jun-2021.html"),
+    page("about/policy/transparency/jul-dec-2021", "mozorg/about/policy/transparency/jul-dec-2021.html"),
     page("contact", "mozorg/contact/contact-landing.html"),
     page("contact/spaces", "mozorg/contact/spaces/spaces-landing.html"),
     page("contact/spaces/beijing", "mozorg/contact/spaces/beijing.html"),


### PR DESCRIPTION
## Description
Adds report for July-December 2021.

## Issue / Bugzilla link
#11214

## Testing
http://localhost:8000/en-US/about/policy/transparency/jul-dec-2021/