### PR TITLE
fixed Styling and link issues on Firefox Developer page

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -17,6 +17,7 @@
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/developer/apple-touch-icon.png') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-split') }}
   {{ css_bundle('firefox_developer') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -14,6 +14,7 @@
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/developer/apple-touch-icon.png') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-split') }}
   {{ css_bundle('firefox_developer') }}
 {% endblock %}
 


### PR DESCRIPTION
## Description
Fixing of Styling and link issues on Firefox Developer firstrun and Dev Edition whatsnew page.

## Issue / Bugzilla link
#11281

## Testing
![Screenshot 2022-03-07 at 14-14-35 Firefox Developer Edition](https://user-images.githubusercontent.com/73520373/157001091-a6c67ba7-19c7-48c1-a50a-6c96b81e5b3f.png)
