### PR TITLE
Remove period from French WNP99 [#11393]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx99-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx99-fr.html
@@ -26,7 +26,7 @@
   <section class="wnp-content-main">
     <div class="mzp-l-content mzp-t-content-lg">
       <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-pocket">Pocket</div>
-      <h1 class="wnp-main-title">Votre navigateur mérite aussi son ménage de printemps.</h1>
+      <h1 class="wnp-main-title">Votre navigateur mérite aussi son ménage de printemps</h1>
 
       {{ high_res_img('img/firefox/whatsnew/whatsnew99/pocket-hero-eu.png', {'alt': '', 'width': '720', 'height': '406', 'class': 'wnp-main-image'}) }}
 


### PR DESCRIPTION
## Description
Removes a period from the French headline.

## Testing
http://localhost:8000/fr/firefox/99.0/whatsnew/