### PR TITLE
Add Glean click delay for a few more CTAs (Fixes #11770)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -8,7 +8,7 @@
   <div class="c-navigation-shoulder">
     {% if not custom_nav_cta %}
       {% if not hide_nav_download_button %}
-        {{ download_firefox_thanks(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_class='mzp-t-secondary mzp-t-md', download_location='nav') }}
+        {{ download_firefox_thanks(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_class='mzp-t-secondary mzp-t-md js-glean-delay-click', download_location='nav') }}
       {% endif %}
       {% if not hide_nav_get_vpn_button %}
       <div class="c-navigation-vpn-cta-container">

--- a/bedrock/firefox/templates/firefox/new/basic/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_download.html
@@ -68,9 +68,7 @@
   ) %}
 
     <div class="c-intro-download">
-      {% block download_button_primary %}
-        {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
-      {% endblock %}
+      {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), button_class='js-glean-delay-click', locale_in_transition=True, download_location='primary cta') }}
 
       {% block small_links %}
       <ul class="small-links">

--- a/bedrock/firefox/templates/firefox/new/basic/download_windows.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_windows.html
@@ -33,10 +33,6 @@
 {% set card3_desc = ftl('new-platform-easy-migration') %}
 {% set card3_image_url = 'img/firefox/new/platform/icon-seamless.svg' %}
 
-{% block download_button_primary %}
-  {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), button_class='glean-delay-test', locale_in_transition=True, download_location='primary cta') }}
-{% endblock %}
-
 {% block structured_data %}
   {% include 'includes/structured-data/software/firefox-windows-software.json' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -66,7 +66,7 @@
           <p>{{ ftl('firefox-desktop-download-no-shady') }}</p>
         {% endif %}
         <div class="c-intro-download">
-          {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+          {{ download_firefox_thanks(locale_in_transition=True, button_class='js-glean-delay-click', download_location='primary cta') }}
 
           <div class="c-intro-download-alt"><a href="{{ url('firefox.all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 
@@ -341,7 +341,7 @@
         </div>
       </div>
 
-      {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
+      {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, button_class='js-glean-delay-click', download_location='features cta') }}
 
     </div>
   </section>
@@ -462,7 +462,7 @@
       </div>
     </div>
 
-    {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+    {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, button_class='js-glean-delay-click', download_location='discover cta') }}
   </section>
 
   <section class="c-support">
@@ -505,7 +505,7 @@
 
   <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
 
-  {{ download_firefox_thanks(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_class='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
+  {{ download_firefox_thanks(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_class='mzp-t-secondary js-glean-delay-click', locale_in_transition=True, download_location='other') }}
 </aside>
 {% endif %}
 

--- a/bedrock/products/templates/products/vpn/includes/pricing-variable.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-variable.html
@@ -32,7 +32,7 @@
         entrypoint=_utm_source,
         link_text=ftl('vpn-shared-pricing-get-12-month-v2', fallback='vpn-shared-pricing-get-12-month'),
         plan='12-month',
-        class_name='mzp-c-button mzp-t-xl',
+        class_name='mzp-c-button mzp-t-xl js-glean-delay-click',
         country_code=country_code,
         lang=LANG,
         optional_parameters={
@@ -60,7 +60,7 @@
         entrypoint=_utm_source,
         link_text=ftl('vpn-shared-pricing-get-6-month-v2', fallback='vpn-shared-pricing-get-6-month'),
         plan='6-month',
-        class_name='mzp-c-button mzp-t-secondary mzp-t-xl',
+        class_name='mzp-c-button mzp-t-secondary mzp-t-xl js-glean-delay-click',
         country_code=country_code,
         lang=LANG,
         optional_parameters={
@@ -88,7 +88,7 @@
        entrypoint=_utm_source,
        link_text=ftl('vpn-shared-pricing-get-monthly'),
        plan='monthly',
-       class_name='mzp-c-button mzp-t-secondary mzp-t-xl',
+       class_name='mzp-c-button mzp-t-secondary mzp-t-xl js-glean-delay-click',
        country_code=country_code,
        lang=LANG,
        optional_parameters={

--- a/media/js/firefox/new/desktop/join-modal.js
+++ b/media/js/firefox/new/desktop/join-modal.js
@@ -37,6 +37,10 @@
                 showFxAModal,
                 false
             );
+
+            // If we're opening a modal on click, prevent Glean from
+            // delaying & redirecting the click (issue 11770)
+            downloadLinkPrimary[i].classList.remove('js-glean-delay-click');
         }
 
         // Don't trigger the modal for signed in users
@@ -47,6 +51,11 @@
                         'click',
                         showFxAModal,
                         false
+                    );
+
+                    // add back click delay for Glean (issue 11770)
+                    downloadLinkPrimary[i].classList.add(
+                        'js-glean-delay-click'
                     );
                 }
             }

--- a/media/js/glean/elements.es6.js
+++ b/media/js/glean/elements.es6.js
@@ -24,8 +24,12 @@ function interaction(obj) {
         data['position'] = obj.position;
     }
 
-    element.clicked.record(data);
-    interactionPing.submit();
+    try {
+        element.clicked.record(data);
+        interactionPing.submit();
+    } catch (e) {
+        //do nothing
+    }
 }
 
 function getElementAttributes(e) {
@@ -47,7 +51,7 @@ function getElementAttributes(e) {
     const newTab = e.metaKey || e.ctrlKey;
     const delayClick =
         el.nodeName === 'A' &&
-        el.className.indexOf('glean-delay-test') !== -1 &&
+        el.className.indexOf('js-glean-delay-click') !== -1 &&
         !newTab;
 
     if (delayClick) {


### PR DESCRIPTION
## One-line summary

This builds on https://github.com/mozilla/bedrock/pull/11771 by adding the click delay to a few more CTAs (temporarily). This should only be needed for a couple of weeks and then I think we can turn Glean off for now.

## Issue / Bugzilla link

#11770

## Testing

- [x] http://localhost:8000/en-US/firefox/new/ (download buttons)
- [x] http://localhost:8000/en-US/firefox/new/?xv=basic (download buttons)
- [x] http://localhost:8000/en-US/firefox/windows/ (download buttons)
- [x] http://localhost:8000/en-US/firefox/mac/ (download buttons)
- [x] http://localhost:8000/en-US/firefox/linux/ (download buttons)
- [x] http://localhost:8000/en-US/product/vpn/ (subscribe buttons)
- [x] http://localhost:8000/en-US/firefox/new/ (clicking download button should still open a modal if using Firefox and not signed into FxA)
