### PR TITLE
Fix subnav, add dividers

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -26,6 +26,8 @@
 {% block twitter_id %}firefox{% endblock %}
 <!-- metadata q ends -->
 
+{% block body_class %}t-firefox-family{% endblock %}
+
 {% block sub_navigation %}
   {% include 'firefox/family/includes/subnav.html' %}
 {% endblock %}
@@ -64,4 +66,8 @@
 </main>
 <!-- dad jokes cookie banner -->
 {% include 'firefox/family/includes/dad-jokes-banner.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-family') }}
 {% endblock %}

--- a/media/css/firefox/family/_utils.scss
+++ b/media/css/firefox/family/_utils.scss
@@ -33,6 +33,10 @@ $border-width: 3px;
     border: $border-width solid $border-color;
 }
 
+@mixin section-divider {
+    border-bottom: 5px solid $black;
+}
+
 // Shadows
 @mixin card-shadow($color: $black) {
     box-shadow: $spacing-sm $spacing-sm 0 $color;

--- a/media/css/firefox/family/components/_subnav.scss
+++ b/media/css/firefox/family/components/_subnav.scss
@@ -1,0 +1,170 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// * -------------------------------------------------------------------------- */
+// Should be replaced by https://github.com/mozilla/protocol/issues/471
+
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.t-firefox-family .c-sub-navigation {
+    background: $color-marketing-gray-10;
+    box-shadow:
+        inset 0 10px 2px -10px rgba(29, 17, 51, 0.04),
+        inset 0 10px 4px -10px rgba(9, 32, 77, 0.12),
+        inset 0 10px 3px -10px rgba(29, 17, 51, 0.12);
+
+    .mzp-l-content {
+        padding-top: 0;
+        padding-bottom: $spacing-md;
+    }
+
+    .c-sub-navigation-content {
+        padding-top: $spacing-md;
+    }
+
+    .c-sub-navigation-icon {
+        @include bidi((
+            (float, left, right),
+            (margin-right, $spacing-sm, margin-left, $spacing-sm),
+        ));
+        height: 24px;
+        vertical-align: middle;
+        width: 24px;
+    }
+
+    .c-sub-navigation-title {
+        @include font-base;
+        @include text-body-md;
+        float: unset;
+        font-weight: bold;
+
+        a:link,
+        a:visited {
+            color: $color-black;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:focus,
+        a:active {
+            text-decoration: underline;
+        }
+
+        & button {
+            @include text-body-md;
+            @include bidi(((text-align, left, right),));
+            background-color: transparent;
+            border: 0;
+            color: inherit;
+            font-weight: bold;
+            margin-bottom: 0;
+            padding: 0;
+            position: relative;
+            width: 100%;
+        }
+
+        &.is-summary {
+            padding: 0;
+            margin: 0;
+
+            button:focus {
+                outline: 1px dotted $color-black;
+            }
+
+            button::before {
+                background: $url-image-arrow-down-form top left no-repeat;
+                @include background-size(24px, 24px);
+                @include bidi(((right, $spacing-xs, left, auto),));
+                @include transition(transform 100ms ease-in-out);
+                content: '';
+                height: 24px;
+                margin-top: -12px;
+                position: absolute;
+                top: 50%;
+                width: 24px;
+            }
+
+            button[aria-expanded='true']::before {
+                @include transform(rotate(180deg));
+            }
+        }
+    }
+
+    .c-sub-navigation-list {
+        margin: 0;
+        float: unset;
+
+        // minimize sub navigation on mobile by default to reduce CLS
+        // see issue https://github.com/mozilla/bedrock/issues/9823
+        &.is-closed {
+            display: none;
+
+            // ensure sub-nav is still accessible with JS disabled
+            .no-js & {
+                display: block;
+            }
+
+            @media (min-width: 950px) {
+                display: block;
+            }
+        }
+
+        &.mzp-js-details-wrapper {
+            margin-top: $spacing-sm;
+        }
+    }
+
+    .c-sub-navigation-item {
+        display: block;
+        padding: $spacing-xs 0;
+
+        a:link,
+        a:visited {
+            @include font-base;
+            @include text-body-sm;
+            color: $color-black;
+            text-decoration: none;
+
+            &:hover,
+            &:focus,
+            &:active {
+                text-decoration: underline;
+            }
+        }
+
+        a[aria-current='page'] {
+            font-weight: bold;
+        }
+    }
+
+    @media (min-width: 950px) {
+        @include clearfix;
+
+        .c-sub-navigation-title {
+            @include bidi((
+                (float, left, right),
+                (margin-right, $spacing-sm * 2, margin-left, 0),
+            ));
+            margin-bottom: 0;
+        }
+
+        .c-sub-navigation-list {
+            @include bidi((
+                (float, right, left),
+                (margin-right, -$spacing-sm, margin-left, 0),
+            ));
+
+            &.mzp-js-details-wrapper {
+                margin-top: 0;
+            }
+        }
+
+        .c-sub-navigation-item {
+            display: inline-block;
+            padding: 0 $spacing-sm;
+        }
+    }
+}

--- a/media/css/firefox/family/components/_typography.scss
+++ b/media/css/firefox/family/components/_typography.scss
@@ -5,7 +5,7 @@
 @use '../utils' as f3;
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
-body {
+main {
     @include text-body-xl;
     color: f3.$black;
 }

--- a/media/css/firefox/family/components/modules/_bullying.scss
+++ b/media/css/firefox/family/components/modules/_bullying.scss
@@ -6,6 +6,7 @@
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .c-bullying {
+    @include f3.section-divider;
     background-color: f3.$yellow-dark;
 
     .c-module-tag-title {

--- a/media/css/firefox/family/components/modules/_passwords.scss
+++ b/media/css/firefox/family/components/modules/_passwords.scss
@@ -6,6 +6,7 @@
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .c-passwords {
+    @include f3.section-divider;
     background-color: f3.$orange-primary;
 
     .c-module-tag-title {

--- a/media/css/firefox/family/components/modules/_privacy.scss
+++ b/media/css/firefox/family/components/modules/_privacy.scss
@@ -6,6 +6,7 @@
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .c-privacy {
+    @include f3.section-divider;
     background-color: f3.$pink-light;
 
     .c-module-tag-title {

--- a/media/css/firefox/family/styles.scss
+++ b/media/css/firefox/family/styles.scss
@@ -18,6 +18,7 @@
 @use './components/modules/public-wifi';
 @use './components/news-ticker';
 @use './components/pro-tip';
+@use './components/subnav';
 @use './components/typography';
 
 @font-face {

--- a/media/js/firefox/family/subnav.js
+++ b/media/js/firefox/family/subnav.js
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    // check we have global variable
+    if (typeof window.Mzp !== 'undefined') {
+        var Mzp = window.Mzp;
+        var subNavTitle =
+            '.t-firefox-family .c-sub-navigation .c-sub-navigation-title';
+
+        // check we have global Supports and Details library
+        if (
+            typeof Mzp.Supports !== 'undefined' &&
+            typeof Mzp.Details !== 'undefined'
+        ) {
+            // check browser supports matchMedia
+            if (Mzp.Supports.matchMedia) {
+                var _mqWide = matchMedia('(max-width: 950px)');
+
+                // initialize details if screen is small
+                if (_mqWide.matches) {
+                    Mzp.Details.init(subNavTitle);
+                }
+
+                // remove details if screen is big
+                _mqWide.addListener(function (mq) {
+                    if (mq.matches) {
+                        Mzp.Details.init(subNavTitle);
+                    } else {
+                        Mzp.Details.destroy(subNavTitle);
+                    }
+                });
+            }
+        }
+    }
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1848,6 +1848,12 @@
         "js/stories/stories-article.es6.js"
       ],
       "name": "stories-article"
+    },
+    {
+      "files": [
+        "js/firefox/family/subnav.js"
+      ],
+      "name": "firefox-family"
     }
   ]
 }


### PR DESCRIPTION
## One-line summary

Style fixes for subnav and sections

## Significant changes and points to review

- copy/pasted subnav and added a t-firefox-family container class
- changed subnav collapse/expand breakpoint to 950 and reset float/display styles below that
- added black border bottom to sections that needed it
- changed scope for typography styles to fix subnav vertical alignment

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12004
figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families

## Testing
http://localhost:8000/firefox/family/

privacy, bullying, and password sections should have underline
nav should be properly center aligned and collapse at 950px


