### PR TITLE
Updated subsection underline for visibility

### DIFF
--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -808,7 +808,7 @@ You can find import examples and parameter definitions for the available Protoco
     You can use Protocol without macros. They are not dependent on each other but they work well together. 10/10 would recommend!
 
 Picto
-<<<<<
+^^^^^
 
 **HTML import**
 
@@ -894,7 +894,7 @@ Picto
 
 
 Call out
-<<<<<<<<
+^^^^^^^^
 
 **HTML import**
 
@@ -943,7 +943,7 @@ Call out
 
 
 Split
-<<<<<
+^^^^^
 
 **HTML import**
 
@@ -1048,7 +1048,7 @@ Split
 
 
 Billboard
-<<<<<<<<<
+^^^^^^^^^
 
 **HTML import**
 
@@ -1136,7 +1136,7 @@ Billboard
 
 
 Feature Card
-<<<<<<<<<<<<
+^^^^^^^^^^^^
 
 **HTML import**
 
@@ -1238,7 +1238,7 @@ Feature Card
 
 
 Card
-<<<<
+^^^^
 
 **HTML import**
 


### PR DESCRIPTION
## One-line summary
It seems that some sub-subsection titles were broken and couldn't be seen anymore from [my previous PR](https://github.com/mozilla/bedrock/pull/11526) because I had to update their underlines.
Here is a good explanation as to what underlines represent different subsections for reStructured text: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections

## Significant changes and points to review
Updated the underlines from `<<<<` to `^^^^`

## Testing
#### Local run:
`make livedocs` and go to http://127.0.0.1:8100/coding.html#working-with-protocol-design-system

#### Docker:
`make docs` and go to http://127.0.0.1:8100/coding.html#working-with-protocol-design-system


