### PR TITLE
Add region1.google-analytics.com to CSP list (Fixes #11768)

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -207,6 +207,7 @@ else:
     _csp_connect_src = [
         "www.googletagmanager.com",
         "www.google-analytics.com",
+        "region1.google-analytics.com",
         "logs.convertexperiments.com",
         "1003350.metrics.convertexperiments.com",
         "1003343.metrics.convertexperiments.com",


### PR DESCRIPTION
## One-line summary

I don't feel great about adding a wild card for all GA sub domains, but I'm not sure if there's a better way seeing as there seem to be several regions?

## Issue / Bugzilla link

#11768