### PR TITLE
Small fixup of patch.dict to fix VPN tests

### DIFF
--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -77,7 +77,7 @@ class TestVPNInviteWaitlist(TestCase):
         )
 
 
-@patch.dict(os.environ, {"SWITCH_VPN_COUPON_PROMO_BANNER": "True"})
+@patch.dict(os.environ, SWITCH_VPN_COUPON_PROMO_BANNER="True")
 class TestVPNLandingPageBanners(TestCase):
     def _request(self, variation, lang):
         req = RequestFactory().get(


### PR DESCRIPTION
## One-line summary

This changeset attempts to fix the broken test on `main` (which passes locally without the fix, but fails in CI)
