### PR TITLE
Lay in Pocket l10n workflow support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,11 +40,23 @@ update-l10n:
   only:
     changes:
       - "l10n/**/*"
-      - "l10n-pocket/**/*"
     refs:
       - main
   script:
     - SITE_MODE=Mozorg bin/open-ftl-pr.sh
+  retry: 2
+
+update-pocket-l10n:
+  stage: update-config
+  tags:
+    - mozmeao
+    - aws
+  only:
+    changes:
+      - "l10n-pocket/**/*"
+    refs:
+      - main
+  script:
     - SITE_MODE=Pocket bin/open-ftl-pr.sh
   retry: 2
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,10 +40,12 @@ update-l10n:
   only:
     changes:
       - "l10n/**/*"
+      - "l10n-pocket/**/*"
     refs:
       - main
   script:
-    - bin/open-ftl-pr.sh
+    - SITE_MODE=Mozorg bin/open-ftl-pr.sh
+    - SITE_MODE=Pocket bin/open-ftl-pr.sh
   retry: 2
 
 .update-config:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ COPY manage.py LICENSE newrelic.ini contribute.json ./
 COPY ./docker ./docker
 COPY ./bedrock ./bedrock
 COPY ./l10n ./l10n
+COPY ./l10n-pocket ./l10n-pocket
 COPY ./media ./media
 
 

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -154,12 +154,14 @@ if IS_POCKET_MODE:
     }
 
     FALLBACK_LOCALES = {
+        # TODO: double-check for correctness when we have real translations flowing in to Bedrock
         "es-AR": "es",
         "es-CL": "es",
         "es-MX": "es",
     }
 
     PROD_LANGUAGES = [
+        # TODO: double-check for correctness and completeness when we have real translations from the vendor
         "de",
         "en",
         "es-AR",

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -143,6 +143,50 @@ if IS_POCKET_MODE:
         FLUENT_REPO_PATH,
     ]
 
+    DEV_LANGUAGES = get_dev_languages(
+        fluent_repo_path=FLUENT_REPO_PATH,
+        ignore_lang_dirs=IGNORE_LANG_DIRS,
+        prod_languages=PROD_LANGUAGES,
+    )
+    DEV_LANGUAGES.append("en")
+
+    CANONICAL_LOCALES = {
+        # TODO: check whether redundant
+        "en-US": "en",
+        "en-GB": "en",
+        "en-CA": "en",
+        "es-ES": "es-ES",  # TODO: check whether redundant
+        "es-CL": "es",
+        "es-MX": "es",
+    }
+
+    FALLBACK_LOCALES = {
+        "es-AR": "es",
+        "es-CL": "es",
+        "es-MX": "es",
+    }
+
+    PROD_LANGUAGES = [
+        "de",
+        "en",
+        "es-AR",
+        "es-CL",
+        "es-ES",
+        "es-MX",
+        "fr-CA",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "nl",
+        "pl",
+        "pt-BR",
+        "pt-PT",
+        "ru",
+        "zh-CN",
+        "zh-TW",
+    ]
+
 else:
     ROOT_URLCONF = "bedrock.urls.mozorg_mode"
 
@@ -161,4 +205,4 @@ if (len(sys.argv) > 1 and sys.argv[1] == "test") or "pytest" in sys.modules:
 
     DATABASES["default"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
 
-sys.stdout.write(f"Using SITE_MODE of '{site_mode}' and ROOT_URLCONF of '{ROOT_URLCONF}'\n")
+sys.stdout.write(f"Using SITE_MODE of '{site_mode}'\n")

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -114,24 +114,22 @@ if IS_POCKET_MODE:
         "footer",
     ]
 
-    # Note that for Pocket mode, we don't need an intermediary mozmeao/* repo to hold the translations
-    # while we calculate activation metadata via a CI task (which does happen for Mozorg). Why? All
-    # locales in Pocket should be 100% ready to go, because they are translated by a vendor, whereas
-    # Mozorg has community translation contributions as well, which aren't always exhaustive.
+    # The following lines do two things, both related to L10N and Pocket.
     #
-    # As a result, both FLUENT_REPO and FLUENT_L10N_TEAM_REPO point to the same git repo
+    # 1) For Pocket mode, we don't need an intermediary mozmeao repo to hold translations while
+    # we calculate activation metadata via CI (which does happen for Mozorg). Why? All locales
+    # in Pocket are translated by a vendor, so should be 100% ready to go. This means that both
+    # FLUENT_REPO and FLUENT_L10N_TEAM_REPO can point to the same git repo.
+    #
+    # 2) Pocket-specific config has already been defined in settings/base.py (for other reasons),
+    # so here we can use those existing POCKET_FLUENT_* values to override our regular FLUENT_*
+    # defaults. This means the L10N mechanics don't need to include any Pocket-related code
+    # branching and just work on whatever the configured repos and directories are.
 
-    # These are already pre-defined in settings.base, but we make the POCKET_ ones here the defaults
-    # so that L10N mechanics don't need any other code branching in them
-    FLUENT_REPO = POCKET_FLUENT_REPO
-    FLUENT_REPO_URL = POCKET_FLUENT_REPO_URL
-    FLUENT_REPO_BRANCH = POCKET_FLUENT_REPO_BRANCH
-    FLUENT_REPO_PATH = POCKET_FLUENT_REPO_PATH
-
-    FLUENT_L10N_TEAM_REPO = config("POCKET_FLUENT_L10N_TEAM_REPO", default="mozilla-l10n/pocket-www-l10n")
-    FLUENT_L10N_TEAM_REPO_URL = f"https://github.com/{FLUENT_L10N_TEAM_REPO}"
-    FLUENT_L10N_TEAM_REPO_BRANCH = config("POCKET_FLUENT_L10N_TEAM_REPO_BRANCH", default="main")
-    FLUENT_L10N_TEAM_REPO_PATH = DATA_PATH / "l10n-pocket-team"
+    FLUENT_REPO = FLUENT_L10N_TEAM_REPO = POCKET_FLUENT_REPO
+    FLUENT_REPO_URL = FLUENT_L10N_TEAM_REPO_URL = POCKET_FLUENT_REPO_URL
+    FLUENT_REPO_BRANCH = FLUENT_L10N_TEAM_REPO_BRANCH = POCKET_FLUENT_REPO_BRANCH
+    FLUENT_REPO_PATH = FLUENT_L10N_TEAM_REPO_PATH = POCKET_FLUENT_REPO_PATH
 
     # Note: No need to redefine FLUENT_REPO_AUTH - we'll use the same for Pocket mode as for Mozorg mode
 
@@ -146,7 +144,7 @@ if IS_POCKET_MODE:
     ]
 
     CANONICAL_LOCALES = {
-        # TODO: check whether redundant
+        # TODO: check whether redundant when we have real translations flowing in to Bedrock
         "en-US": "en",
         "en-GB": "en",
         "en-CA": "en",

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -184,6 +184,7 @@ if IS_POCKET_MODE:
 
     # No reason to have separate Dev and Prod lang sets for Pocket mode
     DEV_LANGUAGES = PROD_LANGUAGES
+    LANGUAGE_CODE = "en"  # Pocket uses `en` not `en-US`
 
 else:
     ROOT_URLCONF = "bedrock.urls.mozorg_mode"

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -143,13 +143,6 @@ if IS_POCKET_MODE:
         FLUENT_REPO_PATH,
     ]
 
-    DEV_LANGUAGES = get_dev_languages(
-        fluent_repo_path=FLUENT_REPO_PATH,
-        ignore_lang_dirs=IGNORE_LANG_DIRS,
-        prod_languages=PROD_LANGUAGES,
-    )
-    DEV_LANGUAGES.append("en")
-
     CANONICAL_LOCALES = {
         # TODO: check whether redundant
         "en-US": "en",
@@ -186,6 +179,9 @@ if IS_POCKET_MODE:
         "zh-CN",
         "zh-TW",
     ]
+
+    # No reason to have separate Dev and Prod lang sets for Pocket mode
+    DEV_LANGUAGES = PROD_LANGUAGES
 
 else:
     ROOT_URLCONF = "bedrock.urls.mozorg_mode"

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -106,13 +106,33 @@ if IS_POCKET_MODE:
     INSTALLED_APPS.pop(INSTALLED_APPS.index("bedrock.redirects"))
     MIDDLEWARE.pop(MIDDLEWARE.index("bedrock.redirects.middleware.RedirectsMiddleware"))
 
-    # TODO: define in Pocket-appropriate versions of
-    # DEV_LANGUAGES, PROD_LANGUAGES, CANONICAL_LOCALES,
+    # Override the FLUENT_* config for Pocket mode
+
     FLUENT_DEFAULT_FILES = [
         "brands",
         "nav",
         "footer",
     ]
+
+    # Note that for Pocket mode, we don't need an intermediary mozmeao/* repo to hold the translations
+    # while we calculate activation metadata via a CI task (which does happen for Mozorg). Why? All
+    # locales in Pocket should be 100% ready to go, because they are translated by a vendor, whereas
+    # Mozorg has community translation contributions as well, which aren't always exhaustive.
+    #
+    # As a result, both FLUENT_REPO and FLUENT_L10N_TEAM_REPO point to the same git repo
+
+    FLUENT_REPO = config("POCKET_FLUENT_REPO", default="mozilla-l10n/pocket-www-l10n")
+    FLUENT_REPO_URL = f"https://github.com/{FLUENT_REPO}"
+    FLUENT_REPO_BRANCH = config("POCKET_FLUENT_REPO_BRANCH", default="main")
+    FLUENT_REPO_PATH = DATA_PATH / "pocket-www-l10n"
+
+    FLUENT_L10N_TEAM_REPO = config("POCKET_FLUENT_L10N_TEAM_REPO", default="mozilla-l10n/pocket-www-l10n")
+    FLUENT_L10N_TEAM_REPO_URL = f"https://github.com/{FLUENT_L10N_TEAM_REPO}"
+    FLUENT_L10N_TEAM_REPO_BRANCH = config("POCKET_FLUENT_L10N_TEAM_REPO_BRANCH", default="main")
+    FLUENT_L10N_TEAM_REPO_PATH = DATA_PATH / "l10n-pocket-team"
+
+    # Note: No need to redefine FLUENT_REPO_AUTH - we'll use the same for Pocket mode as for Mozorg mode
+
     # Redefine the FLUENT_LOCAL_PATH for a Pocket-specific one and
     # ensure it is the first one we check, because order matters.
     FLUENT_LOCAL_PATH = ROOT_PATH / "l10n-pocket"

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -152,9 +152,6 @@ if IS_POCKET_MODE:
     }
 
     FALLBACK_LOCALES = {
-        "es-CL": "es",
-        "es-MX": "es",
-        "es-AR": "es",
         # NB: es-LA isn't a real locale, but it is what getpocket.com has used
         # and we need to deal with it, by redirecting to international Spanish
         "es-la": "es",

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -149,15 +149,15 @@ if IS_POCKET_MODE:
         "en-GB": "en",
         "en-CA": "en",
         "es-ES": "es-ES",
-        "es-la": "es",  # NB: es-LA isn't a real locale, but it is what getpocket.com has used and we need to deal with it
     }
 
     FALLBACK_LOCALES = {
-        # TODO: double-check for correctness when we have real translations flowing in to Bedrock
-        # "es" is the fallback for non-Spain Spanish, not for "es-ES"
         "es-CL": "es",
         "es-MX": "es",
         "es-AR": "es",
+        # NB: es-LA isn't a real locale, but it is what getpocket.com has used
+        # and we need to deal with it, by redirecting to international Spanish
+        "es-la": "es",
     }
 
     PROD_LANGUAGES = [

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -148,16 +148,16 @@ if IS_POCKET_MODE:
         "en-US": "en",
         "en-GB": "en",
         "en-CA": "en",
-        "es-ES": "es-ES",  # TODO: check whether redundant
-        "es-CL": "es",
-        "es-MX": "es",
     }
 
     FALLBACK_LOCALES = {
         # TODO: double-check for correctness when we have real translations flowing in to Bedrock
+        # "es" is the fallback for non-Spain Spanish, not "es-ES"
+        "es-LA": "es",
         "es-AR": "es",
         "es-CL": "es",
         "es-MX": "es",
+        "es-ES": "es-ES",
     }
 
     PROD_LANGUAGES = [

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -144,10 +144,7 @@ if IS_POCKET_MODE:
     ]
 
     CANONICAL_LOCALES = {
-        # TODO: check whether redundant when we have real translations flowing in to Bedrock
-        "en-US": "en",
-        "en-GB": "en",
-        "en-CA": "en",
+        # We want to ensure es-ES gets its specific translations, rather than falling back to 'es'
         "es-ES": "es-ES",
     }
 

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -148,26 +148,25 @@ if IS_POCKET_MODE:
         "en-US": "en",
         "en-GB": "en",
         "en-CA": "en",
+        "es-ES": "es-ES",
+        "es-la": "es",  # NB: es-LA isn't a real locale, but it is what getpocket.com has used and we need to deal with it
     }
 
     FALLBACK_LOCALES = {
         # TODO: double-check for correctness when we have real translations flowing in to Bedrock
-        # "es" is the fallback for non-Spain Spanish, not "es-ES"
-        "es-LA": "es",
-        "es-AR": "es",
+        # "es" is the fallback for non-Spain Spanish, not for "es-ES"
         "es-CL": "es",
         "es-MX": "es",
-        "es-ES": "es-ES",
+        "es-AR": "es",
     }
 
     PROD_LANGUAGES = [
-        # TODO: double-check for correctness and completeness when we have real translations from the vendor
+        # TODO: double-check for correctness and completeness
+        # when we have real translations from the vendor
         "de",
         "en",
-        "es-AR",
-        "es-CL",
+        "es",
         "es-ES",
-        "es-MX",
         "fr-CA",
         "fr",
         "it",

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -121,10 +121,12 @@ if IS_POCKET_MODE:
     #
     # As a result, both FLUENT_REPO and FLUENT_L10N_TEAM_REPO point to the same git repo
 
-    FLUENT_REPO = config("POCKET_FLUENT_REPO", default="mozilla-l10n/pocket-www-l10n")
-    FLUENT_REPO_URL = f"https://github.com/{FLUENT_REPO}"
-    FLUENT_REPO_BRANCH = config("POCKET_FLUENT_REPO_BRANCH", default="main")
-    FLUENT_REPO_PATH = DATA_PATH / "pocket-www-l10n"
+    # These are already pre-defined in settings.base, but we make the POCKET_ ones here the defaults
+    # so that L10N mechanics don't need any other code branching in them
+    FLUENT_REPO = POCKET_FLUENT_REPO
+    FLUENT_REPO_URL = POCKET_FLUENT_REPO_URL
+    FLUENT_REPO_BRANCH = POCKET_FLUENT_REPO_BRANCH
+    FLUENT_REPO_PATH = POCKET_FLUENT_REPO_PATH
 
     FLUENT_L10N_TEAM_REPO = config("POCKET_FLUENT_L10N_TEAM_REPO", default="mozilla-l10n/pocket-www-l10n")
     FLUENT_L10N_TEAM_REPO_URL = f"https://github.com/{FLUENT_L10N_TEAM_REPO}"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -276,22 +276,7 @@ POCKET_FLUENT_REPO_URL = f"https://github.com/{POCKET_FLUENT_REPO}"
 POCKET_FLUENT_REPO_PATH = DATA_PATH / "pocket-www-l10n"
 POCKET_FLUENT_REPO_BRANCH = config("POCKET_FLUENT_REPO_BRANCH", default="main")
 
-# This config is used to ensure that l10n_update.py can pull from both, separate,
-# L10N repos for Mozorg and for Pocket and update the appropriate dirs
-FLUENT_L10N_UPDATE_PARAMS = {
-    "Mozorg": dict(
-        path=FLUENT_REPO_PATH,
-        remote_url=FLUENT_REPO_URL,
-        branch_name=FLUENT_REPO_BRANCH,
-    ),
-    "Pocket": dict(
-        path=POCKET_FLUENT_REPO_PATH,
-        remote_url=POCKET_FLUENT_REPO_URL,
-        branch_name=POCKET_FLUENT_REPO_BRANCH,
-    ),
-}
-
-# templates to exclude from having an "edit this page" link in the footer
+# Templates to exclude from having an "edit this page" link in the footer
 # these are typically ones for which most of the content is in the DB
 EXCLUDE_EDIT_TEMPLATES = [
     "firefox/releases/nightly-notes.html",

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -223,8 +223,8 @@ PROD_LANGUAGES = sorted(sum(LOCALES_BY_REGION.values(), []) + ["ja-JP-mac"])
 
 GITHUB_REPO = "https://github.com/mozilla/bedrock"
 
-# NOTE: This default l10n config is for mozorg.
-# In settings/__init__.py we plug in an alternative Pocket-appropriate l10n setup.
+# IMPORTANT: The default l10n config here is for Mozorg. See settings/__init__.py
+# for where we plug in an alternative Pocket-appropriate l10n setup.
 
 # Global L10n files.
 FLUENT_DEFAULT_FILES = [
@@ -258,7 +258,7 @@ FLUENT_L10N_TEAM_REPO_BRANCH = config("FLUENT_L10N_TEAM_REPO_BRANCH", default="m
 FLUENT_L10N_TEAM_REPO_PATH = DATA_PATH / "l10n-team"
 # 10 seconds during dev and 10 min in prod
 FLUENT_CACHE_TIMEOUT = config("FLUENT_CACHE_TIMEOUT", default="10" if DEBUG else "600", parser=int)
-# order matters. first sting found wins.
+# Order matters. first string found wins.
 FLUENT_PATHS = [
     # local FTL files
     FLUENT_LOCAL_PATH,
@@ -291,23 +291,15 @@ IGNORE_LANG_DIRS = [
 ]
 
 
-def get_dev_languages(
-    fluent_repo_path,
-    ignore_lang_dirs,
-    prod_languages,
-):
+def get_dev_languages():
     try:
-        return [lang.name for lang in fluent_repo_path.iterdir() if lang.is_dir() and lang.name not in ignore_lang_dirs]
+        return [lang.name for lang in FLUENT_REPO_PATH.iterdir() if lang.is_dir() and lang.name not in IGNORE_LANG_DIRS]
     except OSError:
         # no locale dir
-        return list(prod_languages)
+        return list(PROD_LANGUAGES)
 
 
-DEV_LANGUAGES = get_dev_languages(
-    fluent_repo_path=FLUENT_REPO_PATH,
-    ignore_lang_dirs=IGNORE_LANG_DIRS,
-    prod_languages=PROD_LANGUAGES,
-)
+DEV_LANGUAGES = get_dev_languages()
 DEV_LANGUAGES.append("en-US")
 
 # Map short locale names to long, preferred locale names. This

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -223,8 +223,8 @@ PROD_LANGUAGES = sorted(sum(LOCALES_BY_REGION.values(), []) + ["ja-JP-mac"])
 
 GITHUB_REPO = "https://github.com/mozilla/bedrock"
 
-# IMPORTANT: The default l10n config here is for Mozorg. See settings/__init__.py
-# for where we plug in an alternative Pocket-appropriate l10n setup.
+# NOTE: This default l10n config is for mozorg.
+# In settings/__init__.py we plug in an alternative Pocket-appropriate l10n setup.
 
 # Global L10n files.
 FLUENT_DEFAULT_FILES = [
@@ -258,7 +258,7 @@ FLUENT_L10N_TEAM_REPO_BRANCH = config("FLUENT_L10N_TEAM_REPO_BRANCH", default="m
 FLUENT_L10N_TEAM_REPO_PATH = DATA_PATH / "l10n-team"
 # 10 seconds during dev and 10 min in prod
 FLUENT_CACHE_TIMEOUT = config("FLUENT_CACHE_TIMEOUT", default="10" if DEBUG else "600", parser=int)
-# Order matters. first string found wins.
+# order matters. first sting found wins.
 FLUENT_PATHS = [
     # local FTL files
     FLUENT_LOCAL_PATH,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -266,6 +266,31 @@ FLUENT_PATHS = [
     FLUENT_REPO_PATH,
 ]
 
+# These are defined up front, because we need them for more than just Pocket mode, but
+# note that they are also swapped in as the Fluent defaults in settings/__init__.py
+POCKET_FLUENT_REPO = config(
+    "POCKET_FLUENT_REPO",
+    default="mozilla-l10n/pocket-www-l10n",
+)
+POCKET_FLUENT_REPO_URL = f"https://github.com/{POCKET_FLUENT_REPO}"
+POCKET_FLUENT_REPO_PATH = DATA_PATH / "pocket-www-l10n"
+POCKET_FLUENT_REPO_BRANCH = config("POCKET_FLUENT_REPO_BRANCH", default="main")
+
+# This config is used to ensure that l10n_update.py can pull from both, separate,
+# L10N repos for Mozorg and for Pocket and update the appropriate dirs
+FLUENT_L10N_UPDATE_PARAMS = {
+    "Mozorg": dict(
+        path=FLUENT_REPO_PATH,
+        remote_url=FLUENT_REPO_URL,
+        branch_name=FLUENT_REPO_BRANCH,
+    ),
+    "Pocket": dict(
+        path=POCKET_FLUENT_REPO_PATH,
+        remote_url=POCKET_FLUENT_REPO_URL,
+        branch_name=POCKET_FLUENT_REPO_BRANCH,
+    ),
+}
+
 # templates to exclude from having an "edit this page" link in the footer
 # these are typically ones for which most of the content is in the DB
 EXCLUDE_EDIT_TEMPLATES = [

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -223,8 +223,8 @@ PROD_LANGUAGES = sorted(sum(LOCALES_BY_REGION.values(), []) + ["ja-JP-mac"])
 
 GITHUB_REPO = "https://github.com/mozilla/bedrock"
 
-# IMPORTANT: The default l10n config here is for Mozorg. See settings/__init__.py
-# for where we plug in an alternative Pocket-appropriate l10n setup.
+# NOTE: This default l10n config is for mozorg.
+# In settings/__init__.py we plug in an alternative Pocket-appropriate l10n setup.
 
 # Global L10n files.
 FLUENT_DEFAULT_FILES = [
@@ -258,7 +258,7 @@ FLUENT_L10N_TEAM_REPO_BRANCH = config("FLUENT_L10N_TEAM_REPO_BRANCH", default="m
 FLUENT_L10N_TEAM_REPO_PATH = DATA_PATH / "l10n-team"
 # 10 seconds during dev and 10 min in prod
 FLUENT_CACHE_TIMEOUT = config("FLUENT_CACHE_TIMEOUT", default="10" if DEBUG else "600", parser=int)
-# Order matters. first string found wins.
+# order matters. first sting found wins.
 FLUENT_PATHS = [
     # local FTL files
     FLUENT_LOCAL_PATH,
@@ -291,15 +291,23 @@ IGNORE_LANG_DIRS = [
 ]
 
 
-def get_dev_languages():
+def get_dev_languages(
+    fluent_repo_path,
+    ignore_lang_dirs,
+    prod_languages,
+):
     try:
-        return [lang.name for lang in FLUENT_REPO_PATH.iterdir() if lang.is_dir() and lang.name not in IGNORE_LANG_DIRS]
+        return [lang.name for lang in fluent_repo_path.iterdir() if lang.is_dir() and lang.name not in ignore_lang_dirs]
     except OSError:
         # no locale dir
-        return list(PROD_LANGUAGES)
+        return list(prod_languages)
 
 
-DEV_LANGUAGES = get_dev_languages()
+DEV_LANGUAGES = get_dev_languages(
+    fluent_repo_path=FLUENT_REPO_PATH,
+    ignore_lang_dirs=IGNORE_LANG_DIRS,
+    prod_languages=PROD_LANGUAGES,
+)
 DEV_LANGUAGES.append("en-US")
 
 # Map short locale names to long, preferred locale names. This

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -258,7 +258,7 @@ FLUENT_L10N_TEAM_REPO_BRANCH = config("FLUENT_L10N_TEAM_REPO_BRANCH", default="m
 FLUENT_L10N_TEAM_REPO_PATH = DATA_PATH / "l10n-team"
 # 10 seconds during dev and 10 min in prod
 FLUENT_CACHE_TIMEOUT = config("FLUENT_CACHE_TIMEOUT", default="10" if DEBUG else "600", parser=int)
-# order matters. first sting found wins.
+# Order matters. first string found wins.
 FLUENT_PATHS = [
     # local FTL files
     FLUENT_LOCAL_PATH,

--- a/bin/open-ftl-pr.sh
+++ b/bin/open-ftl-pr.sh
@@ -18,5 +18,6 @@ docker run --rm \
     -e FLUENT_REPO_AUTH \
     -e FLUENT_L10N_TEAM_REPO \
     -e FLUENT_L10N_TEAM_REPO_BRANCH \
+    --env SITE_MODE=${SITE_MODE:-Mozorg} \
     "$DEPLOYMENT_DOCKER_IMAGE" \
     python manage.py open_ftl_pr

--- a/bin/open-ftl-pr.sh
+++ b/bin/open-ftl-pr.sh
@@ -18,6 +18,6 @@ docker run --rm \
     -e FLUENT_REPO_AUTH \
     -e FLUENT_L10N_TEAM_REPO \
     -e FLUENT_L10N_TEAM_REPO_BRANCH \
-    -e SITE_MODE=${SITE_MODE:-Mozorg} \
+    -e SITE_MODE="${SITE_MODE:-Mozorg}" \
     "$DEPLOYMENT_DOCKER_IMAGE" \
     python manage.py open_ftl_pr

--- a/bin/open-ftl-pr.sh
+++ b/bin/open-ftl-pr.sh
@@ -18,6 +18,6 @@ docker run --rm \
     -e FLUENT_REPO_AUTH \
     -e FLUENT_L10N_TEAM_REPO \
     -e FLUENT_L10N_TEAM_REPO_BRANCH \
-    --env SITE_MODE=${SITE_MODE:-Mozorg} \
+    -e SITE_MODE=${SITE_MODE:-Mozorg} \
     "$DEPLOYMENT_DOCKER_IMAGE" \
     python manage.py open_ftl_pr

--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -203,6 +203,11 @@ def get_active_locales(ftl_files, force=False):
     available languages. You can pass `force=True` to override this
     behavior.
     """
+    if settings.IS_POCKET_MODE:
+        # All locales in Pocket should be 100% ready to go, because they are
+        # translated by a vendor, so we can just use Prod languages all the time
+        return settings.PROD_LANGUAGES
+
     if settings.DEV and not force:
         return settings.DEV_LANGUAGES
 

--- a/lib/l10n_utils/management/commands/_ftl_repo_base.py
+++ b/lib/l10n_utils/management/commands/_ftl_repo_base.py
@@ -34,7 +34,7 @@ class FTLRepoCommand(BaseCommand):
         except FileNotFoundError:
             pass
         self.l10n_repo.update()
-        self.stdout.write("Updated l10n team .ftl files")
+        self.stdout.write(f"Updated l10n team .ftl files for {settings.FLUENT_L10N_TEAM_REPO_URL}")
 
     def update_fluent_files(self):
         try:
@@ -42,7 +42,7 @@ class FTLRepoCommand(BaseCommand):
         except FileNotFoundError:
             pass
         self.meao_repo.update()
-        self.stdout.write("Updated .ftl files")
+        self.stdout.write(f"Updated .ftl files for {settings.FLUENT_REPO_URL}")
 
     def config_git(self):
         """Set user config so that committing will work"""

--- a/lib/l10n_utils/management/commands/l10n_update.py
+++ b/lib/l10n_utils/management/commands/l10n_update.py
@@ -8,6 +8,21 @@ from django.core.management.base import BaseCommand
 
 from bedrock.utils.git import GitRepo
 
+# This config is used to ensure that l10n_update.py can pull from both, separate,
+# L10N repos for Mozorg and for Pocket and update the appropriate dirs
+FLUENT_L10N_UPDATE_PARAMS = {
+    "Mozorg": dict(
+        path=settings.FLUENT_REPO_PATH,
+        remote_url=settings.FLUENT_REPO_URL,
+        branch_name=settings.FLUENT_REPO_BRANCH,
+    ),
+    "Pocket": dict(
+        path=settings.POCKET_FLUENT_REPO_PATH,
+        remote_url=settings.POCKET_FLUENT_REPO_URL,
+        branch_name=settings.POCKET_FLUENT_REPO_BRANCH,
+    ),
+}
+
 
 class Command(BaseCommand):
     help = "Clones or updates l10n info from github"
@@ -25,7 +40,7 @@ class Command(BaseCommand):
         self.update_fluent_files(options["clean"])
 
     def update_fluent_files(self, clean=False):
-        for site, params in settings.FLUENT_L10N_UPDATE_PARAMS.items():
+        for site, params in FLUENT_L10N_UPDATE_PARAMS.items():
             repo = GitRepo(**params)
             if clean:
                 repo.reclone()

--- a/lib/l10n_utils/management/commands/l10n_update.py
+++ b/lib/l10n_utils/management/commands/l10n_update.py
@@ -25,11 +25,12 @@ class Command(BaseCommand):
         self.update_fluent_files(options["clean"])
 
     def update_fluent_files(self, clean=False):
-        repo = GitRepo(settings.FLUENT_REPO_PATH, settings.FLUENT_REPO_URL, settings.FLUENT_REPO_BRANCH)
-        if clean:
-            repo.reclone()
-        else:
-            repo.update()
+        for site, params in settings.FLUENT_L10N_UPDATE_PARAMS.items():
+            repo = GitRepo(**params)
+            if clean:
+                repo.reclone()
+            else:
+                repo.update()
 
-        repo.update()
-        self.stdout.write("Updated .ftl files")
+            repo.update()
+            self.stdout.write(f"Updated .ftl files for {site}")

--- a/lib/l10n_utils/management/commands/open_ftl_pr.py
+++ b/lib/l10n_utils/management/commands/open_ftl_pr.py
@@ -93,8 +93,8 @@ class Command(FTLRepoCommand):
     def push_changes(self):
         try:
             self.l10n_repo.git("push", self.git_push_url, "HEAD")
-        except CalledProcessError:
-            raise CommandError(f"There was a problem pushing to {self.l10n_repo.remote_url}")
+        except CalledProcessError as cpe:
+            raise CommandError(f"There was a problem pushing to {self.l10n_repo.remote_url}: {cpe}")
 
         commit = self.l10n_repo.git("rev-parse", "--short", "HEAD")
         self.stdout.write(f"Pushed {commit} to {self.l10n_repo.remote_url} as {self.branch_name}")


### PR DESCRIPTION
## One-line summary

This changeset is the first/main pass to support a Pocket-specific `mozilla-l10n` / Fluent workflow. The relevant new repo for translations exists at https://github.com/mozilla-l10n/pocket-www-l10n.

## Significant changes and points to review

When `SITE_MODE=Pocket` updated defaults for almost all `FLUENT_*` settings are set - e.g. pointing at a Pocket-specific repo for translations, etc.

For Pocket mode, we don't need an intermediary mozmeao/* repo to hold the translations while we calculate activation metadata via a CI task (which does happen for Mozorg). Why? All locales in Pocket should be 100% ready to go, because they are translated by a vendor, whereas Mozorg has community translation contributions as well, which aren't always exhaustive.

As a result,  we are in Pocket mode, both `FLUENT_REPO` and `FLUENT_L10N_TEAM_REPO` point to the same repository. The locale activation logic now automatically forces the use of `PROD_LANGUAGES`, so the metadata added in CI is not needed.

There is also an iniital cut of DEV_LANGUAGES, PROD_LANGUAGES and fallback and canonical locale config, ~but these may need updating to bridge between what Smartling is giving us back and what GetPocket.com is using as live language codes. Views on this config are particularly welcome :)~

There is a change in behaviour where getpocket.com/es/ is will be used for international Spanish, whereas for now it is Spain Spanish, and `es-la` (a non-real locale) is used for Latin American Spanish, which now will be served as International Spanish at`/es/`

## Issue / Bugzilla link

Resolves #11521 

## Checklist

- [ ] ~Tests added~ TESTS TO COME
 
## Testing

- [ ] set up FLUENT_REPO_AUTH credentials (eg same as used in CI) in your local .env
- [ ] locally `./manage.py l10n_update` should run for both Mozorg and Pocket l10n - find no changes to pull in
- [ ] locally `SITE_MODE=Mozorg ./manage.py open_ftl_pr` should run and may find changes, triggering a PR - close it ASAP if so.
- [ ] locally `SITE_MODE=Pocket ./manage.py open_ftl_pr` should run and open a PR against the `mozilla-l10n/pocket-www-l10n` repo, which we should then close
- [ ] locally `SITE_MODE=Pocket ./bin/open-ftl-pr.sh` should do the same as above but via Docker, but **before** you cado it you need to set up the docker image:
  - `make build-ci` to build a fresh release-like image 
  -  bootstrap the l10n directories in the docker image with `docker run -it mozmeao/bedrock:<latest hash> ./manage.py l10n_update`
  - Note that the FTL PR made from within the Docker image will fail to be pushed because by default the container lacks auth. My _assumption_ right now is that in CI this is not a problem, as it currently works for Mozorg and the FLUENT_REPO_AUTH value required is the same
