### PR TITLE
Bump @mozmeao/trafficcop to v2.0.1 (Fixes #11884)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mozilla-protocol/core": "16.0.0",
         "@mozilla/glean": "^1.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
-        "@mozmeao/trafficcop": "^2.0.0",
+        "@mozmeao/trafficcop": "^2.0.1",
         "@sentry/browser": "^7.0.0",
         "babel-loader": "^8.2.4",
         "clean-webpack-plugin": "^4.0.0",
@@ -1659,9 +1659,9 @@
       "integrity": "sha512-9eF1kckwlNw28pJhMcheE0jdMOJXgRnDOYkp0q86I16uoeyR5jhCT7B68EXWW1JFJILsX7tY0snZlAksTCp8hw=="
     },
     "node_modules/@mozmeao/trafficcop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.0.tgz",
-      "integrity": "sha512-lLifVditnaA8gVuJA79c16vlrRwLXYzRZ684kdWKXD72XLkj1UgpeUZh/SjG8mC3WTEd9jw9bv0e9OTKLG4+CA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.1.tgz",
+      "integrity": "sha512-MMoXGx2Evjr3Y8aYFsC8S8DqOduC8oBtUXK4CDtFd/+YaLNAM7DM4gdwLrOAHX2DBRB0J9XOlPSgdzp/JPOGnw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10961,9 +10961,9 @@
       "integrity": "sha512-9eF1kckwlNw28pJhMcheE0jdMOJXgRnDOYkp0q86I16uoeyR5jhCT7B68EXWW1JFJILsX7tY0snZlAksTCp8hw=="
     },
     "@mozmeao/trafficcop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.0.tgz",
-      "integrity": "sha512-lLifVditnaA8gVuJA79c16vlrRwLXYzRZ684kdWKXD72XLkj1UgpeUZh/SjG8mC3WTEd9jw9bv0e9OTKLG4+CA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.1.tgz",
+      "integrity": "sha512-MMoXGx2Evjr3Y8aYFsC8S8DqOduC8oBtUXK4CDtFd/+YaLNAM7DM4gdwLrOAHX2DBRB0J9XOlPSgdzp/JPOGnw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@mozilla-protocol/core": "16.0.0",
     "@mozilla/glean": "^1.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
-    "@mozmeao/trafficcop": "^2.0.0",
+    "@mozmeao/trafficcop": "^2.0.1",
     "@sentry/browser": "^7.0.0",
     "babel-loader": "^8.2.4",
     "clean-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
## One-line summary

Bug fixes: https://github.com/mozmeao/trafficcop/releases/tag/v2.0.1

## Issue / Bugzilla link

#11884

## Testing

- [ ] http://localhost:8000/en-US/products/vpn/ still triggers experiment redirect