### PR TITLE
Rename contentful prod env from master to main

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1051,7 +1051,7 @@ CONTENT_CARDS_URL = config("CONTENT_CARDS_URL", default=STATIC_URL)
 
 CONTENTFUL_SPACE_ID = config("CONTENTFUL_SPACE_ID", raise_error=False)
 CONTENTFUL_SPACE_KEY = config("CONTENTFUL_SPACE_KEY", raise_error=False)
-CONTENTFUL_ENVIRONMENT = config("CONTENTFUL_ENVIRONMENT", default="master")
+CONTENTFUL_ENVIRONMENT = config("CONTENTFUL_ENVIRONMENT", default="main")
 CONTENTFUL_SPACE_API = ("preview" if DEV else "cdn") + ".contentful.com"
 CONTENTFUL_API_TIMEOUT = config("CONTENTFUL_API_TIMEOUT", default="5", parser=int)
 CONTENTFUL_CONTENT_TYPES = config(

--- a/docs/contentful.rst
+++ b/docs/contentful.rst
@@ -405,10 +405,10 @@ To get values for these vars, please check with someone on the backend team.
 
 If you are working on the Contentful Sync backed by the message-queue (and if you don't know what this is, you don't need it for local dev), you will also need to set the following env vars:
 
-``CONTENTFUL_NOTIFICATION_QUEUE_URL``
-``CONTENTFUL_NOTIFICATION_QUEUE_REGION``
-``CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID``
-``CONTENTFUL_NOTIFICATION_QUEUE_SECRET_ACCESS_KEY``
+* ``CONTENTFUL_NOTIFICATION_QUEUE_URL``
+* ``CONTENTFUL_NOTIFICATION_QUEUE_REGION``
+* ``CONTENTFUL_NOTIFICATION_QUEUE_ACCESS_KEY_ID``
+* ``CONTENTFUL_NOTIFICATION_QUEUE_SECRET_ACCESS_KEY``
 
 
 How to preview your changes on localhost
@@ -438,6 +438,7 @@ On top of this, Contentful has the concept of aliases for environments and we us
 
 While updating ``master`` is something that we generally don't do (at the moment only a product owner and/or admin would do this), updating the sandbox happens more often, typically to populate it with data more recently added to master.
 To do this:
+
 * Go to ``Settings > Environments``
 * Ensure we have at least one spare environment slot. If we don't delete the oldest ``sandbox-XXXX-XX-XX`` environment.
 * Click the blue Add Environment button, to the right. Name it using the ``sandbox-YYYY-MM-DD`` pattern and base it on whatever environment is aliased to ``master`` - this will basically create a new 'branch' with the content currently in master.
@@ -467,12 +468,8 @@ https://github.com/contentful/rich-text-renderer.py/blob/a1274a11e65f3f728c278de
 
 
 
+Assumptions we still need to deal with
+--------------------------------------
 
-
-
-
-
-
-Assumptions
     - image sizes
 

--- a/docs/contentful.rst
+++ b/docs/contentful.rst
@@ -399,7 +399,7 @@ set up.
 * ``CONTENTFUL_SPACE_ID`` - this is the ID of our Contentful integration
 * ``CONTENTFUL_SPACE_KEY`` - this is the API key that allows you access to our space. Note that two types of key are available: a Preview key allows you to load in draft content; the Delivery key only loads published contnet. For local dev, you want a Preview key.
 * ``SWITCH_CONTENTFUL_HOMEPAGE_DE`` should be set to ``True`` if you are working on the German Contentful-powered homepage
-* ``CONTENTFUL_ENVIRONMENT`` Contentful has 'branches' which it calls environments. `master` is what we use in production, and `sandbox` is generally what we use in development. It's also possible to reference a specific environment - e.g. ``CONTENTFUL_ENVIRONMENT=sandbox-2021-11-02``
+* ``CONTENTFUL_ENVIRONMENT`` Contentful has 'branches' which it calls environments. ``main`` is what we use in production, and ``sandbox`` is generally what we use in development. It's also possible to reference a specific environment - e.g. ``CONTENTFUL_ENVIRONMENT=sandbox-2021-11-02``
 
 To get values for these vars, please check with someone on the backend team.
 
@@ -432,24 +432,23 @@ How to update/refresh the sandbox environment
 It helps to think of Contentful 'environments' as simply branches of a git-like repo full of content. You can take a particular environment and branch off it to make a new environment for :abbr:`WIP (Work in Progress)` or experimental content, using the original one as your starting point.
 On top of this, Contentful has the concept of aliases for environments and we use two aliases in our setup:
 
-* ``master`` is used for production and is an alias currently pointing to the `V1` environment. It is pretty stable and access to it is limited.
+* ``main`` is used for production and is an alias currently pointing to the `V1` environment. It is pretty stable and access to it is limited.
 * ``sandbox`` is used for development and more team members have access to edit content. Again, it's an alias and is pointed at an environment (think, branch) with a name in the format ``sandbox-YYYY-MM-DD``.
 
 
-While updating ``master`` is something that we generally don't do (at the moment only a product owner and/or admin would do this), updating the sandbox happens more often, typically to populate it with data more recently added to master.
-To do this:
+While updating what ``main`` points to is something that we generally don't do (at the moment only a product owner and/or admin would do this), updating ``sandbox`` happens more often, typically to populate it with data more recently added to ``main``. To do this:
 
 * Go to ``Settings > Environments``
 * Ensure we have at least one spare environment slot. If we don't delete the oldest ``sandbox-XXXX-XX-XX`` environment.
-* Click the blue Add Environment button, to the right. Name it using the ``sandbox-YYYY-MM-DD`` pattern and base it on whatever environment is aliased to ``master`` - this will basically create a new 'branch' with the content currently in master.
-* In the Environment Aliases section of the main page, find `sandbox` and click Change alias target, then select the ``sandbox-XXXX-XX-XX`` environment you just made.
+* Click the blue Add Environment button, to the right. Name it using the ``sandbox-YYYY-MM-DD`` pattern and base it on whatever environment is aliased to ``main`` - this will basically create a new 'branch' with the content currently in ``main``.
+* In the Environment Aliases section of the main page, find ``sandbox`` and click Change alias target, then select the ``sandbox-XXXX-XX-XX`` environment you just made.
 
 Which environment is connected to where?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``master`` is the environment used in Bedrock production, stage, dev and test
+``main`` is the environment used in Bedrock production, stage, dev and test
 ``sandbox`` may, in the future, be made the default environment for dev. It's also the one we should use for local development.
 
-If you develop a new feature that adds to Contentful (e.g. page or component) and you author it in the sandbox, you will need to re-create it in master before the corresponding bedrock changes hit production.
+If you develop a new feature that adds to Contentful (e.g. page or component) and you author it in ``sandbox``, you will need to re-create it in ``main`` before the corresponding bedrock changes hit production.
 
 
 Useful Contentful Docs

--- a/docs/contentful.rst
+++ b/docs/contentful.rst
@@ -4,14 +4,14 @@
 
 .. _contentful:
 
-==========================
-Contentful CMS Integration
-==========================
+==============================================================
+Contentful :abbr:`CMS (Content Management System)` Integration
+==============================================================
 
 Overview
 --------
 
-Contentful is a headless CMS. It stores content for our website in a structured
+Contentful is a headless :abbr:`CMS (Content Management System)`. It stores content for our website in a structured
 format. We request the content from Contentful using an API. Then the content
 gets made into Protocol components for display on the site.
 
@@ -399,7 +399,7 @@ set up.
 * ``CONTENTFUL_SPACE_ID`` - this is the ID of our Contentful integration
 * ``CONTENTFUL_SPACE_KEY`` - this is the API key that allows you access to our space. Note that two types of key are available: a Preview key allows you to load in draft content; the Delivery key only loads published contnet. For local dev, you want a Preview key.
 * ``SWITCH_CONTENTFUL_HOMEPAGE_DE`` should be set to ``True`` if you are working on the German Contentful-powered homepage
-* ``CONTENTFUL_ENVIRONMENT`` Contentful has 'branches' which it calls environments. `master` is what we use in production, and `sandbox` is generally what we use in development. It's also possible to refference a specific environment - eg ``CONTENTFUL_ENVIRONMENT=sandbox-2021-11-02``
+* ``CONTENTFUL_ENVIRONMENT`` Contentful has 'branches' which it calls environments. `master` is what we use in production, and `sandbox` is generally what we use in development. It's also possible to reference a specific environment - e.g. ``CONTENTFUL_ENVIRONMENT=sandbox-2021-11-02``
 
 To get values for these vars, please check with someone on the backend team.
 
@@ -414,7 +414,7 @@ If you are working on the Contentful Sync backed by the message-queue (and if yo
 How to preview your changes on localhost
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When viewing a page in Contentful, it's possible to trigger a preview of the draft page. This is typically rendered on www-dev.allizom.org. However, that's only useful for code that's already in ``main``.
-If you want to preview Contentful content on your local machine - eg you're working on a feature branch that isn't ready for merging - do the following:
+If you want to preview Contentful content on your local machine - e.g. you're working on a feature branch that isn't ready for merging - do the following:
 
 * In the right-hand sidebar of the editor page in Contentful...
 * ...find the Preview section...
@@ -429,14 +429,14 @@ Also note that when you select ``Localhost preview``, the choice sticks, so you 
 How to update/refresh the sandbox environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It helps to think of Contentful 'environments' as simply branches of a git-like repo full of content. You can take a particular environment and branch off it to make a new environment for WIP or experimental content, using the original one as your starting point.
+It helps to think of Contentful 'environments' as simply branches of a git-like repo full of content. You can take a particular environment and branch off it to make a new environment for :abbr:`WIP (Work in Progress)` or experimental content, using the original one as your starting point.
 On top of this, Contentful has the concept of aliases for environments and we use two aliases in our setup:
 
 * ``master`` is used for production and is an alias currently pointing to the `V1` environment. It is pretty stable and access to it is limited.
 * ``sandbox`` is used for development and more team members have access to edit content. Again, it's an alias and is pointed at an environment (think, branch) with a name in the format ``sandbox-YYYY-MM-DD``.
 
 
-While updating ``master`` is something that we generally don't do (at the moment only Dan B would do this), updating the sandbox happens more often, typically to populate it with data more recently added to master.
+While updating ``master`` is something that we generally don't do (at the moment only a product owner and/or admin would do this), updating the sandbox happens more often, typically to populate it with data more recently added to master.
 To do this:
 * Go to ``Settings > Environments``
 * Ensure we have at least one spare environment slot. If we don't delete the oldest ``sandbox-XXXX-XX-XX`` environment.
@@ -448,7 +448,7 @@ Which environment is connected to where?
 ``master`` is the environment used in Bedrock production, stage, dev and test
 ``sandbox`` may, in the future, be made the default environment for dev. It's also the one we should use for local development.
 
-If you develop a new feature that adds to Contentful (eg page or component) and you author it in the sandbox, you will need to re-create it in master before the corresponding bedrock changes hit production.
+If you develop a new feature that adds to Contentful (e.g. page or component) and you author it in the sandbox, you will need to re-create it in master before the corresponding bedrock changes hit production.
 
 
 Useful Contentful Docs


### PR DESCRIPTION
## Description

This changeset facilitates the move from us calling the production Contentful environment `master` to `main`, in line with recent updates to Bedrock.

~NB: This is a branch off an another branch which has yet to be merged to `mozilla/bedrock` - merging https://github.com/mozilla/bedrock/pull/11523 will significantly reduce the size of this PR's diff.~

~In terms of reviewing it, the relevant changes in this changeset are:~

~* https://github.com/mozilla/bedrock/commit/d15ac70a1c7928451461951305fd85d980e6c81c~
~* https://github.com/mozilla/bedrock/commit/ead11fd6df2cf3a9359b825c8fc5365445e2ba60~



## Issue / Bugzilla link

#11528 - note that there is a manual follow-up step for this ticket

## Testing

* Contentful should work as before
