### PR TITLE
Add transparency report H1 2022 (Fixes #12057)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,7 @@
 <nav class="prev-reports-nav">
   <h3>Previous Reports</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2021') }}">July-December 2021</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2021') }}">January-June 2021</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2020') }}">July-December 2020</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2020') }}">January-June 2020</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -15,7 +15,7 @@
     </li>
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2021') }}">July-December 2021 Report</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2022') }}">January-June 2022 Report</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -12,10 +12,6 @@
   {{ css_bundle('about-transparency') }}
 {% endblock %}
 
-{% block js %}
-  {{ js_bundle('about-transparency') }}
-{% endblock %}
-
 {% block content %}
 <main role="main">
   <header class="c-page-header">
@@ -26,10 +22,15 @@
 
   <div class="mzp-l-content mzp-t-content-lg">
     <p>
-      Transparency is a key part of how Mozilla approaches user trust. As an open source project that relies on open development, we build transparency into the way we write our code. Additionally, our product documentation and notices describe how our products work and how we handle user data.
+      Transparency is a key part of how Mozilla approaches user trust. As an open source project that relies on open development,
+      we build transparency into the way we write our code. Additionally, our product documentation and notices describe how our
+      products work and how we handle user data.
     </p>
     <p>
-      With this transparency in mind, we intend to publish bi­-annual transparency reports that help provide additional transparency to government disclosures and takedown requests.
+      With this transparency in mind, we publish bi-annual transparency reports. Most industry transparency reports offer insights
+      into government disclosures and takedown requests. Mozilla's transparency report goes further with the number of personal
+      data requests we receive, the number of copyright, trademark, and other takedown requests we receive, and details on our
+      <a href="{{ url('privacy.notices.ad-targeting-guidelines') }}">targeted advertising practices</a>.
     </p>
   </div>
 
@@ -44,13 +45,15 @@
     <section class="mzp-c-details">
       <h3>What is the scope of the Transparency Report?</h3>
       <p>
-        The purpose is to provide public insight into the types of government demands we receive for our user data or to
-        remove content; and requests from individuals or companies to remove content based on copyright or trademark
-        claims. Each report also includes a supplement describing our efforts to reform laws on privacy, surveillance,
+        The purpose is to provide public insight into Mozilla’s data privacy practices, including the types of government
+        demands we receive for our user data or to remove content, requests from individuals or companies to remove
+        content based on copyright or trademark claims, and targeted advertising practices. Each report also includes a
+        supplement describing our efforts to reform laws on privacy, surveillance,
         cybersecurity, and intellectual property for a healthier internet.
       </p>
       <p>
-        With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent. To this end, starting in H2 2018, we started reporting on the number of requests we receive from individuals inquiring about their personal data.
+        With each additional report that we publish, we’ll continue to reevaluate how we can be more transparent. To this end,
+        starting in H1 2022, we started disclosing our targeted advertising practices.
       </p>
     </section>
 
@@ -155,6 +158,19 @@
         We believe that everyone should have control over their personal data, understand how it’s obtained and used, and be able to access, modify, or delete it.  We extend these principles to all of our users regardless of when they submit a <a href="#dfn-personal-data-request">Personal Data Request</a>, where they are located, or whether a data protection law (such as the GDPR) grants them express privacy rights.
       </p>
     </section>
+
+    <section class="mzp-c-details">
+      <h3>Why Does Mozilla Disclose Its Targeted Advertisements?</h3>
+
+      <p>
+        Most organizations are secretive about what personal data they use to target advertising,
+        what <a href="#dfn-targeting-parameters">targeting parameters</a> they use to reach the intended audience,
+        how much they spend, and in what geographies. And yet this information is vital to understand how
+        individuals and communities are targeted online. Although some targeted advertising may be socially useful,
+        other targeted advertising results in misinformation, discrimination and other social harm. To uncover and
+        address the harms, we need more organizations to be transparent about their targeted advertising practices.
+      </p>
+    </section>
   </div>
 
   <div id="definitions" class="mzp-l-content mzp-t-content-lg">
@@ -256,6 +272,14 @@
         </p>
       </dd>
 
+      <dt id="dfn-targeting-parameters">Targeting Parameters</dt>
+      <dd>
+        <p>
+          Pieces of information that an advertiser chooses to determine which users of a platform will see their advertisements.
+          These may include device type, location, engagement with the platform, demographic information, interests, or other information.
+        </p>
+      </dd>
+
       <dt id="dfn-takedown-notice">Takedown Notice</dt>
       <dd>
         <p>
@@ -272,4 +296,8 @@
     </dl>
   </div>
 </main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('about-transparency') }}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2022.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2022.html
@@ -1,0 +1,470 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}Transparency Report - January-June 2022{% endblock %}
+
+{% block report_title %}
+<h1>Transparency Report <span>Reporting Period: January 1, 2022 to June 30, 2022</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for User Data</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received the following.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Legal Processes</th>
+          <th scope="col">Received</th>
+          <th scope="col">User Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">Search Warrants</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">Subpoenas</a>
+          </th>
+          <td>4</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">Court Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">Wiretap Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">Pen Register Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">Emergency Requests</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">National Security Requests</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>0-249</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p id="footnote-1">
+        We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for Content Removal</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received 1 government request for content removal from our services.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Requesting Country</th>
+          <th scope="col">Requests Received</th>
+          <th scope="col">Items Removed</th>
+          <th scope="col">Items Geographically Restricted</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Brazil</th>
+          <td>1</td>
+          <td>0</td>
+          <td>2</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="takedown-requests" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Takedown Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received five Copyright Takedown Notices and one Counter Notice.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>5</td>
+          <td>1</td>
+          <td>4</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Trademark</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received nine Trademark Takedown Notices and one Counter Notice (note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>8</td>
+          <td>1</td>
+          <td>68</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>1</td>
+          <td>0</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="other-content" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Other Content Removal Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received two content removal requests from private actors (i.e. companies or individuals) based on grounds other than copyright or trademark.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>2</td>
+          <td>0</td>
+          <td>7</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="personal-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Personal Data Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 10,716 requests.</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Received</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Mozilla</th>
+          <td>7,842</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>2,874</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="targeted-advertising" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Targeted Advertising Disclosures</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, and during the time we started targeted advertising, we have placed the following targeted advertisements.</p>
+
+    <h3>Mozilla</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/north-america-mozilla-may-2021-campaign.pdf">
+          Mozilla North America May 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/mozilla-european-june-2022-campaign.pdf">
+          Mozilla European June 2022 Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Firefox</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-july-2021-campaign.pdf">
+          North America July 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-europe-october-2021-campaign.pdf">
+          Europe October 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-october-2021-campaign.pdf">
+          North America October 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-november-2021-campaign.pdf">
+          North America November 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-february-2021-instagram-campaign.pdf">
+          North America February 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-march-2021-facebook-instagram-campaign.pdf">
+          North America March 2022 Facebook/IG Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-facebook-ig-march-2021-campaign.pdf">
+          North America March 2022 TikTok Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-north-america-may-2021-campaign.pdf">
+          North America May 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/firefox-june-2022-campaign.pdf">
+          North America June 2022 Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Mozilla VPN</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/vpn-europe-october-2021-campaign.pdf">
+          European October 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/vpn-north-america-october-2021-campaign.pdf">
+          North America October 2021 Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Pocket</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-north-america-july-2021-campaign.pdf">
+          North America July 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-europe-november-2021-campaign.pdf">
+          Europe November 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-north-america-november-2021-campaign.pdf">
+          North America November 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-europe-december-2021-campaign.pdf">
+          Europe December 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-us-uk-december-2021-campaign.pdf">
+          North America & UK December 2021 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-north-america-june-2022-campaign.pdf">
+          North America June 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/pocket-kenya-campaign.pdf">
+          Kenya Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Mozilla Foundation Ads</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/mozilla-foundation-ads-2022.pdf">
+          Mozilla Foundation Ads 2022
+        </a>
+      </li>
+    </ul>
+
+    <h3>Issue Advertising</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/security-risk-ahead-campaign.pdf">
+          Security Risk Ahead Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2022/lean-data-practices-campaign.pdf">
+          Lean Data Practices Campaign
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Supplement</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>During the course of this reporting period, Mozilla continued its efforts to provide our users with strong privacy and security protections through public policy engagements. In the European Union, we ramped up our work on the eIDAS legislation, which threatens web security by placing a ceiling on the security standards. This included delivering a technical briefing to the European Parliament, engaging with civil society allies, and launching a public <a href="https://securityriskahead.eu/">campaign</a> to drive awareness of the risks posed by the issue. We also published an <a href="https://blog.mozilla.org/en/security/mozilla-eff-cybersecurity-experts-publish-letter-on-dangers-of-article-452-eidas-regulation/">open letter</a> by 38 cybersecurity experts that highlighted the flaws with Article 45 and which received significant attention. We also held a workshop for Mozilla’s OpenDoTT Fellows on website security and the various interventions we’ve led around the world in <a href="https://blog.mozilla.org/netpolicy/2020/12/18/kazakhstan-root-2020/">Kazakhstan</a>, <a href="https://blog.mozilla.org/netpolicy/2021/05/12/defending-users-security-in-mauritius/">Mauritius</a>, and <a href="https://blog.mozilla.org/netpolicy/2021/11/04/mozilla-publishes-position-paper-on-the-eu-digital-identity-framework/">Europe</a> on defending our root store programs. We once again supported the <a href="https://www.cpdpconferences.org/">Computer, Privacy, and Data Protection conference</a> as a premier sponsor. In addition to sponsoring the conference, we organised our <a href="https://www.cpdpconferences.org/cpdp-panels/privacy-preserving-advertising-prospects-and-paradigms">own panel discussion</a> on privacy preserving advertising, which also received <a href="https://www.euractiv.com/section/digital/news/regulator-industry-collaboration-key-for-adtech-success-mozilla-official-says/">media coverage</a>. We also continued our <a href="https://blog.mozilla.org/netpolicy/2022/01/20/european-parliament-green-lights-crucial-new-rulebook-for-big-tech/">work</a> on advertising transparency in the Digital Services Act (DSA) and the EU Code of Practice on Disinformation.</p>
+    <p>In the United States, we testified at a US Congressional hearing on privacy; we published a <a href="https://blog.mozilla.org/en/mozilla/americans-deserve-federal-privacy-protections-and-greater-transparency-into-hidden-harms-online/">blog post</a> detailing the testimony. In close coordination with allies, we also engaged on ad transparency and researcher access with the Federal Trade Commission (FTC) and Congress. In the United Kingdom, we continued our work on privacy preserving advertising and mitigating online tracking via <a href="https://blog.mozilla.org/netpolicy/2022/04/12/competition-should-not-be-weaponized-to-hobble-privacy-protections-on-the-open-web/">submissions</a> and conversations with the Competition and Markets Authority (CMA) and the Information Commissioner's Office (ICO). In India, we were <a href="https://www.ft.com/content/7b6f91c3-8324-467b-953a-d5325a5aacd3">quoted</a> in the Financial Times on contact tracing apps and the risks they pose to civil liberties, based on our previous <a href="https://www.aninews.in/news/national/general-news/decision-to-open-source-aarogya-setu-app-will-help-improve-user-trust-security-mozilla20200527153954/">work</a> on India’s contact tracing app and its open sourcing. We also <a href="https://portswigger.net/daily-swig/indian-vpn-providers-resist-incoming-data-logging-law">engaged</a> on India’s CERT-In regulations surrounding vastly expanded data retention requirements for VPN service providers. In the Philippines, our <a href="https://mb.com.ph/2022/04/11/mozilla-bucks-philippine-sim-card-registration-law/">outreach</a> (working closely with the community) played a role in the <a href="https://www.philstar.com/headlines/2022/04/15/2174584/duterte-rejects-bill-requiring-sim-card-social-media-account-registration">vetoing</a> of the SIM Card Registration Act which mandated that ‘social media platforms’ (which were very vaguely defined) verified the identity of real world users. In the African continent, we also ramped up our Lean Data Practices <a href="https://blog.mozilla.org/netpolicy/2022/01/26/lean-data-practice-journey/">work</a> by taking our online <a href="https://www.udemy.com/course/lean-data-practices/">course</a> to new audiences from the startup ecosystem.</p>
+
+    <h3>Voluntary Threat Indicators & Data Disclosures</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Type of Disclosure</th>
+          <th scope="col">Number of Disclosures</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">Cybersecurity Threat Indicator</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            Other <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-specific-user' }}">Specific User</a> Data Disclosure
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
@@ -9,11 +9,7 @@
 {% block page_title %}Transparency Report{% endblock %}
 
 {% block page_css %}
-{{ css_bundle('about-transparency') }}
-{% endblock %}
-
-{% block js %}
-{{ js_bundle('about-transparency') }}
+  {{ css_bundle('about-transparency') }}
 {% endblock %}
 
 {% block content %}
@@ -38,4 +34,6 @@
 </main>
 {% endblock %}
 
-{% block email_form %}{% endblock %}
+{% block js %}
+  {{ js_bundle('about-transparency') }}
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -82,6 +82,7 @@ urlpatterns = (
     page("about/policy/transparency/jul-dec-2020/", "mozorg/about/policy/transparency/jul-dec-2020.html"),
     page("about/policy/transparency/jan-jun-2021/", "mozorg/about/policy/transparency/jan-jun-2021.html"),
     page("about/policy/transparency/jul-dec-2021/", "mozorg/about/policy/transparency/jul-dec-2021.html"),
+    page("about/policy/transparency/jan-jun-2022/", "mozorg/about/policy/transparency/jan-jun-2022.html"),
     page("contact/", "mozorg/contact/contact-landing.html"),
     page("contact/spaces/", "mozorg/contact/spaces/spaces-landing.html"),
     page("contact/spaces/beijing/", "mozorg/contact/spaces/beijing.html"),

--- a/bedrock/privacy/templates/privacy/notices/ad-targeting-guidelines.html
+++ b/bedrock/privacy/templates/privacy/notices/ad-targeting-guidelines.html
@@ -1,0 +1,11 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "privacy/notices/base-notice-paragraphs.html" %}
+
+{% block body_class %}mzp-t-mozilla format-paragraphs{% endblock%}
+
+{% block article_header_logo %}{{ static('img/trademarks/logo-mozm.png') }}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -29,6 +29,7 @@ urlpatterns = (
     path("firefox-relay/", views.firefox_relay_notices, name="privacy.notices.firefox-relay"),
     path("mozilla-vpn/", views.mozilla_vpn, name="privacy.notices.mozilla-vpn"),
     path("mdn-plus/", views.mdn_plus, name="privacy.notices.mdn-plus"),
+    path("ad-targeting-guidelines/", views.ad_targeting_guidelines, name="privacy.notices.ad-targeting-guidelines"),
     page("archive/", "privacy/archive/index.html", ftl_files=["privacy/index"], active_locales=["en-US"]),
     page("archive/firefox/2006-10/", "privacy/archive/firefox-2006-10.html", ftl_files=["privacy/index"], active_locales=["en-US"]),
     page("archive/firefox/2008-06/", "privacy/archive/firefox-2008-06.html", ftl_files=["privacy/index"], active_locales=["en-US"]),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -83,6 +83,10 @@ mozilla_vpn = PrivacyDocView.as_view(template_name="privacy/notices/mozilla-vpn.
 
 mdn_plus = PrivacyDocView.as_view(template_name="privacy/notices/mdn-plus.html", legal_doc_name="mdn_plus_privacy")
 
+ad_targeting_guidelines = PrivacyDocView.as_view(
+    template_name="privacy/notices/ad-targeting-guidelines.html", legal_doc_name="AdTargeting_Guidelines"
+)
+
 
 @cache_page(60 * 60)  # cache for 1 hour
 def privacy(request):


### PR DESCRIPTION
## One-line summary

Adds H1 2022 transparency report, and a new privacy notice detailing Mozilla's policy on targeted advertising.

This needs to go live on **Tuesday Sept 13th**, so labelling as a P1.

## Issue / Bugzilla link

#12057

## Testing

Note: you may need to update legal docs locally to render the new ad-targeting-guidelines notice.

- http://localhost:8000/en-US/about/policy/transparency/
- http://localhost:8000/en-US/about/policy/transparency/jan-jun-2022/
- http://localhost:8000/en-US/privacy/ad-targeting-guidelines/
