### PR TITLE
Make Pocket-mode integration tests automatically skip if no BASE_POCKET_URL exists

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.sqlite3.base import BaseDatabaseWrapper as SQLiteWrapper
 
 import pytest
@@ -31,5 +30,5 @@ def base_url(base_url, request):
 def pocket_base_url(request):
     base_url = config("BASE_POCKET_URL", parser=str, default="")
     if not base_url:
-        raise ImproperlyConfigured("No BASE_POCKET_URL detected in env vars")
+        pytest.skip("No BASE_POCKET_URL detected in env vars")
     return base_url


### PR DESCRIPTION
This will make the Frankfurt integration tests happy again, where there is
not yet a prod deployment to test against

## Before change:

```
$ pytest -m pocket_mode
...
ERROR tests/functional/pocket/test_navigation.py::test_mobile_menu - django.core.exceptions.ImproperlyConfigured: No BASE_P...
ERROR tests/functional/pocket/test_navigation.py::test_accessible_mobile_menu_open_name - django.core.exceptions.Improperly...
ERROR tests/functional/pocket/test_navigation.py::test_accessible_mobile_menu_close_name - django.core.exceptions.Improperl..
```

## After change:

```
$ pytest -m pocket_mode
...
SKIPPED [3] tests/conftest.py:34: No BASE_POCKET_URL detected in env vars
```

