### PR TITLE
Upgrade Django to 3.2.13 following security release announcement

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -315,9 +315,9 @@ deprecated==1.2.13 \
 dirsync==2.2.5 \
     --hash=sha256:1e3a4cd2b639a2eae5afc03c2b8a003fc43d56a0da5114db579386da9a14a8be
     # via -r requirements/prod.txt
-django==3.2.12 \
-    --hash=sha256:9772e6935703e59e993960832d66a614cf0233a1c5123bc6224ecc6ad69e41e2 \
-    --hash=sha256:9b06c289f9ba3a8abea16c9c9505f25107809fb933676f6c891ded270039d965
+django==3.2.13 \
+    --hash=sha256:6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6 \
+    --hash=sha256:b896ca61edc079eb6bbaa15cf6071eb69d6aac08cce5211583cfb41515644fdf
     # via
     #   -r requirements/prod.txt
     #   django-allow-cidr

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -20,7 +20,7 @@ django-jsonview==2.0.0
 django-memoize==2.3.1
 django-mozilla-product-details==1.0.3
 django-watchman==1.3.0
-Django==3.2.12
+Django==3.2.13
 docutils==0.17.1
 envcat==0.1.1
 everett==3.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -154,9 +154,9 @@ deprecated==1.2.13 \
 dirsync==2.2.5 \
     --hash=sha256:1e3a4cd2b639a2eae5afc03c2b8a003fc43d56a0da5114db579386da9a14a8be
     # via -r requirements/prod.in
-django==3.2.12 \
-    --hash=sha256:9772e6935703e59e993960832d66a614cf0233a1c5123bc6224ecc6ad69e41e2 \
-    --hash=sha256:9b06c289f9ba3a8abea16c9c9505f25107809fb933676f6c891ded270039d965
+django==3.2.13 \
+    --hash=sha256:6d93497a0a9bf6ba0e0b1a29cccdc40efbfc76297255b1309b3a884a688ec4b6 \
+    --hash=sha256:b896ca61edc079eb6bbaa15cf6071eb69d6aac08cce5211583cfb41515644fdf
     # via
     #   -r requirements/prod.in
     #   django-allow-cidr


### PR DESCRIPTION
## Description

Upgrade Django to 3.2.13 following security release announcement

## Issue / Bugzilla link

No ticket

## Testing
* CI passing should be enough  - the diff for 3.2.12 to 3.2.13 seems _almost_ entirely focused on the security issue and the change to the template reloading seems safe - https://github.com/django/django/compare/3.2.12...3.2.13