### PR TITLE
Updating `call-out` Protocol component to CSS bundle

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/best-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/best-browser.html
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
+  {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('best-browser') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('browser-history') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('incognito-browser') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/update-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/update-browser.html
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('update-browser') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -15,6 +15,8 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('windows-64-bit') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/campaign/unfck/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/index.html
@@ -16,6 +16,7 @@
 {% block page_image %}{{ static('img/firefox/campaign/unfck/en/og.jpg') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('firefox-unfck') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -11,6 +11,9 @@
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-picto') }}
+  {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('firefox_channel') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -16,6 +16,7 @@
 
 {% block page_css %}
   {{ super() }}
+  {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('adblocker') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/features/safebrowser.html
+++ b/bedrock/firefox/templates/firefox/features/safebrowser.html
@@ -15,7 +15,9 @@
 {% endblock %}
 
 {% block page_css %}
-{{ css_bundle('safebrowser') }}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-article') }}
+  {{ css_bundle('safebrowser') }}
 {% endblock %}
 
 {% block sub_navigation %}

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -14,6 +14,8 @@
 
 {% block extrahead %}
   {{ super() }}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_desktop_download_thanks') }}
 
   <!--[if IE]>

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -45,6 +45,8 @@
 {% block body_class %}mzp-t-firefox {{ theme_class }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('firefox_releasenotes') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -19,6 +19,7 @@
 {% block body_class %}mzp-t-firefox mzp-t-{{ channel_name|lower }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('firefox_system_requirements') }}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -17,6 +17,8 @@
 {% block body_id %}manifesto-landing{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('manifesto') }}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-contentful.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-contentful.html
@@ -20,6 +20,8 @@
 
 {% block page_css %}
   {% include 'includes/contentful/css.html' %}
+  {{ css_bundle('protocol-call-out') }}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('home-contentful') }}
 
   {% if show_turning_red_banner %}

--- a/media/css/firefox/browsers/best-browser.scss
+++ b/media/css/firefox/browsers/best-browser.scss
@@ -6,8 +6,7 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
+
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 

--- a/media/css/firefox/browsers/browser-history.scss
+++ b/media/css/firefox/browsers/browser-history.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 
 .mzp-c-article {
     margin: 0 auto $layout-lg;

--- a/media/css/firefox/browsers/incognito-browser.scss
+++ b/media/css/firefox/browsers/incognito-browser.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 
 .mzp-c-article {
     margin: $layout-lg auto;

--- a/media/css/firefox/browsers/update-browser.scss
+++ b/media/css/firefox/browsers/update-browser.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 
 .mzp-c-article {
     margin: $layout-lg auto;

--- a/media/css/firefox/browsers/windows-64-bit.scss
+++ b/media/css/firefox/browsers/windows-64-bit.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 

--- a/media/css/firefox/channel.scss
+++ b/media/css/firefox/channel.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
-// @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 @import '../protocol/components/sub-navigation';
 
 // * -------------------------------------------------------------------------- */

--- a/media/css/firefox/channel.scss
+++ b/media/css/firefox/channel.scss
@@ -7,10 +7,7 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
-@import '~@mozilla-protocol/core/protocol/css/components/picto';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
+// @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 @import '../protocol/components/sub-navigation';
 
 // * -------------------------------------------------------------------------- */

--- a/media/css/firefox/features/safebrowser.scss
+++ b/media/css/firefox/features/safebrowser.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 

--- a/media/css/firefox/new/basic/thanks.scss
+++ b/media/css/firefox/new/basic/thanks.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 // Hide the /thanks download button as selection is made via JS automatically.

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -9,8 +9,6 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '../protocol/components/sub-navigation';
 
 // * -------------------------------------------------------------------------- */

--- a/media/css/firefox/system-requirements.scss
+++ b/media/css/firefox/system-requirements.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 
 // * -------------------------------------------------------------------------- */
 // Header

--- a/media/css/firefox/unfck.scss
+++ b/media/css/firefox/unfck.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/includes/forms/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
 
 // --------------------------------------------------------------------------

--- a/media/css/mozorg/home/home-contentful.scss
+++ b/media/css/mozorg/home/home-contentful.scss
@@ -8,8 +8,6 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
 @import '~@mozilla-protocol/core/protocol/css/components/billboard';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 @import 'includes/home-base';

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -6,8 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/call-out';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 .manifesto-title {
     @include text-title-sm;


### PR DESCRIPTION
## Description
Converting `call-out` CSS imports to CSS bundles
## Issue / Bugzilla link

## Testing
#11032 
#### Call-out CSS bundle
http://localhost:8000/en-US/firefox/channel/desktop/
http://localhost:8000/en-US/firefox/97.0/releasenotes/
http://localhost:8000/en-US/firefox/97.0.1/system-requirements/
http://localhost:8000/en-US/firefox/unfck/
http://localhost:8000/en-US/firefox/browsers/best-browser/
http://localhost:8000/en-US/firefox/browsers/browser-history/
http://localhost:8000/en-US/firefox/browsers/incognito-browser/
http://localhost:8000/en-US/firefox/browsers/update-your-browser/
http://localhost:8000/en-US/firefox/browsers/windows-64-bit/
http://localhost:8000/en-US/firefox/features/adblocker/
http://localhost:8000/en-US/firefox/features/safebrowser/
`/firefox/new/desltop/thanks.html` (i can't find the URL for this page)
http://localhost:8000/en-US/about/manifesto/
http://localhost:8000/en-US/

#### Picto
http://localhost:8000/en-US/firefox/channel/desktop/

#### Newsletter
http://localhost:8000/en-US/firefox/channel/desktop/
http://localhost:8000/en-US/about/manifesto/
http://localhost:8000/en-US/

#### Article
http://localhost:8000/en-US/firefox/97.0/releasenotes/
http://localhost:8000/en-US/firefox/browsers/best-browser/
http://localhost:8000/en-US/firefox/browsers/browser-history/
http://localhost:8000/en-US/firefox/browsers/incognito-browser/
http://localhost:8000/en-US/firefox/browsers/update-your-browser/
http://localhost:8000/en-US/firefox/browsers/windows-64-bit/
http://localhost:8000/en-US/firefox/features/safebrowser/

#### Emphasis box
`/firefox/new/desltop/thanks.html` (i can't find the URL for this page)
