### PR TITLE
Update Mozilla Instagram account links for /de/ (Fixes #11953)

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -450,7 +450,7 @@ def mozilla_instagram_url(ctx):
 
     For DE this would output:
 
-        https://www.instagram.com/unfcktheinternet/
+        https://www.instagram.com/mozilla_deutschland/
 
     """
     locale = getattr(ctx["request"], "locale", "en-US")

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -464,7 +464,7 @@ class TestMozillaInstagramUrl(TestCase):
 
     def test_mozilla_instagram_url_german(self):
         """de locale, a local account"""
-        assert self._render("de") == "https://www.instagram.com/unfcktheinternet/"
+        assert self._render("de") == "https://www.instagram.com/mozilla_deutschland/"
 
     def test_mozilla_instagram_url_other_locale(self):
         """No account for locale, fallback to default account"""

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -968,7 +968,7 @@ MOZILLA_TWITTER_ACCOUNTS = {
 # Official Firefox Instagram accounts
 MOZILLA_INSTAGRAM_ACCOUNTS = {
     "en-US": "https://www.instagram.com/mozilla/",
-    "de": "https://www.instagram.com/unfcktheinternet/",
+    "de": "https://www.instagram.com/mozilla_deutschland/",
 }
 
 # Firefox Accounts product links


### PR DESCRIPTION
## One-line summary

Fixes 404 Instagram link in page footer for /de/

## Issue / Bugzilla link

#11953

## Testing

http://localhost:8000/de/
