### PR TITLE
Removed UTM param from same-site link

### DIFF
--- a/bedrock/base/templates/includes/sticky-promo.html
+++ b/bedrock/base/templates/includes/sticky-promo.html
@@ -16,7 +16,7 @@
       <h3 class="mzp-c-sticky-promo-title">{{ ftl('firefox-sticky-promo-meet-our-family-of') }}</h3>
       <ul class="promo-products-list">
         <li>
-          <a data-link-name="Browsers" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="{{ url('firefox.browsers.index') }}{{ promo_referrals }}">
+          <a data-link-name="Browsers" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="{{ url('firefox.browsers.index') }}">
             <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-browsers') }}
           </a>


### PR DESCRIPTION
## One-line summary
Since it's not good practice to have UTM parameters in same-site link, we've decided to remove it in the sticky promo
## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11725
## Testing
- [ ] open http://localhost:8000/en-US/firefox/browsers/
- [ ] scroll to activate sticky-promo
- [ ] click on "Browsers" link, and it shouldn't have anymore UTM parameters.
