### PR TITLE
modify program policy to exclude harmful testing on services

### DIFF
--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -31,6 +31,8 @@
     <li>You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.</li>
     <li>You should use your best effort not to access, modify, delete, or store user data or Mozilla’s data. Instead, use your own accounts or test accounts for security research purposes.</li>
     <li>If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at <a href="mailto:security@mozilla.org">security@mozilla.org</a> and delete any stored data after notifying us.</li>
+    <li>You should also use your best effort not to harm the availability or stability of our services, for example, by running aggressive scanning of those services. Instead, use a local development instance of the service that you want to test. </li>
+    <li>Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances instead of production.</li>
     <li>You must not be on a US sanctions list or in a country (e.g. Cuba, Iran, North Korea, Crimea region of Ukraine, Sudan, and Syria) on the US sanctions list.</li>
     <li>You must not exploit the security vulnerability for your own gain.</li>
     <li>Before sharing any part of the security issue with a third party, you must give us a reasonable amount of time to address the security issue.</li>

--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -32,7 +32,7 @@
     <li>You should use your best effort not to access, modify, delete, or store user data or Mozilla’s data. Instead, use your own accounts or test accounts for security research purposes.</li>
     <li>If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at <a href="mailto:security@mozilla.org">security@mozilla.org</a> and delete any stored data after notifying us.</li>
     <li>You should also use your best effort not to harm the availability or stability of our services, for example, by running aggressive scanning of those services. Instead, use a local development instance of the service that you want to test. </li>
-    <li>Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances instead of production.</li>
+    <li>Whenever it is explicitly stated in our program scope, you are expected to test on the provided instances (e.g. staging) instead of production.</li>
     <li>You must not be on a US sanctions list or in a country (e.g. Cuba, Iran, North Korea, Crimea region of Ukraine, Sudan, and Syria) on the US sanctions list.</li>
     <li>You must not exploit the security vulnerability for your own gain.</li>
     <li>Before sharing any part of the security issue with a third party, you must give us a reasonable amount of time to address the security issue.</li>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -146,6 +146,9 @@
   <ul class="mzp-u-list-styled">
     <li>www.mozilla.org</li>
   </ul>
+  <p>
+    Please use our <a href="https://www.allizom.org">staging instance</a> for testing to avoid site disruption.
+  </p>
 
   <h3>Firefox Monitor</h3>
   <ul class="mzp-u-list-styled">


### PR DESCRIPTION
## One-line summary

- modify bug bounty program policy to exclude harmful testing on services
- request testing on bedrock staging instead of production