### PR TITLE
Ensure GET views are protected

### DIFF
--- a/bedrock/careers/views.py
+++ b/bedrock/careers/views.py
@@ -4,16 +4,16 @@
 
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
-from django.views.generic import DetailView, ListView, TemplateView
+from django.views.generic import DetailView, ListView
 
 from bedrock.careers.forms import PositionFilterForm
 from bedrock.careers.models import Position
 from bedrock.careers.utils import generate_position_meta_description
 from bedrock.wordpress.models import BlogPost
-from lib.l10n_utils import LangFilesMixin, render
+from lib.l10n_utils import L10nTemplateView, LangFilesMixin, RequireSafeMixin, render
 
 
-class HomeView(LangFilesMixin, TemplateView):
+class HomeView(L10nTemplateView):
     template_name = "careers/home.html"
 
     def get_context_data(self, **kwargs):
@@ -31,15 +31,15 @@ class HomeView(LangFilesMixin, TemplateView):
         return context
 
 
-class InternshipsView(LangFilesMixin, TemplateView):
+class InternshipsView(L10nTemplateView):
     template_name = "careers/internships.html"
 
 
-class BenefitsView(LangFilesMixin, TemplateView):
+class BenefitsView(L10nTemplateView):
     template_name = "careers/benefits.html"
 
 
-class PositionListView(LangFilesMixin, ListView):
+class PositionListView(LangFilesMixin, RequireSafeMixin, ListView):
     model = Position
     template_name = "careers/listings.html"
     context_object_name = "positions"
@@ -50,7 +50,7 @@ class PositionListView(LangFilesMixin, ListView):
         return context
 
 
-class PositionDetailView(LangFilesMixin, DetailView):
+class PositionDetailView(LangFilesMixin, RequireSafeMixin, DetailView):
     model = Position
     context_object_name = "position"
     template_name = "careers/position.html"

--- a/bedrock/exp/views.py
+++ b/bedrock/exp/views.py
@@ -2,9 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.views.decorators.http import require_safe
+
 from lib import l10n_utils
 
 
+@require_safe
 def new(request):
 
     # note: v and xv params only allow a-z, A-Z, 0-9, -, and _ characters

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -516,6 +516,13 @@ class TestSendToDeviceView(TestCase):
 @override_settings(DEV=False)
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
 class TestFirefoxNew(TestCase):
+    def test_post(self, render_mock):
+        req = RequestFactory().post("/firefox/new/")
+        req.locale = "en-US"
+        view = views.NewView.as_view()
+        resp = view(req)
+        assert resp.status_code == 405
+
     @patch.object(views, "ftl_file_is_active", lambda *x: True)
     def test_download_template(self, render_mock):
         req = RequestFactory().get("/firefox/new/")

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -18,8 +18,7 @@ from django.http import (
 from django.utils.cache import add_never_cache_headers, patch_response_headers
 from django.utils.encoding import force_str
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_GET, require_POST
-from django.views.generic.base import TemplateView
+from django.views.decorators.http import require_POST, require_safe
 
 import basket
 import querystringsafe_base64
@@ -105,7 +104,7 @@ class InstallerHelpView(L10nTemplateView):
         return ctx
 
 
-@require_GET
+@require_safe
 def stub_attribution_code(request):
     """Return a JSON response containing the HMAC signed stub attribution value"""
     if not request.headers.get("x-requested-with") == "XMLHttpRequest":
@@ -283,6 +282,7 @@ def send_to_device_ajax(request):
     return JsonResponse(resp_data)
 
 
+@require_safe
 def firefox_all(request):
     ftl_files = "firefox/all"
     product_android = firefox_android
@@ -455,8 +455,7 @@ def show_default_account_whatsnew(version):
     return version >= Version("60.0")
 
 
-class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
-
+class FirstrunView(L10nTemplateView):
     ftl_files_map = {
         "firefox/firstrun/firstrun.html": ["firefox/firstrun"],
         "firefox/developer/firstrun.html": ["firefox/developer"],
@@ -801,6 +800,7 @@ class PlatformViewWindows(L10nTemplateView):
     activation_files = ["firefox/new/download", "firefox/new/platform"]
 
 
+@require_safe
 def ios_testflight(request):
     # no country field, so no need to send locale
     newsletter_form = NewsletterFooterForm("ios-beta-test-flight", "")
@@ -847,6 +847,7 @@ BREACH_TIPS_URLS = {
 }
 
 
+@require_safe
 def firefox_welcome_page1(request):
     locale = l10n_utils.get_locale(request)
 
@@ -864,6 +865,7 @@ def firefox_welcome_page1(request):
     return l10n_utils.render(request, template_name, context, ftl_files="firefox/welcome/page1")
 
 
+@require_safe
 def firefox_features_translate(request):
 
     to_translate_langs = [

--- a/bedrock/legal_docs/views.py
+++ b/bedrock/legal_docs/views.py
@@ -37,7 +37,7 @@ def load_legal_doc(doc_name, locale):
     return doc
 
 
-class LegalDocView(TemplateView):
+class LegalDocView(l10n_utils.RequireSafeMixin, TemplateView):
     """
     Generic view for loading a legal doc and displaying it with a template.
 

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -84,6 +84,12 @@ class TestHomePage(TestCase):
         views.home_view(req)
         render_mock.assert_called_once_with(req, "mozorg/home/home.html", ANY)
 
+    def test_no_post(self, render_mock):
+        req = RequestFactory().post("/")
+        req.locale = "en-US"
+        resp = views.home_view(req)
+        self.assertEqual(resp.status_code, 405)
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(

--- a/bedrock/mozorg/util.py
+++ b/bedrock/mozorg/util.py
@@ -7,6 +7,7 @@ import os
 from django.conf import settings
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_safe
 
 import commonware.log
 
@@ -51,9 +52,8 @@ def page(name, tmpl, decorators=None, url_name=None, ftl_files=None, **kwargs):
         (base, ext) = os.path.splitext(tmpl)
         url_name = base.replace("/", ".")
 
-    # we don't have a caching backend yet, so no csrf (it's just a
-    # newsletter form anyway)
     @csrf_exempt
+    @require_safe
     def _view(request):
         if newrelic:
             # Name this in New Relic to differentiate pages

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -22,7 +22,7 @@ from bedrock.mozorg.credits import CreditsFile
 from bedrock.mozorg.models import WebvisionDoc
 from bedrock.pocketfeed.models import PocketArticle
 from lib import l10n_utils
-from lib.l10n_utils import L10nTemplateView
+from lib.l10n_utils import L10nTemplateView, RequireSafeMixin
 
 credits_file = CreditsFile("credits")
 TECH_BLOG_SLUGS = ["hacks", "cd", "futurereleases"]
@@ -52,7 +52,7 @@ def forums_view(request):
     return l10n_utils.render(request, "mozorg/about/forums/forums.html")
 
 
-class Robots(TemplateView):
+class Robots(RequireSafeMixin, TemplateView):
     template_name = "mozorg/robots.txt"
     content_type = "text/plain"
 
@@ -111,6 +111,7 @@ def locales(request):
     return l10n_utils.render(request, "mozorg/locales.html", context)
 
 
+@require_safe
 def namespaces(request, namespace):
     context = NAMESPACES[namespace]
     context["slug"] = namespace
@@ -118,6 +119,7 @@ def namespaces(request, namespace):
     return django_render(request, template, context)
 
 
+@require_safe
 def home_view(request):
     locale = l10n_utils.get_locale(request)
     donate_params = settings.DONATE_PARAMS.get(locale, settings.DONATE_PARAMS["en-US"])
@@ -194,7 +196,7 @@ class ContentfulPreviewView(L10nTemplateView):
         return l10n_utils.render(self.request, template, context, **response_kwargs)
 
 
-class WebvisionDocView(TemplateView):
+class WebvisionDocView(RequireSafeMixin, TemplateView):
     """
     Generic view for loading a webvision doc and displaying it with a template.
 

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -141,6 +141,7 @@ def _filter_articles(articles_list, category):
     return [article for article in articles_list if article.category == category]
 
 
+@require_safe
 def resource_center_landing_view(request):
 
     ARTICLE_GROUP_SIZE = 6
@@ -194,6 +195,7 @@ def resource_center_landing_view(request):
     )
 
 
+@require_safe
 def resource_center_article_view(request, slug):
     """Individual detail pages for the VPN Resource Center"""
 

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -8,6 +8,7 @@ from operator import attrgetter
 from django.conf import settings
 from django.http import Http404, HttpResponseRedirect
 from django.urls import NoReverseMatch
+from django.views.decorators.http import require_safe
 
 from bedrock.base.urlresolvers import reverse
 from bedrock.firefox.firefox_details import firefox_desktop
@@ -81,6 +82,7 @@ def check_url(product, version):
         return reverse("firefox.system_requirements", args=[version])
 
 
+@require_safe
 def release_notes(request, version, product="Firefox"):
 
     if not version:
@@ -127,6 +129,7 @@ def release_notes(request, version, product="Firefox"):
     )
 
 
+@require_safe
 def system_requirements(request, version, product="Firefox"):
     release = get_release_or_404(version, product)
     dir = "firefox"
@@ -151,16 +154,19 @@ def latest_release(product="firefox", platform=None, channel=None):
     return get_latest_release_or_404(product, channel)
 
 
+@require_safe
 def latest_notes(request, product="firefox", platform=None, channel=None):
     release = latest_release(product, platform, channel)
     return HttpResponseRedirect(release.get_absolute_url())
 
 
+@require_safe
 def latest_sysreq(request, product="firefox", platform=None, channel=None):
     release = latest_release(product, platform, channel)
     return HttpResponseRedirect(release.get_sysreq_url())
 
 
+@require_safe
 def releases_index(request, product):
     releases = {}
     major_releases = []
@@ -189,6 +195,7 @@ def releases_index(request, product):
     return l10n_utils.render(request, f"{product.lower()}/releases/index.html", {"releases": sorted(releases.items(), reverse=True)})
 
 
+@require_safe
 def nightly_feed(request):
     """Serve an Atom feed with the latest changes in Firefox Nightly"""
     notes = {}

--- a/bedrock/security/views.py
+++ b/bedrock/security/views.py
@@ -16,7 +16,7 @@ from product_details.version_compare import Version
 from bedrock.base.urlresolvers import reverse
 from bedrock.mozorg.decorators import cache_control_expires
 from bedrock.security.models import HallOfFamer, MitreCVE, Product, SecurityAdvisory
-from lib.l10n_utils import LangFilesMixin
+from lib.l10n_utils import LangFilesMixin, RequireSafeMixin
 
 
 @json_view
@@ -61,7 +61,7 @@ def product_is_obsolete(prod_name, version):
     return True
 
 
-class HallOfFameView(LangFilesMixin, ListView):
+class HallOfFameView(LangFilesMixin, RequireSafeMixin, ListView):
     template_names = {
         "client": "security/bug-bounty/hall-of-fame.html",
         "web": "security/bug-bounty/web-hall-of-fame.html",
@@ -77,19 +77,19 @@ class HallOfFameView(LangFilesMixin, ListView):
         return HallOfFamer.objects.filter(program=self.program)
 
 
-class AdvisoriesView(LangFilesMixin, ListView):
+class AdvisoriesView(LangFilesMixin, RequireSafeMixin, ListView):
     template_name = "security/advisories.html"
     queryset = SecurityAdvisory.objects.only("id", "impact", "title", "announced")
     context_object_name = "advisories"
 
 
-class AdvisoryView(LangFilesMixin, DetailView):
+class AdvisoryView(LangFilesMixin, RequireSafeMixin, DetailView):
     model = SecurityAdvisory
     template_name = "security/advisory.html"
     context_object_name = "advisory"
 
 
-class ProductView(LangFilesMixin, ListView):
+class ProductView(LangFilesMixin, RequireSafeMixin, ListView):
     template_name = "security/product-advisories.html"
     context_object_name = "product_versions"
     allow_empty = False
@@ -113,7 +113,7 @@ class ProductView(LangFilesMixin, ListView):
         return cxt
 
 
-class ProductVersionView(LangFilesMixin, ListView):
+class ProductVersionView(LangFilesMixin, RequireSafeMixin, ListView):
     template_name = "security/product-advisories.html"
     context_object_name = "product_versions"
     allow_empty = False

--- a/bedrock/sitemaps/tests/test_views.py
+++ b/bedrock/sitemaps/tests/test_views.py
@@ -95,3 +95,7 @@ class TestSitemapView(TestCase):
         )
         resp = self.client.get("/fr/sitemap.xml")
         assert resp.content.decode() == good_resp
+
+    def test_post(self):
+        resp = self.client.post("/en-US/sitemap.xml")
+        assert resp.status_code == 405

--- a/bedrock/sitemaps/views.py
+++ b/bedrock/sitemaps/views.py
@@ -7,10 +7,11 @@ from django.views.generic import TemplateView
 
 from bedrock.mozorg.decorators import cache_control_expires
 from bedrock.sitemaps.models import NO_LOCALE, SitemapURL
+from lib.l10n_utils import RequireSafeMixin
 
 
 @method_decorator(cache_control_expires(1), name="dispatch")
-class SitemapView(TemplateView):
+class SitemapView(RequireSafeMixin, TemplateView):
     content_type = "text/xml"
 
     def _get_locale(self):

--- a/bedrock/utils/views.py
+++ b/bedrock/utils/views.py
@@ -3,10 +3,9 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from django.utils.functional import cached_property
-from django.views.generic import TemplateView
 
 from bedrock.utils import expand_locale_groups
-from lib.l10n_utils import LangFilesMixin, get_locale
+from lib.l10n_utils import L10nTemplateView, get_locale
 
 
 class VariationMixin:
@@ -48,5 +47,5 @@ class VariationMixin:
         return cxt
 
 
-class VariationTemplateView(VariationMixin, LangFilesMixin, TemplateView):
+class VariationTemplateView(VariationMixin, L10nTemplateView):
     pass

--- a/bedrock/wordpress/views.py
+++ b/bedrock/wordpress/views.py
@@ -2,12 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.views.generic import TemplateView
-
 from sentry_sdk import capture_exception
 
 from bedrock.wordpress.models import BlogPost
-from lib.l10n_utils import LangFilesMixin
+from lib.l10n_utils import L10nTemplateView
 
 
 class BlogPostsMixin:
@@ -46,5 +44,5 @@ class BlogPostsMixin:
         return ctx
 
 
-class BlogPostsView(BlogPostsMixin, LangFilesMixin, TemplateView):
+class BlogPostsView(BlogPostsMixin, L10nTemplateView):
     pass

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -466,6 +466,10 @@ template.
 
     from lib import l10n_utils
 
+    from django.views.decorators.http import require_safe
+
+
+    @require_safe
     def my_view(request):
         # do your fancy things
         ctx = {"template_variable": "awesome data"}
@@ -475,6 +479,8 @@ Make sure to namespace your templates by putting them in a directory
 named after your app, so instead of templates/template.html they would
 be in templates/blog/template.html if `blog` was the name of your app.
 
+The `require_safe` ensures that only `GET` or `HEAD` requests will make it
+through to your view.
 
 If you prefer to use Django's Generic View classes we have a convenient
 helper for that. You can use it either to create a custom view class of
@@ -497,7 +503,8 @@ your own, or use it directly in a `urls.py` file.
     ]
 
 The `L10nTemplateView` functionality is mostly in a template mixin called `LangFilesMixin` which
-you can use with other generic Django view classes if you need one other than `TemplateView`.
+you can use with other generic Django view classes if you need one other than `TemplateView`. 
+The `L10nTemplateView` already ensures that only `GET` or `HEAD` requests will be served.
 
 Variation Views
 ~~~~~~~~~~~~~~~

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -254,5 +254,9 @@ class LangFilesMixin:
         )
 
 
-class L10nTemplateView(LangFilesMixin, TemplateView):
+class RequireSafeMixin:
+    http_method_names = ["get", "head"]
+
+
+class L10nTemplateView(LangFilesMixin, RequireSafeMixin, TemplateView):
     pass

--- a/lib/l10n_utils/tests/test_base.py
+++ b/lib/l10n_utils/tests/test_base.py
@@ -148,6 +148,11 @@ class TestL10nTemplateView(TestCase):
     def setUp(self):
         self.req = RequestFactory().get("/")
 
+    def test_post(self, render_mock):
+        view = l10n_utils.L10nTemplateView.as_view(template_name="post.html", ftl_files="dude")
+        resp = view(RequestFactory().post("/"))
+        self.assertEqual(resp.status_code, 405)
+
     def test_ftl_files(self, render_mock):
         view = l10n_utils.L10nTemplateView.as_view(template_name="dude.html", ftl_files="dude")
         view(self.req)


### PR DESCRIPTION
## Description

This updates the `page` URL helper to wrap the view using the `require_safe` decorator, and also limits the HTTP methods on the `L10nTemplateView` to `GET` or `HEAD`. All other views explicitly get decorated with `@require_safe`.

## Issue / Bugzilla link

#11536 

## Testing

`curl -i -X POST localhost:8000/en-US/` and various pages return `HTTP/1.1 405 Method Not Allowed`