### PR TITLE
Fix Monitor Terms & Privacy title (Fixes #12129)

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/base-notice.html
+++ b/bedrock/privacy/templates/privacy/notices/base-notice.html
@@ -9,7 +9,7 @@
 {% do doc.select('body > section > section ul')|htmlattr(class="mzp-u-list-styled") %}
 {% do doc.select('body > section > section ol')|htmlattr(class="mzp-u-list-styled") %}
 
-{% block page_title %}{{ doc.h1.string }}{% endblock %}
+{% block page_title %}{{ doc.h1.string|join|safe }}{% endblock %}
 
 {% block body_id %}firefox-notice{% endblock %}
 {% block body_class %}{{ super() }} format-none{% endblock %}


### PR DESCRIPTION
## One-line summary

Fix Monitor Terms & Privacy title 

## Issue / Bugzilla link

#12129 

## Testing

Demo server URL: http://localhost:8000//en-US/privacy/firefox-monitor/

