### PR TITLE
Pocket mode fixups

### DIFF
--- a/bedrock/pocket/templates/pocket/base.html
+++ b/bedrock/pocket/templates/pocket/base.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANG }}">
   <head>
     {% block shared_meta %}
       <meta charset="utf-8" />

--- a/bedrock/pocket/templates/pocket/home.html
+++ b/bedrock/pocket/templates/pocket/home.html
@@ -108,7 +108,7 @@
                   <li>{{ ftl('pocket-home-unlimited-highlights') }}</li>
                   <li>{{ ftl('pocket-home-premium-fonts') }}</li>
                 </ul>
-                <a href="https://getpocket.com/premium#plans" class="mzp-c-button">Get Pocket Premium</a>
+                <a href="https://getpocket.com/premium#plans" class="mzp-c-button">{{ ftl('pocket-home-get-pocket-premium') }}</a>
               </div>
             </div>
           </div>

--- a/l10n-pocket/en/pocket/home.ftl
+++ b/l10n-pocket/en/pocket/home.ftl
@@ -36,6 +36,7 @@ pocket-home-suggested-tags = Suggested tags
 pocket-home-full-text-search = Full-text search
 pocket-home-unlimited-highlights = Unlimited highlights
 pocket-home-premium-fonts = Premium fonts
+pocket-home-get-pocket-premium = Get { -brand-name-pocket-premium }
 
 pocket-home-discover-and-save = Discover and save the most interesting stories on the web
 


### PR DESCRIPTION
## One-line summary

Small fixups noted while QAing Pocket on Bedrock

## Testing

To test this work:

- [ ] `npm run in-pocket-mode`
- [ ] visit http://localhost:8080/{LOCALE}/ and confirm that for {LOCALE} the `lang` attr on the root `html` matches what you expect. (All lower case, too)
- [ ] On the homepage, confirm in /en/ that you can see 'Get Pocket Premium' as the CTA text  (which is now a Fluent string). Once merged, this string will be ready for markup in Smartling and @stevejalim will shuffle it along