### PR TITLE
Rename 'fmt' to 'format' in newsletter template (Issue #11944)

### DIFF
--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -72,10 +72,10 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
           <fieldset class="mzp-u-inline">
             <legend>Format</legend>
               <label for="format-html" class="mzp-u-inline">
-                <input type="radio" id="format-html" name="fmt" value="H" checked> HTML
+                <input type="radio" id="format-html" name="format" value="H" checked> HTML
               </label>
               <label for="format-text" class="mzp-u-inline">
-                <input type="radio" id="format-text" name="fmt" value="T"> Text
+                <input type="radio" id="format-text" name="format" value="T"> Text
               </label>
           </fieldset>
             <label for="id_terms" class="mzp-u-inline">

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -95,10 +95,10 @@
           <legend>{{ ftl('newsletter-form-format') }}</legend>
           <p>
             <label for="format-html" class="mzp-u-inline">
-              <input type="radio" id="format-html" name="fmt" value="H" checked> {{ ftl('newsletter-form-html') }}
+              <input type="radio" id="format-html" name="format" value="H" checked> {{ ftl('newsletter-form-html') }}
             </label>
             <label for="format-text" class="mzp-u-inline">
-              <input type="radio" id="format-text" name="fmt" value="T"> {{ ftl('newsletter-form-text') }}
+              <input type="radio" id="format-text" name="format" value="T"> {{ ftl('newsletter-form-text') }}
             </label>
           </p>
         </fieldset>

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -35,7 +35,7 @@
       {{ newsletter_form.newsletters|safe }}
     </div>
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
-    <input type="hidden" name="fmt" id="format-html" value="H">
+    <input type="hidden" name="format" id="format-html" value="H">
 
     <fieldset class="mzp-c-newsletter-content">
       <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">

--- a/media/js/newsletter/newsletter.es6.js
+++ b/media/js/newsletter/newsletter.es6.js
@@ -76,7 +76,7 @@ const NewsletterForm = {
         );
 
         // Newsletter format
-        const format = form.querySelector('input[name="fmt"]:checked').value;
+        const format = form.querySelector('input[name="format"]:checked').value;
 
         // Country (optional form <select>)
         const countrySelect = form.querySelector('select[name="country"]');

--- a/tests/unit/spec/newsletter/newsletter.js
+++ b/tests/unit/spec/newsletter/newsletter.js
@@ -75,10 +75,10 @@ describe('NewsletterForm', function () {
                                 <legend>Format</legend>
                                 <p>
                                     <label for="format-html" class="mzp-u-inline">
-                                        <input type="radio" id="format-html" name="fmt" value="H" checked=""> HTML
+                                        <input type="radio" id="format-html" name="format" value="H" checked=""> HTML
                                     </label>
                                     <label for="format-text" class="mzp-u-inline">
-                                        <input type="radio" id="format-text" name="fmt" value="T"> Text
+                                        <input type="radio" id="format-text" name="format" value="T"> Text
                                     </label>
                                 </p>
                             </fieldset>

--- a/tests/unit/spec/products/vpn/invite.js
+++ b/tests/unit/spec/products/vpn/invite.js
@@ -28,7 +28,7 @@ describe('WaitListForm', function () {
                     </ul>
                 </div>
                 <input type="hidden" name="source_url" value="https://www.mozilla.org/en-US/products/vpn/invite/">
-                <input type="hidden" name="fmt" id="format-html" value="H">
+                <input type="hidden" name="format" id="format-html" value="H">
 
                 <fieldset class="mzp-c-newsletter-content">
                     <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">


### PR DESCRIPTION
## One-line summary

We're seeing a small amount of errors in Sentry due to newsletter submissions posting the old `fmt` parameter instead of the new `format` one, which was changed as part of https://github.com/mozilla/bedrock/issues/11944.

This PR updates the form HTML to use `name="format"` as well, should someone try to submit the form with JS disabled.

## Issue / Bugzilla link

#11944

## Testing

I pushed this up on demo for easier testing: https://www-demo5.allizom.org/en-US/
