### PR TITLE
Updating `card` Protocol component to CSS bundle

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -16,6 +16,7 @@
 
 {% block page_css %}
   {{ css_bundle('protocol-split')}}
+  {{ css_bundle('protocol-card')}}
   {{ css_bundle('protocol-call-out')}}
   {{ css_bundle('firefox_facebook_container') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -13,6 +13,7 @@
 {% block body_id %}installer-help{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-card') }}
   {{ css_bundle('installer_help') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -19,6 +19,7 @@
 
 {% block extrahead %}
   {{ super() }}
+  {{ css_bundle('protocol-card') }}
   {{ css_bundle('firefox_desktop_download') }}
 
   <!--[if IE 9]>

--- a/bedrock/firefox/templates/firefox/privacy/base.html
+++ b/bedrock/firefox/templates/firefox/privacy/base.html
@@ -15,6 +15,7 @@
   {{ css_bundle('protocol-split') }}
   {{ css_bundle('protocol-picto') }}
   {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-card') }}
   {{ css_bundle('firefox-privacy-common') }}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
@@ -15,6 +15,7 @@
 {% block page_image %}{{ static('img/mozorg/diversity/2021/card-images/dni-2021-meta.jpg') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-card') }}
   {{ css_bundle('diversity-2021') }}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/moss/base.html
+++ b/bedrock/mozorg/templates/mozorg/moss/base.html
@@ -15,6 +15,9 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-picto') }}
+  {{ css_bundle('protocol-card') }}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('moss') }}
 {% endblock %}
 

--- a/media/css/firefox/facebook-container.scss
+++ b/media/css/firefox/facebook-container.scss
@@ -7,12 +7,10 @@ $image-path: '/media/protocol/img';
 $brand-theme: 'firefox';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
 @import '~@mozilla-protocol/core/protocol/css/components/feature-card';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/video';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 
 // * -------------------------------------------------------------------------- */
 // Components

--- a/media/css/firefox/installer-help.scss
+++ b/media/css/firefox/installer-help.scss
@@ -6,9 +6,7 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 
 .mzp-c-card {
     .mzp-c-card-desc {

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -8,7 +8,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
 @import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
@@ -16,7 +15,6 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/components/section-heading';
 @import '~@mozilla-protocol/core/protocol/css/components/zap';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 @import '../../../protocol/components/sub-navigation';
 @import '../../sticky-promo';
 

--- a/media/css/firefox/privacy/products.scss
+++ b/media/css/firefox/privacy/products.scss
@@ -6,14 +6,12 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
 @import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 @import '../../protocol/components/fxa-form';
 
 .t-medium .mzp-l-content,

--- a/media/css/mozorg/diversity/2021/diversity-2021.scss
+++ b/media/css/mozorg/diversity/2021/diversity-2021.scss
@@ -6,12 +6,9 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 @import '~@mozilla-protocol/core/protocol/css/components/feature-card';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '~@mozilla-protocol/core/protocol/css/components/split';
 @import '~@mozilla-protocol/core/protocol/css/components/video';
 
 // * -------------------------------------------------------------------------- */

--- a/media/css/mozorg/moss.scss
+++ b/media/css/mozorg/moss.scss
@@ -6,11 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/components/picto';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
-@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
 
 /* -------------------------------------------------------------------------- */
 // Custom container width


### PR DESCRIPTION
## Description
This PR will primarily work on converting the `card` & `card-layout` (they are coupled here) component. I also converted some other components because they resided in the same file, and thought it be best to kill two birds (or, however many birds in this case) with one stone (or, rather, a PR).
## Issue / Bugzilla link
#11032 
## Testing
#### Card CSS bundle:
http://localhost:8000/en-US/firefox/facebookcontainer/
http://localhost:8000/en-US/firefox/installer-help/
http://localhost:8000/en-US/firefox/new/
http://localhost:8000/en-US/firefox/privacy/products/ (just removed the `card` + `card-layout` imports from `firefox/privacy/products.scss` as it's not being used for the page)
http://localhost:8000/en-US/moss/
http://localhost:8000/en-US/diversity/2021/ (all pages in the diversity nav)

#### Picto CSS bundle:
http://localhost:8000/en-US/moss/

#### Newsletter CSS bundle:
http://localhost:8000/en-US/moss/

