### PR TITLE
2022-08-15 Dependency bumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ check-requirements: .docker-build-pull
 ######################################################
 
 install-local-python-deps:
-	# Dev requirements are a superset of prod requirements, but we install in
+	# Dev requirements are a superset of prod requirements, but we install
 	# them in the same separate steps that we use for our Docker-based build,
 	# so that it mirrors Production and Dev image building
 	pip install -r requirements/prod.txt

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ help:
 	@echo "  compile-requirements       - update Python requirements files using pip-compile"
 	@echo "  check-requirements         - get a report on stale/old Python dependencies in use"
 	@echo "  install-local-python-deps  - install Python dependencies for local development"
+	@echo "  install-local-docs-deps  	- install Python dependencies for documentation building"
 
 .env:
 	@if [ ! -f .env ]; then \
@@ -165,7 +166,13 @@ check-requirements: .docker-build-pull
 ######################################################
 
 install-local-python-deps:
-	# Dev requirements are a superset of prod requirements
+	# Dev requirements are a superset of prod requirements, but we install in
+	# them in the same separate steps that we use for our Docker-based build,
+	# so that it mirrors Production and Dev image building
+	pip install -r requirements/prod.txt
 	pip install -r requirements/dev.txt
 
-.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod run-pocket run-pocket-prod build-prod test-cdn compile-requirements check-requirements install-local-python-deps
+install-local-docs-deps: install-local-python-deps
+	pip install -r requirements/docs.txt
+
+.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod run-pocket run-pocket-prod build-prod test-cdn compile-requirements check-requirements install-local-python-deps install-local-docs-deps

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,13 +88,13 @@ blessings==1.7 \
     --hash=sha256:b1fdd7e7a675295630f9ae71527a8ebc10bfefa236b3d6aa4932ee4462c17ba3 \
     --hash=sha256:caad5211e7ba5afe04367cdd4cfc68fa886e2e08f6f35e76b7387d2109ccea6e
     # via curtsies
-boto3==1.24.36 \
-    --hash=sha256:8844bbcb69ac0afc68225b58abe105852231cf1b562e6c8c9eb6b2b97fd4757a \
-    --hash=sha256:b1855ede59e725b968d6336908ffc864b65985ca441d730625b09c43ccd6413b
+boto3==1.24.46 \
+    --hash=sha256:44026e44549148dbc5b261ead5f6b339e785680c350ef621bf85f7e2fca05b49 \
+    --hash=sha256:b2d9d55f123a9a91eea2fd8e379d90abf37634420fbb45c22d67e10b324ec71b
     # via -r requirements/prod.txt
-botocore==1.27.36 \
-    --hash=sha256:3119ce186053b9bf6bd0bd0ad19a8cedeb626b205ce6ad26ea0894634f702cd5 \
-    --hash=sha256:8109526f55742539d2311d742b40c89e65781ad18966e577dda360cd55c9d047
+botocore==1.27.51 \
+    --hash=sha256:328d2baca30e66016acdf9ad3c5e6fa6522fca249f54c5affce8774c0faa564f \
+    --hash=sha256:4ba1678bc78fbdac9a7e1c010b057ad9ed96dc6534d1c82718af08d746b652ed
     # via
     #   -r requirements/prod.txt
     #   boto3
@@ -587,9 +587,9 @@ lxml==4.9.1 \
     #   -r requirements/prod.txt
     #   pyquery
     #   translate-toolkit
-markdown==3.3.6 \
-    --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
-    --hash=sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3
+markdown==3.4.1 \
+    --hash=sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186 \
+    --hash=sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff
     # via
     #   -r requirements/prod.txt
     #   django-jinja-markdown
@@ -727,9 +727,9 @@ pathspec==0.9.0 \
     #   -r requirements/prod.txt
     #   black
     #   yamllint
-phonenumberslite==8.12.52 \
-    --hash=sha256:8cfee539ebcbe2874e8f0bdfe753e60265c198b33f8bfeb57f0fc59ba55c6d74 \
-    --hash=sha256:ade5346ac9f7ed0289d69ffc9e9f3f84b56b2b7010aa23fecf7bb22140b170d5
+phonenumberslite==8.12.53 \
+    --hash=sha256:e1e16ff056127ae9ccf7a2ca78050dbe2ee43321d8a5ea20704752a2f46b8a9a \
+    --hash=sha256:ece2f65b16f00bd8dda0cc6b0eb3d3d3d0cfae348d6c8f9fafd47882841546d7
     # via -r requirements/prod.txt
 pillow==9.2.0 \
     --hash=sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927 \
@@ -1083,9 +1083,9 @@ selenium==4.1.3 \
 sentry-processor==0.0.1 \
     --hash=sha256:fd7a30fb57aaf05c01cd04cf7d949c628376b2b55d7a0aaa222efe58a8f122bc
     # via -r requirements/prod.txt
-sentry-sdk==1.8.0 \
-    --hash=sha256:5daae00f91dd72d9bb1a65307221fe291417a7b9c30527de3a6f0d9be4ddf08d \
-    --hash=sha256:9c68e82f7b1ad78aee6cdef57c2c0f6781ddd9ffa8848f4503c5a8e02b360eea
+sentry-sdk==1.9.2 \
+    --hash=sha256:011155f11ab828a977fe8a60c5b534c30f49d70c9938362536d206bb230bb519 \
+    --hash=sha256:9921e76e29135aa1fa65fe231aaaef47355f85470c5ec59ce32715e22e6340b6
     # via -r requirements/prod.txt
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -1166,9 +1166,9 @@ trio-websocket==0.9.2 \
     --hash=sha256:5b558f6e83cc20a37c3b61202476c5295d1addf57bd65543364e0337e37ed2bc \
     --hash=sha256:a3d34de8fac26023eee701ed1e7bf4da9a8326b61a62934ec9e53b64970fd8fe
     # via selenium
-twilio==7.12.0 \
-    --hash=sha256:1f070cf041938a1848603fe3beabf03625d8686810664d0525347e0398211323 \
-    --hash=sha256:ba79ab89fbed67caae02cf027dfb17776f3aa875edcc30d031e15ade40b3b0b5
+twilio==7.12.1 \
+    --hash=sha256:da92f00c1ed4dbe448d2ce92356995cb5a47d865e3ff9127d3f69ef15c9eb2bb \
+    --hash=sha256:e93b6850724cc0fa45ad6bb7039ab8ff10340576471b349c2875dd43c4ab4022
     # via -r requirements/prod.txt
 typing-extensions==4.1.1 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
@@ -1188,9 +1188,9 @@ tzlocal==4.1 \
     # via
     #   -r requirements/prod.txt
     #   apscheduler
-urllib3[secure,socks]==1.26.9 \
-    --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
-    --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
+urllib3[secure,socks]==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
     # via
     #   -r requirements/prod.txt
     #   botocore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -587,9 +587,9 @@ lxml==4.9.1 \
     #   -r requirements/prod.txt
     #   pyquery
     #   translate-toolkit
-markdown==3.4.1 \
-    --hash=sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186 \
-    --hash=sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff
+markdown==3.3.6 \
+    --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
+    --hash=sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3
     # via
     #   -r requirements/prod.txt
     #   django-jinja-markdown

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,9 +1,9 @@
-chardet==4.0.0
+chardet==5.0.0
 fluent.pygments==0.1.0
 fluent.syntax==0.17.0  # hard-pinned subdep to avoid compatibility issues
 markupsafe==2.0.1
 myst-parser==0.18.0
-Sphinx==4.5.0
+Sphinx==5.1.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.0
 sphinx-rtd-theme==1.0.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,9 +20,9 @@ certifi==2021.10.8 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
     --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569
     # via requests
-chardet==4.0.0 \
-    --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
-    --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
+chardet==5.0.0 \
+    --hash=sha256:0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa \
+    --hash=sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557
     # via -r requirements/docs.in
 charset-normalizer==2.0.12 \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
@@ -228,9 +228,9 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via sphinx
-sphinx==4.5.0 \
-    --hash=sha256:7bf8ca9637a4ee15af412d1a1d9689fec70523a68ca9bb9127c2f3eeb344e2e6 \
-    --hash=sha256:ebf612653238bcc8f4359627a9b7ce44ede6fdd75d9d30f68255c7383d3a6226
+sphinx==5.1.1 \
+    --hash=sha256:309a8da80cb6da9f4713438e5b55861877d5d7976b69d87e336733637ea12693 \
+    --hash=sha256:ba3224a4e206e1fbdecf98a4fae4992ef9b24b85ebf7b584bb340156eaf08d89
     # via
     #   -r requirements/docs.in
     #   myst-parser

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -3,7 +3,7 @@ babis==0.2.4
 basket-client==1.0.0
 beautifulsoup4==4.11.1
 bleach[css]==5.0.1
-boto3==1.24.36
+boto3==1.24.46
 chardet==5.0.0
 commonware==0.6.0
 contentful==1.13.1
@@ -33,12 +33,12 @@ honcho==1.1.0
 html5lib==1.1
 jinja2==3.1.2  # Moved to top-level dep to control its upgrade, to avoid breaking changes later if glean-parser updates it
 lxml==4.9.1  # Needed as a top-level dep so that it's available for BeautifulSoup, which doesn't explicitly pull it in
-Markdown==3.3.6
+Markdown==3.4.1
 https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz#egg=mdx_outline
 markupsafe==2.0.1
 meinheld==1.0.2
 newrelic==7.16.0.178
-phonenumberslite==8.12.52
+phonenumberslite==8.12.53
 Pillow==9.2.0
 PyGithub==1.55
 pyjwt>=2.4.0  # subdep of PyGithub and Twilio but needs to be > 2.3.0
@@ -49,9 +49,9 @@ qrcode==7.3.1
 querystringsafe-base64==1.1.1
 requests-oauthlib==1.3.1
 rich-text-renderer==0.2.4
-sentry-sdk==1.8.0
+sentry-sdk==1.9.2
 sentry-processor==0.0.1
 supervisor==4.2.4
 timeago==1.0.15
-twilio==7.12.0
+twilio==7.12.1
 whitenoise==6.2.0

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -33,7 +33,7 @@ honcho==1.1.0
 html5lib==1.1
 jinja2==3.1.2  # Moved to top-level dep to control its upgrade, to avoid breaking changes later if glean-parser updates it
 lxml==4.9.1  # Needed as a top-level dep so that it's available for BeautifulSoup, which doesn't explicitly pull it in
-Markdown==3.4.1
+Markdown==3.3.6
 https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz#egg=mdx_outline
 markupsafe==2.0.1
 meinheld==1.0.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -386,9 +386,9 @@ lxml==4.9.1 \
     --hash=sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8 \
     --hash=sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f
     # via -r requirements/prod.in
-markdown==3.4.1 \
-    --hash=sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186 \
-    --hash=sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff
+markdown==3.3.6 \
+    --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
+    --hash=sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3
     # via
     #   -r requirements/prod.in
     #   django-jinja-markdown

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -42,13 +42,13 @@ bleach[css]==5.0.1 \
     --hash=sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a \
     --hash=sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c
     # via -r requirements/prod.in
-boto3==1.24.36 \
-    --hash=sha256:8844bbcb69ac0afc68225b58abe105852231cf1b562e6c8c9eb6b2b97fd4757a \
-    --hash=sha256:b1855ede59e725b968d6336908ffc864b65985ca441d730625b09c43ccd6413b
+boto3==1.24.46 \
+    --hash=sha256:44026e44549148dbc5b261ead5f6b339e785680c350ef621bf85f7e2fca05b49 \
+    --hash=sha256:b2d9d55f123a9a91eea2fd8e379d90abf37634420fbb45c22d67e10b324ec71b
     # via -r requirements/prod.in
-botocore==1.27.36 \
-    --hash=sha256:3119ce186053b9bf6bd0bd0ad19a8cedeb626b205ce6ad26ea0894634f702cd5 \
-    --hash=sha256:8109526f55742539d2311d742b40c89e65781ad18966e577dda360cd55c9d047
+botocore==1.27.51 \
+    --hash=sha256:328d2baca30e66016acdf9ad3c5e6fa6522fca249f54c5affce8774c0faa564f \
+    --hash=sha256:4ba1678bc78fbdac9a7e1c010b057ad9ed96dc6534d1c82718af08d746b652ed
     # via
     #   boto3
     #   s3transfer
@@ -386,9 +386,9 @@ lxml==4.9.1 \
     --hash=sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8 \
     --hash=sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f
     # via -r requirements/prod.in
-markdown==3.3.6 \
-    --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
-    --hash=sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3
+markdown==3.4.1 \
+    --hash=sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186 \
+    --hash=sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff
     # via
     #   -r requirements/prod.in
     #   django-jinja-markdown
@@ -503,9 +503,9 @@ pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
     --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
     # via yamllint
-phonenumberslite==8.12.52 \
-    --hash=sha256:8cfee539ebcbe2874e8f0bdfe753e60265c198b33f8bfeb57f0fc59ba55c6d74 \
-    --hash=sha256:ade5346ac9f7ed0289d69ffc9e9f3f84b56b2b7010aa23fecf7bb22140b170d5
+phonenumberslite==8.12.53 \
+    --hash=sha256:e1e16ff056127ae9ccf7a2ca78050dbe2ee43321d8a5ea20704752a2f46b8a9a \
+    --hash=sha256:ece2f65b16f00bd8dda0cc6b0eb3d3d3d0cfae348d6c8f9fafd47882841546d7
     # via -r requirements/prod.in
 pillow==9.2.0 \
     --hash=sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927 \
@@ -716,9 +716,9 @@ s3transfer==0.6.0 \
 sentry-processor==0.0.1 \
     --hash=sha256:fd7a30fb57aaf05c01cd04cf7d949c628376b2b55d7a0aaa222efe58a8f122bc
     # via -r requirements/prod.in
-sentry-sdk==1.8.0 \
-    --hash=sha256:5daae00f91dd72d9bb1a65307221fe291417a7b9c30527de3a6f0d9be4ddf08d \
-    --hash=sha256:9c68e82f7b1ad78aee6cdef57c2c0f6781ddd9ffa8848f4503c5a8e02b360eea
+sentry-sdk==1.9.2 \
+    --hash=sha256:011155f11ab828a977fe8a60c5b534c30f49d70c9938362536d206bb230bb519 \
+    --hash=sha256:9921e76e29135aa1fa65fe231aaaef47355f85470c5ec59ce32715e22e6340b6
     # via -r requirements/prod.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -752,9 +752,9 @@ tinycss2==1.1.1 \
     --hash=sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf \
     --hash=sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8
     # via bleach
-twilio==7.12.0 \
-    --hash=sha256:1f070cf041938a1848603fe3beabf03625d8686810664d0525347e0398211323 \
-    --hash=sha256:ba79ab89fbed67caae02cf027dfb17776f3aa875edcc30d031e15ade40b3b0b5
+twilio==7.12.1 \
+    --hash=sha256:da92f00c1ed4dbe448d2ce92356995cb5a47d865e3ff9127d3f69ef15c9eb2bb \
+    --hash=sha256:e93b6850724cc0fa45ad6bb7039ab8ff10340576471b349c2875dd43c4ab4022
     # via -r requirements/prod.in
 tzdata==2021.5 \
     --hash=sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5 \
@@ -764,9 +764,9 @@ tzlocal==4.1 \
     --hash=sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09 \
     --hash=sha256:28ba8d9fcb6c9a782d6e0078b4f6627af1ea26aeaa32b4eab5324abc7df4149f
     # via apscheduler
-urllib3==1.26.9 \
-    --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
-    --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
+urllib3==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
## One-line summary

This changeset updates dependencies for main Bedrock and also for the docs site.

## Significant changes and points to review

* Most of it is pretty standard. I've checked `Sphinx` builds the docs ok and it does.

* Note that the `urllib3` upgrade clashes for the docs install - Sphinx wants and gets a lower version than sentry-sdk asks for, but docs generation doesn't need sentry-sdk anyway. We should look to build out a separate docs image that doesn't also need the dev deps, but it's not a big deal as-is.

## Issue / Bugzilla link

Resolves #12033 Bump boto3 from 1.24.36 to 1.24.51 in /requirements
Resolves #12032 Bump sentry-sdk from 1.8.0 to 1.9.4 in /requirements
Resolves #12031 Bump twilio from 7.12.0 to 7.12.1 in /requirements
Resolves #12008 Bump phonenumberslite from 8.12.52 to 8.12.53 in /requirements
Resolves #11989 Bump sphinx from 4.5.0 to 5.1.1 in /requirements
Resolves #11988 Bump chardet from 4.0.0 to 5.0.0 in /requirements
Resolves #11985 Bump urllib3 from 1.26.8 to 1.26.11 in /requirements

## Testing

To test:

- [ ] Confirm Integration tests passing [bedrock build](https://gitlab.com/mozmeao/bedrock/-/pipelines/613697246) and [www-config test](https://gitlab.com/mozmeao/www-config/-/pipelines/613703372)
- [ ] Make a new bedrock virtualenv (or empty out your existing one with `pip uninstall mdx_outline && pip freeze | xargs pip uninstall -y`)
- [ ] Pull this branch and run `make install-local-python-deps` in 
- [ ] run make `install-local-docs-deps` and confirm they go in fine, too, albeit with the `urllib` warning mentioned above