### PR TITLE
Stop the mandala animation on the whatsnew page

### DIFF
--- a/media/css/firefox/developer/whatsnew-mdnplus.scss
+++ b/media/css/firefox/developer/whatsnew-mdnplus.scss
@@ -86,7 +86,7 @@ $image-path: '/media/protocol/img';
     }
 
     .mandala-rotate > svg {
-        animation: rotation 500s linear infinite;
+        /* animation: rotation 500s linear infinite; */
     }
 
     svg {


### PR DESCRIPTION
## One-line summary

Stops the mandala on the whatsnew page from animating.

## Motivation

This keeps wasting CPU cycles whenever my Firefox (Developer Edition) updates.

(Part of the reason is that I have two Firefox windows. If I open FIrefox but I'm focused on the wrong window, then I don't see this page. I just hear my laptop's CPU spinning, begin to wonder why, and then have to track it down.)

There were 6 upvotes when I raised [this issue on Mozilla Connect](https://connect.mozilla.org/t5/ideas/do-not-put-a-continuous-animation-on-the-whatsnew-page-or-stop/idi-p/7297), so I guess I'm not the only person bothered by this.

## Alternative solutions

Use a `:hover` selector, so the animation is only spinning when the user's mouse is on top of it.

Or, enable the animation only when it's visible to the user. (Note that the user might have multiple Firefox windows, and this page may have opened in the background.)

I suggest:

- Only start the animation if a window `focus` event or a `mousemove` or `keydown` event is detected.

- Disable the animation when a window `blur` event is detected.

I'm sorry I didn't have time to write this solution today. Hence this PR is just a quick fix.

It's very pretty by the way! Just a bit too hot.

This issue may be of interest to @alexgibson. Some optimisations were previously made to address this concern, in #11793