### PR TITLE
Stop sending people to the legacy VPN download page (Fixes #11748)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -107,25 +107,9 @@
       </a>
     {% endif %}
 
-    {% if ftl_file_is_active('products/vpn/download') %}
-      <a href="{{ url('products.vpn.download') }}" class="mzp-c-cta-link" data-cta-type="link" data-cta-text="Already a subscriber?" data-cta-position="navigation">
-        {{ download_link_text }}
-      </a>
-    {% else %}
-      {{ vpn_download_link(
-        entrypoint=utm_source,
-        link_text=download_link_text,
-        class_name='mzp-c-cta-link',
-        optional_parameters={
-          'utm_campaign': utm_campaign
-        },
-        optional_attributes={
-          'data-cta-type': 'fxa-vpn',
-          'data-cta-text': 'VPN Sign In',
-          'data-cta-position': 'navigation',
-        }
-      ) }}
-    {% endif %}
+    <a href="{{ url('products.vpn.download') }}" class="mzp-c-cta-link" data-cta-type="link" data-cta-text="Already a subscriber?" data-cta-position="navigation">
+      {{ download_link_text }}
+    </a>
   </div>
 {%- endmacro %}
 

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -280,7 +280,7 @@
       <p class="vpn-faq-item-detail">{{ ftl('vpn-landing-faq-manage-subscription-question-desc', url='https://vpn.mozilla.org/r/vpn/subscription' + _params) }}</p>
     </details>
 
-    {% if ftl_file_is_active('products/vpn/download') and ftl_has_messages('vpn-landing-faq-download-heading', 'vpn-landing-faq-download-desc') %}
+    {% if ftl_has_messages('vpn-landing-faq-download-heading', 'vpn-landing-faq-download-desc') %}
     <details id="faq-download" class="vpn-faq-item mzp-is-anchor-link">
       <summary class="vpn-faq-item-heading">
         <h3>{{ ftl('vpn-landing-faq-download-heading') }}</h3>

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -54,25 +54,6 @@ def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optio
 
 @library.global_function
 @jinja2.contextfunction
-def vpn_download_link(ctx, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
-    """
-    Render a vpn.mozilla.org download link with required params for product referrals.
-
-    Examples
-    ========
-
-    In Template
-    -----------
-
-        {{ vpn_download_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Already a subscriber?') }}
-    """
-    product_url = f"{settings.VPN_ENDPOINT}vpn/download"
-
-    return _vpn_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)
-
-
-@library.global_function
-@jinja2.contextfunction
 def vpn_subscribe_link(
     ctx, entrypoint, link_text, plan="12-month", class_name=None, country_code=None, lang=None, optional_parameters=None, optional_attributes=None
 ):

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -726,37 +726,6 @@ class TestVPNSubscribeLink(TestCase):
         self.assertIn("?plan=price_1JcdsSJNcmPzuWtRGF9Y5TMJ", markup)
 
 
-@override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT, VPN_ENDPOINT=TEST_VPN_ENDPOINT)
-class TestVPNDownloadLink(TestCase):
-    rf = RequestFactory()
-
-    def _render(self, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
-        req = self.rf.get("/")
-        req.locale = "en-US"
-        return render(
-            f"{{{{ vpn_download_link('{entrypoint}', '{link_text}', '{class_name}', {optional_parameters}, {optional_attributes}) }}}}",
-            {"request": req},
-        )
-
-    def test_download_in_link(self):
-        """Should return expected markup"""
-        markup = self._render(
-            entrypoint="www.mozilla.org-vpn-product-page",
-            link_text="Already a Subscriber?",
-            class_name="mzp-c-cta-link",
-            optional_parameters={"utm_campaign": "vpn-product-page"},
-            optional_attributes={"data-cta-text": "VPN Sign In", "data-cta-type": "fxa-vpn", "data-cta-position": "navigation"},
-        )
-        expected = (
-            '<a href="https://vpn.mozilla.org/vpn/download?entrypoint=www.mozilla.org-vpn-product-page'
-            "&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral"
-            '&utm_campaign=vpn-product-page&data_cta_position=navigation" data-action="https://accounts.firefox.com/" '
-            'class="js-vpn-cta-link js-fxa-product-button mzp-c-cta-link" data-cta-text="VPN Sign In" '
-            'data-cta-type="fxa-vpn" data-cta-position="navigation">Already a Subscriber?</a>'
-        )
-        self.assertEqual(markup, expected)
-
-
 @override_settings(VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING)
 class TestVPNMonthlyPrice(TestCase):
     rf = RequestFactory()

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -200,16 +200,6 @@ all support the same standard parameters:
 Mozilla :abbr:`VPN (Virtual Private Network)` Links
 ---------------------------------------------------
 
-Use the ``vpn_download_link`` helper to create a link to https://vpn.mozilla.org/vpn/download/
-with :abbr:`FxA (Firefox Account)` metrics params attached.
-
-Usage
-~~~~~
-
-.. code-block:: jinja
-
-    {{ vpn_download_link(entrypoint='www.mozilla.org-vpn-product-page', link_text='Already a subscriber?') }}
-
 Use the ``vpn_subscribe_link`` helpers to create a :abbr:`VPN (Virtual Private Network)` subscription link via a
 Firefox Accounts auth flow.
 


### PR DESCRIPTION
## One-line summary

Removes `vpn_download_link` helper and points all VPN download page links to the new bedrock page.

## Issue / Bugzilla link

#11748

## Testing

http://localhost:8000/en-US/products/vpn/