### PR TITLE
Remove /mobile/get-app/ experiment variations (Fixes #12159)

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -25,21 +25,9 @@
   {% endwith %}
 {% endblock %}
 
-{% if variation == 'mfm' %}
-  {% set message_set = 'fx-mobile-download-desktop-experiment' %}
-  {% set android_url = 'https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-and&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F' %}
-  {% set ios_url = 'https://app.adjust.com/y68hlxi?campaign=firefox-desktop&adgroup=about-prefs&creative=mfm-fxvt-default-global-email-site-ios&fallback=http%3A%2F%2Fmozilla.org%2Ffirefox%2Fmobile%2F' %}
-{% elif variation == 'eco-a' %}
-  {% set message_set = 'fx-mobile-download-desktop-reco-exp-a' %}
-{% elif variation == 'eco-b' %}
-  {% set message_set = 'fx-mobile-download-desktop-reco-exp-b' %}
-{% elif variation == 'eco-c' %}
-  {% set message_set = 'fx-mobile-download-desktop-reco-exp-c' %}
-{% else %}
-  {% set message_set = 'fx-mobile-download-desktop' %}
-  {% set android_url = firefox_adjust_url('android', 'mobile-get-app-page') %}
-  {% set ios_url = firefox_adjust_url('ios', 'mobile-get-app-page') %}
-{% endif %}
+{% set message_set = 'fx-mobile-download-desktop' %}
+{% set android_url = firefox_adjust_url('android', 'mobile-get-app-page') %}
+{% set ios_url = firefox_adjust_url('ios', 'mobile-get-app-page') %}
 
 {% block content %}
 <main role="main" class="mzp-l-content mzp-t-content-md mzp-t-firefox">
@@ -57,7 +45,6 @@
     {% endif %}
   </section>
 
-  {% if variation not in ['eco-a', 'eco-b', 'eco-c'] %}
   <aside class="mobile-download-buttons-wrapper">
     <ul class="mobile-download-buttons">
       <li class="android">
@@ -70,7 +57,7 @@
       </li>
     </ul>
   </aside>
-  {% endif %}
+
 </main>
 {% endblock %}
 

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -569,22 +569,6 @@ class TestFirefoxURL(TestCase):
             {"newsletter_id": "download-firefox-mobile-reco"},
         ),
         (
-            "message_set='fx-mobile-download-desktop-experiment'",
-            {"newsletter_id": "download-firefox-mobile-reco-exp"},
-        ),
-        (
-            "message_set='fx-mobile-download-desktop-reco-exp-a'",
-            {"newsletter_id": "download-firefox-mobile-reco-exp-a"},
-        ),
-        (
-            "message_set='fx-mobile-download-desktop-reco-exp-b'",
-            {"newsletter_id": "download-firefox-mobile-reco-exp-b"},
-        ),
-        (
-            "message_set='fx-mobile-download-desktop-reco-exp-c'",
-            {"newsletter_id": "download-firefox-mobile-reco-exp-c"},
-        ),
-        (
             "message_set='fx-mobile-ios-twilio-experiment'",
             {"newsletter_id": "download-firefox-ios-twilio-experiment"},
         ),

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -74,13 +74,7 @@ urlpatterns = (
         name="firefox.features.tips",
     ),
     path("firefox/ios/testflight/", views.ios_testflight, name="firefox.ios.testflight"),
-    path(
-        "firefox/mobile/get-app/",
-        VariationTemplateView.as_view(
-            template_name="firefox/mobile/get-app.html", template_context_variations=["mfm", "eco-a", "eco-b", "eco-c"], ftl_files=["firefox/mobile"]
-        ),
-        name="firefox.mobile.get-app",
-    ),
+    page("firefox/mobile/get-app/", "firefox/mobile/get-app.html", ftl_files=["firefox/mobile"]),
     path("firefox/sms-send-to-device-post/", views.sms_send_to_device_ajax, name="firefox.sms-send-to-device-post"),
     page("firefox/unsupported-systems/", "firefox/unsupported-systems.html"),
     path("firefox/new/", views.NewView.as_view(), name="firefox.new"),

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1031,26 +1031,6 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
             "all": "download-firefox-mobile-reco",
         }
     },
-    "fx-mobile-download-desktop-experiment": {
-        "email": {
-            "all": "download-firefox-mobile-reco-exp",
-        }
-    },
-    "fx-mobile-download-desktop-reco-exp-a": {
-        "email": {
-            "all": "download-firefox-mobile-reco-exp-a",
-        }
-    },
-    "fx-mobile-download-desktop-reco-exp-b": {
-        "email": {
-            "all": "download-firefox-mobile-reco-exp-b",
-        }
-    },
-    "fx-mobile-download-desktop-reco-exp-c": {
-        "email": {
-            "all": "download-firefox-mobile-reco-exp-c",
-        }
-    },
     "fx-mobile-ios-twilio-experiment": {
         "email": {
             "all": "download-firefox-ios-twilio-experiment",


### PR DESCRIPTION
## One-line summary

Removes outdated send-to-device experiment variations

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/12159

## Testing

http://localhost:8000/en-US/firefox/mobile/get-app/
