### PR TITLE
Dev WNP, only animate mandala when visible [#11793]

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
@@ -35,8 +35,8 @@
     </div>
 
     <div class="mandala-wrapper">
-      <div class="mandala-container animate-colors" aria-hidden="true">
-        <div class="mandala-translate">
+      <div id="mandala" class="mandala-container animate-colors" aria-hidden="true">
+        <div class="mandala-translate mandala-rotate">
           <svg width="675" height="675" viewBox="0 0 675 675" fill="none" xmlns="http://www.w3.org/2000/svg" class="mandala">
             <defs>
               <path d="M337.5,337.5 m-320,0 a320,320 0 1,1 640,0 a320,320 0 1,1 -640,0" id="circle1"></path>
@@ -45,24 +45,19 @@
               <path d="M337.5,337.5 m-200,0 a200,200 0 1,1 400,0 a200,200 0 1,1 -400,0" id="circle4"></path>
               <path d="M337.5,337.5 m-160,0 a160,160 0 1,1 320,0 a160,160 0 1,1 -320,0" id="circle5"></path>
             </defs>
-            <text class="mandala-accent-1" dy="70" textLength="2010">
-              <animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="0 337.5 337.5" to="360 337.5 337.5" repeatCount="indefinite"></animateTransform>
+            <text class="mandala-ring mandala-accent-1" dy="70" textLength="2010">
               <textPath textLength="2010" href="#circle1">&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>&nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan></textPath>
             </text>
-            <text class="mandala-accent-2" dy="70" textLength="1760">
-              <animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="360 337.5 337.5" to="0 337.5 337.5" repeatCount="indefinite"></animateTransform>
+            <text class="mandala-ring mandala-accent-2" dy="70" textLength="1760">
               <textPath textLength="1760" href="#circle2">&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>&nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan></textPath>
             </text>
-            <text class="mandala-accent-3" dy="70" textLength="1507">
-              <animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="0 337.5 337.5" to="360 337.5 337.5" repeatCount="indefinite"></animateTransform>
+            <text class="mandala-ring mandala-accent-3" dy="70" textLength="1507">
               <textPath textLength="1507" href="#circle3"><tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;<tspan>{</tspan>{<tspan>{</tspan>{&nbsp;<tspan>}</tspan>}<tspan>}</tspan>}&nbsp;&nbsp;</textPath>
             </text>
-            <text class="mandala-accent-4" dy="70" textLength="1257">
-              <animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="360 337.5 337.5" to="0 337.5 337.5" repeatCount="indefinite"></animateTransform>
-              <textPath textLength="1257" href="#circle4">&nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../</textPath>
+            <text class="mandala-ring mandala-accent-4" dy="70" textLength="1257">
+              <textPath textLength="1257" href="#circle4">&nbsp;&nbsp;&nbsp;<tspan>../../</tspan> &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;<tspan>../../</tspan> &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;<tspan>../../</tspan> &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;<tspan>../../</tspan> &nbsp;&nbsp;&nbsp;../../ </textPath>
             </text>
-            <text class="mandala-accent-5" dy="70" textLength="1005">
-              <animateTransform attributeName="transform" begin="0s" dur="500s" type="rotate" from="0 337.5 337.5" to="360 337.5 337.5" repeatCount="indefinite"></animateTransform>
+            <text class="mandala-ring mandala-accent-5" dy="70" textLength="1005">
               <textPath textLength="1005" href="#circle5"><tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;<tspan>&lt;&gt;</tspan>&lt;/&gt;</textPath>
             </text>
           </svg>
@@ -108,3 +103,7 @@
 
 {# Exclude stub attribution for in-product pages: issue 9620 #}
 {% block stub_attribution %}{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_developer_whatsnew_mdnplus') }}
+{% endblock %}

--- a/media/css/firefox/developer/whatsnew-mdnplus.scss
+++ b/media/css/firefox/developer/whatsnew-mdnplus.scss
@@ -78,73 +78,12 @@ $image-path: '/media/protocol/img';
     --mandala-accent-1: #{$color-violet-30};
     --mandala-accent-2: #{$color-yellow-30};
     --mandala-accent-3: #{$color-green-30};
-    --mandala-accent-4: #{$color-light-gray-60};
+    --mandala-accent-4: #{$color-red-20};
+    --mandala-accent-5: #{$color-light-gray-30};
 
     @keyframes rotation {
         from { transform: rotate(0deg); }
         to { transform: rotate(360deg); }
-    }
-
-    .mandala-rotate > svg {
-        animation: rotation 500s linear infinite;
-    }
-
-    svg {
-        font-size: 1.5rem;
-        font-weight: 300;
-        user-select: none;
-    }
-
-    svg > text {
-        fill: var(--mandala-primary);
-    }
-
-    .mandala-accent-1 {
-        font-size: 1.5rem;
-    }
-
-    .mandala-accent-2 {
-        font-size: 1.3rem;
-    }
-
-    .mandala-accent-3 {
-        font-size: 1.2rem;
-    }
-
-    .mandala-accent-4 {
-        font-size: 1.1rem;
-    }
-
-    .mandala-accent-5 {
-        font-size: 1rem;
-    }
-
-    &.animate-colors {
-        svg > text > textPath > tspan {
-            animation: mandala-color-change 50s infinite;
-            animation-timing-function: ease-in-out;
-            fill: var(--mandala-primary);
-        }
-
-        .mandala-accent-1 > textPath > tspan {
-            fill: var(--mandala-accent-1);
-            animation-delay: -15s;
-        }
-
-        .mandala-accent-2 > textPath > tspan {
-            fill: var(--mandala-accent-2);
-            animation-delay: -20s;
-        }
-
-        .mandala-accent-3 > textPath > tspan {
-            fill: var(--mandala-accent-3);
-            animation-delay: -30s;
-        }
-
-        .mandala-accent-5 > textPath > tspan {
-            fill: var(--mandala-accent-4);
-            animation-delay: -40s;
-        }
     }
 
     @keyframes mandala-color-change {
@@ -203,6 +142,97 @@ $image-path: '/media/protocol/img';
         100% {
             fill: var(--mandala-primary);
         }
+    }
+
+    &.animated {
+        .mandala-rotate > svg {
+            .mandala-accent-1 {
+                animation: rotation 505s linear infinite;
+            }
+
+            .mandala-accent-2 {
+                animation: rotation 480s linear infinite reverse;
+            }
+
+            .mandala-accent-3 {
+                animation: rotation 515s linear infinite;
+            }
+
+            .mandala-accent-4 {
+                animation: rotation 425s linear infinite reverse;
+            }
+
+            .mandala-accent-5 {
+                animation: rotation 415s linear infinite;
+            }
+        }
+
+        &.animate-colors {
+            svg > text > textPath > tspan {
+                animation: mandala-color-change 50s infinite;
+                animation-timing-function: ease-in-out;
+                fill: var(--mandala-primary);
+            }
+
+            .mandala-accent-1 > textPath > tspan {
+                fill: var(--mandala-accent-1);
+                animation-delay: -15s;
+            }
+
+            .mandala-accent-2 > textPath > tspan {
+                fill: var(--mandala-accent-2);
+                animation-delay: -20s;
+            }
+
+            .mandala-accent-3 > textPath > tspan {
+                fill: var(--mandala-accent-3);
+                animation-delay: -30s;
+            }
+
+            .mandala-accent-4 > textPath > tspan {
+                fill: var(--mandala-accent-4);
+                animation-delay: -5s;
+            }
+
+            .mandala-accent-5 > textPath > tspan {
+                fill: var(--mandala-accent-4);
+                animation-delay: -40s;
+            }
+        }
+    }
+
+    svg {
+        font-size: 1.5rem;
+        font-weight: 300;
+        user-select: none;
+
+        .mandala-ring {
+            transform-origin: 50% 50%;
+        }
+    }
+
+    svg > text {
+        fill: var(--mandala-primary);
+    }
+
+    .mandala-accent-1 {
+        font-size: 1.5rem;
+    }
+
+    .mandala-accent-2 {
+        font-size: 1.3rem;
+    }
+
+    .mandala-accent-3 {
+        font-size: 1.2rem;
+    }
+
+    .mandala-accent-4 {
+        font-size: 1.1rem;
+    }
+
+    .mandala-accent-5 {
+        font-size: 1rem;
     }
 }
 

--- a/media/js/firefox/developer/whatsnew-mdnplus.js
+++ b/media/js/firefox/developer/whatsnew-mdnplus.js
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    var hidden;
+    var visibilityChange;
+    var mandalaElement = document.getElementById('mandala');
+
+    // Check for support of the Page Visbility API
+    if (typeof document.hidden !== 'undefined') {
+        hidden = 'hidden';
+        visibilityChange = 'visibilitychange';
+    } else {
+        return;
+    }
+
+    // If the page is hidden, stop the mandala.
+    // If the page is visible, animate the mandala.
+    function handleVisibilityChange() {
+        if (document[hidden]) {
+            mandalaElement.classList.remove('animated');
+        } else {
+            mandalaElement.classList.add('animated');
+            // Stop animating after five minutes
+            setTimeout(function () {
+                mandalaElement.classList.remove('animated');
+            }, 300000);
+        }
+    }
+
+    // Check if the browser doesn't support addEventListener or the Page Visibility API
+    if (
+        typeof document.addEventListener === 'undefined' ||
+        hidden === undefined
+    ) {
+        return;
+    } else {
+        // Handle page visibility change
+        document.addEventListener(
+            visibilityChange,
+            handleVisibilityChange,
+            false
+        );
+    }
+
+    window.Mozilla.run(handleVisibilityChange);
+})(window.Mozilla);

--- a/media/js/firefox/developer/whatsnew-mdnplus.js
+++ b/media/js/firefox/developer/whatsnew-mdnplus.js
@@ -7,46 +7,35 @@
 (function () {
     'use strict';
 
-    var hidden;
-    var visibilityChange;
+    var stopAnimTimeout;
     var mandalaElement = document.getElementById('mandala');
 
     // Check for support of the Page Visbility API
-    if (typeof document.hidden !== 'undefined') {
-        hidden = 'hidden';
-        visibilityChange = 'visibilitychange';
-    } else {
+    if (typeof document.hidden === 'undefined') {
         return;
     }
 
     // If the page is hidden, stop the mandala.
     // If the page is visible, animate the mandala.
     function handleVisibilityChange() {
-        if (document[hidden]) {
+        if (document.hidden) {
             mandalaElement.classList.remove('animated');
+            clearTimeout(stopAnimTimeout);
         } else {
             mandalaElement.classList.add('animated');
             // Stop animating after five minutes
-            setTimeout(function () {
+            stopAnimTimeout = setTimeout(function () {
                 mandalaElement.classList.remove('animated');
+                document.title = 'timeout';
             }, 300000);
         }
     }
 
-    // Check if the browser doesn't support addEventListener or the Page Visibility API
-    if (
-        typeof document.addEventListener === 'undefined' ||
-        hidden === undefined
-    ) {
-        return;
-    } else {
-        // Handle page visibility change
-        document.addEventListener(
-            visibilityChange,
-            handleVisibilityChange,
-            false
-        );
-    }
+    document.addEventListener(
+        'visibilitychange',
+        handleVisibilityChange,
+        false
+    );
 
     window.Mozilla.run(handleVisibilityChange);
 })(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1570,6 +1570,12 @@
     },
     {
       "files": [
+        "js/firefox/developer/whatsnew-mdnplus.js"
+      ],
+      "name": "firefox_developer_whatsnew_mdnplus"
+    },
+    {
+      "files": [
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/firefox/accounts-2019.es6.js"


### PR DESCRIPTION
## One-line summary
The Dev Edition WNP promoting MDN Plus features an animated graphic in the header which is fairly processor-intensive. Since the page opens automatically upon updating, this can sometimes happen in the background or in an inactive tab taxing CPU without a user being aware of what's causing it.

This updates the animation to only trigger when the page is visible, and when it is visible the animation automatically stops after five minutes (note that switching away from the tab and back will reset that timer because it restarts the animation).

## Issue / Bugzilla link
#11793 

## Testing

http://locahost:8000/firefox/105.0a2/whatsnew/