### PR TITLE
Add protocol-split bundle to vpn article

### DIFF
--- a/bedrock/products/templates/products/vpn/resource-center/base-article.html
+++ b/bedrock/products/templates/products/vpn/resource-center/base-article.html
@@ -9,6 +9,7 @@
 {% extends "products/vpn/base.html" %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-split')}}
   {{ css_bundle('vpn-resource-center')}}
 {% endblock page_css %}
 


### PR DESCRIPTION
## Description

We missed a protocol-split import in VPN Resource Center articles. Added here.
<img width="1340" alt="Screen Shot 2022-03-18 at 2 48 06 PM" src="https://user-images.githubusercontent.com/19650432/159025331-c9b5bf44-5603-48cf-9d58-9cc8073c7d3b.png">

## Issue / Bugzilla link

## Testing
should have proper split styling
http://localhost:8000/en-US/products/vpn/resource-center/5-reasons-you-should-use-a-vpn/
