### PR TITLE
Add sub_nav macro and current page styling (fixes #10038)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -256,7 +256,7 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         {% if title.href %}
           <a href="{{ title.href }}" data-link-type="nav" data-link-position="subnav" data-link-name="{{ title.cta_name }}">
             {% if title.icon %}<img class="c-sub-navigation-icon" src="{{ title.icon }}" width="24" height="24" alt="">{% endif %}
@@ -267,7 +267,7 @@
           {{ title.text }}
         {% endif %}
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         {% for link in links %}
         <li class="c-sub-navigation-item">
           <a

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -234,3 +234,55 @@
     <img src="{{ src }}" alt="{{ alt }}" {% if class %}class="{{ class }}" {% endif %}{% if loading %}loading="{{ loading }}" {% endif %}{% if width %}width="{{ width }}" {% endif %}{% if height %}height="{{ height }}" {% endif %}/>
   {% endif %}
 {%- endmacro %}
+
+{% macro sub_nav(
+  title,
+  links
+) -%}
+
+{% if 'releasenotes' in request.path %}
+  <!-- remove 'releasenotes' and version number -->
+  {% set root_path = ("/").join(request.path.split("/")[0:-3]) %}
+  <!-- Firefox Desktop, Android, and iOS include channel in request path -->
+  {% if release.channel == 'Release' %}
+    {% set current_page = ("{}/notes/").format(root_path) %}
+  {% else %}
+  <!-- Beta/Developer and Nightly need the channel added -->
+    {% set current_page = ("{}/{}/notes/").format(root_path, release.channel.lower()) %}
+  {% endif %}
+{% else %}
+  {% set current_page = request.path %}
+{% endif %}
+<nav class="c-sub-navigation">
+  <div class="mzp-l-content">
+    <div class="c-sub-navigation-content">
+      <h2 class="c-sub-navigation-title">
+        {% if title.href %}
+          <a href="{{ title.href }}" data-link-type="nav" data-link-position="subnav" data-link-name="{{ title.cta_name }}">
+            {% if title.icon %}<img class="c-sub-navigation-icon" src="{{ title.icon }}" width="24" height="24" alt="">{% endif %}
+            {{ title.text }}
+          </a>
+        {% else %}
+          {% if title.icon %}<img class="c-sub-navigation-icon" src="{{ title.icon }}" width="24" height="24" alt="">{% endif %}
+          {{ title.text }}
+        {% endif %}
+      </h2>
+      <ul class="c-sub-navigation-list">
+        {% for link in links %}
+        <li class="c-sub-navigation-item">
+          <a
+            href="{{ link.href }}"
+            data-link-type="nav"
+            data-link-position="subnav"
+            data-link-name="{{ link.cta_name }}"
+            {% if current_page == link.href %} aria-current="page"{% endif %}
+          >
+            {{ link.text }}
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</nav>
+{%- endmacro %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -239,7 +239,6 @@
   title,
   links
 ) -%}
-
 {% if 'releasenotes' in request.path %}
   <!-- remove 'releasenotes' and version number -->
   {% set root_path = ("/").join(request.path.split("/")[0:-3]) %}

--- a/bedrock/base/tests/test_macros.py
+++ b/bedrock/base/tests/test_macros.py
@@ -2,8 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import re
+
 import pytest
 from django_jinja.backend import Jinja2
+from pyquery import PyQuery as pq
 
 jinja_env = Jinja2.get_default()
 
@@ -11,6 +14,11 @@ jinja_env = Jinja2.get_default()
 def render(s, context=None):
     t = jinja_env.from_string(s)
     return t.render(context or {}).strip()
+
+
+def inner_html(el):
+    # always remove newlines and excess whitespace
+    return re.sub(r"\s+", " ", el.html()).strip()
 
 
 EXPECTED_IMAGES = {
@@ -47,7 +55,7 @@ EXPECTED_IMAGES = {
         ),
     ],
 )
-def test_markup(test_input, expected):
+def test_image_markup(test_input, expected):
     # note: this isn't actually setting the locale, it's matching the default expected locale
     mock_request = {"request": {"locale": "en-US"}}
     # need to split these strings and re-combine them to allow python formatting
@@ -55,3 +63,70 @@ def test_markup(test_input, expected):
     # need to import with context for the request key to appear in l10n_img helper
     markup = render("{% from 'macros.html' import image with context %}" + "{{{{ image({0}) }}}}".format(test_input), mock_request)
     assert markup == expected
+
+
+current_link_input = {"text": "Testing current link", "href": "/current", "cta_name": "Test Link"}
+regular_link_input = {"text": "Testing link", "href": "/regular", "cta_name": "Test Link"}
+
+EXPECTED_NAV_HTML = {
+    "title_text": """Testing title""",
+    "title_icon": """<img class="c-sub-navigation-icon" src="icon.png" width="24" height="24" alt="">""",
+    "title_link": """<a href="/category" data-link-type="nav" data-link-position="subnav" data-link-name="Test Title">""",
+    "current_link": """<a href="/current" data-link-type="nav" data-link-position="subnav" data-link-name="Test Link" aria-current="page"> Testing current link </a>""",  # noqa: E501
+    "regular_link": """<a href="/regular" data-link-type="nav" data-link-position="subnav" data-link-name="Test Link"> Testing link </a>""",
+}
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        (
+            f"title={{'text': 'Testing title'}}, links=[{regular_link_input}, {regular_link_input}]",
+            {"title_text": EXPECTED_NAV_HTML["title_text"], "links": [EXPECTED_NAV_HTML["regular_link"], EXPECTED_NAV_HTML["regular_link"]]},
+        ),
+        (
+            f"title={{'text': 'Testing title', 'icon': 'icon.png'}}, links=[{regular_link_input}, {current_link_input}]",
+            {
+                "title_text": EXPECTED_NAV_HTML["title_text"],
+                "title_icon": EXPECTED_NAV_HTML["title_icon"],
+                "links": [EXPECTED_NAV_HTML["regular_link"], EXPECTED_NAV_HTML["current_link"]],
+            },
+        ),
+        (
+            f"title={{'text': 'Testing title', 'href': '/category', 'cta_name': 'Test Title'}}, links=[{current_link_input}, {regular_link_input}]",
+            {
+                "title_text": EXPECTED_NAV_HTML["title_text"],
+                "title_link": EXPECTED_NAV_HTML["title_link"],
+                "links": [EXPECTED_NAV_HTML["current_link"], EXPECTED_NAV_HTML["regular_link"]],
+            },
+        ),
+        (
+            f"title={{'text': 'Testing title', 'href': '/category', 'cta_name': 'Test Title', 'icon': 'icon.png'}}, links=[{regular_link_input}, {current_link_input}, {regular_link_input}]",  # noqa: E501
+            {
+                "title_text": EXPECTED_NAV_HTML["title_text"],
+                "title_link": EXPECTED_NAV_HTML["title_link"],
+                "title_icon": EXPECTED_NAV_HTML["title_icon"],
+                "links": [EXPECTED_NAV_HTML["regular_link"], EXPECTED_NAV_HTML["current_link"], EXPECTED_NAV_HTML["regular_link"]],
+            },
+        ),
+    ],
+)
+def test_sub_nav_markup(test_input, expected):
+    mock_request = {"request": {"path": "/current"}}
+    # need to import with context for the request key to pass along the path value
+    markup = render("{% from 'macros.html' import sub_nav with context %}" + "{{{{ sub_nav({0}) }}}}".format(test_input), mock_request)
+    doc = pq(markup)
+
+    title = doc(".c-sub-navigation-title")
+    assert title.text() == expected["title_text"]
+
+    links = doc(".c-sub-navigation-list").find(".c-sub-navigation-item")
+    assert len(links) == len(expected["links"])
+    for index, link in enumerate(links):
+        assert inner_html(pq(link)) == expected["links"][index]
+
+    if "title_icon" in expected:
+        assert title.find(".c-sub-navigation-icon").outer_html() == expected["title_icon"]
+
+    if "title_link" in expected:
+        assert expected["title_link"] in inner_html(title)

--- a/bedrock/base/tests/test_macros.py
+++ b/bedrock/base/tests/test_macros.py
@@ -119,20 +119,20 @@ def test_sub_nav_markup(test_input, expected):
     markup = render("{% from 'macros.html' import sub_nav with context %}" + "{{{{ sub_nav({0}) }}}}".format(test_input), mock_request)
     doc = pq(markup)
 
-    title = doc(".c-sub-navigation-title")
-    assert title.text() == expected["title_text"]
-    assert EXPECTED_NAV_HTML["is_summary"] in title.outer_html()
+    nav_title = doc(".c-sub-navigation-title")
+    assert nav_title.text() == expected["title_text"]
+    assert EXPECTED_NAV_HTML["is_summary"] in nav_title.outer_html()
 
-    list = doc(".c-sub-navigation-list")
-    assert EXPECTED_NAV_HTML["is_details_default_closed"] in list.outer_html()
+    nav_list = doc(".c-sub-navigation-list")
+    assert EXPECTED_NAV_HTML["is_details_default_closed"] in nav_list.outer_html()
 
-    links = list.find(".c-sub-navigation-item")
-    assert len(links) == len(expected["links"])
-    for index, link in enumerate(links):
-        assert inner_html(pq(link)) == expected["links"][index]
+    nav_links = nav_list.find(".c-sub-navigation-item")
+    assert len(nav_links) == len(expected["links"])
+    for index, nav_link in enumerate(nav_links):
+        assert inner_html(pq(nav_link)) == expected["links"][index]
 
     if "title_icon" in expected:
-        assert title.find(".c-sub-navigation-icon").outer_html() == expected["title_icon"]
+        assert nav_title.find(".c-sub-navigation-icon").outer_html() == expected["title_icon"]
 
     if "title_link" in expected:
-        assert expected["title_link"] in inner_html(title)
+        assert expected["title_link"] in inner_html(nav_title)

--- a/bedrock/base/tests/test_macros.py
+++ b/bedrock/base/tests/test_macros.py
@@ -74,6 +74,8 @@ EXPECTED_NAV_HTML = {
     "title_link": """<a href="/category" data-link-type="nav" data-link-position="subnav" data-link-name="Test Title">""",
     "current_link": """<a href="/current" data-link-type="nav" data-link-position="subnav" data-link-name="Test Link" aria-current="page"> Testing current link </a>""",  # noqa: E501
     "regular_link": """<a href="/regular" data-link-type="nav" data-link-position="subnav" data-link-name="Test Link"> Testing link </a>""",
+    "is_summary": """is-summary""",
+    "is_details_default_closed": """is-details is-closed""",
 }
 
 
@@ -119,8 +121,12 @@ def test_sub_nav_markup(test_input, expected):
 
     title = doc(".c-sub-navigation-title")
     assert title.text() == expected["title_text"]
+    assert EXPECTED_NAV_HTML["is_summary"] in title.outer_html()
 
-    links = doc(".c-sub-navigation-list").find(".c-sub-navigation-item")
+    list = doc(".c-sub-navigation-list")
+    assert EXPECTED_NAV_HTML["is_details_default_closed"] in list.outer_html()
+
+    links = list.find(".c-sub-navigation-item")
     assert len(links) == len(expected["links"])
     for index, link in enumerate(links):
         assert inner_html(pq(link)) == expected["links"][index]

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -22,21 +22,7 @@
 {% set android_url = firefox_adjust_url('android', 'firefox-browsers-chromebook') %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows">{{ ftl('sub-navigation-windows') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.windows-64-bit') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 64-bit">{{ ftl('sub-navigation-windows-64-bit') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('sub-navigation-mac') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.linux') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Linux">{{ ftl('sub-navigation-linux') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+ {% include '/firefox/includes/desktop-platform-sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/browsers/compare/includes/subnav.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/includes/subnav.html
@@ -4,20 +4,44 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# Subnav menu for /firefox/browsers/compare/ #}
+{% from 'macros.html' import sub_nav with context %}
 
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.compare.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Browsers">{{ ftl('sub-navigation-compare-browsers') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.chrome') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chrome">{{ ftl('sub-navigation-chrome') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.edge') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Edge">{{ ftl('sub-navigation-edge') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.safari') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Safari">{{ ftl('sub-navigation-safari') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.opera') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Opera">{{ ftl('sub-navigation-opera') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.brave') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Brave">{{ ftl('sub-navigation-brave') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.ie') }}" data-link-type="nav" data-link-position="subnav" data-link-name="IE">{{ ftl('sub-navigation-ie') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+{# Subnav menu for /firefox/browsers/compare/ #}
+{{ sub_nav(
+  title={
+    'text': ftl('sub-navigation-compare-browsers'),
+    'href': url('firefox.browsers.compare.index'),
+    'cta_name': "Compare browsers"
+  },
+  links=[
+  {
+    'text': ftl('sub-navigation-chrome'),
+    'href': url('firefox.browsers.compare.chrome'),
+    'cta_name': "Chrome"
+  },
+  {
+    'text': ftl('sub-navigation-edge'),
+    'href': url('firefox.browsers.compare.edge'),
+    'cta_name': "Edge"
+  },
+  {
+    'text': ftl('sub-navigation-safari'),
+    'href': url('firefox.browsers.compare.safari'),
+    'cta_name': "Safari"
+  },
+  {
+    'text': ftl('sub-navigation-opera'),
+    'href': url('firefox.browsers.compare.opera'),
+    'cta_name': "Opera"
+  },
+  {
+    'text': ftl('sub-navigation-brave'),
+    'href': url('firefox.browsers.compare.brave'),
+    'cta_name': "Brave"
+  },
+  {
+    'text': ftl('sub-navigation-ie'),
+    'href': url('firefox.browsers.compare.ie') ,
+    'cta_name': "IE"
+  }]
+) }}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -41,20 +41,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.compare') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Mobile Browsers">{{ ftl('sub-navigation-compare-mobile-browsers') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+  {% include 'firefox/browsers/mobile/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
@@ -22,20 +22,7 @@
 {% set ios_url = firefox_adjust_url('ios', 'mobile-compare-page') %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.compare') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Mobile Browsers">{{ ftl('sub-navigation-compare-mobile-browsers') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+  {% include 'firefox/browsers/mobile/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
@@ -49,20 +49,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.compare') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Mobile Browsers">{{ ftl('sub-navigation-compare-mobile-browsers') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+  {% include 'firefox/browsers/mobile/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/includes/sub-nav.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/includes/sub-nav.html
@@ -1,0 +1,41 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import sub_nav with context %}
+
+{{ sub_nav(
+  title={
+    'text':  ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile'),
+    'href':  url('firefox.browsers.mobile.index'),
+    'cta_name': "Firefox for Mobile"
+  },
+  links=[
+  {
+    'text': ftl('sub-navigation-android'),
+    'href': url('firefox.browsers.mobile.android'),
+    'cta_name': "Android"
+  },
+  {
+    'text': ftl('sub-navigation-ios'),
+    'href': url('firefox.browsers.mobile.ios'),
+    'cta_name': "iOS"
+  },
+  {
+    'text': ftl('sub-navigation-firefox-focus'),
+    'href': url('firefox.browsers.mobile.focus'),
+    'cta_name': "Firefox Focus"
+  },
+  {
+    'text': ftl('sub-navigation-chromebook'),
+    'href': url('firefox.browsers.chromebook'),
+    'cta_name': "Chromebook"
+  },
+  {
+    'text': ftl('sub-navigation-compare-mobile-browsers'),
+    'href': url('firefox.browsers.mobile.compare'),
+    'cta_name': "Compare Mobile Browsers"
+  }]
+) }}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -37,20 +37,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.compare') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Mobile Browsers">{{ ftl('sub-navigation-compare-mobile-browsers') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+  {% include 'firefox/browsers/mobile/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -57,20 +57,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.compare') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Mobile Browsers">{{ ftl('sub-navigation-compare-mobile-browsers') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+  {% include 'firefox/browsers/mobile/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -21,21 +21,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows">{{ ftl('sub-navigation-windows') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.windows-64-bit') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 64-bit">{{ ftl('sub-navigation-windows-64-bit') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('sub-navigation-mac') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.linux') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Linux">{{ ftl('sub-navigation-linux') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+ {% include '/firefox/includes/desktop-platform-sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -6,6 +6,7 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
+{% from "macros.html" import sub_nav with context %}
 {% from "macros-protocol.html" import hero, feature_card, call_out_compact, picto with context %}
 
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}
@@ -20,23 +21,30 @@
 {% block body_class %}{% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">
-        <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
-          <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
-         {{ ftl('sub-navigation-firefox') }}
-        </a>
-      </h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta', fallback='firefox-channel-desktop') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android Nightly and Beta">{{ ftl('sub-navigation-android-nightly-and-beta', fallback='firefox-channel-android') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS TestFlight">{{ ftl('sub-navigation-ios-test-flight', fallback='firefox-channel-ios') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+{{ sub_nav(
+  title={
+    'text':  ftl('sub-navigation-firefox'),
+    'href':  url('firefox.browsers.index'),
+    'cta_name': "Firefox",
+    'icon': static('protocol/img/logos/firefox/logo.svg')
+  },
+  links=[
+  {
+    'text': ftl('sub-navigation-nightly-and-beta', fallback='firefox-channel-desktop'),
+    'href': url('firefox.channel.desktop'),
+    'cta_name': "Nightly and Beta"
+  },
+  {
+    'text': ftl('sub-navigation-android-nightly-and-beta', fallback='firefox-channel-android'),
+    'href': url('firefox.channel.android'),
+    'cta_name': "Android Nightly and Beta"
+  },
+  {
+    'text': ftl('sub-navigation-ios-test-flight', fallback='firefox-channel-ios'),
+    'href': url('firefox.channel.ios'),
+    'cta_name': "iOS TestFlight"
+  }]
+) }}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/includes/desktop-platform-sub-nav.html
+++ b/bedrock/firefox/templates/firefox/includes/desktop-platform-sub-nav.html
@@ -1,0 +1,45 @@
+
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import sub_nav with context %}
+
+{{ sub_nav(
+  title={
+    'text': ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop')
+  },
+  links=[
+  {
+    'text':  ftl('sub-navigation-windows') ,
+    'href':  url('firefox.windows'),
+    'cta_name': "Windows"
+  },
+  {
+    'text': ftl('sub-navigation-windows-64-bit'),
+    'href': url('firefox.browsers.windows-64-bit') ,
+    'cta_name': "Windows 64-bit"
+  },
+  {
+    'text': ftl('sub-navigation-mac'),
+    'href': url('firefox.mac'),
+    'cta_name': "Mac"
+  },
+  {
+    'text': ftl('sub-navigation-linux'),
+    'href': url('firefox.linux'),
+    'cta_name': "Linux"
+  },
+  {
+    'text': ftl('sub-navigation-chromebook'),
+    'href': url('firefox.browsers.chromebook'),
+    'cta_name': "Chromebook"
+  },
+  {
+    'text': ftl('sub-navigation-all-languages', fallback='download-button-systems-languages'),
+    'href': url('firefox.all'),
+    'cta_name': "All Languages "
+  }]
+) }}

--- a/bedrock/firefox/templates/firefox/new/basic/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_download.html
@@ -48,21 +48,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows">{{ ftl('sub-navigation-windows') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.windows-64-bit') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 64-bit">{{ ftl('sub-navigation-windows-64-bit') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('sub-navigation-mac') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.linux') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Linux">{{ ftl('sub-navigation-linux') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.chromebook') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chromebook">{{ ftl('sub-navigation-chromebook') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+ {% include '/firefox/includes/desktop-platform-sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/privacy/base.html
+++ b/bedrock/firefox/templates/firefox/privacy/base.html
@@ -25,8 +25,6 @@
 
 {% block content %}
 <main role="main">
-  {% block sub_nav %}{% endblock %}
-
   {% block hub_content %}{% endblock %}
 
   {{ call_out(

--- a/bedrock/firefox/templates/firefox/privacy/base.html
+++ b/bedrock/firefox/templates/firefox/privacy/base.html
@@ -20,31 +20,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-privacy', fallback='firefox-privacy-privacy') }}</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Our Promise">{{ ftl('sub-navigation-our-promise', fallback='firefox-privacy-our-promise') }}</a>
-        </li>
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.products') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Our Products">{{ ftl('sub-navigation-our-products', fallback='firefox-privacy-our-products') }}</a>
-        </li>
-      {% if ftl_has_messages('sub-navigation-little-book-of-privacy') %}
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.book') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Little Book of Privacy">{{ ftl('sub-navigation-little-book-of-privacy') }}</a>
-        </li>
-      {% endif %}
-      {% if ftl_has_messages('sub-navigation-safe-passwords') %}
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.passwords') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Safe Passwords">{{ ftl('sub-navigation-safe-passwords') }}</a>
-        </li>
-      {% endif %}
-      </ul>
-    </div>
-  </div>
-</nav>
+  {% include 'firefox/privacy/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -21,26 +21,7 @@
 {% endblock %}
 
 {% block sub_navigation %}
-{% if ftl_has_messages('sub-navigation-privacy', 'sub-navigation-our-promise', 'sub-navigation-our-products', 'sub-navigation-little-book-of-privacy') %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-privacy') }}</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Our Promise">{{ ftl('sub-navigation-our-promise') }}</a>
-        </li>
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.products') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Our Products">{{ ftl('sub-navigation-our-products') }}</a>
-        </li>
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.privacy.book') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Little Book of Privacy">{{ ftl('sub-navigation-little-book-of-privacy') }}</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
-{% endif %}
+  {% include 'firefox/privacy/includes/sub-nav.html' %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/privacy/includes/sub-nav.html
+++ b/bedrock/firefox/templates/firefox/privacy/includes/sub-nav.html
@@ -1,0 +1,36 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% from "macros.html" import sub_nav with context %}
+
+{% if ftl_has_messages('sub-navigation-privacy', 'sub-navigation-our-promise', 'sub-navigation-our-products', 'sub-navigation-little-book-of-privacy') %}
+  {{ sub_nav(
+    title={
+      'text':  ftl('sub-navigation-privacy', fallback='firefox-privacy-privacy')
+    },
+    links=[
+    {
+      'text': ftl('sub-navigation-our-promise', fallback='firefox-privacy-our-promise'),
+      'href': url('firefox.privacy.index'),
+      'cta_name': "Our Promise"
+    },
+    {
+      'text': ftl('sub-navigation-our-products', fallback='firefox-privacy-our-products'),
+      'href': url('firefox.privacy.products') ,
+      'cta_name': "Our Products"
+    },
+    {
+      'text': ftl('sub-navigation-little-book-of-privacy'),
+      'href': url('firefox.privacy.book'),
+      'cta_name': "Little Book of Privacy"
+    },
+    {
+      'text': ftl('sub-navigation-safe-passwords'),
+      'href': url('firefox.privacy.passwords'),
+      'cta_name': "Safe Passwords"
+    }]
+  ) }}
+{% endif %}

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -4,6 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "macros.html" import sub_nav with context %}
 {% from "macros-protocol.html" import call_out, call_out_compact %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -55,47 +56,37 @@
 {% set download_title = download_title|default('Get the most recent version') %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-release-notes', fallback='navigation-release-notes') }}</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-      {% if release.channel == 'Release' and release.product == 'Firefox for Android' and equivalent_release_url %}
-        <li class="c-sub-navigation-item">
-          <a class="mzp-c-menu-title" href="{{ equivalent_release_url }}" data-link-type="nav" data-link-position="subnav" data-link-name="Desktop">{{ ftl('sub-navigation-desktop') }}</a>
-        </li>
-      {% else %}
-        <li class="c-sub-navigation-item">
-          <a class="mzp-c-menu-title" href="{{ url('firefox.notes') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Desktop">{{ ftl('sub-navigation-desktop') }}</a>
-        </li>
-      {% endif %}
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.notes', channel='beta') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Desktop Beta and Developer Edition">{{ ftl('sub-navigation-desktop-beta-and-developer') }}</a>
-        </li>
-        <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.notes', channel='nightly') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Desktop Nightly">{{ ftl('sub-navigation-desktop-nightly') }}</a>
-        </li>
-      {% if release.channel == 'Release' and release.product == 'Firefox' and equivalent_release_url %}
-        <li class="c-sub-navigation-item">
-          <a class="mzp-c-menu-title" href="{{ equivalent_release_url }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a>
-        </li>
-      {% else %}
-        <li class="c-sub-navigation-item">
-          <a class="mzp-c-menu-title" href="{{ url('firefox.notes', platform='android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a>
-        </li>
-      {% endif %}
-        {# Bug # 1701489
-          <li class="c-sub-navigation-item">
-            <a href="{{ url('firefox.notes', platform='android', channel='beta') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android Beta">{{ ftl('sub-navigation-android-beta') }}</a>
-          </li>
-        #}
-        <li class="c-sub-navigation-item">
-          <a class="mzp-c-menu-title" href="{{ url('firefox.notes', platform='ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
+  {{ sub_nav(
+    title={
+      'text':  ftl('sub-navigation-release-notes', fallback='navigation-release-notes')
+    },
+    links=[
+    {
+      'text': ftl('sub-navigation-desktop'),
+      'href': equivalent_release_url if release.channel == 'Release' and release.product == 'Firefox for Android' and equivalent_release_url else url('firefox.notes'),
+      'cta_name': "Desktop"
+    },
+    {
+      'text': ftl('sub-navigation-desktop-beta-and-developer'),
+      'href': url('firefox.notes', channel='beta'),
+      'cta_name': "Desktop Beta and Developer Edition"
+    },
+    {
+      'text': ftl('sub-navigation-desktop-nightly'),
+      'href': url('firefox.notes', channel='nightly'),
+      'cta_name': "Desktop Nightly"
+    },
+    {
+      'text': ftl('sub-navigation-android'),
+      'href': equivalent_release_url if release.channel == 'Release' and release.product == 'Firefox' and equivalent_release_url else url('firefox.notes', platform='android'),
+      'cta_name': "Android"
+    },
+    {
+      'text': ftl('sub-navigation-ios'),
+      'href': url('firefox.notes', platform='ios'),
+      'cta_name': "iOS"
+    }]
+  ) }}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
@@ -6,7 +6,7 @@
 
 {% extends "base-protocol-mozilla.html" %}
 
-{% from "macros.html" import image with context %}
+{% from "macros.html" import image, sub_nav with context %}
 {% from "macros-protocol.html" import split, picto, card, feature_card, with context %}]
 
 
@@ -24,22 +24,47 @@
 {% endblock %}
 
 {% block sub_navigation %}
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">Diversity & Inclusion 2021</h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Diversity and inclusion overview">Overview</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.mofo-data') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla Foundation data">Foundation data</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.moco-data') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla Corporation data">Corporation data</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.racial-justice') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Racial justice commitments">Racial justice commitments</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.who-we-are') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Who we are">Who we are</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.what-we-build') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What we build">What we build</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.beyond-products') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Beyond our products">Beyond our products</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+{{ sub_nav(
+  title={
+    'text': "Diversity & Inclusion 2021"
+  },
+  links=[
+  {
+    'text': "Overview",
+    'href': url('mozorg.diversity.2021.index'),
+    'cta_name': "Diversity and inclusion overview"
+  },
+  {
+    'text': "Foundation data",
+    'href': url('mozorg.diversity.2021.mofo-data'),
+    'cta_name': "Mozilla Foundation data"
+  },
+  {
+    'text': "Corporation data",
+    'href': url('mozorg.diversity.2021.moco-data'),
+    'cta_name': "Mozilla Corporation data"
+  },
+  {
+    'text': "Racial justice commitments",
+    'href': url('mozorg.diversity.2021.racial-justice'),
+    'cta_name': "Racial justice commitments"
+  },
+  {
+    'text': "Who we are",
+    'href': url('mozorg.diversity.2021.who-we-are'),
+    'cta_name': "Who we are"
+  },
+  {
+    'text': "What we build",
+    'href': url('mozorg.diversity.2021.what-we-build'),
+    'cta_name': "What we build"
+  },
+  {
+    'text': "Beyond our products",
+    'href': url('mozorg.diversity.2021.beyond-products'),
+    'cta_name': "Beyond our products"
+  }]
+) }}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/products/templates/products/vpn/includes/subnav-more.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav-more.html
@@ -4,18 +4,36 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "macros.html" import sub_nav with context %}
+
 {% if ftl_has_messages('vpn-subnav-whats-a-vpn', 'vpn-subnav-faqs', 'vpn-subnav-get-help') %}
-  <nav class="c-sub-navigation">
-    <div class="mzp-l-content">
-      <div class="c-sub-navigation-content">
-        <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-        <ul class="c-sub-navigation-list is-details is-closed">
-          <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.what-is-a-vpn') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What’s a VPN?">{{ ftl('vpn-subnav-whats-a-vpn') }}</a></li>
-          <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.ip-address') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What’s an IP address?">{{ ftl('vpn-subnav-whats-an-ip-address') }}</a></li>
-          <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.when-to-use') }}" data-link-type="nav" data-link-position="subnav" data-link-name="When to use a VPN">{{ ftl('vpn-subnav-when-to-use-a-vpn') }}</a></li>
-          <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.vpn-or-proxy') }}" data-link-type="nav" data-link-position="subnav" data-link-name="VPN vs Proxy">{{ ftl('vpn-subnav-vpn-vs-proxy') }}</a></li>
-        </ul>
-      </div>
-    </div>
-  </nav>
+  {{ sub_nav(
+    title={
+      'text': ftl('vpn-subnav-title'),
+      'href': url('products.vpn.landing'),
+      'cta_name': "Mozilla VPN"
+    },
+    links=[
+    {
+      'text': ftl('vpn-subnav-whats-a-vpn'),
+      'href': url('products.vpn.more.what-is-a-vpn'),
+      'cta_name': "What’s a VPN?"
+    },
+    {
+      'text': ftl('vpn-subnav-whats-an-ip-address'),
+      'href': url('products.vpn.more.ip-address') ,
+      'cta_name': "What’s an IP address?"
+    },
+    {
+      'text': ftl('vpn-subnav-when-to-use-a-vpn'),
+      'href': url('products.vpn.more.when-to-use'),
+      'cta_name': "When to use a VPN"
+    },
+    {
+      'text': ftl('vpn-subnav-vpn-vs-proxy'),
+      'href': url('products.vpn.more.vpn-or-proxy'),
+      'cta_name': "VPN vs Proxy"
+    }]
+  ) }}
 {% endif %}
+

--- a/bedrock/products/templates/products/vpn/platforms/includes/subnav-desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/includes/subnav-desktop.html
@@ -4,19 +4,39 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# Subnav menu for /products/vpn/desktop/ and desktop subpages #}
+{% from "macros.html" import sub_nav with context %}
 
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.mobile') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-mobile') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-desktop') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-mac') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 10">{{ ftl('vpn-subnav-platform-windows') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.linux') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Linux">{{ ftl('vpn-subnav-platform-linux') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+{# Subnav menu for /products/vpn/desktop/ and desktop subpages #}
+{{ sub_nav(
+  title={
+    'text': ftl('vpn-subnav-title'),
+    'href': url('products.vpn.landing'),
+    'cta_name': "Mozilla VPN"
+  },
+  links=[
+  {
+    'text': ftl('vpn-subnav-platform-mobile'),
+    'href': url('products.vpn.platforms.mobile'),
+    'cta_name': "Mobile"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-desktop'),
+    'href': url('products.vpn.platforms.desktop'),
+    'cta_name': "Desktop"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-mac'),
+    'href': url('products.vpn.platforms.mac'),
+    'cta_name': "Mac"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-windows'),
+    'href': url('products.vpn.platforms.windows'),
+    'cta_name': "Windows"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-linux'),
+    'href': url('products.vpn.platforms.linux'),
+    'cta_name': "Linux"
+  }]
+) }}

--- a/bedrock/products/templates/products/vpn/platforms/includes/subnav-mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/includes/subnav-mobile.html
@@ -4,18 +4,36 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# Subnav menu for /products/vpn/mobile/ and mobile subpages #}
+{% from "macros.html" import sub_nav with context %}
 
-<nav class="c-sub-navigation">
-  <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-desktop') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.mobile') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-mobile') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-ios') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-android') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
+{# Subnav menu for /products/vpn/mobile/ and mobile subpages #}
+{{ sub_nav(
+  title={
+    'text': ftl('vpn-subnav-title'),
+    'href': url('products.vpn.landing'),
+    'cta_name': "Mozilla VPN"
+  },
+  links=[
+  {
+    'text': ftl('vpn-subnav-platform-desktop'),
+    'href': url('products.vpn.platforms.desktop'),
+    'cta_name': "Desktop"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-mobile'),
+    'href': url('products.vpn.platforms.mobile'),
+    'cta_name': "Mobile"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-ios'),
+    'href': url('products.vpn.platforms.ios'),
+    'cta_name': "iOS"
+  },
+  {
+    'text': ftl('vpn-subnav-platform-android'),
+    'href': url('products.vpn.platforms.android'),
+    'cta_name': "Android"
+  }]
+) }}
+
+

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -127,6 +127,10 @@
                 text-decoration: underline;
             }
         }
+
+        a[aria-current='page'] {
+            font-weight: bold;
+        }
     }
 
     @media #{$mq-md} {


### PR DESCRIPTION
## Description

Adds sub_nav macro for standard HTML structure and dynamic `aria-current=page` attribute. This applies to our most consistent sub navigations.

Removes commented out Android Beta link in Release Notes sub nav: https://github.com/mozilla/bedrock/issues/10064

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10038

## Testing

Check subnavs have expected text and links for the following

- [ ] Firefox Nightly & Beta: http://localhost:8000/en-US/firefox/channel/desktop/
- [ ] Firefox Desktop: http://localhost:8000/en-US/firefox/windows/
- [ ] Firefox Desktop Compare: http://localhost:8000/en-US/firefox/browsers/compare/
- [ ] Firefox Mobile: http://localhost:8000/en-US/firefox/browsers/mobile/
- [ ] Firefox Privacy: http://localhost:8000/en-US/firefox/privacy/safe-passwords/
- [ ] Diversity: http://localhost:8000/en-US/diversity/2021/
- [ ] Release Notes: http://localhost:8000/en-US/firefox/notes/
- [ ] VPN More: http://localhost:8000/en-US/products/vpn/more/what-is-a-vpn/
- [ ] VPN Desktop: http://localhost:8000/en-US/products/vpn/desktop/
- [ ] VPN Mobile: http://localhost:8000/en-US/products/vpn/mobile/
- [ ] mobile size, no js, the sub nav is visible in block display (no regression from https://github.com/mozilla/bedrock/pull/11451)

Test locally `py.test bedrock/base/tests/test_macros.py`
