### PR TITLE
Revert back to serving FF stub installer for Windows 7 (Fixes #11654)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -73,14 +73,6 @@
   <p class="mzp-l-content download-another-language-link">
     <a href="{{ firefox_url('desktop', 'all') }}">{{ ftl('firefox-new-download-in-another-language') }}</a>
   </p>
-
-  {# Temporary full installer links for Windows 7 see: https://github.com/mozilla/bedrock/issues/11606 #}
-  {{ download_firefox(
-    platform='desktop',
-    force_direct=true,
-    force_full_installer=true,
-    dom_id='thanks-full-installer')
-  }}
 </main>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -88,14 +88,6 @@
   <div class="c-support-lang">
     <a href="{{ firefox_url('desktop', 'all') }}">{{ ftl('firefox-desktop-download-in-another-language') }}</a>
   </div>
-
-  {# Temporary full installer links for Windows 7 see: https://github.com/mozilla/bedrock/issues/11606 #}
-  {{ download_firefox(
-    platform='desktop',
-    force_direct=true,
-    force_full_installer=true,
-    dom_id='thanks-full-installer')
-  }}
 </main>
 {% endblock %}
 

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -227,7 +227,7 @@ def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button
         "win",
         locale,
         force_direct=True,
-        force_full_installer=True,  # Temporarily force full installer for legacy IE https://github.com/mozilla/bedrock/issues/11606
+        force_full_installer=False,
         force_funnelcake=False,
         funnelcake_id=funnelcake_id,
     )

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -335,7 +335,7 @@ class TestDownloadThanksButton(TestCase):
         assert link.attr("data-link-type") == "download"
 
         # Direct attribute for legacy IE browsers should always be win 32bit
-        assert link.attr("data-direct-link") == "https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US"
+        assert link.attr("data-direct-link") == "https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US"
 
     def test_download_firefox_thanks_attributes(self):
         """

--- a/media/css/firefox/new/basic/thanks.scss
+++ b/media/css/firefox/new/basic/thanks.scss
@@ -9,8 +9,7 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 // Hide the /thanks download button as selection is made via JS automatically.
-#thanks-download-button,
-#thanks-full-installer {
+#thanks-download-button {
     display: none;
 }
 

--- a/media/css/firefox/new/desktop/thanks.scss
+++ b/media/css/firefox/new/desktop/thanks.scss
@@ -59,8 +59,7 @@ main {
 }
 
 // Hide the /thanks download button as selection is made via JS automatically.
-#thanks-download-button,
-#thanks-full-installer {
+#thanks-download-button {
     display: none;
 }
 

--- a/media/js/firefox/new/common/thanks.js
+++ b/media/js/firefox/new/common/thanks.js
@@ -41,19 +41,7 @@ if (typeof window.Mozilla === 'undefined') {
 
         switch (site.platform) {
             case 'windows':
-                /**
-                 * Temporarily serve Windows 7 users the full installer.
-                 * See: https://github.com/mozilla/bedrock/issues/11606
-                 */
-
-                var version = site.platformVersion
-                    ? parseFloat(site.platformVersion)
-                    : 0;
-                if (version === 6.1) {
-                    link = document.getElementById('thanks-full-installer-win');
-                } else {
-                    link = document.getElementById(prefix + 'win');
-                }
+                link = document.getElementById(prefix + 'win');
                 break;
             case 'osx':
                 link = document.getElementById(prefix + 'osx');

--- a/tests/unit/spec/firefox/new/common/thanks.js
+++ b/tests/unit/spec/firefox/new/common/thanks.js
@@ -51,20 +51,7 @@ describe('thanks.js', function () {
                     <li><a id="thanks-download-button-ios" href="https://itunes.apple.com/us/app/firefox-private-safe-browser/id989804926" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">Firefox for iOS</a></li>
                 </ul>`;
 
-            const fullInstallerButton = `<ul class="download-list">
-                    <li><a id="thanks-full-installer-win64" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win64&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-win64-msi" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&amp;os=win64&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-win64-aarch64" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win64-aarch64&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-win" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-win-msi" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&amp;os=win&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-osx" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=osx&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-linux64" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux64&amp;lang=en-US">Download Firefox</a></li>
-                    <li><a id="thanks-full-installer-linux" href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=linux&amp;lang=en-US">Download Firefox</a></li>
-
-                </ul>`;
-
             document.body.insertAdjacentHTML('beforeend', button);
-            document.body.insertAdjacentHTML('beforeend', fullInstallerButton);
         });
 
         afterEach(function () {
@@ -80,17 +67,6 @@ describe('thanks.js', function () {
             const result = Mozilla.DownloadThanks.getDownloadURL(site);
             expect(result).toEqual(
                 'https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US'
-            );
-        });
-
-        it('should return the full installer download for Windows 7', function () {
-            const site = {
-                platform: 'windows',
-                platformVersion: '6.1'
-            };
-            const result = Mozilla.DownloadThanks.getDownloadURL(site);
-            expect(result).toEqual(
-                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US'
             );
         });
 


### PR DESCRIPTION
## One-line summary

Reverts the changes made in https://github.com/mozilla/bedrock/pull/11609

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11654

## Testing

Window 7 should get served the stub installer:

- [ ] http://localhost:8000/en-US/firefox/new/
- [ ] http://localhost:8000/en-US/firefox/download/thanks/
- [ ] http://localhost:8000/en-US/firefox/download/thanks/?xv=basic
