### PR TITLE
Style public wifi section

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/modules/public-wifi.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/public-wifi.html
@@ -9,7 +9,7 @@
 <section id="public-wifi" class="c-public-wifi">
   <div class="mzp-l-content mzp-t-content-xl">
     {{ module_tag(title='Public Wifi', anchor='public-wifi') }}
-    <div class="l-flex">
+    <div class="l-grid">
       <div class="c-card t-yellow">
         <h3 class="c-subtitle">An extra sloppy scoop of public wifi</h3>
         <p>Lots of schools offer free wifi to students, but they also offer sloppy
@@ -32,6 +32,6 @@
             and activate it before you connect to the network.</p>
         </div> <!-- .c-card ends -->
       </div> <!-- .l-container ends -->
-    </div> <!-- .l-flex ends -->
+    </div> <!-- .l-grid ends -->
   </div> <!-- .mzp-l-content ends -->
 </section>

--- a/media/css/firefox/family/components/modules/_public-wifi.scss
+++ b/media/css/firefox/family/components/modules/_public-wifi.scss
@@ -18,10 +18,15 @@
 
     .c-card.t-yellow {
         background-color: f3.$yellow-primary;
+        max-width: 35ch;
+
+        .c-subtitle {
+            max-width: 10ch;
+        }
     }
 
     .c-card {
-        margin-bottom: $spacing-md;
+        margin-bottom: $layout-2xs;
 
         &:last-of-type {
             margin-bottom: 0;
@@ -29,41 +34,65 @@
     }
 }
 
-// todo: test overflow on smaller screens
-@supports (display: flex) {
-    @media #{$mq-md} {
-        .c-public-wifi {
-            .l-flex {
-                display: flex;
-                align-items: center;
-                gap: 5%;
+@media (max-width: $screen-lg) {
+    .c-public-wifi {
+        .mzp-l-content {
+            padding-right: 0;
+            padding-left: 0;
+        }
+
+        // match mzp-l-content padding for module tag
+        .c-module-tag,
+        .c-card.t-yellow {
+            margin-left: $layout-xs;
+            margin-right: $layout-xs;
+        }
+
+        @media #{$mq-md} {
+            .c-module-tag,
+            .c-card.t-yellow {
+                margin-left: $layout-lg;
+                margin-right: $layout-lg;
             }
 
-            .l-container {
-                flex: 1 0 50%;
+            .t-scroll-snap {
+                padding-right: $layout-lg;
+                padding-left: $layout-lg;
             }
         }
     }
-}
 
-// todo: handle padding from inside scroll container so there aren't cut offs
-// todo: cross browser testing, scrollbar consistency (hidden?)
-@supports (scroll-snap-align: start) {
     .t-scroll-snap {
         display: flex;
         gap: $spacing-md;
         overflow-x: auto;
         scroll-snap-type: x mandatory;
+        padding: $layout-sm;
+
+        // hide scrollbar, visible overflow card should be enough of a UI cue
+        &::-webkit-scrollbar {
+            display: none; /* Hide scrollbar for Chrome, Safari and Opera */
+        }
+        -ms-overflow-style: none;  /* IE and Edge */
+        scrollbar-width: none;  /* Firefox */
 
         .c-card {
             flex: 0 0 65vw;
-            scroll-snap-align: start;
+            scroll-snap-align: center;
         }
     }
+}
 
-    @media #{$mq-md} {
-        .t-scroll-snap {
-            display: block;
+@supports (display: grid) {
+    @media #{$mq-lg} {
+        .c-public-wifi {
+            .l-grid {
+                display: grid;
+                justify-content: space-between;
+                align-items: center;
+                grid-template-columns: minmax(20ch, 35ch) minmax(30%, 50%);
+                gap: $layout-lg;
+            }
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Cleans up and finalizes responsive styling for public wifi section

## Significant changes and points to review

[scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) is a newer property meant to enhance scrolling experience by allowing a "snap" to a particular alignment after the user stops scrolling, will be ignored and regular scroll behaviour used for browsers without support

Because this is built from the feature branch, it only shows changes from the existing files. Best to review the entire html & css files for public-wifi.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12004
figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families

## Testing

On large screens and above, on browsers that support grid
- Yellow card in first column and white cards in second column

Below large screen
- Yellow card in first row, does not stretch beyond the space needed to fit "public wifi" on one line
- White cards in second row, horizontal overflow is obvious, swipe or keyboard press moves cards

http://localhost:8000/en-US/firefox/family/#public-wifi
