### PR TITLE
Exclude non-VPN countries from banner experiment [fix #11907]

### DIFF
--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -13,7 +13,7 @@
 
 {% block page_desc %}{{ ftl('vpn-landing-page-desc', countries=available_countries) }}{% endblock %}
 
-{% set show_vpn_coupon_promo_banner = switch('vpn-coupon-promo-banner', ['en', 'de', 'fr']) %}
+{% set show_vpn_coupon_promo_banner = vpn_available and switch('vpn-coupon-promo-banner', ['en', 'de', 'fr']) %}
 
 {% block html_attrs %}{{ super() }} data-vpn-affiliate-endpoint="{{ settings.VPN_AFFILIATE_ENDPOINT }}"{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Excludes countries where VPN isn't currently available from the promo banner experiment.

## Issue / Bugzilla link

#11907 

## Testing

- [ ] http://localhost:8000/en-US/products/vpn/?geo=cn should not be enrolled in the Traffic Cop experiment
- [ ] http://localhost:8000/en-US/products/vpn/?geo=cn&entrypoint_experiment=vpn-coupon-promo-banner&entrypoint_variation=1 should not display a banner

For thoroughness you can also check both banner variations, in the French and German localized versions, and try a few other non-VPN countries (Denmark, Argentina, Saudi Arabia, Namibia, etc... go wild!).

