### PR TITLE
Return locale selection page at root URL if no header sent

### DIFF
--- a/bedrock/base/templates/404-locale.html
+++ b/bedrock/base/templates/404-locale.html
@@ -1,0 +1,48 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "base-protocol-mozilla.html" %}
+
+{% block page_title %}{% if not is_root %}404 - {% endif %}Choose your language or locale to browse Mozilla.org{% endblock %}
+
+{% block page_desc -%}
+  Select your country or region to indicate your preferred language.
+{%- endblock %}
+
+{% block canonical_urls %}
+{% if is_root %}
+  <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL + '/' }}">
+{% endif %}
+{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('locales') }}
+{% endblock %}
+
+{% block content %}
+<main role="main" class="mzp-l-content">
+  <header class="c-simple-header">
+    <h1 class="c-simple-header-title">
+      {%- if is_root -%}
+        Choose your language or locale to browse Mozilla.org
+      {%- else -%}
+        Page is not yet translated
+      {%- endif -%}
+    </h1>
+    {% if has_header -%}
+      <p>Join our <a href="https://community.mozilla.org/activities/localize-mozilla/">community team</a> and help us <a href="https://wiki.mozilla.org/L10n:Contribute">translate this page.</a></p>
+    {%- endif %}
+    <p>It is available in the following languages:</p>
+  </header>
+  <section class="c-block-list">
+    <ul>
+      {% for locale in available_locales if locale in languages %}
+        <li lang="{{ locale }}"><a href="/{{ locale }}{{ request.path_info }}" title="{{ 'Browse {0} in the {1} language'|f(request.path_info, languages[locale]["native"]) }}">{{ languages[locale]['native'] }}</a></li>
+      {% endfor %}
+    </ul>
+  </section>
+</main>
+{% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -450,14 +450,14 @@ class TestFirefoxNew(TestCase):
 class TestFirefoxNewNoIndex(TestCase):
     def test_download_noindex(self):
         # Scene 1 of /firefox/new/ should never contain a noindex tag.
-        response = self.client.get("/firefox/new/", follow=True)
+        response = self.client.get("/en-US/firefox/new/")
         doc = pq(response.content)
         robots = doc('meta[name="robots"]')
         assert robots.length == 0
 
     def test_thanks_canonical(self):
         # Scene 2 /firefox/download/thanks/ should always contain a noindex tag.
-        response = self.client.get("/firefox/download/thanks/", follow=True)
+        response = self.client.get("/en-US/firefox/download/thanks/")
         doc = pq(response.content)
         robots = doc('meta[name="robots"]')
         assert robots.length == 1

--- a/bedrock/mozorg/context_processors.py
+++ b/bedrock/mozorg/context_processors.py
@@ -22,7 +22,7 @@ def canonical_path(request):
     """
     lang = getattr(request, "locale", settings.LANGUAGE_CODE)
     url = getattr(request, "path", "/")
-    return {"canonical_path": re.sub(r"^/" + lang, "", url)}
+    return {"canonical_path": re.sub(r"^/" + lang, "", url) if lang else url}
 
 
 def current_year(request):

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -557,7 +557,7 @@ class TestNewsletterSubscribe(TestCase):
 
     def test_shows_form_single(self):
         """The MPL page only subscribes to 'mozilla-foundation', so not a multi-newsletter form."""
-        resp = self.client.get("/MPL", follow=True)
+        resp = self.client.get("/en-US/MPL/", follow=True)
         doc = pq(resp.content)
         self.assertTrue(doc("#newsletter-form"))
         self.assertTrue(doc('input[value="mozilla-foundation"]'))

--- a/bedrock/urls/mozorg_mode.py
+++ b/bedrock/urls/mozorg_mode.py
@@ -14,6 +14,7 @@ from bedrock.base import views as base_views
 # which breaks the base template page. So we replace them with views that do!
 handler500 = "bedrock.base.views.server_error_view"
 handler404 = "bedrock.base.views.page_not_found_view"
+locale404 = "lib.l10n_utils.locale_selection"
 
 
 urlpatterns = (
@@ -36,6 +37,13 @@ urlpatterns = (
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("healthz-cron/", base_views.cron_health_check),
 )
+
+if settings.DEV:
+
+    urlpatterns += (
+        # Add /404-locale/ for localizers.
+        path("404-locale/", import_string(locale404)),
+    )
 
 if settings.DEBUG:
 

--- a/lib/l10n_utils/tests/test_files/templates/404-locale.html
+++ b/lib/l10n_utils/tests/test_files/templates/404-locale.html
@@ -1,0 +1,6 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+

--- a/media/css/mozorg/locales.scss
+++ b/media/css/mozorg/locales.scss
@@ -7,6 +7,8 @@ $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
+// note: these styles are used for both /locales and a locale-specific 404 page
+
 .c-simple-header {
     @include at2x('/media/img/mozorg/locales/world-map.png', 179px, 90px);
     background-position: top center;

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -98,8 +98,8 @@ def pytest_generate_tests(metafunc):
 
 def get_web_page(url):
     try:
-        r = requests.get(url, timeout=TIMEOUT)
+        r = requests.get(url, timeout=TIMEOUT, headers={"accept-language": "en"})
     except requests.RequestException:
         # retry
-        r = requests.get(url, timeout=TIMEOUT)
+        r = requests.get(url, timeout=TIMEOUT, headers={"accept-language": "en"})
     return BeautifulSoup(r.content, "html.parser")

--- a/tests/functional/test_experiment_pages.py
+++ b/tests/functional/test_experiment_pages.py
@@ -21,5 +21,5 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.headless
 @pytest.mark.nondestructive
 def test_experiment_pages(url):
-    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
+    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT, headers={"accept-language": "en"})
     assert requests.codes.ok == r.status_code

--- a/tests/functional/test_generated_pages.py
+++ b/tests/functional/test_generated_pages.py
@@ -62,5 +62,5 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.headless
 @pytest.mark.nondestructive
 def test_generated_pages(url):
-    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
+    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT, headers={"accept-language": "en"})
     assert requests.codes.ok == r.status_code

--- a/tests/redirects/base.py
+++ b/tests/redirects/base.py
@@ -131,8 +131,11 @@ def assert_valid_url(
     :param final_status_code: Expected status code after following any redirects.
     """
     kwargs = {"allow_redirects": follow_redirects}
-    if req_headers:
+    if req_headers is None:
+        kwargs["headers"] = {"Accept-language": "en"}
+    else:
         kwargs["headers"] = req_headers
+
     if req_kwargs:
         kwargs.update(req_kwargs)
 


### PR DESCRIPTION
## One-line summary

Return locale selection page at root URL if no header sent

## Significant changes and points to review

Test home page with various accept-language headers and lack of header.

## Issue / Bugzilla link

#11538 

