### PR TITLE
Fix zh-CN bold fonts

### DIFF
--- a/media/css/l10n/zh-CN/intl.css
+++ b/media/css/l10n/zh-CN/intl.css
@@ -30,7 +30,7 @@
      * DroidSansFallbackFull (linux)
      */
     src:
-        local(FZLTZHK--GBK1-0)
+        local(FZLTZHK--GBK1-0),
         local(HiraginoSansGB-W6),
         local('Microsoft YaHei Bold'),
         local(DroidSansFallbackFull);


### PR DESCRIPTION
We found that there is a small miss of zh-CN intl.css here: https://github.com/mozilla/bedrock/commit/0f59dc09485c86d8eeb9bb8678d1c38198b2a551#diff-7ac7b33cf917c31888237b97fdcbf3a5392495e091acbfc6635c83e8da56784dL20-R36

So just wanna fix it, thx
