### PR TITLE
Added `/firefox/families` redirect for F3

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -551,4 +551,6 @@ redirectpatterns = (
     redirect(r"firefox/lockwise/?", "https://support.mozilla.org/kb/end-of-support-firefox-lockwise"),
     # issue 10879
     redirect(r"^/exp/?$", "mozorg.home"),
+    # issue 12107
+    redirect(r"^/firefox/families/?$", "firefox.family.index"),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1176,6 +1176,8 @@ URLS = flatten(
         url_test("/vpn/", "/products/vpn/"),
         # issue 10703
         url_test("/firefox/lockwise/", "https://support.mozilla.org/kb/end-of-support-firefox-lockwise"),
+        # issue 12107
+        url_test("/firefox/families/", "/firefox/family/"),
         # issue 10879
         url_test("/exp/", "/"),
         # issue 11092


### PR DESCRIPTION
## One-line summary
Added the needed redirect. Also ran the test to make sure its well tested

## Issue / Bugzilla link
#12107 

## Testing

- [ ] http://localhost:8000/en-US/firefox/families 👉🏼 **redirects to** 👉🏼 http://localhost:8000/en-US/firefox/family/
- [ ] run `py.test -r a tests/redirects` to test that redirect works
