### PR TITLE
Update `NewsletterFooterForm` to use `MultipleChoiceField`

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -81,12 +81,11 @@
           <fieldset class="mzp-u-inline">
             <legend>{{ ftl('multi-newsletter-form-checkboxes-legend') }}</legend>
             <p>
-              <label for="newsletter-mozilla" class="mzp-u-inline">
-                <input type="checkbox" id="newsletter-mozilla" name="newsletter-id" value="mozilla-foundation" checked> {{ ftl('multi-newsletter-form-checkboxes-label-mozilla')}}
-              </label>
-              <label for="newsletter-firefox" class="mzp-u-inline">
-                <input type="checkbox" id="newsletter-firefox" name="newsletter-id" value="mozilla-and-you" checked> {{ ftl('multi-newsletter-form-checkboxes-label-firefox') }}
-              </label>
+              {% for field in form.newsletters %}
+                <label for="{{ field.id_for_label }}" class="mzp-u-inline">
+                  {{ field.tag() }} {{ field.choice_label }}
+                </label>
+              {% endfor %}
             </p>
           </fieldset>
         {% endif %}

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -11,7 +11,9 @@
     {% if is_multi_newsletter_form %}
       <div id="newsletter-error-strings" data-form-checkboxes-error="{{ ftl('multi-newsletter-form-checkboxes-error') }}"></div>
     {% else %}
-      {{ form.newsletters|safe }}
+      <div hidden="true">
+        {{ form.newsletters|safe }}
+      </div>
     {% endif %}
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
 

--- a/bedrock/newsletter/templatetags/helpers.py
+++ b/bedrock/newsletter/templatetags/helpers.py
@@ -49,9 +49,14 @@ def email_newsletter_form(
     if not form:
         form = NewsletterFooterForm(newsletters, get_locale(request))
 
+    if isinstance(newsletters, list):
+        newsletters = ", ".join(newsletters)
+
+    is_multi_newsletter = "," in newsletters
+
     context.update(
         dict(
-            id=newsletters,
+            id="mozilla-firefox-multi" if is_multi_newsletter else newsletters,
             title=title,
             subtitle=subtitle,  # nested in/depends on include_title
             desc=desc,  # nested in/depends on include_title
@@ -70,7 +75,7 @@ def email_newsletter_form(
             success=success,
             email_label=email_label,
             email_placeholder=email_placeholder,
-            is_multi_newsletter_form="," in newsletters,
+            is_multi_newsletter_form=is_multi_newsletter,
         )
     )
 

--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -171,7 +171,7 @@ class TestNewsletterFooterForm(TestCase):
             "privacy": True,
             "fmt": "H",
             "source_url": "https://accounts.firefox.com",
-            "newsletters": self.newsletter_name,
+            "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data.copy())
         self.assertTrue(form.is_valid(), form.errors)
@@ -190,7 +190,7 @@ class TestNewsletterFooterForm(TestCase):
             "privacy": True,
             "fmt": "H",
             "source_url": "about:devtools?dude=abiding",
-            "newsletters": self.newsletter_name,
+            "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data.copy())
         self.assertTrue(form.is_valid(), form.errors)
@@ -207,7 +207,7 @@ class TestNewsletterFooterForm(TestCase):
             "privacy": True,
             "fmt": "H",
             "source_url": "about:devtools" * 20,
-            "newsletters": self.newsletter_name,
+            "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data.copy())
         self.assertTrue(form.is_valid(), form.errors)
@@ -257,7 +257,7 @@ class TestNewsletterFooterForm(TestCase):
             "email": "foo@example.com",
             "privacy": True,
             "fmt": "H",
-            "newsletters": self.newsletter_name,
+            "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data.copy())
         self.assertTrue(form.is_valid(), form.errors)
@@ -272,7 +272,7 @@ class TestNewsletterFooterForm(TestCase):
             "email": "foo@example.com",
             "privacy": False,
             "fmt": "H",
-            "newsletters": self.newsletter_name,
+            "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data)
         self.assertFalse(form.is_valid())
@@ -289,7 +289,7 @@ class TestNewsletterFooterForm(TestCase):
             "lang": "fr",
             "privacy": True,
             "fmt": "H",
-            "newsletters": "",
+            "newsletters": [],
         }
         form = NewsletterFooterForm("", locale="en-US", data=data.copy())
         self.assertFalse(form.is_valid())
@@ -302,16 +302,16 @@ class TestNewsletterFooterForm(TestCase):
             "lang": "fr",
             "privacy": True,
             "fmt": "H",
-            "newsletters": invalid_newsletter,
+            "newsletters": [invalid_newsletter],
         }
         form = NewsletterFooterForm(invalid_newsletter, locale="en-US", data=data.copy())
         self.assertFalse(form.is_valid())
         self.assertIn("newsletters", form.errors)
-        self.assertEqual(form.errors["newsletters"], ["Invalid Newsletter"])
+        self.assertTrue(form.errors["newsletters"][0].startswith("Select a valid choice."))
 
     def test_multiple_newsletters(self):
-        """Should allow to subscribe to multiple newsletters at a time."""
-        newsletters = "mozilla-and-you,beta"
+        newsletters = ["mozilla-and-you", "beta"]
+        spacey_newsletters = [f" {n} " for n in newsletters]
         data = {
             "email": "dude@example.com",
             "lang": "en",
@@ -320,10 +320,10 @@ class TestNewsletterFooterForm(TestCase):
             "newsletters": newsletters,
         }
         form = NewsletterFooterForm(newsletters, "en-US", data=data.copy())
-        self.assertTrue(form.is_valid())
+        self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.cleaned_data["newsletters"], newsletters)
 
         # whitespace shouldn't matter
-        form = NewsletterFooterForm("mozilla-and-you , beta ", "en-US", data=data.copy())
+        form = NewsletterFooterForm(spacey_newsletters, "en-US", data=data.copy())
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data["newsletters"], newsletters)

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -594,12 +594,21 @@ class TestNewsletterSubscribe(TestCase):
         self.assertFalse(resp_data["success"])
         self.assertEqual(resp_data["errors"][0], str(general_error))
 
-    def test_shows_normal_form(self):
-        """A normal GET should show the form."""
+    def test_shows_form_multi(self):
+        """The footer form subscribes to multiple newsletters."""
         resp = self.request()
         doc = pq(resp.content)
         self.assertTrue(doc("#newsletter-form"))
         self.assertTrue(doc('input[value="mozilla-foundation"]'))
+        self.assertEqual(doc("#newsletter-submit")[0].attrib["data-cta-type"], "Newsletter-mozilla-firefox-multi")
+
+    def test_shows_form_single(self):
+        """The MPL page only subscribes to 'mozilla-foundation', so not a multi-newsletter form."""
+        resp = self.client.get("/MPL", follow=True)
+        doc = pq(resp.content)
+        self.assertTrue(doc("#newsletter-form"))
+        self.assertTrue(doc('input[value="mozilla-foundation"]'))
+        self.assertEqual(doc("#newsletter-submit")[0].attrib["data-cta-type"], "Newsletter-mozilla-foundation")
 
     @patch("bedrock.newsletter.views.basket")
     def test_returns_success(self, basket_mock):

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -492,7 +492,7 @@ class TestNewsletterSubscribe(TestCase):
     def test_returns_ajax_errors(self, basket_mock):
         """Incomplete data should return specific errors in JSON"""
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
         }
@@ -510,7 +510,7 @@ class TestNewsletterSubscribe(TestCase):
         Bug 1116754
         """
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -529,7 +529,7 @@ class TestNewsletterSubscribe(TestCase):
     def test_no_source_url_use_referrer(self, basket_mock):
         """Should set source_url to referrer if not sent"""
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -544,7 +544,7 @@ class TestNewsletterSubscribe(TestCase):
     def test_use_source_url_with_referer(self, basket_mock):
         """Should use source_url even if there's a good referrer"""
         source_url = "https://example.com/bambam"
-        data = {"newsletters": "flintstones", "email": "fred@example.com", "fmt": "H", "privacy": True, "source_url": source_url}
+        data = {"newsletters": ["flintstones"], "email": "fred@example.com", "fmt": "H", "privacy": True, "source_url": source_url}
         resp = self.ajax_request(data, HTTP_REFERER=source_url + "_WILMA")
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {"success": True})
@@ -554,7 +554,7 @@ class TestNewsletterSubscribe(TestCase):
     def test_returns_ajax_success(self, basket_mock):
         """Good post should return success JSON"""
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -569,7 +569,7 @@ class TestNewsletterSubscribe(TestCase):
         """Invalid email AJAX post should return proper error."""
         subscribe_mock.side_effect = basket.BasketException(code=basket.errors.BASKET_INVALID_EMAIL)
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -584,7 +584,7 @@ class TestNewsletterSubscribe(TestCase):
         """Basket error AJAX post should return proper error."""
         subscribe_mock.side_effect = basket.BasketException(code=basket.errors.BASKET_NETWORK_FAILURE)
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -605,7 +605,7 @@ class TestNewsletterSubscribe(TestCase):
     def test_returns_success(self, basket_mock):
         """Good non-ajax post should return thank-you page."""
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -627,7 +627,7 @@ class TestNewsletterSubscribe(TestCase):
 
         """
         data = {
-            "newsletters": "fl!ntstones",
+            "newsletters": ["!nv@lid"],
             "email": "fred@example.com",
             "fmt": "H",
             "privacy": True,
@@ -635,7 +635,7 @@ class TestNewsletterSubscribe(TestCase):
         resp = self.request(data=data)
         doc = pq(resp.content)
         self.assertTrue(doc("#newsletter-form"))
-        self.assertTrue(doc('input[value="mozilla-and-you"]')[0].checked)
+        self.assertFalse(doc('input[value="mozilla-and-you"]')[0].checked)
         self.assertFalse(doc("#email-form"))
         # Note: An invalid newsletter isn't shown as an error since these are
         # chosen from a checkbox or hidden field and isn't something the user
@@ -646,14 +646,14 @@ class TestNewsletterSubscribe(TestCase):
     def test_returns_failure__missing_privacy(self, basket_mock):
         """Test non-ajax POST with missing privacy acceptance."""
         data = {
-            "newsletters": "flintstones",
+            "newsletters": ["flintstones"],
             "email": "fred@example.com",
             "fmt": "H",
         }
         resp = self.request(data=data)
         doc = pq(resp.content)
         self.assertTrue(doc("#newsletter-form"))
-        self.assertTrue(doc('input[value="mozilla-and-you"]')[0].checked)
+        self.assertTrue(doc('input[value="flintstones"]')[0].checked)
         self.assertFalse(doc("#email-form"))
         self.assertIn("privacy", doc("#newsletter-errors").text())
         self.assertFalse(basket_mock.subscribe.called)

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -608,7 +608,7 @@ def recovery(request):
 
 def newsletter_subscribe(request):
     if request.method == "POST":
-        newsletters = request.POST.get("newsletters")
+        newsletters = request.POST.getlist("newsletters")
         form = NewsletterFooterForm(newsletters, l10n_utils.get_locale(request), request.POST)
         errors = []
         if form.is_valid():

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -635,13 +635,18 @@ def newsletter_subscribe(request):
             if not kwargs.get("source_url") and request.headers.get("Referer"):
                 kwargs["source_url"] = request.headers["Referer"]
 
+            # Convert data["newsletters"] to a comma separated string.
+            newsletters = data["newsletters"]
+            if isinstance(newsletters, list):
+                newsletters = ",".join(newsletters)
+
             try:
-                basket.subscribe(data["email"], data["newsletters"], **kwargs)
+                basket.subscribe(data["email"], newsletters, **kwargs)
             except basket.BasketException as e:
                 if e.code == basket.errors.BASKET_INVALID_EMAIL:
                     errors.append(str(invalid_email_address))
                 else:
-                    log.exception(f"Error subscribing {data['email']} to newsletter {data['newsletters']}")
+                    log.exception(f"Error subscribing {data['email']} to newsletter(s) {newsletters}")
                     errors.append(str(general_error))
 
         else:

--- a/docs/newsletters.rst
+++ b/docs/newsletters.rst
@@ -11,8 +11,8 @@ Newsletters
 Bedrock includes support for signing up for and managing subscriptions and
 preferences for Mozilla newsletters.
 
-By default, every page's footer has a form to signup for the default newsletter,
-"Firefox & You".
+By default, every page's footer has a form to signup for the default newsletters,
+"Mozilla Foundation" and "Firefox & You".
 
 Features
 --------
@@ -129,14 +129,23 @@ The default is:
 
 which gives a signup for Firefox & You.  You can pass parameters to the
 macro ``email_newsletter_form`` to change that.  For example, the
-``newsletter_id`` parameter controls which newsletter is signed up for,
+``newsletters`` parameter controls which newsletter is signed up for,
 and ``title`` can override the text:
 
 .. code-block:: jinja
 
     {% block email_form %}
         {{ email_newsletter_form('app-dev',
-                                 _('Sign up for more news about the Firefox Marketplace.')) }})
+                                 _('Sign up for more news about the Firefox Marketplace.')) }}
+    {% endblock %}
+
+The `newsletters` parameter, the first positional argument, can be either a list
+of newsletter IDs or a comma separated list of newsletters IDs:
+
+.. code-block:: jinja
+
+    {% block email_form %}
+        {{ email_newsletter_form('mozilla-foundation, mozilla-and-you') }}
     {% endblock %}
 
 Pages can control whether country or language fields are included by passing

--- a/media/js/newsletter/form-protocol.es6.js
+++ b/media/js/newsletter/form-protocol.es6.js
@@ -118,26 +118,20 @@
         const fmt = fmtText.checked ? fmtText.value : fmtHtml.value;
         const email = document.getElementById('id_email').value;
 
-        // Get newsletters by hidden id or checked inputs
-        let newsletters = '';
-        const singleNewsletterForm = document.getElementById('id_newsletters');
-        if (singleNewsletterForm) {
-            newsletters = singleNewsletterForm.value;
-        } else {
-            const checkedNewsletters = Array.from(
-                document.querySelectorAll("input[name='newsletter-id']:checked")
-            ).map((newsletter) => newsletter.value);
+        // Get newsletters by checked inputs
+        const checkedNewsletters = Array.from(
+            document.querySelectorAll("input[name='newsletters']:checked")
+        ).map((newsletter) => newsletter.value);
 
-            // confirm at least one newsletter is checked
-            if (checkedNewsletters.length === 0) {
-                const errorString = document
-                    .getElementById('newsletter-error-strings')
-                    .getAttribute('data-form-checkboxes-error');
-                errorArray.push(errorString);
-                return newsletterError();
-            }
-            newsletters = checkedNewsletters.join(',');
+        // confirm at least one newsletter is checked
+        if (checkedNewsletters.length === 0) {
+            const errorString = document
+                .getElementById('newsletter-error-strings')
+                .getAttribute('data-form-checkboxes-error');
+            errorArray.push(errorString);
+            return newsletterError();
         }
+        const newsletters = checkedNewsletters;
         const privacy = document.querySelector('input[name="privacy"]:checked')
             ? '&privacy=true'
             : '';
@@ -146,8 +140,12 @@
         const params =
             'email=' +
             encodeURIComponent(email) +
-            '&newsletters=' +
-            newsletters +
+            '&' +
+            newsletters
+                .map((n) => {
+                    return 'newsletters=' + n;
+                })
+                .join('&') +
             privacy +
             '&fmt=' +
             fmt +


### PR DESCRIPTION
## Description

This updates the form submission to accept newsletters as a list value and convert to CSV for Basket call.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11270

## Testing

- [ ] Verify footer form functions as expected
- [ ] Verify other newsletter forms work as expected (e.g. `/contribute`, `/about`)