### PR TITLE
Add contribute banner (fixes #11233)

### DIFF
--- a/bedrock/base/templates/includes/banners/mozilla-connect.html
+++ b/bedrock/base/templates/includes/banners/mozilla-connect.html
@@ -1,0 +1,13 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends 'includes/banners/base.html' %}
+
+{% block banner_id %}mozilla-connect-banner{% endblock %}
+
+{% block banner_title %}<a rel="external" data-cta-text="Mozilla Connect is here" data-cta-type="link" data-cta-position="banner" href="https://connect.mozilla.org?utm_source=contribute-website&utm_medium=banner&utm_campaign=connect-campaign&utm_content=15032022">{{ ftl('banner-mozilla-connect-title') }}</a>{% endblock %}
+
+{% block banner_content %}{{ ftl('banner-mozilla-connect-content') }}{% endblock %}

--- a/bedrock/base/templates/includes/banners/mozilla-connect.html
+++ b/bedrock/base/templates/includes/banners/mozilla-connect.html
@@ -10,4 +10,4 @@
 
 {% block banner_title %}<a rel="external" data-cta-text="Mozilla Connect is here" data-cta-type="link" data-cta-position="banner" href="https://connect.mozilla.org?utm_source=contribute-website&utm_medium=banner&utm_campaign=connect-campaign&utm_content=15032022">{{ ftl('banner-mozilla-connect-title') }}</a>{% endblock %}
 
-{% block banner_content %}{{ ftl('banner-mozilla-connect-content') }}{% endblock %}
+{% block banner_content %}<p>{{ ftl('banner-mozilla-connect-content') }}</p>{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -8,7 +8,12 @@
 
 {% extends "base-protocol-mozilla.html" %}
 
+{% set show_mozilla_connect_banner = switch('mozilla-connect-banner') %}
+
 {% block page_css %}
+  {% if show_mozilla_connect_banner %}
+    {{ css_bundle('mozilla-connect-banner') }}
+  {% endif %}
   {{ css_bundle('protocol-split') }}
   {{ css_bundle('protocol-card') }}
   {{ css_bundle('protocol-newsletter') }}
@@ -20,6 +25,12 @@
 {% block body_class %}{{ super() }} contribute{% endblock %}
 
 {% set utm_params = '?utm_source=mozilla.org-contribute&utm_medium=referral&utm_campaign=contribute-page' %}
+
+{% block page_banner %}
+  {% if show_mozilla_connect_banner %}
+    {% include 'includes/banners/mozilla-connect.html' %}
+  {% endif %}
+{% endblock %}
 
 {% block content %}
 <main role="main">
@@ -217,5 +228,8 @@
 {% endblock content %}
 
 {% block js %}
+  {% if show_mozilla_connect_banner %}
+    {{ js_bundle('mozilla-connect-banner') }}
+  {% endif %}
   {{ js_bundle('contribute') }}
 {% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -98,7 +98,7 @@ urlpatterns = (
     page("MPL/2.0/combining-mpl-and-gpl", "mozorg/mpl/2.0/combining-mpl-and-gpl.html"),
     page("MPL/2.0/differences", "mozorg/mpl/2.0/differences.html"),
     page("MPL/2.0/permissive-code-into-mpl", "mozorg/mpl/2.0/permissive-code-into-mpl.html"),
-    page("contribute", "mozorg/contribute.html", ftl_files=["mozorg/contribute"]),
+    page("contribute", "mozorg/contribute.html", ftl_files=["mozorg/contribute", "banners/mozilla-connect"]),
     page("moss", "mozorg/moss/index.html"),
     page("moss/foundational-technology", "mozorg/moss/foundational-technology.html"),
     page("moss/mission-partners", "mozorg/moss/mission-partners.html"),

--- a/l10n/en/banners/mozilla-connect.ftl
+++ b/l10n/en/banners/mozilla-connect.ftl
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/contribute
+
+banner-mozilla-connect-title = { -brand-name-mozilla-connect } is here
+
+banner-mozilla-connect-content = Submit your ideas for Firefox and other Mozilla products and participate to conversations with Mozilla's product managers.

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -101,6 +101,7 @@
 -brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
+-brand-name-mozilla-connect = Mozilla Connect
 
 ## Mozilla projects (short names)
 

--- a/media/css/base/banners/mozilla-connect.scss
+++ b/media/css/base/banners/mozilla-connect.scss
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import 'includes/base';
+
+.c-banner {
+    background-color: #e7ffff; // match light blue in image backgrounds
+
+    &,
+    & a:link,
+    & a:visited {
+        color: $color-black;
+    }
+}
+
+.c-banner-close {
+    background: transparent url('/media/protocol/img/icons/close.svg') center center no-repeat;
+}

--- a/media/css/base/banners/mozilla-connect.scss
+++ b/media/css/base/banners/mozilla-connect.scss
@@ -8,6 +8,16 @@
 .c-banner {
     background-color: #e7ffff; // match light blue in image backgrounds
 
+    &-title {
+        @include text-title-md;
+    }
+
+    &-content {
+        p {
+            margin-bottom: 0;
+        }
+    }
+
     &,
     & a:link,
     & a:visited {

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -12,7 +12,6 @@ $image-path: '/media/protocol/img';
 .contribute-intro {
     overflow: hidden;
     padding-bottom: 90%;
-    padding-top: 0;
     position: relative;
 
     @media #{$mq-md} {
@@ -21,6 +20,7 @@ $image-path: '/media/protocol/img';
 
     @media #{$mq-lg} {
         padding-bottom: $layout-xl;
+        padding-top: 0;
     }
 
     @media #{$mq-xl} {

--- a/media/js/base/banners/mozilla-connect-banner-init.js
+++ b/media/js/base/banners/mozilla-connect-banner-init.js
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    function onLoad() {
+        window.Mozilla.Banner.init('mozilla-connect-banner');
+    }
+
+    window.Mozilla.run(onLoad);
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -276,6 +276,12 @@
     },
     {
       "files": [
+        "css/base/banners/mozilla-connect.scss"
+      ],
+      "name": "mozilla-connect-banner"
+    },
+    {
+      "files": [
         "css/protocol/common-old-ie.scss"
       ],
       "name": "common-old-ie"
@@ -1320,6 +1326,13 @@
         "js/base/banners/turning-red-banner-init.js"
       ],
       "name": "turning-red-banner"
+    },
+    {
+      "files": [
+        "js/base/banners/mozilla-banner.js",
+        "js/base/banners/mozilla-connect-banner-init.js"
+      ],
+      "name": "mozilla-connect-banner"
     },
     {
       "files": [


### PR DESCRIPTION
## Description

Adds a Mozilla Connect banner on the contribute page with link to https://connect.mozilla.org/

Banner is behind switch. Should be live **March 15**.

switch PR: https://github.com/mozmeao/www-config/pull/437

analytics link: https://connect.mozilla.org?utm_source=contribute-website&utm_medium=banner&utm_campaign=connect-campaign&utm_content=15032022

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11233

## Testing

http://localhost:8000/en-US/contribute/

`SWITCH_MOZILLA_CONNECT_BANNER=on` (default in DEV mode) shows banner

`SWITCH_MOZILLA_CONNECT_BANNER=off` does not show banner
