### PR TITLE
Reduce bottom spacing on browser container content

### DIFF
--- a/media/css/firefox/family/components/_browser.scss
+++ b/media/css/firefox/family/components/_browser.scss
@@ -70,5 +70,10 @@
         &.mzp-t-dark {
             background-color: f3.$violet-extra-dark;
         }
+
+        *:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
     }
 }

--- a/media/css/firefox/family/components/modules/_mental-health.scss
+++ b/media/css/firefox/family/components/modules/_mental-health.scss
@@ -32,7 +32,7 @@
 
     // dimensions from figma
     .t-doomscroll-container {
-        height: 317px;
+        height: 369px;
         width: 484px;
         position: absolute;
         top: 40%;
@@ -41,7 +41,7 @@
 
         .c-browser-content {
             overflow-y: hidden;
-            height: 300px;
+            height: 317px;
         }
     }
 
@@ -90,7 +90,7 @@
             .l-grid {
                 display: grid;
                 grid-template-columns: repeat(12, 1fr);
-                grid-template-rows: [start] minmax($spacing-md, 100px) 50px 60px 1fr minmax($spacing-lg, auto) [end];
+                grid-template-rows: [start] minmax($spacing-md, 80px) 50px 40px 1fr minmax($spacing-lg, auto) [end];
             }
 
             .t-content-container {


### PR DESCRIPTION
## One-line summary
Adjust grid rows to better show doomscroll text
Update dimensions of doomscroll container to match figma

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12091

## Testing
http://localhost:8000/en-US/firefox/family/#mental-health

