### PR TITLE
11703 changed broken link to working link

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -81,7 +81,7 @@
               <a class="mzp-c-cta-link" rel="external" href="https://blog.mozilla.org/blog/2017/08/08/mozilla-information-trust-initiative-building-movement-fight-misinformation-online/{{ referrals }}">{{ ftl('home-mozilla-information-trust-initiative') }}</a>
             </li>
             <li>
-              <a class="mzp-c-cta-link" rel="external" href="https://learning.mozilla.org/blog/new-partnership-with-un-women-to-teach-key-digital-skills-to-women/{{ referrals }}">{{ ftl('home-empowering-women-online') }}</a>
+              <a class="mzp-c-cta-link" rel="external" href="https://blog.mozilla.org/foundation-archive/mozilla-learning/new-partnership-with-un-women-to-teach-key-digital-skills-to-women/{{ referrals }}">{{ ftl('home-empowering-women-online') }}</a>
             </li>
             <li>
               <a class="mzp-c-cta-link" rel="external" href="https://blog.mozilla.org/blog/2017/09/06/mozilla-washington-post-reinventing-online-comments/{{ referrals }}">{{ ftl('home-the-coral-project') }}</a>


### PR DESCRIPTION
## One-line summary

Empowering Women Online link was redirecting to blank page

## Significant changes and points to review

Changed the link in [this path](https://github.com/mozilla/bedrock/blob/487ecbad3381507bbac5b9244f409853c9473fa1/bedrock/mozorg/templates/mozorg/home/home.html#L84)

## Issue / Bugzilla link
#11703 


## Screenshots
![Image 09-06-22 at 10 23 PM](https://user-images.githubusercontent.com/49924204/172902055-3a65150c-4a85-4e6b-bc1d-5867d6e51ba7.jpg)


## Checklist


## Testing


To test this work:

1. Open https://www.mozilla.org/es-ES/
2. Click the link [Empoderando a las mujeres en línea](https://learning.mozilla.org/blog/new-partnership-with-un-women-to-teach-key-digital-skills-to-women/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage)
