### PR TITLE
Set nativeEvents to false for IE SauceLabs tests

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -136,7 +136,7 @@ For example, to run the home page tests using Internet Explorer via Sauce Labs:
 
 .. code-block:: bash
 
-    $ SAUCELABS_USERNAME=thedude SAUCELABS_API_KEY=123456789 SAUCELABS_W3C=true py.test --base-url https://www-dev.allizom.org --driver SauceLabs --capability browserName 'internet explorer' --capability platformName='Windows 10' --html tests/functional/results.html tests/functional/test_home.py
+    $ SAUCELABS_USERNAME=thedude SAUCELABS_API_KEY=123456789 SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs py.test --base-url https://www-dev.allizom.org --driver SauceLabs --capability browserName 'internet explorer' --capability platformName 'Windows 10' --html tests/functional/results.html tests/functional/test_home.py
 
 
 Writing Selenium tests

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -24,11 +24,17 @@ def driver_log():
 
 @pytest.fixture(scope="session")
 def session_capabilities(pytestconfig, session_capabilities):
-    if pytestconfig.getoption("driver") == "SauceLabs":
+    driver = pytestconfig.getoption("driver")
+    if driver == "SauceLabs":
         session_capabilities.setdefault("tags", []).append("bedrock")
 
-        # Avoid default SauceLabs proxy for IE.
-        session_capabilities["avoidProxy"] = True
+        if session_capabilities.get("browserName", driver).lower() == "internet explorer":
+            # Avoid default SauceLabs proxy for IE.
+            session_capabilities["avoidProxy"] = True
+
+            # Use JavaScript events instead of native
+            # window events for more reliable IE testing.
+            session_capabilities["se:ieOptions"] = {"nativeEvents": False}
 
     return session_capabilities
 


### PR DESCRIPTION
## Description
This should hopefully help with flakey test clicks in IE, such as https://gitlab.com/mozmeao/www-config/-/jobs/2289800872

## Issue / Bugzilla link
N/A

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/509413100 (I re-ran this a bunch of times)