### PR TITLE
Add a reference in the web bug bounty program to the eligibility requirements

### DIFF
--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -18,6 +18,8 @@
 
   <p>The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who find unique and original bugs in our web infrastructure.</p>
 
+  <p><strong>Guidelines:</strong> Submissions must conform to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a></p>
+
   <p>Please submit all bug reports via our <a href="{{ url('security.bug-bounty.faq-webapp') }}#bug-reporting">secure bug reporting process</a>.</p>
 
   <h2 id="payouts-section">Payouts</h2>


### PR DESCRIPTION
## One-line summary

This changeset adds a reference in the web bug bounty page to the general program eligibility requirements in order to make the web bug bounty page a single page that we can point researchers to where they won't miss the general program details.

The client bug bounty page has this but our web bug bounty page was missing it.

## Significant changes and points to review


## Issue / Bugzilla link


## Screenshots

![Add web bug bounty reference](https://user-images.githubusercontent.com/1134034/178363174-89c6a3af-3c9a-475f-b420-b40f7caf98ef.png)

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

