### PR TITLE
Add support for dark mode for credits page 

### DIFF
--- a/media/css/mozorg/credits.scss
+++ b/media/css/mozorg/credits.scss
@@ -3,11 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 html {
-    background: -moz-dialog;
-    color: -moz-dialogtext;
+    background: #ffffff;
+    color: #15141a;
     padding: 0 1em;
     font: message-box;
     line-height: 1.6em;
+}
+
+@media (prefers-color-scheme: dark) {
+    html {
+        background: #fbfbfe;
+        color: #2b2a33;
+    }
 }
 
 body {

--- a/media/css/mozorg/credits.scss
+++ b/media/css/mozorg/credits.scss
@@ -12,8 +12,8 @@ html {
 
 @media (prefers-color-scheme: dark) {
     html {
-        background: #fbfbfe;
-        color: #2b2a33;
+        background: #2b2a33;
+        color: #fbfbfe;
     }
 }
 

--- a/media/css/mozorg/credits.scss
+++ b/media/css/mozorg/credits.scss
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 html {
-    background: #ffffff;
+    background: #fff;
     color: #15141a;
     padding: 0 1em;
     font: message-box;
@@ -15,6 +15,10 @@ html {
         background: #2b2a33;
         color: #fbfbfe;
     }
+    
+    a:not([name]) {
+        color: #0df;
+    }   
 }
 
 body {


### PR DESCRIPTION
Colors are based on Firefox Design System (Proton)

## One-line summary

Add support for dark mode

## Significant changes and points to review

Add support for dark mode to the credits page (https://www.mozilla.org/credits/) linked to about:credits in Firefox.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1580956

## Screenshots

![image](https://user-images.githubusercontent.com/7339076/175326365-ca3c8e6d-759d-464e-a96a-b5a7181f1b0e.png)


## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: None
To test this work:

- [ ]
