### PR TITLE
Also clear preference cookies that specify www.mozilla.org sub domain (issue #12056)

### DIFF
--- a/media/js/privacy/data-preferences-cookie.es6.js
+++ b/media/js/privacy/data-preferences-cookie.es6.js
@@ -41,6 +41,21 @@ DataPreferencesCookie.doOptIn = function () {
         false,
         'lax'
     );
+
+    // Also try and remove preference cookies that existed before the
+    // cookie domain switched from `www.mozilla.org` to `.mozilla.org`.
+    if (
+        domain === '.mozilla.org' &&
+        window.Mozilla.Cookies.hasItem(preferenceCookieID)
+    ) {
+        window.Mozilla.Cookies.removeItem(
+            preferenceCookieID,
+            '/',
+            'www.mozilla.org',
+            false,
+            'lax'
+        );
+    }
 };
 
 DataPreferencesCookie.hasOptedOut = function () {

--- a/tests/unit/spec/privacy/data-preferences-cookie.js
+++ b/tests/unit/spec/privacy/data-preferences-cookie.js
@@ -61,6 +61,35 @@ describe('doOptIn', function () {
         DataPreferencesCookie.doOptIn();
         expect(window.Mozilla.Cookies.removeItem).not.toHaveBeenCalled();
     });
+
+    // See https://github.com/mozilla/bedrock/issues/12056
+    it('should also remove pre-existing cookies that specified the www.mozilla.org subdomain', function () {
+        spyOn(DataPreferencesCookie, 'hasOptedOut').and.returnValue(true);
+        spyOn(DataPreferencesCookie, 'getCookieDomain').and.returnValue(
+            '.mozilla.org'
+        );
+        spyOn(window.Mozilla.Cookies, 'removeItem');
+        spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(true);
+        DataPreferencesCookie.doOptIn();
+        expect(window.Mozilla.Cookies.removeItem).toHaveBeenCalledTimes(2);
+        expect(Mozilla.Cookies.hasItem).toHaveBeenCalledWith(
+            'moz-1st-party-data-opt-out'
+        );
+        expect(window.Mozilla.Cookies.removeItem).toHaveBeenCalledWith(
+            'moz-1st-party-data-opt-out',
+            '/',
+            '.mozilla.org',
+            false,
+            'lax'
+        );
+        expect(window.Mozilla.Cookies.removeItem).toHaveBeenCalledWith(
+            'moz-1st-party-data-opt-out',
+            '/',
+            'www.mozilla.org',
+            false,
+            'lax'
+        );
+    });
 });
 
 describe('getCookieDomain', function () {


### PR DESCRIPTION
## One-line summary

Fixes an issue whereby trying to opt back in to data collection fails, if the previous cookie specified `www.mozilla.org` as the domain and not `.mozilla.org`.

## Issue / Bugzilla link

#12056

## Testing

This is not so easy to test manually as it relies on behaviour that only takes effect in production, but I added a JS test that should hopefully give enough confidence that the change works.

I'll test this manually on stage / prod also as we deploy.

http://localhost:8000/en-US/privacy/websites/data-preferences/
