### PR TITLE
Leadership page, delete extra period [no bug]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/index.html
@@ -254,7 +254,7 @@
         Officer at Hearsay Systems, a mid-sized startup with offices around the
         world. She also spent more than five years at Netflix where she supported
         a variety of teams including a two year assignment scaling the Netflix
-        culture to Amsterdam, their first office outside the U.S..</p>
+        culture to Amsterdam, their first office outside the U.S.</p>
 
       <p>Kristen lives in San Francisco and is passionate about travel and exploring
         new places and cultures. She also serves on the board of The Orchard at


### PR DESCRIPTION
## One-line summary

Removes an extraneous dot.

## Testing

http://localhost:8000/en-US/about/leadership/#kristen-trubey
