### PR TITLE
Update meta description on WNP 103 Rally page [#11940]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx103-en-rally.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx103-en-rally.html
@@ -7,7 +7,7 @@
 {% extends "firefox/whatsnew/base.html" %}
 
 {% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
-{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+{% block page_desc %}The Mozilla Rally community pools our data to hold big tech accountable. Our data also helps create products with more privacy and control.{% endblock %}
 
 {% block body_id %}firefox-whatsnew{% endblock %}
 {% block body_class %}{% endblock %}


### PR DESCRIPTION
## One-line summary
Updates the meta description since the default is a bit inaccurate.

## Testing
http://localhost:8000/en-US/firefox/103.0/whatsnew/?v=2