### PR TITLE
Reduce ticker font size on mobile

### DIFF
--- a/media/css/firefox/family/components/_news-ticker.scss
+++ b/media/css/firefox/family/components/_news-ticker.scss
@@ -72,7 +72,7 @@
 
     &-title,
     &-item {
-        @include f3.text-body-lg;
+        @include f3.text-body-md;
         display: inline;
         margin-bottom: 0; // protocol override
     }
@@ -86,6 +86,15 @@
         &-content,
         .set-one {
             animation: none;
+        }
+    }
+}
+
+@media #{f3.$mq-md} {
+    .c-news-ticker {
+        &-title,
+        &-item {
+            @include f3.text-body-lg;
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Fix from design feedback

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12091

## Testing

http://localhost:8000/en-US/firefox/family/
ticker is available below hero when there is no reduced motion preference

font size 16px
increases at medium breakpoint to 18px
