### PR TITLE
Bump @sentry/browser to v7.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mozilla/glean": "^1.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/trafficcop": "^2.0.1",
-        "@sentry/browser": "^7.0.0",
+        "@sentry/browser": "^7.6.0",
         "babel-loader": "^8.2.5",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
@@ -1736,13 +1736,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.0.0.tgz",
-      "integrity": "sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.6.0.tgz",
+      "integrity": "sha512-1gdvV8RtTnNFyc790t49MAgFuHAP43NEZvdQOMw5KFnDwSGYFqfBtvJ8tUm125UPbi2fghBryO9M1gfIWboKUg==",
       "dependencies": {
-        "@sentry/core": "7.0.0",
-        "@sentry/types": "7.0.0",
-        "@sentry/utils": "7.0.0",
+        "@sentry/core": "7.6.0",
+        "@sentry/types": "7.6.0",
+        "@sentry/utils": "7.6.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1750,13 +1750,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.0.0.tgz",
-      "integrity": "sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.6.0.tgz",
+      "integrity": "sha512-vXIuUZbHVSAXh2xZ3NyXYXqVvVQSbGEpgtQxLutwocvD88JFK6aZqO+WQG69GY1b1fKSeE9faEDDS6WGAi46mQ==",
       "dependencies": {
-        "@sentry/hub": "7.0.0",
-        "@sentry/types": "7.0.0",
-        "@sentry/utils": "7.0.0",
+        "@sentry/hub": "7.6.0",
+        "@sentry/types": "7.6.0",
+        "@sentry/utils": "7.6.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1764,12 +1764,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.0.0.tgz",
-      "integrity": "sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.6.0.tgz",
+      "integrity": "sha512-TbieNZInpnR5STXykT1zXoKVAsm8ju1RZyzMqYR8nzURbjlMVVEzFRglNY1Ap5MRkbEuYpAc6zUvgLQe8b6Q3w==",
       "dependencies": {
-        "@sentry/types": "7.0.0",
-        "@sentry/utils": "7.0.0",
+        "@sentry/types": "7.6.0",
+        "@sentry/utils": "7.6.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1777,19 +1777,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.6.0.tgz",
+      "integrity": "sha512-POimbDwr9tmHSKksJTXe5VQpvjkFO4/UWUptigwqf8684rkS7Ie2BT2uyp5GD2EgYFf0BwUOWi98FTYTvUGT+Q==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.0.0.tgz",
-      "integrity": "sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.6.0.tgz",
+      "integrity": "sha512-p0Byi6hgawp/sBMY88RY8OmkiAR2jxbjnl8gSo+y3YEu+KeXBUxXMBsI7YeW+1lSb6z8DGhUAOBszTeI4wAr2w==",
       "dependencies": {
-        "@sentry/types": "7.0.0",
+        "@sentry/types": "7.6.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -10911,48 +10911,48 @@
       }
     },
     "@sentry/browser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.0.0.tgz",
-      "integrity": "sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.6.0.tgz",
+      "integrity": "sha512-1gdvV8RtTnNFyc790t49MAgFuHAP43NEZvdQOMw5KFnDwSGYFqfBtvJ8tUm125UPbi2fghBryO9M1gfIWboKUg==",
       "requires": {
-        "@sentry/core": "7.0.0",
-        "@sentry/types": "7.0.0",
-        "@sentry/utils": "7.0.0",
+        "@sentry/core": "7.6.0",
+        "@sentry/types": "7.6.0",
+        "@sentry/utils": "7.6.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.0.0.tgz",
-      "integrity": "sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.6.0.tgz",
+      "integrity": "sha512-vXIuUZbHVSAXh2xZ3NyXYXqVvVQSbGEpgtQxLutwocvD88JFK6aZqO+WQG69GY1b1fKSeE9faEDDS6WGAi46mQ==",
       "requires": {
-        "@sentry/hub": "7.0.0",
-        "@sentry/types": "7.0.0",
-        "@sentry/utils": "7.0.0",
+        "@sentry/hub": "7.6.0",
+        "@sentry/types": "7.6.0",
+        "@sentry/utils": "7.6.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.0.0.tgz",
-      "integrity": "sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.6.0.tgz",
+      "integrity": "sha512-TbieNZInpnR5STXykT1zXoKVAsm8ju1RZyzMqYR8nzURbjlMVVEzFRglNY1Ap5MRkbEuYpAc6zUvgLQe8b6Q3w==",
       "requires": {
-        "@sentry/types": "7.0.0",
-        "@sentry/utils": "7.0.0",
+        "@sentry/types": "7.6.0",
+        "@sentry/utils": "7.6.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA=="
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.6.0.tgz",
+      "integrity": "sha512-POimbDwr9tmHSKksJTXe5VQpvjkFO4/UWUptigwqf8684rkS7Ie2BT2uyp5GD2EgYFf0BwUOWi98FTYTvUGT+Q=="
     },
     "@sentry/utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.0.0.tgz",
-      "integrity": "sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.6.0.tgz",
+      "integrity": "sha512-p0Byi6hgawp/sBMY88RY8OmkiAR2jxbjnl8gSo+y3YEu+KeXBUxXMBsI7YeW+1lSb6z8DGhUAOBszTeI4wAr2w==",
       "requires": {
-        "@sentry/types": "7.0.0",
+        "@sentry/types": "7.6.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mozilla/glean": "^1.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/trafficcop": "^2.0.1",
-    "@sentry/browser": "^7.0.0",
+    "@sentry/browser": "^7.6.0",
     "babel-loader": "^8.2.5",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
## One-line summary

Release notes: https://github.com/getsentry/sentry-javascript/releases (nothing notable for us here just some bug fixes)

## Issue / Bugzilla link

N/A

## Testing

- `npm install`

Set `SENTRY_FRONTEND_DSN=https://c1f94ae1b8c54ed0adcf223328157caf@o1069899.ingest.sentry.io/6260211` in your `.env` if you would like to test this locally.
