### PR TITLE
fix wrong browser compare link

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -113,7 +113,7 @@
       ) %}
         <h2>{{ ftl('browsers-mobile-see-how-firefox-for-desktop-compare') }}</h2>
         <p class="c-compare-title mzp-has-zap-06">{{ ftl('browsers-mobile-see-how-firefox-for-desktop-strong') }}</p>
-        <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.mobile.compare') }}" data-cta-type="link" data-cta-text="Compare">{{ ftl('browsers-mobile-compare') }}</a></p>
+        <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.compare.index') }}" data-cta-type="link" data-cta-text="Compare">{{ ftl('browsers-mobile-compare') }}</a></p>
       {% endcall %}
     </div>
   </section>


### PR DESCRIPTION
## One-line summary
The compare link of browser compare was wrong.

## Screenshots

![Firefox mobile browsers put your privacy first - Google Chrome](https://user-images.githubusercontent.com/30198386/181856370-f6d244d5-84d5-4311-a7c2-9a10b8eea60f.jpg)


## Issue / Bugzilla link
#11975 

## Testing
See how Firefox for desktop stacks up to seven other browsers. compare button 
- http://localhost:8080/en-US/firefox/browsers/mobile/




