### PR TITLE
removed outdated doc from foundation list

### DIFF
--- a/bedrock/foundation/templates/foundation/base.html
+++ b/bedrock/foundation/templates/foundation/base.html
@@ -13,7 +13,6 @@
 {% set navigation_bar = [
     ('https://foundation.mozilla.org/', 'index', 'The Mozilla Foundation'),
     ('https://foundation.mozilla.org/about/', 'about', 'About the Foundation'),
-    ('https://mzl.la/foundation-strategy', 'strategy', '2016-2018 Strategy'),
     (url('foundation.licensing'), 'licensing', 'Licensing & Trademarks'),
     ('https://foundation.mozilla.org/about/public-records/', 'documents', 'Public Documents'),
     (url('careers.home'), 'careers', 'Careers'),


### PR DESCRIPTION
## One-line summary

The strategy 2016-2016 was inaccessible and outdated.

## Significant changes and points to review

removal of the item from list

## Issue / Bugzilla link
#11460 


## Screenshots

![Image 10-06-22 at 2 45 PM](https://user-images.githubusercontent.com/49924204/173033573-ae753e10-818e-48fa-ab1a-96a7daec38e8.jpg)

## Testing

Demo server URL: (or None)

To test this work:

1. go to link  /en-US/foundation/trademarks/list/
2. verify the 2016-2018 link is absent.
