### PR TITLE
Fix shadow offset sizing

### DIFF
--- a/media/css/firefox/family/_utils.scss
+++ b/media/css/firefox/family/_utils.scss
@@ -38,8 +38,16 @@ $border-width: 3px;
 }
 
 // Shadows
+:root {
+    --shadow-offset: #{$spacing-sm};
+    @media #{$mq-md} {
+        --shadow-offset: 14px;
+    }
+}
+
 @mixin card-shadow($color: $black) {
-    box-shadow: $spacing-sm $spacing-sm 0 $color;
+    box-shadow: $spacing-sm $spacing-sm 0 $color; // older browser fallback
+    box-shadow: var(--shadow-offset) var(--shadow-offset) 0 $color;
 }
 
 // Font


### PR DESCRIPTION
## One-line summary

Matches figma offset more closely

## Significant changes and points to review

affects both card and browser component shadows
note: this will create merge conflict with https://github.com/mozilla/bedrock/pull/12125

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12091

## Testing
desktop shadow should be larger to match figma: https://www.figma.com/file/zEWcXI6tFGtGcEvdwBWYz0/Firefox-Families?node-id=1799%3A8474

mobile shadow should be reduced

[http://localhost:8000/en-US/firefox/family](http://localhost:8000/en-US/firefox/family)
