### PR TITLE
F3 design feedback: fix heart sizing and spacing

### DIFF
--- a/media/css/firefox/family/components/_download-firefox.scss
+++ b/media/css/firefox/family/components/_download-firefox.scss
@@ -26,7 +26,11 @@ $image-path: '/media/protocol/img';
         margin-bottom: $spacing-sm;
 
         img {
-            width: 1em;
+            width: 0.9em;
+            margin-right: -0.1em;
+            margin-left: -0.1em;
+            position: relative;
+            top: 5px;
         }
 
         @media #{$mq-lg} {


### PR DESCRIPTION
## One-line summary

Downsizes the heart and pulls in the words on either side for spacing to more closely match figma

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12091
figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families?node-id=1799%3A8474

## Testing

Download section is below Public Wifi: http://localhost:8000/en-US/firefox/family/#public-wifi
