### PR TITLE
Add no-important rule to Stylelint (Fixes #11594)

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,6 +4,7 @@
         "indentation": 4,
         "string-quotes": "single",
         "declaration-empty-line-before": "never",
+        "declaration-no-important": true,
         "color-function-notation": "legacy",
         "alpha-value-notation": "number",
         "property-no-vendor-prefix": null,

--- a/media/css/pocket/components/add.scss
+++ b/media/css/pocket/components/add.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'sass:color';
+
 @import '../utils/variables';
 @import '../includes/platform-nav';
 @import '../includes/platform-footer';
@@ -48,9 +50,8 @@ $image-path: '/media/img/pocket';
         &:hover,
         &:focus,
         &:active {
-            text-decoration: underline !important;
-            background-color: $color-button-red;
-            border: 2px solid $color-button-red;
+            background-color: color.adjust($color-button-red, $lightness: -10%);
+            border: 2px solid color.adjust($color-button-red, $lightness: -10%);
             color: $color-white;
         }
     }

--- a/media/css/pocket/components/new-tab-learn-more.scss
+++ b/media/css/pocket/components/new-tab-learn-more.scss
@@ -196,9 +196,9 @@ $image-path: '/media/protocol/img';
     max-width: 425px;
 }
 
-.hidden-gem-media {
+.mzp-c-split-media.hidden-gem-media {
     width: 125%;
-    margin-left: -25% !important;
+    margin-left: -25%;
 }
 
 // override protocol style because of the shape of this image

--- a/media/css/pocket/components/platforms.scss
+++ b/media/css/pocket/components/platforms.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'sass:color';
+
 @import '../utils/variables';
 @import '../includes/platform-footer';
 @import '../includes/platform-nav';
@@ -40,8 +42,8 @@ $image-path: '/media/img/pocket';
             &:hover,
             &:focus,
             &:active {
+                background-color: color.adjust($color-button-red, $lightness: -10%);
                 color: $color-white;
-                text-decoration: underline !important;
             }
         }
     }

--- a/media/css/pocket/components/pocket-features.scss
+++ b/media/css/pocket/components/pocket-features.scss
@@ -78,8 +78,8 @@ $image-path: '/media/protocol/img';
         justify-content: flex-start;
         flex-direction: row;
 
-        .apple-store {
-            margin-bottom: 0 !important;
+        a.apple-store {
+            margin-bottom: 0;
             margin-right: $spacing-md;
         }
     }


### PR DESCRIPTION
## One-line summary

- Reinstate `declaration-no-important` rule for Stylelint.
- Fix existing errors in Pocket pages.

## Issue / Bugzilla link

#11594

## Testing

Demo server URL: (or None)

To test this work:

- [x] http://localhost:8000/en-US/add/
- [x] http://localhost:8000/en-US/firefox/new_tab_learn_more/
- [x] http://localhost:8000/en-US/ios/
- [x] http://localhost:8000/en-US/get-inspired/
