### PR TITLE
Dependency bump: pyjwt 

### DIFF
--- a/bin/compile-requirements.sh
+++ b/bin/compile-requirements.sh
@@ -12,8 +12,8 @@ export CUSTOM_COMPILE_COMMAND="$ make compile-requirements"
 # We need this installed, but we don't want it to live in the main requirements
 # We will need to periodically review this pinning
 
-pip install -U pip==22.1
-pip install pip-tools==6.6.1
+pip install -U pip==22.1.1
+pip install pip-tools==6.6.2
 
 pip-compile --generate-hashes -r requirements/prod.in
 pip-compile --generate-hashes -r requirements/dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -800,9 +800,9 @@ pygments==2.11.2 \
     --hash=sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65 \
     --hash=sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a
     # via bpython
-pyjwt==2.3.0 \
-    --hash=sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
-    --hash=sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f
+pyjwt==2.4.0 \
+    --hash=sha256:72d1d253f32dbd4f5c88eaf1fdc62f3a19f676ccbadb9dbc5d07e951b2b26daf \
+    --hash=sha256:d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba
     # via
     #   -r requirements/prod.txt
     #   pygithub

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -39,6 +39,7 @@ newrelic==7.10.0.175
 phonenumberslite==8.12.46
 Pillow==9.1.0
 PyGithub==1.55
+pyjwt>=2.4.0  # subdep of PyGithub and Twilio but needs to be > 2.3.0
 pyOpenSSL==22.0.0
 python-memcached==1.59
 PyYAML==6.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -20,7 +20,7 @@ attrs==21.4.0 \
     --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
-    #   fluent.runtime
+    #   fluent-runtime
     #   jsonschema
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
@@ -539,10 +539,11 @@ pygithub==1.55 \
     --hash=sha256:1bbfff9372047ff3f21d5cd8e07720f3dbfdaf6462fcaed9d815f528f1ba7283 \
     --hash=sha256:2caf0054ea079b71e539741ae56c5a95e073b81fa472ce222e81667381b9601b
     # via -r requirements/prod.in
-pyjwt==2.3.0 \
-    --hash=sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
-    --hash=sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f
+pyjwt==2.4.0 \
+    --hash=sha256:72d1d253f32dbd4f5c88eaf1fdc62f3a19f676ccbadb9dbc5d07e951b2b26daf \
+    --hash=sha256:d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba
     # via
+    #   -r requirements/prod.in
     #   pygithub
     #   twilio
 pynacl==1.5.0 \


### PR DESCRIPTION
Manually force upgrade of pyjwt (a subdep of Pygithub and fluent-runtime. Even though neither top-level dep specifies a hard version of pyjwt to use, pip-tools was coming back with 2.3.0, not the security-patched 2.4.0, so this subdep was promoted to top-level dep, at least for now
