### PR TITLE
Stop making CJMS calls if FxA flow params are undefined (Fixes #11998)

### DIFF
--- a/media/js/products/vpn/affiliate-attribution.es6.js
+++ b/media/js/products/vpn/affiliate-attribution.es6.js
@@ -199,6 +199,11 @@ AffiliateAttribution.init = function () {
 
         FxaProductButton.init()
             .then((flowParams) => {
+                if (!flowParams) {
+                    reject('FxA flow params are undefined.');
+                    return;
+                }
+
                 const flowId = AffiliateAttribution.getQueryStringParam(
                     'flow_id',
                     flowParams

--- a/media/js/products/vpn/affiliate-init.es6.js
+++ b/media/js/products/vpn/affiliate-init.es6.js
@@ -116,7 +116,7 @@ if (AffiliateAttribution.shouldInitiateAttributionFlow()) {
             }
         })
         .catch((e) => {
-            throw new Error(e);
+            console.error(e); // eslint-disable-line no-console
         });
 } else {
     // Just add flow params as normal.

--- a/tests/unit/spec/products/vpn/affiliate-attribution.js
+++ b/tests/unit/spec/products/vpn/affiliate-attribution.js
@@ -258,6 +258,25 @@ describe('affiliate-attribution.es6.js', function () {
                 });
             });
 
+            it('should reject if FxA flow params are undefined', function () {
+                spyOn(
+                    AffiliateAttribution,
+                    'meetsRequirements'
+                ).and.returnValue(true);
+                spyOn(AffiliateAttribution, 'getCJEventParam').and.returnValue(
+                    _cjEventParam
+                );
+                spyOn(AffiliateAttribution, 'getCJMSEndpoint').and.returnValue(
+                    _endpoint
+                );
+                spyOn(FxaProductButton, 'init').and.resolveTo(undefined);
+                spyOn(window, 'fetch');
+                return AffiliateAttribution.init().catch((reason) => {
+                    expect(reason).toEqual('FxA flow params are undefined.');
+                    expect(window.fetch).not.toHaveBeenCalled();
+                });
+            });
+
             it('should do a new POST if PUT fails with a 404', function () {
                 const mock404Response = new window.Response(
                     JSON.stringify({}),


### PR DESCRIPTION
## One-line summary

This fixes an edge case we ran into in #11998. If flow params are undefined then we should throw an error instead of passing over a bad value to the CJMS.

## Issue / Bugzilla link

#11998

## Testing

Prerequisites:

1. Use a browser with DNT disabled.
2. Make sure you have `Persist logs` checked in the dev tools web console so that you can see logs across page redirects.

Testing:

1. Open http://localhost:8000/en-US/products/vpn/?cjevent=123456789
2. You should be redirected to a traffic cop experiment with `entrypoint_experiment=vpn-coupon-promo-banner` in the URL.
3. Open the web console.
4. You should see an error saying `Error: FxA flow params are undefined.`
5. You should not see a 500 error posting data to `https://stage.cjms.nonprod.cloudops.mozgcp.net/` (which is what you get on the `main` branch).
