### PR TITLE
Link to about:preferences in Nightly /whatsnew page (Fixes #11487)

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -48,7 +48,14 @@
 
       <p>{{ ftl('nightly-whatsnew-if-you-want-to', blog='https://blog.nightly.mozilla.org/', twitter='https://twitter.com/FirefoxNightly') }}</p>
 
-      <p>{{ ftl('nightly-whatsnew-want-to-know-which', mdn='https://developer.mozilla.org/Firefox/Experimental_features?utm_source=firefox&utm_medium=whatsnew&utm_campaign=nightly') }}</p>
+      <p>
+        {% if ftl_has_messages('nightly-whatsnew-want-to-know-which-v2') %}
+          {% set attrs = 'href="#" class="nightly-experiments-link"' %}
+          {{ ftl('nightly-whatsnew-want-to-know-which-v2', attrs=attrs) }}
+        {% else %}
+          {{ ftl('nightly-whatsnew-want-to-know-which', mdn='https://developer.mozilla.org/Firefox/Experimental_features?utm_source=firefox&utm_medium=whatsnew&utm_campaign=nightly') }}
+        {% endif %}
+        </p>
 
       <p>{{ ftl('nightly-whatsnew-do-you-experience', bugzilla='https://bugzilla.mozilla.org') }}</p>
 
@@ -60,6 +67,7 @@
 
 {% block js %}
   {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_nightly') }}
 {% endblock %}
 
 {# Exclude stub attribution for in-product pages: issus 9620 #}

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -25,6 +25,11 @@ nightly-whatsnew-this-is-a-good = This is a good time to thank you for helping u
 nightly-whatsnew-if-you-want-to = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a href="{ $blog }">blog</a> and following us on <a href="{ $twitter }">{ -brand-name-twitter }</a> are good starting points!
 
 # Variables:
+#   $attrs (string) - link href and additional attributes
+nightly-whatsnew-want-to-know-which-v2 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>Nightly Experiments</a> preferences page.
+
+# Obsolete
+# Variables:
 #   $mdn (url) - link to https://developer.mozilla.org/Firefox/Experimental_features
 nightly-whatsnew-want-to-know-which = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a href="{ $mdn }">Experimental Features</a> page on <abbr title="{ -brand-name-mozilla-developer-network }">{ -brand-name-mdn }</abbr>.
 

--- a/media/js/firefox/whatsnew/nightly.js
+++ b/media/js/firefox/whatsnew/nightly.js
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    // Link to `about:preferences#experimental` via UItour.
+    const experimentsLink = document.querySelector('.nightly-experiments-link');
+
+    if (experimentsLink) {
+        experimentsLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            window.Mozilla.UITour.openPreferences('experimental');
+        });
+    }
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1486,6 +1486,12 @@
     },
     {
       "files": [
+        "js/firefox/whatsnew/nightly.js"
+      ],
+      "name": "firefox_whatsnew_nightly"
+    },
+    {
+      "files": [
         "js/firefox/whatsnew/up-to-date.js",
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",


### PR DESCRIPTION
## One-line summary

Updates Nightly /whatsnew page to link to `about:preferences#experimental` via UITour.

## Issue / Bugzilla link

#11487

## Testing

http://localhost:8000/en-US/firefox/102.0a1/whatsnew/

To test this work:

Make sure you have UITour enabled for local dev: https://bedrock.readthedocs.io/en/latest/uitour.html#local-development

- [x] Clicking the `Nightly Experiments` link should open `about:preferences#experimental`.
