### PR TITLE
11611 fix pocket mode 500s

### DIFF
--- a/bedrock/pocket/templates/pocket/404.html
+++ b/bedrock/pocket/templates/pocket/404.html
@@ -7,5 +7,5 @@
 {% extends "pocket/base.html" %}
 
 {% block content %}
-  <h1>Pocket 404 test</h1>
+  <h1>Page not found</h1>
 {% endblock  %}

--- a/bedrock/pocket/templates/pocket/404.html
+++ b/bedrock/pocket/templates/pocket/404.html
@@ -1,0 +1,11 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "pocket/base.html" %}
+
+{% block content %}
+  <h1>Pocket 404 test</h1>
+{% endblock  %}

--- a/bedrock/pocket/templates/pocket/500.html
+++ b/bedrock/pocket/templates/pocket/500.html
@@ -7,5 +7,5 @@
  {% extends "pocket/base.html" %}
 
  {% block content %}
-   <h1>Pocket 500 test</h1>
+   <h1>Server Error</h1>
  {% endblock  %}

--- a/bedrock/pocket/templates/pocket/500.html
+++ b/bedrock/pocket/templates/pocket/500.html
@@ -1,0 +1,11 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+ {% extends "pocket/base.html" %}
+
+ {% block content %}
+   <h1>Pocket 500 test</h1>
+ {% endblock  %}

--- a/bedrock/pocket/views.py
+++ b/bedrock/pocket/views.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from lib import l10n_utils
+
+
+def server_error_view(request, template_name="pocket/500.html"):
+    """500 error handler that runs context processors."""
+    return l10n_utils.render(request, template_name, ftl_files=["500"], status=500)
+
+
+def page_not_found_view(request, exception=None, template_name="pocket/404.html"):
+    """404 error handler that runs context processors."""
+    return l10n_utils.render(request, template_name, ftl_files=["404", "500"], status=404)

--- a/bedrock/urls/pocket_mode.py
+++ b/bedrock/urls/pocket_mode.py
@@ -12,8 +12,8 @@ from bedrock.base import views as base_views
 
 # The default django 404 and 500 handler doesn't run the ContextProcessors,
 # which breaks the base template page. So we replace them with views that do!
-handler500 = "bedrock.base.views.server_error_view"
-handler404 = "bedrock.base.views.page_not_found_view"
+handler500 = "bedrock.pocket.views.server_error_view"
+handler404 = "bedrock.pocket.views.page_not_found_view"
 
 
 urlpatterns = (


### PR DESCRIPTION
## One-line summary

This changeset fixes 500s we're seeing for Pocket-Dev when spiders/bots/whatever hit URLs that would normally 404. It does this by quickly adding minimal 404 and 500 templates (pinched from @maureenlholland's WIP branch for proper error pages)

## Significant changes and points to review

Without this changeset, Pocket-Dev tries to render the default Mozorg 404 page, which tries to reverse `mozorg.home`, fails hard and then tries to render the 500 page, which tries to reverse `mozorg.home` and fails harder.

The templates added are super low-fi, but will do the job of reducing Sentry noise for now. As @pmac mentioned, we may not need them in production, but they are useful for now.

Snaps to @maureenlholland, whose branch I stole most of this 😄 

## Issue / Bugzilla link

Resolves #11611

## Screenshots

<img width="1440" alt="Screenshot 2022-05-11 at 17 29 58" src="https://user-images.githubusercontent.com/101457/167901303-02ac0316-c3b5-47cd-9c68-b87404d60efd.png">


## Testing

Demo server URL: (or None)

To test this work:

- set DEBUG=False in your .env
- ./manage.py collectstatic
- npm run in-pocket-mode
- Visit a URL which will 404 - eg http://localhost:8080/en/asdasdad - and confirm it does not 500 but shows the super-light 404 page.
