### PR TITLE
Fix hard-coded brand names in Pocket strings

### DIFF
--- a/l10n-pocket/en/pocket/contact-info.ftl
+++ b/l10n-pocket/en/pocket/contact-info.ftl
@@ -35,7 +35,7 @@ contact-view-job-page = To view all open positions at { -brand-name-pocket }, pl
 contact-security = Security
 # Variables:
 #   $security_bug (url) link to https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/
-contact-report-security-vulnerability = If you believe you have discovered a security vulnerability in { -brand-name-pocket }, please follow Mozilla’s bug reporting process documented on <a href="{ $security_bug }">Mozilla’s Security page</a>.
+contact-report-security-vulnerability = If you believe you have discovered a security vulnerability in { -brand-name-pocket }, please follow { -brand-name-mozilla }’s bug reporting process documented on <a href="{ $security_bug }">{ -brand-name-mozilla }’s Security page</a>.
 # Variables:
 #   $security_email_link (email link) mailto:security@getpocket.com
 #   $security_email (string) security@getpocket.com

--- a/l10n-pocket/en/pocket/legal.ftl
+++ b/l10n-pocket/en/pocket/legal.ftl
@@ -6,4 +6,4 @@
 ### URL: https://dev.tekcopteg.com/privacy/
 
 pocket-privacy-title = Privacy Policy
-pocket-tos-terms-of-service = Pocket Terms of Service
+pocket-tos-terms-of-service = { -brand-name-pocket } Terms of Service


### PR DESCRIPTION
## One-line summary

This replaces a couple of hard-coded brand names in Pocket strings. Found them while working on https://github.com/mozilla-l10n/pocket-www-l10n/pull/9