### PR TITLE
Add missing protocol-call-out bundle to /thanks/ page (Fixes #11608)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -14,6 +14,7 @@
 
 {% block extrahead %}
   {{ super() }}
+  {{ css_bundle('protocol-call-out') }}
   {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox_new_thanks') }}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Adds missing CSS bundle to fix page headline styling.

## Issue / Bugzilla link

#11608

## Screenshots

![image](https://user-images.githubusercontent.com/400117/168280070-56e21ce5-51eb-4a44-add9-d64e64f2700e.png)

## Testing

http://localhost:8000/en-US/firefox/download/thanks/?xv=basic