### PR TITLE
Add pocket google analytics

### DIFF
--- a/media/js/pocket/google-analytics.js
+++ b/media/js/pocket/google-analytics.js
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* global ga */
+
+(function (i, s, o, g, r, a, m) {
+    'use strict';
+
+    i['GoogleAnalyticsObject'] = r;
+    (i[r] =
+        i[r] ||
+        function () {
+            (i[r].q = i[r].q || []).push(arguments);
+        }),
+        (i[r].l = 1 * new Date());
+    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+    a.async = 1;
+    a.src = g;
+    m.parentNode.insertBefore(a, m);
+})(
+    window,
+    document,
+    'script',
+    'https://www.google-analytics.com/analytics.js',
+    'ga'
+);
+ga('create', 'UA-370613-9', 'auto');
+ga('require', 'displayfeatures');
+ga('send', 'pageview');

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1762,7 +1762,8 @@
       "files": [
         "js/pocket/base.js",
         "js/base/mozilla-cookie-helper.js",
-        "js/pocket/snowplow.es6.js"
+        "js/pocket/snowplow.es6.js",
+        "js/pocket/google-analytics.js"
       ],
       "name": "pocket-site"
     },


### PR DESCRIPTION
## One-line summary

Adds ga to pocket base template (ga script taken from [existing pocket-marketing-pages script](https://github.com/mozmeao/pocket-marketing-pages/blob/master/content/_includes/scripts.njk))

## Testing

`npm run in-pocket-mode`

Inspect head element. Analytics script should appear near bottom.

<img width="365" alt="ga" src="https://user-images.githubusercontent.com/19650432/194888752-71015cd3-7c04-4992-bc2b-4debe07bf696.png">

