### PR TITLE
Reduce content layout shift (CLS) caused by sub navigation. (Fixes #9823)

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -40,13 +40,13 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.accounts') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Accounts">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
           {{ ftl('sub-navigation-firefox-accounts') }}
         </a>
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
           <a href="{{ url('firefox.sync') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Sync">{{ ftl('sub-navigation-sync') }}</a>
         </li>

--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -25,13 +25,13 @@
     <nav class="c-sub-navigation">
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
-          <h2 class="c-sub-navigation-title">
+          <h2 class="c-sub-navigation-title is-summary">
             <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
               {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
-          <ul class="c-sub-navigation-list">
+          <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item">
               <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
             </li>

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -25,8 +25,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows">{{ ftl('sub-navigation-windows') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.windows-64-bit') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 64-bit">{{ ftl('sub-navigation-windows-64-bit') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('sub-navigation-mac') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/compare/includes/subnav.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/includes/subnav.html
@@ -9,8 +9,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.compare.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Browsers">{{ ftl('sub-navigation-compare-browsers') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.compare.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Compare Browsers">{{ ftl('sub-navigation-compare-browsers') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.chrome') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Chrome">{{ ftl('sub-navigation-chrome') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.edge') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Edge">{{ ftl('sub-navigation-edge') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.compare.safari') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Safari">{{ ftl('sub-navigation-safari') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -39,13 +39,13 @@
     <nav class="c-sub-navigation">
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
-          <h2 class="c-sub-navigation-title">
+          <h2 class="c-sub-navigation-title is-summary">
             <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
               {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
-          <ul class="c-sub-navigation-list">
+          <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item">
               <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
             </li>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -44,8 +44,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
@@ -25,8 +25,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
@@ -50,8 +50,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -40,8 +40,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -44,8 +44,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('firefox.browsers.mobile.index') }}">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android">{{ ftl('sub-navigation-android') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS">{{ ftl('sub-navigation-ios') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Focus">{{ ftl('sub-navigation-firefox-focus') }}</a></li>

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -20,13 +20,13 @@
     <nav class="c-sub-navigation">
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
-          <h2 class="c-sub-navigation-title">
+          <h2 class="c-sub-navigation-title is-summary">
             <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
               {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
-          <ul class="c-sub-navigation-list">
+          <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
           </ul>
         </div>

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -24,8 +24,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows">{{ ftl('sub-navigation-windows') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.windows-64-bit') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 64-bit">{{ ftl('sub-navigation-windows-64-bit') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('sub-navigation-mac') }}</a></li>

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -23,13 +23,13 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
          {{ ftl('sub-navigation-firefox') }}
         </a>
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta', fallback='firefox-channel-desktop') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.android') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Android Nightly and Beta">{{ ftl('sub-navigation-android-nightly-and-beta', fallback='firefox-channel-android') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="iOS TestFlight">{{ ftl('sub-navigation-ios-test-flight', fallback='firefox-channel-ios') }}</a></li>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -35,13 +35,13 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
          {{ ftl('sub-navigation-firefox') }}
         </a>
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.enterprise.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Enterprise">{{ ftl('sub-navigation-enterprise') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -32,13 +32,13 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
          {{ ftl('sub-navigation-firefox') }}
         </a>
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.developer.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Developer Edition">{{ ftl('sub-navigation-developer-edition') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -21,13 +21,13 @@
     <nav class="c-sub-navigation">
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
-          <h2 class="c-sub-navigation-title">
+          <h2 class="c-sub-navigation-title is-summary">
             <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
              {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
-          <ul class="c-sub-navigation-list">
+          <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item">
               <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
             </li>

--- a/bedrock/firefox/templates/firefox/features/includes/subnav.html
+++ b/bedrock/firefox/templates/firefox/features/includes/subnav.html
@@ -9,12 +9,12 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.features.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Features">
           {{ ftl('sub-navigation-firefox-features') }}
         </a>
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
           <a href="{{ url('firefox.sync') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Sync">{{ ftl('sub-navigation-sync') }}</a>
         </li>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -60,11 +60,11 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
         {{ ftl('sub-navigation-firefox') }}
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.faq') }}" data-link-type="nav" data-link-position="subnav" data-link-name="FAQ">{{ ftl('sub-navigation-faq') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.more') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Learn More">{{ ftl('sub-navigation-learn-more') }}</a></li>
       </ul>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -43,9 +43,9 @@
 {% block sub_navigation %}
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
-    <div class="c-sub-navigation-content">
+    <div class="c-sub-navigation-content is-summary">
       <h2 class="c-sub-navigation-title"><a href="{{ url('firefox.browsers.mobile.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox for Mobile">{{ ftl('sub-navigation-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/ios/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="iOS Support">{{ ftl('sub-navigation-ios-support', fallback='navigation-ios-support') }}</a></li>
         <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/mobile/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="Android Support">{{ ftl('sub-navigation-android-support', fallback='navigation-android-support') }}</a></li>
         <li class="c-sub-navigation-item"><a href="https://addons.mozilla.org/android/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox-mobile" data-link-type="nav" data-link-position="subnav" data-link-name="Android Addons">{{ ftl('sub-navigation-android-add-ons', fallback='sub-navigation-android-addons') }}</a></li>

--- a/bedrock/firefox/templates/firefox/new/basic/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_download.html
@@ -51,8 +51,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.windows') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows">{{ ftl('sub-navigation-windows') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.windows-64-bit') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Windows 64-bit">{{ ftl('sub-navigation-windows-64-bit') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('firefox.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('sub-navigation-mac') }}</a></li>

--- a/bedrock/firefox/templates/firefox/new/desktop/includes/sub_nav.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/includes/sub_nav.html
@@ -7,8 +7,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
           <a href="{{ url('firefox.features.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Features">{{ ftl('sub-navigation-features', fallback='navigation-features') }}</a>
         </li>

--- a/bedrock/firefox/templates/firefox/privacy/base.html
+++ b/bedrock/firefox/templates/firefox/privacy/base.html
@@ -23,8 +23,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-privacy', fallback='firefox-privacy-privacy') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-privacy', fallback='firefox-privacy-privacy') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
           <a href="{{ url('firefox.privacy.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Our Promise">{{ ftl('sub-navigation-our-promise', fallback='firefox-privacy-our-promise') }}</a>
         </li>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -25,8 +25,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-privacy') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-privacy') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
           <a href="{{ url('firefox.privacy.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Our Promise">{{ ftl('sub-navigation-our-promise') }}</a>
         </li>

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -58,8 +58,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ ftl('sub-navigation-release-notes', fallback='navigation-release-notes') }}</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-release-notes', fallback='navigation-release-notes') }}</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
       {% if release.channel == 'Release' and release.product == 'Firefox for Android' and equivalent_release_url %}
         <li class="c-sub-navigation-item">
           <a class="mzp-c-menu-title" href="{{ equivalent_release_url }}" data-link-type="nav" data-link-position="subnav" data-link-name="Desktop">{{ ftl('sub-navigation-desktop') }}</a>

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -23,13 +23,13 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">
+      <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.accounts') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Accounts">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
           {{ ftl('sub-navigation-firefox-accounts') }}
         </a>
       </h2>
-      <ul class="c-sub-navigation-list">
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/firefox/sync-and-save/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=sync-page" data-link-type="nav" data-link-position="subnav" data-link-name="Support">{{ ftl('sub-navigation-support', fallback='navigation-support') }}</a></li>
       </ul>
     </div>

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
@@ -27,8 +27,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">Diversity & Inclusion 2021</h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary">Diversity & Inclusion 2021</h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Diversity and inclusion overview">Overview</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.mofo-data') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla Foundation data">Foundation data</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('mozorg.diversity.2021.moco-data') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla Corporation data">Corporation data</a></li>

--- a/bedrock/products/templates/products/vpn/includes/subnav-more.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav-more.html
@@ -8,8 +8,8 @@
   <nav class="c-sub-navigation">
     <div class="mzp-l-content">
       <div class="c-sub-navigation-content">
-        <h2 class="c-sub-navigation-title"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-        <ul class="c-sub-navigation-list">
+        <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
+        <ul class="c-sub-navigation-list is-details is-closed">
           <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.what-is-a-vpn') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What’s a VPN?">{{ ftl('vpn-subnav-whats-a-vpn') }}</a></li>
           <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.ip-address') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What’s an IP address?">{{ ftl('vpn-subnav-whats-an-ip-address') }}</a></li>
           <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.when-to-use') }}" data-link-type="nav" data-link-position="subnav" data-link-name="When to use a VPN">{{ ftl('vpn-subnav-when-to-use-a-vpn') }}</a></li>

--- a/bedrock/products/templates/products/vpn/includes/subnav.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav.html
@@ -8,8 +8,8 @@
   <nav class="c-sub-navigation">
     <div class="mzp-l-content">
       <div class="c-sub-navigation-content">
-        <h2 class="c-sub-navigation-title"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-        <ul class="c-sub-navigation-list">
+        <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
+        <ul class="c-sub-navigation-list is-details is-closed">
           <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.more.what-is-a-vpn') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What’s a VPN?">{{ ftl('vpn-subnav-whats-a-vpn') }}</a></li>
           <li class="c-sub-navigation-item"><a href="#faq" data-link-type="nav" data-link-position="subnav" data-link-name="FAQs">{{ ftl('vpn-subnav-faqs') }}</a></li>
           <li class="c-sub-navigation-item"><a href="https://support.mozilla.org/products/firefox-private-network-vpn{{ _params }}&utm_content=vpn-sub-nav-link" data-link-type="nav" data-link-position="subnav" data-link-name="Get Help">{{ ftl('vpn-subnav-get-help') }}</a></li>

--- a/bedrock/products/templates/products/vpn/platforms/includes/subnav-desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/includes/subnav-desktop.html
@@ -9,8 +9,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.mobile') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-mobile') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-desktop') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.mac') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-mac') }}</a></li>

--- a/bedrock/products/templates/products/vpn/platforms/includes/subnav-mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/includes/subnav-mobile.html
@@ -9,8 +9,8 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
-      <ul class="c-sub-navigation-list">
+      <h2 class="c-sub-navigation-title is-summary"><a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">{{ ftl('vpn-subnav-title') }}</a></h2>
+      <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-desktop') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.mobile') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-mobile') }}</a></li>
         <li class="c-sub-navigation-item"><a href="{{ url('products.vpn.platforms.ios') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mac">{{ ftl('vpn-subnav-platform-ios') }}</a></li>

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -91,8 +91,19 @@
     .c-sub-navigation-list {
         margin: 0;
 
-        &.is-closed[aria-hidden='true'] {
+        // minimize sub navigation on mobile by default to reduce CLS
+        // see issue https://github.com/mozilla/bedrock/issues/9823
+        &.is-closed {
             display: none;
+
+            // ensure sub-nav is still accessible with JS disabled
+            .no-js & {
+                display: block;
+            }
+
+            @media #{$mq-md} {
+                display: block;
+            }
         }
 
         &.mzp-js-details-wrapper {


### PR DESCRIPTION
## Description
Reduced page jump (CLS) on mobile when loading pages that have sub navigation links.

## Issue / Bugzilla link

## Testing

- [ ] Pages that contain sub nav should still work just as they do now, but will load in the collapsed state on small viewports.

Effected URLs:

- [ ] http://localhost:8000/en-US/firefox/accounts/
- [ ] http://localhost:8000/en-US/firefox/browsers/browser-history/
- [ ] http://localhost:8000/en-US/firefox/browsers/chromebook/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/
- [ ] http://localhost:8000/en-US/firefox/browsers/
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/android/
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/compare/
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/focus/
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/ios/
- [ ] http://localhost:8000/en-US/firefox/browsers/what-is-a-browser/
- [ ] http://localhost:8000/en-US/firefox/browsers/windows-64-bit/
- [ ] http://localhost:8000/en-US/firefox/channel/desktop/
- [ ] http://localhost:8000/en-US/firefox/developer/
- [ ] http://localhost:8000/en-US/firefox/enterprise/
- [ ] http://localhost:8000/en-US/firefox/faq/
- [ ] http://localhost:8000/en-US/firefox/features/
- [ ] http://localhost:8000/en-US/firefox/
- [ ] http://localhost:8000/en-US/firefox/new/?xv=basic
- [ ] http://localhost:8000/en-US/firefox/new/
- [ ] http://localhost:8000/en-US/firefox/privacy/
- [ ] http://localhost:8000/en-US/firefox/privacy/book/
- [ ] http://localhost:8000/en-US/firefox/releasenotes/
- [ ] http://localhost:8000/en-US/firefox/sync/
- [ ] http://localhost:8000/en-US/diversity/2021/
- [ ] http://localhost:8000/en-US/products/vpn/
- [ ] http://localhost:8000/en-US/products/vpn/more/what-is-a-vpn/
- [ ] http://localhost:8000/en-US/products/vpn/mobile/
- [ ] http://localhost:8000/en-US/products/vpn/desktop/