### PR TITLE
Update supported iOS version on VPN pages (Fixes #11980)

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -108,7 +108,7 @@
           image_width=100,
           body=True,
         ) %}
-          <p>{{ ftl('vpn-download-version-requirements', version='12.0') }}</p>
+          <p>{{ ftl('vpn-download-version-requirements', version='13.0') }}</p>
           <a class="mzp-c-button mzp-t-secondary" href="{{ ios_download_url }}" data-cta-type="button" data-cta-text="VPN Download (iOS)">
             {{ ftl('vpn-download-get-on-app-store') }}
           </a>

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -256,12 +256,10 @@
           {% endif %}
         </li>
         <li>
-          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-ios-v3') %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v3', url=url('products.vpn.platforms.ios')) }}
-          {% elif ftl_has_messages('vpn-landing-faq-compatibility-question-desc-ios-v2') %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v2', url=url('products.vpn.platforms.ios')) }}
+          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-ios-v4') %}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v4', url=url('products.vpn.platforms.ios'), version='13.0') }}
           {% else %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios') }}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v3', url=url('products.vpn.platforms.ios')) }}
           {% endif %}
         </li>
         <li>

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -136,15 +136,13 @@ vpn-landing-faq-compatibility-question-desc-android = { -brand-name-android } (v
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/mobile/ios/
-vpn-landing-faq-compatibility-question-desc-ios-v3 = <a href="{ $url }">{ -brand-name-ios }</a> (12.0 and up)
+#   $version (number) - minimum supported version number
+vpn-landing-faq-compatibility-question-desc-ios-v4 = <a href="{ $url }">{ -brand-name-ios }</a> ({ $version } and up)
 
 # Outdated string
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/mobile/ios/
-vpn-landing-faq-compatibility-question-desc-ios-v2 = <a href="{ $url }">{ -brand-name-ios }</a> (13.0 and up)
-
-# Outdated string
-vpn-landing-faq-compatibility-question-desc-ios = { -brand-name-ios } (13.0 and up)
+vpn-landing-faq-compatibility-question-desc-ios-v3 = <a href="{ $url }">{ -brand-name-ios }</a> (12.0 and up)
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/linux/


### PR DESCRIPTION
## One-line summary

Bumps minimum supported iOS version to 13.0

## Issue / Bugzilla link

#11980

## Testing

- http://localhost:8000/en-US/products/vpn/#faq-compatibility
- http://localhost:8000/en-US/products/vpn/download/
