### PR TITLE
Replaced old archived MDN pages with new links

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -63,12 +63,12 @@
             <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly">{{ ftl('footer-nightly') }}</a></li>
             <li><a href="{{ url('firefox.channel.android') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
             <li><a href="{{ url('firefox.enterprise.index') }}" data-link-type="footer" data-link-name="Firefox for Enterprise">{{ ftl('footer-enterprise') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Tools/?{{ utm_params }}&utm_content=developers" data-link-type="footer" data-link-name="Tools">{{ ftl('footer-tools') }}</a></li>
+            <li><a rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" data-link-type="footer" data-link-name="Tools">{{ ftl('footer-tools') }}</a></li>
           </ul>
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-mozilla') }}</h5>
+          <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-mozilla') }}</h5>s
           <ul class="mzp-c-footer-links-social">
             <li><a class="twitter" href="{{ mozilla_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
             <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>

--- a/bedrock/firefox/templates/firefox/developer/includes/features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/features.html
@@ -17,7 +17,7 @@
         {{ ftl('firefox-developer-inspect-and-refine') }}
         {% if ftl_has_messages('firefox-developer-learn-about-page-inspector') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Page_Inspector" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-about-page-inspector') }}
             </a>
           </p>
@@ -32,7 +32,7 @@
         {{ ftl('firefox-developer-track-css') }}
         {% if ftl_has_messages('firefox-developer-learn-about-web-console') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Web_Console" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/web_console/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-about-web-console') }}
             </a>
           </p>
@@ -47,7 +47,7 @@
         {{ ftl('firefox-developer-powerful-javascript') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-debugger') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Debugger" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/debugger/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-debugger') }}
             </a>
           </p>
@@ -62,7 +62,7 @@
         {{ ftl('firefox-developer-monitor-network-requests') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-newtork-monitor') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Network_Monitor" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-newtork-monitor') }}
             </a>
           </p>
@@ -77,7 +77,7 @@
         {{ ftl('firefox-developer-add-modify-remove') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-storage') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Storage_Inspector" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-storage') }}
             </a>
           </p>
@@ -92,7 +92,7 @@
         {{ ftl('firefox-developer-test-sites-emulated') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-responsive') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Responsive_Design_View" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-responsive') }}
             </a>
           </p>
@@ -122,7 +122,7 @@
         {{ ftl('firefox-developer-unblock-bottlenecks') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-performance') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Performance" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/performance/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-performance') }}
             </a>
           </p>
@@ -137,7 +137,7 @@
         {{ ftl('firefox-developer-find-memory-leaks') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-memory') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Memory" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/memory/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-memory') }}
             </a>
           </p>
@@ -152,7 +152,7 @@
         {{ ftl('firefox-developer-edit-and-manage') }}
         {% if ftl_has_messages('firefox-developer-learn-more-about-style') %}
           <p class="c-feature-more">
-            <a href="https://developer.mozilla.org/docs/Tools/Style_Editor" class="mzp-c-cta-link" rel="external">
+            <a href="https://firefox-source-docs.mozilla.org/devtools-user/style_editor/" class="mzp-c-cta-link" rel="external">
               {{ ftl('firefox-developer-learn-more-about-style') }}
             </a>
           </p>

--- a/bedrock/firefox/templates/firefox/developer/includes/highlights.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/highlights.html
@@ -52,7 +52,7 @@
     {% if ftl_has_messages('firefox-developer-faster-innovation', 'firefox-developer-the-new-fonts-panel') %}
       {% if not ftl_has_messages('firefox-developer-new-tools', 'firefox-developer-firefox-devtools-now-grays-out') %}
         <div class="c-gallery-item">
-          <a rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">
+          <a rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/">
             <img class="highlight-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="{{ ftl('firefox-developer-shapes-editor') }}">
           </a>
           <h2 class="c-title">{{ ftl('firefox-developer-convenient-features') }}</h2>
@@ -60,12 +60,12 @@
           <p>
             {{ ftl('firefox-developer-firefox-devtools-has-a-brand-new-v2', fallbacl='firefox-developer-firefox-devtools-has-a-brand-new') }}
           </p>
-          <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">{{ ftl('ui-learn-more') }}</a></p>
+          <p><a class="mzp-c-cta-link" rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/">{{ ftl('ui-learn-more') }}</a></p>
         </div>
       {% endif %}
 
       <div class="c-gallery-item">
-        <a rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_fonts">
+        <a rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_fonts/">
           <img class="highlight-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="{{ ftl('firefox-developer-fonts-panel') }}">
         </a>
         <h2 class="c-title">{{ ftl('firefox-developer-faster-innovation') }}</h2>
@@ -73,7 +73,7 @@
         <p>
           {{ ftl('firefox-developer-the-new-fonts-panel') }}
         </p>
-        <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_fonts">{{ ftl('ui-learn-more') }}</a></p>
+        <p><a class="mzp-c-cta-link" rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_fonts/">{{ ftl('ui-learn-more') }}</a></p>
       </div>
     {% endif %}
   </div>

--- a/bedrock/foundation/templates/foundation/annualreport/2011.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2011.html
@@ -202,7 +202,7 @@
           <div class="overlay">
             <p>
             {% with cmdline_url='https://hacks.mozilla.org/2012/08/new-firefox-command-line-helps-you-develop-faster/',
-                    console_url='https://developer.mozilla.org/docs/Tools/Web_Console',
+                    console_url='https://firefox-source-docs.mozilla.org/devtools-user/web_console/',
                     tilt_url='https://blog.mozilla.org/tilt/'
             %}
               Firefox will always be the part of the Mozilla mission that people


### PR DESCRIPTION
Replaced old archived MDN pages (https://developer.mozilla.org/docs/Tools/) with new links 
(https://firefox-source-docs.mozilla.org/devtools-user/) in total 4 files.
I'm new here and I don't know this project well so If I misunderstood something and did not complete the task correctly - I apologize.