### PR TITLE
Fix typos in /de/ VPN promo banner (Issue #11826)

### DIFF
--- a/bedrock/base/templates/includes/banners/vpn-coupon-variations/vpn-coupon-promo-1.html
+++ b/bedrock/base/templates/includes/banners/vpn-coupon-variations/vpn-coupon-promo-1.html
@@ -7,7 +7,7 @@
 {% if LANG == 'de' %}
   {% set banner_title = "Sicher durchs Netz" %}
   {% set banner_subtitle = "Mit 20 % Rabatt aufs Jahresabo!" %}
-  {% set banner_text = "Nutze jetzt den code <span class='c-coupon-code'>VPN20</span> beim checkout" %}
+  {% set banner_text = "Nutze jetzt den Code <span class='c-coupon-code'>VPN20</span> beim Checkout" %}
   {% set link_text = "Jetzt sparen" %}
 {% elif LANG == 'fr' %}
   {% set banner_title = "Voyagez en toute sécurité" %}


### PR DESCRIPTION
## One-line summary
Talked to Hanns on the EU team re: https://github.com/mozilla/bedrock/issues/11826#issuecomment-1178726858

He agreed that the first two items should be fixed.

## Issue / Bugzilla link

#11826

## Testing

http://localhost:8000/de/products/vpn/?entrypoint_experiment=vpn-coupon-promo-banner&entrypoint_variation=1
