### PR TITLE
Add front-end dependencies section in documentation (fixes #11795)

### DIFF
--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -37,6 +37,16 @@ To check for stale Python dependencies (basically ``pip list -o`` but in the Doc
 For Node packages we use `NPM <https://docs.npmjs.com/cli/v8/commands/npm-install>`_, which should already be
 installed alongside `Node.js <https://nodejs.org/>`_.
 
+Front-end Dependencies
+~~~~~~~~~~~~~~~~~~~~~~
+
+We currently have a few dependencies we serve on Bedrock's front-end.
+
+- `@mozilla-protocol/core <https://www.npmjs.com/package/@mozilla-protocol/core>`_: Bedrock's primary design system
+- `@mozmeao/trafficcop <https://www.npmjs.com/package/@mozmeao/trafficcop>`_: Used for A/B testing page variants
+- `@mozmeao/cookie-helper <https://www.npmjs.com/package/@mozmeao/cookie-helper>`_: A complete cookies reader/writer framework
+
+
 Asset Management and Bundling
 -----------------------------
 

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -40,11 +40,14 @@ installed alongside `Node.js <https://nodejs.org/>`_.
 Front-end Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~
 
-We currently have a few dependencies we serve on Bedrock's front-end.
+Our team maintains a few dependencies that we serve on Bedrock's front-end.
 
 - `@mozilla-protocol/core <https://www.npmjs.com/package/@mozilla-protocol/core>`_: Bedrock's primary design system
 - `@mozmeao/trafficcop <https://www.npmjs.com/package/@mozmeao/trafficcop>`_: Used for A/B testing page variants
 - `@mozmeao/cookie-helper <https://www.npmjs.com/package/@mozmeao/cookie-helper>`_: A complete cookies reader/writer framework
+
+Because they are all published on NPM, install the packages and keep up-to-date with the latest version of each dependency by running an ``npm install``. For further documentation on installing NPM packages, `check out the official documentation <https://docs.npmjs.com/cli/v6/commands/npm-install>`_.
+
 
 
 Asset Management and Bundling


### PR DESCRIPTION
## One-line summary

Added a sub-section in our documentation to list the front-end dependencies we currently have in place for Bedrock.
I listed it as a sub-section under `Managing Dependencies`. I thought this would be a good spot for it? Let me know if you think otherwise.

## Issue / Bugzilla link
#11795 

## Testing
- If using Docker, run `make docs`
- If using locally, run `make livedocs`
- Go to http://127.0.0.1:8100/coding.html#front-end-dependencies

