### PR TITLE
Newsletter recovery page should post directly to basket (Fixes #11963)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,8 +7,7 @@
 module.exports = {
     env: {
         browser: true,
-        commonjs: true,
-        jasmine: true
+        commonjs: true
     },
     extends: ['eslint:recommended', 'plugin:json/recommended', 'prettier'],
     rules: {
@@ -82,10 +81,14 @@ module.exports = {
             // JS Karma test files.
             files: ['tests/unit/**/*.js'],
             env: {
-                es2017: true
+                es2017: true,
+                jasmine: true
             },
             parserOptions: {
                 sourceType: 'module'
+            },
+            globals: {
+                sinon: 'writable'
             }
         },
         {

--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -22,55 +22,60 @@
       <h1>{{ self.page_title() }}</h1>
       <p class="tagline mzp-u-title-sm">{{ self.page_desc() }}</p>
     </header>
-    {% if messages %}
-      <ul class="mzp-u-list-styled">
-        {% for message in messages %}
-          <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
 
-    {% if form %}
-      <form method="post" action="{{ url('newsletter.opt-out-confirmation') }}">
-        <div class="mzp-c-form">
-          <header class="mzp-c-form-header">
-            <p>
-              {{ ftl('opt-out-confirmation-youll-continue') }}
-            </p>
-          </header>
+    <form method="post" action="{{ recovery_url }}" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">
+      <header class="mzp-c-form-header">
+        <p>
+          {{ ftl('opt-out-confirmation-youll-continue') }}
+        </p>
+      </header>
 
-          {% if form.non_field_errors() %}
-            <div class="mzp-c-form-errors">
-              {{ form.non_field_errors() }}
-            </div>
-          {% endif %}
-          <div class="mzp-c-field mzp-l-stretch">
-            {{ form.email.errors }}
-            <label for="id_email" class="mzp-c-field-label">{{ ftl('opt-out-confirmation-your-email') }}</label>
-            {{ field_with_attrs(form.email, placeholder=ftl('opt-out-confirmation-yournameexamplecom')|safe, class='mzp-c-field-control'|safe) }}
-          </div>
-          <div class="mzp-c-button-container mzp-l-stretch">
-            <button class="mzp-c-button" type="submit">{{ ftl('opt-out-confirmation-manage-preferences') }}</button>
-          </div>
+      <div class="hide-from-legacy-ie">
+        <p class="mzp-c-form-errors error-email-invalid">
+          {{ ftl('newsletters-this-is-not-a-valid-email') }}
+        </p>
+        <p class="mzp-c-form-errors error-email-not-found">
+          {{ ftl('newsletters-this-email-address-is-not', url=url('newsletter.subscribe')) }}
+        </p>
+        <p class="mzp-c-form-errors error-try-again-later">
+          {{ ftl('newsletters-we-are-sorry-but-there') }}
+        </p>
+        <div class="newsletter-recovery-form-success-msg">
+          <p>{{ ftl('newsletters-success-an-email-has-been-sent') }}</p>
         </div>
-      </form>
+      </div>
 
-      <aside>
-        <h2>{{ ftl('opt-out-confirmation-prefer-to-get') }}</h2>
-        <ul class="mzp-u-list-styled">
-          <li><a href="https://blog.mozilla.org/">{{ ftl('opt-out-confirmation-check-out-our') }}</a></li>
-          <li><a href="https://support.mozilla.org/">{{ ftl('opt-out-confirmation-get-help') }}</a></li>
-          <li><a href="{{ url('newsletter.firefox') }}">{{ ftl('opt-out-confirmation-subscribe-to') }}</a></li>
-        </ul>
+      <div class="newsletter-recovery-form-fields">
+        <div class="mzp-c-field mzp-l-stretch">
+          {{ form.email.errors }}
+          <label for="id_email" class="mzp-c-field-label">{{ ftl('opt-out-confirmation-your-email') }}</label>
+          {{ field_with_attrs(form.email, placeholder=ftl('opt-out-confirmation-yournameexamplecom')|safe, class='mzp-c-field-control'|safe) }}
+        </div>
+        <div class="mzp-c-button-container mzp-l-stretch">
+          <button class="mzp-c-button" type="submit">{{ ftl('opt-out-confirmation-manage-preferences') }}</button>
+        </div>
+      </div>
+    </form>
 
-        <ul class="social-links">
-          <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
-          <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
-          <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
-          <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>
-        </ul>
-      </aside>
-    {% endif %}
+    <aside>
+      <h2>{{ ftl('opt-out-confirmation-prefer-to-get') }}</h2>
+      <ul class="mzp-u-list-styled">
+        <li><a href="https://blog.mozilla.org/">{{ ftl('opt-out-confirmation-check-out-our') }}</a></li>
+        <li><a href="https://support.mozilla.org/">{{ ftl('opt-out-confirmation-get-help') }}</a></li>
+        <li><a href="{{ url('newsletter.firefox') }}">{{ ftl('opt-out-confirmation-subscribe-to') }}</a></li>
+      </ul>
+
+      <ul class="social-links">
+        <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
+        <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
+        <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
+        <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>
+      </ul>
+    </aside>
   </div>{#-- /.content --#}
 </main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('newsletter-recovery') }}
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -11,50 +11,47 @@
 
 {% block page_title %}{{ ftl('newsletters-newsletter-email-recovery') }}{% endblock page_title %}
 
+{% block page_css %}
+  {{ css_bundle('newsletter-recovery') }}
+{% endblock %}
+
 {% block content %}
   <main role="main" class="mzp-l-content mzp-t-content-sm">
-    {% block messages %}
     <h1 class="mzp-u-title-sm">{{ ftl('newsletters-manage-your-newsletter') }}</h1>
-      {% if messages %}
-        <ul>
-          {% for message in messages %}
-            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-    {% endblock messages %}
 
-    {% if form %}
-      <form method="post" action="{{ url('newsletter.recovery') }}" id="newsletter-recovery-form" class="mzp-c-form">
-        <header class="mzp-c-newsletter-header">
-          <p>{{ ftl('newsletters-enter-your-email-address') }}</p>
-        </header>
+    <form method="post" action="{{ recovery_url }}" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">
+      <header class="mzp-c-newsletter-header">
+        <p>{{ ftl('newsletters-enter-your-email-address') }}</p>
+      </header>
 
-        {% if form.non_field_errors() %}
-          <div class="mzp-c-form-errors" id="newsletter-errors">
-            {{ form.non_field_errors()|safe }}
-          </div>
-        {% endif %}
+      <div class="hide-from-legacy-ie">
+        <p class="mzp-c-form-errors error-email-invalid">
+          {{ ftl('newsletters-this-is-not-a-valid-email') }}
+        </p>
+        <p class="mzp-c-form-errors error-email-not-found">
+          {{ ftl('newsletters-this-email-address-is-not', url=url('newsletter.subscribe')) }}
+        </p>
+        <p class="mzp-c-form-errors error-try-again-later">
+          {{ ftl('newsletters-we-are-sorry-but-there') }}
+        </p>
+        <div class="newsletter-recovery-form-success-msg">
+          <p>{{ ftl('newsletters-success-an-email-has-been-sent') }}</p>
+        </div>
+      </div>
 
-        <div class="mzp-c-field mzp-l-stretch {% if form.email.errors %} mzp-is-error{% endif %}">
-          <label for="id_email" class="mzp-c-field-label">
-            {{ ftl('newsletters-your-email-address') }}
-            {% if form.email.errors %}
-              <em class="mzp-c-fieldnote">
-                <ul class="errorlist">
-                {% for error in form.email.errors %}
-                  <li> {{ error|safe }} </li>
-                {% endfor %}
-                </ul>
-              </em>
-            {% endif %}
-          </label>
+      <div class="newsletter-recovery-form-fields">
+        <div class="mzp-c-field mzp-l-stretch">
+          <label for="id_email" class="mzp-c-field-label">{{ ftl('newsletters-your-email-address') }}</label>
           {{ field_with_attrs(form.email, class='mzp-c-field-control'|safe) }}
         </div>
         <div class="mzp-c-button-container mzp-l-stretch">
           <button class="mzp-c-button" id="newsletter-submit" type="submit">{{ ftl('newsletters-send-me-a-link') }}</button>
         </div>
-      </form>
-    {% endif %}
+      </div>
+    </form>
   </main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('newsletter-recovery') }}
 {% endblock %}

--- a/media/css/newsletter/newsletter-opt-out-confirmation.scss
+++ b/media/css/newsletter/newsletter-opt-out-confirmation.scss
@@ -6,9 +6,6 @@ $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 
 /* -------------------------------------------------------------------------- */
 // Common elements
@@ -42,9 +39,10 @@ header {
     margin-bottom: $layout-lg;
 }
 
-.mzp-c-field {
+.mzp-c-field,
+.mzp-c-form-errors {
+    @include border-box;
     max-width: $content-xs;
-    padding-bottom: $label-v-spacing;
 }
 
 .mzp-c-button-container {

--- a/media/css/newsletter/newsletter-recovery.scss
+++ b/media/css/newsletter/newsletter-recovery.scss
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.newsletter-recovery-form {
+    .mzp-c-field {
+        padding-bottom: $label-v-spacing;
+    }
+
+    .mzp-c-form-errors {
+        display: none;
+
+        &.show {
+            display: block;
+        }
+    }
+}
+
+.newsletter-recovery-form-success-msg {
+    display: none;
+
+    &.show {
+        display: block;
+    }
+}
+
+.newsletter-recovery-form-fields {
+    display: block;
+
+    &.hide {
+        display: none;
+    }
+}

--- a/media/js/newsletter/form-utils.es6.js
+++ b/media/js/newsletter/form-utils.es6.js
@@ -1,0 +1,16 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Reallly primative validation (e.g a@a)
+ * matches built-in validation in Firefox
+ * @param {email}
+ */
+function checkEmailValidity(email) {
+    return /\S+@\S+/.test(email);
+}
+
+export { checkEmailValidity };

--- a/media/js/newsletter/recovery-init.es6.js
+++ b/media/js/newsletter/recovery-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import RecoveryEmailForm from './recovery.es6';
+
+RecoveryEmailForm.init();

--- a/media/js/newsletter/recovery.es6.js
+++ b/media/js/newsletter/recovery.es6.js
@@ -1,0 +1,130 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { checkEmailValidity } from './form-utils.es6';
+let _recoveryForm;
+
+const RecoveryEmailForm = {
+    handleFormSuccess: () => {
+        document
+            .querySelector('.newsletter-recovery-form-fields')
+            .classList.add('hide');
+        document
+            .querySelector('.newsletter-recovery-form-success-msg')
+            .classList.add('show');
+    },
+
+    handleFormError: (msg) => {
+        if (msg && msg === 'Invalid email address') {
+            document
+                .querySelector('.error-email-invalid')
+                .classList.add('show');
+        } else if (msg && msg === 'Email address not known') {
+            document
+                .querySelector('.error-email-not-found')
+                .classList.add('show');
+        } else {
+            document
+                .querySelector('.error-try-again-later')
+                .classList.add('show');
+        }
+    },
+
+    clearFormErrors: () => {
+        const errorMsgs = document.querySelectorAll('.mzp-c-form-errors');
+
+        for (let i = 0; i < errorMsgs.length; i++) {
+            errorMsgs[i].classList.remove('show');
+        }
+    },
+
+    disableFormFields: () => {
+        const formFields = _recoveryForm.querySelectorAll('input, button');
+
+        for (let i = 0; i < formFields.length; i++) {
+            formFields[i].disabled = true;
+        }
+    },
+
+    enableFormFields: () => {
+        const formFields = _recoveryForm.querySelectorAll('input, button');
+
+        for (let i = 0; i < formFields.length; i++) {
+            formFields[i].disabled = false;
+        }
+    },
+
+    recoverEmail: (e) => {
+        e.preventDefault();
+
+        const email = document.getElementById('id_email').value;
+        const params = 'email=' + encodeURIComponent(email);
+        const url = _recoveryForm.getAttribute('action');
+        const xhr = new XMLHttpRequest();
+
+        // Disable form fields until POST has completed.
+        RecoveryEmailForm.disableFormFields();
+
+        // Really basic client side email validity check.
+        if (!checkEmailValidity(email)) {
+            RecoveryEmailForm.handleFormError('Invalid email address');
+            RecoveryEmailForm.enableFormFields();
+            return;
+        }
+
+        xhr.onload = (r) => {
+            let response = r.target.response || r.target.responseText;
+
+            // Clear any prior messages that might have been displayed.
+            RecoveryEmailForm.clearFormErrors();
+
+            if (typeof response !== 'object') {
+                response = JSON.parse(response);
+            }
+
+            if (response) {
+                if (
+                    response.status === 'ok' &&
+                    r.target.status >= 200 &&
+                    r.target.status < 300
+                ) {
+                    RecoveryEmailForm.handleFormSuccess();
+                } else if (response.status === 'error' && response.desc) {
+                    RecoveryEmailForm.handleFormError(response.desc);
+                } else {
+                    RecoveryEmailForm.handleFormError();
+                }
+            } else {
+                RecoveryEmailForm.handleFormError();
+            }
+
+            RecoveryEmailForm.enableFormFields();
+        };
+
+        xhr.onerror = RecoveryEmailForm.handleFormError;
+        xhr.open('POST', url, true);
+        xhr.setRequestHeader(
+            'Content-type',
+            'application/x-www-form-urlencoded'
+        );
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        xhr.timeout = 5000;
+        xhr.ontimeout = RecoveryEmailForm.handleFormError;
+        xhr.responseType = 'json';
+        xhr.send(params);
+    },
+
+    init: function () {
+        _recoveryForm = document.getElementById('newsletter-recovery-form');
+        _recoveryForm.addEventListener(
+            'submit',
+            RecoveryEmailForm.recoverEmail,
+            false
+        );
+    }
+};
+
+export default RecoveryEmailForm;

--- a/media/js/newsletter/recovery.es6.js
+++ b/media/js/newsletter/recovery.es6.js
@@ -68,6 +68,9 @@ const RecoveryEmailForm = {
         // Disable form fields until POST has completed.
         RecoveryEmailForm.disableFormFields();
 
+        // Clear any prior messages that might have been displayed.
+        RecoveryEmailForm.clearFormErrors();
+
         // Really basic client side email validity check.
         if (!checkEmailValidity(email)) {
             RecoveryEmailForm.handleFormError('Invalid email address');
@@ -75,11 +78,19 @@ const RecoveryEmailForm = {
             return;
         }
 
+        // Emails used in automation for page-level integration tests
+        // should avoid hitting basket directly.
+        if (email === 'success@example.com') {
+            RecoveryEmailForm.handleFormSuccess();
+            return;
+        } else if (email === 'failure@example.com') {
+            RecoveryEmailForm.handleFormError();
+            RecoveryEmailForm.enableFormFields();
+            return;
+        }
+
         xhr.onload = (r) => {
             let response = r.target.response || r.target.responseText;
-
-            // Clear any prior messages that might have been displayed.
-            RecoveryEmailForm.clearFormErrors();
 
             if (typeof response !== 'object') {
                 response = JSON.parse(response);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -536,6 +536,13 @@
     },
     {
       "files": [
+        "css/newsletter/newsletter-recovery.scss"
+      ],
+      "name": "newsletter-recovery"
+    },
+    {
+      "files": [
+        "css/newsletter/newsletter-recovery.scss",
         "css/newsletter/newsletter-opt-out-confirmation.scss"
       ],
       "name": "newsletter-opt-out-confirmation"
@@ -1771,6 +1778,13 @@
         "js/newsletter/confirm.js"
       ],
       "name": "newsletter-confirm"
+    },
+    {
+      "files": [
+        "js/newsletter/recovery.es6.js",
+        "js/newsletter/recovery-init.es6.js"
+      ],
+      "name": "newsletter-recovery"
     },
     {
       "files": [

--- a/tests/functional/newsletter/test_newsletter_recovery.py
+++ b/tests/functional/newsletter/test_newsletter_recovery.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.newsletter.recovery import NewsletterRecoveryPage
+
+
+@pytest.mark.nondestructive
+def test_newsletter_recovery_success(base_url, selenium):
+    page = NewsletterRecoveryPage(selenium, base_url).open()
+    page.type_email("success@example.com")
+    page.click_submit()
+    assert page.is_success_message_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_newsletter_recovery_failure(base_url, selenium):
+    page = NewsletterRecoveryPage(selenium, base_url).open()
+    page.type_email("failure@example.com")
+    page.click_submit(expected_result="error")
+    assert page.is_error_message_displayed

--- a/tests/pages/newsletter/recovery.py
+++ b/tests/pages/newsletter/recovery.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+from pages.base import BasePage
+
+
+class NewsletterRecoveryPage(BasePage):
+
+    _URL_TEMPLATE = "/{locale}/newsletter/recovery/"
+
+    _email_locator = (By.ID, "id_email")
+    _submit_button_locator = (By.ID, "newsletter-submit")
+    _success_message_locator = (By.CLASS_NAME, "newsletter-recovery-form-success-msg")
+    _error_message_locator = (By.CLASS_NAME, "error-try-again-later")
+
+    def type_email(self, value):
+        self.find_element(*self._email_locator).send_keys(value)
+
+    def click_submit(self, expected_result=None):
+        self.find_element(*self._submit_button_locator).click()
+        if expected_result == "error":
+            self.wait.until(expected.visibility_of_element_located(self._error_message_locator))
+        else:
+            self.wait.until(expected.visibility_of_element_located(self._success_message_locator))
+
+    @property
+    def is_success_message_displayed(self):
+        return self.is_element_displayed(*self._success_message_locator)
+
+    @property
+    def is_error_message_displayed(self):
+        return self.is_element_displayed(*self._error_message_locator)

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -38,6 +38,8 @@ module.exports = function (config) {
             'media/js/firefox/new/common/thanks.js',
             'media/js/pocket/mobile-nav.es6.js',
             'media/js/products/vpn/affiliate-attribution.es6.js',
+            'media/js/newsletter/form-utils.es6.js',
+            'media/js/newsletter/recovery.es6.js',
             'tests/unit/spec/base/core-datalayer-page-id.js',
             'tests/unit/spec/base/core-datalayer.js',
             'tests/unit/spec/base/dnt-helper.js',
@@ -67,6 +69,8 @@ module.exports = function (config) {
             'tests/unit/spec/glean/page.js',
             'tests/unit/spec/glean/utils.js',
             'tests/unit/spec/products/vpn/affiliate-attribution.js',
+            'tests/unit/spec/newsletter/form-utils.js',
+            'tests/unit/spec/newsletter/recovery.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',
                 watched: false,

--- a/tests/unit/spec/base/fxa-form.js
+++ b/tests/unit/spec/base/fxa-form.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 import FxaForm from '../../../../media/js/base/fxa-form.es6.js';
 
 describe('fxa-form.js', function () {

--- a/tests/unit/spec/base/fxa-link.js
+++ b/tests/unit/spec/base/fxa-link.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 import FxaLink from '../../../../media/js/base/fxa-link.es6.js';
 
 describe('fxa-link.js', function () {

--- a/tests/unit/spec/base/mozilla-banner.js
+++ b/tests/unit/spec/base/mozilla-banner.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon, */
-
 describe('mozilla-banner.js', function () {
     beforeEach(function () {
         // stub out google tag manager

--- a/tests/unit/spec/base/mozilla-pixel.js
+++ b/tests/unit/spec/base/mozilla-pixel.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 describe('mozilla-pixel.js', function () {
     afterEach(function () {
         document.querySelectorAll('.moz-px').forEach((e) => {

--- a/tests/unit/spec/base/send-to-device.js
+++ b/tests/unit/spec/base/send-to-device.js
@@ -9,7 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon, */
 /* eslint camelcase: [2, {properties: "never"}] */
 /* eslint new-cap: [2, {"capIsNewExceptions": ["Deferred"]}] */
 

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -9,8 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 describe('site.js', function () {
     describe('getPlatform', function () {
         it('should identify Windows', function () {

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -9,7 +9,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
 /* eslint new-cap: [2, {"capIsNewExceptions": ["Deferred"]}] */
 
 describe('stub-attribution.js', function () {

--- a/tests/unit/spec/newsletter/form-utils.js
+++ b/tests/unit/spec/newsletter/form-utils.js
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { checkEmailValidity } from '../../../../media/js/newsletter/form-utils.es6';
+
+describe('checkEmailValidity', function () {
+    it('should return true for primitive email format', function () {
+        expect(checkEmailValidity('a@a')).toBeTruthy();
+        expect(checkEmailValidity('example@example.com')).toBeTruthy();
+    });
+
+    it('should return false for anything else', function () {
+        expect(checkEmailValidity(1234567890)).toBeFalsy();
+        expect(checkEmailValidity('aaa')).toBeFalsy();
+        expect(checkEmailValidity(null)).toBeFalsy();
+        expect(checkEmailValidity(undefined)).toBeFalsy();
+        expect(checkEmailValidity(true)).toBeFalsy();
+        expect(checkEmailValidity(false)).toBeFalsy();
+    });
+});

--- a/tests/unit/spec/newsletter/recovery.js
+++ b/tests/unit/spec/newsletter/recovery.js
@@ -63,7 +63,7 @@ describe('RecoveryEmailForm', function () {
         it('should handle success', function () {
             spyOn(RecoveryEmailForm, 'handleFormSuccess').and.callThrough();
             RecoveryEmailForm.init();
-            document.getElementById('id_email').value = 'success@example.com';
+            document.getElementById('id_email').value = 'fox@example.com';
             document.getElementById('newsletter-submit').click();
             xhrRequests[0].respond(
                 200,
@@ -103,7 +103,7 @@ describe('RecoveryEmailForm', function () {
         it('should handle unknown email', function () {
             spyOn(RecoveryEmailForm, 'handleFormError').and.callThrough();
             RecoveryEmailForm.init();
-            document.getElementById('id_email').value = 'unknown@example.com';
+            document.getElementById('id_email').value = 'ohnoes@example.com';
             document.getElementById('newsletter-submit').click();
             xhrRequests[0].respond(
                 400,
@@ -121,10 +121,29 @@ describe('RecoveryEmailForm', function () {
             ).toBeTrue();
         });
 
+        it('should handle unknown error', function () {
+            spyOn(RecoveryEmailForm, 'handleFormError').and.callThrough();
+            RecoveryEmailForm.init();
+            document.getElementById('id_email').value = 'ohnoes@example.com';
+            document.getElementById('newsletter-submit').click();
+            xhrRequests[0].respond(
+                400,
+                { 'Content-Type': 'application/json' },
+                '{"status": "error", "desc": "Unknown non-helpful error"}'
+            );
+
+            expect(RecoveryEmailForm.handleFormError).toHaveBeenCalled();
+            expect(
+                document
+                    .querySelector('.error-try-again-later')
+                    .classList.contains('show')
+            ).toBeTrue();
+        });
+
         it('should handle failure', function () {
             spyOn(RecoveryEmailForm, 'handleFormError').and.callThrough();
             RecoveryEmailForm.init();
-            document.getElementById('id_email').value = 'failure@example.com';
+            document.getElementById('id_email').value = 'ohnoes@example.com';
             document.getElementById('newsletter-submit').click();
             xhrRequests[0].respond(
                 500,

--- a/tests/unit/spec/newsletter/recovery.js
+++ b/tests/unit/spec/newsletter/recovery.js
@@ -1,0 +1,143 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import RecoveryEmailForm from '../../../../media/js/newsletter/recovery.es6';
+
+describe('RecoveryEmailForm', function () {
+    beforeEach(async function () {
+        const form = `<form method="post" action="https://basket.mozilla.org/news/recover/" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">
+        <header class="mzp-c-newsletter-header">
+          <p>Enter your email address and we’ll send you a link to your email preference center.</p>
+        </header>
+
+        <p class="mzp-c-form-errors error-email-invalid">
+          This is not a valid email address. Please check the spelling.
+        </p>
+        <p class="mzp-c-form-errors error-email-not-found">
+          This email address is not in our system. Please double check your address or <a href="/en-US/newsletter/">subscribe to our newsletters.</a>
+        </p>
+        <p class="mzp-c-form-errors error-try-again-later">
+          We are sorry, but there was a problem with our system. Please try again later!
+        </p>
+        <div class="newsletter-recovery-form-success-msg">
+          <p>Success! An email has been sent to you with your preference center link. Thanks!</p>
+        </div>
+
+        <div class="newsletter-recovery-form-fields">
+          <div class="mzp-c-field mzp-l-stretch">
+            <label for="id_email" class="mzp-c-field-label">Your email address:</label>
+            <input type="email" name="email" required="" class="mzp-c-field-control" id="id_email">
+          </div>
+          <div class="mzp-c-button-container mzp-l-stretch">
+            <button class="mzp-c-button" id="newsletter-submit" type="submit">Send me a link</button>
+          </div>
+        </div>
+      </form>`;
+        document.body.insertAdjacentHTML('beforeend', form);
+    });
+
+    afterEach(function () {
+        const form = document.getElementById('newsletter-recovery-form');
+        form.parentNode.removeChild(form);
+    });
+
+    describe('form submission', function () {
+        let xhr;
+        let xhrRequests = [];
+
+        beforeEach(function () {
+            xhr = sinon.useFakeXMLHttpRequest();
+            xhr.onCreate = (req) => {
+                xhrRequests.push(req);
+            };
+        });
+
+        afterEach(function () {
+            xhr.restore();
+            xhrRequests = [];
+        });
+
+        it('should handle success', function () {
+            spyOn(RecoveryEmailForm, 'handleFormSuccess').and.callThrough();
+            RecoveryEmailForm.init();
+            document.getElementById('id_email').value = 'success@example.com';
+            document.getElementById('newsletter-submit').click();
+            xhrRequests[0].respond(
+                200,
+                { 'Content-Type': 'application/json' },
+                '{"status": "ok"}'
+            );
+
+            expect(RecoveryEmailForm.handleFormSuccess).toHaveBeenCalled();
+            expect(
+                document
+                    .querySelector('.newsletter-recovery-form-success-msg')
+                    .classList.contains('show')
+            ).toBeTrue();
+        });
+
+        it('should handle invalid email', function () {
+            spyOn(RecoveryEmailForm, 'handleFormError').and.callThrough();
+            RecoveryEmailForm.init();
+            document.getElementById('id_email').value = 'invalid@email';
+            document.getElementById('newsletter-submit').click();
+            xhrRequests[0].respond(
+                400,
+                { 'Content-Type': 'application/json' },
+                '{"status": "error", "desc": "Invalid email address"}'
+            );
+
+            expect(RecoveryEmailForm.handleFormError).toHaveBeenCalledWith(
+                'Invalid email address'
+            );
+            expect(
+                document
+                    .querySelector('.error-email-invalid')
+                    .classList.contains('show')
+            ).toBeTrue();
+        });
+
+        it('should handle unknown email', function () {
+            spyOn(RecoveryEmailForm, 'handleFormError').and.callThrough();
+            RecoveryEmailForm.init();
+            document.getElementById('id_email').value = 'unknown@example.com';
+            document.getElementById('newsletter-submit').click();
+            xhrRequests[0].respond(
+                400,
+                { 'Content-Type': 'application/json' },
+                '{"status": "error", "desc": "Email address not known"}'
+            );
+
+            expect(RecoveryEmailForm.handleFormError).toHaveBeenCalledWith(
+                'Email address not known'
+            );
+            expect(
+                document
+                    .querySelector('.error-email-not-found')
+                    .classList.contains('show')
+            ).toBeTrue();
+        });
+
+        it('should handle failure', function () {
+            spyOn(RecoveryEmailForm, 'handleFormError').and.callThrough();
+            RecoveryEmailForm.init();
+            document.getElementById('id_email').value = 'failure@example.com';
+            document.getElementById('newsletter-submit').click();
+            xhrRequests[0].respond(
+                500,
+                { 'Content-Type': 'application/json' },
+                null
+            );
+
+            expect(RecoveryEmailForm.handleFormError).toHaveBeenCalled();
+            expect(
+                document
+                    .querySelector('.error-try-again-later')
+                    .classList.contains('show')
+            ).toBeTrue();
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Migrates the newsletter recovery form from Python to JS, which now posts directly to Basket.

## Significant changes and points to review

Did I miss any edge cases that were in the back-end code?

## Issue / Bugzilla link

#11963

## Testing

- http://localhost:8000/en-US/newsletter/recovery/
- http://localhost:8000/en-US/newsletter/opt-out-confirmation/
