### PR TITLE
Set strict-origin-when-cross-origin as default Referrer Policy

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -622,6 +622,7 @@ VARY_NOCACHE_EXEMPT_URL_PREFIXES = (
 # legacy setting. backward compat.
 DISABLE_SSL = config("DISABLE_SSL", default="true", parser=bool)
 # SecurityMiddleware settings
+SECURE_REFERRER_POLICY = config("SECURE_REFERRER_POLICY", default="strict-origin-when-cross-origin")
 SECURE_HSTS_SECONDS = config("SECURE_HSTS_SECONDS", default="0", parser=int)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 SECURE_BROWSER_XSS_FILTER = config("SECURE_BROWSER_XSS_FILTER", default="true", parser=bool)


### PR DESCRIPTION
See:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives
- https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SECURE_REFERRER_POLICY

Re https://bugzilla.mozilla.org/show_bug.cgi?id=1697793
