### PR TITLE
Add samesite attr to Cookies.SetItem calls within 1st party JS

### DIFF
--- a/media/js/base/banners/mozilla-banner.js
+++ b/media/js/base/banners/mozilla-banner.js
@@ -20,7 +20,15 @@ if (typeof window.Mozilla === 'undefined') {
         var date = new Date();
         var cookieDuration = 1 * 24 * 60 * 60 * 1000; // 1 day expiration
         date.setTime(date.getTime() + cookieDuration); // 1 day expiration
-        Mozilla.Cookies.setItem(id, true, date.toUTCString(), '/');
+        Mozilla.Cookies.setItem(
+            id,
+            true,
+            date.toUTCString(),
+            '/',
+            undefined,
+            false,
+            'lax'
+        );
     };
 
     Banner.hasCookie = function (id) {

--- a/media/js/base/fxa-utm.es6.js
+++ b/media/js/base/fxa-utm.es6.js
@@ -121,7 +121,15 @@ FxaUtm.setFxALinkReferralCookie = function (id) {
         date.setTime(date.getTime() + 1 * 3600 * 1000); // expiry in 1 hour.
         const expires = date.toUTCString();
 
-        Mozilla.Cookies.setItem('fxa-product-referral-id', id, expires, '/');
+        Mozilla.Cookies.setItem(
+            'fxa-product-referral-id',
+            id,
+            expires,
+            '/',
+            undefined,
+            false,
+            'lax'
+        );
     }
 };
 

--- a/media/js/base/mozilla-cookie-helper.js
+++ b/media/js/base/mozilla-cookie-helper.js
@@ -154,11 +154,11 @@ Mozilla.Cookies = {
          */
         try {
             // Create cookie
-            document.cookie = 'cookietest=1';
+            document.cookie = 'cookietest=1; SameSite=Lax';
             var ret = document.cookie.indexOf('cookietest=') !== -1;
             // Delete cookie
             document.cookie =
-                'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+                'cookietest=1; SameSite=Lax; expires=Thu, 01-Jan-1970 00:00:01 GMT';
             return ret;
         } catch (e) {
             return false;

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -92,13 +92,19 @@ if (typeof window.Mozilla === 'undefined') {
             StubAttribution.COOKIE_CODE_ID,
             data.attribution_code,
             expires,
-            '/'
+            '/',
+            undefined,
+            false,
+            'lax'
         );
         Mozilla.Cookies.setItem(
             StubAttribution.COOKIE_SIGNATURE_ID,
             data.attribution_sig,
             expires,
-            '/'
+            '/',
+            undefined,
+            false,
+            'lax'
         );
     };
 

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -82,7 +82,10 @@
                 STICKY_PROMO_COOKIE_ID,
                 true,
                 date.toUTCString(),
-                '/'
+                '/',
+                undefined,
+                false,
+                'lax'
             );
         };
 

--- a/media/js/libs/mozilla-traffic-cop.js
+++ b/media/js/libs/mozilla-traffic-cop.js
@@ -132,7 +132,7 @@ Mozilla.TrafficCop.prototype.init = function() {
  */
 Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function() {
     // set a cookie to remember the chosen variation
-    Mozilla.Cookies.setItem(this.id, this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate);
+    Mozilla.Cookies.setItem(this.id, this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate, undefined, undefined, false, "lax");
 
     // invoke the developer supplied callback, passing in the chosen variation
     this.customCallback(this.chosenVariation);
@@ -166,13 +166,13 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function() {
             }
 
             // set a cookie containing the chosen variation
-            Mozilla.Cookies.setItem(this.id, this.chosenVariation, this.cookieExpiresDate);
+            Mozilla.Cookies.setItem(this.id, this.chosenVariation, this.cookieExpiresDate, undefined, undefined, false, "lax");
 
             Mozilla.TrafficCop.performRedirect(redirectUrl);
         } else {
             // if no variation, set a cookie so user isn't re-entered into
             // the dice roll on next page load
-            Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate);
+            Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate, undefined, undefined, false, "lax");
 
             // same as above - referrer cookie could be set from previous experiment, so best to clear
             Mozilla.TrafficCop.clearReferrerCookie();
@@ -320,7 +320,7 @@ Mozilla.TrafficCop.setReferrerCookie = function(expirationDate, referrer) {
     // 3. 'direct' string literal
     referrer = referrer || Mozilla.TrafficCop.getDocumentReferrer() || 'direct';
 
-    Mozilla.Cookies.setItem(Mozilla.TrafficCop.referrerCookieName, referrer, expirationDate);
+    Mozilla.Cookies.setItem(Mozilla.TrafficCop.referrerCookieName, referrer, expirationDate, undefined, undefined, false, "lax");
 };
 
 Mozilla.TrafficCop.clearReferrerCookie = function() {

--- a/media/js/libs/mozilla-traffic-cop.js
+++ b/media/js/libs/mozilla-traffic-cop.js
@@ -132,7 +132,7 @@ Mozilla.TrafficCop.prototype.init = function() {
  */
 Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function() {
     // set a cookie to remember the chosen variation
-    Mozilla.Cookies.setItem(this.id, this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate, undefined, undefined, false, "lax");
+    Mozilla.Cookies.setItem(this.id, this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate, undefined, undefined, false, 'lax');
 
     // invoke the developer supplied callback, passing in the chosen variation
     this.customCallback(this.chosenVariation);
@@ -166,13 +166,13 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function() {
             }
 
             // set a cookie containing the chosen variation
-            Mozilla.Cookies.setItem(this.id, this.chosenVariation, this.cookieExpiresDate, undefined, undefined, false, "lax");
+            Mozilla.Cookies.setItem(this.id, this.chosenVariation, this.cookieExpiresDate, undefined, undefined, false, 'lax');
 
             Mozilla.TrafficCop.performRedirect(redirectUrl);
         } else {
             // if no variation, set a cookie so user isn't re-entered into
             // the dice roll on next page load
-            Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate, undefined, undefined, false, "lax");
+            Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate, undefined, undefined, false, 'lax');
 
             // same as above - referrer cookie could be set from previous experiment, so best to clear
             Mozilla.TrafficCop.clearReferrerCookie();
@@ -320,7 +320,7 @@ Mozilla.TrafficCop.setReferrerCookie = function(expirationDate, referrer) {
     // 3. 'direct' string literal
     referrer = referrer || Mozilla.TrafficCop.getDocumentReferrer() || 'direct';
 
-    Mozilla.Cookies.setItem(Mozilla.TrafficCop.referrerCookieName, referrer, expirationDate, undefined, undefined, false, "lax");
+    Mozilla.Cookies.setItem(Mozilla.TrafficCop.referrerCookieName, referrer, expirationDate, undefined, undefined, false, 'lax');
 };
 
 Mozilla.TrafficCop.clearReferrerCookie = function() {

--- a/tests/unit/spec/base/fxa-utm.js
+++ b/tests/unit/spec/base/fxa-utm.js
@@ -455,7 +455,10 @@ describe('fxa-utm.js', function () {
                 'fxa-product-referral-id',
                 'navigation',
                 jasmine.any(String),
-                '/'
+                '/',
+                undefined,
+                false,
+                'lax'
             );
         });
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -904,13 +904,19 @@ describe('stub-attribution.js', function () {
                 Mozilla.StubAttribution.COOKIE_CODE_ID,
                 data.attribution_code,
                 jasmine.any(String),
-                '/'
+                '/',
+                undefined,
+                false,
+                'lax'
             );
             expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(
                 Mozilla.StubAttribution.COOKIE_SIGNATURE_ID,
                 data.attribution_sig,
                 jasmine.any(String),
-                '/'
+                '/',
+                undefined,
+                false,
+                'lax'
             );
         });
 


### PR DESCRIPTION
## Description
Updated the calls to Mozilla.Cookies.SetItem inside bedrock to include the sameSite=lax (if none was set previously) attribute to fix the warnings we were getting previously.

## Issue / Bugzilla link
#11058

## Testing
These are the javascript files that are effected (from what I can tell) - you should no longer get a warning about SameSite being added to cookies that are set inside of bedrock
Mozilla Banner & fxa-utm.js: http://localhost:8000/
Mozilla.Cookies.enabled: http://localhost:8000/ (think this is run on launch of any page? could be wrong!)
Traffic Cop: http://localhost:8000/en-US/firefox/welcome/8/
Sticky promo: http://localhost:8000/en-US/firefox/browsers/compare/brave/