### PR TITLE
Update get-ios Adjust link

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/mobile/get-ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/get-ios.html
@@ -32,7 +32,7 @@
     {{ ftl('get-ios-firefox-mobile-adapts') }}
   </p>
   <p class="c-cta">
-      <a href="https://app.adjust.com/ucunb4r" data-link-type="download" data-download-os="iOS">
+      <a href="https://nn8g.adj.st/?adjust_t=ucunb4r" data-link-type="download" data-download-os="iOS">
         <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
       </a>
     </p>


### PR DESCRIPTION
## One-line summary
Updated link in the `get-ios` page to be the correct universal Adjust link

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12055

## Testing
To test this work:
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/get-ios/
