### PR TITLE
converting articles

### DIFF
--- a/bedrock/exp/templates/exp/opt-out.html
+++ b/bedrock/exp/templates/exp/opt-out.html
@@ -19,6 +19,7 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('exp-opt-out') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -11,6 +11,7 @@
 {% block page_desc %}{{ ftl('what-is-a-browser-a-web-browser') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('what-is-a-browser') }}
 {% endblock %}
 

--- a/bedrock/privacy/templates/privacy/email.de.html
+++ b/bedrock/privacy/templates/privacy/email.de.html
@@ -9,6 +9,7 @@
 {% block page_title %}Wie verwendet Mozilla meine E-Mail-Adresse?{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('privacy_email') }}
 {% endblock %}
 

--- a/bedrock/privacy/templates/privacy/email.fr.html
+++ b/bedrock/privacy/templates/privacy/email.fr.html
@@ -9,6 +9,7 @@
 {% block page_title %}Comment mon adresse sera-t-elle utilisée par Mozilla ?{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('privacy_email') }}
 {% endblock %}
 

--- a/bedrock/privacy/templates/privacy/email.html
+++ b/bedrock/privacy/templates/privacy/email.html
@@ -9,6 +9,7 @@
 {% block page_title %}{{ _('How Will Mozilla Use My Email?') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('privacy_email') }}
 {% endblock %}
 

--- a/bedrock/products/templates/products/vpn/more/base-article.html
+++ b/bedrock/products/templates/products/vpn/more/base-article.html
@@ -9,6 +9,7 @@
 {% extends "products/vpn/base.html" %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-article') }}
   {{ css_bundle('mozilla-vpn-article') }}
 {% endblock %}
 

--- a/media/css/exp/opt-out.scss
+++ b/media/css/exp/opt-out.scss
@@ -1,6 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';

--- a/media/css/firefox/browsers/what-is-a-browser.scss
+++ b/media/css/firefox/browsers/what-is-a-browser.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
 
 .mzp-c-article {
     margin: 0 auto $layout-lg;

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -5,7 +5,6 @@
 @use 'sass:math';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
 @import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
 
 // * -------------------------------------------------------------------------- */

--- a/media/css/privacy/privacy-email.scss
+++ b/media/css/privacy/privacy-email.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
 
 .mzp-c-article-title {
     @include text-title-md;

--- a/media/css/products/vpn/article.scss
+++ b/media/css/products/vpn/article.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/article';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -154,12 +154,6 @@
     },
     {
       "files": [
-        "css/exp/opt-out.scss"
-      ],
-      "name": "exp-opt-out"
-    },
-    {
-      "files": [
         "css/security/security.scss"
       ],
       "name": "security"


### PR DESCRIPTION
## Description
Converting `article` CSS imports to CSS bundles
## Issue / Bugzilla link
#11032 
## Testing
http://localhost:8000/en-US/exp/opt-out/
http://localhost:8000/en-US/firefox/browsers/what-is-a-browser/
http://localhost:8000/en-US/about/policy/transparency/ (removed the `article` CSS import from its respective CSS file (`about-transparency.scss`) since the page doesn't use it.
http://localhost:8000/en-US/privacy/email/
http://localhost:8000/fr/privacy/email/
http://localhost:8000/de/privacy/email/
http://localhost:8000/en-US/products/vpn/more/do-i-need-a-vpn/ 
http://localhost:8000/en-US/products/vpn/more/what-is-a-vpn/
http://localhost:8000/en-US/products/vpn/more/what-is-an-ip-address/
http://localhost:8000/en-US/products/vpn/more/when-to-use-a-vpn/
http://localhost:8000/en-US/products/vpn/more/vpn-or-proxy/