### PR TITLE
Add 'OK' button to VPN affiliate banner (Fixes #11454)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/cookie-notification.html
+++ b/bedrock/products/templates/products/vpn/includes/cookie-notification.html
@@ -7,9 +7,14 @@
 <aside class="mzp-c-notification-bar vpn-affiliate-notification">
   {% set attrs = 'href="' ~ url('privacy.notices.websites') ~ '" target="_blank" rel="noopener noreferrer"' %}
   {{ ftl('vpn-shared-affiliate-notification-message', attrs=attrs) }}
-  <button class="vpn-affiliate-notification-reject mzp-c-button mzp-t-neutral mzp-t-sm" type="button">
-    {{ ftl('vpn-shared-affiliate-notification-reject') }}
-  </button>
+  <div class="vpn-affiliate-notification-options">
+    <button class="vpn-affiliate-notification-ok mzp-c-button mzp-t-neutral mzp-t-sm" type="button">
+      {{ ftl('vpn-shared-affiliate-notification-ok') }}
+    </button>
+    <button class="vpn-affiliate-notification-reject mzp-c-button mzp-t-neutral mzp-t-sm" type="button">
+      {{ ftl('vpn-shared-affiliate-notification-reject') }}
+    </button>
+  </div>
   <button class="mzp-c-notification-bar-button" type="button">
     {{ ftl('ui-close') }}
   </button>

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -153,5 +153,6 @@ vpn-subnav-vpn-vs-proxy = VPN vs Proxy
 vpn-shared-affiliate-notification-message = We use cookies to understand which affiliate partner led you to { -brand-name-mozilla-vpn }. We do not share personally identifying information with our partners. Read our <a { $attrs }>Privacy Policy</a>.
 
 vpn-shared-affiliate-notification-reject = Reject
+vpn-shared-affiliate-notification-ok = OK
 
 ##

--- a/media/css/products/vpn/components/affiliate.scss
+++ b/media/css/products/vpn/components/affiliate.scss
@@ -32,14 +32,26 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    .vpn-affiliate-notification-reject {
-        display: block;
-        margin: $spacing-sm auto 0;
+    .vpn-affiliate-notification-options {
+        margin: $spacing-md auto 0;
     }
 
-    @media #{$mq-md} {
+    .vpn-affiliate-notification-ok,
+    .vpn-affiliate-notification-reject {
+        margin: $spacing-sm $spacing-sm 0;
+        width: calc(100% - #{ $spacing-sm * 2});
+    }
+
+    @media #{$mq-sm} {
         margin: $spacing-lg auto 0;
         max-width: $content-md;
+
+        .vpn-affiliate-notification-ok,
+        .vpn-affiliate-notification-reject {
+            margin: 0 $spacing-sm;
+            width: auto;
+            min-width: 100px;
+        }
     }
 }
 

--- a/media/js/products/vpn/affiliate-init.es6.js
+++ b/media/js/products/vpn/affiliate-init.es6.js
@@ -11,6 +11,10 @@ const notification = document.querySelector('.vpn-affiliate-notification');
 function bindNotificationEvents() {
     if (notification) {
         notification
+            .querySelector('.vpn-affiliate-notification-ok')
+            .addEventListener('click', handleOkClick, false);
+
+        notification
             .querySelector('.vpn-affiliate-notification-reject')
             .addEventListener('click', handleOptOutClick, false);
 
@@ -22,6 +26,10 @@ function bindNotificationEvents() {
 
 function unbindNotificationEvents() {
     if (notification) {
+        notification
+            .querySelector('.vpn-affiliate-notification-ok')
+            .removeEventListener('click', handleOkClick, false);
+
         notification
             .querySelector('.vpn-affiliate-notification-reject')
             .removeEventListener('click', handleOptOutClick, false);
@@ -42,9 +50,10 @@ function handleOptOutClick(e) {
             unbindNotificationEvents();
 
             window.dataLayer.push({
-                event: 'in-page-interaction',
-                eAction: 'link click',
-                eLabel: 'Affiliate notification opt-out'
+                eLabel: 'Banner Click (Reject)',
+                'data-banner-name': 'VPN affiliate notification',
+                'data-banner-click': '1',
+                event: 'in-page-interaction'
             });
         })
         .catch((e) => {
@@ -52,11 +61,32 @@ function handleOptOutClick(e) {
         });
 }
 
+function handleOkClick(e) {
+    e.preventDefault();
+    AffiliateAttribution.setPreferenceCookie('accept');
+    notification.classList.remove('show');
+    unbindNotificationEvents();
+
+    window.dataLayer.push({
+        eLabel: 'Banner Click (OK)',
+        'data-banner-name': 'VPN affiliate notification',
+        'data-banner-click': '1',
+        event: 'in-page-interaction'
+    });
+}
+
 function handleCloseNotification(e) {
     e.preventDefault();
     AffiliateAttribution.setPreferenceCookie('accept');
     notification.classList.remove('show');
     unbindNotificationEvents();
+
+    window.dataLayer.push({
+        eLabel: 'Banner Dismissal',
+        'data-banner-name': 'VPN affiliate notification',
+        'data-banner-dismissal': '1',
+        event: 'in-page-interaction'
+    });
 }
 
 function showOptOutNotification() {
@@ -67,9 +97,10 @@ function showOptOutNotification() {
         bindNotificationEvents();
 
         window.dataLayer.push({
-            event: 'non-interaction',
-            eAction: 'affiliate-attribution',
-            eLabel: 'Affiliate notification shown'
+            eLabel: 'Banner Impression',
+            'data-banner-name': 'VPN affiliate notification',
+            'data-banner-impression': '1',
+            event: 'non-interaction'
         });
     }
 }


### PR DESCRIPTION
## Description
- Adds additional 'OK' button to dismiss the affiliate banner.
- Updates GA events for banner interaction.

## Issue / Bugzilla link
#11454

## Testing
http://localhost:8000/en-US/products/vpn/?cjevent=09d8676b716a11ec831e01500a18050e

- [ ] Clicking the OK button will dismiss the banner and not display it again on refresh / repeat visit.