### PR TITLE
Add Referrer-Policy header to all responses

### DIFF
--- a/bedrock/mozorg/middleware.py
+++ b/bedrock/mozorg/middleware.py
@@ -30,6 +30,20 @@ class CacheMiddleware:
         return response
 
 
+class ReferrerPolicyMiddleware:
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return self.process_response(request, response)
+
+    @staticmethod
+    def process_response(request, response):
+        response["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
+
 class ClacksOverheadMiddleware:
     # bug 1144901
 

--- a/bedrock/mozorg/tests/test_middleware.py
+++ b/bedrock/mozorg/tests/test_middleware.py
@@ -5,8 +5,23 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.test.utils import override_settings
 
-from bedrock.mozorg.middleware import ClacksOverheadMiddleware, HostnameMiddleware
+from bedrock.mozorg.middleware import (
+    ClacksOverheadMiddleware,
+    HostnameMiddleware,
+    ReferrerPolicyMiddleware,
+)
 from bedrock.mozorg.tests import TestCase
+
+
+class TestReferrerPolicyMiddleware(TestCase):
+    def setUp(self):
+        self.middleware = ReferrerPolicyMiddleware()
+        self.request = HttpRequest()
+        self.response = HttpResponse()
+
+    def test_good_response_has_header(self):
+        self.middleware.process_response(self.request, self.response)
+        self.assertEqual(self.response["Referrer-Policy"], "strict-origin-when-cross-origin")
 
 
 class TestClacksOverheadMiddleware(TestCase):

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -538,6 +538,7 @@ MIDDLEWARE = [
     "allow_cidr.middleware.AllowCIDRMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "bedrock.mozorg.middleware.ReferrerPolicyMiddleware",
     "bedrock.mozorg.middleware.HostnameMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
This should enforce a Referrer Policy on all outbound links from
WMO. See MDN documentation for details:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives

Re https://bugzilla.mozilla.org/show_bug.cgi?id=1697793
