### PR TITLE
Add AMO referrer check for /thanks/?s=direct page (Fixes #11467)

### DIFF
--- a/media/js/firefox/new/common/thanks-direct.js
+++ b/media/js/firefox/new/common/thanks-direct.js
@@ -92,7 +92,12 @@
         Mozilla.StubAttribution.waitForGoogleAnalytics(function () {
             var data = Mozilla.StubAttribution.getAttributionData();
 
-            if (data && Mozilla.StubAttribution.withinAttributionRate()) {
+            // make sure we check referrer for AMO (issue 11467)
+            if (
+                data &&
+                Mozilla.StubAttribution.withinAttributionRate() &&
+                Mozilla.StubAttribution.hasValidData(data)
+            ) {
                 Mozilla.StubAttribution.successCallback = onSuccess;
                 Mozilla.StubAttribution.timeoutCallback = onTimeout;
                 // We don't want to delay the download indefinitely for a stub attribution call,


### PR DESCRIPTION
## Description
Adds referrer check for AMO to /thanks/ attribution page.

## Issue / Bugzilla link
#11467

## Testing
Please test on a Windows VM / browser:

- [x] https://www-demo1.allizom.org/en-US/firefox/download/thanks/?s=direct&utm_source=addons.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button&utm_content=rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20 (no moz-stub-attribution-code cookie created)
- [x] https://www-demo1.allizom.org/en-US/firefox/download/thanks/?s=direct&utm_source=test&utm_medium=referral&utm_campaign=test&utm_content=test (moz-stub-attribution-code cookie is created)