### PR TITLE
Minor fix to the label element when showing the XUL namespace page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/namespaces.html
+++ b/bedrock/mozorg/templates/mozorg/namespaces.html
@@ -21,12 +21,17 @@
     <dl>
         <dt>Namespace</dt>
         <dd><code>{{ namespace }}</code></dd>
+        {% if slug == 'xul' %}
+        <dt>Background information</dt>
+        {% else%}
         <dt>Documentation</dt>
+        {% endif %}
         <dd><a href="{{ docs }}">{{ docs }}</a></dd>
     </dl>
     {% if slug == 'xul' %}
         <p class="xul">
-            There is no data.<br/>There is only XUL!</p>
+            There is no data.<br/>There is only XUL!
+        </p>
     {% endif %}
 </section>
 </body>


### PR DESCRIPTION
Because we're now linking off to a Wikipedia page (thanks to https://github.com/mozilla/bedrock/pull/11242), calling it 'documentation' didn't seem appropriate.

<img width="726" alt="Screenshot 2022-02-23 at 17 39 14" src="https://user-images.githubusercontent.com/101457/155375787-f019d8a1-bd99-433c-83db-83b096c51213.png">


## Issue / Bugzilla link
No ticket

## Testing

Go to http://localhost:8080/keymaster/gatekeeper/there.is.only.xul locally and confirm the page is not broken

