### PR TITLE
Specify a downpinned version of the CircleCI image to avoid CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ orbs:
 jobs:
   test_py:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.9.13
+        # 3.9.13 is a temporary downpin while we shake out test failures that happen only on 3.9.14
+        # See https://github.com/mozilla/bedrock/issues/12203
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
As of 5 Oct, our CI pipeline started seeing test errors unrelated to code changes in _any_ particular PR. These failures were not replicable locally (bare metal MacOS, or via Docker) and were not replicable via a SSH session to CircleCI, despite using the same images that had just failed.

My theory is that there is something about how Bedrock interacts with the 3.9.14 version of Python in the Circle container that causes the very odd failures (eg Mocks not returning the expected values). We will continue to explore this, but this changeset downpins us to using an earlier cut of Circle's Python 3.9 image, which we know works. The vulnerabilities fixed in 3.9.14 seem to pose a low risk, given that we are not building production images here, and the actual Bedrock Docker images are using 3.9.14 -- it's just the "outer" image which is being downpinned, and ideally only temporarily.


## Issue / Bugzilla link

Resolves #12198

## Testing

Demo server URL: (or None)

To test this work:

- [x] Confirm there are no other code changes on this branch other than Circle CI config
- [x] Ensure Circle CI passes for this branch
