### PR TITLE
Ensure GA visit_id is not an empty string when passing attribution (Fixes #11808)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -325,7 +325,12 @@ if (typeof window.Mozilla === 'undefined') {
      */
     StubAttribution.getGAVisitID = function () {
         try {
-            return window.ga.getAll()[0].get('clientId');
+            var clientID = window.ga.getAll()[0].get('clientId');
+
+            if (clientID && typeof clientID === 'string' && clientID !== '') {
+                return clientID;
+            }
+            return null;
         } catch (e) {
             return null;
         }
@@ -346,7 +351,7 @@ if (typeof window.Mozilla === 'undefined') {
             clearTimeout(timeout);
             var clientID = StubAttribution.getGAVisitID();
 
-            if (clientID && typeof clientID === 'string') {
+            if (clientID) {
                 callback(true);
             } else {
                 if (pollRetry <= limit) {

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -15,13 +15,6 @@
 describe('stub-attribution.js', function () {
     const GA_VISIT_ID = '1456954538.1610960957';
 
-    beforeEach(function () {
-        // stub out GA client ID
-        spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
-            GA_VISIT_ID
-        );
-    });
-
     describe('init', function () {
         let data = {};
 
@@ -39,6 +32,11 @@ describe('stub-attribution.js', function () {
 
             spyOn(Mozilla.StubAttribution, 'requestAuthentication');
             spyOn(Mozilla.StubAttribution, 'updateBouncerLinks');
+
+            // stub out GA client ID
+            spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
+                GA_VISIT_ID
+            );
         });
 
         it('should update download links if session cookie exists', function () {
@@ -488,6 +486,13 @@ describe('stub-attribution.js', function () {
     });
 
     describe('waitForGoogleAnalytics', function () {
+        beforeEach(function () {
+            // stub out GA client ID
+            spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
+                GA_VISIT_ID
+            );
+        });
+
         it('should fire a callback with the GA visit ID', function () {
             const callback = jasmine.createSpy('callback');
 
@@ -497,6 +502,13 @@ describe('stub-attribution.js', function () {
     });
 
     describe('getAttributionData', function () {
+        beforeEach(function () {
+            // stub out GA client ID
+            spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
+                GA_VISIT_ID
+            );
+        });
+
         it('should return attribution data if utm params are present', function () {
             const referrer = '';
 
@@ -1007,6 +1019,37 @@ describe('stub-attribution.js', function () {
         it('should return false if exceeds sample rate', function () {
             spyOn(window.Math, 'random').and.returnValue(0.6);
             expect(Mozilla.StubAttribution.withinAttributionRate()).toBeFalsy();
+        });
+    });
+
+    describe('getGAVisitID', function () {
+        it('should return a valid Google Analytics visit ID', function () {
+            window.ga = sinon.stub();
+            window.ga.getAll = sinon.stub().returns([
+                {
+                    get: () => GA_VISIT_ID
+                }
+            ]);
+
+            expect(Mozilla.StubAttribution.getGAVisitID()).toEqual(GA_VISIT_ID);
+        });
+
+        it('should return a null if Google Analytics visit ID', function () {
+            window.ga = sinon.stub();
+            window.ga.getAll = sinon.stub().returns([
+                {
+                    get: () => ''
+                }
+            ]);
+
+            expect(Mozilla.StubAttribution.getGAVisitID()).toBeNull();
+        });
+
+        it('should return a null if accessing Google Analytics object throws an error', function () {
+            window.ga = sinon.stub().throws(function () {
+                return new Error();
+            });
+            expect(Mozilla.StubAttribution.getGAVisitID()).toBeNull();
         });
     });
 });


### PR DESCRIPTION
## One-line summary

Ensures we return `null` if the `clientId` property on the GA object is an empty string.

## Significant changes and points to review

This one is not easy to test manually, as I haven't been able to reproduce the issue locally myself. But hopefully the added tests here are pretty clear and straight forward enough to review.

## Issue / Bugzilla link

#11808

## Testing

To manually test that stub attribution is working as expected you can try this on a Windows VM:

1. Using a browser with DNT disabled, open https://www-demo1.allizom.org/en-US/
2. Using Dev Tools, open the Application tab and inspect cookies.
3. Look for a cookie called `moz-stub-attribution-code` and copy its value (should be a base64 encoded string).
4. Decode the base64 string (e.g. using https://base64decode.org).
5. Verify that `visit_id` looks something like `0700077325.1656063224` (the numbers will differ but the format with the middle period should look the same).
