### PR TITLE
Render sidebar at the end of /privacy pages for mobile (Fixes #10628)

### DIFF
--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -46,10 +46,6 @@
 
 {% block content %}
 <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
-  <aside class="mzp-l-sidebar">
-    {{ sidemenu_lists([navigation_bar], body_id) }}
-    {% block side_extra %}{% endblock %}
-  </aside>
   <article class="mzp-l-main" itemtype="http://schema.org/Article">
     {% block article %}
     <header>
@@ -80,6 +76,10 @@
     </footer>
     {% endblock %}
   </article>
+  <aside class="mzp-l-sidebar">
+    {{ sidemenu_lists([navigation_bar], body_id) }}
+    {% block side_extra %}{% endblock %}
+  </aside>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Description
Moves sidebar to the bottom of the page for mobile users when trying to view privacy notices.

## Issue / Bugzilla link
#10628

## Testing
http://localhost:8000/en-US/privacy/