### PR TITLE
Style passwords section

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
@@ -16,23 +16,22 @@
           bucket list after he guessed your kid’s pet-name password.</p>
       </div>
 
-      <div class="l-container">
-        {% call browser_border() %}
-          <div class="c-password-example">
-            <div class="l-container">
-              <h4 class="c-title-uppercase">Log-in</h4>
-              <div class="c-password-example-input t-username"><span class="visually-hidden">Example username: </span>nerdzarecool@mozilla.com</div>
-              <div class="c-password-example-input t-password"><span class="visually-hidden">Example password: </span>MrFlounder_Sweats_Clam_Chowder77</div>
-              <div class="c-password-example-submit mzp-c-button mzp-t-product">Enter</div>
-            </div> <!-- .l-container -->
-          </div> <!-- .c-password-example -->
-        {% endcall %}
-        <div class="c-blurb">
-          <p><a href="https://support.mozilla.org/kb/how-generate-secure-password-firefox" rel="external">Generate a secure password</a>
-            in Firefox or create a fun, random passphrase instead of a password. Make
-            it alphanumeric and at least 12 characters long.</p>
-        </div> <!-- .c-blurb-->
-      </div> <!-- .l-container-->
-    </div> <!-- .l-flex-->
-  </div> <!-- .mzp-l-content-->
+      {% call browser_border() %}
+        <div class="c-passwords-example">
+          <h4 class="c-title-uppercase"><span class="visually-hidden">Example form: </span>Log-in</h4>
+          <p class="c-passwords-example-input t-username"><span class="visually-hidden">Example username: </span>nerdzarecool@mozilla.com</p>
+          <p data-password-length="long" class="c-passwords-example-input t-password"><span class="visually-hidden">Example password: </span>MrFlounder_Sweats_Clam_Chowder77</p>
+          <p data-password-length="short" class="c-passwords-example-input t-password"><span class="visually-hidden">Example password: </span>I_eats_thechowder77</p>
+          <p aria-hidden="true" class="c-passwords-example-submit mzp-c-button mzp-t-product">Enter</p>
+        </div> <!-- .c-password-example ends -->
+      {% endcall %}
+
+      <div class="c-blurb">
+        <p><a href="https://support.mozilla.org/kb/how-generate-secure-password-firefox" rel="external">Generate a secure password</a>
+          in Firefox or create a fun, random passphrase instead of a password. Make
+          it alphanumeric and at least 12 characters long.</p>
+      </div> <!-- .c-blurb ends-->
+    </div> <!-- .l-flex ends-->
+  </div> <!-- .mzp-l-content ends-->
+>>>>>>> b5cbce716 (Add short alt password, remove unfinished styles)
 </section>

--- a/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
@@ -9,7 +9,7 @@
 <section id="passwords" class="c-passwords">
   <div class="mzp-l-content mzp-t-content-xl">
     {{ module_tag(title='Passwords', anchor='passwords') }}
-    <div class="l-flex">
+    <div class="l-grid">
       <div class="c-content">
         <h3 class="c-subtitle">A quick word about passwords</h3>
         <p>“I’m in!” says the hacker who just crossed saying that phrase off his
@@ -19,7 +19,7 @@
       {% call browser_border() %}
         <div class="c-passwords-example">
           <h4 class="c-title-uppercase"><span class="visually-hidden">Example form: </span>Log-in</h4>
-          <p class="c-passwords-example-input t-username"><span class="visually-hidden">Example username: </span>nerdzarecool@mozilla.com</p>
+          <p class="c-passwords-example-input t-username"><span class="visually-hidden">Example username: </span>nerdzrcool@mozilla.com</p>
           <p data-password-length="long" class="c-passwords-example-input t-password"><span class="visually-hidden">Example password: </span>MrFlounder_Sweats_Clam_Chowder77</p>
           <p data-password-length="short" class="c-passwords-example-input t-password"><span class="visually-hidden">Example password: </span>I_eats_thechowder77</p>
           <p aria-hidden="true" class="c-passwords-example-submit mzp-c-button mzp-t-product">Enter</p>
@@ -31,7 +31,7 @@
           in Firefox or create a fun, random passphrase instead of a password. Make
           it alphanumeric and at least 12 characters long.</p>
       </div> <!-- .c-blurb ends-->
-    </div> <!-- .l-flex ends-->
+    </div> <!-- .l-grid ends-->
   </div> <!-- .mzp-l-content ends-->
 >>>>>>> b5cbce716 (Add short alt password, remove unfinished styles)
 </section>

--- a/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
@@ -8,8 +8,8 @@
 
 <section id="passwords" class="c-passwords">
   <div class="mzp-l-content mzp-t-content-xl">
-    {{ module_tag(title='Passwords', anchor='passwords') }}
     <div class="l-grid">
+      {{ module_tag(title='Passwords', anchor='passwords') }}
       <div class="c-content">
         <h3 class="c-subtitle">A quick word about passwords</h3>
         <p>“I’m in!” says the hacker who just crossed saying that phrase off his

--- a/media/css/firefox/family/components/_blurb.scss
+++ b/media/css/firefox/family/components/_blurb.scss
@@ -15,10 +15,6 @@
     margin-top: $layout-sm;
     margin-bottom: $layout-sm;
 
-    @media #{$mq-md} {
-        border-radius: 6em;
-    }
-
     &-title {
         font-size: 1rem;
         @include f3.mono-font;

--- a/media/css/firefox/family/components/modules/_passwords.scss
+++ b/media/css/firefox/family/components/modules/_passwords.scss
@@ -144,23 +144,36 @@
     @media #{$mq-lg} {
         .c-passwords {
             .c-blurb {
-                max-width: 100%;
+                margin-top: 0;
+                max-width: 40ch;
+                width: 70%;
             }
 
             .l-grid {
                 display: grid;
-                grid-template-columns: [column-one] minmax(30ch, 45%) [column-two] 1fr [end];
+                grid-template-columns: [column-one] minmax(30ch, 42%) [column-two] 1fr [end];
+                grid-template-rows: auto auto [overlap-start] $layout-sm [overlap-end] auto;
                 column-gap: $layout-lg;
 
                 .c-content {
                     align-self: center;
                     grid-column-start: column-one;
-                    grid-row: 1 / span 2;
+                    grid-row: 2 / -1;
                 }
 
                 .c-browser,
                 .c-blurb {
                     grid-column-start: column-two;
+                }
+
+                .c-browser {
+                    grid-row: 1 / overlap-end;
+                    align-self: end;
+                }
+
+                .c-blurb {
+                    grid-row: overlap-start / -1;
+                    align-self: start;
                 }
             }
         }

--- a/media/css/firefox/family/components/modules/_passwords.scss
+++ b/media/css/firefox/family/components/modules/_passwords.scss
@@ -34,6 +34,8 @@
 }
 
 .c-passwords-example {
+    @include f3.mono-font;
+
     .visually-hidden {
         @include visually-hidden;
     }

--- a/media/css/firefox/family/components/modules/_passwords.scss
+++ b/media/css/firefox/family/components/modules/_passwords.scss
@@ -15,6 +15,7 @@
 
     .c-browser {
         @include f3.card-shadow(f3.$orange-dark);
+        max-width: $screen-sm;
         text-align: center;
 
         &-bar {
@@ -23,8 +24,6 @@
 
         &-content {
             @include text-body-md;
-            padding-right: $spacing-md;
-            padding-left: $spacing-md;
         }
     }
 
@@ -47,21 +46,30 @@
 
     &-input {
         @include f3.border;
+        margin-right: auto;
+        margin-left: auto;
         overflow-wrap: break-word;
-        padding: $spacing-xs $spacing-sm;
+        padding: $spacing-sm;
         text-align: left;
 
-        &::before {
+        &::before,
+        &::after {
+            content: '';
+            display: inline-block;
             margin-right: $spacing-sm;
+            width: 20px;
+            height: 20px;
+            vertical-align: middle;
+            background-size: contain;
+            background-repeat: no-repeat;
         }
 
-        // todo: fix icon sizing, probably best as background imgs
         &.t-username::before {
-            content: url('/media/img/firefox/family/icon-person.svg');
+            background-image: url('/media/img/firefox/family/icon-person.svg');
         }
 
         &.t-password::before {
-            content: url('/media/img/firefox/family/icon-lock.svg');
+            background-image: url('/media/img/firefox/family/icon-lock.svg');
         }
 
         &[data-password-length='long'] {
@@ -71,5 +79,81 @@
 
     &-submit {
         text-transform: uppercase;
+        cursor: not-allowed;
+    }
+}
+
+// handle extra small screens
+@media (max-width: #{$content-sm}) {
+    .c-passwords {
+        .c-subtitle {
+            max-width: 9ch;
+        }
+
+        .c-browser {
+            padding-right: $spacing-sm;
+            padding-left: $spacing-sm;
+        }
+
+        &-example-input {
+            &::before,
+            &::after {
+                width: 16px;
+                height: 16px;
+            }
+        }
+    }
+}
+
+@media #{$mq-md} {
+    .c-passwords {
+        .c-blurb {
+            width: 50%;
+            min-width: 40ch;
+            margin-left: auto;
+            margin-top: -#{$layout-sm};
+        }
+
+        .c-browser-content {
+            padding-top: $layout-lg;
+            padding-bottom: $layout-lg;
+        }
+
+        &-example-input {
+            &[data-password-length='short'] {
+                display: none;
+            }
+
+            &[data-password-length='long'] {
+                display: block;
+            }
+        }
+    }
+}
+
+@supports (display: grid) {
+    @media #{$mq-lg} {
+        .c-passwords {
+            .c-blurb {
+                max-width: 100%;
+            }
+
+            .l-grid {
+                display: grid;
+                grid-template-columns: [column-one] minmax(30ch, 45%) [column-two] 1fr [end];
+                column-gap: $layout-lg;
+
+                .c-content {
+                    align-self: center;
+                    grid-column-start: column-one;
+                    grid-row: 1 / span 2;
+                }
+
+                .c-browser,
+                .c-blurb {
+                    grid-column-start: column-two;
+                }
+            }
+        }
     }
 }

--- a/media/css/firefox/family/components/modules/_passwords.scss
+++ b/media/css/firefox/family/components/modules/_passwords.scss
@@ -15,7 +15,6 @@
 
     .c-browser {
         @include f3.card-shadow(f3.$orange-dark);
-        max-width: 600px;
         text-align: center;
 
         &-bar {
@@ -23,78 +22,52 @@
         }
 
         &-content {
-            padding-top: $spacing-2xl;
-            padding-bottom: $spacing-2xl;
+            @include text-body-md;
+            padding-right: $spacing-md;
+            padding-left: $spacing-md;
         }
     }
 
     .c-blurb {
-        max-width: 500px;
         background-color: f3.$green-light;
     }
 }
 
-.c-password-example-input {
-    @include f3.border;
-    overflow-wrap: break-word;
-    padding: $spacing-xs $spacing-sm;
-    text-align: left;
-
-    &::before {
-        margin-right: $spacing-sm;
-    }
-
-    // todo: fix icon sizing, probably best as background imgs
-    &.t-username::before {
-        content: url('/media/img/firefox/family/icon-person.svg');
-    }
-
-    &.t-password::before {
-        content: url('/media/img/firefox/family/icon-lock.svg');
-    }
-
+.c-passwords-example {
     .visually-hidden {
         @include visually-hidden;
     }
 
-    &:first-of-type {
-        margin-top: $spacing-md;
-        margin-bottom: $spacing-sm;
+    .c-title-uppercase,
+    .t-password {
+        margin-bottom: $spacing-lg;
     }
-}
 
-.c-password-example-submit {
-    margin-top: $spacing-md;
-    text-transform: uppercase;
-}
+    &-input {
+        @include f3.border;
+        overflow-wrap: break-word;
+        padding: $spacing-xs $spacing-sm;
+        text-align: left;
 
-@supports (display: flex) {
-    @media #{$mq-md} {
-        .c-passwords {
-            .l-flex {
-                display: flex;
-                align-items: center;
-                gap: 5%;
-            }
-
-            .c-content {
-                flex: 1 1 40%;
-            }
-
-            .l-container {
-                flex: 1 1 55%;
-            }
-
-            .c-browser {
-                width: fit-content;
-            }
-
-            .c-blurb {
-                width: 30%;
-                margin-left: auto;
-                margin-top: -#{$layout-2xs};
-                min-width: 30ch;
-            }
+        &::before {
+            margin-right: $spacing-sm;
         }
+
+        // todo: fix icon sizing, probably best as background imgs
+        &.t-username::before {
+            content: url('/media/img/firefox/family/icon-person.svg');
+        }
+
+        &.t-password::before {
+            content: url('/media/img/firefox/family/icon-lock.svg');
+        }
+
+        &[data-password-length='long'] {
+            display: none;
+        }
+    }
+
+    &-submit {
+        text-transform: uppercase;
     }
 }

--- a/media/css/firefox/family/components/modules/_passwords.scss
+++ b/media/css/firefox/family/components/modules/_passwords.scss
@@ -15,6 +15,8 @@
 
     .c-browser {
         @include f3.card-shadow(f3.$orange-dark);
+        margin-left: auto;
+        margin-right: auto;
         max-width: $screen-sm;
         text-align: center;
 
@@ -24,11 +26,17 @@
 
         &-content {
             @include text-body-md;
+            padding-right: $spacing-md;
+            padding-left: $spacing-md;
         }
     }
 
     .c-blurb {
         background-color: f3.$green-light;
+    }
+
+    .mzp-c-button {
+        margin-bottom: 0;
     }
 }
 
@@ -46,14 +54,14 @@
 
     &-input {
         @include f3.border;
-        margin-right: auto;
+        max-width: $content-xs;
         margin-left: auto;
+        margin-right: auto;
         overflow-wrap: break-word;
         padding: $spacing-sm;
         text-align: left;
 
-        &::before,
-        &::after {
+        &::before {
             content: '';
             display: inline-block;
             margin-right: $spacing-sm;
@@ -90,14 +98,8 @@
             max-width: 9ch;
         }
 
-        .c-browser {
-            padding-right: $spacing-sm;
-            padding-left: $spacing-sm;
-        }
-
         &-example-input {
-            &::before,
-            &::after {
+            &::before {
                 width: 16px;
                 height: 16px;
             }
@@ -109,17 +111,24 @@
     .c-passwords {
         .c-blurb {
             width: 50%;
-            min-width: 40ch;
+            min-width: 30ch;
             margin-left: auto;
             margin-top: -#{$layout-sm};
         }
 
-        .c-browser-content {
-            padding-top: $layout-lg;
-            padding-bottom: $layout-lg;
+        .c-browser {
+            margin-left: unset;
+            margin-right: unset;
+
+            &-content {
+                padding-top: $layout-lg;
+                padding-bottom: $layout-lg;
+            }
         }
 
         &-example-input {
+            max-width: 350px;
+
             &[data-password-length='short'] {
                 display: none;
             }


### PR DESCRIPTION
## One-line summary

Finishes responsive styling for Passwords section

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12004
figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families?node-id=971%3A2714

## Testing

This builds on styling from feature branch. Please review entire css and html files for passwords module.

http://localhost:8000/en-US/firefox/family/#passwords

design feedback
- On mobile, email in password section breaks to next line
- On mobile: Shadow behind log-in box looks incorrect on mobile (separates)
