### PR TITLE
Add ftl file for pocket contact-info (fixes #11598)

### DIFF
--- a/bedrock/pocket/templates/pocket/contact-info.html
+++ b/bedrock/pocket/templates/pocket/contact-info.html
@@ -6,7 +6,7 @@
 
 {% extends "pocket/base.html" %}
 
-{% block page_title %}Contact Info{% endblock %}
+{% block page_title %}{{ ftl('contact-info') }}{% endblock %}
 
 {% block pocket_css %}
  {{ css_bundle('pocket-contact-info') }}
@@ -15,35 +15,35 @@
 {% block content %}
 {% include 'pocket/includes/nav.html' %}
 <section class="mzp-l-content mzp-t-content-xl">
-    <h1 class="contact-info-header">Contact info</h1>
+    <h1 class="contact-info-header">{{ ftl('contact-info') }}</h1>
 
-    <h2 class="contact-info-subheader">Support</h2>
-    <p class="contact-info-body-text">To get help with Pocket or to request features, please visit our <a href="http://help.getpocket.com">support page</a>.</p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-support') }}</h2>
+    <p class="contact-info-body-text">{{ ftl('contact-to-get-help', help='http://help.getpocket.com') }}</p>
 
-    <h2 class="contact-info-subheader">Press</h2>
-    <p class="contact-info-body-text">For press inquiries or media assets, please visit our <a href="https://getpocket.com/press">press page</a>.</p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-press') }}</h2>
+    <p class="contact-info-body-text">{{ ftl('contact-for-press-inquiries', press='https://getpocket.com/press') }}</p>
 
-    <h2 class="contact-info-subheader">Sponsorships/Business</h2>
-    <p class="contact-info-body-text">For questions related to business, please contact us at <a href="mailto:business@getpocket.com">business@getpocket.com</a>.</p>
-    <p class="contact-info-body-text">For questions related to sponsorships, please contact us at <a href="mailto:sponsor@getpocket.com">sponsor@getpocket.com</a>.</p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-sponsorships-business') }}</h2>
+    <p class="contact-info-body-text">{{ ftl('contact-related-to-business', business_email_link='mailto:business@getpocket.com', business_email='business@getpocket.com') }}</p>
+    <p class="contact-info-body-text">{{ ftl('contact-related-to-sponsorships', sponsor_email_link='mailto:sponsor@getpocket.com', sponsor_email='sponsor@getpocket.com') }}</p>
 
-    <h2 class="contact-info-subheader">API</h2>
-    <p class="contact-info-body-text">For questions, problems, and suggestions regarding our API, please contact us at <a href="mailto:api@getpocket.com">api@getpocket.com</a>.</p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-api') }}</h2>
+    <p class="contact-info-body-text">{{ ftl('contact-regarding-api', api_email_link='mailto:api@getpocket.com', api_email='api@getpocket.com') }}</p>
 
-    <h2 class="contact-info-subheader">Jobs</h2>
-    <p class="contact-info-body-text">To view all open positions at Pocket, please visit our <a href="https://getpocket.com/jobs">Jobs Page</a>.</p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-jobs') }}</h2>
+    <p class="contact-info-body-text">{{ ftl('contact-view-job-page', jobs=url('pocket.jobs')) }}</p>
 
-    <h2 class="contact-info-subheader">Security</h2>
-    <p class="contact-info-body-text">If you believe you have discovered a security vulnerability in Pocket, please follow Mozilla’s bug reporting process documented on <a href="https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/">Mozilla’s Security page</a>.</p>
-    <p class="contact-info-body-text">For questions related to security, please contact us at <a href="mailto:security@getpocket.com">security@getpocket.com</a>.</p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-security') }}</h2>
+    <p class="contact-info-body-text">{{ ftl('contact-report-security-vulnerability', security_bug='https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/') }}</p>
+    <p class="contact-info-body-text">{{ ftl('contact-related-to-security', security_email_link='mailto:security@getpocket.com', security_email='security@getpocket.com') }}</p>
 
-    <h2 class="contact-info-subheader">Follow Us</h2>
-    <p class="contact-info-body-text"><a href="https://blog.getpocket.com/">Pocket Blog</a></p>
-    <p class="contact-info-body-text">Twitter (<a href="https://twitter.com/pocket">@pocket</a>, <a href="https://twitter.com/pocketsupport">@pocketsupport</a>)</p>
-    <p class="contact-info-body-text"><a href="https://www.facebook.com/getpocket">Facebook</a></p>
-    <p class="contact-info-body-text"><a href="https://www.instagram.com/pocket/">Instagram</a></p>
+    <h2 class="contact-info-subheader">{{ ftl('contact-follow-us') }}</h2>
+    <p class="contact-info-body-text"><a href="https://blog.getpocket.com/">{{ ftl('contact-blog') }}</a></p>
+    <p class="contact-info-body-text">{{ ftl('contact-twitter', twitter_main='@pocket', twitter_main_link='https://twitter.com/pocket', twitter_support='@pocketsupport', twitter_support_link='https://twitter.com/pocketsupport') }}</p>
+    <p class="contact-info-body-text"><a href="https://www.facebook.com/getpocket">{{ ftl('contact-facebook') }}</a></p>
+    <p class="contact-info-body-text"><a href="https://www.instagram.com/pocket/">{{ ftl('contact-instagram') }}</a></p>
 
-    <h2 class="contact-info-subheader">Pocket HQ</h2>
+    <h2 class="contact-info-subheader">{{ ftl('contact-hq') }}</h2>
     <address class="contact-info-body-text address">
         Mozilla Corporation/Pocket Business Unit <br/>
         2 Harrison Street, Suite 175 <br/>

--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -51,11 +51,7 @@ urlpatterns = (
         "pocket/welcome.html",
         url_name="pocket.welcome",
     ),
-    page(
-        "contact-info/",
-        "pocket/contact-info.html",
-        url_name="pocket.contact-info",
-    ),
+    page("contact-info/", "pocket/contact-info.html", url_name="pocket.contact-info", ftl_files=["pocket/contact-info"]),
     page(
         "firefox/new_tab_learn_more/",
         "pocket/firefox/new-tab-learn-more.html",

--- a/l10n-pocket/en/brands.ftl
+++ b/l10n-pocket/en/brands.ftl
@@ -23,6 +23,7 @@
 
 -brand-name-twitter = Twitter
 -brand-name-facebook = Facebook
+-brand-name-instagram = Instagram
 -brand-name-google-play = Google Play
 -brand-name-apple-app-store = Apple App Store
 

--- a/l10n-pocket/en/pocket/contact-info.ftl
+++ b/l10n-pocket/en/pocket/contact-info.ftl
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+## Contact info URL: https://dev.tekcopteg.com/contact-info/
+
+
+contact-info = Contact Info
+contact-support = Support
+# Variables:
+#   $help (url) link to http://help.getpocket.com
+contact-to-get-help = To get help with { -brand-name-pocket } or to request features, please visit our <a href="{$help}">support page</a>.
+contact-press = Press
+# Variables:
+#   $press (url) link to https://getpocket.com/press
+contact-for-press-inquiries = For press inquiries or media assets, please visit our <a href="{$press}">press page</a>.
+contact-sponsorships-business = Sponsorships/Business
+# Variables:
+#   $business_email_link (email link) mailto:business@getpocket.com
+#   $business_email (string) business@getpocket.com
+contact-related-to-business = For questions related to business, please contact us at <a href="{$business_email_link}">{$business_email}</a>.
+# Variables:
+#   $sponsor_email_link (email link) mailto:sponsor@getpocket.com
+#   $sponsor_email (string) sponsor@getpocket.com
+contact-related-to-sponsorships = For questions related to sponsorships, please contact us at <a href="{$sponsor_email_link}">{$sponsor_email}</a>.
+# API = Application Programming Interface
+contact-api = API
+# Variables:
+#   $api_email_link (email link) mailto:api@getpocket.com
+#   $api_email (string) sponsor@getpocket.com
+contact-regarding-api = For questions, problems, and suggestions regarding our API, please contact us at <a href="{$api_email_link}">{$api_email}</a>.
+contact-jobs = Jobs
+# Variables:
+#   $jobs (url) link to https://getpocket.com/jobs
+contact-view-job-page = To view all open positions at { -brand-name-pocket }, please visit our <a href="{$jobs}">Jobs Page</a>.
+contact-security = Security
+# Variables:
+#   $security_bug (url) link to https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/
+contact-report-security-vulnerability = If you believe you have discovered a security vulnerability in { -brand-name-pocket }, please follow Mozilla’s bug reporting process documented on <a href="{$security_bug}">Mozilla’s Security page</a>.
+# Variables:
+#   $security_email_link (email link) mailto:security@getpocket.com
+#   $security_email (string) security@getpocket.com
+contact-related-to-security = For questions related to security, please contact us at <a href="{$security_email_link}">{$security_email}</a>.
+contact-follow-us = Follow Us
+contact-blog = { -brand-name-pocket } Blog
+# Variables:
+#   $twitter_main (string) Pocket twitter handle
+#   $twitter_main_link (url) link to https://twitter.com/pocket
+#   $twitter_support (string) Pocket support twitter handle
+#   $twitter_support_link (url) link to https://twitter.com/pocketsupport
+contact-twitter = { -brand-name-twitter } (<a href="{$twitter_main_link}">{$twitter_main}</a>, <a href="{$twitter_support_link}">{$twitter_support}</a>)
+contact-facebook = { -brand-name-facebook }
+contact-instagram = { -brand-name-instagram }
+# HQ = Headquarters
+contact-hq = { -brand-name-pocket } HQ


### PR DESCRIPTION
## One-line summary

Use Fluent with Pocket contact-info page

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11598

## Testing

To test this work:
http://localhost:8000/en-US/contact-info/

- [x] Page should look the same as `main` version
- [x] Variables are correctly implemented and have expected values on page
- [x] Brand names are used where appropriate
