### PR TITLE
Fix label for the Your Firefox Account form on privacy/products

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -111,7 +111,7 @@
 
     <div class="fxa-email-field-container">
       <div class="mzp-c-field mzp-l-stretch">
-        <label for="mzp-c-field-label">{{ ftl('fxa-form-email-address') }}</label>
+        <label class="mzp-c-field-label" for="fxa-email-field">{{ ftl('fxa-form-email-address') }}</label>
         <input type="email" name="email" id="fxa-email-field" class="mzp-c-field-control" placeholder="user@example.com" required>
         <p class="mzp-c-field-info">
           {{ ftl('fxa-form-by-proceeding', url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy') }}


### PR DESCRIPTION
## One-line summary
Simply fixed the erroneous for attribute on the Your Firefox Account form on [privacy/products/](https://www.mozilla.org/en-GB/about/this-site/).
 
## Significant changes and points to review
This was causing an a11y issue on the page.

## Issue / Bugzilla link
N/A

## Screenshots

(If the changeset updates the UI, please include screenshots so reviewers know what to look for when testing)

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: (or None)

To test this work:

- [ ] Run the site locally and go to to the products promise page
- [ ] Using the [WAVES browser plugin](https://wave.webaim.org/extension/) check there are no 0 errors
- [ ] Run the same on the live site and see there is 1 error. 
