### PR TITLE
Code variations for set to default page (fixes #11772)

### DIFF
--- a/bedrock/firefox/templates/firefox/set-as-default/landing.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/landing.html
@@ -16,11 +16,11 @@
   {{ css_bundle('firefox-default-landing') }}
 {% endblock %}
 
-{% if switch('set-as-default-experiment', 'en-US') %}
-  {% block js %}
+{% block experiments %}
+  {% if switch('set-as-default-experiment', ['en-US']) %}
     {{ js_bundle("firefox-default-landing") }}
-  {% endblock %}
-{% endif %}
+  {% endif %}
+{% endblock %}
 
 
 {% if variation == '2' %}

--- a/bedrock/firefox/templates/firefox/set-as-default/landing.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/landing.html
@@ -16,24 +16,43 @@
   {{ css_bundle('firefox-default-landing') }}
 {% endblock %}
 
+{% block js %}
+  {{ js_bundle("firefox-default-landing") }}
+{% endblock %}
+
+{% if switch('set-as-default-experiment') and  variation == '1' %}
+  {% set landing_header = ftl('set-as-default-landing-you-should-get') %}
+  {% set landing_body = ftl('set-as-default-landing-if-you-recently') %}
+{% elif switch('set-as-default-experiment') and variation == '2' %}
+  {% set landing_header = "Feel safe every time you explore the web" %}
+  {% set landing_body = "Choose the browser that puts your privacy first everyday. Make sure Firefox is your default browser" %}
+{% elif switch('set-as-default-experiment') and variation == '3' %}
+  {% set landing_header = "Choose a browser that supports a better web for you and everyone else" %}
+  {% set landing_body = "Set Firefox back to your default browser and enjoy peace of mind with every link you open." %}
+{% else %}
+    {% set landing_header = ftl('set-as-default-landing-you-should-get') %}
+    {% set landing_body = ftl('set-as-default-landing-if-you-recently') %}
+{% endif %}
+
 {% block content %}
   <main role="main">
-    {% call hero(
-      title=ftl('set-as-default-landing-make-sure-youre-protected'),
-      desc=ftl('set-as-default-landing-thanks-for-using-the'),
-      class='mzp-c-hero',
-      include_cta=True,
-      heading_level=1,
-    ) %}
-    <div class="cta-container">
-      <div class="mzp-c-button-download-container">
-        <a id="set-as-default-button" href="{{ url('firefox.set-as-default.thanks') }}" class="mzp-c-button mzp-t-product" data-cta-text="Make Firefox your default browser" data-cta-type="button">
-          {{ ftl('set-as-default-landing-make-firefox-your-default') }}
-        </a>
+    <section class="mzp-c-hero">
+      <div class="mzp-l-content">
+        <div class="mzp-c-hero-body">
+          <h1 class="mzp-c-hero-title">{{ landing_header }} </h1>
+          <div class="mzp-c-hero-desc">
+            <p>{{ landing_body }}</p>
+          </div>
+          <div class="cta-container">
+            <div class="mzp-c-button-download-container">
+              <a id="set-as-default-button" href="{{ url('firefox.set-as-default.thanks') }}" class="mzp-c-button mzp-t-product" data-cta-text="Make Firefox your default browser" data-cta-type="button">
+                {{ ftl('set-as-default-landing-make-firefox-your-default') }}
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-    {% endcall %}
-
+    </section>
     <ul class="mzp-l-columns mzp-t-columns-three mzp-l-content mzp-t-content-lg">
       {% call picto(
         title=ftl('set-as-default-landing-choose-automatic-privacy'),

--- a/bedrock/firefox/templates/firefox/set-as-default/landing.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/landing.html
@@ -16,43 +16,40 @@
   {{ css_bundle('firefox-default-landing') }}
 {% endblock %}
 
-{% block js %}
-  {{ js_bundle("firefox-default-landing") }}
-{% endblock %}
+{% if switch('set-as-default-experiment', 'en-US') %}
+  {% block js %}
+    {{ js_bundle("firefox-default-landing") }}
+  {% endblock %}
+{% endif %}
 
-{% if switch('set-as-default-experiment') and  variation == '1' %}
-  {% set landing_header = ftl('set-as-default-landing-you-should-get') %}
-  {% set landing_body = ftl('set-as-default-landing-if-you-recently') %}
-{% elif switch('set-as-default-experiment') and variation == '2' %}
+
+{% if variation == '2' %}
   {% set landing_header = "Feel safe every time you explore the web" %}
   {% set landing_body = "Choose the browser that puts your privacy first everyday. Make sure Firefox is your default browser" %}
-{% elif switch('set-as-default-experiment') and variation == '3' %}
+{% elif variation == '3' %}
   {% set landing_header = "Choose a browser that supports a better web for you and everyone else" %}
   {% set landing_body = "Set Firefox back to your default browser and enjoy peace of mind with every link you open." %}
 {% else %}
-    {% set landing_header = ftl('set-as-default-landing-you-should-get') %}
-    {% set landing_body = ftl('set-as-default-landing-if-you-recently') %}
+    {% set landing_header = ftl('set-as-default-landing-you-should-get', fallback='set-as-default-landing-make-sure-youre-protected') %}
+    {% set landing_body = ftl('set-as-default-landing-if-you-recently', fallback='set-as-default-landing-thanks-for-using-the') %}
 {% endif %}
 
 {% block content %}
-  <main role="main">
-    <section class="mzp-c-hero">
-      <div class="mzp-l-content">
-        <div class="mzp-c-hero-body">
-          <h1 class="mzp-c-hero-title">{{ landing_header }} </h1>
-          <div class="mzp-c-hero-desc">
-            <p>{{ landing_body }}</p>
-          </div>
-          <div class="cta-container">
-            <div class="mzp-c-button-download-container">
-              <a id="set-as-default-button" href="{{ url('firefox.set-as-default.thanks') }}" class="mzp-c-button mzp-t-product" data-cta-text="Make Firefox your default browser" data-cta-type="button">
-                {{ ftl('set-as-default-landing-make-firefox-your-default') }}
-              </a>
-            </div>
-          </div>
+   <main role="main">
+    {% call hero(
+      title=landing_header,
+      desc=landing_body,
+      include_cta=True,
+      heading_level=1,
+    ) %}
+      <div class="cta-container">
+        <div class="mzp-c-button-download-container">
+          <a id="set-as-default-button" href="{{ url('firefox.set-as-default.thanks') }}" class="mzp-c-button mzp-t-product" data-cta-text="Make Firefox your default browser" data-cta-type="button">
+            {{ ftl('set-as-default-landing-make-firefox-your-default') }}
+          </a>
         </div>
       </div>
-    </section>
+    {% endcall %}
     <ul class="mzp-l-columns mzp-t-columns-three mzp-l-content mzp-t-content-lg">
       {% call picto(
         title=ftl('set-as-default-landing-choose-automatic-privacy'),

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -210,7 +210,16 @@ urlpatterns = (
     # Issue 8432
     page("firefox/set-as-default/thanks/", "firefox/set-as-default/thanks.html", ftl_files="firefox/set-as-default/thanks"),
     # Default browser campaign
-    page("firefox/set-as-default/", "firefox/set-as-default/landing.html", ftl_files="firefox/set-as-default/landing"),
+    path(
+        "firefox/set-as-default/",
+        VariationTemplateView.as_view(
+            template_name="firefox/set-as-default/landing.html",
+            ftl_files="firefox/set-as-default/landing",
+            variation_locales=["en-US"],
+            template_context_variations=["1", "2", "3"],
+        ),
+        name="firefox.set-as-default",
+    ),
     # Issue 8536
     page("firefox/retention/thank-you/", "firefox/retention/thank-you.html", ftl_files="firefox/retention/thank-you"),
     # Unfck campaign

--- a/l10n/en/firefox/set-as-default/landing.ftl
+++ b/l10n/en/firefox/set-as-default/landing.ftl
@@ -9,10 +9,13 @@ set-as-default-landing-make-firefox-your-default = Make { -brand-name-firefox } 
 
 # HTML page description
 set-as-default-landing-choose-the-browser = Choose the browser that protects your privacy. Set { -brand-name-firefox } as your default browser.
+# Obsolete string
+set-as-default-landing-thanks-for-using-the = Thanks for using the latest { -brand-name-firefox } browser. When you choose { -brand-name-firefox }, you support a better web for you and everyone else. Now take the next step to protect yourself.
+# Obsolete string
+set-as-default-landing-make-sure-youre-protected = Make sure you’re protected, every time you get online
 
 set-as-default-landing-you-should-get = You should get a say in how you browse
 set-as-default-landing-if-you-recently = If you recently updated your computer, your settings may have changed. Support a free and open internet every time you get online with { -brand-name-firefox }.
-
 set-as-default-landing-choose-automatic-privacy = Choose automatic privacy
 set-as-default-landing-companies-keep-finding = Companies keep finding new ways to poach your personal data. { -brand-name-firefox } is the browser with a mission of finding new ways to protect you.
 set-as-default-landing-choose-freedom-on-every = Choose freedom on every device

--- a/l10n/en/firefox/set-as-default/landing.ftl
+++ b/l10n/en/firefox/set-as-default/landing.ftl
@@ -10,8 +10,9 @@ set-as-default-landing-make-firefox-your-default = Make { -brand-name-firefox } 
 # HTML page description
 set-as-default-landing-choose-the-browser = Choose the browser that protects your privacy. Set { -brand-name-firefox } as your default browser.
 
-set-as-default-landing-make-sure-youre-protected = Make sure you’re protected, every time you get online
-set-as-default-landing-thanks-for-using-the = Thanks for using the latest { -brand-name-firefox } browser. When you choose { -brand-name-firefox }, you support a better web for you and everyone else. Now take the next step to protect yourself.
+set-as-default-landing-you-should-get = You should get a say in how you browse
+set-as-default-landing-if-you-recently = If you recently updated your computer, your settings may have changed. Support a free and open internet every time you get online with { -brand-name-firefox }.
+
 set-as-default-landing-choose-automatic-privacy = Choose automatic privacy
 set-as-default-landing-companies-keep-finding = Companies keep finding new ways to poach your personal data. { -brand-name-firefox } is the browser with a mission of finding new ways to protect you.
 set-as-default-landing-choose-freedom-on-every = Choose freedom on every device

--- a/media/js/firefox/set-as-default/landing.js
+++ b/media/js/firefox/set-as-default/landing.js
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-(function (Mozilla) {
+(function () {
     'use strict';
-    require('@mozmeao/trafficcop');
+    var TrafficCop = require('@mozmeao/trafficcop');
     /* update dataLayer with experiment info */
     var href = window.location.href;
 
@@ -28,8 +28,8 @@
                     'data-ex-name': 'firefox-set-as-default-experiment'
                 });
             }
-        } else if (Mozilla.TrafficCop) {
-            var cop = new Mozilla.TrafficCop({
+        } else if (TrafficCop) {
+            var cop = new TrafficCop({
                 id: 'exp-firefox-set-as-default',
                 cookieExpires: 0,
                 variations: {
@@ -42,4 +42,4 @@
         }
     };
     initTrafficCop();
-})(window.Mozilla);
+})();

--- a/media/js/firefox/set-as-default/landing.js
+++ b/media/js/firefox/set-as-default/landing.js
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function (Mozilla) {
+    'use strict';
+    require('@mozmeao/trafficcop');
+    /* update dataLayer with experiment info */
+    var href = window.location.href;
+
+    var initTrafficCop = function () {
+        if (href.indexOf('v=') !== -1) {
+            if (href.indexOf('v=1') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'v1-pointed',
+                    'data-ex-name': 'firefox-set-as-default-experiment'
+                });
+            } else if (href.indexOf('v=2') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'v2-privacy',
+                    'data-ex-name': 'firefox-set-as-default-experiment'
+                });
+            } else if (href.indexOf('v=3') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'v3-mission',
+                    'data-ex-name': 'firefox-set-as-default-experiment'
+                });
+            }
+        } else if (Mozilla.TrafficCop) {
+            var cop = new Mozilla.TrafficCop({
+                id: 'exp-firefox-set-as-default',
+                cookieExpires: 0,
+                variations: {
+                    'v=1': 33,
+                    'v=2': 33,
+                    'v=3': 33
+                }
+            });
+            cop.init();
+        }
+    };
+    initTrafficCop();
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1440,6 +1440,12 @@
     },
     {
       "files": [
+        "js/firefox/set-as-default/landing.js"
+      ],
+      "name": "firefox-default-landing"
+    },
+    {
+      "files": [
         "protocol/js/protocol-sticky-promo.js",
         "js/firefox/sticky-promo.js",
         "js/firefox/home/master.js"


### PR DESCRIPTION
## One-line summary

- Added new copy to the Firefox set-as-default page
- Added Traffic cop for a split test with three variations. The experiment is behind a switch, otherwise it will default to the copy for variation 1.

The switch on www/config in this PR: https://github.com/mozmeao/www-config/pull/466

## Issue / Bugzilla link
Fixes #11772 and #11773 

## Testing

Demo server URL: https://localhost:8000/firefox/set-as-default
 - [x] Make sure all three variations are rendering correctly
