### PR TITLE
Update @mozmeao/trafficcop to v2.0.0 (Fixes #11775)

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -288,10 +288,11 @@ not Traffic Cop should initiate.
 
 .. code-block:: javascript
 
+    var TrafficCop = require('@mozmeao/trafficcop');
     var isApprovedToRun = require('../../base/experiment-utils.es6.js').isApprovedToRun; // relative path
 
     if (isApprovedToRun()) {
-        var cop = new Mozilla.TrafficCop({
+        var cop = new TrafficCop({
             id: 'experiment-name',
             variations: {
                 'entrypoint_experiment=experiment-name&entrypoint_variation=a': 10,

--- a/media/js/firefox/browsers/firefox-ios-sms-experiment.js
+++ b/media/js/firefox/browsers/firefox-ios-sms-experiment.js
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-(function (Mozilla) {
+(function () {
     'use strict';
-    require('@mozmeao/trafficcop');
+    var TrafficCop = require('@mozmeao/trafficcop');
     var href = window.location.href;
 
     var initTrafficCop = function () {
@@ -27,8 +27,8 @@
                     'data-ex-name': 'firefox-ios-sms-experiment'
                 });
             }
-        } else if (Mozilla.TrafficCop) {
-            var cop = new Mozilla.TrafficCop({
+        } else if (TrafficCop) {
+            var cop = new TrafficCop({
                 id: 'exp-firefox-ios-sms',
                 cookieExpires: 0,
                 variations: {
@@ -45,4 +45,4 @@
     if (href.indexOf('automation=true') === -1) {
         initTrafficCop();
     }
-})(window.Mozilla);
+})();

--- a/media/js/firefox/welcome/welcome8-traffic-cop.js
+++ b/media/js/firefox/welcome/welcome8-traffic-cop.js
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-(function (Mozilla) {
+(function () {
     'use strict';
-    require('@mozmeao/trafficcop');
+    var TrafficCop = require('@mozmeao/trafficcop');
     /* update dataLayer with experiment info */
     var href = window.location.href;
 
@@ -33,8 +33,8 @@
                     'data-ex-name': 'experiment-hvt-visual'
                 });
             }
-        } else if (Mozilla.TrafficCop) {
-            var cop = new Mozilla.TrafficCop({
+        } else if (TrafficCop) {
+            var cop = new TrafficCop({
                 id: 'welcome8_experiment_hvt_visual',
                 cookieExpires: 0,
                 variations: {
@@ -48,4 +48,4 @@
         }
     };
     initTrafficCop();
-})(window.Mozilla);
+})();

--- a/media/js/firefox/whatsnew/whatsnew-101-en-experiment.js
+++ b/media/js/firefox/whatsnew/whatsnew-101-en-experiment.js
@@ -4,10 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-(function (Mozilla) {
+(function () {
     'use strict';
 
-    require('@mozmeao/trafficcop');
+    var TrafficCop = require('@mozmeao/trafficcop');
     var href = window.location.href;
 
     var initTrafficCop = function () {
@@ -28,8 +28,8 @@
                     'data-ex-name': 'wnp-101-en-experiment'
                 });
             }
-        } else if (Mozilla.TrafficCop) {
-            var acab = new Mozilla.TrafficCop({
+        } else if (TrafficCop) {
+            var acab = new TrafficCop({
                 id: 'exp-wnp-101-en',
                 cookieExpires: 0,
                 variations: {
@@ -46,4 +46,4 @@
     if (href.indexOf('automation=true') === -1) {
         initTrafficCop();
     }
-})(window.Mozilla);
+})();

--- a/media/js/firefox/whatsnew/whatsnew-99-en-experiment.js
+++ b/media/js/firefox/whatsnew/whatsnew-99-en-experiment.js
@@ -4,10 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-(function (Mozilla) {
+(function () {
     'use strict';
 
-    require('@mozmeao/trafficcop');
+    var TrafficCop = require('@mozmeao/trafficcop');
     var href = window.location.href;
 
     var initTrafficCop = function () {
@@ -23,8 +23,8 @@
                     'data-ex-name': 'wnp-99-en-experiment'
                 });
             }
-        } else if (Mozilla.TrafficCop) {
-            var cop = new Mozilla.TrafficCop({
+        } else if (TrafficCop) {
+            var cop = new TrafficCop({
                 id: 'exp-wnp-99-en',
                 cookieExpires: 0,
                 variations: {
@@ -40,4 +40,4 @@
     if (href.indexOf('automation=true') === -1) {
         initTrafficCop();
     }
-})(window.Mozilla);
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-env": "^7.16.11",
         "@mozilla-protocol/core": "16.0.0",
         "@mozilla/glean": "^1.0.0",
-        "@mozmeao/trafficcop": "^1.0.1",
+        "@mozmeao/trafficcop": "^2.0.0",
         "@sentry/browser": "^7.0.0",
         "babel-loader": "^8.2.4",
         "clean-webpack-plugin": "^4.0.0",
@@ -1636,9 +1636,9 @@
       }
     },
     "node_modules/@mozmeao/trafficcop": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-1.0.1.tgz",
-      "integrity": "sha512-F+jHoF6kft/33jCR0fSdqynzf68+gNK8Dk+08LUhvoonq0F1EbcjHx/L8ObXqHg0QFow599LMdp/D649nQSd3w=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.0.tgz",
+      "integrity": "sha512-lLifVditnaA8gVuJA79c16vlrRwLXYzRZ684kdWKXD72XLkj1UgpeUZh/SjG8mC3WTEd9jw9bv0e9OTKLG4+CA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10945,9 +10945,9 @@
       }
     },
     "@mozmeao/trafficcop": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-1.0.1.tgz",
-      "integrity": "sha512-F+jHoF6kft/33jCR0fSdqynzf68+gNK8Dk+08LUhvoonq0F1EbcjHx/L8ObXqHg0QFow599LMdp/D649nQSd3w=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.0.tgz",
+      "integrity": "sha512-lLifVditnaA8gVuJA79c16vlrRwLXYzRZ684kdWKXD72XLkj1UgpeUZh/SjG8mC3WTEd9jw9bv0e9OTKLG4+CA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/preset-env": "^7.16.11",
     "@mozilla-protocol/core": "16.0.0",
     "@mozilla/glean": "^1.0.0",
-    "@mozmeao/trafficcop": "^1.0.1",
+    "@mozmeao/trafficcop": "^2.0.0",
     "@sentry/browser": "^7.0.0",
     "babel-loader": "^8.2.4",
     "clean-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
## One-line summary

Updates TrafficCop to v2.0.0, so it no longer needs to dangle off a `Mozilla` global variable.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/11775

## Testing

The following URLs should all trigger traffic cop experiment redirects (make sure you don't have DNT set):

- [x] http://localhost:8000/en-US/firefox/101.0/whatsnew/
- [x] http://localhost:8000/en-US/firefox/99.0/whatsnew/
- [x] http://localhost:8000/en-US/firefox/welcome/8/ (this one only has a 12% chance of redirecting)
- [x] http://localhost:8000/en-US/firefox/browsers/mobile/ios/
