### PR TITLE
Add link for Stories to global nav (Fixes #12101)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
@@ -47,8 +47,8 @@
               <a class="c-menu-item-link" href="{{ url('stories.landing') }}" data-link-name="Stories Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                <svg class="c-menu-item-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(2 1.87868)"><path d="m8.3.4h-7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h9l2 4 2-4h2c1.1 0 2-.9 2-2v-6"/><path d="m14.8-.1c.8-.8 2.2-.8 3 0s.8 2.2 0 3l-7.5 7.5-4 1 1-4z"/></g></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-stories') }}</h4>
-              {% if ftl_has_messages('navigation-v2-learn-about-mozilla-and') %}
-                <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-about-mozilla-and') }}</p>
+              {% if ftl_has_messages('navigation-v2-navigation-v2-stories-about-how') %}
+                <p class="c-menu-item-desc">{{ ftl('navigation-v2-stories-about-how') }}</p>
               {% endif %}
               </a>
             </section>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
@@ -12,7 +12,7 @@
     <div class="c-menu-panel-container">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-about">{{ ftl('navigation-v2-close-who-we-are-menu', fallback='navigation-close-about-menu') }}</button>
       <div class="c-menu-panel-content">
-        <ul class="mzp-l-rows-three">
+        <ul class="mzp-l-rows-four">
           <li>
             <section class="c-menu-item mzp-has-icon">
               <a class="c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-name="Mozilla Manifesto" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
@@ -67,6 +67,17 @@
               <a class="c-menu-item-link" href="https://blog.mozilla.org/?{{ utm_params }}" data-link-name="Mozilla Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-blog') }}</h4>
+              {% if ftl_has_messages('navigation-v2-learn-about-mozilla-and') %}
+                <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-about-mozilla-and') }}</p>
+              {% endif %}
+              </a>
+            </section>
+          </li>
+          <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="{{ url('stories.landing') }}" data-link-name="Stories Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+               <svg class="c-menu-item-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(2 1.87868)"><path d="m8.3.4h-7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h9l2 4 2-4h2c1.1 0 2-.9 2-2v-6"/><path d="m14.8-.1c.8-.8 2.2-.8 3 0s.8 2.2 0 3l-7.5 7.5-4 1 1-4z"/></g></svg>
+                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-stories') }}</h4>
               {% if ftl_has_messages('navigation-v2-learn-about-mozilla-and') %}
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-about-mozilla-and') }}</p>
               {% endif %}

--- a/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
@@ -42,6 +42,17 @@
               </a>
             </section>
           </li>
+           <li>
+            <section class="c-menu-item mzp-has-icon">
+              <a class="c-menu-item-link" href="{{ url('stories.landing') }}" data-link-name="Stories Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+               <svg class="c-menu-item-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(2 1.87868)"><path d="m8.3.4h-7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h9l2 4 2-4h2c1.1 0 2-.9 2-2v-6"/><path d="m14.8-.1c.8-.8 2.2-.8 3 0s.8 2.2 0 3l-7.5 7.5-4 1 1-4z"/></g></svg>
+                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-stories') }}</h4>
+              {% if ftl_has_messages('navigation-v2-learn-about-mozilla-and') %}
+                <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-about-mozilla-and') }}</p>
+              {% endif %}
+              </a>
+            </section>
+          </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
               <a class="c-menu-item-link" href="{{ url('mozorg.about.leadership.index') }}" data-link-name="Leadership" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
@@ -73,17 +84,7 @@
               </a>
             </section>
           </li>
-          <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('stories.landing') }}" data-link-name="Stories Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
-               <svg class="c-menu-item-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(2 1.87868)"><path d="m8.3.4h-7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h9l2 4 2-4h2c1.1 0 2-.9 2-2v-6"/><path d="m14.8-.1c.8-.8 2.2-.8 3 0s.8 2.2 0 3l-7.5 7.5-4 1 1-4z"/></g></svg>
-                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-stories') }}</h4>
-              {% if ftl_has_messages('navigation-v2-learn-about-mozilla-and') %}
-                <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-about-mozilla-and') }}</p>
-              {% endif %}
-              </a>
-            </section>
-          </li>
+
         </ul>
         <p class="c-menu-category-link">
           <a href="{{ url('mozorg.about.index') }}" data-link-name="More About Mozilla" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">{{ ftl('navigation-v2-more-about-mozilla') }}</a>

--- a/l10n/en/navigation_v2.ftl
+++ b/l10n/en/navigation_v2.ftl
@@ -70,7 +70,10 @@ navigation-v2-careers = Careers
 navigation-v2-work-for-a-mission-driven-updated = Work for a mission-driven organization that makes people-first products.
 navigation-v2-mozilla-blog = { -brand-name-mozilla } Blog
 navigation-v2-learn-about-mozilla-and = Learn about { -brand-name-mozilla } and the issues that matter to us.
+navigation-v2-stories = Stories
 navigation-v2-more-about-mozilla = More About { -brand-name-mozilla }
+
+
 
 ## Innovation menu
 

--- a/l10n/en/navigation_v2.ftl
+++ b/l10n/en/navigation_v2.ftl
@@ -71,6 +71,7 @@ navigation-v2-work-for-a-mission-driven-updated = Work for a mission-driven orga
 navigation-v2-mozilla-blog = { -brand-name-mozilla } Blog
 navigation-v2-learn-about-mozilla-and = Learn about { -brand-name-mozilla } and the issues that matter to us.
 navigation-v2-stories = Stories
+navigation-v2-stories-about-how = Stories about how our people and products are changing the world for the better.
 navigation-v2-more-about-mozilla = More About { -brand-name-mozilla }
 
 ## Innovation menu

--- a/l10n/en/navigation_v2.ftl
+++ b/l10n/en/navigation_v2.ftl
@@ -73,8 +73,6 @@ navigation-v2-learn-about-mozilla-and = Learn about { -brand-name-mozilla } and 
 navigation-v2-stories = Stories
 navigation-v2-more-about-mozilla = More About { -brand-name-mozilla }
 
-
-
 ## Innovation menu
 
 navigation-v2-innovation = Innovation


### PR DESCRIPTION
## One-line summary

Added a link in the "Who we are" section of global navigation

## Issue / Bugzilla link
#12101 


## Screenshots
<img width="1345" alt="Screen Shot 2022-09-06 at 10 47 56 AM" src="https://user-images.githubusercontent.com/30009669/188704497-aa59f96f-5f49-4655-a2f2-610abcdf5431.png">

## Testing

Demo server URL: https://localhost:8000 

- Link should navigate to mozilla.org/stories 
