### PR TITLE
Document CSS bundles updates

### DIFF
--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -611,9 +611,9 @@ see `editorconfig.org <http://editorconfig.org/>`_. for a list of supported
 editors and available plugins.
 
 Working with Protocol Design System
----------------------
+-----------------------------------
 
-Bedrock uses the `Protocol Design System <https://protocol.mozilla.org/>`_ to quickly produce consistent, stable components. There are different methods -- depending on the component -- to import a Protocol component in our codebase.
+Bedrock uses the `Protocol Design System <https://protocol.mozilla.org/>`_ to quickly produce consistent, stable components. There are different methods -- depending on the component -- to import a Protocol component into our codebase.
 
 One method involves two steps:
 
@@ -664,7 +664,7 @@ Then we need to include those Protocol styles in the page's SCSS file:
 Macros
 ~~~~~~
 
-The team has created several `Jinja macros <https://jinja2docs.readthedocs.io/en/stable/templates.html#macros>`_ out of Protocol components to simplify the usage of components housing larger blocks of code (i.e. Split). The code housing the custom macros can be found in our `protocol macros file <https://github.com/mozilla/bedrock/blob/main/bedrock/base/templates/macros-protocol.html>`_. These Jinja macros include parameters that are simple to define and customize based on how the component should look like on a given page.
+The team has created several `Jinja macros <https://jinja.palletsprojects.com/en/3.1.x/templates/?=macros#macros>`_ out of Protocol components to simplify the usage of components housing larger blocks of code (i.e. Billboard). The code housing the custom macros can be found in our `protocol macros file <https://github.com/mozilla/bedrock/blob/main/bedrock/base/templates/macros-protocol.html>`_. These Jinja macros include parameters that are simple to define and customize based on how the component should look like on a given page.
 
 To use these macros in files, we simply import a macro to the page's HTML code and call it with the desired arguments, instead of manually adding Protocol markup. We can import multiple macros in a comma-separated fashion, ending the import with ``with context``:
 
@@ -679,10 +679,10 @@ To use these macros in files, we simply import a macro to the page's HTML code a
         ga_title='This is Firefox',
         desc='Firefox is an awesome web browser.',
         link_cta='Click here to install',
-        link_url='mozilla.org/firefox',
+        link_url=url('firefox.new')
       )}}
 
-Because component styles are not global, we still have to import the page-specific Protocol styles in SCSS:
+Because not all component styles are global, we still have to import the page-specific Protocol styles in SCSS:
 
 .. code-block:: css
 
@@ -696,7 +696,7 @@ Because component styles are not global, we still have to import the page-specif
 
 Import CSS Bundles
 ~~~~~~~~~~~~~~~~~~
-We created pre-built CSS bundles to be used for said components due to their frequency of use. This method only requires an import into the HTML page. Since it’s already a CSS bundle, we don’t need to import it in the respective CSS page.
+We created pre-built CSS bundles to be used for some components due to their frequency of use. This method only requires an import into the HTML template. Since it’s a separate CSS bundle, we don’t need to import that component in the respective page CSS.
 The CSS bundle import only works for the following components:
 
 * Split
@@ -707,13 +707,14 @@ The CSS bundle import only works for the following components:
 * Newsletter form
 * Emphasis box
 
-To import a respective bundle, all that is required to place the CSS bundle into the ``page_css`` block like the following:
+Include a CSS bundle in the template's ``page_css`` block along with any other page-specific bundles, like so:
 
 .. code-block:: html
 
     {% block page_css %}
         {{ css_bundle('protocol-split') }}
         {{ css_bundle('protocol-card') }}
+        {{ css_bundle('page-specific-bundle') }}
     {% endblock %}
 
 
@@ -732,7 +733,7 @@ Picto
 
 .. code-block:: html
 
-   {% block page_css %}
+    {% block page_css %}
         {{ css_bundle('protocol-picto') }}
     {% endblock %}
 
@@ -818,7 +819,7 @@ Call out
 
 .. code-block:: html
 
-   {% block page_css %}
+    {% block page_css %}
         {{ css_bundle('protocol-call-out') }}
     {% endblock %}
 
@@ -867,7 +868,7 @@ Split
 
 .. code-block:: html
 
-   {% block page_css %}
+    {% block page_css %}
         {{ css_bundle('protocol-split') }}
     {% endblock %}
 

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -610,13 +610,18 @@ use with your code editor to help maintain consistent coding styles. Please
 see `editorconfig.org <http://editorconfig.org/>`_. for a list of supported
 editors and available plugins.
 
-Working with Protocol
+Working with Protocol Design System
 ---------------------
 
-Bedrock uses the `Protocol Design System <https://protocol.mozilla.org/>`_ to quickly produce consistent, stable components. This involves two steps:
+Bedrock uses the `Protocol Design System <https://protocol.mozilla.org/>`_ to quickly produce consistent, stable components. There are different methods -- depending on the component -- to import a Protocol component in our codebase.
+
+One method involves two steps:
 
 1. Adding the `correct markup <#styles-and-components>`_ or importing the `appropriate macro <#macros>`_ to the page's HTML file.
 2. Importing the necessary Protocol styles to a page's SCSS file.
+
+The other method is to `import CSS bundles <#import-css-bundles>`_ onto the HTML file. However, this only works for certain components, which are listed below in the respective section.
+
 
 Styles and Components
 ~~~~~~~~~~~~~~~~~~~~~
@@ -667,20 +672,17 @@ To use these macros in files, we simply import a macro to the page's HTML code a
 
     // bedrock/bedrock/firefox/templates/firefox/{specific-page}.html
 
-    {% from "macros-protocol.html" import split, picto with context %}
+    {% from "macros-protocol.html" import billboard with context %}
 
-    {% call split(
-        image_url='img/firefox/browsers/hero.jpg',
-        include_highres_image=True,
-        block_class='mzp-l-split-center-on-sm-md',
-        media_class='mzp-l-split-media-overflow',
-        media_after=True
-    ) %}
-        <h1>This is Mozilla</h1>
-        <p>Get the privacy you deserve with Firefox</p>
-    {% endcall %}
+    {{ billboard(
+        title='This is Firefox.',
+        ga_title='This is Firefox',
+        desc='Firefox is an awesome web browser.',
+        link_cta='Click here to install',
+        link_url='mozilla.org/firefox',
+      )}}
 
-Because Split styles are not global, we still have to import the page-specific Protocol styles in SCSS:
+Because component styles are not global, we still have to import the page-specific Protocol styles in SCSS:
 
 .. code-block:: css
 
@@ -689,14 +691,39 @@ Because Split styles are not global, we still have to import the page-specific P
     $brand-theme: 'firefox';
 
     @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-    @import '~@mozilla-protocol/core/protocol/css/components/split';
-    @import '~@mozilla-protocol/core/protocol/css/components/picto';
+    @import '~@mozilla-protocol/core/protocol/css/components/billboard';
 
 
-You can find parameter definitions for the available Protocol macros below, including their import paths.
+Import CSS Bundles
+~~~~~~~~~~~~~~~~~~
+We created pre-built CSS bundles to be used for said components due to their frequency of use. This method only requires an import into the HTML page. Since it’s already a CSS bundle, we don’t need to import it in the respective CSS page.
+The CSS bundle import only works for the following components:
+
+* Split
+* Card
+* Picto
+* Callout
+* Article
+* Newsletter form
+* Emphasis box
+
+To import a respective bundle, all that is required to place the CSS bundle into the ``page_css`` block like the following:
+
+.. code-block:: html
+
+    {% block page_css %}
+        {{ css_bundle('protocol-split') }}
+        {{ css_bundle('protocol-card') }}
+    {% endblock %}
+
+
+Imports and Parameters
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can find import examples and parameter definitions for the available Protocol macros below.
 
 .. note::
-    You can use macros without Protocol and you can use Protocol without macros. They are not dependent on each other but they work well together. 10/10 would recommend!
+    You can use Protocol without macros. They are not dependent on each other but they work well together. 10/10 would recommend!
 
 Picto
 <<<<<
@@ -705,13 +732,9 @@ Picto
 
 .. code-block:: html
 
-   {% from "macros-protocol.html" import picto with context %}
-
-**CSS import**
-
-.. code-block:: css
-
-   @import '~@mozilla-protocol/core/protocol/css/components/picto';
+   {% block page_css %}
+        {{ css_bundle('protocol-picto') }}
+    {% endblock %}
 
 **Macro parameters**
 
@@ -795,13 +818,9 @@ Call out
 
 .. code-block:: html
 
-   {% from "macros-protocol.html" import call_out with context %}
-
-**CSS import**
-
-.. code-block:: css
-
-   @import '~@mozilla-protocol/core/protocol/css/components/call-out';
+   {% block page_css %}
+        {{ css_bundle('protocol-call-out') }}
+    {% endblock %}
 
 **Macro parameters**
 
@@ -848,13 +867,9 @@ Split
 
 .. code-block:: html
 
-   {% from "macros-protocol.html" import split with context %}
-
-**CSS import**
-
-.. code-block:: css
-
-   @import '~@mozilla-protocol/core/protocol/css/components/split';
+   {% block page_css %}
+        {{ css_bundle('protocol-split') }}
+    {% endblock %}
 
 **Macro parameters**
 
@@ -1147,14 +1162,9 @@ Card
 
 .. code-block:: html
 
-   {% from "macros-protocol.html" import card with context %}
-
-**CSS import**
-
-.. code-block:: css
-
-   @import '~@mozilla-protocol/core/protocol/css/components/card';
-   @import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
+    {% block page_css %}
+        {{ css_bundle('protocol-split') }}
+    {% endblock %}
 
 **Macro parameters**
 


### PR DESCRIPTION
## Description
We updated how we import some Protocol components by creating some CSS bundles for them. The original ticket explaining it is here: https://github.com/mozilla/bedrock/issues/11032
## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11382
## Testing
#### Local run:
`make livedocs` and go to http://127.0.0.1:8100/coding.html#working-with-protocol-design-system

#### Docker:
`make docs` and go to http://127.0.0.1:8100/coding.html#working-with-protocol-design-system
