### PR TITLE
Make Codecov refrain from commenting on a PR if coverage has not changed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,5 @@ coverage:
         informational: true
 comment:
   require_changes: true
+github_checks:
+    annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,5 @@ coverage:
     patch:
       default:
         informational: true
+comment:
+  require_changes: true


### PR DESCRIPTION
Pinched from https://docs.codecov.com/docs/common-recipe-list#only-comment-on-coverage-changes

Resolves #11786 