### PR TITLE
Add Contentful Split API tests

### DIFF
--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -750,7 +750,7 @@ class ContentfulPage:
             return " ".join(media_classes)
 
         def get_mobile_class():
-            mobile_display = fields.get("mobileDisplay")
+            mobile_display = fields.get("mobile_display")
             if not mobile_display:
                 return ""
 

--- a/bedrock/contentful/tests/test_contentful_api.py
+++ b/bedrock/contentful/tests/test_contentful_api.py
@@ -1360,8 +1360,36 @@ def test_ContentfulPage__get_split_data__get_media_class(mock__get_image_url, ba
     assert output["media_class"].strip() == expected
 
 
-# def test_ContentfulPage__get_split_data__get_mobile_class():
-#     assert False, "WRITE ME"
+@pytest.mark.parametrize(
+    "mobile_class_fields, expected",
+    (
+        (None, ""),
+        ({"mobile_display": "Center content"}, "mzp-l-split-center-on-sm-md"),
+        ({"mobile_display": "Hide image"}, "mzp-l-split-hide-media-on-sm-md"),
+    ),
+)
+@patch("bedrock.contentful.api._get_image_url")
+def test_ContentfulPage__get_split_data__get_mobile_class(mock__get_image_url, basic_contentful_page, mobile_class_fields, expected):
+    # mock self and entry data
+    basic_contentful_page.page = Mock()
+    basic_contentful_page.page.content_type.id = "mockPage"
+    basic_contentful_page.render_rich_text = Mock()
+    mock_entry_obj = Mock()
+    mock_entry_obj.fields.return_value = {
+        "name": "Split Test",
+        "image": "Stub image",
+        "body": "Stub body",
+        "heading_level": "h2",
+        "mobile_media_after": False,
+    }
+    if mobile_class_fields:
+        mock_entry_obj.fields.return_value.update(mobile_class_fields)
+
+    mock_entry_obj.content_type.id = "mock-split-type"
+
+    output = basic_contentful_page.get_split_data(mock_entry_obj)
+
+    assert output["mobile_class"].strip() == expected
 
 
 # FURTHER TESTS TO COME


### PR DESCRIPTION
## One-line summary

Add tests to verify Contentful Split API is returning expected data

**Note:** we need a master Contentful Content Model update for Split Mobile Display options, "Center conent" is missing a "t" in the middle.
<img width="185" alt="typo" src="https://user-images.githubusercontent.com/19650432/175018794-52c00cf1-99e1-41ae-9684-0f9e5b2bcc4b.png">

**update 23/06/2022:** this typo is fixed in master Contentful Content Model

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11766

Test the following locally:

- [x] `py.test bedrock/contentful/tests/test_contentful_api.py::test_ContentfulPage__get_split_data`
- [x] `py.test bedrock/contentful/tests/test_contentful_api.py::test_ContentfulPage__get_split_data__get_split_class`
- [x] `py.test bedrock/contentful/tests/test_contentful_api.py::test_ContentfulPage__get_split_data__get_body_class`
- [x] `py.test bedrock/contentful/tests/test_contentful_api.py::test_ContentfulPage__get_split_data__get_media_class`
- [x] `py.test bedrock/contentful/tests/test_contentful_api.py::test_ContentfulPage__get_split_data__get_mobile_class`
