### PR TITLE
F3 landing page fixes

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/download-firefox.html
+++ b/bedrock/firefox/templates/firefox/family/includes/download-firefox.html
@@ -22,7 +22,6 @@
       </a>
     </div>
 
-    <!-- TODO: JS logic to check IF is Firefox AND is default, hide others and show mobile. -->
     <div class="show-mobile">
       <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.mobile.get-app') }}" data-cta-text="Get Firefox on your phone" data-cta-type="button">
         Get Firefox on your phone

--- a/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
@@ -19,7 +19,7 @@
       {% call browser_border() %}
         <div class="c-passwords-example">
           <h4 class="c-title-uppercase"><span class="visually-hidden">Example form: </span>Log-in</h4>
-          <p class="c-passwords-example-input t-username"><span class="visually-hidden">Example username: </span>nerdzrcool@mozilla.com</p>
+          <p class="c-passwords-example-input t-username"><span class="visually-hidden">Example username: </span>nerdzrcool@example.com</p>
           <p data-password-length="long" class="c-passwords-example-input t-password"><span class="visually-hidden">Example password: </span>MrFlounder_Sweats_Clam_Chowder77</p>
           <p data-password-length="short" class="c-passwords-example-input t-password"><span class="visually-hidden">Example password: </span>I_eats_thechowder77</p>
           <p aria-hidden="true" class="c-passwords-example-submit mzp-c-button mzp-t-product">Enter</p>

--- a/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/passwords.html
@@ -27,7 +27,7 @@
       {% endcall %}
 
       <div class="c-blurb">
-        <p><a href="https://support.mozilla.org/kb/how-generate-secure-password-firefox" rel="external">Generate a secure password</a>
+        <p><a href="https://support.mozilla.org/kb/how-generate-secure-password-firefox?{{ utm_params }}" rel="external">Generate a secure password</a>
           in Firefox or create a fun, random passphrase instead of a password. Make
           it alphanumeric and at least 12 characters long.</p>
       </div> <!-- .c-blurb ends-->

--- a/bedrock/firefox/templates/firefox/family/includes/modules/privacy.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/privacy.html
@@ -23,7 +23,7 @@
           <li>Keep data private by turning off location services for apps.</li>
           <li>Opt into “Ask app not to track” if your kid is using an iPhone.</li>
           <li>Set Firefox as the <a href="{{ url('firefox.set-as-default') }}">default browser</a>
-            to <a href="https://support.mozilla.org/kb/introducing-total-cookie-protection-standard-mode">block ad trackers</a>
+            to <a rel="external" href="https://support.mozilla.org/kb/introducing-total-cookie-protection-standard-mode?{{ utm_params }}">block ad trackers</a>
             from sneaking data.</li>
         </ul>
       {% endcall %}

--- a/bedrock/firefox/templates/firefox/family/includes/modules/private-mode.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/private-mode.html
@@ -33,7 +33,7 @@
         <p>Note: Private browsing might be the elephant in the room or it could be
           a thing they haven’t discovered yet. Proceed with caution.</p>
         <p>Consider talking about
-          <a href="https://support.mozilla.org/kb/block-and-unblock-websites-parental-controls-firef">dangers of things like adult content</a>
+          <a rel="external" href="https://support.mozilla.org/kb/block-and-unblock-websites-parental-controls-firef?{{ utm_params }}">dangers of things like adult content</a>
           in a way that’s appropriate for their age.</p>
       </div>
 

--- a/bedrock/firefox/templates/firefox/family/includes/subnav.html
+++ b/bedrock/firefox/templates/firefox/family/includes/subnav.html
@@ -5,7 +5,6 @@
 #}
 
 {# Subnav menu for /firefox/families/ #}
-<!-- todo: get official campaign analytics naming, replace "tbd-" namespace -->
 {% from "macros.html" import sub_nav with context %}
 
 {{ sub_nav(
@@ -16,36 +15,36 @@
   {
     'text': 'Privacy',
     'href': '#privacy',
-    'cta_name': 'tbd-privacy'
+    'cta_name': 'firefox-for-families-privacy'
   },
   {
     'text': 'Mental health',
     'href': '#mental-health',
-    'cta_name': 'tbd-mental-health'
+    'cta_name': 'firefox-for-families-mental-health'
   },
   {
     'text': 'Bullying',
     'href': '#bullying',
-    'cta_name': 'tbd-bullying'
+    'cta_name': 'firefox-for-families-bullying'
   },
   {
     'text': 'Public wifi',
     'href': '#public-wifi',
-    'cta_name': 'tbd-public-wifi'
+    'cta_name': 'firefox-for-families-public-wifi'
   },
   {
     'text': 'Passwords',
     'href': '#passwords',
-    'cta_name': 'tbd-passwords'
+    'cta_name': 'firefox-for-families-passwords'
   },
   {
     'text': 'Private mode',
     'href': '#private-mode',
-    'cta_name': 'tbd-private-mode'
+    'cta_name': 'firefox-for-families-private-mode'
   },
   {
     'text': 'Agreement',
     'href': '#agreement',
-    'cta_name': 'tbd-agreement'
+    'cta_name': 'firefox-for-families-agreement'
   }]
 ) }}

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -30,6 +30,8 @@
   {% include 'firefox/family/includes/subnav.html' %}
 {% endblock %}
 
+{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-for-families' %}
+
 {% block content %}
 {% include 'firefox/family/includes/hero.html' %}
 {% include 'firefox/family/includes/news-ticker.html' %}

--- a/media/css/firefox/family/components/_download-firefox.scss
+++ b/media/css/firefox/family/components/_download-firefox.scss
@@ -59,3 +59,14 @@ $image-path: '/media/protocol/img';
         display: none;
     }
 }
+
+.is-firefox .is-firefox-default {
+    .show-mobile {
+        display: block;
+    }
+
+    .show-not-default,
+    .show-not-firefox {
+        display: none;
+    }
+}

--- a/media/js/firefox/family/banner.es6.js
+++ b/media/js/firefox/family/banner.es6.js
@@ -17,6 +17,12 @@ function showBanner() {
 }
 
 function hideBanner() {
+    window.dataLayer.push({
+        eLabel: 'Banner Dismissal',
+        'data-banner-name': 'firefox-for-families-banner',
+        'data-banner-dismissal': '1',
+        event: 'in-page-interaction'
+    });
     // hide banner
     dadJokesBanner.setAttribute('aria-hidden', 'true');
     // remove unusable event listener

--- a/media/js/firefox/family/fx-is-default.js
+++ b/media/js/firefox/family/fx-is-default.js
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    // copy/pasted from thanks.js
+    function isDefaultBrowser() {
+        return new window.Promise(function (resolve, reject) {
+            Mozilla.UITour.getConfiguration('appinfo', function (details) {
+                if (details.defaultBrowser) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
+        });
+    }
+
+    function isSupported() {
+        return Mozilla.Client.isFirefoxDesktop && 'Promise' in window;
+    }
+
+    function onLoad() {
+        if (!isSupported()) {
+            return;
+        }
+
+        /**
+         * Check to see if Firefox is the default browser.
+         * If true, add class to main
+         */
+        isDefaultBrowser().then(function () {
+            document.querySelector('main').classList.add('is-firefox-default');
+        });
+    }
+
+    Mozilla.run(onLoad);
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1904,7 +1904,8 @@
       "files": [
         "js/firefox/family/subnav.js",
         "js/firefox/family/banner.es6.js",
-        "js/firefox/family/banner-init.es6.js"
+        "js/firefox/family/banner-init.es6.js",
+        "js/firefox/family/fx-is-default.js"
       ],
       "name": "firefox-family"
     }


### PR DESCRIPTION
## One-line summary

Adds F3 analytics and updates `mozilla.com` to `example.com` in passwords section

## Issue / Bugzilla link
No issue, follow up from[ feature PR](https://github.com/mozilla/bedrock/pull/12086)

## Testing

http://localhost:8000/en-US/firefox/family/

- all external links have utm params, all subnav links have gtm data
- email in passwords section is now using `example.com`
- CTA conditionals work in download section (tests are coming in the [fast-follow issue](https://github.com/mozilla/bedrock/issues/12091))
   - if not on Firefox, download Firefox CTA
   - if on Firefox but not default, default Firefox CTA
   - if on Firefox and default, mobile Firefox CTA
