### PR TITLE
update the contentful API to use Split

### DIFF
--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -730,7 +730,6 @@ class ContentfulPage:
                 "mzp-l-split-reversed" if fields.get("image_side") == "Left" else "",
                 self.SPLIT_LAYOUT_CLASS.get(fields.get("body_width"), ""),
                 self.SPLIT_POP_CLASS.get(fields.get("image_pop"), ""),
-                "mzp-l-split-center-on-sm-md",
             ]
             return " ".join(block_classes)
 

--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -721,6 +721,8 @@ class ContentfulPage:
 
     def get_split_data(self, entry_obj):
         fields = entry_obj.fields()
+        # Checking if the split component is being used on the contentful homepage
+        # If so, we will add a class to the body which will match the style of the depreciated hero component
         is_home_page = self.page.content_type.id == "pageHome"
 
         def get_split_class():

--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -730,6 +730,7 @@ class ContentfulPage:
                 "mzp-l-split-reversed" if fields.get("image_side") == "Left" else "",
                 self.SPLIT_LAYOUT_CLASS.get(fields.get("body_width"), ""),
                 self.SPLIT_POP_CLASS.get(fields.get("image_pop"), ""),
+                "mzp-l-split-center-on-sm-md",
             ]
             return " ".join(block_classes)
 
@@ -750,7 +751,7 @@ class ContentfulPage:
             return " ".join(media_classes)
 
         def get_mobile_class():
-            mobile_display = fields.get("mobile_display")
+            mobile_display = fields.get("mobileDisplay")
             if not mobile_display:
                 return ""
 
@@ -771,6 +772,7 @@ class ContentfulPage:
             "heading": fields.get("heading"),
             "heading_level": fields.get("heading_level"),
             "media_class": get_media_class(),
+            "media_after": fields.get("mobile_media_after"),
             "image": split_image_url,
             "mobile_class": get_mobile_class(),
             "cta": _make_cta_button(fields.get("cta")) if fields.get("cta") else "",

--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -218,6 +218,15 @@ def _make_cta_button(entry):
     return render_to_string("includes/contentful/cta.html", data, get_current_request())
 
 
+def _make_product_icon(entry):
+    content_type = entry.sys["content_type"].id
+
+    if content_type == "componentLogo":
+        return _make_logo(entry)
+    elif content_type == "componentWordmark":
+        return _make_wordmark(entry)
+
+
 def _make_plain_text(node):
     content = node["content"]
     plain = ""
@@ -712,6 +721,7 @@ class ContentfulPage:
 
     def get_split_data(self, entry_obj):
         fields = entry_obj.fields()
+        is_home_page = self.page.content_type.id == "pageHome"
 
         def get_split_class():
             block_classes = [
@@ -725,6 +735,7 @@ class ContentfulPage:
             body_classes = [
                 self.SPLIT_V_ALIGN_CLASS.get(fields.get("body_vertical_alignment"), ""),
                 self.SPLIT_H_ALIGN_CLASS.get(fields.get("body_horizontal_alignment"), ""),
+                "c-home-body" if is_home_page else "",
             ]
             return " ".join(body_classes)
 
@@ -755,9 +766,13 @@ class ContentfulPage:
             "theme_class": _get_theme_class(fields.get("theme")),
             "body_class": get_body_class(),
             "body": self.render_rich_text(fields.get("body")),
+            "heading": fields.get("heading"),
+            "heading_level": fields.get("heading_level"),
             "media_class": get_media_class(),
             "image": split_image_url,
             "mobile_class": get_mobile_class(),
+            "cta": _make_cta_button(fields.get("cta")) if fields.get("cta") else "",
+            "product_icon": _make_product_icon(fields.get("product_icon")) if fields.get("product_icon") else "",
         }
         return data
 

--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -132,6 +132,7 @@
         theme_class=entry.theme_class,
         media_class=entry.media_class,
         mobile_class=entry.mobile_class,
+        media_after=entry.media_after,
         image_url=entry.image,
         include_highres_image=False,
         loading=loading,

--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -134,10 +134,12 @@
         mobile_class=entry.mobile_class,
         image_url=entry.image,
         include_highres_image=False,
-        loading=loading
+        loading=loading,
       ) %}
-
+        {% if entry.product_icon %}{{ entry.product_icon }}{% endif %}
+        {% if entry.heading %}<{{ entry.heading_level }}>{{ entry.heading }}</{{ entry.heading_level}}>{% endif %}
         {{ entry.body|external_html }}
+        {% if entry.cta %}{{ entry.cta }}{% endif %}
 
       {% endcall %}
 

--- a/media/css/contentful/mozilla/c-split.scss
+++ b/media/css/contentful/mozilla/c-split.scss
@@ -10,13 +10,3 @@ $brand-theme: 'mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/split';
 
 @import '../patch';
-
-.mzp-c-split-body.c-home-body {
-    .mzp-c-button {
-        margin-top: $spacing-md;
-    }
-
-    p {
-        @include text-body-lg;
-    }
-}

--- a/media/css/contentful/mozilla/c-split.scss
+++ b/media/css/contentful/mozilla/c-split.scss
@@ -10,3 +10,19 @@ $brand-theme: 'mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/split';
 
 @import '../patch';
+
+// Temporary fix to center the wordmark and logo on mobile when the split component also has the class "mzp-l-split-center-on-sm-md"
+.mzp-c-split.mzp-l-split-center-on-sm-md {
+    .mzp-c-wordmark,
+    .mzp-c-logo {
+        background-position: center;
+        margin-left: auto;
+        margin-right: auto;
+
+        @media #{$mq-md} {
+            background-position: top left;
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
+}

--- a/media/css/contentful/mozilla/c-split.scss
+++ b/media/css/contentful/mozilla/c-split.scss
@@ -10,3 +10,13 @@ $brand-theme: 'mozilla';
 @import '~@mozilla-protocol/core/protocol/css/components/split';
 
 @import '../patch';
+
+.mzp-c-split-body.c-home-body {
+    .mzp-c-button {
+        margin-top: $spacing-md;
+    }
+
+    p {
+        @include text-body-lg;
+    }
+}

--- a/media/css/mozorg/home/home-contentful.scss
+++ b/media/css/mozorg/home/home-contentful.scss
@@ -11,3 +11,15 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
 
 @import 'includes/home-base';
+
+// If split is used on the homepage, we will add a class to the body
+// which will match the style of the depreciated hero component
+.mzp-c-split-body.c-home-body {
+    .mzp-c-button {
+        margin-top: $spacing-md;
+    }
+
+    p {
+        @include text-body-lg;
+    }
+}


### PR DESCRIPTION
## One-line summary
This PR updated the code in bedrock to update the split component to be used on the contentful homepage instead of hero

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10445

## Screenshots
The following screenshots are from the local preview viewing the EN-US homepage - both are using the updated split component:
<img width="1248" alt="Screen Shot 2022-06-01 at 3 48 27 PM" src="https://user-images.githubusercontent.com/30009669/171514423-1a246754-8197-40c7-a5b7-908ce310dad9.png">
<img width="1253" alt="Screen Shot 2022-06-01 at 3 48 18 PM" src="https://user-images.githubusercontent.com/30009669/171514431-d86f6f68-7414-45a2-b4de-7257e6b83937.png">
## Checklist
- [x] Added Heading and Heading level attribute (defaults to a H2)
- [x] Added Product Icon attribute (you can choose between logo and wordmark)
- [x] Added CTA attribute
- [x] To match the body styles of the hero component, I added a class to the `.mzp-c-split-body` element if the current page is the homepage 

## Testing
Pull down this branch, and then start a local server - load a contentful preview of the sandbox environment and you should be able to see both the hero components and split components to compare. Once this PR merges, we can remove the old Hero components from the contentful homepage.

- [ ] Can successfully re-create the homepage split components for Pocket & VPN
