### PR TITLE
Update OS availability when comparing Firefox and Edge (Fixes #11593)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -188,7 +188,7 @@
                     <th scope="row">{{ ftl('firefox-desktop-download-os-availability') }}</th>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
-                    <td>{{ picture('icon-dash', 24, 24, ftl('firefox-desktop-download-no')) }}</td>
+                    <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
                     <td>{{ picture('icon-dash', 24, 24, ftl('firefox-desktop-download-no')) }}</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
## One-line summary

Edge is now available on Windows, macOS and Linux.

## Issue / Bugzilla link

#11593

## Screenshots

<img src="https://user-images.githubusercontent.com/400117/167600668-81229387-9c5b-4bea-82e9-89cf64f6615b.png" alt="image" style="max-width: 100%;" width="400">

## Testing

http://localhost:8000/en-US/firefox/new/
