### PR TITLE
Fix WNP 104 referrals for VPN (Fixes #12088)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-de-coupon.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-de-coupon.html
@@ -45,7 +45,15 @@
       </aside>
 
       <p class="wnp-main-cta">
-        <a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') }}">Hol dir Mozilla VPN</a>
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-104-vpn-de-coupon',
+          link_text='Hol dir Mozilla VPN',
+          class_name='mzp-t-product',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
       </p>
     </div>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-de.html
@@ -36,7 +36,15 @@
         mit einem einzigen Mozilla VPN Abo.</p>
 
       <p class="wnp-main-cta">
-        <a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') }}">Hol dir Mozilla VPN</a>
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-104-vpn-de',
+          link_text='Hol dir Mozilla VPN',
+          class_name='mzp-t-product',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
       </p>
     </div>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-en-coupon.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-en-coupon.html
@@ -43,7 +43,15 @@
       </aside>
 
       <p class="wnp-main-cta">
-        <a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') }}">Get Mozilla VPN</a>
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-104-vpn-en-coupon',
+          link_text='Get Mozilla VPN',
+          class_name='mzp-t-product',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
       </p>
     </div>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-en.html
@@ -35,7 +35,15 @@
         Connect up to 5 devices with just one Mozilla VPN subscription. </p>
 
       <p class="wnp-main-cta">
-        <a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') }}">Get Mozilla VPN</a>
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-104-vpn-en',
+          link_text='Get Mozilla VPN',
+          class_name='mzp-t-product',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
       </p>
     </div>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-fr-coupon.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-fr-coupon.html
@@ -43,7 +43,15 @@
       </aside>
 
       <p class="wnp-main-cta">
-        <a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') }}">Installer Mozilla VPN</a>
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-104-vpn-fr-coupon',
+          link_text='Installer Mozilla VPN',
+          class_name='mzp-t-product',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
       </p>
     </div>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx104-vpn-fr.html
@@ -36,7 +36,15 @@
         abonnement à Mozilla VPN.</p>
 
       <p class="wnp-main-cta">
-        <a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') }}">Installer Mozilla VPN</a>
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-104-vpn-fr',
+          link_text='Installer Mozilla VPN',
+          class_name='mzp-t-product',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
       </p>
     </div>
   {% endcall %}


### PR DESCRIPTION
## One-line summary

Updates WNP 104 templates to use `vpn_product_referral_link()` for the main CTA.

## Issue / Bugzilla link

#12088

## Testing

Test with `SWITCH_FIREFOX_104_WHATSNEW_VPN_COUPON_EN` and `SWITCH_FIREFOX_104_WHATSNEW_VPN_COUPON_FRDE` both `on` and `off`:

- [ ] http://localhost:8000/en-US/firefox/104.0/whatsnew/
- [ ] http://localhost:8000/de/firefox/104.0/whatsnew/
- [ ] http://localhost:8000/fr/firefox/104.0/whatsnew/
