### PR TITLE
Remove gap space on firefox pages (fixes #11457)

### DIFF
--- a/bedrock/firefox/templates/firefox/features/tips/tips.html
+++ b/bedrock/firefox/templates/firefox/features/tips/tips.html
@@ -35,7 +35,7 @@
 {% block content %}
   <main>
     {% call split(
-      block_class='mzp-l-split-center-on-sm-md mzp-t-split-nospace',
+      block_class='mzp-l-split-center-on-sm-md mzp-t-split-nospace t-mobile-nospace',
       theme_class='mzp-t-dark',
       media_class='mzp-l-split-h-center',
       media_include=media_include,

--- a/bedrock/firefox/templates/firefox/more.html
+++ b/bedrock/firefox/templates/firefox/more.html
@@ -22,7 +22,7 @@
   {% call split(
     image_url='img/firefox/privacy/promise/privacy-hero.png',
     include_highres_image=True,
-    block_class='page-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace',
+    block_class='page-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-v-end'
   ) %}

--- a/bedrock/firefox/templates/firefox/more/misinformation.html
+++ b/bedrock/firefox/templates/firefox/more/misinformation.html
@@ -25,7 +25,7 @@
 {% call split(
   image_url='img/firefox/more/misinformation/hero.jpg',
   include_highres_image=True,
-  block_class='c-hero mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md mzp-t-split-nospace',
+  block_class='c-hero mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md mzp-t-split-nospace t-mobile-nospace',
   media_class='mzp-l-split-media-overflow',
   theme_class='mzp-t-dark'
 ) %}

--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -35,7 +35,7 @@
     block_id='pocket-hero',
     image_url='img/firefox/pocket/pocket-hero.png',
     include_highres_image=True,
-    block_class='pocket-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace mzp-l-split-pop-bottom',
+    block_class='pocket-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace mzp-l-split-pop-bottom',
     media_class='mzp-l-split-media-overflow mzp-l-split-v-end',
     theme_class='mzp-t-dark'
   ) %}

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -27,7 +27,7 @@
   {% call split(
     image_url='img/firefox/privacy/promise/privacy-hero.png',
     include_highres_image=True,
-    block_class='privacy-promise-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace',
+    block_class='privacy-promise-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-v-end'
   ) %}

--- a/bedrock/firefox/templates/firefox/privacy/passwords.html
+++ b/bedrock/firefox/templates/firefox/privacy/passwords.html
@@ -23,7 +23,7 @@
 
 {% block hub_content %}
 {% call split(
-    block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
+    block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
     image_url='img/firefox/privacy/passwords/passwords.png',

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -28,7 +28,7 @@
 {% call split(
     image_url='img/mozorg/about/lean-data/build-security-hero.png',
     include_highres_image=True,
-    block_class='mzp-t-split-nospace',
+    block_class='mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -28,7 +28,7 @@
 {% call split(
     image_url='img/mozorg/about/lean-data/engage-users-hero.png',
     include_highres_image=True,
-    block_class='mzp-t-split-nospace',
+    block_class='mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
@@ -27,7 +27,7 @@
 {% call split(
     image_url='img/mozorg/about/lean-data/lean-data-hero.png',
     include_highres_image=True,
-    block_class='mzp-t-split-nospace',
+    block_class='mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -28,7 +28,7 @@
 {% call split(
     image_url='img/mozorg/about/lean-data/stay-lean-hero.png',
     include_highres_image=True,
-    block_class='mzp-t-split-nospace',
+    block_class='mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-background-secondary',
     media_class='mzp-l-split-h-center',
     media_after=True

--- a/media/css/firefox/privacy/common.scss
+++ b/media/css/firefox/privacy/common.scss
@@ -25,7 +25,6 @@ $brand-theme: 'firefox';
 /* -------------------------------------------------------------------------- */
 // Reduce vertical padding on stacked split components
 
-.privacy-promise-hero,
 .mzp-c-split + .mzp-c-split {
     padding-top: 0;
 }

--- a/media/css/protocol/components/split.scss
+++ b/media/css/protocol/components/split.scss
@@ -7,3 +7,12 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/split';
+
+// Issue 11457
+
+@media screen and (max-width: $screen-md) {
+    .t-mobile-nospace {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}


### PR DESCRIPTION
## Description

Some of the `nospace` split components at the top of firefox pages have a gap on mobile sizes. These changes remove that gap.

update (21/4/22): there are more instances of pages with this gap, so this PR will widen scope to address those. A [discussion issue ](https://github.com/mozilla/protocol/issues/779)has been created in Protocol to decide how to handle these cases in future

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11457

## Testing
fix checks
http://localhost:8000/en-US/firefox/more/
http://localhost:8000/en-US/firefox/privacy/safe-passwords/
(updated 21/4/22)
http://localhost:8000/en-US/firefox/features/tips/
http://localhost:8000/en-US/firefox/pocket/
http://localhost:8000/en-US/firefox/more/misinformation/
http://localhost:8000/en-US/about/policy/lean-data/ (and sub-pages)


no regression checks
https://www.mozilla.org/en-US/firefox/privacy/
https://www.mozilla.org/en-US/firefox/privacy/products/
https://www.mozilla.org/en-US/firefox/privacy/book/

