### PR TITLE
Skipping the compatibility test for not-prod

### DIFF
--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -165,6 +165,7 @@ def test_enabled_ciphers(cipher, get_ssllabs_results):
 
 
 @pytest.mark.cdn
+@pytest.mark.cdnprod
 @pytest.mark.nondestructive
 def test_tls(get_ssllabs_results):
     """Check get_ssllabs_results to make sure that all expected clients connected without issue"""


### PR DESCRIPTION
We're not paying for the extra backwards compatability on the cdns,
so it makes sense to skip this test for dev/stage

## Description

## Issue / Bugzilla link

## Testing
