### PR TITLE
Return 404 page if locale is unavailable or no header sent 

### DIFF
--- a/bedrock/base/templates/404-locale.html
+++ b/bedrock/base/templates/404-locale.html
@@ -1,0 +1,48 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "base-protocol-mozilla.html" %}
+
+{% block page_title %}{% if not is_root %}404 - {% endif %}{{ ftl('not-found-locale-title') }}{% endblock %}
+
+{% block page_desc -%}
+  {{ ftl('not-found-locale-desc') }}
+{%- endblock %}
+
+{% block canonical_urls %}
+{% if is_root %}
+  <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL + '/' }}">
+{% endif %}
+{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('locales') }}
+{% endblock %}
+
+{% block content %}
+<main role="main" class="mzp-l-content">
+  <header class="c-simple-header">
+    <h1 class="c-simple-header-title">
+      {%- if is_root -%}
+        {{ ftl('not-found-locale-title') }}
+      {%- else -%}
+        {{ ftl('not-found-locale-not-yet-translated') }}
+      {%- endif -%}
+    </h1>
+    {% if has_header -%}
+      <p>{{ ftl('not-found-locale-join-us', community='https://community.mozilla.org/activities/localize-mozilla/', contribute='https://wiki.mozilla.org/L10n:Contribute') }}</p>
+    {%- endif %}
+    <p>{{ ftl('not-found-locale-available') }}</p>
+  </header>
+  <section class="c-block-list">
+    <ul>
+      {% for locale in available_locales if locale in languages %}
+        <li lang="{{ locale }}"><a href="/{{ locale }}{{ request.path_info }}" title="{{ ftl('not-found-locale-link-title', requested_page=request.path_info, link_language=languages[locale]['native']) }}">{{ languages[locale]['native'] }}</a></li>
+      {% endfor %}
+    </ul>
+  </section>
+</main>
+{% endblock %}

--- a/bedrock/careers/tests/test_views.py
+++ b/bedrock/careers/tests/test_views.py
@@ -14,6 +14,9 @@ from bedrock.wordpress.models import BlogPost
 
 
 class PositionTests(TestCase):
+    def setUp(self):
+        self.client = self.client_class(HTTP_ACCEPT_LANGUAGE="en")
+
     def test_context(self):
         response = self.client.get(reverse("careers.listings"), follow=True)
         self.assertEqual(response.status_code, 200)
@@ -52,6 +55,9 @@ class BlogTests(TestCase):
         "excerpt": "",
         "link": "",
     }
+
+    def setUp(self):
+        self.client = self.client_class(HTTP_ACCEPT_LANGUAGE="en")
 
     def _populate_blog_posts(self):
         today = timezone.now()

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -625,14 +625,14 @@ class TestFirefoxNew(TestCase):
 class TestFirefoxNewNoIndex(TestCase):
     def test_download_noindex(self):
         # Scene 1 of /firefox/new/ should never contain a noindex tag.
-        response = self.client.get("/firefox/new/", follow=True)
+        response = self.client.get("/en-US/firefox/new/")
         doc = pq(response.content)
         robots = doc('meta[name="robots"]')
         assert robots.length == 0
 
     def test_thanks_canonical(self):
         # Scene 2 /firefox/download/thanks/ should always contain a noindex tag.
-        response = self.client.get("/firefox/download/thanks/", follow=True)
+        response = self.client.get("/en-US/firefox/download/thanks/")
         doc = pq(response.content)
         robots = doc('meta[name="robots"]')
         assert robots.length == 1

--- a/bedrock/mozorg/context_processors.py
+++ b/bedrock/mozorg/context_processors.py
@@ -22,7 +22,7 @@ def canonical_path(request):
     """
     lang = getattr(request, "locale", settings.LANGUAGE_CODE)
     url = getattr(request, "path", "/")
-    return {"canonical_path": re.sub(r"^/" + lang, "", url)}
+    return {"canonical_path": re.sub(r"^/" + lang, "", url) if lang else url}
 
 
 def current_year(request):

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -601,7 +601,7 @@ class TestNewsletterSubscribe(TestCase):
 
     def test_shows_form_single(self):
         """The MPL page only subscribes to 'mozilla-foundation', so not a multi-newsletter form."""
-        resp = self.client.get("/MPL", follow=True)
+        resp = self.client.get("/en-US/MPL/", follow=True)
         doc = pq(resp.content)
         self.assertTrue(doc("#newsletter-form"))
         self.assertTrue(doc('input[value="mozilla-foundation"]'))

--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -383,12 +383,10 @@ class TestVPNResourceListingView(TestCase):
         )
 
     def test_simple_get__for_unavailable_locale(self, render_mock):
-        resp = self._request(locale="sk")
-        self.assertEqual(resp.redirect_chain, [("/en-US/products/vpn/resource-center/", 302)])
+        self._request(locale="sk", expected_status=404)
 
     def test_simple_get__for_invalid_locale(self, render_mock):
-        resp = self._request(locale="xx")
-        self.assertEqual(resp.redirect_chain, [("/en-US/products/vpn/resource-center/", 302)])
+        self._request(locale="xx", expected_status=404)
 
     @override_settings(CONTENTFUL_LOCALE_ACTIVATION_PERCENTAGE=95)
     def test_simple_get__for_valid_locale_WITHOUT_enough_content(self, render_mock):
@@ -397,9 +395,7 @@ class TestVPNResourceListingView(TestCase):
         # percentage, we should send you to the default locale by calling render() early
         ContentfulEntry.objects.filter(locale="fr").last().delete()
         assert ContentfulEntry.objects.filter(locale="fr").count() < ContentfulEntry.objects.filter(locale="en-US").count()
-
-        resp = self._request(locale="fr")
-        self.assertEqual(resp.redirect_chain, [("/en-US/products/vpn/resource-center/", 302)])
+        self._request(locale="fr", expected_status=404)
 
     def test_category_filtering(self, render_mock):
 
@@ -491,13 +487,13 @@ class TestVPNResourceArticleView(TestCase):
     @patch("bedrock.products.views.l10n_utils.render", return_value=HttpResponse())
     def test_simple_get__for_unavailable_locale(self, render_mock):
         resp = self.client.get("/products/vpn/resource-center/slug-2/", HTTP_ACCEPT_LANGUAGE="de")
-        # Which will 302 as expected
-        self.assertEqual(resp.headers["location"], "/en-US/products/vpn/resource-center/slug-2/")
+        # Which will 404 as expected
+        self.assertEqual(resp.status_code, 404)
         render_mock.assert_not_called()
 
     @patch("bedrock.products.views.l10n_utils.render", return_value=HttpResponse())
     def test_simple_get__for_invalid_locale(self, render_mock):
         resp = self.client.get("/products/vpn/resource-center/slug-2/", HTTP_ACCEPT_LANGUAGE="xx")
-        # Which will 302 as expected
-        self.assertEqual(resp.headers["location"], "/en-US/products/vpn/resource-center/slug-2/")
+        # Which will 404 as expected
+        self.assertEqual(resp.status_code, 404)
         render_mock.assert_not_called()

--- a/bedrock/urls/mozorg_mode.py
+++ b/bedrock/urls/mozorg_mode.py
@@ -14,6 +14,7 @@ from bedrock.base import views as base_views
 # which breaks the base template page. So we replace them with views that do!
 handler500 = "bedrock.base.views.server_error_view"
 handler404 = "bedrock.base.views.page_not_found_view"
+locale404 = "lib.l10n_utils.locale_selection"
 
 
 urlpatterns = (
@@ -35,6 +36,13 @@ urlpatterns = (
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("healthz-cron/", base_views.cron_health_check),
 )
+
+if settings.DEV:
+
+    urlpatterns += (
+        # Add /404-locale/ for localizers.
+        path("404-locale/", import_string(locale404)),
+    )
 
 if settings.DEBUG:
 

--- a/l10n/en/404-locale.ftl
+++ b/l10n/en/404-locale.ftl
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/404-locale/
+
+not-found-locale-title = Choose your language or locale to browse Mozilla.org
+not-found-locale-desc = Select your country or region to indicate your preferred language.
+
+not-found-locale-not-yet-translated = Page is not yet translated
+# Variables:
+#   $community (url) - link to https://community.mozilla.org/activities/localize-mozilla/
+#   $contribute (url) - link to https://wiki.mozilla.org/L10n:Contribute
+not-found-locale-join-us = Join our <a href="{ $community }">community team</a> and help us <a href="{ $contribute }">translate this page.</a>
+not-found-locale-available = It is available in the following languages:
+# Variables:
+#   $requested_page (string) - path of originally requested page
+#   $link_language (string) - name of language used in page link
+not-found-locale-link-title = Browse { $requested_page } in the { $link_language } language

--- a/lib/l10n_utils/tests/test_base.py
+++ b/lib/l10n_utils/tests/test_base.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 import pytest
 from django_jinja.backend import Jinja2
 
+from bedrock.base.urlresolvers import Prefixer
 from lib import l10n_utils
 
 ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_files")
@@ -29,7 +30,9 @@ class TestRender(TestCase):
     def _test(self, path, template, locale, accept_lang, status, destination=None, active_locales=None, add_active_locales=None):
         request = RequestFactory().get(path)
         request.META["HTTP_ACCEPT_LANGUAGE"] = accept_lang
-        request.locale = locale
+        prefixer = Prefixer(request)
+        request.locale = prefixer.locale
+
         ctx = {}
         if active_locales:
             ctx["active_locales"] = active_locales
@@ -43,8 +46,37 @@ class TestRender(TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response["Location"], destination)
             self.assertEqual(response["Vary"], "Accept-Language")
+        elif status == 404:
+            self.assertEqual(response.status_code, 404)
         else:
             self.assertEqual(response.status_code, 200)
+
+    def test_no_accept_language_header(self):
+        template = "firefox/new.html"
+        locales = ["en-US", "en-GB", "fr", "es-ES"]
+
+        # Test no accept language header and locale-less root path returns 200.
+        self._test("/", template, "", "", 200, active_locales=locales)
+
+        # Test no accept language header and locale-less path returns 404.
+        self._test("/firefox/new/", template, "", "", 404, active_locales=locales)
+
+        # Test that a locale+path and no accept language header returns 200 as long as the locales are supported.
+        self._test("/en-US/firefox/new/", template, "", "", 200, active_locales=locales)
+        self._test("/en-GB/firefox/new/", template, "", "", 200, active_locales=locales)
+        self._test("/fr/firefox/new/", template, "", "", 200, active_locales=locales)
+        self._test("/es-ES/firefox/new/", template, "", "", 200, active_locales=locales)
+        self._test("/de/firefox/new/", template, "", "", 404, active_locales=locales)
+
+        # Test that a path in the `SUPPORTED_NONLOCALES` doesn't 404.
+        self._test("/credits/", template, "", "", 200, active_locales=locales)
+        self._test("/robots.txt", template, "", "", 200, active_locales=locales)
+        self._test("/sitemap_none.xml", template, "", "", 200, active_locales=locales)
+
+        # Test that a path in the `SUPPORTED_LOCALE_IGNORE` works both with and without locale in the path.
+        self._test("/sitemap.xml", template, "", "", 200, active_locales=locales)
+        self._test("/en-US/sitemap.xml", template, "", "", 200, active_locales=locales)
+        self._test("/fr/sitemap.xml", template, "", "", 200, active_locales=locales)
 
     def test_firefox(self):
         path = "/firefox/new/"
@@ -178,23 +210,23 @@ class TestL10nTemplateView(TestCase):
 @pytest.mark.parametrize(
     "translations, accept_languages, expected",
     (
-        # Anything with a 'en-US' transtion and 'en' root accept languages, goes to 'en-US'.
+        # Anything with a 'en-US' translation and 'en' root accept languages, goes to 'en-US'.
         (["en-US"], ["en-US"], "en-US"),
         (["en-US"], ["en-CA"], "en-US"),
         (["en-US"], ["en"], "en-US"),
         (["en-US", "de"], ["en-GB"], "en-US"),
-        # Anything with a 'en-US' transtion and unsupported translations, goes to 'en-US' by default.
-        (["en-US"], ["zu"], "en-US"),
-        (["en-US"], ["fr"], "en-US"),
-        (["en-US", "de"], ["fr"], "en-US"),
+        # Anything with a 'en-US' translation and unsupported translations, returns `None`.
+        (["en-US"], ["zu"], None),
+        (["en-US"], ["fr"], None),
+        (["en-US", "de"], ["fr"], None),
         # The user's prioritized accept language should be chosen first.
         (["en-US", "de"], ["de", "en-US"], "de"),
         (["en-US", "de", "fr"], ["fr", "de"], "fr"),
         (["en-US", "de", "fr"], ["en-CA", "fr", "de"], "en-US"),
-        # A request for only inactive translations should default to 'en-US'. Bug 1752823
-        (["am", "an", "en-US"], ["mk", "gu-IN"], "en-US"),
+        # A request for only inactive translations should return `None`.
+        (["am", "an", "en-US"], ["mk", "gu-IN"], None),
         # "am" is not a valid language in the list of PROD_LANGUAGES
-        (["am", "an"], ["mk", "gu-IN"], "an"),
+        (["am", "an"], ["mk", "gu-IN"], None),
     ),
 )
 def test_get_best_translation(translations, accept_languages, expected):

--- a/lib/l10n_utils/tests/test_files/templates/404-locale.html
+++ b/lib/l10n_utils/tests/test_files/templates/404-locale.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/media/css/mozorg/locales.scss
+++ b/media/css/mozorg/locales.scss
@@ -7,6 +7,8 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
+// note: these styles are used for both /locales and a locale-specific 404 page
+
 .c-simple-header {
     @include at2x('/media/img/mozorg/locales/world-map.png', 179px, 90px);
     background-position: top center;

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -98,8 +98,8 @@ def pytest_generate_tests(metafunc):
 
 def get_web_page(url):
     try:
-        r = requests.get(url, timeout=TIMEOUT)
+        r = requests.get(url, timeout=TIMEOUT, headers={"accept-language": "en"})
     except requests.RequestException:
         # retry
-        r = requests.get(url, timeout=TIMEOUT)
+        r = requests.get(url, timeout=TIMEOUT, headers={"accept-language": "en"})
     return BeautifulSoup(r.content, "html.parser")

--- a/tests/functional/test_experiment_pages.py
+++ b/tests/functional/test_experiment_pages.py
@@ -21,5 +21,5 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.headless
 @pytest.mark.nondestructive
 def test_experiment_pages(url):
-    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
+    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT, headers={"accept-language": "en"})
     assert requests.codes.ok == r.status_code

--- a/tests/functional/test_generated_pages.py
+++ b/tests/functional/test_generated_pages.py
@@ -62,5 +62,5 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.headless
 @pytest.mark.nondestructive
 def test_generated_pages(url):
-    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
+    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT, headers={"accept-language": "en"})
     assert requests.codes.ok == r.status_code

--- a/tests/redirects/base.py
+++ b/tests/redirects/base.py
@@ -131,8 +131,11 @@ def assert_valid_url(
     :param final_status_code: Expected status code after following any redirects.
     """
     kwargs = {"allow_redirects": follow_redirects}
-    if req_headers:
+    if req_headers is None:
+        kwargs["headers"] = {"Accept-language": "en"}
+    else:
         kwargs["headers"] = req_headers
+
     if req_kwargs:
         kwargs.update(req_kwargs)
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -780,7 +780,7 @@ URLS = flatten(
         url_test("/de/impressum/", "/de/about/legal/impressum/"),
         # bug 1248393
         url_test("/de/about/legal/impressum/", status_code=requests.codes.ok),
-        url_test("/{en-US,fr,ja}/about/legal/impressum/", "/de/about/legal/impressum/", status_code=requests.codes.found),
+        url_test("/{en-US,fr,ja}/about/legal/impressum/", status_code=requests.codes.not_found),
         # bug 960543
         url_test("/firefox/{2,3}.0/eula/random/stuff/", "/legal/eula/firefox-{2,3}/"),
         # bug 724633 - Porting foundation pages


### PR DESCRIPTION
## One-line summary

This changes the default of unsupported locales from redirect to `/en-US/` to a 404 with a locale selection page.

## Testing

The redirect to best locale logic depends on the `Accept-language` header. If yours is set to an English locale it will be hard to trigger the 404 locale selection page. So this is what I have done:

1. Set your preferred language in your browser settings to remove English and pick an uncommonly supported locale. I chose `ast` since it was near the top.
2. Navigate to localhost:8000 or localhost:8000/firefox/new/

You can also use `curl` to test responses with and without an accept language header like so:

1. `curl -IL localhost:8000/ -H "Accept-language: ast"`
2. `curl -IL localhost:8000/`
