### PR TITLE
Remove blank target on pocket support links, fix typo, (fixes #11666)

### DIFF
--- a/bedrock/pocket/templates/pocket/add.html
+++ b/bedrock/pocket/templates/pocket/add.html
@@ -28,9 +28,9 @@
           )%}
           <h2>{{ ftl('pocket-add-save-to-pocket') }}</h2>
           <p>{{ ftl('pocket-add-click-the-pocket-button') }}</p>
-          <a href="https://help.getpocket.com/article/900-saving-to-pocket-and-viewing-your-list-in-firefox" class="mzp-c-button" target="_blank" rel="external noopener">{{ ftl('pocket-add-learn-how') }}</a>
+          <a href="https://help.getpocket.com/article/900-saving-to-pocket-and-viewing-your-list-in-firefox" class="mzp-c-button">{{ ftl('pocket-add-learn-how') }}</a>
            <p>
-              <a href="https://help.getpocket.com/article/942-where-is-the-pocket-button-in-firefox" class="dark-inline-link rarrow" target="_blank" rel="noopener noreferrer">
+              <a href="https://help.getpocket.com/article/942-where-is-the-pocket-button-in-firefox" class="dark-inline-link rarrow">
                {{ ftl('pocket-add-dont-see-the-pocket') }}
               </a>
           </p>
@@ -53,7 +53,7 @@
             </ul>
             <ul class="device-list">
                <li><a href="https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj?hl=en" target="_blank" rel="noopener noreferrer" class="dark-inline-link rarrow">{{ ftl('pocket-add-windows') }}</a></li>
-               <li><a href="https://help.getpocket.com/article/1006-getting-started-with-kobo" target="_blank" rel="noopener noreferrer" class="dark-inline-link rarrow">{{ ftl('pocket-add-kobo-e-reader') }}</a></li>
+               <li><a href="https://help.getpocket.com/article/1006-getting-started-with-kobo" class="dark-inline-link rarrow">{{ ftl('pocket-add-kobo-e-reader') }}</a></li>
                <li><a href="https://getpocket.com/apps/windowsphone/" class="dark-inline-link rarrow">{{ ftl('pocket-add-windows-mobile') }}</a></li>
                <li><a href="https://getpocket.com/apps/blackberry/" class="dark-inline-link rarrow">{{ ftl('pocket-add-blackberry') }}</a></li>
                <li><a href="https://getpocket.com/apps/" class="dark-inline-link rarrow">{{ ftl('pocket-add-more-apps') }}</a></li>
@@ -76,7 +76,7 @@
                     <p class="save-email-card-line no-border">https://www.example.com</p>
                   </div>
                 </a>
-                <a href="https://help.getpocket.com/article/1020-saving-to-pocket-via-email" target="_blank" rel="noopener noreferrer" class="dark-inline-link rarrow">{{ ftl('pocket-add-learn-more') }}</a>
+                <a href="https://help.getpocket.com/article/1020-saving-to-pocket-via-email" class="dark-inline-link rarrow">{{ ftl('pocket-add-learn-more') }}</a>
             </div>
             <div class="save-apps">
                <h3>{{ ftl('pocket-add-integrated-in') }}</h3>

--- a/bedrock/pocket/templates/pocket/jobs.html
+++ b/bedrock/pocket/templates/pocket/jobs.html
@@ -37,7 +37,7 @@
         <figure>
           {{ high_res_img('img/pocket/jobs/jobs-planning.jpg', {'alt': '', 'width': '360', 'height': '240'}) }}
         </figure>
-        <figcaption>{{ ftl('pocket-jobs-photo-by', pocket_photo_author='<a href="http://www.themogli.com/ target="_blank" rel="external noopener"">Mogli</a>',) }}</figcaption>
+        <figcaption>{{ ftl('pocket-jobs-photo-by', pocket_photo_author='<a href="http://www.themogli.com/" target="_blank" rel="external noopener">Mogli</a>',) }}</figcaption>
       </figure>
     </section>
     <section>


### PR DESCRIPTION
## One-line summary

Removes `rel` and `target` attributes for the help.getpocket domain as it is Mozilla controlled. Also small syntax fix on quotations in an href.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11666

## Testing

`npm run in-pocket-mode`

To test this work:
- [ ] http://localhost:8000/en/add/ all help.getpocket urls open in same tab by default
- [ ] bugfix: http://localhost:8000/en/jobs/ has proper syntax on the "Photo by Mogli" figcaption

In code, there should be no more _blank links for help.getpocket domain
