### PR TITLE
Fix highres image sources for home page content cards (Fixes #12168)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -250,6 +250,7 @@
         alt=image_alt,
         class='mzp-c-card-image',
         height=image_height,
+        highres_image_url=highres_image_url,
         include_highres=include_highres_image,
         include_l10n=l10n_image,
         loading='lazy',

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -146,6 +146,7 @@
   class=None,
   width=None,
   height=None,
+  highres_image_url=None,
   loading=None,
   srcset=None,
   sizes=None,
@@ -180,7 +181,7 @@
     {% else %}
       {% set src = static(url) %}
     {% endif %}
-    <img src="{{ src }}" alt="{{ alt }}" {% if class %}class="{{ class }}" {% endif %}{% if loading %}loading="{{ loading }}" {% endif %}{% if width %}width="{{ width }}" {% endif %}{% if height %}height="{{ height }}" {% endif %}/>
+    <img src="{{ src }}"{% if highres_image_url %} srcset="{{ highres_image_url }} 2x"{% endif %} alt="{{ alt }}" {% if class %}class="{{ class }}" {% endif %}{% if loading %}loading="{{ loading }}" {% endif %}{% if width %}width="{{ width }}" {% endif %}{% if height %}height="{{ height }}" {% endif %}/>
   {% endif %}
 {%- endmacro %}
 

--- a/bedrock/base/tests/test_macros.py
+++ b/bedrock/base/tests/test_macros.py
@@ -66,6 +66,7 @@ EXPECTED_IMAGES = {
         '<source media="(min-width: 800px)" srcset="/media/test-desktop.png">'
         '<img src="/media/test-mobile.jpg" alt="test" class="test" width="64" height="64" loading="lazy"></picture>'
     ),
+    "highres_image_url": ('<img src="https://www.example.com/test.jpg" srcset="https://www.example.com/test-high-res.jpg 2x" alt="" />'),
 }
 
 
@@ -134,6 +135,10 @@ EXPECTED_IMAGES = {
                 "{'media': '(min-width: 800px)', 'srcset': {'test-desktop.png': 'default'}}]"
             ),
             EXPECTED_IMAGES["picture_attributes"],
+        ),
+        (
+            "url='https://www.example.com/test.jpg', highres_image_url='https://www.example.com/test-high-res.jpg'",
+            EXPECTED_IMAGES["highres_image_url"],
         ),
     ],
 )


### PR DESCRIPTION
## One-line summary

Fixes high res home page content card images served via https://github.com/mozmeao/www-admin/

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/12168
https://github.com/mozilla/bedrock/issues/12021

## Testing

- http://localhost:8000/de/
- http://localhost:8000/fr/
