### PR TITLE
Update copy for private mode

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/modules/private-mode.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/private-mode.html
@@ -24,7 +24,7 @@
           </defs>
         </svg>
         <h3 class="c-subtitle">The private browsing mode paradox</h3>
-        <p>On the one hand it keeps your kid’s data from being collected
+        <p>On the one hand, private browsing can make it harder for advertisers to track your kid
           <em>*dramatic pause*</em> but it also erases their browsing history.</p>
       {% endcall %}
 


### PR DESCRIPTION
Original statement was too broad as some data can still be collected by websites in private mode

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12150

## Testing
http://localhost:8000/en-US/firefox/family/#private-mode
updates copy to say "private browsing can make it harder for advertisers to track your kid"

