### PR TITLE
fix bug 11476 - Adds css selector for hidden attribute

### DIFF
--- a/media/css/protocol/common-old-ie.scss
+++ b/media/css/protocol/common-old-ie.scss
@@ -36,6 +36,10 @@ label {
     display: block;
 }
 
+[hidden] {
+    display: none;
+}
+
 .visually-hidden {
     @include visually-hidden;
 }

--- a/media/css/protocol/protocol-firefox.scss
+++ b/media/css/protocol/protocol-firefox.scss
@@ -38,6 +38,10 @@ $image-path: '/media/protocol/img';
 @import 'components/menu-item';
 @import 'components/sub-navigation';
 
+[hidden] {
+    display: none;
+}
+
 // Temporary styling until the newsletter component is updated in Protocol
 // https://github.com/mozilla/protocol/issues/578
 .mzp-c-newsletter-subtitle {

--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -40,6 +40,11 @@ $image-path: '/media/protocol/img';
 
 // Temporary styling until the newsletter component is updated in Protocol
 // https://github.com/mozilla/protocol/issues/578
+
+[hidden] {
+    display: none;
+}
+
 .mzp-c-newsletter-subtitle {
     @include text-title-xs;
 }


### PR DESCRIPTION
## One-line summary

This changeset adds a CSS selector for the hidden attribute in order to provide backwards compatibility for old browsers like IE10. Old browsers were not registering the hidden attribute to hide elements.

## Significant changes and points to review

- `./media/css/protocol/common-old-ie.scss` seemed like a better place for this change, however, it didn't seem to be loading on every page.

- I attempted to push up a demo branch to one of the on-demand demos for manual testing in IE, however, was denied permissions. This might be user error here and will ask about this on the mozilla.org chat. https://bedrock.readthedocs.io/en/latest/contribute.html#server-architecture

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11476
