### PR TITLE
fx100 promo for FR and DE

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -56,6 +56,8 @@
 
   {% if switch('homepage-fx100-promo-eu') %}
     {% include 'mozorg/home/includes/fx100-promo-eu.html' %}
+  {% elif switch('homepage-mr2-promo-eu')%}
+    {% include 'mozorg/home/includes/mr2-promo-eu.html' %}
   {% else %}
     {% call download_banner(
       title='Aus Liebe zum Web',

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -26,6 +26,8 @@
 
   {% if switch('homepage-fx100-promo-eu') %}
     {{ css_bundle('home-fx100-promo') }}
+  {% elif switch('homepage-mr2-promo-eu') %}
+    {{ css_bundle('home-mr2-promo') }}
   {% endif %}
 
   {% if show_fundraising_banner %}

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -24,8 +24,8 @@
   {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('home-eu') }}
 
-  {% if switch('homepage-mr2-promo-eu') %}
-    {{ css_bundle('home-mr2-promo') }}
+  {% if switch('homepage-fx100-promo-eu') %}
+    {{ css_bundle('home-fx100-promo') }}
   {% endif %}
 
   {% if show_fundraising_banner %}
@@ -54,8 +54,8 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if switch('homepage-mr2-promo-eu') %}
-    {% include 'mozorg/home/includes/mr2-promo-eu.html' %}
+  {% if switch('homepage-fx100-promo-eu') %}
+    {% include 'mozorg/home/includes/fx100-promo-eu.html' %}
   {% else %}
     {% call download_banner(
       title='Aus Liebe zum Web',

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -23,8 +23,8 @@
   {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('home-eu') }}
 
-  {% if switch('homepage-mr2-promo-eu') %}
-    {{ css_bundle('home-mr2-promo') }}
+  {% if switch('homepage-fx100-promo-eu') %}
+    {{ css_bundle('home-fx100-promo') }}
   {% endif %}
 
   {% if show_fundraising_banner %}
@@ -53,8 +53,8 @@
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  {% if switch('homepage-mr2-promo-eu') %}
-    {% include 'mozorg/home/includes/mr2-promo-eu.html' %}
+  {% if switch('homepage-fx100-promo-eu') %}
+      {% include 'mozorg/home/includes/fx100-promo-eu.html'%}
   {% else %}
     {% call download_banner(
       title='Par amour du Net',

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -55,6 +55,8 @@
 
   {% if switch('homepage-fx100-promo-eu') %}
       {% include 'mozorg/home/includes/fx100-promo-eu.html'%}
+  {% elif switch('homepage-mr2-promo-eu')%}
+      {% include 'mozorg/home/includes/mr2-promo-eu.html' %}
   {% else %}
     {% call download_banner(
       title='Par amour du Net',

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -25,6 +25,8 @@
 
   {% if switch('homepage-fx100-promo-eu') %}
     {{ css_bundle('home-fx100-promo') }}
+  {% elif switch('homepage-mr2-promo-eu') %}
+    {{ css_bundle('home-mr2-promo') }}
   {% endif %}
 
   {% if show_fundraising_banner %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/fx100-promo-eu.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/fx100-promo-eu.html
@@ -1,0 +1,23 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% set title = 'Aus Liebe zum Web. Seit 2004.' if LANG == 'de' else 'Pour l’amour du Web. Depuis 2004.' %}
+{% set cta = 'Hol dir den neuen Firefox' if LANG == 'de' else 'Installer le nouveau Firefox' %}
+{% set blog_cta = 'Zur Geschichte von Firefox 100' if LANG == 'de' else 'Lire le récit de notre 100è version' %}
+{% set blog_link = 'https://blog.mozilla.org/press-de/2022/05/03/wir-feiern-firefox-wie-wir-die-100-erreichten/' if LANG == 'de' else 'https://blog.mozilla.org/press-fr/2022/05/03/firefox-100-est-la-comment-y-sommes-nous-arrives/' %}
+
+<section class="fx100-hero">
+  <div class="mzp-l-content mzp-t-content-md">
+  <div class="fx100-hero-title-container">
+    <div class="fx100-hero-wordmark">Firefox 100</div>
+    <h1 class="fx100-hero-title">{{ title }}</h1>
+  </div>
+  <div class="fx100-hero-cta-container">
+    <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.browsers.index') }}">{{ cta }}</a>
+    <a class="fx100-story-link" href="{{ blog_link }}">{{ blog_cta }}</a>
+  </div>
+  </div>
+</section>

--- a/bedrock/mozorg/templates/mozorg/home/includes/fx100-promo-eu.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/fx100-promo-eu.html
@@ -16,7 +16,7 @@
     <h1 class="fx100-hero-title">{{ title }}</h1>
   </div>
   <div class="fx100-hero-cta-container">
-    <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.browsers.index') }}">{{ cta }}</a>
+    <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.new') }}">{{ cta }}</a>
     <a class="fx100-story-link" href="{{ blog_link }}">{{ blog_cta }}</a>
   </div>
   </div>

--- a/bedrock/mozorg/templates/mozorg/home/includes/fx100-promo.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/fx100-promo.html
@@ -10,7 +10,7 @@
     <h1 class="fx100-hero-title">Building a better internet since 2004</h1>
   </div>
   <div class="fx100-hero-cta-container">
-    <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.browsers.index') }}">Get the new Firefox</a>
+    <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.new') }}">Get the new Firefox</a>
     <a class="fx100-story-link" href="https://blog.mozilla.org/en/mozilla/celebrating-firefox-100/">Read the story of our 100th release</a>
   </div>
   </div>


### PR DESCRIPTION
## One-line summary

Created promo for firefox 100 for FR and DE locales - also updated the CTA to link to `firefox/new` for EN as well

## Testing

Demo server URL: https://localhost8000/fr and https://localhost8000/de

To test this work:

Just load your local server to the homepage and the fx100 promo should be viewable in both FR and DE locales.

