### PR TITLE
Remove affiliate marketing cookie if aic id is unknown and there's no cjevent param (Fixes #11506)

### DIFF
--- a/media/js/products/vpn/affiliate-attribution.es6.js
+++ b/media/js/products/vpn/affiliate-attribution.es6.js
@@ -270,6 +270,18 @@ AffiliateAttribution.init = function () {
                             resolve();
                         })
                         .catch((e) => {
+                            /**
+                             * If PUT throws a 404 due to unknown aic id then the cookie
+                             * is no longer active in CJMS and has been archived. We can't
+                             * treat this as a new affiliate request since there is no
+                             * cjevent param, so instead we delete the existing marketing
+                             * cookie rather than throw an unhandled error.
+                             * See https://github.com/mozilla/bedrock/issues/11506
+                             */
+                            if (e === 'Unknown aicID') {
+                                AffiliateAttribution.removeMarketingCookie();
+                                resolve();
+                            }
                             reject(e);
                         });
                 }

--- a/tests/unit/spec/products/vpn/affiliate-attribution.js
+++ b/tests/unit/spec/products/vpn/affiliate-attribution.js
@@ -330,6 +330,61 @@ describe('affiliate-attribution.es6.js', function () {
                     );
                 });
             });
+
+            it('should delete marketing cookie if PUT fails with a 404 and there is no cjevent param', function () {
+                const mock404Response = new window.Response(
+                    JSON.stringify({}),
+                    {
+                        status: 404,
+                        headers: {
+                            'Content-type': 'application/json'
+                        }
+                    }
+                );
+
+                spyOn(
+                    AffiliateAttribution,
+                    'meetsRequirements'
+                ).and.returnValue(true);
+                spyOn(AffiliateAttribution, 'getCJEventParam').and.returnValue(
+                    false
+                );
+                spyOn(AffiliateAttribution, 'getCJMSEndpoint').and.returnValue(
+                    _endpoint
+                );
+                spyOn(
+                    AffiliateAttribution,
+                    'hasMarketingCookie'
+                ).and.returnValue(true);
+                spyOn(
+                    AffiliateAttribution,
+                    'getMarketingCookie'
+                ).and.returnValue(_cjmsCookieValue);
+                spyOn(AffiliateAttribution, 'removeMarketingCookie');
+                spyOn(FxaProductButton, 'init').and.resolveTo(_flowParamString);
+
+                spyOn(window, 'fetch').and.returnValue(
+                    window.Promise.resolve(mock404Response)
+                );
+
+                return AffiliateAttribution.init().then(() => {
+                    expect(window.fetch).toHaveBeenCalledTimes(1);
+                    expect(window.fetch).toHaveBeenCalledWith(
+                        'https://stage.cjms.nonprod.cloudops.mozgcp.net/aic/365fd94a-c507-43b3-b867-034f786d2cee',
+                        {
+                            method: 'PUT',
+                            headers: {
+                                Accept: 'application/json',
+                                'Content-Type': 'application/json'
+                            },
+                            body: '{"flow_id":"75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1"}'
+                        }
+                    );
+                    expect(
+                        AffiliateAttribution.removeMarketingCookie
+                    ).toHaveBeenCalled();
+                });
+            });
         });
     });
 


### PR DESCRIPTION
## One-line summary

Small edge case fix to avoid throwing an un-handled error when certain conditions are met:

1. Visitor has an existing affiliate marketing cookie set.
2. The ID for that cookie has since expired in the CJMS database.
3. Visitor returns to the page with no `cjevent` query parameter set. 

## Issue / Bugzilla link

#11506

## Checklist

If relevant:

- [x] Tests added

## Testing

http://localhost:8000/en-US/products/vpn/

The included tests should already cover this, but manual testing is not so easy as you need a cookie with an ID that's not in the database. The easiest way I could mock this was to manually create a cookie in the console using:

```javascript
Mozilla.Cookies.setItem(
    'moz-vpn-affiliate',
    'some-unique-to-you-test-value',
    new Date(Date.now() * 1000).toUTCString(),
    '/',
    null,
    false,
    'lax'
);
```

Then reload the page and you should be able to verify the following:

- [x] You should see a `PUT` fail with a 404 in the network tab.
- [x] The `moz-vpn-affiliate` you set above should be deleted.
