### PR TITLE
Update governance discussion forum link (fixes #10866)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/governance.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/governance.html
@@ -18,7 +18,7 @@
 {% trans roles_url=url('mozorg.about.governance.roles'),
     policies_url=url('mozorg.about.governance.policies.policies'),
     organizations_url=url('mozorg.about.governance.organizations'),
-    discussion_url='//groups.google.com/a/mozilla.org/g/governance'%}
+    discussion_url='https://groups.google.com/a/mozilla.org/g/governance'%}
 <ol class="mzp-u-list-styled">
   <li><a href="{{ roles_url }}">Roles and Responsibilities</a></li>
   <li><a href="{{ policies_url }}">Policies</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/governance/governance.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/governance.html
@@ -18,7 +18,7 @@
 {% trans roles_url=url('mozorg.about.governance.roles'),
     policies_url=url('mozorg.about.governance.policies.policies'),
     organizations_url=url('mozorg.about.governance.organizations'),
-    discussion_url='//groups.google.com/group/mozilla.governance/topics'%}
+    discussion_url='//groups.google.com/a/mozilla.org/g/governance'%}
 <ol class="mzp-u-list-styled">
   <li><a href="{{ roles_url }}">Roles and Responsibilities</a></li>
   <li><a href="{{ policies_url }}">Policies</a></li>


### PR DESCRIPTION
## Description

Update discussion forum link to non-archived mailing list

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1743147

## Testing
http://localhost:8000/en-US/about/governance/

Discussion forum link goes to https://groups.google.com/a/mozilla.org/g/governance