### PR TITLE
Fix VPN banner tests when in an excluded country [#11907]

### DIFF
--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -81,7 +81,9 @@ class TestVPNInviteWaitlist(TestCase):
 class TestVPNLandingPageBanners(TestCase):
     def _request(self, variation, lang):
         req = RequestFactory().get(
-            f"/{lang}/products/vpn/?entrypoint_experiment=vpn-coupon-promo-banner&entrypoint_variation={variation}", HTTP_ACCEPT_LANGUAGE=lang
+            f"/{lang}/products/vpn/?entrypoint_experiment=vpn-coupon-promo-banner&entrypoint_variation={variation}",
+            HTTP_ACCEPT_LANGUAGE=lang,
+            HTTP_CF_IPCOUNTRY="us",
         )
         req.locale = lang
         return views.vpn_landing_page(req)


### PR DESCRIPTION
## One-line summary

Since excluding non-VPN countries in https://github.com/mozilla/bedrock/pull/11908 tests will fail if the test runner is in one of those non-VPN countries. This explicitly sets the test to identify as US.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/pull/11908#issuecomment-1180891759

## Testing

When `py.test bedrock/products/tests/test_views.py` the `TestVPNLandingPageBanners` tests should all pass regardless of actual location. Not sure how to truly test this unless you're in an excluded country, but locally at least if I set the tests to identify as China they fail, and if it's set to US they pass.