### PR TITLE
Add `rev` fallback to "prod"

### DIFF
--- a/bin/open-compare.py
+++ b/bin/open-compare.py
@@ -30,7 +30,7 @@ def get_current_rev(env):
     url = None
     try:
         url = urllib.request.urlopen(ENV_URLS[env] + REV_PATH)
-        return url.read().strip()[:10]
+        return url.read().strip()[:10] or "prod"
     finally:
         if url:
             url.close()


### PR DESCRIPTION
The https://www.mozilla.org/revision.txt seems to be empty, but using "prod" seems to work just as well to compare the prod and master branches.