### PR TITLE
Update billboard macro to make link optional (Fixes #11569)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -8,7 +8,7 @@
 
 
 {# Billboard: https://protocol.mozilla.org/patterns/organisms/billboard.html #}
-{% macro billboard(title, ga_title, desc, link_cta, link_url, image_url, include_highres_image=False, reverse=False, heading_level=2, loading=None) -%}
+{% macro billboard(title, ga_title, desc, image_url, link_cta=None, link_url=None, include_highres_image=False, reverse=False, heading_level=2, loading=None) -%}
 <section class="mzp-c-billboard {% if reverse %}mzp-l-billboard-left{% else %}mzp-l-billboard-right{% endif %}">
   <div class="mzp-c-billboard-image-container">
     {{ image(
@@ -27,7 +27,9 @@
       <div class="mzp-c-billboard-content-inner">
         <h{{ heading_level }} class="mzp-c-billboard-title">{{ title }}</h{{ heading_level }}>
         <p class="mzp-c-billboard-desc">{{ desc }}</p>
-        <a class="mzp-c-cta-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link">{{ link_cta }}</a>
+        {% if link_url and link_cta %}
+          <a class="mzp-c-cta-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link">{{ link_cta }}</a>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## One-line summary

Fixes a rendering bug on the home page by making `link_url` and `link_cta` optional macro params.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11569

## Testing

http://localhost:8000/es-ES/
