### PR TITLE
Convert save-to-pocket to use FTL strings (fixes #11623)

### DIFF
--- a/bedrock/pocket/templates/pocket/includes/pocket-premium.html
+++ b/bedrock/pocket/templates/pocket/includes/pocket-premium.html
@@ -5,12 +5,12 @@
 #}
 
 <div class="pocket-premium">
-  <a href="https://getpocket.com/premium" target="_blank" rel="external noopener">
+  <a href="https://getpocket.com/premium">
     <div class="pocket-premium-wrapper">
       <div class="premium-diamond">
         <img src="{{ static('img/pocket/colorful-diamond.gif') }}" alt="">
       </div>
-      <p>Ready for the ultimate Pocket experience? Get <span>Pocket Premium</span> and you’ll have access to our full array of features, including a personal, backed-up copy of everything you save.</p>
+      <p>{{ ftl('pocket-premium-ready-for') }}</p>
     </div>
   </a>
 </div>

--- a/bedrock/pocket/templates/pocket/save-to-pocket.html
+++ b/bedrock/pocket/templates/pocket/save-to-pocket.html
@@ -13,7 +13,9 @@
   {{ css_bundle('pocket-features') }}
 {% endblock  %}
 
-{% block page_title %}Save to Pocket{% endblock %}
+{{ ftl('pocket-save-') }}
+
+{% block page_title %}{{ ftl('pocket-save-save-to-pocket') }}{% endblock %}
 
 {% block content %}
 
@@ -25,11 +27,11 @@
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/save-inspirations.png',
   )%}
-  <h1 class="section-heading">Build a home for everything that interests you with Pocket.</h1>
-  <p class="section-lede">Use Pocket to save anything that sparks your curiosity and enjoy it when you’re ready to focus. In no time your list will become a personal library filled with enticing content to inform, inspire, and fuel you.</p>
+  <h1 class="section-heading">{{ ftl('pocket-save-build') }}</h1>
+  <p class="section-lede">{{ ftl('pocket-save-use-pocket') }}</p>
   <div class="section-ctas">
-    <a href="https://getpocket.com/signup" role="button" class="red-cta">Get started</a>
-    <a href="https://getpocket.com/login" class="secondary-cta">Already have an account? Log in</a>
+    <a href="https://getpocket.com/signup" role="button" class="red-cta">{{ ftl('pocket-save-get-started') }}</a>
+    <a href="https://getpocket.com/login" class="secondary-cta">{{ ftl('pocket-save-already-have') }}</a>
   </div>
   {% endcall %}
 </section>
@@ -42,9 +44,9 @@
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/save-button-doodle.svg',
   )%}
-  <h2 class="sub-section-heading">Save from anywhere on the web</h2>
-  <p class="section-lede">Once you’ve signed up, add the <span class="pocket-logo-inline">Pocket Logo</span> button to your browser for the fastest and easiest way to save articles, videos, and links to your personal library.</p>
-  <a href="https://getpocket.com/signup" class="green-line-cta">Start saving content</a>
+  <h2 class="sub-section-heading">{{ ftl('pocket-save-save-from-anywhere') }}</h2>
+  <p class="section-lede">{{ ftl('pocket-save-once-you', span_css_class_name='pocket-logo-inline') }}</p>
+  <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-save-start-saving') }}</a>
   {% endcall %}
 </section>
 
@@ -54,9 +56,9 @@
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/reading-nook.png',
   )%}
-  <h2 class="sub-section-heading">Absorb content in a quiet space</h2>
-  <p class="section-lede">Away from flashing banners and internet pop-ups, you’ll be able to read, watch, or listen to everything you’ve collected.</p>
-  <a href="https://getpocket.com/signup" class="green-line-cta">Create your quiet space</a>
+  <h2 class="sub-section-heading">{{ ftl('pocket-save-absorb-content') }}</h2>
+  <p class="section-lede">{{ ftl('pocket-save-away-from') }}</p>
+  <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-save-create-your') }}</a>
   {% endcall %}
 </section>
 
@@ -66,25 +68,25 @@
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/focused-reading.png',
   )%}
-  <h2 class="sub-section-heading">Customize your experience</h2>
+  <h2 class="sub-section-heading">{{ ftl('pocket-save-customize-your') }}</h2>
   <ul class="section-lede">
-    <li>Tailor text sizes, font styles, or viewing mode for focused reading.</li>
-    <li>Categorize saves with tags, and mark key passages with highlights.</li>
-    <li>Listen to articles on the Pocket app with our audio playback option.</li>
+    <li>{{ ftl('pocket-save-tailor-text') }}</li>
+    <li>{{ ftl('pocket-save-categorize-saves') }}</li>
+    <li>{{ ftl('pocket-save-listen-to') }}</li>
   </ul>
-  <a href="https://getpocket.com/signup" class="green-line-cta">Get started with Pocket</a>
+  <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-save-get-started-with') }}</a>
   {% endcall %}
 </section>
 
 <section class="personal-library">
   <h2 class="section-heading">
-    Start building your personal library now
+    {{ ftl('pocket-save-start-building') }}
   </h2>
   <div class="library-ctas">
     <div>
-      <a href="https://getpocket.com/signup" role="button" class="red-cta">Get started</a>
+      <a href="https://getpocket.com/signup" role="button" class="red-cta">{{ ftl('pocket-save-get-started') }}</a>
     </div>
-    <a href="https://getpocket.com/explore" class="black-white-cta login-cta" role="button">Log in</a>
+    <a href="https://getpocket.com/explore" class="black-white-cta login-cta" role="button">{{ ftl('pocket-save-log-in') }}</a>
   </div>
   </section>
 

--- a/bedrock/pocket/templates/pocket/save-to-pocket.html
+++ b/bedrock/pocket/templates/pocket/save-to-pocket.html
@@ -13,7 +13,6 @@
   {{ css_bundle('pocket-features') }}
 {% endblock  %}
 
-{{ ftl('pocket-save-') }}
 
 {% block page_title %}{{ ftl('pocket-save-save-to-pocket') }}{% endblock %}
 
@@ -30,7 +29,7 @@
   <h1 class="section-heading">{{ ftl('pocket-save-build') }}</h1>
   <p class="section-lede">{{ ftl('pocket-save-use-pocket') }}</p>
   <div class="section-ctas">
-    <a href="https://getpocket.com/signup" role="button" class="red-cta">{{ ftl('pocket-save-get-started') }}</a>
+    <a href="https://getpocket.com/signup" class="red-cta">{{ ftl('pocket-save-get-started') }}</a>
     <a href="https://getpocket.com/login" class="secondary-cta">{{ ftl('pocket-save-already-have') }}</a>
   </div>
   {% endcall %}
@@ -84,9 +83,9 @@
   </h2>
   <div class="library-ctas">
     <div>
-      <a href="https://getpocket.com/signup" role="button" class="red-cta">{{ ftl('pocket-save-get-started') }}</a>
+      <a href="https://getpocket.com/signup" class="red-cta">{{ ftl('pocket-save-get-started') }}</a>
     </div>
-    <a href="https://getpocket.com/explore" class="black-white-cta login-cta" role="button">{{ ftl('pocket-save-log-in') }}</a>
+    <a href="https://getpocket.com/explore" class="black-white-cta login-cta">{{ ftl('pocket-save-log-in') }}</a>
   </div>
   </section>
 

--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -98,6 +98,6 @@ urlpatterns = (
         "save-to-pocket/",
         "pocket/save-to-pocket.html",
         url_name="pocket.save-to-pocket",
-        ftl_files=["pocket/save-to-pocket"],
+        ftl_files=["pocket/save-to-pocket", "pocket/banners/pocket-premium"],
     ),
 )

--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -58,7 +58,12 @@ urlpatterns = (
         url_name="pocket.welcome",
         ftl_files=["pocket/platforms"],
     ),
-    page("contact-info/", "pocket/contact-info.html", url_name="pocket.contact-info", ftl_files=["pocket/contact-info"]),
+    page(
+        "contact-info/",
+        "pocket/contact-info.html",
+        url_name="pocket.contact-info",
+        ftl_files=["pocket/contact-info"],
+    ),
     page(
         "firefox/new_tab_learn_more/",
         "pocket/firefox/new-tab-learn-more.html",
@@ -93,5 +98,6 @@ urlpatterns = (
         "save-to-pocket/",
         "pocket/save-to-pocket.html",
         url_name="pocket.save-to-pocket",
+        ftl_files=["pocket/save-to-pocket"],
     ),
 )

--- a/l10n-pocket/en/pocket/banners/pocket-premium.ftl
+++ b/l10n-pocket/en/pocket/banners/pocket-premium.ftl
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+pocket-premium-ready-for = Ready for the ultimate { -brand-name-pocket } experience? Get <span>{ -brand-name-pocket-premium }</span> and you’ll have access to our full array of features, including a personal, backed-up copy of everything you save.

--- a/l10n-pocket/en/pocket/save-to-pocket.ftl
+++ b/l10n-pocket/en/pocket/save-to-pocket.ftl
@@ -28,6 +28,3 @@ pocket-save-get-started-with = Get started with { -brand-name-pocket }
 
 pocket-save-start-building = Start building your personal library now
 pocket-save-log-in = Log in
-
-
-

--- a/l10n-pocket/en/pocket/save-to-pocket.ftl
+++ b/l10n-pocket/en/pocket/save-to-pocket.ftl
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+## Save to pocket URL: https://dev.tekcopteg.com/save-to-pocket/
+
+pocket-save-save-to-pocket = Save to { -brand-name-pocket }
+pocket-save-build = Build a home for everything that interests you with { -brand-name-pocket }
+pocket-save-use-pocket = Use { -brand-name-pocket } to save anything that sparks your curiosity and enjoy it when you’re ready to focus. In no time your list will become a personal library filled with enticing content to inform, inspire, and fuel you.
+pocket-save-get-started = Get started
+pocket-save-already-have = Already have an account? Log in
+pocket-save-save-from-anywhere = Save from anywhere on the web
+# Variables:
+#   $span_css_class_name (string) pocket-logo-inline
+#   The text inside of the span will be the alt text for the pocket logo
+pocket-save-once-you = Once you’ve signed up, add the <span class="{ $span_css_class_name }">{ -brand-name-pocket} Logo</span> button to your browser for the fastest and easiest way to save articles, videos, and links to your personal library.
+pocket-save-start-saving = Start saving content
+
+pocket-save-absorb-content = Absorb content in a quiet space
+pocket-save-away-from = Away from flashing banners and internet pop-ups, you’ll be able to read, watch, or listen to everything you’ve collected.
+pocket-save-create-your = Create your quiet space
+
+pocket-save-customize-your = Customize your experience
+pocket-save-tailor-text = Tailor text sizes, font styles, or viewing mode for focused reading.
+pocket-save-categorize-saves = Categorize saves with tags, and mark key passages with highlights.
+pocket-save-listen-to = Listen to articles on the { -brand-name-pocket } app with our audio playback option.
+pocket-save-get-started-with = Get started with { -brand-name-pocket }
+
+pocket-save-start-building = Start building your personal library now
+pocket-save-log-in = Log in
+
+
+


### PR DESCRIPTION
## One-line summary
Convert save-to-pocket to use FTL strings (fixes #11623)
## Testing
- run in pocket mode
- navigate to https://localhost:8000/save-to-pocket and compare to [dev server](https://dev.tekcopteg.com/en/save-to-pocket/)