### PR TITLE
Update agreement cta sizing and mobile alignment

### DIFF
--- a/media/css/firefox/family/components/_agreement.scss
+++ b/media/css/firefox/family/components/_agreement.scss
@@ -36,23 +36,24 @@
     .c-subtitle {
         margin-bottom: $layout-xs;
     }
+
+    .mzp-l-content {
+        text-align: center;
+    }
+
+    .c-subtitle,
+    p {
+        text-align: left;
+    }
 }
 
 .c-download {
     @include f3.button;
+    @include text-body-md; // match Download Fx CTA font size
 }
 
 @media #{$mq-sm} {
     .c-agreement {
-        .mzp-l-content {
-            text-align: center;
-        }
-
-        .c-subtitle,
-        p {
-            text-align: left;
-        }
-
         .l-grid {
             > * {
                 max-width: 500px;


### PR DESCRIPTION
## One-line summary

Updates agreement CTA font size to match download section CTA font size, moves agreement cta centering to start mobile-first

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12091

## Testing
http://localhost:8000/en-US/firefox/family/#agreement
