### PR TITLE
chore(newrelic): Disable distributed tracing

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -184,6 +184,9 @@ browser_monitoring.auto_instrument = false
 # call tree.
 thread_profiler.enabled = true
 
+# Disable distributed tracing
+distributed_tracing.enabled = false
+
 # ---------------------------------------------------------------------------
 
 #


### PR DESCRIPTION
## One-line summary

Distributed tracing was enabled by default in a recent Newrelic update. We want to disable it.
