### PR TITLE
Hide nav CTA on /firefox/family for Firefox users

### DIFF
--- a/media/css/firefox/family/styles.scss
+++ b/media/css/firefox/family/styles.scss
@@ -40,3 +40,8 @@
         url('/media/fonts/families/FiraMono-Bold.woff2') format('woff2'),
         url('/media/fonts/families/FiraMono-Bold.woff') format('woff');
 }
+
+// Hide top-nav CTA for Firefox browsers
+.is-firefox .c-navigation-shoulder {
+    display: none;
+}

--- a/tests/functional/firefox/family/test_family.py
+++ b/tests/functional/firefox/family/test_family.py
@@ -7,11 +7,16 @@ import pytest
 from pages.firefox.family.landing import FamilyPage
 
 
-# confirm if download button is actual download or link to download page
 @pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
 def test_firefox_download_button_is_displayed(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert page.is_firefox_download_button_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason="Nav CTA is only hidden for Firefox users")
+def test_firefox_nav_cta_is_displayed(base_url, selenium):
+    page = FamilyPage(selenium, base_url).open()
+    assert not page.is_firefox_nav_cta_displayed
 
 
 def test_firefox_pdf_download_button_is_displayed(base_url, selenium):

--- a/tests/pages/firefox/family/landing.py
+++ b/tests/pages/firefox/family/landing.py
@@ -11,9 +11,15 @@ class FamilyPage(BasePage):
 
     _URL_TEMPLATE = "/{locale}/firefox/family/"
 
-    _firefox_download_button_locator = (By.CSS_SELECTOR, "[data-link-type='download']")
+    _firefox_nav_cta_locator = (By.CSS_SELECTOR, ".c-navigation-shoulder")
+
+    _firefox_download_button_locator = (By.CSS_SELECTOR, "[data-download-location='nav']")
 
     _firefox_pdf_download_button_locator = (By.CSS_SELECTOR, "[data-cta-text='Download PDF']")
+
+    @property
+    def is_firefox_nav_cta_displayed(self):
+        return self.is_element_displayed(*self._firefox_nav_cta_locator)
 
     @property
     def is_firefox_download_button_displayed(self):


### PR DESCRIPTION
This avoids confusion with the primary goal of the page: to get users to download firefox or make it their default

## Issue / Bugzilla link
slack request from Mary O'Regan

## Testing

http://localhost:8000/en-US/firefox/family/
In Firefox, no nav CTA
In non-Firefox, "Download Firefox" CTA

local testing
`py.test --base-url http://localhost:8000 --driver Chrome tests/functional/firefox/family`
`py.test --base-url http://localhost:8000 --driver Firefox tests/functional/firefox/family`
