### PR TITLE
Update Pocket locale/L10N config based on latest info about translations from Vendor

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -144,23 +144,23 @@ if IS_POCKET_MODE:
     ]
 
     CANONICAL_LOCALES = {
-        # We want to ensure es-ES gets its specific translations, rather than falling back to 'es'
-        "es-ES": "es-ES",
+        # Pocket has some region-less locales that we need to map to full locales
+        "es": "es-ES",
+        "pt": "pt-PT",
+        "zh": "zh-CN",  # TBC whether this is needed in reality, as zh redirects to zh-cn on the previous Pocket site
+        # Case correction
+        "es-la": "es-LA",
     }
 
     FALLBACK_LOCALES = {
-        # NB: es-LA isn't a real locale, but it is what getpocket.com has used
-        # and we need to deal with it, by redirecting to international Spanish
-        "es-la": "es",
+        # "es": "es-ES",
     }
 
     PROD_LANGUAGES = [
-        # TODO: double-check for correctness and completeness
-        # when we have real translations from the vendor
         "de",
         "en",
-        "es",
         "es-ES",
+        "es-LA",  # Not an ISO locale, but a locale-like convention; Pocket uses it as lowercase
         "fr-CA",
         "fr",
         "it",

--- a/l10n-pocket/configs/vendor.toml
+++ b/l10n-pocket/configs/vendor.toml
@@ -5,8 +5,7 @@ basepath = ".."
 
 locales = [
     "de",
-    "en",
-    "es",  # This will be used for International Spanish, incl `es-la`
+    "es-LA",
     "es-ES",
     "fr-CA",
     "fr",


### PR DESCRIPTION
This changeset gets the locales all lined up to be correct based on what's _currently_ configured at the vendor end for the Pocket L10N pipeline.

It's not the entire solution, though: the vendor side is using "es-ES", but getpocket.com currently uses /es/ in its URLs, which means we will need to bridge that gap. That work is written up in #https://github.com/mozilla/bedrock/issues/11738

At least, with the current config in this changeset, Bedrock in Pocket Mode WILL handle the locale differences (redirecting from `/es/add` to `/es-ES/add`, for example), but will do so with a HTTP 302 Temporary Redirect - and that has an SEO impact. (Ideally any redirect due to a locale code being different must be a 301.)

Testing this is tricky until we have translations flowing, which in turn need this merged, so a chicken-and-egg moment 😄 
