### PR TITLE
F3 landing page base

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign/families/includes/about.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/about.html
@@ -7,5 +7,5 @@
 <h2>About</h2>
 <!-- confirm what download button we need to use here -->
 <!-- confirm what happens for users already on Fx (no CTA, different CTA?) -->
-{{ download_firefox() }}
+{{ download_firefox_thanks() }}
 

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/about.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/about.html
@@ -4,3 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+<h2>About</h2>
+<!-- confirm what download button we need to use here -->
+<!-- confirm what happens for users already on Fx (no CTA, different CTA?) -->
+{{ download_firefox() }}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/about.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/about.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/agreement.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/agreement.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/agreement.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/agreement.html
@@ -4,3 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+<h2>Agreement</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/breaking-news.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/breaking-news.html
@@ -4,3 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+<p>Not really a title, just a breaking news scroll, maybe an aside?</p>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/breaking-news.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/breaking-news.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/hero.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/hero.html
@@ -4,3 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+<h1>The Tech Talk</h1>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/hero.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/hero.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/macros.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/macros.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<!-- module tags -->

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/data.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/data.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<h2>Data Profiles</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/mental-health.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/mental-health.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<h2>Mental Health</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/mental-health.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/mental-health.html
@@ -4,4 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<h2>Mental Health</h2>
+<h2>Privacy and Mental Health</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/netiquette.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/netiquette.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<h2>Netiquette</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/passwords.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/passwords.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<h2>Passwords</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/private-browsing.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<h2>Private Browsing</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/modules/public-wifi.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/modules/public-wifi.html
@@ -1,0 +1,7 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<h2>Public Wifi</h2>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/parental-pro-tip.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/parental-pro-tip.html
@@ -4,3 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+<p> Parental Pro tip: {{ tip }}</p>

--- a/bedrock/firefox/templates/firefox/campaign/families/includes/parental-pro-tip.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/includes/parental-pro-tip.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/index.html
@@ -4,3 +4,33 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% extends "firefox/base/base-protocol.html" %}
+
+<!-- will any metadata need to change? -->
+{% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
+
+{% block page_image %}{{ static('protocol/img/logos/firefox/browser/og.png') }}{% endblock %}
+{% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}
+{% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}
+{% block page_ios_icon %}{{ static('img/favicons/firefox/browser/apple-touch-icon.png') }}{% endblock %}
+{% block twitter_card %}summary_large_image{% endblock %}
+
+{% block facebook_id %}14696440021{# facebook.com/Firefox #}{% endblock %}
+{% block twitter_id %}firefox{% endblock %}
+<!-- metadata q ends -->
+
+<!-- include Firefox subnav for desktop/mobile? -->
+
+<!-- Hero -->
+<!-- About -->
+<!-- Breaking news scroll -->
+<!-- MODULE: Data Profiles -->
+<!-- MODULE: Privacy & Mental Health -->
+<!-- Parental Pro-tip -->
+<!-- MODULE: Netiquette -->
+<!-- MODULE: Public Wifi -->
+<!-- MODULE: Passwords -->
+<!-- Parental Pro-tip -->
+<!-- MODULE: Private Browsing -->
+<!-- Agreement (printable) -->

--- a/bedrock/firefox/templates/firefox/campaign/families/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/index.html
@@ -24,17 +24,35 @@
 {% block twitter_id %}firefox{% endblock %}
 <!-- metadata q ends -->
 
+{% block content %}
 <!-- include Firefox subnav for desktop/mobile? -->
 
 <!-- Hero -->
+{% include 'firefox/campaign/families/includes/hero.html' %}
 <!-- About -->
+{% include 'firefox/campaign/families/includes/about.html' %}
 <!-- Breaking news scroll -->
+{% include 'firefox/campaign/families/includes/breaking-news.html' %}
 <!-- MODULE: Data Profiles -->
+{% include 'firefox/campaign/families/includes/modules/data.html' %}
 <!-- MODULE: Privacy & Mental Health -->
+{% include 'firefox/campaign/families/includes/modules/mental-health.html' %}
 <!-- Parental Pro-tip -->
+{% with tip='tip 1' %}
+  {% include 'firefox/campaign/families/includes/parental-pro-tip.html' %}
+{% endwith %}
 <!-- MODULE: Netiquette -->
+{% include 'firefox/campaign/families/includes/modules/netiquette.html' %}
 <!-- MODULE: Public Wifi -->
+{% include 'firefox/campaign/families/includes/modules/public-wifi.html' %}
 <!-- MODULE: Passwords -->
+{% include 'firefox/campaign/families/includes/modules/passwords.html' %}
 <!-- Parental Pro-tip -->
+{% with tip='tip 2' %}
+  {% include 'firefox/campaign/families/includes/parental-pro-tip.html' %}
+{% endwith %}
 <!-- MODULE: Private Browsing -->
+{% include 'firefox/campaign/families/includes/modules/private-browsing.html' %}
 <!-- Agreement (printable) -->
+{% include 'firefox/campaign/families/includes/agreement.html' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/families/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/index.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/bedrock/firefox/templates/firefox/campaign/families/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/families/index.html
@@ -6,6 +6,10 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
+{% block page_css %}
+  {{ css_bundle('firefox-families') }}
+{% endblock %}
+
 <!-- will any metadata need to change? -->
 {% block page_title_prefix %}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -230,7 +230,7 @@ urlpatterns = (
     # Issue 9957
     page("firefox/more/misinformation/", "firefox/more/misinformation.html", ftl_files="firefox/more/misinformation"),
     # Firefox for Families campaign, Issue #12004
-    page("firefox/families/", "firefox/campaign/families/index.html", active_locales=["en-US"]),
+    page("firefox/families/", "firefox/campaign/families/index.html"),
 )
 
 # Contentful

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -229,6 +229,8 @@ urlpatterns = (
     page("firefox/privacy/book/", "firefox/privacy/book.html", ftl_files="firefox/privacy/book"),
     # Issue 9957
     page("firefox/more/misinformation/", "firefox/more/misinformation.html", ftl_files="firefox/more/misinformation"),
+    # Firefox for Families campaign, Issue #12004
+    page("firefox/families/", "firefox/campaign/families/index.html", active_locales=["en-US"]),
 )
 
 # Contentful

--- a/media/css/firefox/campaign/families/_variables.scss
+++ b/media/css/firefox/campaign/families/_variables.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/_variables.scss
+++ b/media/css/firefox/campaign/families/_variables.scss
@@ -1,3 +1,21 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Colors
+$white: #f5f5f5;
+$black: $color-black;
+$violet-primary: $color-violet-10;
+$violet-light: $color-violet-05;
+$violet-dark: $color-violet-50;
+$pink-primary: $color-pink-20;
+$pink-light: $color-red-10;
+$yellow-primary: $color-yellow-20;
+$yellow-dark: $color-yellow-30;
+$blue-primary: $color-blue-10;
+$blue-dark: $color-blue-30;
+$orange-primary: $color-orange-05;
+$orange-dark: $color-orange-20;
+$green-primary: $color-green-10;
+$green-light: $color-green-05;
+$green-dark: $color-green-80;

--- a/media/css/firefox/campaign/families/components/_about.scss
+++ b/media/css/firefox/campaign/families/components/_about.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/_agreement.scss
+++ b/media/css/firefox/campaign/families/components/_agreement.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/_breaking-news.scss
+++ b/media/css/firefox/campaign/families/components/_breaking-news.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/_hero.scss
+++ b/media/css/firefox/campaign/families/components/_hero.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/_pro-tip.scss
+++ b/media/css/firefox/campaign/families/components/_pro-tip.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/modules/_data.scss
+++ b/media/css/firefox/campaign/families/components/modules/_data.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/modules/_mental-health.scss
+++ b/media/css/firefox/campaign/families/components/modules/_mental-health.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/modules/_netiquette.scss
+++ b/media/css/firefox/campaign/families/components/modules/_netiquette.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/modules/_passwords.scss
+++ b/media/css/firefox/campaign/families/components/modules/_passwords.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/modules/_private-browsing.scss
+++ b/media/css/firefox/campaign/families/components/modules/_private-browsing.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/components/modules/_public-wifi.scss
+++ b/media/css/firefox/campaign/families/components/modules/_public-wifi.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/css/firefox/campaign/families/styles.scss
+++ b/media/css/firefox/campaign/families/styles.scss
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1179,6 +1179,12 @@
         "css/stories/stories-article.scss"
       ],
       "name": "mozilla-stories-article"
+    },
+    {
+      "files": [
+        "css/firefox/campaign/families/styles.scss"
+      ],
+      "name": "firefox-families"
     }
   ],
   "js": [

--- a/tests/functional/firefox/campaign/__init__.py
+++ b/tests/functional/firefox/campaign/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/functional/firefox/campaign/families/__init__.py
+++ b/tests/functional/firefox/campaign/families/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/functional/firefox/campaign/families/test_families.py
+++ b/tests/functional/firefox/campaign/families/test_families.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.campaign.families.landing import CampaignFamiliesPage
+
+
+# confirm if download button is actual download or link to download page
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+def test_firefox_download_button_is_displayed(base_url, selenium):
+    page = CampaignFamiliesPage(selenium, base_url).open()
+    assert page.is_firefox_download_button_displayed

--- a/tests/pages/firefox/campaign/__init__.py
+++ b/tests/pages/firefox/campaign/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/firefox/campaign/families/__init__.py
+++ b/tests/pages/firefox/campaign/families/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/firefox/campaign/families/landing.py
+++ b/tests/pages/firefox/campaign/families/landing.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class CampaignFamiliesPage(BasePage):
+
+    _URL_TEMPLATE = "/{locale}/firefox/families/"
+
+    _firefox_download_button_locator = (By.CSS_SELECTOR, "[data-link-type='download']")
+
+    @property
+    def is_firefox_download_button_displayed(self):
+        return self.is_element_displayed(*self._firefox_download_button_locator)


### PR DESCRIPTION
## One-line summary

Supplies a common base for developing the Firefox for Families landing page

⚠️ url isn't finalized, but shouldn't be a blocker for development purposes

## Significant changes and points to review

- New campaign folder in Firefox app
- Basic HTML and CSS folder structure added
- Download Fx button test

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12004

## Checklist

If relevant:

- [x] HTML structure makes sense
- [x] CSS structure makes sense
- [x] Test for Fx Download button

## Testing

http://localhost:8000/en-US/firefox/families/

local functional testing:
Firefox (skips)`py.test --base-url http://localhost:8000 --driver Firefox tests/functional/firefox/campaign/families`
Chrome (passes)`py.test --base-url http://localhost:8000 --driver Chrome tests/functional/firefox/campaign/families`
