### PR TITLE
11759 Pinning to windows desktop fix

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -72,12 +72,11 @@
       <span class="show-mac">{{ ftl('firefox-desktop-download-get-help', attrs=support_mac_attrs) }}</span>
       {% set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-windows%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
       <span class="show-windows">{{ ftl('firefox-desktop-download-get-help', attrs=support_windows_attrs) }}</span>
+      <br>
+      {% set support_windows_pinning_attrs = 'href="https://support.mozilla.org/en-US/kb/how-unpin-firefox-taskbar-windows-10%s" rel="external noopener" data-cta-type="link" data-cta-text="Click Here"'|safe|format(referrals) %}
+      <span class="show-windows">{{ ftl('firefox-desktop-download-pinning-help', attrs=support_windows_pinning_attrs) }}</span>
       {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
       <span class="show-else">{{ ftl('firefox-desktop-download-get-help', attrs=support_else_attrs) }}</span>
-      <div class="c-support-install">
-        {% set support_windows_pinning_attrs = 'href="https://support.mozilla.org/en-US/kb/how-unpin-firefox-taskbar-windows-10%s" rel="external noopener" data-cta-type="link" data-cta-text="Click Here"'|safe|format(referrals) %}
-      <span>{{ ftl('firefox-desktop-download-pinning-help', attrs=support_windows_pinning_attrs) }}</span>
-      </div>
 
       {# Edge-case platform support messaging #}
       <span class="show-linux-arm">{{ ftl('firefox-desktop-download-please-follow', fallback='download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}</span>

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -74,6 +74,10 @@
       <span class="show-windows">{{ ftl('firefox-desktop-download-get-help', attrs=support_windows_attrs) }}</span>
       {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
       <span class="show-else">{{ ftl('firefox-desktop-download-get-help', attrs=support_else_attrs) }}</span>
+      <div class="c-support-install">
+        {% set support_windows_pinning_attrs = 'href="https://support.mozilla.org/en-US/kb/how-unpin-firefox-taskbar-windows-10%s" rel="external noopener" data-cta-type="link" data-cta-text="Click Here"'|safe|format(referrals) %}
+      <span>{{ ftl('firefox-desktop-download-pinning-help', attrs=support_windows_pinning_attrs) }}</span>
+      </div>
 
       {# Edge-case platform support messaging #}
       <span class="show-linux-arm">{{ ftl('firefox-desktop-download-please-follow', fallback='download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}</span>

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -177,7 +177,7 @@ firefox-desktop-download-now-mac = Now <strong>open</strong> the file that just 
 #   $attrs (attrs) - link to https://support.mozilla.org/products/firefox/download-and-install
 firefox-desktop-download-get-help = Having trouble? <a { $attrs }>Get help with your installation</a>.
 firefox-desktop-download-in-another-language = Download in another language or for another operating system.
-
+firefox-desktop-download-pinning-help = Want to pin Firefox on Windows desktop? <a { $attrs }>Click Here</a>.
 firefox-desktop-download-windows-10 = { -brand-name-windows } 10
 # Variables:
 #   $attrs (attrs) - link to https://support.mozilla.org/kb/windows-10-warns-me-use-microsoft-verified-app


### PR DESCRIPTION
## One-line summary

direction to pinning firefox to windwos desktop

## Issue / Bugzilla link
#11759 

## Screenshots
![Image 17-06-22 at 6 53 PM](https://user-images.githubusercontent.com/49924204/174307880-54be3fb1-752f-456d-be54-c9f035de641d.jpg)


To test this work:

- [ ] Go to mozilla homepage and click download form top-right
