### PR TITLE
Fix broken Firefox mobile page (Fixes #12025)

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -12,6 +12,8 @@
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 
 {% block page_css %}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('firefox-mobile') }}
 
   {% if show_firefox_app_store_banner %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -789,3 +789,34 @@ class TestSMSSendToDevice(TestCase):
         data = resp.json()
         assert not data["success"]
         assert data["errors"] == ["SMS not configured"]
+
+
+@override_settings(DEV=False)
+@patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
+class TestFirefoxMobile(TestCase):
+    @patch.object(views, "ftl_file_is_active", lambda *x: True)
+    def test_landing_template(self, render_mock):
+        req = RequestFactory().get("/firefox/browsers/mobile/")
+        req.locale = "en-US"
+        view = views.FirefoxMobileView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/browsers/mobile/index.html"]
+
+    @patch.object(views, "ftl_file_is_active", lambda *x: False)
+    def test_legacy_template(self, render_mock):
+        req = RequestFactory().get("/firefox/browsers/mobile/")
+        req.locale = "en-US"
+        view = views.FirefoxMobileView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/mobile/index.html"]
+
+    @patch.object(views, "ftl_file_is_active", lambda *x: True)
+    def test_legacy_template_param(self, render_mock):
+        req = RequestFactory().get("/firefox/browsers/mobile/?xv=legacy")
+        req.locale = "en-US"
+        view = views.FirefoxMobileView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/mobile/index.html"]

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -1059,7 +1059,9 @@ class FirefoxMobileView(L10nTemplateView):
     ]
 
     def get_template_names(self):
-        if ftl_file_is_active("firefox/browsers/mobile/index"):
+        experience = self.request.GET.get("xv", None)
+
+        if ftl_file_is_active("firefox/browsers/mobile/index") and experience != "legacy":
             template = "firefox/browsers/mobile/index.html"
         else:
             template = "firefox/mobile/index.html"

--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -126,7 +126,9 @@ main .mzp-l-content {
     }
 
     .mzp-c-emphasis-box {
-        align-self: center;
+        margin: 0 auto $spacing-xl;
+        max-width: 350px;
+        padding: $spacing-lg $spacing-2xl;
     }
 }
 

--- a/tests/functional/firefox/browsers/mobile/test_landing.py
+++ b/tests/functional/firefox/browsers/mobile/test_landing.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.browsers.mobile_landing import FirefoxMobilePage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_links_displayed(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url, params="?xv=current").open()
+    assert page.is_android_download_link_displayed
+    assert page.is_ios_download_link_displayed
+    page.focus_menu_list.click()
+    assert page.focus_menu_list.list_is_open
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_send_to_device_success(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url, params="?xv=legacy").open()
+    send_to_device = page.send_to_device
+    send_to_device.type_email("success@example.com")
+    send_to_device.click_send()
+    assert send_to_device.send_successful
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_send_to_device_failure(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url, params="?xv=legacy").open()
+    send_to_device = page.send_to_device
+    send_to_device.type_email("invalid@email")
+    send_to_device.click_send(expected_result="error")
+    assert send_to_device.is_form_error_displayed

--- a/tests/pages/firefox/browsers/mobile_landing.py
+++ b/tests/pages/firefox/browsers/mobile_landing.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.menu_list import MenuList
+from pages.regions.send_to_device import SendToDevice
+
+
+class FirefoxMobilePage(BasePage):
+
+    _URL_TEMPLATE = "/{locale}/firefox/browsers/mobile/{params}"
+
+    _android_download_link_locator = (By.ID, "android-download")
+    _ios_download_link_locator = (By.ID, "ios-download")
+    _focus_menu_list_locator = (By.ID, "menu-focus-wrapper")
+
+    @property
+    def focus_menu_list(self):
+        el = self.find_element(*self._focus_menu_list_locator)
+        return MenuList(self, root=el)
+
+    @property
+    def send_to_device(self):
+        return SendToDevice(self)
+
+    @property
+    def is_android_download_link_displayed(self):
+        return self.is_element_displayed(*self._android_download_link_locator)
+
+    @property
+    def is_ios_download_link_displayed(self):
+        return self.is_element_displayed(*self._ios_download_link_locator)


### PR DESCRIPTION
## One-line summary

- Fixes Firefox mobile page
- Adds integration tests

## Issue / Bugzilla link

#12025

## Testing

- http://localhost:8000/en-US/firefox/browsers/mobile/?xv=legacy
- http://localhost:8000/en-US/firefox/browsers/mobile/
