### PR TITLE
Converting `newsletter-form` into CSS bundle

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -18,6 +18,7 @@
 {% block page_css %}
   {{ css_bundle('protocol-split') }}
   {{ css_bundle('protocol-picto') }}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('firefox_developer') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/retention/thank-you.html
+++ b/bedrock/firefox/templates/firefox/retention/thank-you.html
@@ -15,6 +15,7 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('firefox-retention-thank-you') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -19,7 +19,8 @@
 {% endblock %}
 
 {% block page_css %}
-{{ css_bundle('firefox_ios_testflight') }}
+  {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('firefox_ios_testflight') }}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -20,6 +20,7 @@
 
 {% block page_css %}
   {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_ios_testflight') }}
 {% endblock %}
 

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -9,6 +9,7 @@
 {% block page_title %}Violating Website Report{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('legal') }}
 {% endblock %}
 

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -9,6 +9,7 @@
 {% block page_title %}{{ ftl('legal-legal') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('legal') }}
 {% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/base.html
+++ b/bedrock/newsletter/templates/newsletter/base.html
@@ -12,6 +12,7 @@
 
 {% block site_css %}
   {{ super() }}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('newsletter') }}
 {% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/developer.html
+++ b/bedrock/newsletter/templates/newsletter/developer.html
@@ -13,6 +13,7 @@
 {% block body_class %}{{ super() }} newsletter-developer{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('newsletter-developer') }}
 {% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/firefox.html
+++ b/bedrock/newsletter/templates/newsletter/firefox.html
@@ -12,6 +12,7 @@
 {% block body_class %}{{ super() }} newsletter-mozilla{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('newsletter-firefox') }}
 {% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/mozilla.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla.html
@@ -15,6 +15,7 @@
 {% block body_class %}{{ super() }} newsletter-mozilla{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('newsletter-mozilla') }}
 {% endblock %}
 

--- a/media/css/firefox/retention/thank-you.scss
+++ b/media/css/firefox/retention/thank-you.scss
@@ -6,7 +6,7 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
+// @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 @font-face {
     font-family: Antonio;

--- a/media/css/firefox/retention/thank-you.scss
+++ b/media/css/firefox/retention/thank-you.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-// @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 @font-face {
     font-family: Antonio;

--- a/media/css/firefox/testflight.scss
+++ b/media/css/firefox/testflight.scss
@@ -6,9 +6,7 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
-// @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 // * -------------------------------------------------------------------------- */
 // Hero

--- a/media/css/firefox/testflight.scss
+++ b/media/css/firefox/testflight.scss
@@ -8,7 +8,7 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
+// @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 // * -------------------------------------------------------------------------- */
 // Hero

--- a/media/css/legal/legal.scss
+++ b/media/css/legal/legal.scss
@@ -5,8 +5,6 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';

--- a/media/css/newsletter/newsletter-developer.scss
+++ b/media/css/newsletter/newsletter-developer.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 .section-intro {
     background:

--- a/media/css/newsletter/newsletter-firefox.scss
+++ b/media/css/newsletter/newsletter-firefox.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 .section-intro {
     background-color: $color-ink-80;

--- a/media/css/newsletter/newsletter-mozilla.scss
+++ b/media/css/newsletter/newsletter-mozilla.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 .section-intro {
     background:

--- a/media/css/newsletter/newsletter.scss
+++ b/media/css/newsletter/newsletter.scss
@@ -12,7 +12,6 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
-@import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 


### PR DESCRIPTION
## Description
Converting `newsletter-form` CSS imports to CSS bundles

## Issue / Bugzilla link
#11032 
## Testing
#### Newsletter
http://localhost:8000/en-US/firefox/ios/testflight/
http://localhost:8000/en-US/firefox/developer/
http://localhost:8000/en-US/firefox/retention/thank-you/
http://localhost:8000/en-US/about/legal/
http://localhost:8000/en-US/newsletter/developer/
http://localhost:8000/en-US/newsletter/firefox/
http://localhost:8000/en-US/newsletter/mozilla/
http://localhost:8000/en-US/newsletter/ (I'm not sure if this is the only file associated with the changes in `newsleter/newsletter.scss`, but it's the one I could directly find.

#### Emphasis box
http://localhost:8000/en-US/firefox/ios/testflight/
http://localhost:8000/en-US/about/legal/defend-mozilla-trademarks/