### PR TITLE
Remove trailing spaces after some URLs in hrefs on a D&I page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/diversity/2021/beyond-products.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/beyond-products.html
@@ -427,14 +427,14 @@
           </p>
           <p class="mzp-c-card-feature-desc">
             <ul class="mzp-u-list-styled">
-              <li><a href="https://www.spelman.edu/coe-mws/news-events/the-future-is-intersectional-series/resources-recordings " target="_blank" rel="external noopener">The New Jim Code? Reimagining the Default Settings of Technology and Society – Dr. Ruha Benjamin – March 4, 2021</a></li>
-              <li><a href="https://www.youtube.com/watch?v=9f0ukTzx0Qw " target="_blank" rel="external noopener">Black Women Disrupting the Status Quo in Technology | March 15, 2021 </a></li>
-              <li><a href="https://www.youtube.com/watch?v=F366d5pVLVA " target="_blank" rel="external noopener">Responding to Coded Bias: Black Women Interrogating AI | March 17, 2021</a></li>
-              <li><a href="https://www.youtube.com/watch?v=avh4-t2rUDs&t=948s " target="_blank" rel="external noopener">Misogynoir Transformed: How Nelly Made Me a Digital Alchemist | Wednesday, April 7, 2021</a></li>
-              <li><a href="https://www.youtube.com/watch?v=OL3DowBM9uc&t=10s " target="_blank" rel="external noopener">The Hierarchy of Knowledge in Machine Learning and Related Fields and Its Consequences | April 14, 2021</a></li>
-              <li><a href="https://www.youtube.com/watch?v=2Hukzq_hOQ8 " target="_blank" rel="external noopener">Why We Should Care: Technology and the Black Community | Wednesday, April 21, 2021</a></li>
-              <li><a href="https://www.youtube.com/watch?v=nhIVcvHrxcg " target="_blank" rel="external noopener">Where Do We Go From Here | November 4, 2021</a></li>
-              <li><a href="https://www.spelman.edu/coe-mws/news-events/the-future-is-intersectional-series/resources-recordings " target="_blank" rel="external noopener">Black Feminist Technoculture and the Virtual Beauty Shop – Dr. Catherine Knight Steele – November 11, 2021 </a></li>
+              <li><a href="https://www.spelman.edu/coe-mws/news-events/the-future-is-intersectional-series/resources-recordings" target="_blank" rel="external noopener">The New Jim Code? Reimagining the Default Settings of Technology and Society – Dr. Ruha Benjamin – March 4, 2021</a></li>
+              <li><a href="https://www.youtube.com/watch?v=9f0ukTzx0Qw" target="_blank" rel="external noopener">Black Women Disrupting the Status Quo in Technology | March 15, 2021 </a></li>
+              <li><a href="https://www.youtube.com/watch?v=F366d5pVLVA" target="_blank" rel="external noopener">Responding to Coded Bias: Black Women Interrogating AI | March 17, 2021</a></li>
+              <li><a href="https://www.youtube.com/watch?v=avh4-t2rUDs&t=948s" target="_blank" rel="external noopener">Misogynoir Transformed: How Nelly Made Me a Digital Alchemist | Wednesday, April 7, 2021</a></li>
+              <li><a href="https://www.youtube.com/watch?v=OL3DowBM9uc&t=10s" target="_blank" rel="external noopener">The Hierarchy of Knowledge in Machine Learning and Related Fields and Its Consequences | April 14, 2021</a></li>
+              <li><a href="https://www.youtube.com/watch?v=2Hukzq_hOQ8" target="_blank" rel="external noopener">Why We Should Care: Technology and the Black Community | Wednesday, April 21, 2021</a></li>
+              <li><a href="https://www.youtube.com/watch?v=nhIVcvHrxcg" target="_blank" rel="external noopener">Where Do We Go From Here | November 4, 2021</a></li>
+              <li><a href="https://www.spelman.edu/coe-mws/news-events/the-future-is-intersectional-series/resources-recordings" target="_blank" rel="external noopener">Black Feminist Technoculture and the Virtual Beauty Shop – Dr. Catherine Knight Steele – November 11, 2021 </a></li>
               <li><a href="https://www.spelman.edu/coe-mws/news-events/the-future-is-intersectional-series/resources-recordings" target="_blank" rel="external noopener">The Web of C’s and Bias Amplification – Dr. Fay Cobb Payton – November 18, 2021</a></li>
             </ul>
           </p>


### PR DESCRIPTION
## Description
Remove trailing spaces after some URLs in hrefs on a D&I page

We can't add them to the link checker if they have trailing spaces

## Issue / Bugzilla link

No ticket

## Testing

* Manually checking the links work when running the page -- though eyeballing is probably fine for a few space removals