### PR TITLE
Convert `emphasis-box` into CSS bundle

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -26,7 +26,8 @@
 {% block page_ios_icon %}{{ static('img/favicons/firefox/apple-touch-icon.png') }}{% endblock %}
 
 {% block page_css %}
- {{ css_bundle('firefox_accounts_2019') }}
+  {{ css_bundle('protocol-emphasis-box') }}
+  {{ css_bundle('firefox_accounts_2019') }}
 {% endblock %}
 
 {% block body_class %}firefox-accounts mzp-t-firefox state-fxa-default {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -15,6 +15,7 @@
 
 {% block page_css %}
   {{ css_bundle('protocol-split') }}
+  {{ css_bundle('protocol-emphasis-box')}}
   {{ css_bundle('firefox-browsers-products') }}
 
   {% if show_firefox_app_store_banner %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -20,6 +20,7 @@
 {% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_firstrun_quantum') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -14,6 +14,7 @@
 
 {% block extrahead %}
   {{ super() }}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_new_thanks') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -20,6 +20,7 @@
 {% block extrahead %}
   {{ super() }}
   {{ css_bundle('protocol-card') }}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_desktop_download') }}
 
   <!--[if IE 9]>

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -10,6 +10,7 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('nightly_whatsnew') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -14,6 +14,7 @@
 
 {% block page_css %}
   {{ super() }}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox-privacy-products') }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -15,6 +15,7 @@
 
 {% block page_css %}
   {{ css_bundle('protocol-split')}}
+  {{ css_bundle('protocol-emphasis-box')}}
   {{ css_bundle('firefox-browsers-products') }}
 
   {% if show_firefox_app_store_banner %}

--- a/bedrock/firefox/templates/firefox/unsupported-systems.html
+++ b/bedrock/firefox/templates/firefox/unsupported-systems.html
@@ -10,6 +10,7 @@
 {% block page_desc %}{{ _('We’re sorry to report this, but your computer does not meet the minimum system requirements to run this version.') }}{% endblock %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_unsupported_systems') }}
 {% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/base.html
+++ b/bedrock/newsletter/templates/newsletter/base.html
@@ -13,6 +13,8 @@
 {% block site_css %}
   {{ super() }}
   {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('protocol-emphasis-box') }}
+  {{ css_bundle('protocol-card') }}
   {{ css_bundle('newsletter') }}
 {% endblock %}
 

--- a/bedrock/press/templates/press/speaker-request.html
+++ b/bedrock/press/templates/press/speaker-request.html
@@ -9,6 +9,7 @@
   {% block page_title %}{{_('Speaker Request Form')}}{% endblock %}
 
   {% block page_css %}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('press') }}
   {% endblock %}
 

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '../protocol/components/fxa-form';
 
 .c-section-title {

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 $brand-theme: 'firefox';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/zap';
 @import '../protocol/components/fxa-form';
 @import '../protocol/components/custom-menu-list';

--- a/media/css/firefox/firstrun/firstrun.scss
+++ b/media/css/firefox/firstrun/firstrun.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 $break-large: 1305px;
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 @import '../../protocol/components/fxa-form';

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -8,7 +8,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';

--- a/media/css/firefox/new/desktop/thanks.scss
+++ b/media/css/firefox/new/desktop/thanks.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';

--- a/media/css/firefox/privacy/products.scss
+++ b/media/css/firefox/privacy/products.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';

--- a/media/css/firefox/unsupported-systems.scss
+++ b/media/css/firefox/unsupported-systems.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 
 .c-header-logo {
     @media #{$mq-sm} {

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -6,7 +6,6 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import 'includes/header';
 

--- a/media/css/newsletter/newsletter.scss
+++ b/media/css/newsletter/newsletter.scss
@@ -6,14 +6,11 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/card';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 @import '~@mozilla-protocol/core/protocol/css/components/hero';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 
 // * -------------------------------------------------------------------------- */
 // Global styles.

--- a/media/css/press/press.scss
+++ b/media/css/press/press.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/emphasis-box';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/set';


### PR DESCRIPTION
## Description
Converting the `emphasis-box` Protocol component from CSS imports to CSS bundles
## Issue / Bugzilla link
#11032 
## Testing

#### Emphasis box
http://localhost:8000/en-US/firefox/accounts/
http://localhost:8000/en-US/firefox/products/
http://localhost:8000/en-US/firefox/browsers/
http://localhost:8000/en-US/firefox/unsupported-systems/
http://localhost:8000/en-US/firefox/firstrun/
http://localhost:8000/en-US/firefox/new/
http://localhost:8000/en-US/firefox/privacy/products/
http://localhost:8000/en-US/firefox/100.0a1/whatsnew/
http://localhost:8000/en-US/newsletter/ (I'm not sure if this is the only file associated with the changes in `newsletter/newsletter.scss`, but it's the one I could directly find.)
http://localhost:8000/en-US/press/speakerrequest/

#### Card
http://localhost:8000/en-US/newsletter/ (I'm not sure if this is the only file associated with the changes in `newsletter/newsletter.scss`, but it's the one I could directly find.)
