### PR TITLE
Remove translation file for Mozilla Connect banner

### DIFF
--- a/bedrock/base/templates/includes/banners/mozilla-connect.html
+++ b/bedrock/base/templates/includes/banners/mozilla-connect.html
@@ -8,6 +8,6 @@
 
 {% block banner_id %}mozilla-connect-banner{% endblock %}
 
-{% block banner_title %}<a rel="external" data-cta-text="Mozilla Connect is here" data-cta-type="link" data-cta-position="banner" href="https://connect.mozilla.org?utm_source=contribute-website&utm_medium=banner&utm_campaign=connect-campaign&utm_content=15032022">{{ ftl('banner-mozilla-connect-title') }}</a>{% endblock %}
+{% block banner_title %}<a rel="external" data-cta-text="Mozilla Connect is here" data-cta-type="link" data-cta-position="banner" href="https://connect.mozilla.org?utm_source=contribute-website&utm_medium=banner&utm_campaign=connect-campaign&utm_content=15032022">Mozilla Connect is here</a>{% endblock %}
 
-{% block banner_content %}<p>{{ ftl('banner-mozilla-connect-content') }}</p>{% endblock %}
+{% block banner_content %}<p>Submit your ideas for Firefox and other Mozilla products and participate to conversations with Mozilla's product managers.</p>{% endblock %}

--- a/bedrock/base/templates/includes/banners/mozilla-connect.html
+++ b/bedrock/base/templates/includes/banners/mozilla-connect.html
@@ -10,4 +10,4 @@
 
 {% block banner_title %}<a rel="external" data-cta-text="Mozilla Connect is here" data-cta-type="link" data-cta-position="banner" href="https://connect.mozilla.org?utm_source=contribute-website&utm_medium=banner&utm_campaign=connect-campaign&utm_content=15032022">Mozilla Connect is here</a>{% endblock %}
 
-{% block banner_content %}<p>Submit your ideas for Firefox and other Mozilla products and participate to conversations with Mozilla's product managers.</p>{% endblock %}
+{% block banner_content %}<p>Submit your ideas for Firefox and other Mozilla products and participate in conversations with Mozilla’s product managers.</p>{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -98,7 +98,7 @@ urlpatterns = (
     page("MPL/2.0/combining-mpl-and-gpl", "mozorg/mpl/2.0/combining-mpl-and-gpl.html"),
     page("MPL/2.0/differences", "mozorg/mpl/2.0/differences.html"),
     page("MPL/2.0/permissive-code-into-mpl", "mozorg/mpl/2.0/permissive-code-into-mpl.html"),
-    page("contribute", "mozorg/contribute.html", ftl_files=["mozorg/contribute", "banners/mozilla-connect"]),
+    page("contribute", "mozorg/contribute.html", ftl_files=["mozorg/contribute"]),
     page("moss", "mozorg/moss/index.html"),
     page("moss/foundational-technology", "mozorg/moss/foundational-technology.html"),
     page("moss/mission-partners", "mozorg/moss/mission-partners.html"),

--- a/l10n/en/banners/mozilla-connect.ftl
+++ b/l10n/en/banners/mozilla-connect.ftl
@@ -1,9 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-### URL: https://www-dev.allizom.org/contribute
-
-banner-mozilla-connect-title = { -brand-name-mozilla-connect } is here
-
-banner-mozilla-connect-content = Submit your ideas for Firefox and other Mozilla products and participate to conversations with Mozilla's product managers.

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -101,7 +101,6 @@
 -brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
--brand-name-mozilla-connect = Mozilla Connect
 
 ## Mozilla projects (short names)
 


### PR DESCRIPTION
## Description

Mozilla Connect site is not translated and we decided it's best to [leave the banner English only](https://github.com/mozilla/bedrock/issues/11233#issuecomment-1069299483) across locales.

## Issue / Bugzilla link

## Testing
No leftover FTL connections.
http://localhost:8000/en-US/contribute/ - hardcoded English content is correct
