### PR TITLE
Remove Windows 10 'S mode' detection code

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -20,8 +20,6 @@
             pageHasDownload: analytics.pageHasDownload(),
             pageHasVideo: analytics.pageHasVideo(),
             pageVersion: analytics.getPageVersion(),
-            // permitted for www.mozill.org, will always return false on other domains
-            testPilotUser: 'testpilotAddon' in navigator ? 'true' : 'false',
             releaseWindowVersion: analytics.getLatestFxVersion()
         };
 

--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -22,8 +22,7 @@
             pageVersion: analytics.getPageVersion(),
             // permitted for www.mozill.org, will always return false on other domains
             testPilotUser: 'testpilotAddon' in navigator ? 'true' : 'false',
-            releaseWindowVersion: analytics.getLatestFxVersion(),
-            win10SUser: analytics.isWin10S()
+            releaseWindowVersion: analytics.getLatestFxVersion()
         };
 
         dataLayer.push(dataLayerCore);

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -67,32 +67,6 @@ if (typeof window.Mozilla.Analytics === 'undefined') {
             .getAttribute('data-latest-firefox');
     };
 
-    /** Returns true if user is running Windows 10 in S mode.
-     * @param {String} ua - User Agent string.
-     * @return {Boolean}.
-     */
-    analytics.isWin10S = function (ua) {
-        ua = ua || navigator.userAgent;
-
-        var isEdge = ua.indexOf('Edge') > -1;
-
-        if (!isEdge) {
-            return false;
-        }
-
-        try {
-            var mode = JSON.parse(
-                window.external.getHostEnvironmentValue('os-mode')
-            );
-            if (mode && mode['os-mode'] === '2') {
-                return true;
-            }
-            return false;
-        } catch (e) {
-            return false;
-        }
-    };
-
     analytics.getAMOExperiment = function (params) {
         var allowedExperiment = /^\d{8}_amo_.[\w/.%-]{1,50}$/; // should match the format YYYYMMDD_amo_experiment_name.
         var allowedVariation = /^[\w/.%-]{1,50}$/; // allow alpha numeric & common URL encoded chars.

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 describe('core-datalayer.js', function () {
     describe('pageHasDownload', function () {
         it('will return "true" when download button is present on page.', function () {
@@ -120,52 +118,6 @@ describe('core-datalayer.js', function () {
 
         it('will return null if no data-latest-firefox attribute is present on the html element', function () {
             expect(Mozilla.Analytics.getLatestFxVersion()).toBe(null);
-        });
-    });
-
-    describe('isWin10S', function () {
-        const edgeUA =
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14931';
-        const chromeUA =
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36';
-
-        beforeEach(function () {
-            window.external = sinon.stub();
-            window.external.getHostEnvironmentValue = sinon.stub();
-        });
-
-        it('should return true if Windows 10 has S mode enabled', function () {
-            spyOn(window.external, 'getHostEnvironmentValue').and.returnValue(
-                '{"os-mode": "2"}'
-            );
-            const result = Mozilla.Analytics.isWin10S(edgeUA);
-            expect(
-                window.external.getHostEnvironmentValue
-            ).toHaveBeenCalledWith('os-mode');
-            expect(result).toBeTruthy();
-        });
-
-        it('should return false if Windows 10 is unlocked', function () {
-            spyOn(window.external, 'getHostEnvironmentValue').and.returnValue(
-                '{"os-mode": "0"}'
-            );
-            const result = Mozilla.Analytics.isWin10S(edgeUA);
-            expect(result).toBeFalsy();
-        });
-
-        it('should return false if API is not supported in Edge', function () {
-            spyOn(window.external, 'getHostEnvironmentValue').and.returnValue(
-                new TypeError(
-                    'window.external.getHostEnvironmentValue is not a function'
-                )
-            );
-            const result = Mozilla.Analytics.isWin10S(edgeUA);
-            expect(result).toBeFalsy();
-        });
-
-        it('should return false for other browsers', function () {
-            const result = Mozilla.Analytics.isWin10S(chromeUA);
-            expect(result).toBeFalsy();
         });
     });
 


### PR DESCRIPTION
## One-line summary

- Removes unused S mode detection code and associated tests.
- Also removes outdated test-pilot detection code I noticed whilst here.

## Issue / Bugzilla link

[#11849](https://github.com/mozilla/bedrock/issues/11849)

## Testing

- [ ] No stray references to removed code.
