### PR TITLE
Update docs for new demo servers

### DIFF
--- a/docs/architecture/decisions/0008-move-demos-to-gcp.md
+++ b/docs/architecture/decisions/0008-move-demos-to-gcp.md
@@ -1,0 +1,51 @@
+# 8. Move Demos To GCP
+
+Date: 2022-07-14
+
+## Status
+
+Accepted
+
+## Context
+
+Previously, demos for Bedrock were run on Heroku. This worked fine, but Heroku's
+recent security incident there meant our integration had to be disabled,
+prompting discussion of self-managed demo instances.
+
+In addition, while it was possible to demo Bedrock in Pocket Mode on Heroku, by
+amending the settings via the Heroku web UI, the domains set up (www-demoX.allizom.org) were originally set up for Mozorg, and as such may be confusing
+for colleagues reviewing Pocket changes. Flipping and un-flipping settings in Heroku to enable Mozorg Mode or Pocket Mode was also extra legwork that we
+ideally would do without, too.
+
+## Decision
+
+We have implemented a new, self-managed, approach to running demos, using a
+handful of Google Cloud Platform services: Cloud Build has triggers which
+monitor pushes to specific branches, and the builds either a Mozorg-Mode or Pocket-Mode container  from Bedrock, which Cloud Run then runs as a
+'serverless' webapp.
+
+This process is triggered by a simple push to a specific target branch. e.g.
+pushing code to mozorg-demo-2 will result in the relevant code being deployed in
+Mozorg mode to www-demo2.allizom.org, while pushing to pocket-demo-4 will deploy
+it to www-demo4.tekcopteg.com in Pocket mode.
+
+Evironment variables can also be set, via two dedicated env files in Bedrock,
+which are only used for demo services. Clashes are unlikely, but can still be
+managed with common sense.
+
+## Consequences
+
+Upsides:
+
+It is now easier to stand up Pocket demos in addition to existing Mozorg demos,
+plus we have full control over the infrastructure our demos are run on.
+
+We will no longer need to use Heroku for demos. In the future, we may also be
+able to support ad-hoc 'review apps', which we have also used Heroku for in
+the past.
+
+Downsides:
+
+1) If a new secret value is required on a demo instance, and so that value cannot go into the demo env vars file because our codebase is public, some SRE-like devops is needed to add that secret value to GCP's Secret Manager Service. This can be quick, but requires understanding how that side fits together, plus access, so may need a backender to add them.
+
+2) At the moment, only the MEAO Backend team have GCP access, which is handy to monitor whether a demo has successfull be pushed out, or to amend secrets, etc. Both of these issues can be addressed without a lot of work.

--- a/docs/architecture/decisions/0008-move-demos-to-gcp.md
+++ b/docs/architecture/decisions/0008-move-demos-to-gcp.md
@@ -22,19 +22,26 @@ that we ideally would do without, too.
 ## Decision
 
 We have implemented a new, self-managed, approach to running demos, using a
-handful of Google Cloud Platform services: Cloud Build has triggers which
-monitor pushes to specific branches, and the builds either a Mozorg-Mode or
-Pocket-Mode container  from Bedrock, which Cloud Run then runs as a
-'serverless' webapp.
+handful of Google Cloud Platform services. Cloud Build and Cloud Run are the
+most significant ones.
+
+Cloud Build has triggers which monitor pushes to specific branches, then
+builds a Bedrock container from the branch, using the appropriate env vars
+for Pocket or Mozorg use, including the SITE_MODE env var that specifies the
+mode Bedrock runs in.
+
+Cloud Run then deploys the built container as a 'serverless' webapp. By
+default, supervisord runs in the container, so it updates DB and L10N files
+automatically.
 
 This process is triggered by a simple push to a specific target branch. e.g.
 pushing code to mozorg-demo-2 will result in the relevant code being deployed in
 Mozorg mode to www-demo2.allizom.org, while pushing to pocket-demo-4 will deploy
 it to www-demo4.tekcopteg.com in Pocket mode.
 
-Evironment variables can also be set, via two dedicated env files in Bedrock,
-which are only used for demo services. Clashes are unlikely, but can still be
-managed with common sense.
+Environment variables can also be configured by developers, via two dedicated
+env files in the Bedrock codebase, which are only used for demo services.
+Clashes are unlikely, and can still be managed with common sense.
 
 ## Consequences
 

--- a/docs/architecture/decisions/0008-move-demos-to-gcp.md
+++ b/docs/architecture/decisions/0008-move-demos-to-gcp.md
@@ -13,15 +13,18 @@ recent security incident there meant our integration had to be disabled,
 prompting discussion of self-managed demo instances.
 
 In addition, while it was possible to demo Bedrock in Pocket Mode on Heroku, by
-amending the settings via the Heroku web UI, the domains set up (www-demoX.allizom.org) were originally set up for Mozorg, and as such may be confusing
-for colleagues reviewing Pocket changes. Flipping and un-flipping settings in Heroku to enable Mozorg Mode or Pocket Mode was also extra legwork that we
-ideally would do without, too.
+amending the settings via the Heroku web UI, the domains set up
+(www-demoX.allizom.org) were originally set up for Mozorg, and as such may be
+confusing for colleagues reviewing Pocket changes. Flipping and un-flipping
+settings in Heroku to enable Mozorg Mode or Pocket Mode was also extra legwork
+that we ideally would do without, too.
 
 ## Decision
 
 We have implemented a new, self-managed, approach to running demos, using a
 handful of Google Cloud Platform services: Cloud Build has triggers which
-monitor pushes to specific branches, and the builds either a Mozorg-Mode or Pocket-Mode container  from Bedrock, which Cloud Run then runs as a
+monitor pushes to specific branches, and the builds either a Mozorg-Mode or
+Pocket-Mode container  from Bedrock, which Cloud Run then runs as a
 'serverless' webapp.
 
 This process is triggered by a simple push to a specific target branch. e.g.
@@ -46,6 +49,12 @@ the past.
 
 Downsides:
 
-1) If a new secret value is required on a demo instance, and so that value cannot go into the demo env vars file because our codebase is public, some SRE-like devops is needed to add that secret value to GCP's Secret Manager Service. This can be quick, but requires understanding how that side fits together, plus access, so may need a backender to add them.
+1) If a new secret value is required on a demo instance, and so that value
+cannot go into the demo env vars file because our codebase is public, some
+SRE-like devops is needed to add that secret value to GCP's Secret Manager
+Service. This can be quick, but requires understanding how that side fits
+together, plus access, so may need a backender to add them.
 
-2) At the moment, only the MEAO Backend team have GCP access, which is handy to monitor whether a demo has successfull be pushed out, or to amend secrets, etc. Both of these issues can be addressed without a lot of work.
+2) At the moment, only the MEAO Backend team have GCP access, which is handy
+to monitor whether a demo has successfull be pushed out, or to amend secrets,
+etc. Both of these issues can be addressed without a lot of work.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -112,40 +112,93 @@ Server architecture
 -------------------
 **Demos**
 
-- *URLs:*
-   - http://www-demo1.allizom.org/
-   - http://www-demo2.allizom.org/
-   - http://www-demo3.allizom.org/
-   - http://www-demo4.allizom.org/
-   - http://www-demo5.allizom.org/
-- *Bedrock locales:* dev repo
-- *Bedrock Git branch:* ``demo/1``, ``demo/2``, etc.
+Bedrock as a platform can run in two modes: Mozorg Mode (for content that will
+appear on mozilla.org) and Pocket Mode (for content that will end up on getpocket.com).
 
-These demos can be deployed by pushing a branch to one of the `demo/*` branches
-of the `mozilla/bedrock` repo. The `Github action`_ will then deploy the
-demo to Heroku.
+To support this, we have two separate sets of URLs we use for demos. To get code up to
+one of those URLs, push it to the specified branch on ``github.com/mozilla/bedrock``:
+
+- *Mozorg:*
+   - Branch ``mozorg-demo-1`` -> https://www-demo1.allizom.org/
+   - Branch ``mozorg-demo-2`` -> https://www-demo2.allizom.org/
+   - Branch ``mozorg-demo-3`` -> https://www-demo3.allizom.org/
+   - Branch ``mozorg-demo-4`` -> https://www-demo4.allizom.org/
+   - Branch ``mozorg-demo-5`` -> https://www-demo5.allizom.org/
+
+- *Pocket:*
+   - Branch ``pocket-demo-1`` -> https://www-demo1.tekcopteg.com/
+   - Branch ``pocket-demo-2`` -> https://www-demo2.tekcopteg.com/
+   - Branch ``pocket-demo-3`` -> https://www-demo3.tekcopteg.com/
+   - Branch ``pocket-demo-4`` -> https://www-demo4.tekcopteg.com/
+   - Branch ``pocket-demo-5`` -> https://www-demo5.tekcopteg.com/
+
+For example, for Mozorg:
+
+.. code-block:: bash
+
+  $ git push -f mozilla HEAD:mozorg-demo-2
+
+Or for Pocket:
+
+.. code-block:: bash
+
+  $ git push -f mozilla HEAD:pocket-demo-1
+
+
+**Deployment notification and logs**
+
+At the moment, there is no way to view logs for the deployment unless you have
+access to Google Cloud Platform.
+
+If you *do* have access, the Cloud Build dashboard shows the latest builds,
+and Cloud Run will link off to the relevant logs.
+
+We will be adding Slack notifications to alert developers about the success or
+failure of a demo deployment.
+
+**Env vars**
+
+Rather than tweak env vars via a web UI, they are set in config files.
+Both Mozorg and Pocket mode have specific demo-use-only env var files, which
+are only used by our GCP demo setup. They are:
+
+* ``bedrock/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml``
+* ``bedrock/gcp/bedrock-demos/cloudrun/pocket-demo.env.yaml``
+
+If you need to set/add/remove an env var, you can edit the relevant file on
+your feature branch, commit it and push it along with the rest of
+the code, as above. There is a small risk of clashes, but these can be best
+avoided if you keep up to date with ``bedrock/main`` and can be resolved easily.
+
+**Secret values**
+
+*Remember that the env vars files are public because they are in the Bedrock
+codebase, so sensitive values should not be added there, even temporarily.*
+
+If you need to add a secret value, this currently needs to be added at the GCP
+level by someone with appropriate permissions to edit and apply the Terraform
+configuration. Currently Web-SRE and the backend team have appropriate GCP
+access and adding a secret is relatively quick. (We can make this easier in
+the future if there's sufficient need, of course.)
+
+**DEPRECATED: Heroku Demo Servers**
+
+Demos are now powered by Google Cloud Platform (GCP), and no longer by Heroku.
+
+However, the `Github Action`_ we used to push code to Heroku may still be enabled.
+Pushing a branch to one of the `demo/*` branches of the `mozilla/bedrock` repo
+will trigger this. However, note that URLs that historically used to point to
+Heroku will be pointed to the new GCP demos services instead, so you will have
+to look at Heroku's web UI to see what the URL of the relevant Heroku app is.
 
 .. _Github action: https://github.com/mozilla/bedrock/blob/main/.github/workflows/demo_deploy.yml
+
+To push to launch a demo on Heroku:
 
 .. code-block:: bash
 
   $ git push -f mozilla my-demo-branch:demo/1
 
-**On-demand demos**
-
-- *URLs:* Demo instances can also be spun up on-demand by pushing a branch to the mozilla
-  bedrock repo that matches a specific naming convention (the branch name must start with
-  ``demo/``). Jenkins will then automate spinning up a demo instance based on that
-  branch. For example, pushing a branch named ``demo/feature`` would create a demo
-  instance with the following URL: ``https://bedrock-demo-feature.oregon-b.moz.works/``
-- *Bedrock locales:* dev repo
-- *Bedrock Git branch:* any branch named starting with ``demo/``
-
-.. Note::
-
-    Deployed demo instances are not yet automatically cleaned up when branches are deleted,
-    so to avoid lots of instances piling up it is currently recommended to try and limit
-    a single demo instance per developer, reusing a branch such as `demo/<your_username>`.
 
 **Dev**
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -136,13 +136,13 @@ For example, for Mozorg:
 
 .. code-block:: bash
 
-  $ git push -f mozilla HEAD:mozorg-demo-2
+  $ git push -f mozilla my-demo-branch:mozorg-demo-2
 
 Or for Pocket:
 
 .. code-block:: bash
 
-  $ git push -f mozilla HEAD:pocket-demo-1
+  $ git push -f mozilla my-demo-branch:pocket-demo-1
 
 
 **Deployment notification and logs**

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -184,6 +184,9 @@ browser_monitoring.auto_instrument = false
 # call tree.
 thread_profiler.enabled = true
 
+# Disable distributed tracing
+distributed_tracing.enabled = false
+
 # ---------------------------------------------------------------------------
 
 #


### PR DESCRIPTION
## One-line summary

This changeset updates the Bedrock docs with how to use the new Demo-server infrastructure. 

## Significant changes and points to review

Currently, the new approach is not active for Mozorg demos, only Pocket demos, but we will arrange a switch over v soon, in a way that doesn't impact everyone's workflows. At that point, we can merge these docs, but pre-reading them now is useful, particularly if they raise questions.

We also add an Architecture Decision Record to capture the move from Heroku demo servers to GCP demo servers.

## Testing
To test this work:

- [ ] `make docs`
- [ ] Review http://0.0.0.0:8100/contribute.html#server-architecture
