### PR TITLE
Set bg color on Nightly /whatsnew page for rubber band scrolling (Fixes #10251)

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -16,6 +16,12 @@ $image-path: '/media/protocol/img';
     }
 }
 
+// set dark bg color for rubber band scrolling.
+html,
+body {
+    background-color: $color-ink-80;
+}
+
 .content-wrapper {
     background: $color-ink-80 url('/media/img/firefox/whatsnew/whatsnew_background.svg') no-repeat;
     @include background-size(100%);


### PR DESCRIPTION
## One-line summary

Quick bug fix to add a bg colour to the Nightly /whatsnew page for rubber and scrolling.

## Issue / Bugzilla link

#10251

## Testing

http://localhost:8000/en-US/firefox/101.0a1/whatsnew/

To test this work:

- [ ] Scrolling to the top / button of the page should no longer show a white background colour peeping through.
