### PR TITLE
Fix remaining selectors for new footer styles (fixes #11465)

### DIFF
--- a/media/css/firefox/welcome11.scss
+++ b/media/css/firefox/welcome11.scss
@@ -123,12 +123,12 @@ $image-path: '/media/protocol/img';
         @include white-links;
     }
 
-    .c-footer {
+    .mzp-c-footer.mzp-t-light {
         @include white-links;
         background: $color-dark-gray-60;
         color: $color-white;
 
-        .c-footer-sections {
+        .mzp-c-footer-sections {
             border-color: $color-dark-gray-30;
 
             a:hover,
@@ -137,23 +137,33 @@ $image-path: '/media/protocol/img';
                 text-decoration: underline;
             }
         }
-    }
 
-    .c-footer-list-social li {
-        a.twitter {
-            background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+        .mzp-c-footer-links-social li {
+            a.twitter {
+                background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+            }
+
+            a.instagram {
+                background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+            }
+
+            a.youtube {
+                background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+            }
+
+            a:hover,
+            a:focus,
+            a:active {
+                outline-color: $color-white;
+            }
         }
 
-        a.instagram {
-            background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+        .mzp-c-footer-primary-logo a {
+            background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
         }
 
-        a.youtube {
-            background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+        .mzp-c-footer-heading.is-summary button::before {
+            background: $url-image-expand-white top left no-repeat;
         }
-    }
-
-    .c-footer-primary-logo a {
-        background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
     }
 }

--- a/media/css/firefox/welcome12.scss
+++ b/media/css/firefox/welcome12.scss
@@ -154,12 +154,12 @@ $image-path: '/media/protocol/img';
         @include white-links;
     }
 
-    .c-footer {
+    .mzp-c-footer.mzp-t-light {
         @include white-links;
         background: $color-dark-gray-60;
         color: $color-white;
 
-        .c-footer-sections {
+        .mzp-c-footer-sections {
             border-color: $color-dark-gray-30;
 
             a:hover,
@@ -168,23 +168,33 @@ $image-path: '/media/protocol/img';
                 text-decoration: underline;
             }
         }
-    }
 
-    .c-footer-list-social li {
-        a.twitter {
-            background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+        .mzp-c-footer-links-social li {
+            a.twitter {
+                background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+            }
+
+            a.instagram {
+                background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+            }
+
+            a.youtube {
+                background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+            }
+
+            a:hover,
+            a:focus,
+            a:active {
+                outline-color: $color-white;
+            }
         }
 
-        a.instagram {
-            background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+        .mzp-c-footer-primary-logo a {
+            background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
         }
 
-        a.youtube {
-            background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+        .mzp-c-footer-heading.is-summary button::before {
+            background: $url-image-expand-white top left no-repeat;
         }
-    }
-
-    .c-footer-primary-logo a {
-        background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
     }
 }

--- a/media/css/firefox/welcome13.scss
+++ b/media/css/firefox/welcome13.scss
@@ -154,12 +154,12 @@ $image-path: '/media/protocol/img';
         @include white-links;
     }
 
-    .c-footer {
+    .mzp-c-footer.mzp-t-light {
         @include white-links;
         background: $color-dark-gray-60;
         color: $color-white;
 
-        .c-footer-sections {
+        .mzp-c-footer-sections {
             border-color: $color-dark-gray-30;
 
             a:hover,
@@ -168,23 +168,33 @@ $image-path: '/media/protocol/img';
                 text-decoration: underline;
             }
         }
-    }
 
-    .c-footer-list-social li {
-        a.twitter {
-            background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+        .mzp-c-footer-links-social li {
+            a.twitter {
+                background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+            }
+
+            a.instagram {
+                background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+            }
+
+            a.youtube {
+                background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+            }
+
+            a:hover,
+            a:focus,
+            a:active {
+                outline-color: $color-white;
+            }
         }
 
-        a.instagram {
-            background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+        .mzp-c-footer-primary-logo a {
+            background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
         }
 
-        a.youtube {
-            background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+        .mzp-c-footer-heading.is-summary button::before {
+            background: $url-image-expand-white top left no-repeat;
         }
-    }
-
-    .c-footer-primary-logo a {
-        background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
     }
 }

--- a/media/css/firefox/whatsnew/includes/_dark-mode.scss
+++ b/media/css/firefox/whatsnew/includes/_dark-mode.scss
@@ -23,7 +23,8 @@
         @include white-links;
     }
 
-    .c-footer {
+    // override light theme footer styles
+    .mzp-c-footer.mzp-t-light {
         background: $color-dark-gray-60;
         color: $color-white;
 
@@ -38,26 +39,36 @@
             }
         }
 
-        .c-footer-sections {
+        .mzp-c-footer-sections {
             border-color: $color-dark-gray-30;
         }
-    }
 
-    .c-footer-list-social li {
-        a.twitter {
-            background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+        .mzp-c-footer-links-social li {
+            a.twitter {
+                background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
+            }
+
+            a.instagram {
+                background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+            }
+
+            a.youtube {
+                background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+            }
+
+            a:hover,
+            a:focus,
+            a:active {
+                outline-color: $color-white;
+            }
         }
 
-        a.instagram {
-            background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
+        .mzp-c-footer-primary-logo a {
+            background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
         }
 
-        a.youtube {
-            background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
+        .mzp-c-footer-heading.is-summary button::before {
+            background: $url-image-expand-white top left no-repeat;
         }
-    }
-
-    .c-footer-primary-logo a {
-        background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
     }
 }

--- a/media/css/firefox/whatsnew/includes/_footer.scss
+++ b/media/css/firefox/whatsnew/includes/_footer.scss
@@ -5,60 +5,13 @@
 // * -------------------------------------------------------------------------- */
 // Footer overrides
 
-.c-footer {
+.mzp-c-footer.mzp-t-light {
     background: $color-white;
     color: $color-ink-80;
 
-    a:link,
-    a:visited {
-        color: $color-ink-80;
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: $color-ink-90;
-            text-decoration: underline;
-        }
-    }
-
-    .c-footer-sections {
+    .mzp-c-footer-sections {
         border-top: 1px solid $color-light-gray-30;
         border-bottom: 1px solid $color-light-gray-30;
         padding: $layout-md 0;
-    }
-}
-
-.c-footer-list-social li {
-    a:hover,
-    a:active,
-    a:focus {
-        border-bottom-color: transparent;
-    }
-
-    a.twitter {
-        background-image: url('/media/protocol/img/icons/social/twitter/black.svg');
-    }
-
-    a.instagram {
-        background-image: url('/media/protocol/img/icons/social/instagram/black.svg');
-    }
-
-    a.youtube {
-        background-image: url('/media/protocol/img/icons/social/youtube/black.svg');
-    }
-}
-
-.c-footer-primary-logo a {
-    background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor.svg');
-}
-
-.c-footer-legal {
-    a:link,
-    a:visited {
-        &:hover,
-        &:focus,
-        &:active {
-            text-decoration: none;
-        }
     }
 }

--- a/media/css/firefox/whatsnew/whatsnew-99-en.scss
+++ b/media/css/firefox/whatsnew/whatsnew-99-en.scss
@@ -78,57 +78,6 @@ $image-path: '/media/protocol/img';
 }
 
 // * -------------------------------------------------------------------------- */
-// Utilities (link to release notes)
-.c-utilities {
-    @include text-body-sm;
-    max-width: $content-md;
-    padding-bottom: $layout-xl;
-    text-align: center;
-}
-
-// * -------------------------------------------------------------------------- */
-// Footer overrides
-.c-footer {
-    background: $color-white;
-    color: $color-ink-80;
-
-    a:link,
-    a:visited {
-        color: $color-ink-80;
-    }
-
-    a:hover,
-    a:focus,
-    a:active {
-        color: $color-ink-90;
-    }
-
-    .c-footer-sections {
-        border-top: 1px solid $color-light-gray-30;
-        border-bottom: 1px solid $color-light-gray-30;
-        padding: $layout-md 0;
-    }
-}
-
-.c-footer-list-social li {
-    a.twitter {
-        background-image: url('/media/protocol/img/icons/social/twitter/black.svg');
-    }
-
-    a.instagram {
-        background-image: url('/media/protocol/img/icons/social/instagram/black.svg');
-    }
-
-    a.youtube {
-        background-image: url('/media/protocol/img/icons/social/youtube/black.svg');
-    }
-}
-
-.c-footer-primary-logo a {
-    background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor.svg');
-}
-
-// * -------------------------------------------------------------------------- */
 // For dark mode
 @media (prefers-color-scheme: dark) {
     .content-wrapper {
@@ -170,43 +119,7 @@ $image-path: '/media/protocol/img';
         color: get-theme('title-text-color-inverse');
     }
 
-    .c-utilities,
     .c-sub-cta {
         @include white-links;
-    }
-
-    .c-footer {
-        background: $color-dark-gray-60;
-        color: $color-white;
-
-        a:link,
-        a:visited,
-        a:hover,
-        a:focus,
-        a:active {
-            color: $color-white;
-        }
-
-        .c-footer-sections {
-            border-color: $color-dark-gray-30;
-        }
-    }
-
-    .c-footer-list-social li {
-        a.twitter {
-            background-image: url('/media/protocol/img/icons/social/twitter/white.svg');
-        }
-
-        a.instagram {
-            background-image: url('/media/protocol/img/icons/social/instagram/white.svg');
-        }
-
-        a.youtube {
-            background-image: url('/media/protocol/img/icons/social/youtube/white.svg');
-        }
-    }
-
-    .c-footer-primary-logo a {
-        background-image: url('/media/protocol/img/logos/mozilla/logo-word-hor-white.svg');
     }
 }


### PR DESCRIPTION
## Description

Fix regression from https://github.com/mozilla/bedrock/pull/11300
Updates remaining ".c-footer" selectors
Nests footer styles for firefox pages in ".mzp-c-footer.mzp-t-light" to override new light theme class
Removes redundant styles

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11465

## Testing

- [x] light mode no regression
- [x] dark mode fixed
- [x] mobile dark mode expand icons fixed

http://localhost:8000/en-US/firefox/99.0/whatsnew/
http://localhost:8000/en-US/firefox/welcome/11/
http://localhost:8000/en-US/firefox/welcome/12/
http://localhost:8000/en-US/firefox/welcome/13/
