### PR TITLE
Add asterisks in root store policy [bug #1766461]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
@@ -677,7 +677,7 @@
   <p>When an end entity TLS certificate (i.e. a certificate capable of being used for TLS-enabled servers) is revoked for one of the reasons below, the specified CRLReason MUST be included in the reasonCode extension of the CRL entry corresponding to the end entity TLS certificate. When the CRLReason code is not one of the following, then the reasonCode extension MUST NOT be provided:</p>
   <ul class="mzp-u-list-styled">
     <li>keyCompromise (RFC 5280 CRLReason #1);</li>
-    <li>privilegeWithdrawn (RFC 5280 CRLReason #9);</li>
+    <li>privilegeWithdrawn (RFC 5280 CRLReason #9);**</li>
     <li>cessationOfOperation (RFC 5280 CRLReason #5);</li>
     <li>affiliationChanged (RFC 5280 CRLReason #3); </em>or</em></li>
     <li>superseded (RFC 5280 CRLReason #4).</li>


### PR DESCRIPTION
## One-line summary

Some asterisks got stripped in the conversion from markdown.

## Testing

http://localhost:8000/about/governance/policies/security-group/certs/policy/#611-end-entity-tls-certificate-crlrevocation-reasons