### PR TITLE
Fix newsletter country success / fxa error URLs (Issue #11963)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/country_success.html
+++ b/bedrock/newsletter/templates/newsletter/country_success.html
@@ -4,15 +4,17 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% extends 'newsletter/recovery.html' %}
+{% extends 'newsletter/base.html' %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title %}Newsletter Country or Region{% endblock page_title %}
 
-{% block messages %}
-  <h1>Thanks for updating your country or region!</h1>
-  <p>We'll now be able to keep you up to date on interesting things happening near you.</p>
-  <p>Please be sure to add our sending address: mozilla@email.mozilla.org to your address book to ensure we always reach your inbox.</p>
+{% block content %}
+  <main role="main" class="mzp-l-content mzp-t-content-sm">
+    <h1>Thanks for updating your country or region!</h1>
+    <p>We'll now be able to keep you up to date on interesting things happening near you.</p>
+    <p>Please be sure to add our sending address: mozilla@email.mozilla.org to your address book to ensure we always reach your inbox.</p>
+  </main>
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/fxa-error.html
+++ b/bedrock/newsletter/templates/newsletter/fxa-error.html
@@ -4,11 +4,13 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% extends 'newsletter/recovery.html' %}
+{% extends 'newsletter/base.html' %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
-{% block messages %}
-  <p>{{ ftl('newsletters-we-are-sorry-but-there') }}</p>
+{% block content %}
+  <main role="main" class="mzp-l-content mzp-t-content-sm">
+    <h1>{{ ftl('newsletters-we-are-sorry-but-there') }}</h1>
+  </main>
 {% endblock %}


### PR DESCRIPTION
## One-line summary

I discovered a couple of rogue URLs that I missed in #11963. This PR updates / fixes those URLs to extend `newsletter/base` rather than `newsletter/recovery`, since they have no form and only display simple messages.

## Issue / Bugzilla link

#11963

## Testing

- http://localhost:8000/en-US/newsletter/fxa-error/
- http://localhost:8000/en-US/newsletter/country/success/
