### PR TITLE
Add pocket 404 and 500 pages (fixes #11542)

### DIFF
--- a/bedrock/pocket/templates/pocket/404.html
+++ b/bedrock/pocket/templates/pocket/404.html
@@ -16,7 +16,7 @@
   {% include 'pocket/includes/platform-nav.html' %}
   <div class="mzp-l-content mzp-t-content-lg">
   <h1>{{ ftl('not-found-how-can-i-help') }}</h1>
-  <p>{{ ftl('not-found-the-link-you-followed', home='https://getpocket.com') }}</p>
+  <p>{{ ftl('not-found-the-link-you-followed', home=url('pocket.home')) }}</p>
   <p>{{ ftl('not-found-let-us-know', help='https://help.getpocket.com') }}</p>
 </div>
   {% include 'pocket/includes/platform-footer.html' %}

--- a/bedrock/pocket/templates/pocket/404.html
+++ b/bedrock/pocket/templates/pocket/404.html
@@ -6,6 +6,18 @@
 
 {% extends "pocket/base.html" %}
 
+{% block pocket_css %}
+  {{ css_bundle('pocket-error-page') }}
+{% endblock  %}
+
+{% block page_title %}{{ ftl('not-found-title') }}{% endblock page_title %}
+
 {% block content %}
-  <h1>Page not found</h1>
+  {% include 'pocket/includes/platform-nav.html' %}
+  <div class="mzp-l-content mzp-t-content-lg">
+  <h1>{{ ftl('not-found-how-can-i-help') }}</h1>
+  <p>{{ ftl('not-found-the-link-you-followed', home='https://getpocket.com') }}</p>
+  <p>{{ ftl('not-found-let-us-know', help='https://help.getpocket.com') }}</p>
+</div>
+  {% include 'pocket/includes/platform-footer.html' %}
 {% endblock  %}

--- a/bedrock/pocket/templates/pocket/500.html
+++ b/bedrock/pocket/templates/pocket/500.html
@@ -6,6 +6,17 @@
 
  {% extends "pocket/base.html" %}
 
+ {% block pocket_css %}
+   {{ css_bundle('pocket-error-page') }}
+ {% endblock  %}
+
+ {% block page_title %}{{ ftl('server-error-title') }}{% endblock page_title %}
+
  {% block content %}
-   <h1>Server Error</h1>
+   {% include 'pocket/includes/platform-nav.html' %}
+   <div class="mzp-l-content mzp-t-content-lg">
+    <h1>{{ ftl('server-error-title') }}</h1>
+    <p>{{ ftl('server-error-desc') }}</p>
+  </div>
+   {% include 'pocket/includes/platform-footer.html' %}
  {% endblock  %}

--- a/bedrock/pocket/templates/pocket/includes/platform-footer.html
+++ b/bedrock/pocket/templates/pocket/includes/platform-footer.html
@@ -26,6 +26,8 @@
                   class="svg-social twitter"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 28 28"
+                  width="28px"
+                  height="28px"
                 >
                   <title>Twitter</title>
                   <path
@@ -40,6 +42,8 @@
                   class="svg-social facebook"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 28 28"
+                  width="28px"
+                  height="28px"
                 >
                   <title>facebook</title>
                   <path

--- a/bedrock/pocket/views.py
+++ b/bedrock/pocket/views.py
@@ -7,9 +7,9 @@ from lib import l10n_utils
 
 def server_error_view(request, template_name="pocket/500.html"):
     """500 error handler that runs context processors."""
-    return l10n_utils.render(request, template_name, ftl_files=["500"], status=500)
+    return l10n_utils.render(request, template_name, ftl_files=["pocket/500"], status=500)
 
 
 def page_not_found_view(request, exception=None, template_name="pocket/404.html"):
     """404 error handler that runs context processors."""
-    return l10n_utils.render(request, template_name, ftl_files=["404", "500"], status=404)
+    return l10n_utils.render(request, template_name, ftl_files=["pocket/404"], status=404)

--- a/l10n-pocket/en/pocket/404.ftl
+++ b/l10n-pocket/en/pocket/404.ftl
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://dev.tekcopteg.com/404
+
+not-found-title = Page Not Found
+not-found-how-can-i-help = How Can I Help?
+# Variables:
+#   $home (url) link to http://getpocket.com
+not-found-the-link-you-followed = The link you followed here is no longer working. Would you like to start over at the <a href="{$home}">home page</a>?
+# Variables:
+#   $help (url) link to http://help.getpocket.com
+not-found-let-us-know = If you think there is a problem, <a href="{$help}">please let us know</a>.

--- a/l10n-pocket/en/pocket/500.ftl
+++ b/l10n-pocket/en/pocket/500.ftl
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://dev.tekcopteg.com/500
+
+server-error-title = Server Error
+server-error-desc = Something went wrong! Try refreshing or come back later.

--- a/media/css/pocket/components/error-page.scss
+++ b/media/css/pocket/components/error-page.scss
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import '../utils/variables';
+@import '../includes/platform-nav';
+@import '../includes/platform-footer';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/base/elements/containers';

--- a/media/css/pocket/components/error-page.scss
+++ b/media/css/pocket/components/error-page.scss
@@ -8,3 +8,15 @@
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
+
+a {
+    color: $color-action-primary;
+    text-decoration: underline;
+    transition: color 0.1s ease-out;
+
+    &:hover,
+    &:active,
+    &:focus {
+        color: $color-action-primary-hover;
+    }
+}

--- a/media/css/pocket/includes/_platform-footer.scss
+++ b/media/css/pocket/includes/_platform-footer.scss
@@ -103,13 +103,10 @@ $image-path: '/media/protocol/img';
                     display: block;
                     color: $color-text-primary;
                     width: 30px;
+                    height: 30px;
                     transition: color 100ms ease-in-out;
 
                     &.twitter {
-                        @media #{$mq-md} {
-                            // margin-right: $spacing-sm;
-                        }
-
                         &:hover,
                         &:focus,
                         &:active {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1087,6 +1087,13 @@
     },
     {
       "files": [
+        "css/pocket/style.scss",
+        "css/pocket/components/error-page.scss"
+      ],
+      "name": "pocket-error-page"
+    },
+    {
+      "files": [
         "css/careers/protocol.min.scss",
         "css/careers/protocol-extra.min.scss",
         "css/careers/careers.scss",


### PR DESCRIPTION
## One-line summary

Adds Pocket 500/404 translations and styling. The pages should be cleanly styled and easy to read, showing appropriate template depending on the error (500 = server error, 404 = page not found).

Note: the 404 is using existing Pocket copy but not the existing styles: https://getpocket.com/en/asg

⚠️ we might never see the 404 in production, but it doesn't hurt to have a backup

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11542

## Testing

To test this work:

http://localhost:8000/en/404/
http://localhost:8000/en/500/
