### PR TITLE
changes to Pocket scope

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -133,6 +133,30 @@
     <li>shavar.services.mozilla.com</li>
   </ul>
 
+  <h2 id="pocket"><b>Pocket</b></h2>
+
+  <p>Pocket pays out bounties at a reduced rate and only if the reported bug has Critical or High severity rating. The scope for Pocket in this program is limited to the below targets. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
+
+  <ul class="mzp-u-list-styled">
+    <li>Pocket Web application under the following paths:
+      <ul>
+        <li>getpocket.com/home</li>
+        <li>getpocket.com/account</li>
+        <li>getpocket.com/discover</li>
+        <li>getpocket.com/collections</li>
+        <li>getpocket.com/my-list/*</li>
+      </ul>
+    </li>
+    <li>API endpoints listed in https://getpocket.com/developer/ which include:
+      <ul>
+        <li>getpocket.com/v3/add</li>
+        <li>getpocket.com/v3/send</li>
+        <li>getpocket.com/v3/get</li>
+      </ul>
+    </li>
+    <li>Pocket Android Application</li>
+  </ul>
+
   <h2 id="core-sites"><b>Core</b></h2>
 
   <p>Core websites pay out bounties, but at a reduced rate.</p>
@@ -164,13 +188,6 @@
   <h3>Payment Subscription</h3>
   <ul class="mzp-u-list-styled">
     <li>subscriptions.firefox.com</li>
-  </ul>
-
-  <h3>Pocket</h3>
-  <ul class="mzp-u-list-styled">
-    <li>getpocket.com</li>
-    <li>api.getpocket.com</li>
-    <li>widgets.getpocket.com</li>
   </ul>
 
   <h3>Private Relay</h3>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -169,7 +169,7 @@
   <h3 id="pocket"><b>Pocket</b></h3>
 
   <p>The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
-  <p><strong>Also note that the Pocket iOS application is currently out of scope.</strong></p>
+  <p><strong>Also note that the Pocket iOS and MacOS applications are currently out of scope.</strong></p>
 
   <ul class="mzp-u-list-styled">
     <li>Pocket Web application under the following paths:

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -133,32 +133,6 @@
     <li>shavar.services.mozilla.com</li>
   </ul>
 
-  <h2 id="pocket"><b>Pocket</b></h2>
-
-  <p>Pocket pays out bounties at a lower rate than Mozilla Critical sites. The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
-
-  <ul class="mzp-u-list-styled">
-    <li>Pocket Web application under the following paths:
-      <ul>
-        <li>getpocket.com/home</li>
-        <li>getpocket.com/account</li>
-        <li>getpocket.com/discover</li>
-        <li>getpocket.com/collections</li>
-        <li>getpocket.com/my-list/*</li>
-        <li>getpocket.com/read/*</li>
-      </ul>
-    </li>
-    <li>The following API endpoints:
-      <ul>
-        <li>getpocket.com/v3/add</li>
-        <li>getpocket.com/v3/send</li>
-        <li>getpocket.com/v3/get</li>
-      </ul>
-    </li>
-    <li>Pocket Android Application</li>
-    <li>Pocket Web Extension</li>
-  </ul>
-
   <h2 id="core-sites"><b>Core</b></h2>
 
   <p>Core websites pay out bounties, but at a reduced rate.</p>
@@ -190,6 +164,33 @@
   <h3>Payment Subscription</h3>
   <ul class="mzp-u-list-styled">
     <li>subscriptions.firefox.com</li>
+  </ul>
+
+  <h3 id="pocket"><b>Pocket</b></h3>
+
+  <p>The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
+  <p><strong>Also note that the Pocket iOS application is currently out of scope.</strong></p>
+
+  <ul class="mzp-u-list-styled">
+    <li>Pocket Web application under the following paths:
+      <ul>
+        <li>getpocket.com/home</li>
+        <li>getpocket.com/account</li>
+        <li>getpocket.com/discover</li>
+        <li>getpocket.com/collections</li>
+        <li>getpocket.com/my-list/*</li>
+        <li>getpocket.com/read/*</li>
+      </ul>
+    </li>
+    <li>The following API endpoints:
+      <ul>
+        <li>getpocket.com/v3/add</li>
+        <li>getpocket.com/v3/send</li>
+        <li>getpocket.com/v3/get</li>
+      </ul>
+    </li>
+    <li>Pocket Android Application</li>
+    <li>Pocket Web Extension</li>
   </ul>
 
   <h3>Private Relay</h3>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -145,6 +145,7 @@
         <li>getpocket.com/discover</li>
         <li>getpocket.com/collections</li>
         <li>getpocket.com/my-list/*</li>
+        <li>getpocket.com/read/*</li>
       </ul>
     </li>
     <li>API endpoints listed in https://getpocket.com/developer/ which include:

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -166,7 +166,7 @@
     <li>subscriptions.firefox.com</li>
   </ul>
 
-  <h3 id="pocket"><b>Pocket</b></h3>
+  <h3 id="pocket">Pocket</h3>
 
   <p>The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
   <p><strong>Also note that the Pocket iOS and MacOS applications are currently out of scope.</strong></p>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -135,7 +135,7 @@
 
   <h2 id="pocket"><b>Pocket</b></h2>
 
-  <p>Pocket pays out bounties at a reduced rate and only if the reported bug has Critical or High severity rating. The scope for Pocket in this program is limited to the below targets. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
+  <p>Pocket pays out bounties at a lower rate than Mozilla critical sites and only if the reported bug has Critical or High severity rating. The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
 
   <ul class="mzp-u-list-styled">
     <li>Pocket Web application under the following paths:
@@ -148,7 +148,7 @@
         <li>getpocket.com/read/*</li>
       </ul>
     </li>
-    <li>API endpoints listed in https://getpocket.com/developer/ which include:
+    <li>The following API endpoints:
       <ul>
         <li>getpocket.com/v3/add</li>
         <li>getpocket.com/v3/send</li>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -135,7 +135,7 @@
 
   <h2 id="pocket"><b>Pocket</b></h2>
 
-  <p>Pocket pays out bounties at a lower rate than Mozilla critical sites and only if the reported bug has Critical or High severity rating. The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
+  <p>Pocket pays out bounties at a lower rate than Mozilla Critical sites. The scope for Pocket in this program is limited to the targets below. Any API endpoint or path not explicitly mentioned is considered out of scope.</p>
 
   <ul class="mzp-u-list-styled">
     <li>Pocket Web application under the following paths:
@@ -156,6 +156,7 @@
       </ul>
     </li>
     <li>Pocket Android Application</li>
+    <li>Pocket Web Extension</li>
   </ul>
 
   <h2 id="core-sites"><b>Core</b></h2>

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -144,6 +144,7 @@
     <li>Vulnerabilities discovered shortly after their public release</li>
     <li>Outdated TLS configurations which remain to support downloads from Windows XP systems</li>
     <li><b>Blind</b> SSRF reports on services that are designed to load resources from the internet</li>
+    <li>Pocket MacOS application</li>
     <li>Pocket iOS application until further notice</li>
   </ul>
 

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -144,6 +144,7 @@
     <li>Vulnerabilities discovered shortly after their public release</li>
     <li>Outdated TLS configurations which remain to support downloads from Windows XP systems</li>
     <li><b>Blind</b> SSRF reports on services that are designed to load resources from the internet</li>
+    <li>Pocket iOS application until further notice</li>
   </ul>
 
   <h2 id="how-to-submit-bugs">How To Submit Bugs</h2>


### PR DESCRIPTION
## One-line summary

This changeset explicitly defines the scope for Pocket in the web bug bounty.

## Screenshots


<img width="500" alt="image" src="https://user-images.githubusercontent.com/95376064/184664614-a8c97d77-574e-4fac-84f7-7a4f19ae4394.png">


