### PR TITLE
Serve full Firefox installer for users on Windows 7 (Fixes #11606)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -72,6 +72,14 @@
   <p class="mzp-l-content download-another-language-link">
     <a href="{{ firefox_url('desktop', 'all') }}">{{ ftl('firefox-new-download-in-another-language') }}</a>
   </p>
+
+  {# Temporary full installer links for Windows 7 see: https://github.com/mozilla/bedrock/issues/11606 #}
+  {{ download_firefox(
+    platform='desktop',
+    force_direct=true,
+    force_full_installer=true,
+    dom_id='thanks-full-installer')
+  }}
 </main>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -88,6 +88,14 @@
   <div class="c-support-lang">
     <a href="{{ firefox_url('desktop', 'all') }}">{{ ftl('firefox-desktop-download-in-another-language') }}</a>
   </div>
+
+  {# Temporary full installer links for Windows 7 see: https://github.com/mozilla/bedrock/issues/11606 #}
+  {{ download_firefox(
+    platform='desktop',
+    force_direct=true,
+    force_full_installer=true,
+    dom_id='thanks-full-installer')
+  }}
 </main>
 {% endblock %}
 

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -227,7 +227,7 @@ def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button
         "win",
         locale,
         force_direct=True,
-        force_full_installer=False,
+        force_full_installer=True,  # Temporarily force full installer for legacy IE https://github.com/mozilla/bedrock/issues/11606
         force_funnelcake=False,
         funnelcake_id=funnelcake_id,
     )

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -335,7 +335,7 @@ class TestDownloadThanksButton(TestCase):
         assert link.attr("data-link-type") == "download"
 
         # Direct attribute for legacy IE browsers should always be win 32bit
-        assert link.attr("data-direct-link") == "https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US"
+        assert link.attr("data-direct-link") == "https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US"
 
     def test_download_firefox_thanks_attributes(self):
         """

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -20,17 +20,17 @@ class TestViews(TestCase):
     def test_download_button_funnelcake(self):
         """The download button should have the funnelcake ID."""
         with self.activate("en-US"):
-            resp = self.client.get(reverse("mozorg.home"), {"f": "5"})
+            resp = self.client.get(reverse("firefox.download.thanks"), {"f": "5"})
             assert b"product=firefox-stub-f5&" in resp.content
 
     def test_download_button_bad_funnelcake(self):
         """The download button should not have a bad funnelcake ID."""
         with self.activate("en-US"):
-            resp = self.client.get(reverse("mozorg.home"), {"f": "5dude"})
+            resp = self.client.get(reverse("firefox.download.thanks"), {"f": "5dude"})
             assert b"product=firefox-stub&" in resp.content
             assert b"product=firefox-stub-f5dude&" not in resp.content
 
-            resp = self.client.get(reverse("mozorg.home"), {"f": "999999999"})
+            resp = self.client.get(reverse("firefox.download.thanks"), {"f": "999999999"})
             assert b"product=firefox-stub&" in resp.content
             assert b"product=firefox-stub-f999999999&" not in resp.content
 

--- a/media/css/firefox/new/basic/thanks.scss
+++ b/media/css/firefox/new/basic/thanks.scss
@@ -9,7 +9,8 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 // Hide the /thanks download button as selection is made via JS automatically.
-#thanks-download-button {
+#thanks-download-button,
+#thanks-full-installer {
     display: none;
 }
 

--- a/media/css/firefox/new/desktop/thanks.scss
+++ b/media/css/firefox/new/desktop/thanks.scss
@@ -59,7 +59,8 @@ main {
 }
 
 // Hide the /thanks download button as selection is made via JS automatically.
-#thanks-download-button {
+#thanks-download-button,
+#thanks-full-installer {
     display: none;
 }
 

--- a/media/js/firefox/new/common/thanks.js
+++ b/media/js/firefox/new/common/thanks.js
@@ -41,7 +41,19 @@ if (typeof window.Mozilla === 'undefined') {
 
         switch (site.platform) {
             case 'windows':
-                link = document.getElementById(prefix + 'win');
+                /**
+                 * Temporarily serve Windows 7 users the full installer.
+                 * See: https://github.com/mozilla/bedrock/issues/11606
+                 */
+
+                var version = site.platformVersion
+                    ? parseFloat(site.platformVersion)
+                    : 0;
+                if (version === 6.1) {
+                    link = document.getElementById('thanks-full-installer-win');
+                } else {
+                    link = document.getElementById(prefix + 'win');
+                }
                 break;
             case 'osx':
                 link = document.getElementById(prefix + 'osx');

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -132,6 +132,11 @@ describe('site.js', function () {
         it('should identify a Windows version', function () {
             expect(
                 window.site.getPlatformVersion(
+                    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36'
+                )
+            ).toBe('6.1');
+            expect(
+                window.site.getPlatformVersion(
                     'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)'
                 )
             ).toBe('7.1');

--- a/tests/unit/spec/firefox/new/common/thanks.js
+++ b/tests/unit/spec/firefox/new/common/thanks.js
@@ -51,7 +51,20 @@ describe('thanks.js', function () {
                     <li><a id="thanks-download-button-ios" href="https://itunes.apple.com/us/app/firefox-private-safe-browser/id989804926" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">Firefox for iOS</a></li>
                 </ul>`;
 
+            const fullInstallerButton = `<ul class="download-list">
+                    <li><a id="thanks-full-installer-win64" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win64&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-win64-msi" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&amp;os=win64&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-win64-aarch64" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win64-aarch64&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-win" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-win-msi" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&amp;os=win&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-osx" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-linux64" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US">Download Firefox</a></li>
+                    <li><a id="thanks-full-installer-linux" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US">Download Firefox</a></li>
+
+                </ul>`;
+
             document.body.insertAdjacentHTML('beforeend', button);
+            document.body.insertAdjacentHTML('beforeend', fullInstallerButton);
         });
 
         afterEach(function () {
@@ -67,6 +80,17 @@ describe('thanks.js', function () {
             const result = Mozilla.DownloadThanks.getDownloadURL(site);
             expect(result).toEqual(
                 'https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US'
+            );
+        });
+
+        it('should return the full installer download for Windows 7', function () {
+            const site = {
+                platform: 'windows',
+                platformVersion: '6.1'
+            };
+            const result = Mozilla.DownloadThanks.getDownloadURL(site);
+            expect(result).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US'
             );
         });
 


### PR DESCRIPTION
## One-line summary

Serve the full Firefox installer to users on Windows 7 when hitting `/firefox/download/thanks/`.

## Significant changes and points to review

This is only a temporary measure whilst they fix an issue with the stub installer, so I tried to make the change as low effort as possible so we can roll out a fix quickly. I've added tests for the new condition, but some manual testing on a Windows 7 VM (e.g. using Browser Stack) would be helpful to verify that the change works as expected.

## Issue / Bugzilla link

#11606

## Checklist

If relevant:

- [x] Tests added

## Testing

Test using a Windows 7 VM (I used browserstack.com for dev):

URLs:
- http://localhost:8000/en-US/firefox/new/
- http://localhost:8000/en-US/firefox/download/thanks/
- http://localhost:8000/en-US/firefox/download/thanks/?xv=basic
- http://localhost:8000/en-US/firefox/download/thanks/?s=direct
- http://localhost:8000/en-US/firefox/download/thanks/?s=direct&xv=basic

To test this work:

- [x] Windows 7 users should be redirected to `https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US`.
- [x] Non-Windows 7 users should be redirected to `https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US`
