### PR TITLE
Notify users about pinning Firefox in Windows (Fixes #11759)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -61,6 +61,7 @@
     {% endif %}
 
       <div class="c-support-install">
+        {# shown to all Windows users from the release of Firefox 103 onward. #}
         {% if switch('firefox-103-taskbar-message') and ftl_has_messages('firefox-new-taskbar') %}
           <p class="show-windows">
             <a href="https://support.mozilla.org/kb/how-unpin-firefox-taskbar-windows-10{{ referrals }}">

--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -29,6 +29,8 @@
   {% endwith %}
 {% endblock %}
 
+{% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-download-thanks' %}
+
 {% block content %}
 <main role="main">
   <div class="mzp-l-content">
@@ -59,11 +61,20 @@
     {% endif %}
 
       <div class="c-support-install">
+        {% if switch('firefox-103-taskbar-message') and ftl_has_messages('firefox-new-taskbar') %}
+          <p class="show-windows">
+            <a href="https://support.mozilla.org/kb/how-unpin-firefox-taskbar-windows-10{{ referrals }}">
+              {{ ftl('firefox-new-taskbar') }}
+            </a>
+          </p>
+        {% endif %}
         {# Edge-case platform support messaging #}
-        <span class="show-linux-arm">{{ ftl('firefox-new-please-follow', fallback='download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}</span>
-        <span class="show-unknown">
+        <p class="show-linux-arm">
+          {{ ftl('firefox-new-please-follow', fallback='download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}
+        </p>
+        <p class="show-unknown">
           {{ ftl('firefox-new-your-system-may-not', url=firefox_url('desktop', 'all'))}}
-        </span>
+        </p>
       </div>
 
       {{ download_firefox(force_direct=true, dom_id='thanks-download-button') }}

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -68,18 +68,33 @@
   {% endif %}
 
     <div class="c-support-install">
-      {% set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
-      <span class="show-mac">{{ ftl('firefox-desktop-download-get-help', attrs=support_mac_attrs) }}</span>
-      {% set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-windows%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
-      <span class="show-windows">{{ ftl('firefox-desktop-download-get-help', attrs=support_windows_attrs) }}</span>
-      {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
-      <span class="show-else">{{ ftl('firefox-desktop-download-get-help', attrs=support_else_attrs) }}</span>
+      {% if switch('firefox-103-taskbar-message') and ftl_has_messages('firefox-desktop-download-taskbar') %}
+        <p class="show-windows">
+          <a href="https://support.mozilla.org/kb/how-unpin-firefox-taskbar-windows-10{{ referrals }}">
+            {{ ftl('firefox-desktop-download-taskbar') }}
+          </a>
+        </p>
+      {% endif %}
+      <p class="show-mac">
+        {% set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
+        {{ ftl('firefox-desktop-download-get-help', attrs=support_mac_attrs) }}
+      </p>
+      <p class="show-windows">
+        {% set support_windows_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-windows%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
+        {{ ftl('firefox-desktop-download-get-help', attrs=support_windows_attrs) }}
+      </p>
+      <p class="show-else">
+        {% set support_else_attrs = 'href="https://support.mozilla.org/products/firefox/install-and-update-firefox%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
+        {{ ftl('firefox-desktop-download-get-help', attrs=support_else_attrs) }}
+      </p>
 
       {# Edge-case platform support messaging #}
-      <span class="show-linux-arm">{{ ftl('firefox-desktop-download-please-follow', fallback='download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}</span>
-      <span class="show-unknown">
+      <p class="show-linux-arm">
+        {{ ftl('firefox-desktop-download-please-follow', fallback='download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}
+      </p>
+      <p class="show-unknown">
         {{ ftl('firefox-desktop-download-your-system-may-not', url=firefox_url('desktop', 'all'))}}
-      </span>
+      </p>
     </div>
 
     {{ download_firefox(force_direct=true, dom_id='thanks-download-button') }}

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -68,6 +68,7 @@
   {% endif %}
 
     <div class="c-support-install">
+      {# shown to all Windows users from the release of Firefox 103 onward. #}
       {% if switch('firefox-103-taskbar-message') and ftl_has_messages('firefox-desktop-download-taskbar') %}
         <p class="show-windows">
           <a href="https://support.mozilla.org/kb/how-unpin-firefox-taskbar-windows-10{{ referrals }}">

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -211,3 +211,5 @@ firefox-desktop-download-please-follow = Please follow <a href="{ $url }">these 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/firefox/all/
 firefox-desktop-download-your-system-may-not = Your system may not meet the requirements for { -brand-name-firefox }, but you can try one of <a href="{ $url }">these versions</a>.
+
+firefox-desktop-download-taskbar = { -brand-name-firefox } will be pinned to the { -brand-name-windows } taskbar after installation

--- a/l10n/en/firefox/new/download.ftl
+++ b/l10n/en/firefox/new/download.ftl
@@ -71,3 +71,4 @@ firefox-new-from-mozilla = from { -brand-name-mozilla }
 
 firefox-new-desc = { -brand-name-firefox-browser } is a free web browser with fast page loading, less memory usage, and lots of features - a project of the not-for-profit { -brand-name-mozilla }.
 firefox-new-download-a-different = Download a different platform or language
+firefox-new-taskbar = { -brand-name-firefox } will be pinned to the { -brand-name-windows } taskbar after installation

--- a/media/css/firefox/new/basic/thanks.scss
+++ b/media/css/firefox/new/basic/thanks.scss
@@ -66,12 +66,8 @@ main {
 .c-support-install {
     margin: 0 auto;
     max-width: 30em;
+    padding: $spacing-xl $spacing-lg $spacing-lg;
     text-align: center;
-
-    & > span {
-        display: block;
-        margin-top: $spacing-xl;
-    }
 }
 
 .download-another-language-link {

--- a/media/css/firefox/new/desktop/thanks.scss
+++ b/media/css/firefox/new/desktop/thanks.scss
@@ -100,7 +100,7 @@ main {
 .c-support-install {
     margin: 0 auto;
     max-width: 30em;
-    padding: $spacing-lg;
+    padding: $spacing-xl $spacing-lg $spacing-lg;
     text-align: center;
 }
 


### PR DESCRIPTION
## One-line summary

- Adds a message to `/thanks/` notifying that Firefox will be pinned to the Windows taskbar on installation.
- Content is behind the switch `SWITCH_FIREFOX_103_TASKBAR_MESSAGE`.

## Issue / Bugzilla link

#11759

## Testing

Test on a Windows device / VM:

- [x] http://localhost:8000/en-US/firefox/download/thanks/
- [x] http://localhost:8000/en-US/firefox/download/thanks/?xv=basic
