### PR TITLE
Remove variation #2 from default VPN page

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -56,8 +56,6 @@
   {% if show_vpn_coupon_promo_banner %}
     {% if variation_include %}
       {% include variation_include %}
-    {% else %}
-      {% include 'includes/banners/vpn-coupon-variations/vpn-coupon-promo-2.html' %}
     {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary
We have a Traffic Cop experiment running on the VPN landing page. I  initially set it up to have variation 2 on the default landing page (with no experiment parameters). I misunderstood, so fixing that up here to remove the banner form a no-parameter page.

## Issue / Bugzilla link
Original PR: https://github.com/mozilla/bedrock/pull/11828

## Testing

You should see no banner in the following pages:

- http://localhost:8000/en-US/products/vpn/
- http://localhost:8000/de/products/vpn/
- http://localhost:8000/fr/products/vpn/
