### PR TITLE
Update Pocket locale/L10N config based on latest info about translations from Vendor

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -144,23 +144,23 @@ if IS_POCKET_MODE:
     ]
 
     CANONICAL_LOCALES = {
-        # We want to ensure es-ES gets its specific translations, rather than falling back to 'es'
-        "es-ES": "es-ES",
+        # Pocket has some region-less locales that we need to map to full locales
+        "es": "es-ES",
+        "pt": "pt-PT",
+        "zh": "zh-CN",
+        # Case correction
+        "es-la": "es-LA",
     }
 
     FALLBACK_LOCALES = {
-        # NB: es-LA isn't a real locale, but it is what getpocket.com has used
-        # and we need to deal with it, by redirecting to international Spanish
-        "es-la": "es",
+        # "es": "es-ES",
     }
 
     PROD_LANGUAGES = [
-        # TODO: double-check for correctness and completeness
-        # when we have real translations from the vendor
         "de",
         "en",
-        "es",
         "es-ES",
+        "es-LA",  # Not an ISO locale, but a locale-like convention; Pocket uses it as lowercase
         "fr-CA",
         "fr",
         "it",

--- a/l10n-pocket/configs/vendor.toml
+++ b/l10n-pocket/configs/vendor.toml
@@ -6,7 +6,7 @@ basepath = ".."
 locales = [
     "de",
     "en",
-    "es",  # This will be used for International Spanish, incl `es-la`
+    "es-LA",
     "es-ES",
     "fr-CA",
     "fr",


### PR DESCRIPTION
This changeset gets the locales all lined up to be correct based on what's available via the L10N pipeline.

It's not the entire solution, though: we'll be getting/using "es-ES" not just "es" in our interactions with the vendor, which means we will need to support some kind of redirect/rewrite at the CDN level (which will be in a separate ticket - details TBC).

However, with the current config in this changeset, Bedrock WILL handle the locale differences (redirecting from /es/foo to /es-ES/foo, for example), but will do so with a HTTP 302 Temporary Redirect which has an SEO impact. Ideally any redirect because the locale code has been tweaked must be a 301.

Also, it's not just es-ES and es-la/LA that need attention. Comparing with https://github.com/Pocket/dotcom-gateway/blob/main/lambda/src/config/locales.ts it looks like /zh/ and /pt/ will also need redirects

Testing this is tricky until we have translations flowing, which in turn need this merged, so a chicken-and-egg moment 😄 
