### PR TITLE
Add redirect support for /truecolours

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -541,7 +541,7 @@ redirectpatterns = (
     redirect(r"^vpn/?$", "products.vpn.landing"),
     # Issue 11204
     redirect(
-        r"^(truecolors|turningred)/?$",
+        r"^(truecolou?rs|turningred)/?$",
         "https://truecolors.firefox.com/",
         merge_query=True,
         query={

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1177,7 +1177,7 @@ URLS = flatten(
         url_test("/about/legal/terms/vpn/", "/about/legal/terms/mozilla-vpn/"),
         # Issue 11204
         url_test(
-            "/{truecolors,turningred}/",
+            "/{truecolors,truecolours,turningred}/",
             "https://truecolors.firefox.com/",
             query={
                 "utm_campaign": "firefox-disney-us",
@@ -1187,7 +1187,7 @@ URLS = flatten(
             },
         ),
         url_test(
-            "/{truecolors,turningred}/?utm_source=dude",
+            "/{truecolors,truecolours,turningred}/?utm_source=dude",
             "https://truecolors.firefox.com/",
             query={
                 "utm_campaign": "firefox-disney-us",


### PR DESCRIPTION
Our friends in Canada and the UK might spell it this way if they hear
about the campaign. Let's support them.
