### PR TITLE
Make home page footer CTA more obvious about which product it relates to (Fixes #10706)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-contentful.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-contentful.html
@@ -97,14 +97,14 @@
   </div>
 
 {% call download_banner_secondary(
-  title=_('Privacy over profit'),
-  sub_title=_('No shareholders. No data for sale.')
+  title='Privacy over profit',
+  sub_title='No shareholders. No data for sale.'
 ) %}
   {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
 {% endcall %}
 
 {% call call_out_compact(
-  title=_('The account that protects you rather than profits off you.'),
+  title='A Firefox Account protects you rather than profits off you.',
   class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark hide-from-legacy-ie',
   heading_level=2
 ) %}


### PR DESCRIPTION
## Description
Add the Firefox Account product name to the CTA

## Issue / Bugzilla link
#10706

## Testing
http://localhost:8000/en-US/