### PR TITLE
Support mapping of locales at vendor level for Pocket

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -69,35 +69,33 @@ if IS_POCKET_MODE:
     ]
 
     CANONICAL_LOCALES = {
-        # Pocket has some region-less locales that we need to map to full locales
-        "es": "es-ES",
-        "pt": "pt-PT",
-        "zh": "zh-CN",  # TBC whether this is needed in reality, as zh redirects to zh-cn on the previous Pocket site
-        # Case correction
-        "es-la": "es-LA",
+        # Pocket uses mostly region-less locales, but these will be automatically selected by Bedrock
+        # e.g. /de-DE/ -> /de/ via a 302
     }
 
     FALLBACK_LOCALES = {
-        # "es": "es-ES",
+        # TODO: Drop after confimring longer used _anywhere_
     }
 
     PROD_LANGUAGES = [
+        # Note that all of Pocket's locale strings are lowercase - and mixed case is HTTP 301ed
+        # to lowercase versions. We are retaining this behaviour for legacy consistency and SEO
         "de",
         "en",
-        "es-ES",
-        "es-LA",  # Not an ISO locale, but a locale-like convention; Pocket uses it as lowercase
-        "fr-CA",
+        "es",  # We map es-ES to this in `l10n-pocket/configs/smartling-config.json`
+        "es-la",  # Not an ISO locale, but a locale-like convention; remapped in vendor config
+        "fr-ca",
         "fr",
         "it",
         "ja",
         "ko",
         "nl",
         "pl",
-        "pt-BR",
-        "pt-PT",
+        "pt-br",
+        "pt",  # mapped from "pt-PT"
         "ru",
-        "zh-CN",
-        "zh-TW",
+        "zh-cn",
+        "zh-tw",
     ]
 
     # No reason to have separate Dev and Prod lang sets for Pocket mode

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -74,7 +74,7 @@ if IS_POCKET_MODE:
     }
 
     FALLBACK_LOCALES = {
-        # TODO: Drop after confimring longer used _anywhere_
+        # TODO: Drop after confirming no longer used _anywhere_
     }
 
     PROD_LANGUAGES = [

--- a/l10n-pocket/configs/smartling-config.json
+++ b/l10n-pocket/configs/smartling-config.json
@@ -1,0 +1,73 @@
+{
+  "locales": [
+    {
+      "smartling": "de-DE",
+      "application": "de"
+    },
+    {
+      "smartling": "es-ES",
+      "application": "es"
+    },
+    {
+      "smartling": "es-LA",
+      "application": "es-la"
+    },
+    {
+      "smartling": "fr-CA",
+      "application": "fr-ca"
+    },
+    {
+      "smartling": "fr-FR",
+      "application": "fr"
+    },
+    {
+      "smartling": "it-IT",
+      "application": "it"
+    },
+    {
+      "smartling": "ja-JP",
+      "application": "ja"
+    },
+    {
+      "smartling": "ko-KR",
+      "application": "ko"
+    },
+    {
+      "smartling": "nl-NL",
+      "application": "nl"
+    },
+    {
+      "smartling": "pl-PL",
+      "application": "pl"
+    },
+    {
+      "smartling": "pt-BR",
+      "application": "pt-br"
+    },
+    {
+      "smartling": "pt-PT",
+      "application": "pt"
+    },
+    {
+      "smartling": "ru-RU",
+      "application": "ru"
+    },
+    {
+      "smartling": "zh-CN",
+      "application": "zh-cn"
+    },
+    {
+      "smartling": "zh-TW",
+      "application": "zh-tw"
+    }
+  ],
+  "resourceSets": [
+    {
+      "type": "FLUENT",
+      "authorizeContent": "false",
+      "pathRegex": "en\\/(?<path>.*)\\.ftl",
+      "translationPathExpression": "${locale}/${path}.${originalFile.extension}",
+      "translationCommitMessage": "Translate ${originalFile.fullName} to ${locale}"
+    }
+  ]
+}


### PR DESCRIPTION
The locale codes from our translation vendor don't quite align with the simpler locales used in Pocket's URLs. It looks like  we can address that via translation config, which is what we do here.

## Significant changes and points to review

Note how `PROD_LANGUAGES` for Pocket references the shorter locale code - this is because when they translations emerge from the L10N pipeline, they should (🤞) land in directories like `es` not `es-ES`, etc. 

If this works, even though the locale pattern will be slightly different from Mozorg (where we always use the full `locale-REGION` pattern), we will be providing _exactly_ the same URLs in locale terms as getpocket.com currently does, which saves us UX and SEO pain.

## Issue / Bugzilla link

Resolves #11738 

## Testing

* Not much to manually test until we get L10N data flowing in.