### PR TITLE
Style dad jokes and add banner functionality

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/dad-jokes-banner.html
+++ b/bedrock/firefox/templates/firefox/family/includes/dad-jokes-banner.html
@@ -4,9 +4,9 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<!-- popup fixed at bottom of page -->
-<!-- dismissed on click, no cookie set to remember action on subsequent visits -->
-<aside id="dad-jokes-banner" aria-hidden="true" class="c-dad-jokes-banner mzp-l-content  mzp-t-content-lg">
-  <p>By using continuing to use this site, you consent to allow dad jokes.</p>
-  <button id="dad-jokes-banner-close" type="button">Accept all dad jokes</button>
+<aside id="dad-jokes-banner" aria-hidden="true" class="c-dad-jokes-banner">
+  <div class="l-flex mzp-l-content mzp-t-content-lg">
+    <p>By continuing to use this site, you consent to allow dad jokes.</p>
+    <button id="dad-jokes-banner-close" type="button">Accept all dad jokes</button>
+  </div>
 </aside>

--- a/bedrock/firefox/templates/firefox/family/includes/dad-jokes-banner.html
+++ b/bedrock/firefox/templates/firefox/family/includes/dad-jokes-banner.html
@@ -6,7 +6,7 @@
 
 <!-- popup fixed at bottom of page -->
 <!-- dismissed on click, no cookie set to remember action on subsequent visits -->
-<aside class="c-dad-jokes-banner">
-  <p>This site doesn’t use cookies to track you, but it does contain small bits of data known as  “dad jokes.”</p>
+<aside class="c-dad-jokes-banner mzp-l-content  mzp-t-content-lg">
+  <p>By using continuing to use this site, you consent to allow dad jokes.</p>
   <button>Accept all dad jokes</button>
 </aside>

--- a/bedrock/firefox/templates/firefox/family/includes/dad-jokes-banner.html
+++ b/bedrock/firefox/templates/firefox/family/includes/dad-jokes-banner.html
@@ -6,7 +6,7 @@
 
 <!-- popup fixed at bottom of page -->
 <!-- dismissed on click, no cookie set to remember action on subsequent visits -->
-<aside class="c-dad-jokes-banner mzp-l-content  mzp-t-content-lg">
+<aside id="dad-jokes-banner" aria-hidden="true" class="c-dad-jokes-banner mzp-l-content  mzp-t-content-lg">
   <p>By using continuing to use this site, you consent to allow dad jokes.</p>
-  <button>Accept all dad jokes</button>
+  <button id="dad-jokes-banner-close" type="button">Accept all dad jokes</button>
 </aside>

--- a/media/css/firefox/family/_utils.scss
+++ b/media/css/firefox/family/_utils.scss
@@ -46,3 +46,22 @@ $border-width: 3px;
 @mixin mono-font {
     font-family: 'Fira Mono', 'Andale Mono', monospace;
 }
+
+// Button
+@mixin button($color: transparent) {
+    @include border($color);
+    border-radius: $border-radius-sm;
+    background-color: $white;
+    color: $black;
+    font-weight: bold;
+    padding: $spacing-sm $spacing-2xl;
+    text-decoration: none;
+    transition: background-color 100ms, color 100ms;
+
+    &:hover,
+    &:focus,
+    &:active {
+        background-color: $black;
+        color: $white;
+    }
+}

--- a/media/css/firefox/family/components/_agreement.scss
+++ b/media/css/firefox/family/components/_agreement.scss
@@ -39,22 +39,7 @@
 }
 
 .c-download {
-    @include f3.border(transparent);
-    border-radius: $border-radius-sm;
-    background-color: f3.$white;
-    color: f3.$black;
-    display: inline-block;
-    font-weight: bold;
-    padding: $spacing-sm $spacing-2xl;
-    text-decoration: none;
-    transition: background-color 100ms, color 100ms;
-
-    &:hover,
-    &:focus,
-    &:active {
-        background-color: f3.$black;
-        color: f3.$white;
-    }
+    @include f3.button;
 }
 
 @media #{$mq-sm} {

--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -3,7 +3,80 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @use '../utils' as f3;
+@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+
+.no-js .c-dad-jokes-banner {
+    display: none;
+}
 
 .c-dad-jokes-banner {
+    @include f3.border;
+    @include text-body-md;
     background-color: f3.$yellow-primary;
+    font-weight: bold;
+    text-align: center;
+    position: fixed;
+    bottom: 0;
+    z-index: 4; // mental health section uses z-index 3
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    box-sizing: border-box;
+
+    &.mzp-l-content {
+        padding: $spacing-sm $spacing-md;
+    }
+
+    p {
+        margin-bottom: $spacing-sm;
+    }
+
+    button {
+        @include f3.button(f3.$black);
+        padding-right: $spacing-md;
+        padding-left: $spacing-md;
+    }
+}
+
+@supports (flex: 1 0 auto) {
+    .c-dad-jokes-banner {
+        display: flex;
+        row-gap: $spacing-sm;
+        column-gap: $spacing-lg;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+
+        p {
+            flex: 1 0 auto;
+            margin-bottom: 0;
+        }
+
+        button {
+            flex: 0 0 auto;
+        }
+
+        @media #{$mq-md} {
+            flex-flow: row wrap;
+            justify-content: center;
+
+            button {
+                padding-right: $spacing-2xl;
+                padding-left: $spacing-2xl;
+            }
+        }
+
+        @media #{$mq-lg} {
+            justify-content: space-between;
+
+            &.mzp-l-content {
+                padding-right: $spacing-lg;
+                padding-left: $spacing-lg;
+
+                &::after {
+                    display: none; // Protocol override to allow space-between to work
+                }
+            }
+        }
+    }
 }

--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -10,6 +10,18 @@
 }
 
 .c-dad-jokes-banner {
+    // related to js show/hide behaviour
+    &[aria-hidden='true'] {
+        opacity: 0;
+        transition: opacity 100ms;
+    }
+
+    &[aria-hidden='false'] {
+        opacity: 1;
+        transition: opacity 500ms;
+    }
+
+    // unrelated to js
     @include f3.border;
     @include text-body-md;
     background-color: f3.$yellow-primary;

--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -18,7 +18,7 @@
 
     &[aria-hidden='false'] {
         opacity: 1;
-        transition: opacity 500ms;
+        transition: opacity 1000ms;
     }
 
     // unrelated to js
@@ -35,7 +35,7 @@
     width: 100%;
     box-sizing: border-box;
 
-    &.mzp-l-content {
+    .mzp-l-content {
         padding: $spacing-sm $spacing-md;
     }
 
@@ -52,41 +52,43 @@
 
 @supports (flex: 1 0 auto) {
     .c-dad-jokes-banner {
-        display: flex;
-        row-gap: $spacing-sm;
-        column-gap: $spacing-lg;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-
-        p {
-            flex: 1 0 auto;
-            margin-bottom: 0;
-        }
-
-        button {
-            flex: 0 0 auto;
-        }
-
-        @media #{$mq-md} {
-            flex-flow: row wrap;
+        .l-flex {
+            display: flex;
+            row-gap: $spacing-sm;
+            column-gap: $spacing-lg;
+            flex-direction: column;
+            align-items: center;
             justify-content: center;
 
-            button {
-                padding-right: $spacing-2xl;
-                padding-left: $spacing-2xl;
+            p {
+                flex: 1 0 auto;
+                margin-bottom: 0;
             }
-        }
 
-        @media #{$mq-lg} {
-            justify-content: space-between;
+            button {
+                flex: 0 0 auto;
+            }
 
-            &.mzp-l-content {
-                padding-right: $spacing-lg;
-                padding-left: $spacing-lg;
+            @media #{$mq-md} {
+                flex-flow: row wrap;
+                justify-content: center;
 
-                &::after {
-                    display: none; // Protocol override to allow space-between to work
+                button {
+                    padding-right: $spacing-2xl;
+                    padding-left: $spacing-2xl;
+                }
+            }
+
+            @media #{$mq-lg} {
+                justify-content: space-between;
+
+                &.mzp-l-content {
+                    padding-right: $spacing-lg;
+                    padding-left: $spacing-lg;
+
+                    &::after {
+                        display: none; // Protocol override to allow space-between to work
+                    }
                 }
             }
         }

--- a/media/js/firefox/family/banner-init.es6.js
+++ b/media/js/firefox/family/banner-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import init from './banner.es6';
+
+init();

--- a/media/js/firefox/family/banner.es6.js
+++ b/media/js/firefox/family/banner.es6.js
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+let dadJokesBanner;
+let dadJokesBannerClose;
+
+function showBanner() {
+    // remove unneeded event listener
+    document.removeEventListener('scroll', showBanner);
+    // show banner (potentially use setTimeout?)
+    dadJokesBanner.setAttribute('aria-hidden', 'false');
+    // allow dismissal click
+    dadJokesBannerClose.addEventListener('click', hideBanner);
+}
+
+function hideBanner() {
+    // hide banner
+    dadJokesBanner.setAttribute('aria-hidden', 'true');
+    // remove unusable event listener
+    dadJokesBannerClose.removeEventListener('click', hideBanner);
+}
+
+const init = function () {
+    // set element references
+    dadJokesBanner = document.getElementById('dad-jokes-banner');
+    dadJokesBannerClose = document.getElementById('dad-jokes-banner-close');
+
+    // add event listeners
+    document.addEventListener('scroll', showBanner);
+};
+
+export default init;

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1851,7 +1851,9 @@
     },
     {
       "files": [
-        "js/firefox/family/subnav.js"
+        "js/firefox/family/subnav.js",
+        "js/firefox/family/banner.es6.js",
+        "js/firefox/family/banner-init.es6.js"
       ],
       "name": "firefox-family"
     }


### PR DESCRIPTION
## One-line summary

Adds styling and functionality to dad jokes banner

## Significant changes and points to review

- Updates copy
- Does not show banner if js is disabled

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12004
figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families?node-id=100%3A1597

## Testing

http://localhost:8000/en-US/firefox/family/

**with JS**
on scroll, banner fades in 
on banner click, banner fades out

**without JS**
no banner

Design feedback: keep banner extending full width of page at all screen sizes, slow down fade in (original transition 500ms, increased to 1000ms)
