### PR TITLE
Update contentful split api and css

### DIFF
--- a/bedrock/contentful/api.py
+++ b/bedrock/contentful/api.py
@@ -218,15 +218,6 @@ def _make_cta_button(entry):
     return render_to_string("includes/contentful/cta.html", data, get_current_request())
 
 
-def _make_product_icon(entry):
-    content_type = entry.sys["content_type"].id
-
-    if content_type == "componentLogo":
-        return _make_logo(entry)
-    elif content_type == "componentWordmark":
-        return _make_wordmark(entry)
-
-
 def _make_plain_text(node):
     content = node["content"]
     plain = ""
@@ -768,14 +759,10 @@ class ContentfulPage:
             "theme_class": _get_theme_class(fields.get("theme")),
             "body_class": get_body_class(),
             "body": self.render_rich_text(fields.get("body")),
-            "heading": fields.get("heading"),
-            "heading_level": fields.get("heading_level"),
             "media_class": get_media_class(),
             "media_after": fields.get("mobile_media_after"),
             "image": split_image_url,
             "mobile_class": get_mobile_class(),
-            "cta": _make_cta_button(fields.get("cta")) if fields.get("cta") else "",
-            "product_icon": _make_product_icon(fields.get("product_icon")) if fields.get("product_icon") else "",
         }
         return data
 

--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -137,10 +137,7 @@
         include_highres_image=False,
         loading=loading,
       ) %}
-        {% if entry.product_icon %}{{ entry.product_icon }}{% endif %}
-        {% if entry.heading %}<{{ entry.heading_level }}>{{ entry.heading }}</{{ entry.heading_level}}>{% endif %}
         {{ entry.body|external_html }}
-        {% if entry.cta %}{{ entry.cta }}{% endif %}
 
       {% endcall %}
 

--- a/media/css/contentful/firefox/c-split.scss
+++ b/media/css/contentful/firefox/c-split.scss
@@ -10,3 +10,9 @@ $brand-theme: 'firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/split';
 
 @import '../patch';
+
+// Override until MDN plus logo is added to Protocol.
+// https://github.com/mozilla/protocol-assets/issues/83
+.mzp-c-wordmark.mzp-t-product-mdn-plus {
+    background-image: url('/media/img/logos/mdn/mdn-plus-wordmark.svg');
+}

--- a/media/css/contentful/mozilla/c-split.scss
+++ b/media/css/contentful/mozilla/c-split.scss
@@ -26,3 +26,9 @@ $brand-theme: 'mozilla';
         }
     }
 }
+
+// Override until MDN plus logo is added to Protocol.
+// https://github.com/mozilla/protocol-assets/issues/83
+.mzp-c-wordmark.mzp-t-product-mdn-plus {
+    background-image: url('/media/img/logos/mdn/mdn-plus-wordmark.svg');
+}


### PR DESCRIPTION
## One-line summary

We're making changes to the Contentful content model and prioritizing Split over Hero components

## Significant changes and points to review

This reverts unnecessary fields additions from https://github.com/mozilla/bedrock/pull/11712/files#diff-77ac837e3992065e29560e9150f097cdea55bf59219a4d22ef08cb00f1427f5fR771

And adds a workaround MDN Plus wordmark to split css (copied over from https://github.com/mozilla/bedrock/commit/bdf695fb79e80d79d57680fefe1d8f41762ef67a)

## Issue / Bugzilla link

See https://github.com/mozilla/bedrock/issues/11822#issuecomment-1168752708 for issue and how to test

DO NOT MERGE until Contentful changes are reviewed and approved and Contentful master environment is updated
**edit:** these changes are OK to merge before the contentful master environment change, they won't break anything, but until that environment is changed, they won't have any benefit either.
