### PR TITLE
10327 java script disabled on browser fix

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -146,7 +146,7 @@
   </div>
 
 {% elif use_thankyou %}
-  <div id="newsletter-thanks" class="mzp-c-newsletter-thanks">
+  <div id="newsletter-thanks">
     {% if thankyou_content %}
       <h3>{{ thankyou_head }}</h3>
       <p>{{ thankyou_content }}</p>

--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -1,7 +1,7 @@
 {#
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
 {% extends 'newsletter/base.html' %}
@@ -9,48 +9,19 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% block page_title %}{{ ftl('newsletters-mozilla-newsletter') }}{% endblock %}
 
 {% block content %}
-
-<noscript>
-  <div style="margin-left: 7%;">
-    <h3>Thanks!</h3>
-    <h4>We have received your request.</h4>
-    <h5>You are seeing this page because Javascript is not enabled on your browser.</h5>
-  </div>
-  <div style="margin:2%; margin-left: 7%;">
-    <a href="/">
-      <button class="mzp-c-button button-dark">
-        Go Back
-      </button>
-    </a>
-  </div>
-  <style type="text/css">
-       #main {display: none; }
-
-  </style>
-</noscript>
-<script type="text/javascript">
-  if(!navigator.CookieEnabled){
-     document.getElementById('main').innerHtml = "Cookies are disabled";
-  }
-
-</script>
-
-<div id="main">
-  <main role="main">
-    <div class="mzp-l-content mzp-t-content-sm">
-      {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc',
-      'multi-newsletter-form-checkboxes-legend') %}
+<main role="main">
+  <div class="mzp-l-content mzp-t-content-sm">
+    {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc', 'multi-newsletter-form-checkboxes-legend') %}
       {{ email_newsletter_form(
-      newsletters='mozilla-foundation, mozilla-and-you',
-      button_class='button-dark'
+        newsletters='mozilla-foundation, mozilla-and-you',
+        button_class='button-dark'
       )}}
-      {% else %}
+    {% else %}
       {{ email_newsletter_form(
-      title=ftl('newsletters-read-all-about-it-in-our-newsletter'),
-      desc=ftl('newsletters-subscribe-here-to-keep-current', fallback='newsletters-subscribe-to-updates-and-keep'),
-      newsletters='mozilla-foundation') }}
-      {% endif %}
-    </div>
-  </main>
-</div>
+        title=ftl('newsletters-read-all-about-it-in-our-newsletter'),
+        desc=ftl('newsletters-subscribe-here-to-keep-current', fallback='newsletters-subscribe-to-updates-and-keep'),
+        newsletters='mozilla-foundation') }}
+    {% endif %}
+  </div>
+</main>
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -1,7 +1,7 @@
 {#
- This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
 {% extends 'newsletter/base.html' %}
@@ -9,19 +9,49 @@
 {% block page_title %}{{ ftl('newsletters-mozilla-newsletter') }}{% endblock %}
 
 {% block content %}
-<main role="main">
-  <div class="mzp-l-content mzp-t-content-sm">
-    {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc', 'multi-newsletter-form-checkboxes-legend') %}
-      {{ email_newsletter_form(
-        newsletters='mozilla-foundation, mozilla-and-you',
-        button_class='button-dark'
-      )}}
-    {% else %}
-      {{ email_newsletter_form(
-        title=ftl('newsletters-read-all-about-it-in-our-newsletter'),
-        desc=ftl('newsletters-subscribe-here-to-keep-current', fallback='newsletters-subscribe-to-updates-and-keep'),
-        newsletters='mozilla-foundation') }}
-    {% endif %}
+
+<noscript>
+  <div style="margin-left: 7%;">
+    <h3>Thanks!</h3>
+    <h4>We have received your request.</h4>
+    <h5>You are seeing this page because Javascript is not enabled on your browser.</h5>
   </div>
-</main>
+  <div style="margin:2%; margin-left: 7%;">
+    <a href="/">
+      <button class="mzp-c-button button-dark" data-cta-text="Newsletter Sign Up"
+              data-cta-type="Newsletter-mozilla-firefox-multi" id="newsletter-submit" type="submit">
+        Go Back
+      </button>
+    </a>
+  </div>
+  <style type="text/css">
+       #main {display: none; }
+
+  </style>
+</noscript>
+<script type="text/javascript">
+  if(!navigator.CookieEnabled){
+     document.getElementById('main').innerHtml = "Cookies are disabled";
+  }
+
+</script>
+
+<div id="main">
+  <main role="main">
+    <div class="mzp-l-content mzp-t-content-sm">
+      {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc',
+      'multi-newsletter-form-checkboxes-legend') %}
+      {{ email_newsletter_form(
+      newsletters='mozilla-foundation, mozilla-and-you',
+      button_class='button-dark'
+      )}}
+      {% else %}
+      {{ email_newsletter_form(
+      title=ftl('newsletters-read-all-about-it-in-our-newsletter'),
+      desc=ftl('newsletters-subscribe-here-to-keep-current', fallback='newsletters-subscribe-to-updates-and-keep'),
+      newsletters='mozilla-foundation') }}
+      {% endif %}
+    </div>
+  </main>
+</div>
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -18,8 +18,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   </div>
   <div style="margin:2%; margin-left: 7%;">
     <a href="/">
-      <button class="mzp-c-button button-dark" data-cta-text="Newsletter Sign Up"
-              data-cta-type="Newsletter-mozilla-firefox-multi" id="newsletter-submit" type="submit">
+      <button class="mzp-c-button button-dark">
         Go Back
       </button>
     </a>


### PR DESCRIPTION
## One-line summary

When used older browser or browser where JS is disabled, subscribe to newsletter shows a blank screen.

## Significant changes and points to review

Added no script tag so that optional message will be shown if javascript is disabled.

## Issue / Bugzilla link
#10327 


## Screenshots

![Image 08-06-22 at 3 01 PM](https://user-images.githubusercontent.com/49924204/172584606-02b9cf34-dec3-47b1-9c64-89c0c227e389.jpg)

Demo server URL: (or None)

To test this work:

1.  start bedrock server and go to bottom for subscribing to newsletter
2. disable browser javascript
3. enter email (`success@example.com`)
4.  subscribe
