### PR TITLE
Add additional countries to VPN exclusion list for /whatsnew (Fixes #11572)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -4,6 +4,7 @@
 import os
 from unittest.mock import Mock, call, patch
 
+from django.conf import settings
 from django.core.cache import caches
 from django.http import HttpResponse
 from django.test.client import RequestFactory
@@ -500,6 +501,16 @@ class TestWhatsNew(TestCase):
         self.view(req, version="98.0")
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/whatsnew-fx98-vpn-en.html"]
+
+    @override_settings(DEV=False)
+    def test_fx_98_0_0_excluded_countries(self, render_mock):
+        """Should use default template for 98.0 in English in excluded countries"""
+        for country in settings.VPN_EXCLUDED_COUNTRY_CODES:
+            req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY=country)
+            req.locale = "en-US"
+            self.view(req, version="98.0")
+            template = render_mock.call_args[0][1]
+            assert template == ["firefox/whatsnew/index-account.html"]
 
     # end 98.0 whatsnew tests
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -513,9 +513,9 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx99-en-rally.html": ["firefox/whatsnew/whatsnew"],
     }
 
-    # specific templates that should not be rendered in China
-    # do not promote Mozilla VPN in China in any language
-    china_excluded_templates = [
+    # specific templates that should not be rendered in
+    # countries where we can't advertise Mozilla VPN.
+    vpn_excluded_templates = [
         "firefox/whatsnew/whatsnew-fx98-vpn-en.html",
         "firefox/whatsnew/whatsnew-fx98-vpn-eu.html",
     ]
@@ -625,8 +625,8 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
 
-        # do not promote Mozilla VPN in China.
-        if country == "CN" and template in self.china_excluded_templates:
+        # do not promote Mozilla VPN in excluded countries.
+        if country in settings.VPN_EXCLUDED_COUNTRY_CODES and template in self.vpn_excluded_templates:
             template = "firefox/whatsnew/index-account.html"
 
         # return a list to conform with original intention

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1634,3 +1634,21 @@ VPN_CLIENT_ID = "e6eb0d1e856335fc"
 
 # VNP affiliate micro service (CJMS) endpoint (issue 11212)
 VPN_AFFILIATE_ENDPOINT = "https://stage.cjms.nonprod.cloudops.mozgcp.net/aic" if DEV else "https://cjms.services.mozilla.com/aic"
+
+# Countries where we can't legally sell or advertise Mozilla VPN (e.g via /whatsnew)
+# See: https://github.com/mozilla/bedrock/issues/11572
+VPN_EXCLUDED_COUNTRY_CODES = [
+    "AE",  # United Arab Emirates
+    "BY",  # Belarus
+    "CN",  # China
+    "CU",  # Cuba
+    "IQ",  # Iraq
+    "IR",  # Iran
+    "KP",  # North Korea
+    "OM",  # Oman
+    "RU",  # Russia
+    "SD",  # Sudan
+    "SY",  # Syria
+    "TM",  # Turkmenistan
+    "TR",  # Turkey
+]


### PR DESCRIPTION
## One-line summary

- Adds a list of countries in `settings` where we can't sell or advertise Mozilla VPN.
- Updates our `/whatsnew` logic to reference this list before deciding to promote VPN.

## Significant changes and points to review

Make sure I got the [list of countries](https://docs.google.com/presentation/d/1_TCE85CSXw_A5grv12fAclknXOUe3NYsiaBj4Pelk3Q/edit?usp=sharing) and their [respective codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) correct?

Note: `UA` is left out intentionally after discussion with legal.

## Issue / Bugzilla link

#11572

## Checklist

If relevant:

- [x] Tests added

## Testing

Demo server URL: (or None)

To test this work:

- [ ] http://localhost:8000/en-US/firefox/98.0/whatsnew/?geo=cn should show default /whatsnew template.
- [ ] http://localhost:8000/en-US/firefox/98.0/whatsnew/?geo=us should show VPN /whatsnew template.
