### PR TITLE
Added test suite for Mozilla.Cookies

### DIFF
--- a/media/js/base/mozilla-cookie-helper.js
+++ b/media/js/base/mozilla-cookie-helper.js
@@ -80,27 +80,8 @@ Mozilla.Cookies = {
                     break;
             }
         }
-        /**
-         *  valid vSamesite values are 'lax', 'strict' and 'none' (case insensitive).
-         *  otherwise it will be 'lax'
-         */
-        function checkSameSite(vSamesite) {
-            if (!vSamesite) {
-                return null;
-            }
-            vSamesite = vSamesite.toString().toLowerCase();
 
-            if (
-                vSamesite === 'lax' ||
-                vSamesite === 'none' ||
-                vSamesite === 'strict'
-            ) {
-                return vSamesite;
-            } else {
-                return 'lax';
-            }
-        }
-        vSamesite = checkSameSite(vSamesite);
+        vSamesite = this.checkSameSite(vSamesite);
 
         // setting the samesite attribute to 'none' requires the cookie to be 'secure'
         if (vSamesite === 'none') {
@@ -179,6 +160,29 @@ Mozilla.Cookies = {
             return ret;
         } catch (e) {
             return false;
+        }
+    },
+
+    checkSameSite: function (vSamesite) {
+        'use strict';
+        /**
+         *  valid vSamesite values are 'lax', 'strict' and 'none' (case insensitive).
+         *  otherwise it will be 'lax'
+         */
+
+        if (!vSamesite) {
+            return null;
+        }
+        vSamesite = vSamesite.toString().toLowerCase();
+
+        if (
+            vSamesite === 'lax' ||
+            vSamesite === 'none' ||
+            vSamesite === 'strict'
+        ) {
+            return vSamesite;
+        } else {
+            return 'lax';
         }
     }
 };

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function (config) {
             'media/js/base/mozilla-client.js',
             'media/js/base/search-params.js',
             'media/js/externalpages/pocket/base.js',
+            'media/js/base/mozilla-cookie-helper.js',
             // end common dependencies.
             'media/js/base/banners/mozilla-banner.js',
             'media/js/base/mozilla-run.js',
@@ -40,6 +41,7 @@ module.exports = function (config) {
             'tests/unit/spec/base/core-datalayer-page-id.js',
             'tests/unit/spec/base/core-datalayer.js',
             'tests/unit/spec/base/dnt-helper.js',
+            'tests/unit/spec/base/mozilla-cookie-helper.js',
             'tests/unit/spec/base/experiment-utils.js',
             'tests/unit/spec/base/fxa-form.js',
             'tests/unit/spec/base/fxa-link.js',

--- a/tests/unit/spec/base/core-datalayer-page-id.js
+++ b/tests/unit/spec/base/core-datalayer-page-id.js
@@ -9,17 +9,7 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 describe('core-datalayer-page-id.js', function () {
-    beforeEach(function () {
-        // stub out Mozilla.Cookie lib
-        window.Mozilla.Cookies = sinon.stub();
-        window.Mozilla.Cookies.hasItem = sinon.stub();
-        window.Mozilla.Cookies.getItem = sinon.stub();
-        window.Mozilla.Cookies.removeItem = sinon.stub();
-    });
-
     describe('getPageId', function () {
         const html = document.documentElement;
 

--- a/tests/unit/spec/base/fxa-utm.js
+++ b/tests/unit/spec/base/fxa-utm.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 import FxaUtm from '../../../../media/js/base/fxa-utm.es6.js';
 
 describe('fxa-utm.js', function () {
@@ -445,16 +443,6 @@ describe('fxa-utm.js', function () {
     });
 
     describe('setFxALinkReferralCookie', function () {
-        beforeEach(function () {
-            // stub out Mozilla.Cookies lib
-            window.Mozilla.Cookies = sinon.stub();
-            window.Mozilla.Cookies.enabled = sinon.stub();
-            window.Mozilla.Cookies.setItem = sinon.stub();
-            window.Mozilla.Cookies.getItem = sinon.stub();
-            window.Mozilla.Cookies.hasItem = sinon.stub();
-            window.Mozilla.Cookies.removeItem = sinon.stub();
-        });
-
         it('should set a referral cookie as expected', function () {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
@@ -485,13 +473,8 @@ describe('fxa-utm.js', function () {
 
     describe('init', function () {
         beforeEach(function () {
-            // stub out Mozilla.Cookies lib
-            window.Mozilla.Cookies = sinon.stub();
-            window.Mozilla.Cookies.enabled = sinon.stub().returns(true);
-            window.Mozilla.Cookies.setItem = sinon.stub();
-            window.Mozilla.Cookies.getItem = sinon.stub();
-            window.Mozilla.Cookies.hasItem = sinon.stub();
-            window.Mozilla.Cookies.removeItem = sinon.stub();
+            // assume cookie are enabled.
+            spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
 
             // assume DNT is disabled
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);

--- a/tests/unit/spec/base/mozilla-banner.js
+++ b/tests/unit/spec/base/mozilla-banner.js
@@ -13,13 +13,6 @@
 
 describe('mozilla-banner.js', function () {
     beforeEach(function () {
-        // stub out Mozilla.Cookie lib
-        window.Mozilla.Cookies = sinon.stub();
-        window.Mozilla.Cookies.enabled = sinon.stub().returns(true);
-        window.Mozilla.Cookies.setItem = sinon.stub();
-        window.Mozilla.Cookies.getItem = sinon.stub();
-        window.Mozilla.Cookies.hasItem = sinon.stub();
-
         // stub out google tag manager
         window.dataLayer = sinon.stub();
         window.dataLayer.push = sinon.stub();

--- a/tests/unit/spec/base/mozilla-cookie-helper.js
+++ b/tests/unit/spec/base/mozilla-cookie-helper.js
@@ -30,19 +30,6 @@ describe('mozilla-cookie-helper.js', function () {
             expect(document.cookie).toContain(cookieId);
         });
 
-        it('should add samesite property of "lax" when calling setItem if passed vSameSite argument of string (not including "none" or "strict"', function () {
-            window.Mozilla.Cookies.setItem(
-                cookieId,
-                'test',
-                date,
-                '/',
-                undefined,
-                false,
-                'flour'
-            );
-            expect(document.cookie).toContain('samesite=lax');
-        });
-
         it('will return false if you dont pass the sKey property', function () {
             expect(window.Mozilla.Cookies.setItem()).toBeFalse();
         });
@@ -54,6 +41,37 @@ describe('mozilla-cookie-helper.js', function () {
             expect(window.Mozilla.Cookies.setItem('domain')).toBeFalse();
             expect(window.Mozilla.Cookies.setItem('secure')).toBeFalse();
             expect(window.Mozilla.Cookies.setItem('samesite')).toBeFalse();
+        });
+    });
+
+    describe('checkSameSite method', function () {
+        const cookieId = 'test-cookie';
+        var date = new Date();
+        date.setHours(date.getHours() + 48);
+
+        beforeEach(clearCookies);
+        afterEach(clearCookies);
+
+        it('should be called when calling Mozilla.Cookies.setItem', function () {
+            const spy = spyOn(window.Mozilla.Cookies, 'checkSameSite');
+            window.Mozilla.Cookies.setItem(cookieId);
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it('should return null if no argument is passed', function () {
+            expect(window.Mozilla.Cookies.checkSameSite()).toBeNull();
+        });
+
+        it('should return "lax" if a truthy string is passed (but not strict | none)', function () {
+            expect(window.Mozilla.Cookies.checkSameSite('flour')).toBe('lax');
+            expect(window.Mozilla.Cookies.checkSameSite('lax')).toBe('lax');
+        });
+        it('should return "none" if "none" is passed to function', function () {
+            expect(window.Mozilla.Cookies.checkSameSite('none')).toBe('none');
+        });
+
+        it('should return "lax" if "lax" is passed to function', function () {
+            expect(window.Mozilla.Cookies.checkSameSite('none')).toBe('none');
         });
     });
 

--- a/tests/unit/spec/base/mozilla-cookie-helper.js
+++ b/tests/unit/spec/base/mozilla-cookie-helper.js
@@ -18,13 +18,28 @@
 */
 
 describe('mozilla-cookie-helper.js', function () {
+    function clearCookies() {
+        document.cookies = '';
+    }
+
+    beforeEach(clearCookies);
+
+    afterEach(clearCookies);
+
     describe('setItem method', function () {
         const cookieId = 'test-cookie';
+        var date = new Date();
+        date.setHours(date.getHours() + 48);
+
         it('should set a cookie onto document.cookie', function () {
-            var date = new Date();
-            date.setHours(date.getHours() + 48);
             window.Mozilla.Cookies.setItem(cookieId, true, date, '/');
             expect(document.cookie).toContain(cookieId);
+        });
+        it('will return false if you dont pass the sKey property', function () {
+            expect(window.Mozilla.Cookies.setItem()).toBeFalse();
+        });
+        it('will return false if sKey starts with any: expires|max-age|path|domain|secure|samesite', function () {
+            expect(window.Mozilla.Cookies.setItem()).toBeFalse();
         });
     });
 });

--- a/tests/unit/spec/base/mozilla-cookie-helper.js
+++ b/tests/unit/spec/base/mozilla-cookie-helper.js
@@ -9,28 +9,44 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/*
-|*|  * Mozilla.Cookies.removeItem(name[, path[, domain]])
-|*|  * Mozilla.Cookies.keys()
-*/
-
 describe('mozilla-cookie-helper.js', function () {
     function clearCookies() {
-        document.cookies = '';
+        document.cookie = '';
     }
+
+    beforeEach(clearCookies);
+    afterEach(clearCookies);
 
     describe('setItem method', function () {
         const cookieId = 'test-cookie';
         var date = new Date();
         date.setHours(date.getHours() + 48);
 
+        beforeEach(clearCookies);
+        afterEach(clearCookies);
+
         it('should set a cookie onto document.cookie', function () {
             window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
             expect(document.cookie).toContain(cookieId);
         });
+
+        it('should add samesite property of "lax" when calling setItem if passed vSameSite argument of string (not including "none" or "strict"', function () {
+            window.Mozilla.Cookies.setItem(
+                cookieId,
+                'test',
+                date,
+                '/',
+                undefined,
+                false,
+                'flour'
+            );
+            expect(document.cookie).toContain('samesite=lax');
+        });
+
         it('will return false if you dont pass the sKey property', function () {
             expect(window.Mozilla.Cookies.setItem()).toBeFalse();
         });
+
         it('will return false if sKey equals any of the folllowing: expires|max-age|path|domain|secure|samesite', function () {
             expect(window.Mozilla.Cookies.setItem('expires')).toBeFalse();
             expect(window.Mozilla.Cookies.setItem('max-age')).toBeFalse();
@@ -118,14 +134,12 @@ describe('mozilla-cookie-helper.js', function () {
         var date = new Date();
         date.setHours(date.getHours() + 48);
 
-        beforeEach(function () {
-            clearCookies();
-            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
-        });
+        beforeEach(clearCookies);
 
         afterEach(clearCookies);
 
-        it('should return the cookie keys found in document.cookies', function () {
+        it('should return the cookie keys found in document.cookie', function () {
+            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
             expect(window.Mozilla.Cookies.keys()).toContain(cookieId);
             expect(window.Mozilla.Cookies.keys().length).toEqual(1);
             window.Mozilla.Cookies.setItem(

--- a/tests/unit/spec/base/mozilla-cookie-helper.js
+++ b/tests/unit/spec/base/mozilla-cookie-helper.js
@@ -10,7 +10,6 @@
  */
 
 /*
-|*|  * Mozilla.Cookies.setItem(name, value[, end[, path[, domain[, secure[, samesite]]]]])
 |*|  * Mozilla.Cookies.getItem(name)
 |*|  * Mozilla.Cookies.removeItem(name[, path[, domain]])
 |*|  * Mozilla.Cookies.hasItem(name)
@@ -23,7 +22,6 @@ describe('mozilla-cookie-helper.js', function () {
     }
 
     beforeEach(clearCookies);
-
     afterEach(clearCookies);
 
     describe('setItem method', function () {
@@ -32,14 +30,58 @@ describe('mozilla-cookie-helper.js', function () {
         date.setHours(date.getHours() + 48);
 
         it('should set a cookie onto document.cookie', function () {
-            window.Mozilla.Cookies.setItem(cookieId, true, date, '/');
+            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
             expect(document.cookie).toContain(cookieId);
         });
         it('will return false if you dont pass the sKey property', function () {
             expect(window.Mozilla.Cookies.setItem()).toBeFalse();
         });
-        it('will return false if sKey starts with any: expires|max-age|path|domain|secure|samesite', function () {
-            expect(window.Mozilla.Cookies.setItem()).toBeFalse();
+        it('will return false if sKey equals any of the folllowing: expires|max-age|path|domain|secure|samesite', function () {
+            expect(window.Mozilla.Cookies.setItem('expires')).toBeFalse();
+            expect(window.Mozilla.Cookies.setItem('max-age')).toBeFalse();
+            expect(window.Mozilla.Cookies.setItem('path')).toBeFalse();
+            expect(window.Mozilla.Cookies.setItem('domain')).toBeFalse();
+            expect(window.Mozilla.Cookies.setItem('secure')).toBeFalse();
+            expect(window.Mozilla.Cookies.setItem('samesite')).toBeFalse();
+        });
+    });
+
+    describe('getItem method', function () {
+        const cookieId = 'test-cookie';
+        var date = new Date();
+        date.setHours(date.getHours() + 48);
+        window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+
+        it('should return the value of the cookie that is passed to the getItem method', function () {
+            expect(window.Mozilla.Cookies.getItem(cookieId)).toBe('test');
+        });
+
+        it('should return null if no cookie with that name is found', function () {
+            expect(
+                window.Mozilla.Cookies.getItem("Nathan's secret stuff")
+            ).toBeNull();
+        });
+        it('should return null if no argument for sKey is passed', function () {
+            expect(window.Mozilla.Cookies.getItem()).toBeNull();
+        });
+    });
+
+    describe('hasItem method', function () {
+        const cookieId = 'test-cookie';
+        var date = new Date();
+        date.setHours(date.getHours() + 48);
+        window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+
+        it('should return false if no argument for sKey is passed', function () {
+            expect(window.Mozilla.Cookies.hasItem()).toBeFalse();
+        });
+        it('should return false if no matching cookie is found', function () {
+            expect(
+                window.Mozilla.Cookies.hasItem('chocolate-chip')
+            ).toBeFalse();
+        });
+        it('should return true if matching cookie is found', function () {
+            expect(window.Mozilla.Cookies.hasItem(cookieId)).toBeTrue();
         });
     });
 });

--- a/tests/unit/spec/base/mozilla-cookie-helper.js
+++ b/tests/unit/spec/base/mozilla-cookie-helper.js
@@ -10,9 +10,7 @@
  */
 
 /*
-|*|  * Mozilla.Cookies.getItem(name)
 |*|  * Mozilla.Cookies.removeItem(name[, path[, domain]])
-|*|  * Mozilla.Cookies.hasItem(name)
 |*|  * Mozilla.Cookies.keys()
 */
 
@@ -20,9 +18,6 @@ describe('mozilla-cookie-helper.js', function () {
     function clearCookies() {
         document.cookies = '';
     }
-
-    beforeEach(clearCookies);
-    afterEach(clearCookies);
 
     describe('setItem method', function () {
         const cookieId = 'test-cookie';
@@ -50,16 +45,20 @@ describe('mozilla-cookie-helper.js', function () {
         const cookieId = 'test-cookie';
         var date = new Date();
         date.setHours(date.getHours() + 48);
-        window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+
+        beforeEach(function () {
+            clearCookies();
+            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+        });
+
+        afterEach(clearCookies);
 
         it('should return the value of the cookie that is passed to the getItem method', function () {
             expect(window.Mozilla.Cookies.getItem(cookieId)).toBe('test');
         });
 
         it('should return null if no cookie with that name is found', function () {
-            expect(
-                window.Mozilla.Cookies.getItem("Nathan's secret stuff")
-            ).toBeNull();
+            expect(window.Mozilla.Cookies.getItem('oatmeal-raisin')).toBeNull();
         });
         it('should return null if no argument for sKey is passed', function () {
             expect(window.Mozilla.Cookies.getItem()).toBeNull();
@@ -70,7 +69,13 @@ describe('mozilla-cookie-helper.js', function () {
         const cookieId = 'test-cookie';
         var date = new Date();
         date.setHours(date.getHours() + 48);
-        window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+
+        beforeEach(function () {
+            clearCookies();
+            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+        });
+
+        afterEach(clearCookies);
 
         it('should return false if no argument for sKey is passed', function () {
             expect(window.Mozilla.Cookies.hasItem()).toBeFalse();
@@ -82,6 +87,54 @@ describe('mozilla-cookie-helper.js', function () {
         });
         it('should return true if matching cookie is found', function () {
             expect(window.Mozilla.Cookies.hasItem(cookieId)).toBeTrue();
+        });
+    });
+
+    describe('removeItem method', function () {
+        const cookieId = 'test-cookie';
+        var date = new Date();
+        date.setHours(date.getHours() + 48);
+
+        beforeEach(function () {
+            clearCookies();
+            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+        });
+
+        afterEach(clearCookies);
+
+        it('should return false if the cookie doesnt exist', function () {
+            expect(
+                window.Mozilla.Cookies.removeItem('snickerdoodle')
+            ).toBeFalse();
+        });
+
+        it('should return true if the cookie is found in document.cookie', function () {
+            expect(window.Mozilla.Cookies.removeItem(cookieId)).toBeTrue();
+        });
+    });
+
+    describe('keys method', function () {
+        const cookieId = 'test-cookie';
+        var date = new Date();
+        date.setHours(date.getHours() + 48);
+
+        beforeEach(function () {
+            clearCookies();
+            window.Mozilla.Cookies.setItem(cookieId, 'test', date, '/');
+        });
+
+        afterEach(clearCookies);
+
+        it('should return the cookie keys found in document.cookies', function () {
+            expect(window.Mozilla.Cookies.keys()).toContain(cookieId);
+            expect(window.Mozilla.Cookies.keys().length).toEqual(1);
+            window.Mozilla.Cookies.setItem(
+                'oatmeal-chocolate-chip',
+                'tasty',
+                date,
+                '/'
+            );
+            expect(window.Mozilla.Cookies.keys().length).toEqual(2);
         });
     });
 });

--- a/tests/unit/spec/base/mozilla-cookie-helper.js
+++ b/tests/unit/spec/base/mozilla-cookie-helper.js
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+/*
+|*|  * Mozilla.Cookies.setItem(name, value[, end[, path[, domain[, secure[, samesite]]]]])
+|*|  * Mozilla.Cookies.getItem(name)
+|*|  * Mozilla.Cookies.removeItem(name[, path[, domain]])
+|*|  * Mozilla.Cookies.hasItem(name)
+|*|  * Mozilla.Cookies.keys()
+*/
+
+describe('mozilla-cookie-helper.js', function () {
+    describe('setItem method', function () {
+        const cookieId = 'test-cookie';
+        it('should set a cookie onto document.cookie', function () {
+            var date = new Date();
+            date.setHours(date.getHours() + 48);
+            window.Mozilla.Cookies.setItem(cookieId, true, date, '/');
+            expect(document.cookie).toContain(cookieId);
+        });
+    });
+});

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -16,13 +16,6 @@ describe('stub-attribution.js', function () {
     const GA_VISIT_ID = '1456954538.1610960957';
 
     beforeEach(function () {
-        // stub out Mozilla.Cookie lib
-        window.Mozilla.Cookies = sinon.stub();
-        window.Mozilla.Cookies.enabled = sinon.stub().returns(true);
-        window.Mozilla.Cookies.setItem = sinon.stub();
-        window.Mozilla.Cookies.getItem = sinon.stub();
-        window.Mozilla.Cookies.hasItem = sinon.stub();
-
         // stub out GA client ID
         spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
             GA_VISIT_ID

--- a/tests/unit/spec/firefox/all/all-downloads-unified.js
+++ b/tests/unit/spec/firefox/all/all-downloads-unified.js
@@ -11,7 +11,6 @@
 
 /* eslint camelcase: [2, {properties: "never"}] */
 /* eslint new-cap: [2, {"capIsNewExceptions": ["Deferred"]}] */
-/* global sinon */
 
 describe('all-downloads-unified.js', function () {
     describe('getSelectOption', function () {
@@ -199,7 +198,6 @@ describe('all-downloads-unified.js', function () {
 
     describe('setAttributionURL', function () {
         beforeEach(function () {
-            window.Mozilla.Cookies = sinon.stub();
             spyOn(Mozilla.StubAttribution, 'getCookie').and.returnValue({
                 attribution_code: 'some-attribution-code',
                 attribution_sig: 'some-attribution-signature'


### PR DESCRIPTION
## Description
Added tests for the Mozilla.Cookies helpers: `getItem, setItem, hasItem, removeItem and keys`
## Issue / Bugzilla link
Fixes #11338
## Testing
run `npm run test` and it will run the test suite