### PR TITLE
Fix active locale logic for displaying VPN NWP 98 (Fixes #11262)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -582,6 +582,7 @@ class TestWhatsNew(TestCase):
 
     # begin 98.0 whatsnew tests
 
+    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
     @override_settings(DEV=False)
     def test_fx_98_0_0_se(self, render_mock):
         """Should use whatsnew-fx98-vpn-eu template for 98.0 in Sweden"""
@@ -591,6 +592,7 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/whatsnew-fx98-vpn-eu.html"]
 
+    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
     @override_settings(DEV=False)
     def test_fx_98_0_0_fi(self, render_mock):
         """Should use whatsnew-fx98-vpn-eu template for 98.0 in Finland"""
@@ -599,6 +601,26 @@ class TestWhatsNew(TestCase):
         self.view(req, version="98.0")
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/whatsnew-fx98-vpn-eu.html"]
+
+    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
+    @override_settings(DEV=False)
+    def test_fx_98_0_0_locale_active(self, render_mock):
+        """Should use whatsnew-fx98-vpn-eu template if locale is active"""
+        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="se")
+        req.locale = "sv-SE"
+        self.view(req, version="98.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx98-vpn-eu.html"]
+
+    @patch.object(fx_views, "ftl_file_is_active", lambda *x: False)
+    @override_settings(DEV=False)
+    def test_fx_98_0_0_locale_inactive(self, render_mock):
+        """Should use default template for 98.0 if locale is not active"""
+        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="fi")
+        req.locale = "fi"
+        self.view(req, version="98.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/index.html"]
 
     def test_fx_98_0_0_de(self, render_mock):
         """Should use whatsnew-fx98-mobile-de template for 98.0 for German"""

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -553,7 +553,7 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("98."):
-            if ftl_file_is_active("firefox/whatsnew/whatsnew-fx98-vpn-eu.html") and country in ["SE", "FI"]:
+            if ftl_file_is_active("firefox/whatsnew/whatsnew-98-vpn-eu") and country in ["SE", "FI"]:
                 template = "firefox/whatsnew/whatsnew-fx98-vpn-eu.html"
             elif locale == "de":
                 template = "firefox/whatsnew/whatsnew-fx98-mobile-de.html"


### PR DESCRIPTION
## Description
Fixes `ftl_file_is_active` check preventing translated locales from displaying the correct template.

## Issue / Bugzilla link
#11262

## Testing
1. Make sure to update locales locally first by running `bin/bootstrap.sh`.
2. Set `Dev=False` in your `.env`.

- [x] http://localhost:8000/sv-SE/firefox/98.0/whatsnew/?geo=se should display a fully translated template promoting VPN.
- [x] http://localhost:8000/fi/firefox/98.0/whatsnew/?geo=fi should display the default WNP template (QR Code).