### PR TITLE
Update to Sentry v7.0.0 (Fixes #10473)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1285,6 +1285,7 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC + [
     "1003343.metrics.convertexperiments.com",
     "sentry.prod.mozaws.net",  # DEPRECATED. TODO: remove this once all sites are talking to sentry.io instead
     "o1069899.sentry.io",
+    "o1069899.ingest.sentry.io",
     "cdn.cookielaw.org",
     "privacyportal.onetrust.com",
     FXA_ENDPOINT,

--- a/media/js/base/sentry.es6.js
+++ b/media/js/base/sentry.es6.js
@@ -4,7 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { init } from '@sentry/browser';
+import {
+    BrowserClient,
+    Dedupe,
+    GlobalHandlers,
+    HttpContext,
+    TryCatch,
+    defaultStackParser,
+    getCurrentHub,
+    makeFetchTransport
+} from '@sentry/browser';
 
 // Respect Do Not Track
 if (
@@ -16,32 +25,18 @@ if (
         .getElementsByTagName('html')[0]
         .getAttribute('data-sentry-dsn');
 
-    // Configure Sentry SDK
-    if (sentryDsn) {
-        init({
-            dsn: sentryDsn,
-            sampleRate: 0.1,
-            ignoreErrors: [
-                "SecurityError: Failed to execute 'open' on 'XMLHttpRequest'", // issue 10683
-                'NetworkError when attempting to fetch resource', // issue 10683
-                'Non-Error promise rejection captured with value' // issue 10380
-            ],
-            allowUrls: ['/media/js/', 'https://cdn-3.convertexperiments.com/'],
-            beforeSend(event) {
-                try {
-                    // https://github.com/getsentry/sentry-javascript/issues/3147
-                    if (
-                        event.exception.values[0].stacktrace.frames[0]
-                            .filename === '<anonymous>'
-                    ) {
-                        return null;
-                    }
-                } catch (e) {
-                    // do nothing.
-                }
+    const client = new BrowserClient({
+        dsn: sentryDsn,
+        sampleRate: 0.1,
+        transport: makeFetchTransport,
+        stackParser: defaultStackParser,
+        integrations: [
+            new Dedupe(),
+            new GlobalHandlers(),
+            new HttpContext(),
+            new TryCatch()
+        ]
+    });
 
-                return event;
-            }
-        });
-    }
+    getCurrentHub().bindClient(client);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-env": "^7.16.11",
         "@mozilla-protocol/core": "16.0.0",
         "@mozilla/glean": "^1.0.0",
-        "@sentry/browser": "^6.19.0",
+        "@sentry/browser": "^7.0.0",
         "babel-loader": "^8.2.4",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^10.2.4",
@@ -1667,78 +1667,64 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.0.tgz",
-      "integrity": "sha512-YwahDZxMUxWraFd11dZ+qeflzo91ZYOnW1qdbBe0kRyaWhJQuIsBzLN5onsZBHOADU4EIS3C/np8KxL6420Z/Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.0.0.tgz",
+      "integrity": "sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==",
       "dependencies": {
-        "@sentry/core": "6.19.0",
-        "@sentry/types": "6.19.0",
-        "@sentry/utils": "6.19.0",
+        "@sentry/core": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.0.tgz",
-      "integrity": "sha512-/Csh4Skm5EA7p5SpT5vWY2s0CRiDkCrRCduA1XzrC7yu8H51HRyddXk5IBIrh/rB0Uv8MswpxP9qgucycj4v1Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==",
       "dependencies": {
-        "@sentry/hub": "6.19.0",
-        "@sentry/minimal": "6.19.0",
-        "@sentry/types": "6.19.0",
-        "@sentry/utils": "6.19.0",
+        "@sentry/hub": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.0.tgz",
-      "integrity": "sha512-ZSu4CrWOd7xwZtx8mdbs3GG2TaRCGy3vwu2KjaXYCOIRryyw8xN/B/T8Ucpc7xtJRoYaqzNPuOL9NMcpFFb/+w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.0.0.tgz",
+      "integrity": "sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==",
       "dependencies": {
-        "@sentry/types": "6.19.0",
-        "@sentry/utils": "6.19.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.0.tgz",
-      "integrity": "sha512-Sfw0KOX63nb+11F0ZcXcGBbctBBw6NZZfqvVtZXNhdBfu1cFjYdkMWi9DLuCulHR0BRq88RE+SuOqq1lgLSJEQ==",
-      "dependencies": {
-        "@sentry/hub": "6.19.0",
-        "@sentry/types": "6.19.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-jxxinvue2PzAeEewDwYJlk7tqp1SEnkaQISBSZZsRUvdk1aRWTDR5MgGejzlnaBSihwKVvFhcukd2PKm8EY9AA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.0.tgz",
-      "integrity": "sha512-Q0RT9nuMe/v9VSGs4PMIBJVLZCoUpOcVPsCtKnZNsTDzjs6+4xqDPA1dj3fXDM0A9UiJiiHeXCl66ayzbbAfNA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==",
       "dependencies": {
-        "@sentry/types": "6.19.0",
+        "@sentry/types": "7.0.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -10976,59 +10962,48 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.0.tgz",
-      "integrity": "sha512-YwahDZxMUxWraFd11dZ+qeflzo91ZYOnW1qdbBe0kRyaWhJQuIsBzLN5onsZBHOADU4EIS3C/np8KxL6420Z/Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.0.0.tgz",
+      "integrity": "sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==",
       "requires": {
-        "@sentry/core": "6.19.0",
-        "@sentry/types": "6.19.0",
-        "@sentry/utils": "6.19.0",
+        "@sentry/core": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.0.tgz",
-      "integrity": "sha512-/Csh4Skm5EA7p5SpT5vWY2s0CRiDkCrRCduA1XzrC7yu8H51HRyddXk5IBIrh/rB0Uv8MswpxP9qgucycj4v1Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==",
       "requires": {
-        "@sentry/hub": "6.19.0",
-        "@sentry/minimal": "6.19.0",
-        "@sentry/types": "6.19.0",
-        "@sentry/utils": "6.19.0",
+        "@sentry/hub": "7.0.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.0.tgz",
-      "integrity": "sha512-ZSu4CrWOd7xwZtx8mdbs3GG2TaRCGy3vwu2KjaXYCOIRryyw8xN/B/T8Ucpc7xtJRoYaqzNPuOL9NMcpFFb/+w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.0.0.tgz",
+      "integrity": "sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==",
       "requires": {
-        "@sentry/types": "6.19.0",
-        "@sentry/utils": "6.19.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.0.tgz",
-      "integrity": "sha512-Sfw0KOX63nb+11F0ZcXcGBbctBBw6NZZfqvVtZXNhdBfu1cFjYdkMWi9DLuCulHR0BRq88RE+SuOqq1lgLSJEQ==",
-      "requires": {
-        "@sentry/hub": "6.19.0",
-        "@sentry/types": "6.19.0",
+        "@sentry/types": "7.0.0",
+        "@sentry/utils": "7.0.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-jxxinvue2PzAeEewDwYJlk7tqp1SEnkaQISBSZZsRUvdk1aRWTDR5MgGejzlnaBSihwKVvFhcukd2PKm8EY9AA=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA=="
     },
     "@sentry/utils": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.0.tgz",
-      "integrity": "sha512-Q0RT9nuMe/v9VSGs4PMIBJVLZCoUpOcVPsCtKnZNsTDzjs6+4xqDPA1dj3fXDM0A9UiJiiHeXCl66ayzbbAfNA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==",
       "requires": {
-        "@sentry/types": "6.19.0",
+        "@sentry/types": "7.0.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/preset-env": "^7.16.11",
     "@mozilla-protocol/core": "16.0.0",
     "@mozilla/glean": "^1.0.0",
-    "@sentry/browser": "^6.19.0",
+    "@sentry/browser": "^7.0.0",
     "babel-loader": "^8.2.4",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^10.2.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const Dotenv = require('dotenv-webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 const staticBundles = require('./media/static-bundles.json');
+const webpack = require('webpack');
 
 function resolveBundles(fileList) {
     return fileList.map((f) => {
@@ -99,7 +100,11 @@ const jsConfig = {
                 }
             ]
         }),
-        new Dotenv()
+        new Dotenv(),
+        new webpack.DefinePlugin({
+            __SENTRY_DEBUG__: false,
+            __SENTRY_TRACING__: false
+        })
     ]
 };
 


### PR DESCRIPTION
## One-line summary

This PR updates our Sentry JS SDK bundle to v7.0.

## Significant changes and points to review

This is a major version bump with some breaking changes:

- Sentry 7.0 allows us to "opt in" to use only the [default integrations](https://docs.sentry.io/platforms/javascript/configuration/integrations/default/) that we find most useful. The benefit here is that we can end up with a smaller JS bundle by using only what we need/want. There are some useful [tree shaking docs](https://docs.sentry.io/platforms/javascript/configuration/tree-shaking/) here which I used as reference.
- The 7.0 NPM package is now published directly as ES modules, allowing for a smaller footprint. As discussed on Slack yesterday, we're going to decide against transpiling the Sentry code for older browsers, as doing so loses many of the optimisations we would otherwise gain. A lot of the error traffic we see today from old browsers is more often than not either low-level noise, or ultimately difficult act on in many scenarios.

Default integrations removed:

- `InboundFilters`: The errors we we're previously filtering/ignoring when initialising Sentry JS weren't really all that effective, and we have much better alerting rules set up today (which already cut down the noise considerably). So I don't know how valuable our existing inbound filters really were tbh. We can always add them back later if needed.
- `BreadCrumbs`: This is a nice-to-have, but not really all that useful most of the time imho.
- `FunctionToString`: Used by `BreadCrumbs`.
- `LinkedErrors`: We weren't creating any linked errors previously, so this is OK to drop I think.
- `makeXHRTransport`: dropped in favour of only using `makeFetchTransport` which is now supported in all evergreen browsers.

Potential savings:

- Uncompressed: 336.68kb -> 306.98kb
- Minified: 77.62kb -> 51.50kb
- GZip: 21.25 -> 17.35kb (this is an estimate until it gets to prod)

## Issue / Bugzilla link

#10473

## Testing

This is up on demo for testing: https://www-demo1.allizom.org/en-US/

I also added an intentional error on the home page, which you can see in Sentry here: https://sentry.io/organizations/mozilla/issues/3316870669/?project=6260338&query=error.unhandled%3Atrue+is%3Aunresolved&sort=date&statsPeriod=14d