### PR TITLE
F3 - Adding eyeroll emoji on banner close

### DIFF
--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -69,6 +69,11 @@
                 flex: 0 0 auto;
             }
 
+            #dad-jokes-eyeroll {
+                display: none;
+                @include text-title-md;
+            }
+
             @media #{$mq-md} {
                 flex-flow: row wrap;
                 justify-content: center;

--- a/media/js/firefox/family/banner.es6.js
+++ b/media/js/firefox/family/banner.es6.js
@@ -6,6 +6,8 @@
 
 let dadJokesBanner;
 let dadJokesBannerClose;
+// let dadJokesBannerButton;
+let dadJokesEyeroll;
 
 function showBanner() {
     // remove unneeded event listener
@@ -24,9 +26,14 @@ function hideBanner() {
         event: 'in-page-interaction'
     });
     // hide banner
-    dadJokesBanner.setAttribute('aria-hidden', 'true');
+    dadJokesBannerClose.style.display = 'none';
+    dadJokesEyeroll.style.display = 'block';
+    setTimeout(function () {
+        dadJokesBanner.setAttribute('aria-hidden', 'true');
+    }, 300);
     // remove unusable event listener
     dadJokesBannerClose.removeEventListener('click', hideBanner);
+    // dadJokesEyeroll.style.display = 'block';
 }
 
 const init = function () {
@@ -34,6 +41,7 @@ const init = function () {
     dadJokesBanner = document.getElementById('dad-jokes-banner');
     dadJokesBannerClose = document.getElementById('dad-jokes-banner-close');
 
+    dadJokesEyeroll = document.getElementById('dad-jokes-eyeroll');
     // add event listeners
     document.addEventListener('scroll', showBanner);
 };


### PR DESCRIPTION
## One-line summary
Adding a fade-out eye-rolling emoji when someone clicks `Accept all dad jokes` button

## Issue / Bugzilla link
#12111 

## Testing

To test this work:
- [ ] http://localhost:8000/en-US/firefox/family --> open site and close the bottom banner, an eyeroll emoji should show up for a split second before the whole banner disappears.


