### PR TITLE
Replace Lockwise copy shown when trying to re-download Firefox (Fixes #10795)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -9,7 +9,6 @@
 {% extends "firefox/new/desktop/base.html" %}
 
 {% set show_firefox_join_modal = ftl_has_messages('firefox-desktop-download-youve-already-got-the-browser',
-                                                  'firefox-desktop-download-watch-for-hackers-with',
                                                   'firefox-desktop-download-just-download-the-browser',
                                                   'firefox-desktop-download-get-more-from-firefox') %}
 {% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-desktop' %}
@@ -502,7 +501,7 @@
 {% if show_firefox_join_modal and not manual_update %}
 <aside class="mzp-u-modal-content join-firefox-content hide-from-legacy-ie">
   <h4 class="join-firefox-title">{{ ftl('firefox-desktop-download-youve-already-got-the-browser') }}</h4>
-  <p class="join-firefox-intro">{{ ftl('firefox-desktop-download-watch-for-hackers-with') }}</p>
+  <p class="join-firefox-intro">{{ ftl('firefox-desktop-download-watch-for-hackers-with-v2', 'firefox-desktop-download-watch-for-hackers-with') }}</p>
 
   <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
 

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -155,7 +155,12 @@ firefox-desktop-download-questions = Questions? <a { $attrs }>{ -brand-name-mozi
 
 # The phrase “Now get even more from Firefox” is in specific reference to signing up for an account, which unlocks access to all our new products and services.
 firefox-desktop-download-youve-already-got-the-browser = You’ve already got the browser. Now get even more from { -brand-name-firefox }.
+
+firefox-desktop-download-watch-for-hackers-with-v2 = Watch for hackers with { -brand-name-firefox-monitor }, protect your email address with with { -brand-name-firefox-relay }, and more.
+
+# Outdated string
 firefox-desktop-download-watch-for-hackers-with = Watch for hackers with { -brand-name-firefox-monitor }, protect passwords with { -brand-name-firefox-lockwise }, and more.
+
 firefox-desktop-download-get-more-from-firefox = Get More From { -brand-name-firefox }
 firefox-desktop-download-just-download-the-browser = Just Download The Browser
 

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -156,7 +156,7 @@ firefox-desktop-download-questions = Questions? <a { $attrs }>{ -brand-name-mozi
 # The phrase “Now get even more from Firefox” is in specific reference to signing up for an account, which unlocks access to all our new products and services.
 firefox-desktop-download-youve-already-got-the-browser = You’ve already got the browser. Now get even more from { -brand-name-firefox }.
 
-firefox-desktop-download-watch-for-hackers-with-v2 = Watch for hackers with { -brand-name-firefox-monitor }, protect your email address with with { -brand-name-firefox-relay }, and more.
+firefox-desktop-download-watch-for-hackers-with-v2 = Watch for hackers with { -brand-name-firefox-monitor }, protect your email address with { -brand-name-firefox-relay }, and more.
 
 # Outdated string
 firefox-desktop-download-watch-for-hackers-with = Watch for hackers with { -brand-name-firefox-monitor }, protect passwords with { -brand-name-firefox-lockwise }, and more.


### PR DESCRIPTION
## One-line summary

Replaces outdated Lockwise copy on `/firefox/new/`.

## Issue / Bugzilla link

#10795

## Screenshots

<img src="https://user-images.githubusercontent.com/400117/168588945-6f3d8ae6-17f0-45d7-bd37-54fb88f759d8.png" alt="image" style="max-width: 100%;" width="400">

## Testing

http://localhost:8000/en-US/firefox/new/

To test this work:

- [ ] Using Firefox when signed out of a Firefox Account, Click "Download Firefox" and verify the new copy is displayed.
