### PR TITLE
Fluent-size firefox/new_tab_learn_more

### DIFF
--- a/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
+++ b/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
@@ -84,8 +84,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       <p class="new-tab-section-body">{{ ftl('pocket-new-tab-its-easy', dismiss_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#turn-off') }}</p>
       <ul class="new-tab-helpful-links">
         <li><a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq">{{ ftl('pocket-new-tab-faq') }}</a></li>
-        <li><a href="https://getpocket.com/privacy">{{ ftl('pocket-new-tab-privacy-policy') }}</a></li>
-        <li><a href="https://getpocket.com/tos">{{ ftl('pocket-new-tab-tos') }}</a></li>
+        <li><a href="{{ url('pocket.privacy') }}">{{ ftl('pocket-new-tab-privacy-policy') }}</a></li>
+        <li><a href="{{ url('pocket.tos') }}">{{ ftl('pocket-new-tab-tos') }}</a></li>
         <li><a href="https://getpocket.com/sponsor">{{ ftl('pocket-new-tab-sponsorship') }}</a></li>
       </ul>
     </div>

--- a/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
+++ b/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
@@ -13,13 +13,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {{ css_bundle('pocket-new-tab') }}
 {% endblock %}
 
-{% block page_title %}Learn More{% endblock page_title %}
+{% block page_title %}{{ ftl('pocket-new-tab-learn-more') }}{% endblock page_title %}
 
 {% block content %}
 <header class="new-tab-header">
-  <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-family">Firefox</div>
-  <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket">Pocket</div>
-  <p>Pocket is part of the Firefox family</p>
+  <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-family">{{ ftl('pocket-new-tab-firefox') }}</div>
+  <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket">{{ ftl('pocket-new-tab-pocket') }}</div>
+  <p>{{ ftl('pocket-new-tab-pocket-is-part') }}</p>
 </header>
 <section>
   {% call split(
@@ -27,15 +27,15 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/new-tab/pocket-list.png',
   )%}
-    <p class="section-top-header-lede">POCKET FOR FIREFOX</p>
-    <h2 class="new-tab-section-header top">Build your personal library of fascinating reads.</h2>
-    <p class="new-tab-section-body top">Included inside Firefox, the <span class="pocket-logo-inline">Pocket Logo</span> button lets you save articles from across the web and read them in a quiet, private space.</p>
-     {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>Activate Pocket in Firefox', optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
-    <a href="https://getpocket.com/signup" class="sub-cta">More ways to sign up</a>
+    <span class="tagline">{{ ftl('pocket-new-tab-pocket-for-firefox') }}</span>
+    <h2 class="new-tab-section-header top">{{ ftl('pocket-new-tab-build-your-personal') }}</h2>
+    <p class="new-tab-section-body top">{{ ftl('pocket-new-tab-included-inside') }}</p>
+     {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-new-tab-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
+    <a href="https://getpocket.com/signup" class="sub-cta">{{ ftl('pocket-new-tab-more-ways-to') }}</a>
   {% endcall %}
 </section>
 <section class="new-tab-section">
-  <h1 class="new-tab-page-header mzp-l-content">Discover the most thought-provoking stories out there, curated by Pocket.</h1>
+  <h1 class="new-tab-page-header mzp-l-content">{{ ftl('pocket-new-tab-discover-the-most') }}</h1>
   <section
     class="mzp-c-split mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-t-split-nospace new-tab-section">
     <div class="mzp-c-split-container">
@@ -43,8 +43,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <img class="mzp-c-split-media-asset" src="/media/img/pocket/new-tab/hidden-gem.svg" alt="" loading="eager">
       </div>
       <div class="mzp-c-split-body hidden-gem-body">
-        <h2 class="new-tab-section-header">Finding the hidden gems. Respecting your privacy.</h2>
-        <p class="new-tab-section-body">As part of the Firefox family, Pocket surfaces the best articles out there—new perspectives, intriguing deep-dives, timeless classics—and we do this with the same dedication to privacy you’ve come to expect from Firefox and Mozilla. <a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why">Learn more about how we curate stories.</a></p>
+        <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-finding-the') }}</h2>
+        <p class="new-tab-section-body">{{ ftl('pocket-new-tab-as-part-of') }}</p>
       </div>
     </div>
   </section>

--- a/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
+++ b/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
@@ -44,7 +44,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       </div>
       <div class="mzp-c-split-body hidden-gem-body">
         <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-finding-the') }}</h2>
-        <p class="new-tab-section-body">{{ ftl('pocket-new-tab-as-part-of') }}</p>
+        <p class="new-tab-section-body">{{ ftl('pocket-new-tab-as-part-of', learn_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why') }}</p>
       </div>
     </div>
   </section>
@@ -53,8 +53,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/new-tab/fortress.svg',
   )%}
-    <h2 class="new-tab-section-header">Your data stays private. Always.</h2>
-    <p class="new-tab-section-body">In addition to dishing up captivating stories, we also show you relevant, highly-vetted content from select sponsors. Rest assured, your browsing data never leaves your personal copy of Firefox—we don’t see it, and our sponsors don’t either. Want more details? Here’s the full scoop on <a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#personalized">how privacy works in Pocket.</a></p>
+    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-your-data') }}</h2>
+    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-in-addition-to', privacy_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#personalized') }}</p>
   {% endcall %}
   {% call split(
   block_class='mzp-l-split-center-on-sm-md mzp-t-content-lg mzp-l-split-reversed mzp-t-split-nospace new-tab-section',
@@ -62,30 +62,31 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   body_class="new-tab-books-body",
   image_url='img/pocket/new-tab/books.svg',
   )%}
-    <h2 class="new-tab-section-header">Fuel your mind with even more fascinating stories.</h2>
-    <p class="new-tab-section-body">Check out Pocket’s <a href="https://getpocket.com/explore">Must Reads</a> for some of the best articles on the web. And get thought-provoking stories delivered to you daily by subscribing to <a href="https://getpocket.com/explore/pocket-hits-signup">Pocket’s newsletter</a>.</p>
+    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-fuel') }}</h2>
+    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-check-out', explore_url='https://getpocket.com/explore',
+    hits_signup_url='https://getpocket.com/explore/pocket-hits-signup') }}</p>
   {% endcall %}
   {% call split(
   block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace new-tab-section',
   media_class='mzp-l-split-h-center',
   image_url='img/pocket/new-tab/lounge.svg',
   )%}
-    <h2 class="new-tab-section-header">Save in Pocket & read on your own time.</h2>
-    <p class="new-tab-section-body">Built right into Firefox, Pocket also lets you save stories and come back to them when you’re ready.</p>
-    <p class="new-tab-section-body"><a href="https://getpocket.com/firefox_learnmore">Activate your account</a>, and then the next time you see an article you want to save, click the Pocket icon in the toolbar.</p>
+    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-save-in') }}</h2>
+    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-built-right') }}</p>
+    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-activate-your-account', firefox_learn_url='https://getpocket.com/firefox_learnmore') }}</p>
   {% endcall %}
 </section>
 <section class="mzp-l-content">
   <img class="details-img" src="{{ static('img/pocket/new-tab/sign.svg') }}" />
   <div>
-    <h2 class="new-tab-section-header">You make the call.</h2>
+    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-you-make') }}</h2>
     <div class="helpful-links-wrapper">
-      <p class="new-tab-section-body">It’s easy to turn off Pocket’s recommendations and remove them from your new tab page. But remember: if you don’t like today’s stories, there’s always tomorrow!</p>
+      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-its-easy', dismiss_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#turn-off') }}</p>
       <ul class="new-tab-helpful-links">
-        <li><a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq">Frequently asked questions</a></li>
-        <li><a href="https://getpocket.com/privacy">Privacy Policy</a></li>
-        <li><a href="https://getpocket.com/tos">Terms of service</a></li>
-        <li><a href="https://getpocket.com/sponsor">Sponsorship opportunities</a></li>
+        <li><a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq">{{ ftl('pocket-new-tab-faq') }}</a></li>
+        <li><a href="https://getpocket.com/privacy">{{ ftl('pocket-new-tab-privacy-policy') }}</a></li>
+        <li><a href="https://getpocket.com/tos">{{ ftl('pocket-new-tab-tos') }}</a></li>
+        <li><a href="https://getpocket.com/sponsor">{{ ftl('pocket-new-tab-sponsorship') }}</a></li>
       </ul>
     </div>
   </div>
@@ -95,6 +96,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <img class="right-grass" src="{{ static('img/pocket/new-tab/grass-footer-right.png') }}" />
 </section>
 <footer class="new-tab-footer mzp-t-dark">
-  <span class="mzp-c-wordmark mzp-t-wordmark-xs mzp-t-product-pocket">Pocket</span>
+  <span class="mzp-c-wordmark mzp-t-wordmark-xs mzp-t-product-pocket">{{ ftl('pocket-new-tab-pocket') }}</span>
 </footer>
 {% endblock %}

--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -75,6 +75,7 @@ urlpatterns = (
         "firefox/new_tab_learn_more/",
         "pocket/firefox/new-tab-learn-more.html",
         url_name="pocket.firefox-new-tab-learn-more",
+        ftl_files=["pocket/new-tab"],
     ),
     page(
         "pocket-and-firefox/",

--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -75,7 +75,7 @@ urlpatterns = (
         "firefox/new_tab_learn_more/",
         "pocket/firefox/new-tab-learn-more.html",
         url_name="pocket.firefox-new-tab-learn-more",
-        ftl_files=["pocket/new-tab"],
+        ftl_files=["pocket/firefox/new-tab"],
     ),
     page(
         "pocket-and-firefox/",

--- a/l10n-pocket/en/pocket/firefox/new-tab.ftl
+++ b/l10n-pocket/en/pocket/firefox/new-tab.ftl
@@ -17,33 +17,33 @@ pocket-new-tab-included-inside = Included inside { -brand-name-firefox }, the <s
 pocket-new-tab-activate-pocket = Activate { -brand-name-pocket } in { -brand-name-firefox }
 pocket-new-tab-more-ways-to = More ways to sign up
 
-pocket-new-tab-discover-the-most = Discover the most thought-provoking stories out there, curated by Pocket.
+pocket-new-tab-discover-the-most = Discover the most thought-provoking stories out there, curated by {-brand-name-pocket }.
 # Variables
 #   learn_url (url) - link to https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why
 pocket-new-tab-finding-the = Finding the hidden gems. Respecting your privacy.
-pocket-new-tab-as-part-of = As part of the Firefox family, Pocket surfaces the best articles out there—new perspectives, intriguing deep-dives, timeless classics—and we do this with the same dedication to privacy you’ve come to expect from Firefox and Mozilla. <a href="{ $learn_url }">Learn more about how we curate stories.</a>
+pocket-new-tab-as-part-of = As part of the { -brand-name-firefox } family, {-brand-name-pocket } surfaces the best articles out there—new perspectives, intriguing deep-dives, timeless classics—and we do this with the same dedication to privacy you’ve come to expect from { -brand-name-firefox } and { -brand-name-mozilla }. <a href="{ $learn_url }">Learn more about how we curate stories.</a>
 
 pocket-new-tab-your-data = Your data stays private. Always.
 # Variables
 #   privacy_url (url) - link to https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#personalized
-pocket-new-tab-in-addition-to = In addition to dishing up captivating stories, we also show you relevant, highly-vetted content from select sponsors. Rest assured, your browsing data never leaves your personal copy of Firefox—we don’t see it, and our sponsors don’t either. Want more details? Here’s the full scoop on <a href="{ $privacy_url }">how privacy works in Pocket.</a>
+pocket-new-tab-in-addition-to = In addition to dishing up captivating stories, we also show you relevant, highly-vetted content from select sponsors. Rest assured, your browsing data never leaves your personal copy of { -brand-name-firefox }—we don’t see it, and our sponsors don’t either. Want more details? Here’s the full scoop on <a href="{ $privacy_url }">how privacy works in {-brand-name-pocket }.</a>
 
 pocket-new-tab-fuel = Fuel your mind with even more fascinating stories.
 # Variables
 #   explore_url (url) - link to https://getpocket.com/explore
 #   hits_signup_url (url) - link to https://getpocket.com/explore/pocket-hits-signup
-pocket-new-tab-check-out = Check out Pocket’s <a href="{ $explore_url }">Must Reads</a> for some of the best articles on the web. And get thought-provoking stories delivered to you daily by subscribing to <a href="{ $hits_signup_url }">Pocket’s newsletter</a>.
+pocket-new-tab-check-out = Check out {-brand-name-pocket }’s <a href="{ $explore_url }">Must Reads</a> for some of the best articles on the web. And get thought-provoking stories delivered to you daily by subscribing to <a href="{ $hits_signup_url }">{ -brand-name-pocket }’s newsletter</a>.
 
-pocket-new-tab-save-in = Save in Pocket & read on your own time.
-pocket-new-tab-built-right = Built right into Firefox, Pocket also lets you save stories and come back to them when you’re ready.
+pocket-new-tab-save-in = Save in {-brand-name-pocket } & read on your own time.
+pocket-new-tab-built-right = Built right into { -brand-name-firefox }, { -brand-name-pocket } also lets you save stories and come back to them when you’re ready.
 # Variables
 #   firefox_learn_url (url) - link to https://getpocket.com/firefox_learnmore
-pocket-new-tab-activate-your-account = <a href="{ $firefox_learn_more }">Activate your account</a>, and then the next time you see an article you want to save, click the Pocket icon in the toolbar.
+pocket-new-tab-activate-your-account = <a href="{ $firefox_learn_more }">Activate your account</a>, and then the next time you see an article you want to save, click the {-brand-name-pocket } icon in the toolbar.
 
 pocket-new-tab-you-make = You make the call.
 # Variables
 #   dismiss_url (url) - link to https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#turn-off
-pocket-new-tab-its-easy = It’s easy <a href="{ $dismiss_url }">turn off</a> off Pocket’s recommendations and remove them from your new tab page. But remember: if you don’t like today’s stories, there’s always tomorrow!
+pocket-new-tab-its-easy = It’s easy <a href="{ $dismiss_url }">turn off</a> off {-brand-name-pocket }’s recommendations and remove them from your new tab page. But remember: if you don’t like today’s stories, there’s always tomorrow!
 pocket-new-tab-faq = Frequently asked questions
 pocket-new-tab-privacy-policy = Privacy policy
 pocket-new-tab-tos = Terms of service

--- a/l10n-pocket/en/pocket/new-tab.ftl
+++ b/l10n-pocket/en/pocket/new-tab.ftl
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://dev.tekcopteg.com/firefox/new_tab_learn_more
+
+pocket-new-tab-learn-more = Learn More
+pocket-new-tab-firefox = { -brand-name-firefox }
+pocket-new-tab-pocket = { -brand-name-pocket }
+pocket-new-tab-pocket-is-part = { -brand-name-pocket } is part of the { -brand-name-firefox } family
+
+pocket-new-tab-pocket-for-firefox = { -brand-name-pocket } for { -brand-name-firefox }
+pocket-new-tab-build-your-personal = Build your personal library of fascinating reads.
+# Variables:
+# $pocket-logo-inline (string) class for Pocket's inline logo
+pocket-new-tab-included-inside = Included inside { -brand-name-firefox }, the <span class="{ $pocket-logo-inline }">{ -brand-name-pocket} Logo</span> button lets you save articles from across the web and read them in a quiet, private space.
+pocket-new-tab-activate-pocket = Activate { -brand-name-pocket } in { -brand-name-firefox }
+pocket-new-tab-more-ways-to = More ways to sign up
+
+pocket-new-tab-discover-the-most = Discover the most thought-provoking stories out there, curated by Pocket.
+# Variables
+#   $learn_more: (String) https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why
+pocket-new-tab-finding-the = Finding the hidden gems. Respecting your privacy.
+pocket-new-tab-as-part-of = As part of the Firefox family, Pocket surfaces the best articles out there—new perspectives, intriguing deep-dives, timeless classics—and we do this with the same dedication to privacy you’ve come to expect from Firefox and Mozilla. <a href="{ $learn_more }">Learn more about how we curate stories.</a>

--- a/l10n-pocket/en/pocket/new-tab.ftl
+++ b/l10n-pocket/en/pocket/new-tab.ftl
@@ -19,6 +19,32 @@ pocket-new-tab-more-ways-to = More ways to sign up
 
 pocket-new-tab-discover-the-most = Discover the most thought-provoking stories out there, curated by Pocket.
 # Variables
-#   $learn_more: (String) https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why
+#   learn_url (url) - link to https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why
 pocket-new-tab-finding-the = Finding the hidden gems. Respecting your privacy.
-pocket-new-tab-as-part-of = As part of the Firefox family, Pocket surfaces the best articles out there—new perspectives, intriguing deep-dives, timeless classics—and we do this with the same dedication to privacy you’ve come to expect from Firefox and Mozilla. <a href="{ $learn_more }">Learn more about how we curate stories.</a>
+pocket-new-tab-as-part-of = As part of the Firefox family, Pocket surfaces the best articles out there—new perspectives, intriguing deep-dives, timeless classics—and we do this with the same dedication to privacy you’ve come to expect from Firefox and Mozilla. <a href="{ $learn_url }">Learn more about how we curate stories.</a>
+
+pocket-new-tab-your-data = Your data stays private. Always.
+# Variables
+#   privacy_url (url) - link to https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#personalized
+pocket-new-tab-in-addition-to = In addition to dishing up captivating stories, we also show you relevant, highly-vetted content from select sponsors. Rest assured, your browsing data never leaves your personal copy of Firefox—we don’t see it, and our sponsors don’t either. Want more details? Here’s the full scoop on <a href="{ $privacy_url }">how privacy works in Pocket.</a>
+
+pocket-new-tab-fuel = Fuel your mind with even more fascinating stories.
+# Variables
+#   explore_url (url) - link to https://getpocket.com/explore
+#   hits_signup_url (url) - link to https://getpocket.com/explore/pocket-hits-signup
+pocket-new-tab-check-out = Check out Pocket’s <a href="{ $explore_url }">Must Reads</a> for some of the best articles on the web. And get thought-provoking stories delivered to you daily by subscribing to <a href="{ $hits_signup_url }">Pocket’s newsletter</a>.
+
+pocket-new-tab-save-in = Save in Pocket & read on your own time.
+pocket-new-tab-built-right = Built right into Firefox, Pocket also lets you save stories and come back to them when you’re ready.
+# Variables
+#   firefox_learn_url (url) - link to https://getpocket.com/firefox_learnmore
+pocket-new-tab-activate-your-account = <a href="{ $firefox_learn_more }">Activate your account</a>, and then the next time you see an article you want to save, click the Pocket icon in the toolbar.
+
+pocket-new-tab-you-make = You make the call.
+# Variables
+#   dismiss_url (url) - link to https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#turn-off
+pocket-new-tab-its-easy = It’s easy <a href="{ $dismiss_url }">turn off</a> off Pocket’s recommendations and remove them from your new tab page. But remember: if you don’t like today’s stories, there’s always tomorrow!
+pocket-new-tab-faq = Frequently asked questions
+pocket-new-tab-privacy-policy = Privacy policy
+pocket-new-tab-tos = Terms of service
+pocket-new-tab-sponsorship = Sponsorship opportunities

--- a/media/css/pocket/components/new-tab-learn-more.scss
+++ b/media/css/pocket/components/new-tab-learn-more.scss
@@ -70,12 +70,13 @@ $image-path: '/media/protocol/img';
     }
 }
 
-.section-top-header-lede {
+.tagline {
     @include text-body-sm;
     color: $color-text-grey;
     margin-bottom: $spacing-xs;
     margin-top: 0;
     text-align: center;
+    text-transform: uppercase;
 
     @media #{$mq-lg} {
         text-align: left;


### PR DESCRIPTION
## One-line summary
Add Fluent strings to the new_tab_learn_more page

## Issue / Bugzilla link
#11519 

## Testing
- Local: run `npm run in-pocket-mode`
- Docker: `make run-pocket` and `make run-pocket prod`

- [ ] http://localhost:8000/en/firefox/new_tab_learn_more/  👉🏼 compare to 👉🏼 https://dev.tekcopteg.com/en/firefox/new_tab_learn_more/
