### PR TITLE
Rename 'platforms' to 'fpn_platform' in VPN invite template (Issue #11944)

### DIFF
--- a/bedrock/products/forms.py
+++ b/bedrock/products/forms.py
@@ -16,7 +16,7 @@ class VPNWaitlistForm(NewsletterFooterForm):
         ("chromebook", "Chromebook"),
         ("linux", "Linux"),
     )
-    platforms = forms.MultipleChoiceField(required=False, choices=PLATFORM_CHOICES, widget=forms.CheckboxSelectMultiple)
+    fpn_platform = forms.MultipleChoiceField(required=False, choices=PLATFORM_CHOICES, widget=forms.CheckboxSelectMultiple)
 
     def __init__(self, locale, data=None, *args, **kwargs):
         super().__init__("guardian-vpn-waitlist", locale, data, *args, **kwargs)

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -74,37 +74,37 @@
           <ul class="vpn-invite-platform-options">
             <li>
               <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-windows" name="platforms" value="windows">
+                <input type="checkbox" id="platforms-windows" name="fpn_platform" value="windows">
                 {{ ftl('vpn-landing-invite-platform-windows', fallback='vpn-landing-invite-platform-windows-10') }}
               </label>
             </li>
             <li>
               <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-ios" name="platforms" value="ios">
+                <input type="checkbox" id="platforms-ios" name="fpn_platform" value="ios">
                 {{ ftl('vpn-landing-invite-platform-ios') }}
               </label>
             </li>
             <li>
               <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-android" name="platforms" value="android">
+                <input type="checkbox" id="platforms-android" name="fpn_platform" value="android">
                 {{ ftl('vpn-landing-invite-platform-android') }}
               </label>
             </li>
             <li>
               <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-mac" name="platforms" value="mac">
+                <input type="checkbox" id="platforms-mac" name="fpn_platform" value="mac">
                 {{ ftl('vpn-landing-invite-platform-mac') }}
               </label>
             </li>
             <li>
               <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-chromebook" name="platforms" value="chromebook">
+                <input type="checkbox" id="platforms-chromebook" name="fpn_platform" value="chromebook">
                 {{ ftl('vpn-landing-invite-platform-chromebook') }}
               </label>
             </li>
             <li>
               <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-linux" name="platforms" value="linux">
+                <input type="checkbox" id="platforms-linux" name="fpn_platform" value="linux">
                 {{ ftl('vpn-landing-invite-platform-linux') }}
               </label>
             </li>

--- a/media/js/products/vpn/invite.es6.js
+++ b/media/js/products/vpn/invite.es6.js
@@ -117,7 +117,7 @@ const WaitListForm = {
 
         if (hasPlatformInterest) {
             const checkedPlatforms = document.querySelectorAll(
-                'input[name="platforms"]:checked'
+                'input[name="fpn_platform"]:checked'
             );
 
             if (checkedPlatforms.length) {

--- a/tests/unit/spec/products/vpn/invite.js
+++ b/tests/unit/spec/products/vpn/invite.js
@@ -77,37 +77,37 @@ describe('WaitListForm', function () {
                             <ul class="vpn-invite-platform-options">
                                 <li>
                                     <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-windows" name="platforms" value="windows">
+                                        <input type="checkbox" id="platforms-windows" name="fpn_platform" value="windows">
                                         Windows 10/11
                                     </label>
                                 </li>
                                 <li>
                                     <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-ios" name="platforms" value="ios">
+                                        <input type="checkbox" id="platforms-ios" name="fpn_platform" value="ios">
                                         iOS
                                     </label>
                                 </li>
                                 <li>
                                     <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-android" name="platforms" value="android">
+                                        <input type="checkbox" id="platforms-android" name="fpn_platform" value="android">
                                         Android
                                     </label>
                                 </li>
                                 <li>
                                     <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-mac" name="platforms" value="mac">
+                                        <input type="checkbox" id="platforms-mac" name="fpn_platform" value="mac">
                                         Mac
                                     </label>
                                 </li>
                                 <li>
                                     <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-chromebook" name="platforms" value="chromebook">
+                                        <input type="checkbox" id="platforms-chromebook" name="fpn_platform" value="chromebook">
                                         Chromebook
                                     </label>
                                 </li>
                                 <li>
                                     <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-linux" name="platforms" value="linux">
+                                        <input type="checkbox" id="platforms-linux" name="fpn_platform" value="linux">
                                         Linux
                                     </label>
                                 </li>


### PR DESCRIPTION
## One-line summary

Same as https://github.com/mozilla/bedrock/pull/12222 but for `/products/vpn/invite/`

https://sentry.io/organizations/mozilla/issues/3564819507/?project=6260602&query=error.unhandled%3Atrue+is%3Aunresolved+update_from_kwargs%28%29+got+an+unexpected+keyword+argument+%27unknown_data%27&sort=freq&statsPeriod=14d

## Issue / Bugzilla link

#11944

## Testing

There's no generated email when submitting this form so the best i could do was testing with JS both enabled and disabled, and then making sure there were no visible errors in Sentry: https://www-demo5.allizom.org/en-US/products/vpn/invite/
