### PR TITLE
Add get-app page experiment variations [fix #11547]

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -29,6 +29,12 @@
   {% set message_set = 'fx-mobile-download-desktop-experiment' %}
   {% set android_url = 'https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-and&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F' %}
   {% set ios_url = 'https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-ios&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F' %}
+{% elif variation == 'eco-a' %}
+  {% set message_set = 'fx-mobile-download-desktop-reco-exp-a' %}
+{% elif variation == 'eco-b' %}
+  {% set message_set = 'fx-mobile-download-desktop-reco-exp-b' %}
+{% elif variation == 'eco-c' %}
+  {% set message_set = 'fx-mobile-download-desktop-reco-exp-c' %}
 {% else %}
   {% set message_set = 'fx-mobile-download-desktop' %}
   {% set android_url = firefox_adjust_url('android', 'mobile-get-app-page') %}
@@ -51,6 +57,7 @@
     {% endif %}
   </section>
 
+  {% if variation not in ['eco-a', 'eco-b', 'eco-c'] %}
   <aside class="mobile-download-buttons-wrapper">
     <ul class="mobile-download-buttons">
       <li class="android">
@@ -63,6 +70,7 @@
       </li>
     </ul>
   </aside>
+  {% endif %}
 </main>
 {% endblock %}
 

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -464,6 +464,54 @@ class TestSendToDeviceView(TestCase):
             lang="en-US",
         )
 
+    # issue #11547
+    def test_fx_mobile_download_desktop_reco_exp_a_email(self):
+        resp_data = self._request(
+            {
+                "s2d-email": "dude@example.com",
+                "message-set": "fx-mobile-download-desktop-reco-exp-a",
+            }
+        )
+        assert resp_data["success"]
+        self.mock_subscribe.assert_called_with(
+            "dude@example.com",
+            views.SEND_TO_DEVICE_MESSAGE_SETS["fx-mobile-download-desktop-reco-exp-a"]["email"]["all"],
+            source_url=None,
+            lang="en-US",
+        )
+
+    # issue #11547
+    def test_fx_mobile_download_desktop_reco_exp_b_email(self):
+        resp_data = self._request(
+            {
+                "s2d-email": "dude@example.com",
+                "message-set": "fx-mobile-download-desktop-reco-exp-b",
+            }
+        )
+        assert resp_data["success"]
+        self.mock_subscribe.assert_called_with(
+            "dude@example.com",
+            views.SEND_TO_DEVICE_MESSAGE_SETS["fx-mobile-download-desktop-reco-exp-b"]["email"]["all"],
+            source_url=None,
+            lang="en-US",
+        )
+
+    # issue #11547
+    def test_fx_mobile_download_desktop_reco_exp_c_email(self):
+        resp_data = self._request(
+            {
+                "s2d-email": "dude@example.com",
+                "message-set": "fx-mobile-download-desktop-reco-exp-c",
+            }
+        )
+        assert resp_data["success"]
+        self.mock_subscribe.assert_called_with(
+            "dude@example.com",
+            views.SEND_TO_DEVICE_MESSAGE_SETS["fx-mobile-download-desktop-reco-exp-c"]["email"]["all"],
+            source_url=None,
+            lang="en-US",
+        )
+
 
 @override_settings(DEV=False)
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -76,7 +76,9 @@ urlpatterns = (
     path("firefox/ios/testflight/", views.ios_testflight, name="firefox.ios.testflight"),
     path(
         "firefox/mobile/get-app/",
-        VariationTemplateView.as_view(template_name="firefox/mobile/get-app.html", template_context_variations=["mfm"], ftl_files=["firefox/mobile"]),
+        VariationTemplateView.as_view(
+            template_name="firefox/mobile/get-app.html", template_context_variations=["mfm", "eco-a", "eco-b", "eco-c"], ftl_files=["firefox/mobile"]
+        ),
         name="firefox.mobile.get-app",
     ),
     path("firefox/send-to-device-post/", views.send_to_device_ajax, name="firefox.send-to-device-post"),

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -997,6 +997,21 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
             "all": "download-firefox-mobile-reco-exp",
         }
     },
+    "fx-mobile-download-desktop-reco-exp-a": {
+        "email": {
+            "all": "download-firefox-mobile-reco-exp-a",
+        }
+    },
+    "fx-mobile-download-desktop-reco-exp-b": {
+        "email": {
+            "all": "download-firefox-mobile-reco-exp-b",
+        }
+    },
+    "fx-mobile-download-desktop-reco-exp-c": {
+        "email": {
+            "all": "download-firefox-mobile-reco-exp-c",
+        }
+    },
     "fx-mobile-ios-twilio-experiment": {
         "email": {
             "all": "download-firefox-ios-twilio-experiment",


### PR DESCRIPTION
## One-line summary
Sets up three new variations of the get-app page. The URLs will get direct traffic, no traffic cop needed.

## Issue / Bugzilla link
#11547 

## Checklist
- [x] Tests added  

## Testing
http://localhost:8000/firefox/mobile/get-app/?v=eco-a
http://localhost:8000/firefox/mobile/get-app/?v=eco-b
http://localhost:8000/firefox/mobile/get-app/?v=eco-c

Each variant should hide the app store buttons and set its corresponding message-set in the form (view source and look for the hidden `message-set` field).
