### PR TITLE
Fix up URL name for Set As Default page, to stop retention page from 500ing

### DIFF
--- a/bedrock/firefox/templates/firefox/retention/thank-you.html
+++ b/bedrock/firefox/templates/firefox/retention/thank-you.html
@@ -43,7 +43,7 @@
       <article>
         <h2>{{ ftl('thank-you-make-firefox-your-default') }}</h2>
         <div class="time">{{ ftl('thank-you-1-min-action') }}</div>
-        <a data-link-type="link" data-link-name="Set as your default" href="{{ url('firefox.set-as-default.landing') }}">{{ ftl('thank-you-set-as-your-default') }}</a>
+        <a data-link-type="link" data-link-name="Set as your default" href="{{ url('firefox.set-as-default') }}">{{ ftl('thank-you-set-as-your-default') }}</a>
       </article>
       <article>
         <h2>{{ ftl('thank-you-get-firefox-on-your-phone') }}</h2>


### PR DESCRIPTION
## One-line summary

/es-ES/firefox/retention/thank-you/ and other locales were 500ing because of

> Reverse for 'firefox.set-as-default.landing' not found. 'firefox.set-as-default.landing' is not a valid view function or pattern name.

Turns out that view name changed to firefox.set-as-default in https://github.com/mozilla/bedrock/pull/11774. This changeset updates the only reference in bedrock to the old URL name.

## Issue / Bugzilla link

Resolves #11846


## Screenshots

(If the changeset updates the UI, please include screenshots so reviewers know what to look for when testing)

## Testing

To test this work, ensure `DEBUG=False` in your `.env`, then visit 

- http://localhost:8080/en-US/firefox/retention/thank-you/
- http://localhost:8080/es-ES/firefox/retention/thank-you/

which will no longer 500