### PR TITLE
Get Pocket-mode integration tests working again

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ markers =
     skip_if_internet_explorer
     skip_if_not_firefox
     smoke
+    pocket_mode
 
 
 [tool:paul-mclendahand]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.sqlite3.base import BaseDatabaseWrapper as SQLiteWrapper
 
 import pytest
+
+from bedrock.base.config_manager import config
 
 
 # pytest-django is currently broken by attempting to set the read only
@@ -22,3 +25,11 @@ SQLiteWrapper.allow_thread_sharing = property(SQLiteWrapper.allow_thread_sharing
 @pytest.fixture(scope="session")
 def base_url(base_url, request):
     return base_url or request.getfixturevalue("live_server").url
+
+
+@pytest.fixture(scope="session")
+def pocket_base_url(request):
+    base_url = config("BASE_POCKET_URL", parser=str, default="")
+    if not base_url:
+        raise ImproperlyConfigured("No BASE_POCKET_URL detected in env vars")
+    return base_url

--- a/tests/functional/pocket/test_navigation.py
+++ b/tests/functional/pocket/test_navigation.py
@@ -7,11 +7,12 @@ from selenium.webdriver.common.by import By
 
 from pages.pocket.about import AboutPage
 
+pytestmark = pytest.mark.pocket_mode
 
-@pytest.mark.skip(reason="Disabled until we have a Pocket-mode server to test against - see #11509")
+
 @pytest.mark.nondestructive
-def test_mobile_menu(base_url, selenium_mobile):
-    page = AboutPage(selenium_mobile, base_url).open()
+def test_mobile_menu(pocket_base_url, selenium_mobile):
+    page = AboutPage(selenium_mobile, pocket_base_url).open()
     assert page.navigation.is_mobile_menu_open_button_displayed
     page.navigation.open_mobile_menu()
     assert page.navigation.is_mobile_menu_home_link_displayed
@@ -23,17 +24,16 @@ def test_mobile_menu(base_url, selenium_mobile):
     assert not page.navigation.is_mobile_menu_my_list_link_displayed
 
 
-@pytest.mark.skip(reason="Disabled until we have a Pocket-mode server to test against - see #11509")
-def test_accessible_mobile_menu_open_name(base_url, selenium_mobile):
-    page = AboutPage(selenium_mobile, base_url).open()
+def test_accessible_mobile_menu_open_name(pocket_base_url, selenium_mobile):
+
+    page = AboutPage(selenium_mobile, pocket_base_url).open()
     button_label_reference = page.navigation.mobile_menu_open_button.get_attribute("aria-labelledby")
     string = page.navigation.mobile_menu_open_button.find_element(By.ID, button_label_reference).text
     assert len(string) > 0
 
 
-@pytest.mark.skip(reason="Disabled until we have a Pocket-mode server to test against - see #11509")
-def test_accessible_mobile_menu_close_name(base_url, selenium_mobile):
-    page = AboutPage(selenium_mobile, base_url).open()
+def test_accessible_mobile_menu_close_name(pocket_base_url, selenium_mobile):
+    page = AboutPage(selenium_mobile, pocket_base_url).open()
     page.navigation.open_mobile_menu()
     string = page.navigation.mobile_menu_close_button.text
     assert len(string) > 0

--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -12,8 +12,8 @@ class BaseRegion(Region):
 
 
 class BasePage(Page):
-    def __init__(self, selenium, base_url, locale="en-US", **url_kwargs):
-        super(BasePage, self).__init__(selenium, base_url, locale=locale, **url_kwargs)
+    def __init__(self, selenium, pocket_base_url, locale="en", **url_kwargs):
+        super(BasePage, self).__init__(selenium, pocket_base_url, locale=locale, **url_kwargs)
 
     def wait_for_page_to_load(self):
         self.wait.until(lambda s: self.seed_url in s.current_url)


### PR DESCRIPTION
## One-line summary

This changeset makes the integration tests for Pocket's About page, written by @maureenlholland, work again. They had to be skipped during the initial Pocket-mode work, because we didn't have Pocket-specific dev and test envs.

## Significant changes and points to review

This changeset unskips the Pocket About page tests and uses a new fixture
to provide a Pocket-specific base URL against which to test, drawn from the
env. 

This means we can run the Pocket integration tests at the same time
as the Mozorg/bedrock ones, and all will be run on the relevant test server.

Note that if BASE_POCKET_URL is not defined in the env, the relevant tests fail hard. This shouldn't be a blocker if tests are only run on dev and stage

A `pocket_mode` pytest mark has been added, too, but isn't relied upon at the
moment for anything.


## Issue / Bugzilla link

Resolves #11509


## Checklist

If relevant:

- [X] Tests re-enabled
- [X] Tested on integration-tests-branch

## Testing

- [ ] Look at https://gitlab.com/mozmeao/www-config/-/jobs/2453351841 and search for `tests/functional/pocket/test_navigation.py` to see the tests passing alongside all mozorg tests
-  Locally, if you have geckodriver installed, do `npm run in-pocket-mode` and then in a separate terminal run just the Pocket tests:   
  - [ ] `BASE_POCKET_URL=http://localhost:8080 py.test -m pocket_mode --driver Firefox --html tests/functional/results.html tests/functional/` -- this will pass
  - [ ] `py.test -m pocket_mode --driver Firefox --html tests/functional/results.html tests/functional/` -- this will fail with `django.core.exceptions.ImproperlyConfigured` because `BASE_POCKET_URL` is not defined 