### PR TITLE
Upgrade jinja2, django-jinja and django-jinja-markdown

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -12,6 +12,7 @@ from django.utils.encoding import smart_str
 
 import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 from bedrock.base import waffle
 from bedrock.utils import expand_locale_groups
@@ -24,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def switch(cxt, name, locales=None):
     """A template helper that replaces waffle
 
@@ -53,7 +54,7 @@ def switch(cxt, name, locales=None):
 @library.global_function
 def thisyear():
     """The current year."""
-    return jinja2.Markup(datetime.date.today().year)
+    return Markup(datetime.date.today().year)
 
 
 @library.global_function
@@ -126,7 +127,7 @@ def js_bundle(name):
     """
     path = f"js/{name}.js"
     path = staticfiles_storage.url(path)
-    return jinja2.Markup(JS_TEMPLATE % path)
+    return Markup(JS_TEMPLATE % path)
 
 
 @library.global_function
@@ -137,7 +138,7 @@ def css_bundle(name):
     """
     path = f"css/{name}.css"
     path = staticfiles_storage.url(path)
-    return jinja2.Markup(CSS_TEMPLATE % path)
+    return Markup(CSS_TEMPLATE % path)
 
 
 @library.global_function
@@ -151,7 +152,7 @@ def alternate_url(path, locale):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def get_donate_params(ctx):
     """Returns donation params for the current locale with an added key
     containing a list version of the preset donation amounts.

--- a/bedrock/contentcards/models.py
+++ b/bedrock/contentcards/models.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db import models, transaction
 
 from django_extensions.db.fields.json import JSONField
-from jinja2 import Markup
+from markupsafe import Markup
 
 from bedrock.base.urlresolvers import reverse
 

--- a/bedrock/contentcards/tests/test_models.py
+++ b/bedrock/contentcards/tests/test_models.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from django.test import override_settings
 
-from jinja2 import Markup
+from markupsafe import Markup
 
 from bedrock.contentcards import models
 from bedrock.mozorg.tests import TestCase

--- a/bedrock/contentful/templatetags/helpers.py
+++ b/bedrock/contentful/templatetags/helpers.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import bleach
-import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 # based on bleach.sanitizer.ALLOWED_TAGS
 ALLOWED_TAGS = [
@@ -60,4 +60,4 @@ def _allowed_attrs(tag, name, value):
 @library.filter
 def external_html(content):
     """Clean and mark "safe" HTML content from external data"""
-    return jinja2.Markup(bleach.clean(content, tags=ALLOWED_TAGS, attributes=_allowed_attrs))
+    return Markup(bleach.clean(content, tags=ALLOWED_TAGS, attributes=_allowed_attrs))

--- a/bedrock/contentful/tests/test_templatetags_helpers.py
+++ b/bedrock/contentful/tests/test_templatetags_helpers.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import pytest
-from jinja2 import Markup
+from markupsafe import Markup
 
 from bedrock.contentful.templatetags.helpers import (
     ALLOWED_ATTRS,

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -7,6 +7,7 @@ from django.template.loader import render_to_string
 
 import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 from bedrock.base.urlresolvers import reverse
 from bedrock.firefox.firefox_details import (
@@ -111,7 +112,7 @@ def ios_builds(channel, builds=None):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def download_firefox(
     ctx,
     channel="release",
@@ -188,11 +189,11 @@ def download_firefox(
     }
 
     html = render_to_string("firefox/includes/download-button.html", data, request=ctx["request"])
-    return jinja2.Markup(html)
+    return Markup(html)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button_class=None, locale_in_transition=False, download_location=None):
     """Output a simple "download firefox" button that only points to /download/thanks/
 
@@ -243,11 +244,11 @@ def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button
     }
 
     html = render_to_string("firefox/includes/download-button-thanks.html", data, request=ctx["request"])
-    return jinja2.Markup(html)
+    return Markup(html)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def download_firefox_desktop_list(ctx, channel="release", dom_id=None, locale=None, force_full_installer=False):
     """
     Return a HTML list of platform download links for Firefox desktop
@@ -291,7 +292,7 @@ def download_firefox_desktop_list(ctx, channel="release", dom_id=None, locale=No
     }
 
     html = render_to_string("firefox/includes/download-list.html", data, request=ctx["request"])
-    return jinja2.Markup(html)
+    return Markup(html)
 
 
 @library.global_function

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -11,7 +11,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 from django_jinja.backend import Jinja2
-from jinja2 import Markup
+from markupsafe import Markup
 from pyquery import PyQuery as pq
 
 from bedrock.base.urlresolvers import reverse

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -21,6 +21,7 @@ from django.utils.encoding import smart_str
 import bleach
 import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 from bedrock.base.templatetags.helpers import static
 from bedrock.firefox.firefox_details import firefox_ios
@@ -67,7 +68,7 @@ def l10n_img_file_name(ctx, url):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def l10n_img(ctx, url):
     """Output the url to a localized image.
 
@@ -107,7 +108,7 @@ def l10n_img(ctx, url):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def l10n_css(ctx):
     """
     Output the URL to a locale-specific stylesheet if exists.
@@ -144,7 +145,7 @@ def l10n_css(ctx):
     else:
         markup = ""
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
@@ -156,7 +157,7 @@ def field_with_attrs(bfield, **kwargs):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def platform_img(ctx, url, optional_attributes=None):
     optional_attributes = optional_attributes or {}
     img_urls = {}
@@ -193,11 +194,11 @@ def platform_img(ctx, url, optional_attributes=None):
         "</noscript>"
     ).format(attrs=attrs, win_src=img_attrs["data-src-windows"])
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def high_res_img(ctx, url, optional_attributes=None):
     if optional_attributes and optional_attributes.pop("l10n", False) is True:
         url = _strip_img_prefix(url)
@@ -219,11 +220,11 @@ def high_res_img(ctx, url, optional_attributes=None):
     # Use native srcset attribute for high res images
     markup = f'<img class="{class_name}" src="{url}" srcset="{url_high_res} 1.5x"{attrs}>'
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def video(ctx, *args, **kwargs):
     """
     HTML5 Video tag helper.
@@ -275,11 +276,11 @@ def video(ctx, *args, **kwargs):
     data.update(**kwargs)
     data.update(filetypes=filetypes, mime=mime, videos=videos)
 
-    return jinja2.Markup(render_to_string("mozorg/videotag.html", data, request=ctx["request"]))
+    return Markup(render_to_string("mozorg/videotag.html", data, request=ctx["request"]))
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def press_blog_url(ctx):
     """Output a link to the press blog taking locales into account.
 
@@ -316,7 +317,7 @@ def press_blog_url(ctx):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def donate_url(ctx, source=""):
     """Output a donation link to the donation page formatted using settings.DONATE_PARAMS
 
@@ -360,7 +361,7 @@ def donate_url(ctx, source=""):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def firefox_twitter_url(ctx):
     """Output a link to Twitter taking locales into account.
 
@@ -397,7 +398,7 @@ def firefox_twitter_url(ctx):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def mozilla_twitter_url(ctx):
     """Output a link to Twitter taking locales into account.
 
@@ -430,7 +431,7 @@ def mozilla_twitter_url(ctx):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def mozilla_instagram_url(ctx):
     """Output a link to Instagram taking locales into account.
 
@@ -495,7 +496,7 @@ def absolute_url(url):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def firefox_ios_url(ctx, ct_param=None):
     """
     Output a link to the Firefox for iOS download page on the Apple App Store
@@ -585,10 +586,10 @@ def bleach_tags(text):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def csrf(context):
     """Equivalent of Django's ``{% crsf_token %}``."""
-    return jinja2.Markup(CsrfTokenNode().render(context))
+    return Markup(CsrfTokenNode().render(context))
 
 
 @library.filter
@@ -616,11 +617,11 @@ def datetime(t, fmt=None):
 @library.filter
 def ifeq(a, b, text):
     """Return ``text`` if ``a == b``."""
-    return jinja2.Markup(text if a == b else "")
+    return Markup(text if a == b else "")
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def app_store_url(ctx, product):
     """Returns a localised app store URL for a given product"""
     base_url = getattr(settings, f"APPLE_APPSTORE_{product.upper()}_LINK")
@@ -633,7 +634,7 @@ def app_store_url(ctx, product):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def play_store_url(ctx, product):
     """Returns a localised play store URL for a given product"""
     base_url = getattr(settings, f"GOOGLE_PLAY_{product.upper()}_LINK")
@@ -641,7 +642,7 @@ def play_store_url(ctx, product):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def structured_data_id(ctx, id, domain=None):
     """
     Returns an identifier for a structured data object based on
@@ -658,7 +659,7 @@ def structured_data_id(ctx, id, domain=None):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def lang_short(ctx):
     """Returns a shortened locale code e.g. en."""
     locale = getattr(ctx["request"], "locale", "en-US")
@@ -693,7 +694,7 @@ def _get_adjust_link(adjust_url, app_store_url, google_play_url, redirect, local
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def firefox_adjust_url(ctx, redirect, adgroup, creative=None):
     """
     Return an adjust.com link for Firefox on mobile.
@@ -715,7 +716,7 @@ def firefox_adjust_url(ctx, redirect, adgroup, creative=None):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def focus_adjust_url(ctx, redirect, adgroup, creative=None):
     """
     Return an adjust.com link for Focus/Klar on mobile.
@@ -743,7 +744,7 @@ def focus_adjust_url(ctx, redirect, adgroup, creative=None):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def pocket_adjust_url(ctx, redirect, adgroup, creative=None):
     """
     Return an adjust.com link for Pocket on mobile.
@@ -765,7 +766,7 @@ def pocket_adjust_url(ctx, redirect, adgroup, creative=None):
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def lockwise_adjust_url(ctx, redirect, adgroup, creative=None):
     """
     Return an adjust.com link for Lockwise on mobile.
@@ -825,11 +826,11 @@ def _fxa_product_button(
 
     markup = f'<a href="{href}" data-action="{settings.FXA_ENDPOINT}" class="{css_class}" {attrs}>' f"{button_text}" f"</a>"
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def pocket_fxa_button(
     ctx, entrypoint, button_text, class_name=None, is_button_class=True, include_metrics=True, optional_parameters=None, optional_attributes=None
 ):
@@ -851,7 +852,7 @@ def pocket_fxa_button(
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def monitor_fxa_button(
     ctx, entrypoint, button_text, class_name=None, is_button_class=True, include_metrics=True, optional_parameters=None, optional_attributes=None
 ):
@@ -873,7 +874,7 @@ def monitor_fxa_button(
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def relay_fxa_button(
     ctx, entrypoint, button_text, class_name=None, is_button_class=True, include_metrics=True, optional_parameters=None, optional_attributes=None
 ):
@@ -895,7 +896,7 @@ def relay_fxa_button(
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def fxa_link_fragment(ctx, entrypoint, action="signup", optional_parameters=None):
     """
     Returns `href` attribute as a string fragment. This is useful for inline links
@@ -919,11 +920,11 @@ def fxa_link_fragment(ctx, entrypoint, action="signup", optional_parameters=None
 
     markup = f'href="{fxa_url}"'
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def fxa_button(
     ctx,
     entrypoint,

--- a/bedrock/mozorg/templatetags/qrcode.py
+++ b/bedrock/mozorg/templatetags/qrcode.py
@@ -9,7 +9,7 @@ from django.core.cache import caches
 
 import qrcode as qr
 from django_jinja import library
-from jinja2 import Markup
+from markupsafe import Markup
 from qrcode.image.svg import SvgPathImage
 
 cache = caches["qrcode"]

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -14,7 +14,7 @@ from django.test.utils import override_settings
 
 import pytest
 from django_jinja.backend import Jinja2
-from jinja2 import Markup
+from markupsafe import Markup
 from pyquery import PyQuery as pq
 
 from bedrock.base.templatetags.helpers import static

--- a/bedrock/newsletter/templatetags/helpers.py
+++ b/bedrock/newsletter/templatetags/helpers.py
@@ -8,6 +8,7 @@ from django.template.loader import render_to_string
 
 import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 from bedrock.newsletter.forms import NewsletterFooterForm
 from lib.l10n_utils import get_locale
@@ -16,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def email_newsletter_form(
     ctx,
     newsletters="mozilla-and-you",
@@ -80,4 +81,4 @@ def email_newsletter_form(
     )
 
     html = render_to_string("newsletter/includes/form.html", context, request=request)
-    return jinja2.Markup(html)
+    return Markup(html)

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -20,7 +20,7 @@ import basket
 import basket.errors
 import commonware.log
 import requests
-from jinja2 import Markup
+from markupsafe import Markup
 
 import lib.l10n_utils as l10n_utils
 from bedrock.base import waffle

--- a/bedrock/pocketfeed/models.py
+++ b/bedrock/pocketfeed/models.py
@@ -5,7 +5,7 @@
 from django.db import models
 from django.db.utils import DatabaseError
 
-from jinja2 import Markup
+from markupsafe import Markup
 from sentry_sdk import capture_exception
 
 from bedrock.pocketfeed.api import complete_articles_data, get_articles_data

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils.fluent import ftl
@@ -49,11 +50,11 @@ def _vpn_product_link(product_url, entrypoint, link_text, class_name=None, optio
 
     markup = f'<a href="{href}" data-action="{settings.FXA_ENDPOINT}" class="{css_class}" {attrs}>' f"{link_text}" f"</a>"
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def vpn_subscribe_link(
     ctx, entrypoint, link_text, plan="12-month", class_name=None, country_code=None, lang=None, optional_parameters=None, optional_attributes=None
 ):
@@ -82,7 +83,7 @@ def vpn_subscribe_link(
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def vpn_monthly_price(ctx, plan="monthly", country_code=None, lang=None):
     """
     Render a localized string displaying VPN monthly plan price.
@@ -105,11 +106,11 @@ def vpn_monthly_price(ctx, plan="monthly", country_code=None, lang=None):
 
     markup = f'<span class="vpn-monthly-price-display">{price}</span>'
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def vpn_total_price(ctx, plan="12-month", country_code=None, lang=None):
     """
     Render a localized string displaying VPN total plan price.
@@ -132,11 +133,11 @@ def vpn_total_price(ctx, plan="12-month", country_code=None, lang=None):
 
     markup = price
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def vpn_saving(ctx, plan="12-month", country_code=None, lang=None, ftl_string="vpn-shared-pricing-save-percent"):
     """
     Render a localized string displaying saving (as a percentage) of a given VPN subscription plan.
@@ -159,11 +160,11 @@ def vpn_saving(ctx, plan="12-month", country_code=None, lang=None, ftl_string="v
 
     markup = saving
 
-    return jinja2.Markup(markup)
+    return Markup(markup)
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def vpn_product_referral_link(ctx, referral_id="", page_anchor="", link_text=None, class_name=None, optional_attributes=None):
     """
     Render link to the /products/vpn/ landing page with referral attribution markup
@@ -189,4 +190,4 @@ def vpn_product_referral_link(ctx, referral_id="", page_anchor="", link_text=Non
 
     markup = f'<a href="{href}{page_anchor}" class="{css_class}" {attrs}>{link_text}</a>'
 
-    return jinja2.Markup(markup)
+    return Markup(markup)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -677,10 +677,8 @@ TEMPLATES = [
             ],
             "extensions": [
                 "jinja2.ext.do",
-                "jinja2.ext.with_",
                 "jinja2.ext.i18n",
                 "jinja2.ext.loopcontrols",
-                "jinja2.ext.autoescape",
                 "django_jinja.builtins.extensions.CsrfExtension",
                 "django_jinja.builtins.extensions.StaticFilesExtension",
                 "django_jinja.builtins.extensions.DjangoFiltersExtension",

--- a/bedrock/wordpress/models.py
+++ b/bedrock/wordpress/models.py
@@ -15,7 +15,7 @@ from django.utils.timezone import make_aware, utc
 
 import bleach
 from django_extensions.db.fields.json import JSONField
-from jinja2 import Markup
+from markupsafe import Markup
 from sentry_sdk import capture_exception
 
 from bedrock.wordpress.api import complete_posts_data, get_posts_data

--- a/bin/compile-requirements.sh
+++ b/bin/compile-requirements.sh
@@ -13,7 +13,7 @@ export CUSTOM_COMPILE_COMMAND="$ make compile-requirements"
 # We will need to periodically review this pinning
 
 pip install -U pip==22.1.2
-pip install pip-tools==6.6.2
+pip install pip-tools==6.7.0
 
 pip-compile --generate-hashes -r requirements/prod.in
 pip-compile --generate-hashes -r requirements/dev.in

--- a/lib/l10n_utils/templatetags/fluent.py
+++ b/lib/l10n_utils/templatetags/fluent.py
@@ -4,12 +4,13 @@
 
 import jinja2
 from django_jinja import library
+from markupsafe import Markup
 
 from lib.l10n_utils import fluent
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def ftl(ctx, message_id, fallback=None, **kwargs):
     """Return the translated string.
 
@@ -23,11 +24,11 @@ def ftl(ctx, message_id, fallback=None, **kwargs):
 
         <p>{{ ftl('greeting', name='The Dude') }}
     """
-    return jinja2.Markup(fluent.translate(ctx["fluent_l10n"], message_id, fallback, **kwargs))
+    return Markup(fluent.translate(ctx["fluent_l10n"], message_id, fallback, **kwargs))
 
 
 @library.global_function
-@jinja2.contextfunction
+@jinja2.pass_context
 def ftl_has_messages(ctx, *message_ids, require_all=True):
     """Return True if the current translation has all of the message IDs."""
     return fluent.ftl_has_messages(ctx["fluent_l10n"], *message_ids, require_all=require_all)

--- a/lib/l10n_utils/templatetags/helpers.py
+++ b/lib/l10n_utils/templatetags/helpers.py
@@ -36,7 +36,7 @@ def current_locale():
 
 
 @library.filter
-@jinja2.contextfilter
+@jinja2.pass_context
 def l10n_format_date(ctx, date, format="long"):
     """
     Formats a date according to the current locale. Wraps around
@@ -47,7 +47,7 @@ def l10n_format_date(ctx, date, format="long"):
 
 
 @library.filter
-@jinja2.contextfilter
+@jinja2.pass_context
 def l10n_format_number(ctx, number):
     """
     Formats a number according to the current locale. Wraps around

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -365,13 +365,15 @@ django-extensions==3.1.5 \
     --hash=sha256:28e1e1bf49f0e00307ba574d645b0af3564c981a6dfc87209d48cb98f77d0b1a \
     --hash=sha256:9238b9e016bb0009d621e05cf56ea8ce5cce9b32e91ad2026996a7377ca28069
     # via -r requirements/prod.txt
-django-jinja==2.10.0 \
-    --hash=sha256:ae6a3fdf1ffa7a9ef6fd2f0a59c1a68c96b29f7f00f5166375658ef392f1ed32 \
-    --hash=sha256:cce084eaf0be8a89f0955cde34cf33da7faaf6c68d05c076eda6fcd98481264c
-    # via -r requirements/prod.txt
-django-jinja-markdown==1.0.1 \
-    --hash=sha256:233dcde5d6895416f5613e4ca030e88f18a163e4b676e7aa815d191754f53085 \
-    --hash=sha256:d41db694bbf3085b026df227428427b859478a2846b55088429e3ccc7115c0c5
+django-jinja==2.10.2 \
+    --hash=sha256:bfdfbb55c1f5a679d69ad575d550c4707d386634009152efe014089f3c4d1412 \
+    --hash=sha256:dd003ec1c95c0989eb28a538831bced62b1b61da551cb44a5dfd708fcf75589f
+    # via
+    #   -r requirements/prod.txt
+    #   django-jinja-markdown
+django-jinja-markdown==1.1 \
+    --hash=sha256:07e7235c7e6d8876e8c56016e49c2673882ff075ea8dec5a78a400775e8095bf \
+    --hash=sha256:8f41e7e722f2ef6d489d1768e45883f48a5f4e89ac0b34bb44d819d3c7d4a359
     # via -r requirements/prod.txt
 django-jsonview==2.0.0 \
     --hash=sha256:1871983f6c7ab0bec1bad3249b06ce64c47d3bed57cd190f87e5acaf65722ebb \
@@ -488,12 +490,13 @@ isort==5.10.1 \
     --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
     --hash=sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951
     # via -r requirements/dev.in
-jinja2==3.0.3 \
-    --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
-    --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
+jinja2==3.1.2 \
+    --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
+    --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
     # via
     #   -r requirements/prod.txt
     #   django-jinja
+    #   django-jinja-markdown
     #   glean-parser
 jmespath==0.10.0 \
     --hash=sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9 \
@@ -655,6 +658,7 @@ markupsafe==2.0.1 \
     --hash=sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872
     # via
     #   -r requirements/prod.txt
+    #   django-jinja-markdown
     #   glean-parser
     #   jinja2
 mccabe==0.6.1 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -14,8 +14,8 @@ django-cors-headers==3.11.0
 django-crum==0.7.9
 django-csp==3.7
 django-extensions==3.1.5
-django-jinja-markdown==1.0.1
-django-jinja==2.10.0
+django-jinja-markdown==1.1
+django-jinja==2.10.2
 django-jsonview==2.0.0
 django-memoize==2.3.1
 django-mozilla-product-details==1.0.3
@@ -31,9 +31,11 @@ greenlet==0.4.17  # Pinned for stability but subdep of Meinheld
 gunicorn==19.7.1
 honcho==1.1.0
 html5lib==1.1
-lxml==4.9.0  # Needed as a top-level dep so that it's available for BeautifulSoup
+jinja2==3.1.2  # Moved to top-level dep to control its upgrade, to avoid breaking changes later if glean-parser updates it
+lxml==4.9.0  # Needed as a top-level dep so that it's available for BeautifulSoup, which doesn't explicitly pull it in
 Markdown==3.3.6
 https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz#egg=mdx_outline
+markupsafe==2.0.1
 meinheld==1.0.2
 newrelic==7.12.0.176
 phonenumberslite==8.12.49

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -202,13 +202,15 @@ django-extensions==3.1.5 \
     --hash=sha256:28e1e1bf49f0e00307ba574d645b0af3564c981a6dfc87209d48cb98f77d0b1a \
     --hash=sha256:9238b9e016bb0009d621e05cf56ea8ce5cce9b32e91ad2026996a7377ca28069
     # via -r requirements/prod.in
-django-jinja==2.10.0 \
-    --hash=sha256:ae6a3fdf1ffa7a9ef6fd2f0a59c1a68c96b29f7f00f5166375658ef392f1ed32 \
-    --hash=sha256:cce084eaf0be8a89f0955cde34cf33da7faaf6c68d05c076eda6fcd98481264c
-    # via -r requirements/prod.in
-django-jinja-markdown==1.0.1 \
-    --hash=sha256:233dcde5d6895416f5613e4ca030e88f18a163e4b676e7aa815d191754f53085 \
-    --hash=sha256:d41db694bbf3085b026df227428427b859478a2846b55088429e3ccc7115c0c5
+django-jinja==2.10.2 \
+    --hash=sha256:bfdfbb55c1f5a679d69ad575d550c4707d386634009152efe014089f3c4d1412 \
+    --hash=sha256:dd003ec1c95c0989eb28a538831bced62b1b61da551cb44a5dfd708fcf75589f
+    # via
+    #   -r requirements/prod.in
+    #   django-jinja-markdown
+django-jinja-markdown==1.1 \
+    --hash=sha256:07e7235c7e6d8876e8c56016e49c2673882ff075ea8dec5a78a400775e8095bf \
+    --hash=sha256:8f41e7e722f2ef6d489d1768e45883f48a5f4e89ac0b34bb44d819d3c7d4a359
     # via -r requirements/prod.in
 django-jsonview==2.0.0 \
     --hash=sha256:1871983f6c7ab0bec1bad3249b06ce64c47d3bed57cd190f87e5acaf65722ebb \
@@ -293,11 +295,13 @@ importlib-metadata==4.11.3 \
     --hash=sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6 \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
     # via markdown
-jinja2==3.0.3 \
-    --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
-    --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
+jinja2==3.1.2 \
+    --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
+    --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
     # via
+    #   -r requirements/prod.in
     #   django-jinja
+    #   django-jinja-markdown
     #   glean-parser
 jmespath==0.10.0 \
     --hash=sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9 \
@@ -452,6 +456,8 @@ markupsafe==2.0.1 \
     --hash=sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51 \
     --hash=sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872
     # via
+    #   -r requirements/prod.in
+    #   django-jinja-markdown
     #   glean-parser
     #   jinja2
 mdx_outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz \


### PR DESCRIPTION
All three need upgrading at the same time because jinja 3.1+ removes deprecated
code which we were leaning on in Bedrock and django-jinja markdown - either
a convenience import of `Markup` or a change in decorators

## Issue / Bugzilla link

Fixes #[11561](https://github.com/mozilla/bedrock/pull/11561) - which couldn't be automatically merged without this legwork.

## Checklist

If relevant:

- [X] Tests fixed
- [X] Integration tests run ahead of PR

## Testing

This will need a decent local test drive around, I think
