### PR TITLE
Add `picto` bundle to `firefox/developer` page

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -17,6 +17,7 @@
 
 {% block page_css %}
   {{ css_bundle('protocol-split') }}
+  {{ css_bundle('protocol-picto') }}
   {{ css_bundle('firefox_developer') }}
 {% endblock %}
 

--- a/media/css/firefox/developer/includes/engage.scss
+++ b/media/css/firefox/developer/includes/engage.scss
@@ -3,8 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
-@import '~@mozilla-protocol/core/protocol/css/components/picto';
 
 $brand-theme: 'firefox';
 


### PR DESCRIPTION
## Description
I didn't do it in this PR https://github.com/mozilla/bedrock/pull/11355 so doing it here

## Issue / Bugzilla link
#11032 

## Testing
http://localhost:8000/en-US/firefox/developer/
