### PR TITLE
Make data privacy prefs page work across '.mozilla.org' domains (Fixes #12056)

### DIFF
--- a/bedrock/privacy/templates/privacy/data-preferences.html
+++ b/bedrock/privacy/templates/privacy/data-preferences.html
@@ -6,9 +6,8 @@
 
 {% extends "base-protocol.html" %}
 
-{% block page_title %}Manage your first-party data collection preferences{% endblock %}
-
-{% block page_desc %}Your privacy is very important to Mozilla. This page will enable you to manage your first-party data collection preferences for www.mozilla.org.{% endblock %}
+{% block page_title %}{{ ftl('data-preferences-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('data-preferecnes-page-desc') }}{% endblock %}
 
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
@@ -17,60 +16,49 @@
 {% endblock %}
 
 {% block string_data %}
-  data-notification-opt-out='You are opted out of first-party data collection.'
-  data-notification-opt-in='You are opted in to first-party data collection.'
+  data-notification-opt-out="{{ ftl('data-preferecnes-notification-opt-out') }}"
+  data-notification-opt-in="{{ ftl('data-preferecnes-notification-opt-in') }}"
 {% endblock %}
 
 {% block content %}
 <div class="mzp-l-content">
   <article class="mzp-c-article">
-    <h1 class="mzp-c-article-title">Manage your first-party data collection preferences</h1>
+    <h1 class="mzp-c-article-title">{{ ftl('data-preferences-page-title') }}</h1>
 
     <p>
-      {% with glean='https://docs.telemetry.mozilla.org/concepts/glean/glean.html',
-              lean_data=url('mozorg.about.policy.lean-data.index') %}
-        Your privacy is very important to Mozilla. Our first-party telemetry and analytics platform,
-        called <a href="{{ glean }}">Glean</a>, follows our own high standards for
-        <a href="{{ lean_data }}">lean data practices</a>.
-      {% endwith %}
+      {{ ftl('data-preferences-your-privacy',
+        glean='https://docs.telemetry.mozilla.org/concepts/glean/glean.html',
+        lean_data=url('mozorg.about.policy.lean-data.index'))
+      }}
     </p>
     <p>
-      {% with mozorg=url('mozorg.home'),
-              privacy_notice=url('privacy.notices.websites'),
-              dictionary='https://dictionary.telemetry.mozilla.org/' %}
-        Mozilla uses Glean to collect website usage data on <a href="{{ mozorg }}">www.mozilla.org</a>
-        in order to ensure that we’re delivering the best possible user experience for our visitors.
-        Glean does not share information with any third parties outside of Mozilla. Every piece of
-        data we collect also goes through a strict review process. You can learn more about the
-        specific types of data we collect in the <a href="{{ dictionary }}">Glean Dictionary</a>.
-        For more information about the way we handle and share your data on www.mozilla.org, you can
-        read our <a href="{{ privacy_notice }}">Websites, Communications and Cookies Privacy Notice</a>.
-      {% endwith %}
+      {{ ftl('data-preferences-mozilla-uses',
+        dictionary='https://dictionary.telemetry.mozilla.org/',
+        privacy_notice=url('privacy.notices.websites'))
+      }}
     </p>
 
     <p>
-      If you still want to opt-out of first-party analytics on www.mozilla.org, you can do so below.
-      Clicking the opt-out button will set a preference cookie that is used to prevent it from initializing
-      when you load our web pages. This preference cookie will last for 1 year.
+      {{ ftl('data-preferences-if-you-still-want-to') }}
     </p>
 
     <p id="data-preference-status" class="data-preference-status">
-      <strong>Current preference: </strong>
-      <noscript>Please enable JavaScript to manage your data preference.</noscript>
+      <strong>{{ ftl('data-preferences-current-preference') }}</strong>
+      <noscript>{{ ftl('data-preferences-please-enable-javascript') }}</noscript>
       <span class="data-preference-text"></span>
     </p>
 
     <p>
-      <button type="button" class="mzp-c-button mzp-t-neutral js-opt-out-button" aria-controls="data-preference-status">
-        Opt-out of first-party data collection
+      <button type="button" class="mzp-c-button js-opt-out-button" aria-controls="data-preference-status">
+        {{ ftl('data-preferences-opt-out-button') }}
       </button>
     </p>
 
-    <p>If you change your mind, you can opt-in again here:</p>
+    <p>{{ ftl('data-preferences-if-you-change') }}</p>
 
     <p>
-      <button type="button" class="mzp-c-button mzp-t-neutral js-opt-in-button" aria-controls="data-preference-status">
-        Opt-in to first-party data collection
+      <button type="button" class="mzp-c-button js-opt-in-button" aria-controls="data-preference-status">
+        {{ ftl('data-preferences-opt-in-button') }}
       </button>
     </p>
   </article>

--- a/bedrock/privacy/templates/privacy/data-preferences.html
+++ b/bedrock/privacy/templates/privacy/data-preferences.html
@@ -7,7 +7,7 @@
 {% extends "base-protocol.html" %}
 
 {% block page_title %}{{ ftl('data-preferences-page-title') }}{% endblock %}
-{% block page_desc %}{{ ftl('data-preferecnes-page-desc') }}{% endblock %}
+{% block page_desc %}{{ ftl('data-preferences-page-desc') }}{% endblock %}
 
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
@@ -16,8 +16,8 @@
 {% endblock %}
 
 {% block string_data %}
-  data-notification-opt-out="{{ ftl('data-preferecnes-notification-opt-out') }}"
-  data-notification-opt-in="{{ ftl('data-preferecnes-notification-opt-in') }}"
+  data-notification-opt-out="{{ ftl('data-preferences-notification-opt-out') }}"
+  data-notification-opt-in="{{ ftl('data-preferences-notification-opt-in') }}"
 {% endblock %}
 
 {% block content %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -22,7 +22,7 @@ urlpatterns = (
     path("hubs/", views.hubs_notices, name="privacy.notices.hubs"),
     path("thunderbird/", views.thunderbird_notices, name="privacy.notices.thunderbird"),
     path("websites/", views.websites_notices, name="privacy.notices.websites"),
-    page("websites/data-preferences/", "privacy/data-preferences.html"),
+    page("websites/data-preferences/", "privacy/data-preferences.html", ftl_files=["privacy/data-preferences"]),
     path("facebook/", views.facebook_notices, name="privacy.notices.facebook"),
     path("firefox-monitor/", views.firefox_monitor_notices, name="privacy.notices.firefox-monitor"),
     path("firefox-private-network/", views.firefox_private_network, name="privacy.notices.firefox-private-network"),

--- a/docs/analytics.rst
+++ b/docs/analytics.rst
@@ -260,7 +260,18 @@ For non-interaction events that are not user initiated:
         });
     }
 
+Glean opt-out page
+~~~~~~~~~~~~~~~~~~
+
+Website visitors can opt out of Glean by visiting the first party `data preferences page`_,
+which is linked to in the `websites privacy notice`_. Clicking opt-out will set a
+cookie which Glean checks for before initialising on page load. In production, the
+cookie that is set applies for all ``.mozilla.org`` domains, so other sites such as
+``developer.mozilla.org`` can also make use of the opt-out mechanism.
+
 .. _Glean: https://docs.telemetry.mozilla.org/concepts/glean/glean.html
 .. _Glean Book: https://mozilla.github.io/glean/book/index.html
 .. _Glean debug dashboard: https://debug-ping-preview.firebaseapp.com/
 .. _data review: https://wiki.mozilla.org/Data_Collection
+.. _data preferences page: https://www.mozilla.org/privacy/websites/data-preferences/
+.. _websites privacy notice: https://www.mozilla.org/privacy/websites/

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -96,6 +96,7 @@
 ## Mozilla projects
 
 -brand-name-bugzilla = Bugzilla
+-brand-name-glean = Glean
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-developer-network = Mozilla Developer Network
 -brand-name-mozilla-festival = Mozilla Festival

--- a/l10n/en/privacy/data-preferences.ftl
+++ b/l10n/en/privacy/data-preferences.ftl
@@ -5,9 +5,9 @@
 ### URL: https://www-dev.allizom.org/privacy/websites/data-preferences/
 
 data-preferences-page-title = Manage your first-party data collection preferences
-data-preferecnes-page-desc = Your privacy is very important to { -brand-name-mozilla }. This page will enable you to manage your first-party data collection preferences for mozilla.org websites using { -brand-name-glean }.
-data-preferecnes-notification-opt-out = You are opted out of first-party data collection.
-data-preferecnes-notification-opt-in = You are opted in to first-party data collection.
+data-preferences-page-desc = Your privacy is very important to { -brand-name-mozilla }. This page will enable you to manage your first-party data collection preferences for mozilla.org websites using { -brand-name-glean }.
+data-preferences-notification-opt-out = You are opted out of first-party data collection.
+data-preferences-notification-opt-in = You are opted in to first-party data collection.
 
 # Variables:
 #   $glean (url) - link to https://docs.telemetry.mozilla.org/concepts/glean/glean.html

--- a/l10n/en/privacy/data-preferences.ftl
+++ b/l10n/en/privacy/data-preferences.ftl
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/privacy/websites/data-preferences/
+
+data-preferences-page-title = Manage your first-party data collection preferences
+data-preferecnes-page-desc = Your privacy is very important to { -brand-name-mozilla }. This page will enable you to manage your first-party data collection preferences for mozilla.org websites using { -brand-name-glean }.
+data-preferecnes-notification-opt-out = You are opted out of first-party data collection.
+data-preferecnes-notification-opt-in = You are opted in to first-party data collection.
+
+# Variables:
+#   $glean (url) - link to https://docs.telemetry.mozilla.org/concepts/glean/glean.html
+#   $lean_data (url) - link to https://www.mozilla.org/about/policy/lean-data/
+data-preferences-your-privacy = Your privacy is very important to { -brand-name-mozilla }. Our first-party telemetry and analytics platform, called <a href="{ $glean }">{ -brand-name-glean }</a>, follows our own high standards for <a href="{ $lean_data }">lean data practices</a>.
+
+# Variables:
+#   $dictionary (url) - link to https://dictionary.telemetry.mozilla.org/
+#   $privacy_notice (url) - link to https://www.mozilla.org/privacy/websites/
+data-preferences-mozilla-uses = { -brand-name-mozilla } uses { -brand-name-glean } to collect website usage data on some mozilla.org websites in order to ensure that we’re delivering the best possible user experience for our visitors. { -brand-name-glean } does not share information with any third parties. Every piece of data we collect also goes through a strict review process. You can learn more about the specific types of data we collect in the <a href="{ $dictionary }">{ -brand-name-glean } Dictionary</a>. For more information about the way we handle and share your data on Mozilla websites, you can read our <a href="{ $privacy_notice }">Websites, Communications and Cookies Privacy Notice</a>.
+
+data-preferences-if-you-still-want-to = If you still want to opt-out of first-party analytics you can do so below. Clicking the opt-out button will set a preference cookie that is used to prevent { -brand-name-glean } from sending data when you load our web pages. This preference cookie will last for 1 year.
+
+data-preferences-current-preference = Current preference:
+data-preferences-please-enable-javascript = Please enable JavaScript to manage your data preference.
+data-preferences-opt-out-button = Opt-out of first-party data collection
+data-preferences-if-you-change = If you change your mind, you can opt-in again here:
+data-preferences-opt-in-button = Opt-in to first-party data collection

--- a/media/js/privacy/data-preferences-cookie.es6.js
+++ b/media/js/privacy/data-preferences-cookie.es6.js
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const preferenceCookieID = 'moz-1st-party-data-opt-out';
+
+const DataPreferencesCookie = {};
+
+DataPreferencesCookie.doOptOut = function () {
+    if (DataPreferencesCookie.hasOptedOut()) {
+        return;
+    }
+
+    const date = new Date();
+    const cookieDuration = 365 * 24 * 60 * 60 * 1000; // 1 year expiration
+    const domain = DataPreferencesCookie.getCookieDomain();
+    date.setTime(date.getTime() + cookieDuration);
+    window.Mozilla.Cookies.setItem(
+        preferenceCookieID,
+        'true',
+        date.toUTCString(),
+        '/',
+        domain,
+        false,
+        'lax'
+    );
+};
+
+DataPreferencesCookie.doOptIn = function () {
+    if (!DataPreferencesCookie.hasOptedOut()) {
+        return;
+    }
+
+    const domain = DataPreferencesCookie.getCookieDomain();
+    window.Mozilla.Cookies.removeItem(
+        preferenceCookieID,
+        '/',
+        domain,
+        false,
+        'lax'
+    );
+};
+
+DataPreferencesCookie.hasOptedOut = function () {
+    return window.Mozilla.Cookies.hasItem(preferenceCookieID);
+};
+
+/**
+ * When in production specify we '.mozilla.org' instead of 'www.mozilla.org'
+ * so that external Mozilla websites can use the opt-out cookie (issue #12056).
+ * @param {url} used for testing purposes only.
+ * @returns {domain} string or null.
+ */
+DataPreferencesCookie.getCookieDomain = function (url) {
+    const siteUrl = typeof url === 'string' ? url : window.location.href;
+    let domain = null;
+
+    if (siteUrl.indexOf('www.allizom.org') !== -1) {
+        domain = '.allizom.org';
+    }
+
+    if (siteUrl.indexOf('www.mozilla.org') !== -1) {
+        domain = '.mozilla.org';
+    }
+
+    return domain;
+};
+
+export default DataPreferencesCookie;

--- a/media/js/privacy/data-preferences-cookie.es6.js
+++ b/media/js/privacy/data-preferences-cookie.es6.js
@@ -48,7 +48,7 @@ DataPreferencesCookie.hasOptedOut = function () {
 };
 
 /**
- * When in production specify we '.mozilla.org' instead of 'www.mozilla.org'
+ * When in production specify '.mozilla.org' instead of 'www.mozilla.org'
  * so that external Mozilla websites can use the opt-out cookie (issue #12056).
  * @param {url} used for testing purposes only.
  * @returns {domain} string or null.

--- a/media/js/privacy/data-preferences-init.es6.js
+++ b/media/js/privacy/data-preferences-init.es6.js
@@ -4,67 +4,38 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const preferenceCookieID = 'moz-1st-party-data-opt-out';
+import DataPreferencesCookie from './data-preferences-cookie.es6';
+
 const prefStatus = document.querySelector('.data-preference-status');
 const statusText = prefStatus.querySelector('.data-preference-text');
+const optOutButton = document.querySelector('.js-opt-out-button');
+const optInButton = document.querySelector('.js-opt-in-button');
 let optOutText;
 let optInText;
 
 function updateStatus() {
-    if (hasOptedOut()) {
+    if (DataPreferencesCookie.hasOptedOut()) {
         statusText.innerText = optOutText;
         prefStatus.classList.add('is-opted-out');
         prefStatus.classList.remove('is-opted-in');
+        optOutButton.disabled = true;
+        optInButton.disabled = false;
     } else {
         statusText.innerText = optInText;
         prefStatus.classList.add('is-opted-in');
         prefStatus.classList.remove('is-opted-out');
+        optOutButton.disabled = false;
+        optInButton.disabled = true;
     }
-}
-
-function doOptOut() {
-    if (hasOptedOut()) {
-        return;
-    }
-
-    const date = new Date();
-    const cookieDuration = 365 * 24 * 60 * 60 * 1000; // 1 year expiration
-    date.setTime(date.getTime() + cookieDuration);
-    Mozilla.Cookies.setItem(
-        preferenceCookieID,
-        'true',
-        date.toUTCString(),
-        '/',
-        null,
-        false,
-        'lax'
-    );
-
-    updateStatus();
-}
-
-function doOptIn() {
-    if (!hasOptedOut()) {
-        return;
-    }
-
-    Mozilla.Cookies.removeItem(preferenceCookieID, '/', null, false, 'lax');
-    updateStatus();
-}
-
-function hasOptedOut() {
-    return Mozilla.Cookies.hasItem(preferenceCookieID);
 }
 
 function bindEvents() {
-    const optOutButton = document.querySelector('.js-opt-out-button');
-    const optInButton = document.querySelector('.js-opt-in-button');
-
     optOutButton.addEventListener(
         'click',
         (e) => {
             e.preventDefault();
-            doOptOut();
+            DataPreferencesCookie.doOptOut();
+            updateStatus();
         },
         false
     );
@@ -73,7 +44,8 @@ function bindEvents() {
         'click',
         (e) => {
             e.preventDefault();
-            doOptIn();
+            DataPreferencesCookie.doOptIn();
+            updateStatus();
         },
         false
     );

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1871,7 +1871,8 @@
     },
     {
       "files": [
-        "js/privacy/data-preferences.es6.js"
+        "js/privacy/data-preferences-cookie.es6.js",
+        "js/privacy/data-preferences-init.es6.js"
       ],
       "name": "privacy-data-preferences"
     },

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -71,6 +71,7 @@ module.exports = function (config) {
             'tests/unit/spec/products/vpn/affiliate-attribution.js',
             'tests/unit/spec/newsletter/form-utils.js',
             'tests/unit/spec/newsletter/recovery.js',
+            'tests/unit/spec/privacy/data-preferences-cookie.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',
                 watched: false,

--- a/tests/unit/spec/privacy/data-preferences-cookie.js
+++ b/tests/unit/spec/privacy/data-preferences-cookie.js
@@ -1,0 +1,92 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/2.0/introduction.html
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import DataPreferencesCookie from '../../../../media/js/privacy/data-preferences-cookie.es6';
+
+describe('doOptOut', function () {
+    it('should set an opt-out cookie as expected', function () {
+        spyOn(DataPreferencesCookie, 'hasOptedOut').and.returnValue(false);
+        spyOn(DataPreferencesCookie, 'getCookieDomain').and.returnValue(
+            '.mozilla.org'
+        );
+        spyOn(window.Mozilla.Cookies, 'setItem');
+        DataPreferencesCookie.doOptOut();
+        expect(window.Mozilla.Cookies.setItem).toHaveBeenCalledWith(
+            'moz-1st-party-data-opt-out',
+            'true',
+            jasmine.any(String),
+            '/',
+            '.mozilla.org',
+            false,
+            'lax'
+        );
+    });
+
+    it('should do nothing if visitor has already opted out', function () {
+        spyOn(DataPreferencesCookie, 'hasOptedOut').and.returnValue(true);
+        spyOn(window.Mozilla.Cookies, 'setItem');
+        DataPreferencesCookie.doOptOut();
+        expect(window.Mozilla.Cookies.setItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('doOptIn', function () {
+    it('should remove opt-out cookie as expected', function () {
+        spyOn(DataPreferencesCookie, 'hasOptedOut').and.returnValue(true);
+        spyOn(DataPreferencesCookie, 'getCookieDomain').and.returnValue(
+            '.mozilla.org'
+        );
+        spyOn(window.Mozilla.Cookies, 'removeItem');
+        DataPreferencesCookie.doOptIn();
+        expect(window.Mozilla.Cookies.removeItem).toHaveBeenCalledWith(
+            'moz-1st-party-data-opt-out',
+            '/',
+            '.mozilla.org',
+            false,
+            'lax'
+        );
+    });
+
+    it('should do nothing if visitor has already opted in', function () {
+        spyOn(DataPreferencesCookie, 'hasOptedOut').and.returnValue(false);
+        spyOn(window.Mozilla.Cookies, 'removeItem');
+        DataPreferencesCookie.doOptIn();
+        expect(window.Mozilla.Cookies.removeItem).not.toHaveBeenCalled();
+    });
+});
+
+describe('getCookieDomain', function () {
+    it('should return null by default', function () {
+        expect(DataPreferencesCookie.getCookieDomain()).toEqual(null);
+    });
+
+    it('should return ".mozilla.org" in production', function () {
+        expect(
+            DataPreferencesCookie.getCookieDomain(
+                'https://www.mozilla.org/en-US/privacy/websites/data-preferences/'
+            )
+        ).toEqual('.mozilla.org');
+    });
+
+    it('should return ".allizom.org" in staging', function () {
+        expect(
+            DataPreferencesCookie.getCookieDomain(
+                'https://www.allizom.org/en-US/privacy/websites/data-preferences/'
+            )
+        ).toEqual('.allizom.org');
+    });
+
+    it('should return null when any other domain is specified', function () {
+        expect(
+            DataPreferencesCookie.getCookieDomain('https://www.example.com')
+        ).toEqual(null);
+    });
+});


### PR DESCRIPTION
## One-line summary

- Updates Glean opt-out page so that it will work for other `*.mozilla.org` websites.
- Opens up page for L10n.
- Adds `disabled` properties to opt-out buttons to improve UX a little.
- Improves test coverage.

## Issue / Bugzilla link

#12056

## Testing

Demo: https://www-demo5.allizom.org/en-US/privacy/websites/data-preferences/

http://localhost:8000/en-US/privacy/websites/data-preferences/