### PR TITLE
Remove unused CSS bundle reference (Fixes #11367)

### DIFF
--- a/bedrock/exp/templates/exp/opt-out.html
+++ b/bedrock/exp/templates/exp/opt-out.html
@@ -20,7 +20,6 @@
 
 {% block page_css %}
   {{ css_bundle('protocol-article') }}
-  {{ css_bundle('exp-opt-out') }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Description
Fixes 500 error for mnissing CSS file

## Issue / Bugzilla link
#11367

## Testing
http://localhost:8000/en-US/exp/opt-out/
