### PR TITLE
Adding Fluent file for Pocket Platforms pages

### DIFF
--- a/bedrock/pocket/templates/pocket/android.html
+++ b/bedrock/pocket/templates/pocket/android.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-android.jpg' %}
 
-{% block page_title %}Pocket for Android{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-android-title') }}{% endblock %}
 
-{% block page_desc %}View your list on your Android device. Download the free Pocket app from Google Play.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-android-view-list') }}{% endblock %}
 
-{% block page_cta %}Get the app{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-get-app') }}{% endblock %}
 
 {% block page_url %}https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro{% endblock %}

--- a/bedrock/pocket/templates/pocket/chrome.html
+++ b/bedrock/pocket/templates/pocket/chrome.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-chrome.jpg' %}
 
-{% block page_title %}Pocket for Chrome{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-chrome-title') }}{% endblock %}
 
-{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-browser-installing') }}{% endblock %}
 
-{% block page_cta %}Install{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-install') }}{% endblock %}
 
 {% block page_url %}https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj{% endblock %}

--- a/bedrock/pocket/templates/pocket/edge.html
+++ b/bedrock/pocket/templates/pocket/edge.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-edge.jpg' %}
 
-{% block page_title %}Pocket for Edge{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-edge-title') }}{% endblock %}
 
-{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-browser-installing') }}{% endblock %}
 
-{% block page_cta %}Install{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-install') }}{% endblock %}
 
 {% block page_url %}https://microsoftedge.microsoft.com/addons/detail/save-to-pocket/jicacccodjjgmghnmekophahpmddeemd?source=sfw{% endblock %}

--- a/bedrock/pocket/templates/pocket/ios.html
+++ b/bedrock/pocket/templates/pocket/ios.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-ios.jpg' %}
 
-{% block page_title %}Pocket for iOS{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-ios-title') }}{% endblock %}
 
-{% block page_desc %}View your list on your iPhone or iPad. Download the free Pocket app for iOS from the App Store.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-ios-view-list') }}{% endblock %}
 
-{% block page_cta %}Get the app{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-get-app') }}{% endblock %}
 
 {% block page_url %}https://apps.apple.com/app/read-it-later-pro/id309601447{% endblock %}

--- a/bedrock/pocket/templates/pocket/opera.html
+++ b/bedrock/pocket/templates/pocket/opera.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-opera.jpg' %}
 
-{% block page_title %}Pocket for Opera{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-opera-title') }}{% endblock %}
 
-{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-browser-installing') }}{% endblock %}
 
-{% block page_cta %}Install{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-install') }}{% endblock %}
 
 {% block page_url %}https://addons.opera.com/en/extensions/details/pocket-formerly-read-it-later/?display=en{% endblock %}

--- a/bedrock/pocket/templates/pocket/safari.html
+++ b/bedrock/pocket/templates/pocket/safari.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-safari.jpg' %}
 
-{% block page_title %}Pocket for Safari{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-safari-title') }}{% endblock %}
 
-{% block page_desc %}Installing the Pocket browser extension installs buttons that let you save items with one click.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-browser-installing') }}{% endblock %}
 
-{% block page_cta %}Download{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-install') }}{% endblock %}
 
 {% block page_url %}https://apps.apple.com/us/app/save-to-pocket/id1477385213?ls=1&mt=12{% endblock %}

--- a/bedrock/pocket/templates/pocket/welcome.html
+++ b/bedrock/pocket/templates/pocket/welcome.html
@@ -8,10 +8,10 @@
 
 {% set platform_image = 'img/pocket/welcome-bookmarklet.jpg' %}
 
-{% block page_title %}Pocket for Your Browser{% endblock %}
+{% block page_title %}{{ ftl('pocket-platform-welcome-title') }}{% endblock %}
 
-{% block page_desc %}When browsing the web, simply push this button in your Bookmarks Bar to add pages to your Pocket list.{% endblock %}
+{% block page_desc %}{{ ftl('pocket-platform-welcome-when-browsing') }}{% endblock %}
 
-{% block page_cta %}Log in{% endblock %}
+{% block page_cta %}{{ ftl('pocket-platform-log-in') }}{% endblock %}
 
 {% block page_url %}https://getpocket.com/login/{% endblock %}

--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -20,36 +20,43 @@ urlpatterns = (
         "android/",
         "pocket/android.html",
         url_name="pocket.android",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "ios/",
         "pocket/ios.html",
         url_name="pocket.ios",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "chrome/",
         "pocket/chrome.html",
         url_name="pocket.chrome",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "safari/",
         "pocket/safari.html",
         url_name="pocket.safari",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "opera/",
         "pocket/opera.html",
         url_name="pocket.opera",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "edge/",
         "pocket/edge.html",
         url_name="pocket.edge",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "welcome/",
         "pocket/welcome.html",
         url_name="pocket.welcome",
+        ftl_files=["pocket/platforms"],
     ),
     page(
         "contact-info/",

--- a/l10n-pocket/en/brands.ftl
+++ b/l10n-pocket/en/brands.ftl
@@ -19,16 +19,26 @@
 
 -brand-name-firefox = Firefox
 
+## Platforms
+
+-brand-name-ios = iOS
+-brand-name-android = Android
+
+## Other browsers
+
+-brand-name-chrome = Chrome
+-brand-name-safari = Safari
+-brand-name-edge = Edge
+-brand-name-opera = Opera
+
 ## Third parties
 
 -brand-name-twitter = Twitter
 -brand-name-facebook = Facebook
 -brand-name-google-play = Google Play
 -brand-name-apple-app-store = Apple App Store
--brand-name-ios = iOS
--brand-name-android = Android
--brand-name-chrome = Chrome
--brand-name-safari = Safari
--brand-name-edge = Edge
--brand-name-opera = Opera
 
+## Apple products
+
+-brand-name-iphone = iPhone
+-brand-name-ipad = iPad

--- a/l10n-pocket/en/brands.ftl
+++ b/l10n-pocket/en/brands.ftl
@@ -25,4 +25,10 @@
 -brand-name-facebook = Facebook
 -brand-name-google-play = Google Play
 -brand-name-apple-app-store = Apple App Store
+-brand-name-ios = iOS
+-brand-name-android = Android
+-brand-name-chrome = Chrome
+-brand-name-safari = Safari
+-brand-name-edge = Edge
+-brand-name-opera = Opera
 

--- a/l10n-pocket/en/pocket/platforms.ftl
+++ b/l10n-pocket/en/pocket/platforms.ftl
@@ -34,4 +34,3 @@ pocket-platform-browser-installing = Installing the Pocket browser extension ins
 
 pocket-platform-welcome-title = { -brand-name-pocket } for Your Browser
 pocket-platform-welcome-when-browsing = When browsing the web, simply push this button in your Bookmarks Bar to add pages to your Pocket list.
-pocket-platform-log-in

--- a/l10n-pocket/en/pocket/platforms.ftl
+++ b/l10n-pocket/en/pocket/platforms.ftl
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### iOS URL: https://www-dev-pocket.allizom.org/ios/
+### iOS URL: https://www-dev-pocket.allizom.org/android/
+### iOS URL: https://www-dev-pocket.allizom.org/safari/
+### iOS URL: https://www-dev-pocket.allizom.org/chrome/
+### iOS URL: https://www-dev-pocket.allizom.org/opera/
+### iOS URL: https://www-dev-pocket.allizom.org/edge/
+### iOS URL: https://www-dev-pocket.allizom.org/welcome/
+
+
+pocket-platform-get-app = Get the app
+pocket-platform-install = Install
+pocket-platform-log-in = Log in
+
+pocket-platform-ios-title = { -brand-name-pocket } for { -brand-name-ios }
+pocket-platform-ios-view-list = View your list on your iPhone or iPad. Download the free { -brand-name-pocket } app for { -brand-name-ios } from the { -brand-name-apple-app-store }.
+
+pocket-platform-android-title = { -brand-name-pocket } for { -brand-name-android }
+pocket-platform-android-view-list = View your list on your { -brand-name-android} device. Download the free Pocket app from { -brand-name-google-play }.
+
+
+pocket-platform-chrome-title = { -brand-name-pocket } for { -brand-name-chrome}
+
+pocket-platform-safari-title = { -brand-name-pocket } for { -brand-name-safari}
+
+pocket-platform-opera-title = { -brand-name-pocket } for { -brand-name-opera }
+
+pocket-platform-edge-title = { -brand-name-pocket } for { -brand-name-edge }
+
+pocket-platform-browser-installing = Installing the Pocket browser extension installs buttons that let you save items with one click.
+
+pocket-platform-welcome-title = { -brand-name-pocket } for Your Browser
+pocket-platform-welcome-when-browsing = When browsing the web, simply push this button in your Bookmarks Bar to add pages to your Pocket list.
+pocket-platform-log-in

--- a/l10n-pocket/en/pocket/platforms.ftl
+++ b/l10n-pocket/en/pocket/platforms.ftl
@@ -19,7 +19,7 @@ pocket-platform-ios-title = { -brand-name-pocket } for { -brand-name-ios }
 pocket-platform-ios-view-list = View your list on your iPhone or iPad. Download the free { -brand-name-pocket } app for { -brand-name-ios } from the { -brand-name-apple-app-store }.
 
 pocket-platform-android-title = { -brand-name-pocket } for { -brand-name-android }
-pocket-platform-android-view-list = View your list on your { -brand-name-android} device. Download the free Pocket app from { -brand-name-google-play }.
+pocket-platform-android-view-list = View your list on your { -brand-name-android} device. Download the free { -brand-name-pocket } app from { -brand-name-google-play }.
 
 
 pocket-platform-chrome-title = { -brand-name-pocket } for { -brand-name-chrome}
@@ -30,7 +30,7 @@ pocket-platform-opera-title = { -brand-name-pocket } for { -brand-name-opera }
 
 pocket-platform-edge-title = { -brand-name-pocket } for { -brand-name-edge }
 
-pocket-platform-browser-installing = Installing the Pocket browser extension installs buttons that let you save items with one click.
+pocket-platform-browser-installing = Installing the { -brand-name-pocket } browser extension installs buttons that let you save items with one click.
 
 pocket-platform-welcome-title = { -brand-name-pocket } for Your Browser
-pocket-platform-welcome-when-browsing = When browsing the web, simply push this button in your Bookmarks Bar to add pages to your Pocket list.
+pocket-platform-welcome-when-browsing = When browsing the web, simply push this button in your Bookmarks Bar to add pages to your { -brand-name-pocket } list.

--- a/l10n-pocket/en/pocket/platforms.ftl
+++ b/l10n-pocket/en/pocket/platforms.ftl
@@ -2,35 +2,40 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-### iOS URL: https://www-dev-pocket.allizom.org/ios/
-### iOS URL: https://www-dev-pocket.allizom.org/android/
-### iOS URL: https://www-dev-pocket.allizom.org/safari/
-### iOS URL: https://www-dev-pocket.allizom.org/chrome/
-### iOS URL: https://www-dev-pocket.allizom.org/opera/
-### iOS URL: https://www-dev-pocket.allizom.org/edge/
-### iOS URL: https://www-dev-pocket.allizom.org/welcome/
-
-
-pocket-platform-get-app = Get the app
-pocket-platform-install = Install
-pocket-platform-log-in = Log in
+## iOS URL: https://dev.tekcopteg.com/ios/
 
 pocket-platform-ios-title = { -brand-name-pocket } for { -brand-name-ios }
-pocket-platform-ios-view-list = View your list on your iPhone or iPad. Download the free { -brand-name-pocket } app for { -brand-name-ios } from the { -brand-name-apple-app-store }.
+pocket-platform-ios-view-list = View your list on your { -brand-name-iphone } or { -brand-name-ipad }. Download the free { -brand-name-pocket } app for { -brand-name-ios } from the { -brand-name-apple-app-store }.
+
+## Android URL: https://dev.tekcopteg.com/android/
 
 pocket-platform-android-title = { -brand-name-pocket } for { -brand-name-android }
 pocket-platform-android-view-list = View your list on your { -brand-name-android} device. Download the free { -brand-name-pocket } app from { -brand-name-google-play }.
 
+## Chrome URL: https://dev.tekcopteg.com/chrome/
 
 pocket-platform-chrome-title = { -brand-name-pocket } for { -brand-name-chrome}
 
+## Safari URL: https://dev.tekcopteg.com/safari/
+
 pocket-platform-safari-title = { -brand-name-pocket } for { -brand-name-safari}
+
+## Opera URL: https://dev.tekcopteg.com/opera/
 
 pocket-platform-opera-title = { -brand-name-pocket } for { -brand-name-opera }
 
+## Edge URL: https://dev.tekcopteg.com/edge/
+
 pocket-platform-edge-title = { -brand-name-pocket } for { -brand-name-edge }
 
-pocket-platform-browser-installing = Installing the { -brand-name-pocket } browser extension installs buttons that let you save items with one click.
+## Welcome URL: https://dev.tekcopteg.com/welcome/
 
 pocket-platform-welcome-title = { -brand-name-pocket } for Your Browser
 pocket-platform-welcome-when-browsing = When browsing the web, simply push this button in your Bookmarks Bar to add pages to your { -brand-name-pocket } list.
+
+##
+
+pocket-platform-get-app = Get the app
+pocket-platform-install = Install
+pocket-platform-log-in = Log in
+pocket-platform-browser-installing = Installing the { -brand-name-pocket } browser extension installs buttons that let you save items with one click.


### PR DESCRIPTION
## One-line summary

Created Fluent file for Pocket's platform pages and placed their strings in the respective file.

Fluent file found in `l10n-pocket/en/pocket/platforms.ftl`

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11519

## Testing

To test this work:

- [ ] http://localhost:8000/en-US/ios/
- [ ] http://localhost:8000/en-US/android
- [ ] http://localhost:8000/en-US/chrome/
- [ ] http://localhost:8000/en-US/safari/
- [ ] http://localhost:8000/en-US/opera/
- [ ] http://localhost:8000/en-US/edge/
- [ ] http://localhost:8000/en-US/welcome/
