### PR TITLE
Add pocket home 10 year badge (fixes #11730)

### DIFF
--- a/bedrock/pocket/templates/pocket/home.html
+++ b/bedrock/pocket/templates/pocket/home.html
@@ -30,6 +30,10 @@
           media_after=True,
           loading='eager'
           )%}
+          <div class="c-hero-badge">
+            <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket"></div>
+            <p><strong>{{ ftl('pocket-home-10-year') }}</strong></p>
+          </div>
           <h1 class="section-heading">{{ ftl('pocket-home-get-right-to') }}</h1>
           <p class="section-lede">{{ ftl('pocket-home-your-own-private') }}</p>
           <div class="pocket-homepage-accounts">

--- a/l10n-pocket/en/pocket/home.ftl
+++ b/l10n-pocket/en/pocket/home.ftl
@@ -38,3 +38,5 @@ pocket-home-unlimited-highlights = Unlimited highlights
 pocket-home-premium-fonts = Premium fonts
 
 pocket-home-discover-and-save = Discover and save the most interesting stories on the web
+
+pocket-home-10-year = 10 Years of { -brand-name-pocket }

--- a/media/css/pocket/components/about.scss
+++ b/media/css/pocket/components/about.scss
@@ -6,7 +6,7 @@
 @import '../includes/nav';
 @import '../includes/footer';
 
-$image-path: '/media/img/pocket';
+$pocket-image-path: '/media/img/pocket';
 
 .intro-wrapper {
     background-color: #95d5d2;
@@ -67,7 +67,7 @@ $image-path: '/media/img/pocket';
         padding: 40px 16px 118vw;
 
         &::before {
-            background: url('#{$image-path}/people-enjoying-content-md.svg') no-repeat 100% 0 / contain;
+            background: url('#{$pocket-image-path}/people-enjoying-content-md.svg') no-repeat 100% 0 / contain;
             width: 200vw;
             height: 134vw;
             top: unset;
@@ -102,7 +102,7 @@ $image-path: '/media/img/pocket';
             padding: 128px 40px 352px;
 
             &::before {
-                background-image: url('#{$image-path}/people-enjoying-content-lg.svg');
+                background-image: url('#{$pocket-image-path}/people-enjoying-content-lg.svg');
                 top: 40px;
                 right: calc(50% - 872px);
                 width: 1616px;
@@ -120,7 +120,7 @@ $image-path: '/media/img/pocket';
         margin-bottom: 304px;
 
         &::before {
-            background: url('#{$image-path}/swirly-saving-xs.svg') no-repeat 100% 0 / contain;
+            background: url('#{$pocket-image-path}/swirly-saving-xs.svg') no-repeat 100% 0 / contain;
             bottom: -540px;
             height: 845px;
             right: -370px;
@@ -133,7 +133,7 @@ $image-path: '/media/img/pocket';
             margin-bottom: 490px;
 
             &::before {
-                background-image: url('#{$image-path}/swirly-saving-sm.svg');
+                background-image: url('#{$pocket-image-path}/swirly-saving-sm.svg');
                 height: 845px;
                 right: -195px;
                 top: -160px;
@@ -146,7 +146,7 @@ $image-path: '/media/img/pocket';
             margin-bottom: 608px;
 
             &::before {
-                background-image: url('#{$image-path}/swirly-saving-lg.svg');
+                background-image: url('#{$pocket-image-path}/swirly-saving-lg.svg');
                 height: 750px;
                 right: -90px;
                 top: -212px;
@@ -161,7 +161,7 @@ $image-path: '/media/img/pocket';
         padding-bottom: 656px;
 
         &::before {
-            background: url('#{$image-path}/rainbow-hand-gem-sm.svg') no-repeat 100% 0 / contain;
+            background: url('#{$pocket-image-path}/rainbow-hand-gem-sm.svg') no-repeat 100% 0 / contain;
             bottom: 110px;
             height: 590px;
             right: -155px;
@@ -191,7 +191,7 @@ $image-path: '/media/img/pocket';
                 top: -80px;
                 width: 800px;
                 transform: rotate(13deg);
-                background-image: url('#{$image-path}/rainbow-hand-gem-lg.svg');
+                background-image: url('#{$pocket-image-path}/rainbow-hand-gem-lg.svg');
             }
         }
 
@@ -211,7 +211,7 @@ $image-path: '/media/img/pocket';
         padding-bottom: 668px;
 
         &::before {
-            background: url('#{$image-path}/floating-content-md.svg') no-repeat 100% / contain;
+            background: url('#{$pocket-image-path}/floating-content-md.svg') no-repeat 100% / contain;
             height: 212vw;
             bottom: 80px;
             right: -15vw;
@@ -231,7 +231,7 @@ $image-path: '/media/img/pocket';
             padding-bottom: 272px;
 
             &::before {
-                background-image: url('#{$image-path}/floating-content-lg.svg');
+                background-image: url('#{$pocket-image-path}/floating-content-lg.svg');
                 height: 1175px;
                 left: 57.5%;
                 top: -496px;
@@ -254,7 +254,7 @@ $image-path: '/media/img/pocket';
         padding-bottom: 181vw;
 
         &::before {
-            background: url('#{$image-path}/sunny-content-md.svg') no-repeat 100% 0 / contain;
+            background: url('#{$pocket-image-path}/sunny-content-md.svg') no-repeat 100% 0 / contain;
             bottom: -29vw;
             height: 242vw;
             right: -25vw;
@@ -268,7 +268,7 @@ $image-path: '/media/img/pocket';
             padding-bottom: 520px;
 
             &::before {
-                background-image: url('#{$image-path}/sunny-content-lg.svg');
+                background-image: url('#{$pocket-image-path}/sunny-content-lg.svg');
                 height: 1192px;
                 right: calc(50% - 144px);
                 top: -310px;

--- a/media/css/pocket/components/add.scss
+++ b/media/css/pocket/components/add.scss
@@ -8,8 +8,6 @@
 @import '../includes/platform-nav';
 @import '../includes/platform-footer';
 
-$image-path: '/media/img/pocket';
-
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/button';
 

--- a/media/css/pocket/components/home.scss
+++ b/media/css/pocket/components/home.scss
@@ -4,22 +4,22 @@
 
 @use 'sass:color';
 
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
 @import '~@mozilla-protocol/core/protocol/css/components/button';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
 @import '../utils/variables';
 @import '../includes/platform-nav';
 @import '../includes/platform-footer';
-
-$image-path: '/media/img/pocket';
 
 .pocket-homepage {
     color: $color-text-primary;
     font-family: $font-sans;
 
     .pocket-homepage-header {
-        padding-top: 0;
-
         .mzp-l-split-media-overflow {
             width: 145%;
             transform: translateX(-40%);
@@ -35,6 +35,12 @@ $image-path: '/media/img/pocket';
         .mzp-c-split-media-asset {
             max-height: 800px;
             width: auto;
+        }
+
+        @media #{$mq-md} {
+            &.mzp-l-split-pop {
+                padding-top: 0;
+            }
         }
     }
 
@@ -187,3 +193,36 @@ $image-path: '/media/img/pocket';
         width: 20px;
     }
 }
+
+// 10 year badge
+.c-hero-badge {
+    align-items: center;
+    display: flex;
+
+    .mzp-c-logo {
+        margin-bottom: 0;
+        margin-right: $spacing-sm;
+
+        // override for smaller logo
+        &.mzp-t-logo-xs {
+            height: 20px;
+            width: 20px;
+        }
+    }
+
+    p {
+        @include text-body-xl;
+        margin-bottom: 0;
+        margin-top: 0;
+
+        strong {
+            font-weight: 600;
+        }
+    }
+
+    + h1 {
+        margin-top: $spacing-lg;
+    }
+}
+
+// end 10 year badge

--- a/media/css/pocket/components/platforms.scss
+++ b/media/css/pocket/components/platforms.scss
@@ -9,8 +9,6 @@
 @import '../includes/platform-footer';
 @import '../includes/platform-nav';
 
-$image-path: '/media/img/pocket';
-
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/button';
 

--- a/media/css/pocket/includes/_nav.scss
+++ b/media/css/pocket/includes/_nav.scss
@@ -5,7 +5,7 @@
 @import '../utils/variables';
 @import './mobile-nav';
 
-$image-path: '/media/img/pocket';
+$pocket-image-path: '/media/img/pocket';
 
 .pocket-header {
     width: 100%;
@@ -93,7 +93,7 @@ $image-path: '/media/img/pocket';
     .pocket-logo-svg {
         background-repeat: no-repeat;
         background-size: contain;
-        background-image: url('#{$image-path}/pocket-logo-light-mode.svg');
+        background-image: url('#{$pocket-image-path}/pocket-logo-light-mode.svg');
         width: 94px;
         height: 24px;
 


### PR DESCRIPTION
## One-line summary

Adds 10 year badge to bedrock pocket home to match live site: https://getpocket.com/en/

## Significant Changes

Also removes any unused $image-path vars and updates to use $pocket-image-path namespacing to avoid protocol conflicts

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11730

related pocket pr: https://github.com/mozmeao/pocket-marketing-pages/pull/53

## Testing

Run in pocket mode
http://localhost:8000/en/

You should see pocket logo and "10 Years of Pocket" above the H1 in the hero section.

To test no errors after variable updates:
http://localhost:8000/en/about/
http://localhost:8000/en/add/
http://localhost:8000/en/ios/
Top Navigation
