### PR TITLE
Add Glean to /products/vpn/ landing page (Issue #10746)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -308,6 +308,12 @@
 
 {% endblock %}
 
+{% block glean %}
+  {% if switch('glean-analytics') %}
+    {{ js_bundle('glean') }}
+  {% endif %}
+{% endblock %}
+
 {% block js %}
   {% if vpn_affiliate_attribution_enabled %}
     {{ js_bundle('mozilla-vpn-affiliate') }}


### PR DESCRIPTION
## One-line summary

Adds Glean JS bundle to /products/vpn/ landing page.

## Issue / Bugzilla link

#10746

## Testing

http://localhost:8000/en-US/products/vpn/

To test this work:

- [ ] Glean page view ping should be visible in web console on page load
