### PR TITLE
Add GTM attributes to Rally button on WNP99 [#11393]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx99-en-rally.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx99-en-rally.html
@@ -28,7 +28,7 @@
     {{ high_res_img('img/firefox/whatsnew/whatsnew99/moz-rally.png', {'alt': '', 'width': '600', 'height': '375', 'class': 'wnp-main-image'}) }}
     <h3 class="mzp-c-wordmark t-product-mozrally">Mozilla Rally</h3>
     <p class="wnp-main-body">Help us <strong>uncover Facebook’s tracking network</strong>, understand <strong>search engine choice</strong>, and help <strong>local news</strong> find sustainability.</p>
-    <p><a class="mzp-c-button mzp-t-product qa-rally-cta" rel="external" href="https://rally.mozilla.org{{ referrals }}">Join Mozilla Rally</a></p>
+    <p><a class="mzp-c-button mzp-t-product qa-rally-cta" rel="external" href="https://rally.mozilla.org{{ referrals }}" data-cta-text="Join Mozilla Rally" data-cta-type="button" data-cta-position="primary">Join Mozilla Rally</a></p>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Description
I neglected to include the data attributes so we're not seeing any events in GA for clicks on this button. It has UTM params so it shows up in GA on the Rally site, but we're missing out on counting those clicks on our end.

## Testing
http://localhost:8000/en-US/firefox/99.0/whatsnew/?v=2