### PR TITLE
Use Client Hints to get high entropy platform info (Fixes #8440)

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -6,7 +6,7 @@
 
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% block html_attrs %}{% endblock %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %}>
+<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% block html_attrs %}{% endblock %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -74,7 +74,7 @@ ul.download-list {
 .download-button .os_linux,
 .download-button .os_linux64,
 .android .download-button-desktop,
-.linux.x86.x64 .download-list .os_linux,
+.linux.x64 .download-list .os_linux,
 .download-button .os_win,
 .download-button .os_win-msi,
 .download-button .os_osx,
@@ -86,7 +86,7 @@ ul.download-list {
 }
 
 .linux .download-button .os_linux,
-.linux.x86.x64 .download-button .os_linux64,
+.linux.x64 .download-button .os_linux64,
 .windows .download-button .os_win,
 .osx .download-button .os_osx,
 .android .download-button .os_android,
@@ -101,11 +101,11 @@ ul.download-list {
 }
 
 // 64-bit UA detection for Firefox Beta on Windows (issue #10194)
-.windows.x86.x64 .download-button-beta .os_win {
+.windows.x64 .download-button-beta .os_win {
     display: none !important;
 }
 
-.windows.x86.x64 .download-button-beta .os_win64 {
+.windows.x64 .download-button-beta .os_win64 {
     display: block !important;
 }
 

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -54,6 +54,25 @@
             return match ? match[1].replace('_', '.') : undefined;
         },
 
+        // Madness from https://docs.microsoft.com/microsoft-edge/web-platform/how-to-detect-win11
+        getWindowsVersionCH: function (version) {
+            var fullPlatformVersion = version ? version.toString() : '0';
+            var majorPlatformVersion = parseInt(
+                fullPlatformVersion.split('.')[0],
+                10
+            );
+            if (majorPlatformVersion >= 13) {
+                // Windows 11 or later.
+                return '11.0.0';
+            } else if (majorPlatformVersion > 0) {
+                // Windows 10
+                return '10.0.0';
+            } else {
+                // Might be any Windows version less than 10, who knows.
+                return undefined;
+            }
+        },
+
         getArchType: function (ua, pf) {
             pf = pf === '' ? '' : pf || navigator.platform;
             ua = ua || navigator.userAgent;
@@ -76,6 +95,17 @@
             return 'x86';
         },
 
+        isARM: function (architecture) {
+            var arch =
+                typeof architecture === 'string'
+                    ? architecture
+                    : window.site.archType;
+            if (arch === 'arm' || arch.match(/armv(\d+)/)) {
+                return true;
+            }
+            return false;
+        },
+
         getArchSize: function (ua, pf) {
             pf = pf === '' ? '' : pf || navigator.platform;
             ua = ua || navigator.userAgent;
@@ -90,6 +120,16 @@
             return 32;
         },
 
+        getArchSizeCH: function (bitness) {
+            if (
+                typeof bitness !== 'undefined' &&
+                parseInt(bitness, 10) === 64
+            ) {
+                return 64;
+            }
+            return 32;
+        },
+
         // Universal feature detect to deliver graded browser support (targets IE 11 and above).
         cutsTheMustard: function () {
             return (
@@ -101,43 +141,34 @@
         platform: 'other',
         platformVersion: undefined,
         archType: 'x64',
-        archSize: 32,
-        isARM: false
+        archSize: 32
     };
-    (function () {
+
+    function updateHTML() {
         var h = document.documentElement;
 
-        // if other than 'windows', immediately replace the platform classname on the html-element
-        // to avoid lots of flickering
-        var platform = (window.site.platform = window.site.getPlatform());
-        var version = (window.site.platformVersion =
-            window.site.getPlatformVersion());
-        var _version = version ? parseFloat(version) : 0;
+        if (window.site.platform === 'windows') {
+            // Detect Windows 10 "and up" to display installation
+            // messaging on the /firefox/download/thanks/ page.
+            var _version = window.site.platformVersion
+                ? parseFloat(window.site.platformVersion)
+                : 0;
 
-        if (platform === 'windows') {
             if (_version >= 10.0) {
                 h.className += ' windows-10-plus';
             }
         } else {
-            h.className = h.className.replace('windows', platform);
+            h.className = h.className.replace('windows', window.site.platform);
         }
 
-        // Add class to reflect the microprocessor architecture info
-        var archType = (window.site.archType = window.site.getArchType());
-        var archSize = (window.site.archSize = window.site.getArchSize());
-        var isARM = (window.site.isARM = archType.match(/armv(\d+)/));
-
-        // Used for Linux ARM processor detection.
-        if (archType !== 'x86') {
-            h.className = h.className.replace('x86', archType);
-
-            if (isARM) {
-                h.className += ' arm';
-            }
+        // Used to display a custom installation message and
+        // SUMO link on the /firefox/download/thanks/ page.
+        if (window.site.isARM()) {
+            h.className += ' arm';
         }
 
-        // Used for 64bit download link on Linux.
-        if (archSize === 64) {
+        // Used for 64bit download link on Linux and Firefox Beta on Windows.
+        if (window.site.archSize === 64) {
             h.className += ' x64';
         }
 
@@ -162,5 +193,64 @@
 
         // Add class to reflect javascript availability for CSS
         h.className = h.className.replace(/\bno-js\b/, 'js');
+    }
+
+    function getHighEntropyFromUAString() {
+        window.site.platformVersion = window.site.getPlatformVersion();
+        window.site.archType = window.site.getArchType();
+        window.site.archSize = window.site.getArchSize();
+    }
+
+    (function () {
+        window.site.platform = window.site.getPlatform();
+
+        // For browsers that support client hints, get high entropy
+        // values that might be frozen in the regular user agent string.
+        if (
+            'userAgentData' in navigator &&
+            typeof navigator.userAgentData.getHighEntropyValues === 'function'
+        ) {
+            navigator.userAgentData
+                .getHighEntropyValues([
+                    'architecture',
+                    'bitness',
+                    'platformVersion'
+                ])
+                .then(function (ua) {
+                    if (ua.platformVersion) {
+                        if (window.site.platform === 'windows') {
+                            window.site.platformVersion =
+                                window.site.getWindowsVersionCH(
+                                    ua.platformVersion
+                                );
+                        } else {
+                            window.site.platformVersion = ua.platformVersion;
+                        }
+                    }
+
+                    if (ua.architecture) {
+                        window.site.archType = ua.architecture;
+                    }
+
+                    if (ua.bitness) {
+                        window.site.archSize = window.site.getArchSizeCH(
+                            ua.bitness
+                        );
+                    }
+
+                    updateHTML();
+                })
+                .catch(function () {
+                    // some browsers might deny accessing high entropy info
+                    // and reject the promise, so fall back to UA string instead.
+                    getHighEntropyFromUAString();
+                    updateHTML();
+                });
+        }
+        // Else fall back to UA string parsing for non-supporting browsers.
+        else {
+            getHighEntropyFromUAString();
+            updateHTML();
+        }
     })();
 })();

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -55,7 +55,7 @@
         },
 
         // Madness from https://docs.microsoft.com/microsoft-edge/web-platform/how-to-detect-win11
-        getWindowsVersionCH: function (version) {
+        getWindowsVersionClientHint: function (version) {
             var fullPlatformVersion = version ? version.toString() : '0';
             var majorPlatformVersion = parseInt(
                 fullPlatformVersion.split('.')[0],
@@ -120,7 +120,7 @@
             return 32;
         },
 
-        getArchSizeCH: function (bitness) {
+        getArchSizeClientHint: function (bitness) {
             if (
                 typeof bitness !== 'undefined' &&
                 parseInt(bitness, 10) === 64
@@ -220,7 +220,7 @@
                     if (ua.platformVersion) {
                         if (window.site.platform === 'windows') {
                             window.site.platformVersion =
-                                window.site.getWindowsVersionCH(
+                                window.site.getWindowsVersionClientHint(
                                     ua.platformVersion
                                 );
                         } else {
@@ -233,9 +233,8 @@
                     }
 
                     if (ua.bitness) {
-                        window.site.archSize = window.site.getArchSizeCH(
-                            ua.bitness
-                        );
+                        window.site.archSize =
+                            window.site.getArchSizeClientHint(ua.bitness);
                     }
 
                     updateHTML();

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -95,12 +95,13 @@
             return 'x86';
         },
 
+        // Returns true if CPU is an ARM processor.
         isARM: function (architecture) {
             var arch =
                 typeof architecture === 'string'
                     ? architecture
                     : window.site.archType;
-            if (arch === 'arm' || arch.match(/armv(\d+)/)) {
+            if (arch && (arch === 'arm' || arch.match(/armv(\d+)/))) {
                 return true;
             }
             return false;
@@ -120,11 +121,9 @@
             return 32;
         },
 
+        // Return 64 is CPU is 64bit, else assume that it's 32.
         getArchSizeClientHint: function (bitness) {
-            if (
-                typeof bitness !== 'undefined' &&
-                parseInt(bitness, 10) === 64
-            ) {
+            if (bitness && parseInt(bitness, 10) === 64) {
                 return 64;
             }
             return 32;

--- a/media/js/firefox/new/common/thanks.js
+++ b/media/js/firefox/new/common/thanks.js
@@ -47,7 +47,7 @@ if (typeof window.Mozilla === 'undefined') {
                 link = document.getElementById(prefix + 'osx');
                 break;
             case 'linux':
-                if (site.isARM) {
+                if (site.isARM()) {
                     // Linux ARM users get SUMO install instructions.
                     link = null;
                 } else if (site.archSize === 64) {

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -335,48 +335,66 @@ describe('site.js', function () {
         });
     });
 
-    describe('getArchSizeCH', function () {
+    describe('getArchSizeClientHint', function () {
         it('should identify 64', function () {
-            expect(window.site.getArchSizeCH(64)).toBe(64);
-            expect(window.site.getArchSizeCH('64')).toBe(64);
+            expect(window.site.getArchSizeClientHint(64)).toBe(64);
+            expect(window.site.getArchSizeClientHint('64')).toBe(64);
         });
 
         it('should identify 32', function () {
-            expect(window.site.getArchSizeCH(32)).toBe(32);
-            expect(window.site.getArchSizeCH('32')).toBe(32);
+            expect(window.site.getArchSizeClientHint(32)).toBe(32);
+            expect(window.site.getArchSizeClientHint('32')).toBe(32);
         });
 
         it('should default to 32', function () {
-            expect(window.site.getArchSizeCH()).toBe(32);
-            expect(window.site.getArchSizeCH(null)).toBe(32);
-            expect(window.site.getArchSizeCH(undefined)).toBe(32);
-            expect(window.site.getArchSizeCH('abcd')).toBe(32);
-            expect(window.site.getArchSizeCH('')).toBe(32);
-            expect(window.site.getArchSizeCH(1234)).toBe(32);
+            expect(window.site.getArchSizeClientHint()).toBe(32);
+            expect(window.site.getArchSizeClientHint(null)).toBe(32);
+            expect(window.site.getArchSizeClientHint(undefined)).toBe(32);
+            expect(window.site.getArchSizeClientHint('abcd')).toBe(32);
+            expect(window.site.getArchSizeClientHint('')).toBe(32);
+            expect(window.site.getArchSizeClientHint(1234)).toBe(32);
         });
     });
 
-    describe('getWindowsVersionCH', function () {
+    describe('getWindowsVersionClientHint', function () {
         it('should identify 13 and up as Windows 11 or later', function () {
-            expect(window.site.getWindowsVersionCH('13.0.0')).toBe('11.0.0');
-            expect(window.site.getWindowsVersionCH('14.0.0')).toBe('11.0.0');
+            expect(window.site.getWindowsVersionClientHint('13.0.0')).toBe(
+                '11.0.0'
+            );
+            expect(window.site.getWindowsVersionClientHint('14.0.0')).toBe(
+                '11.0.0'
+            );
         });
 
         it('should identify 1 through 12 as Windows 10', function () {
-            expect(window.site.getWindowsVersionCH('12.0.0')).toBe('10.0.0');
-            expect(window.site.getWindowsVersionCH('11.0.0')).toBe('10.0.0');
-            expect(window.site.getWindowsVersionCH('10.0.0')).toBe('10.0.0');
-            expect(window.site.getWindowsVersionCH('1.0.0')).toBe('10.0.0');
-            expect(window.site.getWindowsVersionCH('1')).toBe('10.0.0');
-            expect(window.site.getWindowsVersionCH(1.0)).toBe('10.0.0');
-            expect(window.site.getWindowsVersionCH(12)).toBe('10.0.0');
+            expect(window.site.getWindowsVersionClientHint('12.0.0')).toBe(
+                '10.0.0'
+            );
+            expect(window.site.getWindowsVersionClientHint('11.0.0')).toBe(
+                '10.0.0'
+            );
+            expect(window.site.getWindowsVersionClientHint('10.0.0')).toBe(
+                '10.0.0'
+            );
+            expect(window.site.getWindowsVersionClientHint('1.0.0')).toBe(
+                '10.0.0'
+            );
+            expect(window.site.getWindowsVersionClientHint('1')).toBe('10.0.0');
+            expect(window.site.getWindowsVersionClientHint(1.0)).toBe('10.0.0');
+            expect(window.site.getWindowsVersionClientHint(12)).toBe('10.0.0');
         });
 
         it('should return undefined for unknown Windows versions', function () {
-            expect(window.site.getWindowsVersionCH('0.0.0')).toBe(undefined);
-            expect(window.site.getWindowsVersionCH(0.0)).toBe(undefined);
-            expect(window.site.getWindowsVersionCH('0')).toBe(undefined);
-            expect(window.site.getWindowsVersionCH('')).toBe(undefined);
+            expect(window.site.getWindowsVersionClientHint('0.0.0')).toBe(
+                undefined
+            );
+            expect(window.site.getWindowsVersionClientHint(0.0)).toBe(
+                undefined
+            );
+            expect(window.site.getWindowsVersionClientHint('0')).toBe(
+                undefined
+            );
+            expect(window.site.getWindowsVersionClientHint('')).toBe(undefined);
         });
     });
 

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -334,4 +334,64 @@ describe('site.js', function () {
             ).toBe(32);
         });
     });
+
+    describe('getArchSizeCH', function () {
+        it('should identify 64', function () {
+            expect(window.site.getArchSizeCH(64)).toBe(64);
+            expect(window.site.getArchSizeCH('64')).toBe(64);
+        });
+
+        it('should identify 32', function () {
+            expect(window.site.getArchSizeCH(32)).toBe(32);
+            expect(window.site.getArchSizeCH('32')).toBe(32);
+        });
+
+        it('should default to 32', function () {
+            expect(window.site.getArchSizeCH()).toBe(32);
+            expect(window.site.getArchSizeCH(null)).toBe(32);
+            expect(window.site.getArchSizeCH(undefined)).toBe(32);
+            expect(window.site.getArchSizeCH('abcd')).toBe(32);
+            expect(window.site.getArchSizeCH('')).toBe(32);
+            expect(window.site.getArchSizeCH(1234)).toBe(32);
+        });
+    });
+
+    describe('getWindowsVersionCH', function () {
+        it('should identify 13 and up as Windows 11 or later', function () {
+            expect(window.site.getWindowsVersionCH('13.0.0')).toBe('11.0.0');
+            expect(window.site.getWindowsVersionCH('14.0.0')).toBe('11.0.0');
+        });
+
+        it('should identify 1 through 12 as Windows 10', function () {
+            expect(window.site.getWindowsVersionCH('12.0.0')).toBe('10.0.0');
+            expect(window.site.getWindowsVersionCH('11.0.0')).toBe('10.0.0');
+            expect(window.site.getWindowsVersionCH('10.0.0')).toBe('10.0.0');
+            expect(window.site.getWindowsVersionCH('1.0.0')).toBe('10.0.0');
+            expect(window.site.getWindowsVersionCH('1')).toBe('10.0.0');
+            expect(window.site.getWindowsVersionCH(1.0)).toBe('10.0.0');
+            expect(window.site.getWindowsVersionCH(12)).toBe('10.0.0');
+        });
+
+        it('should return undefined for unknown Windows versions', function () {
+            expect(window.site.getWindowsVersionCH('0.0.0')).toBe(undefined);
+            expect(window.site.getWindowsVersionCH(0.0)).toBe(undefined);
+            expect(window.site.getWindowsVersionCH('0')).toBe(undefined);
+            expect(window.site.getWindowsVersionCH('')).toBe(undefined);
+        });
+    });
+
+    describe('isARM', function () {
+        it('should return true for ARM processors', function () {
+            expect(window.site.isARM('arm')).toBeTrue();
+            expect(window.site.isARM('armv8')).toBeTrue();
+            expect(window.site.isARM('armv7')).toBeTrue();
+        });
+
+        it('should return false for other values', function () {
+            expect(window.site.isARM('x86')).toBeFalse();
+            expect(window.site.isARM('')).toBeFalse();
+            expect(window.site.isARM(null)).toBeFalse();
+            expect(window.site.isARM(undefined)).toBeFalse();
+        });
+    });
 });

--- a/tests/unit/spec/firefox/new/common/thanks.js
+++ b/tests/unit/spec/firefox/new/common/thanks.js
@@ -83,7 +83,9 @@ describe('thanks.js', function () {
         it('should return the correct download for Linux 32bit', function () {
             const site = {
                 platform: 'linux',
-                isARM: false,
+                isARM: function () {
+                    return false;
+                },
                 archSize: 32
             };
             const result = Mozilla.DownloadThanks.getDownloadURL(site);
@@ -95,7 +97,9 @@ describe('thanks.js', function () {
         it('should return the correct download for Linux 64bit', function () {
             const site = {
                 platform: 'linux',
-                isARM: false,
+                isARM: function () {
+                    return false;
+                },
                 archSize: 64
             };
             const result = Mozilla.DownloadThanks.getDownloadURL(site);
@@ -107,7 +111,9 @@ describe('thanks.js', function () {
         it('should not return a download for Linux ARM', function () {
             const site = {
                 platform: 'linux',
-                isARM: true,
+                isARM: function () {
+                    return true;
+                },
                 archSize: 64
             };
             const result = Mozilla.DownloadThanks.getDownloadURL(site);


### PR DESCRIPTION
## One-line summary

On Oct 25th, Chrome is freezing UA string info that relates to platform version, CPU type, and CPU architecture. These "high entropy" values will then only be available via the Client Hints API in Chromium browsers. This PR adds code to use the new Client Hints API, falling back to regular UA string checks for non-supporting browsers.

This change will help to ensure we carry on detecting things like 32/64 bit for Firefox Linux downloads, as well as info we rely on in a few other places (see below for details). 

## Significant changes and points to review

- Removes redundant `x86` CPU architecture class.
- Updates `site.js` to favour using Client Hints when detecting:
  - CPU size (32/64 bit).
  - CPU type (x86, ARM).

## Issue / Bugzilla link

#8440

## Testing

Demo: https://www-demo1.allizom.org/

This PR should work without any config changes in the latest Chrome, however if you also want to simulate the future UA reduction changes you can enable `chrome://flags/#reduce-user-agent`.

**Test using Chrome or Edge** (BrowserStack Windows VMs are good candidates for 1 and 2):

- [x] http://localhost:8000/en-US/firefox/channel/desktop/ (Firefox Beta 64 bit installer should be served to 64bit Windows devices).
- [x] http://localhost:8000/firefox/download/thanks/ should display an info panel for Windows 10 and 11 saying `If you see a prompt stating the app you’re trying to install isn’t a Microsoft-verified app, click “Install anyway” or change app recommendation settings.`
- [x] http://localhost:8000/en-US/firefox/download/thanks/ (64 bit installer should be served to 64bit Linux devices)
