### PR TITLE
small edits to fx100 promo from design

### DIFF
--- a/media/css/mozorg/home/home-fx100-promo.scss
+++ b/media/css/mozorg/home/home-fx100-promo.scss
@@ -23,9 +23,9 @@
     width: 125px;
 
     @media #{$mq-md} {
-        @include bidi(((margin-right, $spacing-xl, margin-left, $spacing-xl),));
+        margin-top: 5px;
         margin-bottom: 0;
-        height: 75px;
+        height: 55px;
         min-width: 150px;
         width: 150px;
     }
@@ -33,12 +33,11 @@
 
 .fx100-hero-title {
     @include font-firefox;
-    @include font-size(48px);
+    @include font-size(54px);
     line-height: 1.05;
 
     @media #{$mq-md} {
-        @include font-size(74px);
-        max-width: unset;
+        @include font-size(68px);
     }
 }
 

--- a/media/css/mozorg/home/home-fx100-promo.scss
+++ b/media/css/mozorg/home/home-fx100-promo.scss
@@ -20,12 +20,13 @@
     background-size: contain;
     height: 50px;
     margin-bottom: $spacing-lg;
+    margin-top: 0;
     width: 125px;
 
     @media #{$mq-md} {
-        margin-top: 5px;
-        margin-bottom: 0;
         height: 55px;
+        margin-bottom: 0;
+        margin-top: 5px;
         min-width: 150px;
         width: 150px;
     }


### PR DESCRIPTION
## One-line summary
Designers have asked for some small changes to the firefox 100 promo - decreased font-size on medium and above viewports and updated the size of the Firefox 100 logo to match the line height of the title.

## Screenshots
<img width="1488" alt="Screen Shot 2022-05-03 at 3 42 17 PM" src="https://user-images.githubusercontent.com/30009669/166610043-7ee1dca5-7ab2-4c10-bf32-9d01d7c47ca6.png">

## Testing

Demo server URL: https://localhost:8000/en-US

