### PR TITLE
Hide checkboxes on single newsletters (Fixes #11469)

### DIFF
--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -36,7 +36,9 @@
 
   <section class="mzp-l-content mzp-t-content-sm">
     <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ url('newsletter.subscribe') }}" method="post" data-spinner-color="#fff">
-      {{ newsletter_form.newsletters|safe }}
+      <div hidden>
+        {{ newsletter_form.newsletters|safe }}
+      </div>
       {# test flight program is only available in english #}
       <input type="hidden" name="lang" id="id_lang" value="en">
       <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -11,7 +11,7 @@
     {% if is_multi_newsletter_form %}
       <div id="newsletter-error-strings" data-form-checkboxes-error="{{ ftl('multi-newsletter-form-checkboxes-error') }}"></div>
     {% else %}
-      <div hidden="true">
+      <div hidden>
         {{ form.newsletters|safe }}
       </div>
     {% endif %}

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -31,8 +31,9 @@
   <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ url('products.vpn.invite.waitlist') }}" method="post" data-spinner-color="#000">
     <h1 class="mzp-c-form-header">{{ ftl('vpn-landing-invite-page-heading') }}</h1>
     <p class="mzp-c-form-subtitle">{{ ftl('vpn-landing-invite-page-desc') }}</p>
-
-    {{ newsletter_form.newsletters|safe }}
+    <div hidden>
+      {{ newsletter_form.newsletters|safe }}
+    </div>
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
     <input type="hidden" name="privacy" id="id_privacy" value="true">
     <input type="hidden" name="fmt" id="format-html" value="H">


### PR DESCRIPTION
## Description
Hides visible newsletter checkboxes for single newsletters

## Issue / Bugzilla link
#11469

## Testing
- http://localhost:8000/en-US/products/vpn/invite/
- http://localhost:8000/en-US/firefox/ios/testflight/