### PR TITLE
Break download heading on mobile

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/download-firefox.html
+++ b/bedrock/firefox/templates/firefox/family/includes/download-firefox.html
@@ -8,7 +8,7 @@
   <div class="mzp-l-content mzp-t-content-md">
     <div class="mzp-c-wordmark mzp-t-wordmark-lg mzp-t-product-firefox">Firefox</div>
 
-    <h2 class="c-download-firefox-title">We <img src="{{ static('img/firefox/family/icon-heart-outline.svg') }}" alt="heart"> all families</h2>
+    <h2 class="c-download-firefox-title">We <img src="{{ static('img/firefox/family/icon-heart-outline.svg') }}" alt="heart"> <br>all families</h2>
     <p>Firefox is made in part by lots of real-life, tired yet strangely optimistic
       parents, and we’re backed by an awesome non-profit too.</p>
 

--- a/media/css/firefox/family/components/_download-firefox.scss
+++ b/media/css/firefox/family/components/_download-firefox.scss
@@ -33,6 +33,12 @@ $image-path: '/media/protocol/img';
             top: 5px;
         }
 
+        @media #{$mq-sm} {
+            br {
+                display: none;
+            }
+        }
+
         @media #{$mq-lg} {
             @include text-title-2xl;
         }


### PR DESCRIPTION
## One-line summary

Break line after heart on mobile only in download firefox section

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12091

## Testing

download section is under public wifi
http://localhost:8000/en-US/firefox/family/#public-wifi
