### PR TITLE
Add responsive styling for Mental Health section

### DIFF
--- a/media/css/firefox/family/components/modules/_mental-health.scss
+++ b/media/css/firefox/family/components/modules/_mental-health.scss
@@ -46,13 +46,6 @@
         height: 800px;
         position: relative;
         top: -40px;
-
-        // potential animation/easter egg interaction, scroll
-        // transition: top 2s;
-
-        // &:hover {
-        //     top: -300px
-        // }
     }
 
     .c-stop-button {
@@ -76,6 +69,10 @@
 
     .t-content-container,
     .c-card {
+        box-sizing: border-box;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: $content-md;
         position: relative;
         z-index: 2;
     }
@@ -88,7 +85,7 @@
 }
 
 @supports (display: grid) {
-    @media #{$mq-lg} {
+    @media (min-width: 1178px) {
         .c-mental-health {
             // reset mobile styles
             .t-doomscroll-container,


### PR DESCRIPTION
## One-line summary

Add responsive styling for Mental Health section

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12004
figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families

## Testing
http://localhost:8000/en-US/firefox/family/#mental-health