### PR TITLE
Remove "More Mozilla Innovation" link from main nav

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
@@ -50,7 +50,6 @@
             </section>
           </li>
         </ul>
-        <p class="c-menu-category-link"><a href="https://labs.mozilla.org/?{{ utm_params }}" data-link-name="More Mozilla Innovation" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">{{ ftl('navigation-v2-more-mozilla-innovation') }}</a></p>
       </div>
     </div><!-- close .c-menu-panel-container -->
   </div><!-- close .c-menu-panel -->

--- a/l10n/en/navigation_v2.ftl
+++ b/l10n/en/navigation_v2.ftl
@@ -88,4 +88,6 @@ navigation-v2-common-voice = { -brand-name-common-voice }
 navigation-v2-donate-your-voice-so-the-future = Donate your voice so the future of the web can hear everyone.
 navigation-v2-webassembly = { -brand-name-webassembly }
 navigation-v2-learn-more-about-the-new = Learn more about the new, low-level, assembly-like language.
+
+# Obsolete string
 navigation-v2-more-mozilla-innovation = More { -brand-name-mozilla } Innovation

--- a/l10n/en/navigation_v2.ftl
+++ b/l10n/en/navigation_v2.ftl
@@ -89,5 +89,3 @@ navigation-v2-donate-your-voice-so-the-future = Donate your voice so the future 
 navigation-v2-webassembly = { -brand-name-webassembly }
 navigation-v2-learn-more-about-the-new = Learn more about the new, low-level, assembly-like language.
 
-# Obsolete string
-navigation-v2-more-mozilla-innovation = More { -brand-name-mozilla } Innovation


### PR DESCRIPTION
## One-line summary
Removed the link, and deleted its string in respective `.ftl` file.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12103

## Testing

To test this work:

- [ ] http://localhost:8000/en-US/ -- Go to nav and hover over `Innovation` tab
