### PR TITLE
WNP 98 for DE/FR (Fixes #11211)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/fx98-mobile-de/qr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/fx98-mobile-de/qr.html
@@ -1,0 +1,12 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="mzp-c-emphasis-box">
+  <h3>Scanne den <br>QR-Code und los geht's</h3>
+  <div class="qr-code-wrapper">
+    {{ qrcode('https://app.adjust.com/b2arekk') }}
+  </div>
+</div>

--- a/bedrock/firefox/templates/firefox/whatsnew/includes/fx98-mobile-fr/qr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/fx98-mobile-fr/qr.html
@@ -1,0 +1,12 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="mzp-c-emphasis-box">
+  <h3>Scanner le code QR pour démarrer</h3>
+  <div class="qr-code-wrapper">
+    {{ qrcode('https://app.adjust.com/caisb08') }}
+  </div>
+</div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx98-mobile-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx98-mobile-de.html
@@ -1,0 +1,55 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import google_play_button with context %}
+{% from "macros-protocol.html" import split with context %}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew{% endblock %}
+{% block body_class %}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('protocol-emphasis-box') }}
+  {{ css_bundle('firefox_whatsnew_98_mobile_eu') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+<section class="wnp-content-main mzp-t-content-xl">
+  {% call split(
+    block_class='c-main-content mzp-t-split-nospace mzp-l-split-center-on-sm-md',
+    media_class='mzp-l-split-h-center',
+    media_after=True,
+    media_include='firefox/whatsnew/includes/fx98-mobile-de/qr.html'
+  ) %}
+    <h1 class="wnp-main-title">Mach da weiter, wo du aufgehört hast mit Firefox</h1>
+    <p class="wnp-main-tagline">Hab all deine offenen Tabs, Lesezeichen und Lieblingsseiten im Blick. Hol dir Firefox für dein Handy.</p>
+
+    <div class="mobile-download-buttons-wrapper">
+      <ul class="mobile-download-buttons">
+        <li class="android">
+          {{ google_play_button(href='https://app.adjust.com/psjvd69?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox&campaign=www.mozilla.org&adgroup=whatsnew-98-de-qr|safe', id='playStoreLink-primary') }}
+        </li>
+        <li class="ios">
+          <a id="appStoreLink-primary" href="https://app.adjust.com/8bdcye2?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926&campaign=www.mozilla.org&adgroup=whatsnew-98-de-qr" data-link-type="download" data-download-os="iOS">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+          </a>
+        </li>
+      </ul>
+    </div>
+  {% endcall %}
+</section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx98-mobile-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx98-mobile-fr.html
@@ -1,0 +1,55 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import google_play_button with context %}
+{% from "macros-protocol.html" import split with context %}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew{% endblock %}
+{% block body_class %}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('protocol-emphasis-box') }}
+  {{ css_bundle('firefox_whatsnew_98_mobile_eu') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+<section class="wnp-content-main mzp-t-content-xl">
+  {% call split(
+    block_class='c-main-content mzp-t-split-nospace mzp-l-split-center-on-sm-md',
+    media_class='mzp-l-split-h-center',
+    media_after=True,
+    media_include='firefox/whatsnew/includes/fx98-mobile-fr/qr.html'
+  ) %}
+    <h1 class="wnp-main-title">Firefox mobile plus intuitif que jamais</h1>
+    <p class="wnp-main-tagline">Trouvez vos onglets ouverts, marque-pages et sites favoris sur la page d’accueil de votre téléphone ou tablette.</p>
+
+    <div class="mobile-download-buttons-wrapper">
+      <ul class="mobile-download-buttons">
+        <li class="android">
+          {{ google_play_button(href='https://app.adjust.com/8tlw6oj?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox&campaign=www.mozilla.org&adgroup=whatsnew-98-fr-qr'|safe, id='playStoreLink-primary') }}
+        </li>
+        <li class="ios">
+          <a id="appStoreLink-primary" href="https://app.adjust.com/r45f8h1?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926&campaign=www.mozilla.org&adgroup=whatsnew-98-de-qr" data-link-type="download" data-download-os="iOS">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+          </a>
+        </li>
+      </ul>
+    </div>
+  {% endcall %}
+</section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -600,6 +600,30 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/whatsnew-fx98-vpn-eu.html"]
 
+    def test_fx_98_0_0_de(self, render_mock):
+        """Should use whatsnew-fx98-mobile-de template for 98.0 for German"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "de"
+        self.view(req, version="98.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx98-mobile-de.html"]
+
+    def test_fx_98_0_0_fr(self, render_mock):
+        """Should use whatsnew-fx98-mobile-fr template for 98.0 for French"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "fr"
+        self.view(req, version="98.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx98-mobile-fr.html"]
+
+    def test_fx_98_0_0_en(self, render_mock):
+        """Should use default whatsnew template for 98.0 for English"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-US"
+        self.view(req, version="98.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/index.html"]
+
     # end 98.0 whatsnew tests
 
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -467,6 +467,8 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx97-de.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx97-fr.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx98-vpn-eu.html": ["firefox/whatsnew/whatsnew-98-vpn-eu", "firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx98-mobile-de.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx98-mobile-fr.html": ["firefox/whatsnew/whatsnew"],
     }
 
     # specific templates that should not be rendered in China
@@ -550,8 +552,15 @@ class WhatsnewView(L10nTemplateView):
                 template = "firefox/developer/whatsnew.html"
             else:
                 template = "firefox/whatsnew/index.html"
-        elif version.startswith("98.") and ftl_file_is_active("firefox/whatsnew/whatsnew-fx98-vpn-eu.html") and country in ["SE", "FI"]:
-            template = "firefox/whatsnew/whatsnew-fx98-vpn-eu.html"
+        elif version.startswith("98."):
+            if ftl_file_is_active("firefox/whatsnew/whatsnew-fx98-vpn-eu.html") and country in ["SE", "FI"]:
+                template = "firefox/whatsnew/whatsnew-fx98-vpn-eu.html"
+            elif locale == "de":
+                template = "firefox/whatsnew/whatsnew-fx98-mobile-de.html"
+            elif locale == "fr":
+                template = "firefox/whatsnew/whatsnew-fx98-mobile-fr.html"
+            else:
+                template = "firefox/whatsnew/index.html"
         elif version.startswith("97.") and locale == "de":
             template = "firefox/whatsnew/whatsnew-fx97-de.html"
         elif version.startswith("97.") and locale == "fr":

--- a/media/css/firefox/whatsnew/whatsnew-98-mobile-eu.scss
+++ b/media/css/firefox/whatsnew/whatsnew-98-mobile-eu.scss
@@ -16,10 +16,6 @@ $image-path: '/media/protocol/img';
     .mzp-c-emphasis-box {
         margin: 0 auto;
     }
-
-    .send-to-device-input {
-        min-width: 0;
-    }
 }
 
 .wnp-main-title {

--- a/media/css/firefox/whatsnew/whatsnew-98-mobile-eu.scss
+++ b/media/css/firefox/whatsnew/whatsnew-98-mobile-eu.scss
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import 'includes/base';
+
+// * -------------------------------------------------------------------------- */
+// Main content
+
+.c-main-content {
+    .mzp-c-emphasis-box {
+        margin: 0 auto;
+    }
+
+    .send-to-device-input {
+        min-width: 0;
+    }
+}
+
+.wnp-main-title {
+    @include text-title-md;
+    color: get-theme('title-text-color');
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+}
+
+.mobile-download-buttons-wrapper {
+    display: inline-block;
+}
+
+.mobile-download-buttons li {
+    padding-top: $spacing-sm;
+    display: inline-block;
+}
+
+@media #{$mq-md} {
+    .c-main-content {
+        .mzp-c-split-media {
+            @include at2x('/media/img/firefox/whatsnew/whatsnew96-en/watercolor.png', contain);
+            background-position: center center;
+            background-repeat: no-repeat;
+            padding: $layout-md;
+        }
+
+        .mzp-c-emphasis-box {
+            max-width: $content-xs;
+            min-width: 220px;
+        }
+    }
+}
+
+@media #{$mq-lg} {
+    .c-main-content .mzp-c-split-media {
+        padding: $layout-xl;
+    }
+}
+
+.qr-code-wrapper svg {
+    width: 100%;
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -429,6 +429,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-98-mobile-eu.scss"
+      ],
+      "name": "firefox_whatsnew_98_mobile_eu"
+    },
+    {
+      "files": [
         "css/firefox/privacy/common.scss"
       ],
       "name": "firefox-privacy-common"

--- a/tests/functional/firefox/whatsnew/test_whatsnew_98.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_98.py
@@ -13,3 +13,11 @@ from pages.firefox.whatsnew.whatsnew_98 import FirefoxWhatsNew98Page
 def test_vpn_button_is_displayed(country, base_url, selenium):
     page = FirefoxWhatsNew98Page(selenium, base_url, locale="en-US", params=f"?geo={country}").open()
     assert page.is_vpn_button_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason="Whatsnew pages are shown to Firefox only.")
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("locale", [("de"), ("fr")])
+def test_qr_code_is_displayed(locale, base_url, selenium):
+    page = FirefoxWhatsNew98Page(selenium, base_url, locale=locale, params="?geo=us").open()
+    assert page.is_qr_code_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_98.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_98.py
@@ -12,7 +12,12 @@ class FirefoxWhatsNew98Page(BasePage):
     _URL_TEMPLATE = "/{locale}/firefox/98.0/whatsnew/{params}"
 
     _vpn_button_locator = (By.CSS_SELECTOR, ".qa-main-cta-vpn .mzp-c-button")
+    _qrcode_locator = (By.CSS_SELECTOR, ".qr-code-wrapper > svg")
 
     @property
     def is_vpn_button_displayed(self):
         return self.is_element_displayed(*self._vpn_button_locator)
+
+    @property
+    def is_qr_code_displayed(self):
+        return self.is_element_displayed(*self._qrcode_locator)


### PR DESCRIPTION
## Description
Adds a WNP for Firefox 98 in German and French.

## Issue / Bugzilla link
#11211

## Testing
- http://localhost:8000/de/firefox/98.0/whatsnew/
- http://localhost:8000/fr/firefox/98.0/whatsnew/