### PR TITLE
Add country and language newsletter field labels (Fixes #11829)

### DIFF
--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -278,9 +278,11 @@ class NewsletterFooterForm(forms.Form):
             "aria-required": "true",
         }
         country_widget = widgets.Select(attrs=required_args)
-        self.fields["country"] = forms.ChoiceField(widget=country_widget, choices=regions, initial=country, required=False)
+        country_label = ftl_lazy("newsletter-form-select-country-or-region", fallback="newsletter-form-select-country")
+        self.fields["country"] = forms.ChoiceField(widget=country_widget, choices=regions, initial=country, required=False, label=country_label)
         lang_widget = widgets.Select(attrs=required_args)
-        self.fields["lang"] = forms.TypedChoiceField(widget=lang_widget, choices=lang_choices, initial=lang, required=False)
+        lang_label = ftl_lazy("newsletter-form-select-language", fallback="newsletter-form-available-languages")
+        self.fields["lang"] = forms.TypedChoiceField(widget=lang_widget, choices=lang_choices, initial=lang, required=False, label=lang_label)
         self.fields["newsletters"].choices = [(n, self.choice_labels.get(n, n)) for n in newsletters]
         self.fields["newsletters"].initial = newsletters
 

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -54,13 +54,7 @@
       </div>
       {% endif %}
 
-      <label for="id_email">
-      {% if email_label %}
-        {{ email_label }}
-      {% else %}
-        {{ ftl('newsletter-form-your-email-address') }}
-      {% endif %}
-      </label>
+      {{ form.email.label_tag(ftl('newsletter-form-your-email-address') if not email_label else email_label) }}
       {% if email_placeholder %}
         {% set placeholder = email_placeholder %}
       {% else %}
@@ -70,10 +64,12 @@
 
       <div id="newsletter-details" class="mzp-c-newsletter-details">
         {% if include_country %}
+          {{ form.country.label_tag() }}
           <p>{{ form.country|safe }}</p>
         {% endif %}
 
         {% if include_language %}
+          {{ form.lang.label_tag()|safe }}
           <p>{{ form.lang|safe }}</p>
         {% else %}
           <input type="hidden" name="lang" id="id_lang"  value="en">

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -69,7 +69,7 @@
         {% endif %}
 
         {% if include_language %}
-          {{ form.lang.label_tag()|safe }}
+          {{ form.lang.label_tag() }}
           <p>{{ form.lang|safe }}</p>
         {% else %}
           <input type="hidden" name="lang" id="id_lang"  value="en">

--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -10,6 +10,7 @@ newsletter-form-your-email-address = Your email address
 newsletter-form-yournameexamplecom = yourname@example.com
 
 newsletter-form-select-country-or-region = Select country or region
+newsletter-form-select-language = Select language
 newsletter-form-your-email-here = YOUR EMAIL HERE
 newsletter-form-format = Format
 newsletter-form-html = HTML

--- a/media/css/firefox/developer/includes/newsletter.scss
+++ b/media/css/firefox/developer/includes/newsletter.scss
@@ -35,10 +35,6 @@
             min-width: 0; // https://github.com/mozilla/protocol/issues/607
         }
 
-        label[for='id_email'] {
-            @include visually-hidden;
-        }
-
         legend {
             @include font-size(14px);
         }


### PR DESCRIPTION
## One-line summary

Adds localised field labels for country and language to newsletter forms.

## Issue / Bugzilla link

#11829

## Testing

Demo server URL: (or None)

- http://localhost:8000/en-US/
- http://localhost:8000/en-US/newsletter/
- http://localhost:8000/en-US/newsletter/mozilla/
- http://localhost:8000/en-US/newsletter/firefox/
- http://localhost:8000/en-US/newsletter/developer/
- http://localhost:8000/en-US/newsletter/knowledge-is-power/
- http://localhost:8000/en-US/contribute/
