### PR TITLE
Don't show Firefox download interstitial in manual update flow (#11071)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -499,7 +499,7 @@
   </aside>
 </main>
 
-{% if show_firefox_join_modal %}
+{% if show_firefox_join_modal and not manual_update %}
 <aside class="mzp-u-modal-content join-firefox-content hide-from-legacy-ie">
   <h4 class="join-firefox-title">{{ ftl('firefox-desktop-download-youve-already-got-the-browser') }}</h4>
   <p class="join-firefox-intro">{{ ftl('firefox-desktop-download-watch-for-hackers-with') }}</p>
@@ -519,7 +519,7 @@
 {% block js %}
   {{ js_bundle('firefox_desktop_download') }}
 
-  {% if show_firefox_join_modal %}
+  {% if show_firefox_join_modal and not manual_update %}
     {{ js_bundle('firefox_new_desktop_join_modal') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -746,6 +746,10 @@ class NewView(L10nTemplateView):
 
         ctx["variant"] = variant
 
+        reason = self.request.GET.get("reason", None)
+        manual_update = True if reason == "manual-update" else False
+        ctx["manual_update"] = manual_update
+
         return ctx
 
     def get_template_names(self):

--- a/media/js/base/experiment-utils.es6.js
+++ b/media/js/base/experiment-utils.es6.js
@@ -4,14 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const knownExperimentalParams = [
+const knownExcludedarams = [
     'automation=true', // Automated functional tests
     'entrypoint_experiment=', // Firefox Accounts experiments
     'entrypoint_variation=',
     'experiment=', // Stub attribution experiments
     'variation=',
     'utm_medium=cpc', // Ad campaign tests
-    'utm_source=firefox-browser' // Firefox in-product tests
+    'utm_source=firefox-browser', // Firefox in-product tests
+    'reason=manual-update' // https://github.com/mozilla/bedrock/issues/11071
 ];
 
 /**
@@ -27,7 +28,7 @@ function isApprovedToRun(params) {
     if (queryString) {
         queryString = decodeURIComponent(queryString);
 
-        return knownExperimentalParams.every((param) => {
+        return knownExcludedarams.every((param) => {
             return queryString.indexOf(param) === -1;
         });
     }


### PR DESCRIPTION
## One-line summary

Prevent showing the _"You already have Firefox..."_ interstitial modal if we know the visitor is having trouble updating their Firefox.

## Issue / Bugzilla link

#11071

## Testing

Test using Firefox (signed out of a Firefox Account):

- [x] http://localhost:8000/en-US/firefox/new/ Clicking "Download Firefox" should open the modal.
- [x] http://localhost:8000/en-US/firefox/new/?reason=manual-update Clicking "Download Firefox" should not open modal and proceed directly to download.
