### PR TITLE
Lazy load Contentful images on home page (Fixes #10669)

### DIFF
--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -348,7 +348,7 @@ class InlineEntryRenderer(BaseNodeRenderer):
 
 
 class AssetBlockRenderer(BaseBlockRenderer):
-    IMAGE_HTML = '<img src="{src}" srcset="{src_highres} 1.5x" alt="{alt}" />'
+    IMAGE_HTML = '<img src="{src}" srcset="{src_highres} 1.5x" alt="{alt}" loading="lazy" />'
 
     def render(self, node):
         asset_id = node["data"]["target"]["sys"]["id"]

--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -13,8 +13,10 @@
 
     {% if entries.index(entry) == 0: %}
       {% set heading_level = 1 %}
+      {% set loading = 'eager' %}
     {% else %}
       {% set heading_level = 2 %}
+      {% set loading = 'lazy' %}
     {% endif %}
 
       {% call hero(
@@ -27,6 +29,7 @@
         heading_level=heading_level,
         image_url=entry.image,
         include_highres_image=False,
+        loading=loading
       ) %}
 
         {{ entry.cta|external_html }}
@@ -117,6 +120,12 @@
 
     {% elif entry.component == 'split' %}
 
+      {% if entries.index(entry) == 0: %}
+        {% set loading = 'eager' %}
+      {% else %}
+        {% set loading = 'lazy' %}
+      {% endif %}
+
       {% call split(
         block_class=entry.block_class,
         body_class=entry.body_class,
@@ -125,6 +134,7 @@
         mobile_class=entry.mobile_class,
         image_url=entry.image,
         include_highres_image=False,
+        loading=loading
       ) %}
 
         {{ entry.body|external_html }}

--- a/bedrock/contentful/tests/test_contentful_api.py
+++ b/bedrock/contentful/tests/test_contentful_api.py
@@ -666,7 +666,7 @@ def test_AssetBlockRenderer(mock_client, mock__get_image_url):
         "https://example.com/image-hires.png",
     ]
     output = AssetBlockRenderer().render(node)
-    expected = '<img src="https://example.com/image.png" srcset="https://example.com/image-hires.png 1.5x" alt="Test Description" />'
+    expected = '<img src="https://example.com/image.png" srcset="https://example.com/image-hires.png 1.5x" alt="Test Description" loading="lazy" />'
 
     assert mock__get_image_url.call_args_list[0][0] == (mock_asset, 688)
     assert mock__get_image_url.call_args_list[1][0] == (mock_asset, 1376)


### PR DESCRIPTION
## Description
This isn't a perfect solution but seems sane (?) and certainly better than what we have now. Assumes that if the first Contentful entry on a page is either a Hero or Split component, then set `loading="eager"`, else set `loading="lazy"`.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10669

## Testing
http://localhost:8000/en-US/