### PR TITLE
[March 23] Add MDN Plus legal pages (fixes #11184)

### DIFF
--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -61,6 +61,9 @@
   <li>
     <a href="https://webmaker.org/#/legal">{{ ftl('legal-webmaker') }}</a>
   </li>
+  <li>
+    <a href="{{ url('legal.terms.mdn-plus') }}">{{ ftl('legal-mdn-plus') }}</a>
+  </li>
 </ul>
 
 <h2>{{ ftl('legal-privacy-trademarks') }}</h2>

--- a/bedrock/legal/templates/legal/terms/mdn-plus.html
+++ b/bedrock/legal/templates/legal/terms/mdn-plus.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ ftl('legal-mdn-plus-terms') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -61,6 +61,11 @@ urlpatterns = (
         name="legal.terms.thunderbird",
     ),
     path(
+        "terms/mdn-plus/",
+        LegalDocView.as_view(template_name="legal/terms/mdn-plus.html", legal_doc_name="mdn_plus_terms"),
+        name="legal.terms.mdn-plus",
+    ),
+    path(
         "terms/services/",
         LegalDocView.as_view(template_name="legal/terms/services.html", legal_doc_name="firefox_cloud_services_ToS"),
         name="legal.terms.services",

--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -41,6 +41,7 @@
   (url('privacy.notices.firefox-relay'), 'privacy-relay', ftl('privacy-index-firefox-relay')),
   (url('privacy.notices.mozilla-vpn'), 'mozilla-vpn', ftl('privacy-index-mozilla-vpn')),
   (url('privacy.notices.thunderbird'), 'privacy-thunderbird', ftl('privacy-index-thunderbird')),
+  (url('privacy.notices.mdn-plus'), 'privacy-mdn-plus', ftl('privacy-index-mdn-plus')),
 ] -%}
 
 {% block content %}

--- a/bedrock/privacy/templates/privacy/notices/mdn-plus.html
+++ b/bedrock/privacy/templates/privacy/notices/mdn-plus.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "privacy/notices/base-notice-headings.html" %}
+
+{% set body_id = "mdn-plus" %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -30,6 +30,7 @@ urlpatterns = (
     path("firefox-private-network/", views.firefox_private_network, name="privacy.notices.firefox-private-network"),
     path("firefox-relay/", views.firefox_relay_notices, name="privacy.notices.firefox-relay"),
     path("mozilla-vpn/", views.mozilla_vpn, name="privacy.notices.mozilla-vpn"),
+    path("mdn-plus/", views.mdn_plus, name="privacy.notices.mdn-plus"),
     page("archive", "privacy/archive/index.html", ftl_files=["privacy/index"], active_locales=["en-US"]),
     page("archive/firefox/2006-10", "privacy/archive/firefox-2006-10.html", ftl_files=["privacy/index"], active_locales=["en-US"]),
     page("archive/firefox/2008-06", "privacy/archive/firefox-2008-06.html", ftl_files=["privacy/index"], active_locales=["en-US"]),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -83,6 +83,8 @@ firefox_private_network = PrivacyDocView.as_view(
 
 mozilla_vpn = PrivacyDocView.as_view(template_name="privacy/notices/mozilla-vpn.html", legal_doc_name="mozilla_vpn_privacy_notice")
 
+mdn_plus = PrivacyDocView.as_view(template_name="privacy/notices/mdn-plus.html", legal_doc_name="mdn_plus_privacy")
+
 
 @cache_page(60 * 60)  # cache for 1 hour
 def privacy(request):

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -100,6 +100,7 @@
 -brand-name-mozilla-labs = Mozilla Labs
 -brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
+-brand-name-mdn-plus = MDN Plus
 -brand-name-thunderbird = Thunderbird
 
 ## Mozilla projects (short names)

--- a/l10n/en/mozorg/about/legal.ftl
+++ b/l10n/en/mozorg/about/legal.ftl
@@ -31,4 +31,6 @@ legal-firefox-private-network-terms = { -brand-name-firefox-private-network } Te
 legal-firefox-reality-rights = { -brand-name-firefox-reality }: About Your Rights
 legal-firefox-relay-terms = { -brand-name-firefox-relay } Terms of Service
 legal-mozilla-vpn-terms = { -brand-name-mozilla-vpn } Terms of Service
+legal-mdn-plus = { -brand-name-mdn-plus }
+legal-mdn-plus-terms = { -brand-name-mdn-plus } Terms of Service
 legal-report-copyright = Report Copyright or Trademark Infringement

--- a/l10n/en/privacy/index.ftl
+++ b/l10n/en/privacy/index.ftl
@@ -48,3 +48,4 @@ privacy-index-mozilla-vpn = { -brand-name-mozilla-vpn }
 privacy-index-thunderbird = { -brand-name-thunderbird }
 privacy-index-firefox-better-web = { -brand-name-firefox-better-web }
 privacy-index-firefox-fire-tv = { -brand-name-firefox } for { -brand-name-fire-tv }
+privacy-index-mdn-plus = { -brand-name-mdn-plus }


### PR DESCRIPTION
## Description
Adds MDN Plus privacy and terms of service to appropriate pages.

⚠️ DO NOT MERGE until March 23. We can wait until that date or put the changes behind a switch.
✅ This has sign-off from stakeholders.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11184

## Testing

https://www-demo4.allizom.org/en-US/privacy (link listed in side
navigation)
https://www-demo4.allizom.org/en-US/privacy/mdn-plus

https://www-demo4.allizom.org/en-US/about/legal/ (link listed under Terms heading)
https://www-demo4.allizom.org/en-US/about/legal/terms/mdn-plus