### PR TITLE
Fix typo in SEM landing pages function

### DIFF
--- a/bedrock/landing/templates/landing/base-landing.html
+++ b/bedrock/landing/templates/landing/base-landing.html
@@ -10,8 +10,6 @@
   {{ css_bundle('landing-shared')}}
 {% endblock %}
 
-
-
 {% block site_header %}
   <div class="c-navigation top-header-navigation mzp-is-sticky">
     <div class="c-navigation-l-content">
@@ -38,3 +36,6 @@
     {% include 'landing/includes/footer.html' %}
 {% endblock %}
 
+{% block js %}
+  {{ js_bundle('landing-shared') }}
+{% endblock %}

--- a/media/js/landing/landing-shared.js
+++ b/media/js/landing/landing-shared.js
@@ -7,8 +7,8 @@
 (function () {
     'use strict';
 
-    // test to see if users are clicking on the workmark in the header of the SEM landing pages
-    function handleWorkmarkClick(event) {
+    // test to see if users are clicking on the wordmark in the header of the SEM landing pages
+    function handleWordmarkClick(event) {
         var label = event.target.innerText;
         window.dataLayer.push({
             event: 'sem-wordmark-click',
@@ -17,5 +17,5 @@
     }
 
     var wordmark = document.querySelector('.sem-landing-nav-icon');
-    wordmark.addEventListener('click', handleWorkmarkClick);
+    wordmark.addEventListener('click', handleWordmarkClick);
 })();


### PR DESCRIPTION
## One-line summary
Fixed typo for `handleWordmarkClick` function in  the `landing-shared.js` file

## Testing

To test this work:

- http://localhost:8080/en-US/landing/firefox/fx100
