### PR TITLE
Add WNP for Dev Edition promoting MDN Plus [fix #11633]

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
@@ -1,0 +1,82 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('developer-mdnplus-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}
+{% block page_image %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endblock %}
+{% block page_favicon %}{{ static('img/favicons/firefox/browser/developer/favicon.ico') }}{% endblock %}
+{% block page_favicon_large %}{{ static('img/favicons/firefox/browser/developer/favicon-196x196.png') }}{% endblock %}
+{% block page_ios_icon %}{{ static('img/favicons/firefox/browser/developer/apple-touch-icon.png') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_developer_whatsnew_mdnplus') }}
+{% endblock %}
+
+{% block body_id %}firefox-developer{% endblock %}
+{% block body_class %}firefox-developer-whatsnew-mdnplus{% endblock %}
+
+{% block content %}
+<main role="main">
+  <section class="c-mdn-header mzp-t-dark">
+    <div class="mzp-l-content mzp-t-content-md c-mdn-header-content">
+      <div class="mzp-c-notification-bar mzp-t-success">
+        <p>{{ ftl('developer-mdnplus-congrats-you-now-have-latest') }}</p>
+      </div>
+
+      <h1 class="c-mdn-header-title">{{ ftl('developer-mdnplus-more-mdn-your-mdn') }}</h1>
+      <p class="c-mdn-header-intro">{{ ftl('developer-mdnplus-mdn-is-an-open-source') }}</p>
+      <p class="c-mdn-header-tagline">{{ ftl('developer-mdnplus-support-mdn-and-make') }}</p>
+      <p class="c-mdn-header-cta"><a class="mzp-c-button mzp-t-button-lg mzp-t-dark" href="https://developer.mozilla.org/plus/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=fxdev-whatsnew" data-cta-text="Get Started" data-cta-type="link" data-cta-position="primary">{{ ftl('developer-mdnplus-get-started') }}</a></p>
+    </div>
+
+    <div class="mandala-wrapper">
+      <div class="mandala-container animate-colors" aria-hidden="true">
+        <div class="mandala-translate">
+          <svg width="675" height="675" viewBox="0 0 675 675" fill="none" xmlns="http://www.w3.org/2000/svg" class="mandala"><defs><path d="M337.5,337.5 m-320,0 a320,320 0 1,1 640,0 a320,320 0 1,1 -640,0" id="circle1"><animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="0 337.5 337.5" to="360 337.5 337.5" repeatCount="indefinite"></animateTransform></path><path d="M337.5,337.5 m-280,0 a280,280 0 1,1 560,0 a280,280 0 1,1 -560,0" id="circle2"><animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="360 337.5 337.5" to="0 337.5 337.5" repeatCount="indefinite"></animateTransform></path><path d="M337.5,337.5 m-240,0 a240,240 0 1,1 480,0 a240,240 0 1,1 -480,0" id="circle3"><animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="0 337.5 337.5" to="360 337.5 337.5" repeatCount="indefinite"></animateTransform></path><path d="M337.5,337.5 m-200,0 a200,200 0 1,1 400,0 a200,200 0 1,1 -400,0" id="circle4"><animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="360 337.5 337.5" to="0 337.5 337.5" repeatCount="indefinite"></animateTransform></path><path d="M337.5,337.5 m-160,0 a160,160 0 1,1 320,0 a160,160 0 1,1 -320,0" id="circle5"><animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="0 337.5 337.5" to="360 337.5 337.5" repeatCount="indefinite"></animateTransform></path></defs><text class="mandala-accent-1" dy="70" textLength="2010"><textPath textLength="2010" href="#circle1">&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan></textPath></text><text class="mandala-accent-2" dy="70" textLength="1760"><textPath textLength="1760" href="#circle2">&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan></textPath></text><text class="mandala-accent-3" dy="70" textLength="1507"><textPath textLength="1507" href="#circle3"><tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;</textPath></text><text class="mandala-accent-4" dy="70" textLength="1257"><textPath textLength="1257" href="#circle4">&nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../</textPath></text><text class="mandala-accent-5" dy="70" textLength="1005"><textPath textLength="1005" href="#circle5"><tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;</textPath></text></svg>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="c-mdn-body">
+    <div class="mzp-l-content">
+      <h2 class="c-mdn-body-title">{{ ftl('developer-mdnplus-whats-included') }}</h2>
+      <div class="mzp-l-columns mzp-t-columns-three">
+        <div class="c-mdn-feature">
+          <h3 class="c-mdn-feature-pretitle">{{ ftl('developer-mdnplus-notifications') }}</h3>
+          <h4 class="c-mdn-feature-title">{{ ftl('developer-mdnplus-development-in-real-time') }}</h4>
+          <p>{{ ftl('developer-mdnplus-the-web-doesnt-have-a') }}</p>
+        </div>
+
+        <div class="c-mdn-feature">
+          <h3 class="c-mdn-feature-pretitle">{{ ftl('developer-mdnplus-collections') }}</h3>
+          <h4 class="c-mdn-feature-title">{{ ftl('developer-mdnplus-build-your-perfect-library') }}</h4>
+          <p>{{ ftl('developer-mdnplus-no-more-haphazard-hunting') }}</p>
+        </div>
+
+        <div class="c-mdn-feature">
+          <h3 class="c-mdn-feature-pretitle">{{ ftl('developer-mdnplus-mdn-offline') }}</h3>
+          <h4 class="c-mdn-feature-title">{{ ftl('developer-mdnplus-mdns-entire-library-at-your') }}</h4>
+          <p>{{ ftl('developer-mdnplus-taking-your-projects-beyond') }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="c-mdn-footer">
+    <div class="mzp-l-content">
+      <p>{{ ftl('developer-mdnplus-resources-for-developers') }} <a class="mzp-c-button" href="https://developer.mozilla.org/plus/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=fxdev-whatsnew" data-cta-text="Learn more" data-cta-type="link" data-cta-position="secondary">{{ ftl('ui-learn-more') }}</a></p>
+    </div>
+  </aside>
+</main>
+{% endblock %}
+
+{% block email_form %}{% endblock %}
+
+{# Exclude stub attribution for in-product pages: issue 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -363,7 +363,7 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="True")
-    def test_fx_dev_browser_102_0_a2_whatsnew_vpnplus(self, render_mock):
+    def test_fx_dev_browser_102_0_a2_whatsnew_mdnplus(self, render_mock):
         """Should show MDN Plus dev browser whatsnew template when switch is on"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
         self.view(req, version="102.0a2")

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -280,7 +280,6 @@ class TestWhatsNew(TestCase):
         )
 
     @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="False")
     def test_context_variables_whatsnew_developer(self, render_mock):
         """Should pass the correct context variables for developer channel"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
@@ -346,7 +345,6 @@ class TestWhatsNew(TestCase):
         assert template == ["firefox/whatsnew/index.html"]
 
     @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="False")
     def test_fx_dev_browser_57_0_a2_whatsnew(self, render_mock):
         """Should show dev browser 57 whatsnew template"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
@@ -356,19 +354,19 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="False")
-    def test_fx_dev_browser_100_0_a2_whatsnew_off(self, render_mock):
+    def test_fx_dev_browser_102_0_a2_whatsnew_off(self, render_mock):
         """Should show regular dev browser whatsnew template"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
-        self.view(req, version="100.0a2")
+        self.view(req, version="102.0a2")
         template = render_mock.call_args[0][1]
         assert template == ["firefox/developer/whatsnew.html"]
 
     @override_settings(DEV=True)
     @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="True")
-    def test_fx_dev_browser_100_0_a2_whatsnew_vpnplus(self, render_mock):
+    def test_fx_dev_browser_102_0_a2_whatsnew_vpnplus(self, render_mock):
         """Should show MDN Plus dev browser whatsnew template when switch is on"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
-        self.view(req, version="100.0a2")
+        self.view(req, version="102.0a2")
         template = render_mock.call_args[0][1]
         assert template == ["firefox/developer/whatsnew-mdnplus.html"]
 

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -280,6 +280,7 @@ class TestWhatsNew(TestCase):
         )
 
     @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="False")
     def test_context_variables_whatsnew_developer(self, render_mock):
         """Should pass the correct context variables for developer channel"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
@@ -345,6 +346,7 @@ class TestWhatsNew(TestCase):
         assert template == ["firefox/whatsnew/index.html"]
 
     @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="False")
     def test_fx_dev_browser_57_0_a2_whatsnew(self, render_mock):
         """Should show dev browser 57 whatsnew template"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
@@ -353,22 +355,22 @@ class TestWhatsNew(TestCase):
         assert template == ["firefox/developer/whatsnew.html"]
 
     @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68="False")
-    def test_fx_dev_browser_68_0_a2_whatsnew_off(self, render_mock):
-        """Should show regular dev browser whatsnew template"""
-        req = self.rf.get("/en-US/firefox/whatsnew/")
-        self.view(req, version="68.0a2")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/developer/whatsnew.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68="False")
+    @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="False")
     def test_fx_dev_browser_100_0_a2_whatsnew_off(self, render_mock):
         """Should show regular dev browser whatsnew template"""
         req = self.rf.get("/en-US/firefox/whatsnew/")
         self.view(req, version="100.0a2")
         template = render_mock.call_args[0][1]
         assert template == ["firefox/developer/whatsnew.html"]
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_FIREFOX_DEVELOPER_WHATSNEW_MDNPLUS="True")
+    def test_fx_dev_browser_100_0_a2_whatsnew_vpnplus(self, render_mock):
+        """Should show MDN Plus dev browser whatsnew template when switch is on"""
+        req = self.rf.get("/en-US/firefox/whatsnew/")
+        self.view(req, version="100.0a2")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/developer/whatsnew-mdnplus.html"]
 
     # end dev edition whatsnew tests
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -28,6 +28,7 @@ from twilio.rest import Client as TwilioClient
 
 from bedrock.base.geo import get_country_from_request
 from bedrock.base.urlresolvers import reverse
+from bedrock.base.waffle import switch
 from bedrock.base.waffle_config import DictOf, config
 from bedrock.contentful.api import ContentfulPage
 from bedrock.firefox.firefox_details import (
@@ -497,6 +498,7 @@ class WhatsnewView(L10nTemplateView):
 
     ftl_files_map = {
         "firefox/developer/whatsnew.html": ["firefox/developer"],
+        "firefox/developer/whatsnew-mdnplus.html": ["firefox/whatsnew/whatsnew-developer-mdnplus"],
         "firefox/nightly/whatsnew.html": ["firefox/nightly/whatsnew", "firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/index-account.html": ["firefox/whatsnew/whatsnew-account", "firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/index.html": ["firefox/whatsnew/whatsnew-s2d", "firefox/whatsnew/whatsnew"],
@@ -594,7 +596,10 @@ class WhatsnewView(L10nTemplateView):
             template = "firefox/nightly/whatsnew.html"
         elif channel == "developer":
             if show_57_dev_whatsnew(version):
-                template = "firefox/developer/whatsnew.html"
+                if switch("firefox-developer-whatsnew-mdnplus") and ftl_file_is_active("firefox/whatsnew/whatsnew-developer-mdnplus"):
+                    template = "firefox/developer/whatsnew-mdnplus.html"
+                else:
+                    template = "firefox/developer/whatsnew.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("101."):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -428,6 +428,16 @@ def show_57_dev_whatsnew(version):
     return version >= Version("57.0")
 
 
+def show_102_dev_whatsnew(version):
+    version = version[:-2]
+    try:
+        version = Version(version)
+    except ValueError:
+        return False
+
+    return version >= Version("102.0")
+
+
 def show_57_dev_firstrun(version):
     version = version[:-2]
     try:
@@ -595,11 +605,13 @@ class WhatsnewView(L10nTemplateView):
         if channel == "nightly":
             template = "firefox/nightly/whatsnew.html"
         elif channel == "developer":
-            if show_57_dev_whatsnew(version):
+            if show_102_dev_whatsnew(version):
                 if switch("firefox-developer-whatsnew-mdnplus") and ftl_file_is_active("firefox/whatsnew/whatsnew-developer-mdnplus"):
                     template = "firefox/developer/whatsnew-mdnplus.html"
                 else:
                     template = "firefox/developer/whatsnew.html"
+            elif show_57_dev_whatsnew(version):
+                template = "firefox/developer/whatsnew.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("101."):

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -235,6 +235,9 @@ locales = [
         "sv-SE",
     ]
 [[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-developer-mdnplus"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-developer-mdnplus"
+[[paths]]
     reference = "en/mozorg/contribute.ftl"
     l10n = "{locale}/mozorg/contribute.ftl"
 [[paths]]

--- a/l10n/en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/102.0a2/whatsnew/
+
+# HTML page title
+developer-mdnplus-page-title = { -brand-name-firefox-developer-edition }
+developer-mdnplus-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox-browser } { -brand-name-developer-edition }.
+
+# Main title
+developer-mdnplus-more-mdn-your-mdn = More { -brand-name-mdn }. <em>Your</em> { -brand-name-mdn }.
+developer-mdnplus-mdn-is-an-open-source = { -brand-name-mdn-web-docs } is an open-source, collaborative project documenting Web platform technologies, including CSS, HTML, JavaScript and Web APIs. We also provide an extensive set of learning resources for beginning developers and students.
+developer-mdnplus-support-mdn-and-make = Support { -brand-name-mdn } <em>and</em> make it your own.
+
+# CTA button
+developer-mdnplus-get-started = Get Started
+
+developer-mdnplus-whats-included = What’s included
+developer-mdnplus-notifications = Notifications
+developer-mdnplus-development-in-real-time = Development in real time: Get custom alerts
+developer-mdnplus-the-web-doesnt-have-a = The Web doesn't have a changelog, but { -brand-name-mdn } can help. Follow pages and get customizable notifications when documentation changes, CSS features launch, and APIs ship.
+developer-mdnplus-collections = Collections
+developer-mdnplus-build-your-perfect-library = Build your perfect library. Or let us build it for you.
+developer-mdnplus-no-more-haphazard-hunting = No more haphazard hunting through the vast virtual library: unleash your inner curator and collect your favorite articles in one place for convenient consultation.
+developer-mdnplus-mdn-offline = { -brand-name-mdn } offline
+developer-mdnplus-mdns-entire-library-at-your = { -brand-name-mdn }’s entire library at your fingertips: offline
+developer-mdnplus-taking-your-projects-beyond = Taking your projects beyond the nearest wifi signal? Say goodbye to inaccessible pages or cluttered tabs. With { -brand-name-mdn-plus }, have the fully navigable resources of { -brand-name-mdn } at your disposal even when offline.
+developer-mdnplus-resources-for-developers = Resources for Developers, by Developers.

--- a/media/css/firefox/developer/whatsnew-mdnplus.scss
+++ b/media/css/firefox/developer/whatsnew-mdnplus.scss
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
+
+.firefox-developer-whatsnew-mdnplus {
+    h1,
+    h2,
+    h3,
+    h4 {
+        @include font-base;
+        color: $color-black;
+    }
+}
+
+// Header
+.c-mdn-header {
+    background: $color-black;
+    display: grid;
+    grid-template-columns: 100%;
+
+    .c-mdn-header-content {
+        grid-column: 1;
+        grid-row: 1;
+        z-index: 2;
+        padding-top: 0;
+    }
+
+    .mzp-c-notification-bar {
+        margin-bottom: $layout-lg;
+    }
+
+    .c-mdn-header-title {
+        color: $color-light-gray-30;
+        font-weight: bold;
+    }
+
+    .mandala-wrapper {
+        grid-column: 1;
+        grid-row: 1;
+        overflow: hidden;
+        transition: all 1s ease-in-out;
+        width: 100%;
+        z-index: 1;
+        height: 550px;
+    }
+}
+
+.c-mdn-header-intro {
+    margin-bottom: $layout-md;
+}
+
+.c-mdn-header-tagline {
+    @include text-body-xl;
+}
+
+.c-mdn-header-title em,
+.c-mdn-header-tagline em {
+    font-style: normal;
+    border-bottom: 2px solid $color-pink-30;
+}
+
+// Mandala
+.mandala-container {
+    display: flex;
+    justify-content: center;
+    -webkit-transform: translate(12rem, -8rem);
+    transform: translate(12rem, -8rem);
+
+    --mandala-primary: #{$color-dark-gray-10};
+    --mandala-accent-1: #{$color-violet-30};
+    --mandala-accent-2: #{$color-yellow-30};
+    --mandala-accent-3: #{$color-green-30};
+    --mandala-accent-4: #{$color-light-gray-60};
+
+    @keyframes rotation {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+
+    .mandala-rotate > svg {
+        animation: rotation 500s linear infinite;
+    }
+
+    svg {
+        font-size: 1.5rem;
+        font-weight: 300;
+        user-select: none;
+    }
+
+    svg > text {
+        fill: var(--mandala-primary);
+    }
+
+    .mandala-accent-1 {
+        font-size: 1.5rem;
+    }
+
+    .mandala-accent-2 {
+        font-size: 1.3rem;
+    }
+
+    .mandala-accent-3 {
+        font-size: 1.2rem;
+    }
+
+    .mandala-accent-4 {
+        font-size: 1.1rem;
+    }
+
+    .mandala-accent-5 {
+        font-size: 1rem;
+    }
+
+    &.animate-colors {
+        svg > text > textPath > tspan {
+            animation: mandala-color-change 50s infinite;
+            animation-timing-function: ease-in-out;
+            fill: var(--mandala-primary);
+        }
+
+        .mandala-accent-1 > textPath > tspan {
+            fill: var(--mandala-accent-1);
+            animation-delay: -15s;
+        }
+
+        .mandala-accent-2 > textPath > tspan {
+            fill: var(--mandala-accent-2);
+            animation-delay: -20s;
+        }
+
+        .mandala-accent-3 > textPath > tspan {
+            fill: var(--mandala-accent-3);
+            animation-delay: -30s;
+        }
+
+        .mandala-accent-5 > textPath > tspan {
+            fill: var(--mandala-accent-4);
+            animation-delay: -40s;
+        }
+    }
+
+    @keyframes mandala-color-change {
+        0% {
+            fill: var(--mandala-primary);
+        }
+
+        10% {
+            fill: var(--mandala-primary);
+        }
+
+        15% {
+            fill: var(--mandala-accent-1);
+        }
+
+        20% {
+            fill: var(--mandala-primary);
+        }
+
+        25% {
+            fill: var(--mandala-primary);
+        }
+
+        30% {
+            fill: var(--mandala-accent-2);
+        }
+
+        35% {
+            fill: var(--mandala-primary);
+        }
+
+        40% {
+            fill: var(--mandala-primary);
+        }
+
+        50% {
+            fill: var(--mandala-accent-3);
+        }
+
+        55% {
+            fill: var(--mandala-primary);
+        }
+
+        60% {
+            fill: var(--mandala-primary);
+        }
+
+        65% {
+            fill: var(--mandala-accent-4);
+        }
+
+        70% {
+            fill: var(--mandala-primary);
+        }
+
+        100% {
+            fill: var(--mandala-primary);
+        }
+    }
+}
+
+// Body
+.c-mdn-body {
+    color: $color-black;
+
+    .c-mdn-body-title {
+        @include text-title-xs;
+        margin-bottom: $spacing-xl;
+
+        &::after {
+            color: $color-pink-60;
+            content: ' _';
+        }
+    }
+
+    .c-mdn-feature {
+        margin-bottom: $layout-md;
+
+        @media #{$mq-md} {
+            margin: 0;
+        }
+    }
+
+    .c-mdn-feature-pretitle {
+        @include text-body-xs;
+        color: $color-pink-60;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+    }
+}
+
+// Footer
+.c-mdn-footer {
+    background: #8cb4ff;
+    color: $color-black;
+    text-align: center;
+
+    .mzp-l-content {
+        padding-bottom: $spacing-2xl;
+        padding-top: $spacing-2xl;
+    }
+
+    p {
+        @include text-title-xs;
+        font-weight: bold;
+    }
+
+    .mzp-c-button {
+        margin: 0 1em;
+        vertical-align: middle;
+
+        &::after {
+            content: ' →';
+        }
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -92,6 +92,12 @@
     },
     {
       "files": [
+        "css/firefox/developer/whatsnew-mdnplus.scss"
+      ],
+      "name": "firefox_developer_whatsnew_mdnplus"
+    },
+    {
+      "files": [
         "css/firefox/sticky-promo.scss"
       ],
       "name": "sticky_promo"


### PR DESCRIPTION
## One-line summary
A whatsnew page for Firefox Dev Edition to promote MDN Plus. It's controlled by the switch `firefox-developer-whatsnew-mdnplus` and isn't specific to any version as we'll probably run it for more than one release cycle (or could turn it off for a few releases and back on again later).

## Issue / Bugzilla link
#11633 

## Testing
http://localhost:8000/firefox/102.0a2/whatsnew/
