### PR TITLE
Add Glean to core /firefox pages (Issue #10746)

### DIFF
--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -290,6 +290,12 @@
   {% include '/includes/sticky-promo.html' %}
 {% endblock %}
 
+{% block glean %}
+  {% if switch('glean-analytics') %}
+    {{ js_bundle('glean') }}
+  {% endif %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('fxa_product_button') }}
   {{ js_bundle('firefox-master') }}

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -41,3 +41,9 @@
 {% block old_ie_styles %}{% endblock %}
 {% block site_css %}{% endblock %}
 {% block page_css %}{% endblock %}
+
+{% block glean %}
+  {% if switch('glean-analytics') %}
+    {{ js_bundle('glean') }}
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -39,3 +39,9 @@
 {% endblock %}
 
 {% block body_class %}mzp-t-firefox{% endblock %}
+
+{% block glean %}
+  {% if switch('glean-analytics') %}
+    {{ js_bundle('glean') }}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## One-line summary

Adds glean bundle to core Firefox pages.

## Issue / Bugzilla link

#10746

## Testing

Demo server URL: (or None)

Glean page pings on: 

- [ ] http://localhost:8000/en-US/firefox/
- [ ] http://localhost:8000/en-US/firefox/new/
- [ ] http://localhost:8000/en-US/firefox/new/?xv=basic
- [ ] http://localhost:8000/en-US/firefox/download/thanks/
- [ ] http://localhost:8000/en-US/firefox/download/thanks/?xv=basic
- [ ] http://localhost:8000/en-US/firefox/windows/
- [ ] http://localhost:8000/en-US/firefox/mac/
- [ ] http://localhost:8000/en-US/firefox/linux/
