### PR TITLE
Link hover contrast issue on Nightly /whatsnew page

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -40,7 +40,7 @@
   </header>
 
   <div class="mzp-l-content">
-    <div class="mzp-c-emphasis-box mzp-t-dark-override-color">
+    <div class="mzp-c-emphasis-box a-link-color">
       <h2 class="c-emphasis-box-title">{{ self.page_title() }}</h2>
       <p>{{ ftl('nightly-whatsnew-every-4-to-5-weeks', fallback='nightly-whatsnew-every-6-to-8-weeks') }}</p>
 

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -40,7 +40,7 @@
   </header>
 
   <div class="mzp-l-content">
-    <div class="mzp-c-emphasis-box">
+    <div class="mzp-c-emphasis-box mzp-t-dark-override-color">
       <h2 class="c-emphasis-box-title">{{ self.page_title() }}</h2>
       <p>{{ ftl('nightly-whatsnew-every-4-to-5-weeks', fallback='nightly-whatsnew-every-6-to-8-weeks') }}</p>
 

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -40,7 +40,7 @@
   </header>
 
   <div class="mzp-l-content">
-    <div class="mzp-c-emphasis-box a-link-color">
+    <div class="mzp-c-emphasis-box">
       <h2 class="c-emphasis-box-title">{{ self.page_title() }}</h2>
       <p>{{ ftl('nightly-whatsnew-every-4-to-5-weeks', fallback='nightly-whatsnew-every-6-to-8-weeks') }}</p>
 

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -51,3 +51,9 @@ $image-path: '/media/protocol/img';
         text-align: center;
     }
 }
+
+.mzp-t-dark-override-color {
+    a:visited {
+        color: inherit !important;
+    }
+}

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -52,8 +52,14 @@ $image-path: '/media/protocol/img';
     }
 }
 
-.mzp-t-dark-override-color {
+.a-link-color {
+    a:link,
     a:visited {
-        color: inherit !important;
+        color: $color-ink-80;
+
+        &:hover,
+        &:focus {
+            color: inherit;
+        }
     }
 }

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -50,9 +50,7 @@ $image-path: '/media/protocol/img';
         color: get-theme('title-text-color');
         text-align: center;
     }
-}
 
-.a-link-color {
     a:link,
     a:visited {
         color: $color-ink-80;

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -39,6 +39,11 @@ $image-path: '/media/protocol/img';
     a:link,
     a:visited {
         color: $color-ink-80;
+
+        &:hover,
+        &:focus {
+            color: inherit;
+        }
     }
 
     abbr {
@@ -49,15 +54,5 @@ $image-path: '/media/protocol/img';
         @include text-title-sm;
         color: get-theme('title-text-color');
         text-align: center;
-    }
-
-    a:link,
-    a:visited {
-        color: $color-ink-80;
-
-        &:hover,
-        &:focus {
-            color: inherit;
-        }
     }
 }


### PR DESCRIPTION
## One-line summary

I've created new CSS style for the a:visited element (was #e7dfff font color from Protocol class and that was our problem).

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11563

I think this will do the trick.