### PR TITLE
Update last intro feature on dev

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -7,7 +7,7 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% call split(
-  block_id='nextgen',
+  block_id='fordevs',
   image_url='img/firefox/developer/stylo-engine.svg',
   block_class='t-performance'
 ) %}

--- a/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
@@ -17,7 +17,7 @@
   </li>
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/next-gen-icon.svg') }}" alt="">
-    <h3 class="c-title">{{ ftl('firefox-developer-next-gen-css-engine') }}</h3>
-    <p><a href="#nextgen" class="mzp-c-cta-link">{{ ftl('ui-learn-more')}}</a></p>
+    <h3 class="c-title">{{ ftl('firefox-developer-built-for-developers', fallback='firefox-developer-next-gen-css-engine') }}</h3>
+    <p><a href="#fordevs" class="mzp-c-cta-link">{{ ftl('ui-learn-more')}}</a></p>
   </li>
 </ul>

--- a/bedrock/firefox/templates/firefox/developer/includes/performance.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/performance.html
@@ -7,7 +7,7 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% call split(
-  block_id='nextgen',
+  block_id='fordevs',
   image_url='img/firefox/developer/stylo-engine.svg',
   block_class='t-performance'
 ) %}

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -57,7 +57,11 @@ firefox-developer-firefox-devtools-now-grays-out = { -brand-name-firefox-devtool
 firefox-developer-firefox-devtools = { -brand-name-firefox-devtools }
 firefox-developer-the-new-firefox-devtools = The new { -brand-name-firefox-devtools } are powerful, flexible, and best of all, hackable. This includes a best-in-class JavaScript debugger, which can target multiple browsers and is built in React and Redux.
 firefox-developer-master-css-grid = Master CSS Grid
+
+# outdated
 firefox-developer-next-gen-css-engine = Next-Gen CSS Engine
+
+firefox-developer-built-for-developers = Built for Developers
 firefox-developer-a-next-generation = A Next-Generation CSS Engine
 firefox-developer-master-innovative-features = Innovative Features
 firefox-developer-want-to-be-on-the-cutting-edge = Want to be on the cutting-edge?


### PR DESCRIPTION
## Description
Updates last picto text and anchor on Developer Whatsnew and Firstrun pages. Near term fix. Long term fix should involve how (if?) we keep these pages updated.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11281

## Testing
http://localhost:8000/en-US/firefox/98.0a2/firstrun/
http://localhost:8000/en-US/firefox/98.0a2/whatsnew/

last picto should read "Built for Developers" in EN and fallback to "Next gen CSS Engine" in untranslated languages (all except EN at the moment)
