### PR TITLE
Update Sentry-related values in Bedrock

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
     "CSP_DEFAULT_SRC": "*.allizom.org",
     "CSP_EXTRA_FRAME_SRC": "*.mozaws.net",
     "CSP_REPORT_ENABLE": "True",
-    "CSP_REPORT_URI": "https://sentry.prod.mozaws.net/api/156/security/?sentry_key=b89cacf912c24702a2fa6e3dc4610ade",
+    "CSP_REPORT_URI": "https://o1069899.ingest.sentry.io/api/6260338/security/?sentry_key=97ec0cd426714b728e92f3b3aa62f00b",
     "DB_DOWNLOAD_IGNORE_GIT": "True",
     "DEBUG": "False",
     "DEV": "True",
@@ -25,7 +25,7 @@
       "description": "A secret key for verifying the integrity of signed cookies, though we don't use them.",
       "generator": "secret"
     },
-    "SENTRY_DSN": "https://b89cacf912c24702a2fa6e3dc4610ade@sentry.prod.mozaws.net/156",
+    "SENTRY_DSN": "https://97ec0cd426714b728e92f3b3aa62f00b@o1069899.ingest.sentry.io/6260338",
     "WEB_CONCURRENCY": "2"
   }
 }

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1256,7 +1256,8 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "logs.convertexperiments.com",
     "1003350.metrics.convertexperiments.com",
     "1003343.metrics.convertexperiments.com",
-    "sentry.prod.mozaws.net",
+    "sentry.prod.mozaws.net",  # DEPRECATED. TODO: remove this once all sites are talking to sentry.io instead
+    "o1069899.sentry.io",
     "cdn.cookielaw.org",
     "privacyportal.onetrust.com",
     FXA_ENDPOINT,


### PR DESCRIPTION
## Description
This changeset updates the config for the Heroku Review apps to use SaaS Sentry, under the bedrock-demos DSN.

It also updates the django-csp connect-src list to allow `sentry.io`

(The values in Heroku's web-based config have also been updated to the new bedrock-demos DSN)

## Issue / Bugzilla link

No ticket

## Testing
Might need y'all to push up a branch for review (eg this one) and see? Not pushed a review app here before, so would welcome a pointer about how it's done here.