### PR TITLE
Test Glean click pings using a short delay (Fixes #11770)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_download.html
@@ -68,7 +68,9 @@
   ) %}
 
     <div class="c-intro-download">
-      {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
+      {% block download_button_primary %}
+        {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
+      {% endblock %}
 
       {% block small_links %}
       <ul class="small-links">

--- a/bedrock/firefox/templates/firefox/new/basic/download_windows.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_windows.html
@@ -33,6 +33,10 @@
 {% set card3_desc = ftl('new-platform-easy-migration') %}
 {% set card3_image_url = 'img/firefox/new/platform/icon-seamless.svg' %}
 
+{% block download_button_primary %}
+  {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), button_class='glean-delay-test', locale_in_transition=True, download_location='primary cta') }}
+{% endblock %}
+
 {% block structured_data %}
   {% include 'includes/structured-data/software/firefox-windows-software.json' %}
 {% endblock %}

--- a/media/js/glean/elements.es6.js
+++ b/media/js/glean/elements.es6.js
@@ -40,8 +40,22 @@ function getElementAttributes(e) {
         el = el.closest('a') || el.closest('button');
     }
 
+    if (!el) {
+        return;
+    }
+
+    const newTab = e.metaKey || e.ctrlKey;
+    const delayClick =
+        el.nodeName === 'A' &&
+        el.className.indexOf('glean-delay-test') !== -1 &&
+        !newTab;
+
+    if (delayClick) {
+        e.preventDefault();
+    }
+
     // Check all link and button elements for data attributes.
-    if (el && (el.nodeName === 'A' || el.nodeName === 'BUTTON')) {
+    if (el.nodeName === 'A' || el.nodeName === 'BUTTON') {
         const ctaText = el.getAttribute('data-cta-text');
         const linkName = el.getAttribute('data-link-name');
         const linkType = el.getAttribute('data-link-type');
@@ -55,11 +69,9 @@ function getElementAttributes(e) {
                 type: type,
                 position: position
             });
-            return;
         }
-
         // Firefox Download link clicks
-        if (linkType && linkType === 'download') {
+        else if (linkType && linkType === 'download') {
             const os = el.getAttribute('data-download-os');
             const name = el.getAttribute('data-display-name');
             const position = el.getAttribute('data-download-location');
@@ -71,20 +83,23 @@ function getElementAttributes(e) {
                     type: name,
                     position: position
                 });
-                return;
             }
         }
-
         // Older format links
-        if (linkName) {
+        else if (linkName) {
             const position = el.getAttribute('data-link-position');
             interaction({
                 label: linkName,
                 type: linkType,
                 position: position
             });
-            return;
         }
+    }
+
+    if (delayClick) {
+        setTimeout(() => {
+            window.location.href = el.href;
+        }, 1000);
     }
 }
 


### PR DESCRIPTION
## One-line summary

This is a temporary test to try and help verify an assumption around an anomaly we're seeing in some Glean click data. The assumption is that some user agents (particularly Edge), aren't always recording pings in time before a page navigation completes. This might be something that can be improved in Glean longer term, so to help verify the issue this PR creates a small test on one page.

## Issue / Bugzilla link

## Testing

Open: http://localhost:8000/en-US/firefox/windows/

- [ ] Clicking "Download now" should redirect to /thanks/ after a 1 second pause.

Open: http://localhost:8000/en-US/firefox/new/

- [ ] Clicking "Download Firefox" should redirect immediately and not introduce a delay.
