### PR TITLE
WNP98 Turning Red: update copy, center image

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx98-turningred-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx98-turningred-en.html
@@ -32,9 +32,10 @@
 
   <section class="c-common-things">
     <div class="mzp-l-content mzp-t-content-md">
-      <h2>Oh and here are a few things Firefox has in <b>common</b> with Turning Red:</h2>
+      <h2>Oh and here are a few ways Firefox can <b>relate</b> with Turning Red:</h2>
 
       <ul class="c-common-things-list">
+        <li>A mystical connection with red pandas (firefoxes)</li>
         <li>Coming of age in early 2000s</li>
         <li>Dealing with being different</li>
         <li>Embracing your true self</li>

--- a/media/css/firefox/whatsnew/whatsnew-98-turningred-en.scss
+++ b/media/css/firefox/whatsnew/whatsnew-98-turningred-en.scss
@@ -53,7 +53,13 @@ $notebook-gradient-light: #fff radial-gradient(circle at bottom, $notebook-green
 }
 
 .wnp-main-image {
+    left: -25px;
     margin: $layout-sm auto;
+    position: relative;
+
+    @media #{$mq-lg} {
+        left: -50px;
+    }
 }
 
 .wnp-main-title {
@@ -106,20 +112,24 @@ $notebook-gradient-light: #fff radial-gradient(circle at bottom, $notebook-green
         padding-top: 0;
     }
 
-    h2 b {
-        font-weight: inherit;
-        position: relative;
+    h2 {
+        @include text-title-sm;
 
-        &::after {
-            background: transparent url('/media/img/firefox/whatsnew/whatsnew98/circle-red.svg') center center no-repeat;
-            background-size: contain;
-            content: '';
-            display: block;
-            height: calc(100% + 0.7em);
-            left: -0.3em;
-            position: absolute;
-            top: -0.35em;
-            width: calc(100% + 1em);
+        b {
+            font-weight: inherit;
+            position: relative;
+
+            &::after {
+                background: transparent url('/media/img/firefox/whatsnew/whatsnew98/circle-red.svg') center center no-repeat;
+                background-size: contain;
+                content: '';
+                display: block;
+                height: calc(100% + 0.7em);
+                left: -0.3em;
+                position: absolute;
+                top: -0.35em;
+                width: calc(100% + 1em);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

1. Changes the secondary headline to "Oh and here are a few ways Firefox can relate with Turning Red:" to make it a bit less literal.
2. Adds the line "A mystical connection with red pandas (firefoxes)" at the top of the list. It was always supposed to be there but got omitted from the mockup at some point.
3. The hero image has a little "OMG!" cloud which creates some extra whitespace on the left, pushing the red swatch off-center. This just shifts the image a bit left to compensate and look more visually balanced. I didn't really measure anything, just eyeballed it, and 50px felt about right.

## Issue / Bugzilla link
#11208 

## Testing
http://localhost:8000/en-US/firefox/98.0/whatsnew/?geo=us