### PR TITLE
Add spaces in L10N strings

### DIFF
--- a/l10n/en/firefox/new/download.ftl
+++ b/l10n/en/firefox/new/download.ftl
@@ -8,7 +8,7 @@
 
 firefox-new-download-firefox = Download { -brand-name-firefox }
 firefox-new-download-the-fastest-firefox = Download the fastest { -brand-name-firefox } ever
-firefox-new-mozilla = {-brand-name-mozilla}
+firefox-new-mozilla = { -brand-name-mozilla }
 firefox-new-faster-page-loading-less-memory = Faster page loading, less memory usage and packed with features, the new { -brand-name-firefox } is here.
 firefox-new-get-the-latest-firefox = Get the latest { -brand-name-firefox } browser.
 
@@ -63,7 +63,7 @@ firefox-new-visit-support-for-more = Visit Support for More Details
 # The three strings below are joined with a "—" to form a page title like "Download Firefox Browser — Fast, Private & Free — from Mozilla"
 firefox-new-download-browser = Download { -brand-name-firefox-browser }
 firefox-new-fast = Fast, Private & Free
-firefox-new-from-mozilla = from {-brand-name-mozilla}
+firefox-new-from-mozilla = from { -brand-name-mozilla }
 
 firefox-new-desc = { -brand-name-firefox-browser } is a free web browser with fast page loading, less memory usage, and lots of features - a project of the not-for-profit { -brand-name-mozilla }.
 firefox-new-download-a-different = Download a different platform or language


### PR DESCRIPTION
## One-line summary
Two variables in [`firefox/new/download.ftl`](https://github.com/mozilla/bedrock/blob/main/l10n/en/firefox/new/download.ftl) didn't have spaces. I added the spaces for best practices and consistency.

## Issue
https://github.com/mozilla/bedrock/issues/11740

To test this work:

- [ ] `firefox/new/download.ftl`
