### PR TITLE
Add Bookmarklet link to Pocket browser pages (only)

### DIFF
--- a/bedrock/pocket/templates/pocket/android.html
+++ b/bedrock/pocket/templates/pocket/android.html
@@ -15,3 +15,5 @@
 {% block page_cta %}{{ ftl('pocket-platform-get-app') }}{% endblock %}
 
 {% block page_url %}https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro{% endblock %}
+
+{% block bookmarklet %}{% endblock bookmarklet %}

--- a/bedrock/pocket/templates/pocket/ios.html
+++ b/bedrock/pocket/templates/pocket/ios.html
@@ -15,3 +15,5 @@
 {% block page_cta %}{{ ftl('pocket-platform-get-app') }}{% endblock %}
 
 {% block page_url %}https://apps.apple.com/app/read-it-later-pro/id309601447{% endblock %}
+
+{% block bookmarklet %}{% endblock bookmarklet %}

--- a/bedrock/pocket/templates/pocket/platform-pages.html
+++ b/bedrock/pocket/templates/pocket/platform-pages.html
@@ -28,7 +28,7 @@
           <a href="{{ self.page_url() }}" class="mzp-c-button" target="_blank" rel="external noopener">{{ self.page_cta() }}</a>
           {% block bookmarklet %}
           <p>
-            <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">Install the bookmarklet &raquo;</a>
+            <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">Install the bookmarklet</a>
           </p>
           {% endblock bookmarklet %}
 

--- a/bedrock/pocket/templates/pocket/platform-pages.html
+++ b/bedrock/pocket/templates/pocket/platform-pages.html
@@ -30,7 +30,7 @@
           {% if ftl_has_messages('pocket-platform-install-bookmarklet') %}
           <p>
             <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">
-              {{ftl('pocket-platform-install-bookmarklet')}}
+              {{ ftl('pocket-platform-install-bookmarklet') }}
             </a>
           </p>
           {% endif %}

--- a/bedrock/pocket/templates/pocket/platform-pages.html
+++ b/bedrock/pocket/templates/pocket/platform-pages.html
@@ -27,9 +27,13 @@
           <p>{{ self.page_desc() }}</p>
           <a href="{{ self.page_url() }}" class="mzp-c-button" target="_blank" rel="external noopener">{{ self.page_cta() }}</a>
           {% block bookmarklet %}
+          {% if ftl_has_messages('pocket-platform-install-bookmarklet') %}
           <p>
-            <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">Install the bookmarklet</a>
+            <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">
+              {{ftl('pocket-platform-install-bookmarklet')}}
+            </a>
           </p>
+          {% endif %}
           {% endblock bookmarklet %}
 
           {% endcall %}

--- a/bedrock/pocket/templates/pocket/platform-pages.html
+++ b/bedrock/pocket/templates/pocket/platform-pages.html
@@ -26,6 +26,12 @@
           <h1>{{ self.page_title() }}</h1>
           <p>{{ self.page_desc() }}</p>
           <a href="{{ self.page_url() }}" class="mzp-c-button" target="_blank" rel="external noopener">{{ self.page_cta() }}</a>
+          {% block bookmarklet %}
+          <p>
+            <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">Install the bookmarklet &raquo;</a>
+          </p>
+          {% endblock bookmarklet %}
+
           {% endcall %}
     </div>
   {% include 'pocket/includes/platform-footer.html' %}

--- a/bedrock/pocket/templates/pocket/welcome.html
+++ b/bedrock/pocket/templates/pocket/welcome.html
@@ -15,3 +15,5 @@
 {% block page_cta %}{{ ftl('pocket-platform-log-in') }}{% endblock %}
 
 {% block page_url %}https://getpocket.com/login/{% endblock %}
+
+{% block bookmarklet %}{% endblock bookmarklet %}

--- a/l10n-pocket/en/pocket/platforms.ftl
+++ b/l10n-pocket/en/pocket/platforms.ftl
@@ -39,3 +39,4 @@ pocket-platform-get-app = Get the app
 pocket-platform-install = Install
 pocket-platform-log-in = Log in
 pocket-platform-browser-installing = Installing the { -brand-name-pocket } browser extension installs buttons that let you save items with one click.
+pocket-platform-install-bookmarklet = Install the bookmarklet

--- a/media/css/pocket/components/platforms.scss
+++ b/media/css/pocket/components/platforms.scss
@@ -52,6 +52,10 @@
         color: $color-text-grey;
         text-decoration: none;
 
+        &::after {
+            content: ' »';
+        }
+
         &:hover,
         &:focus,
         &:active {

--- a/media/css/pocket/components/platforms.scss
+++ b/media/css/pocket/components/platforms.scss
@@ -46,4 +46,16 @@
             }
         }
     }
+
+    .bookmarklet {
+        @include text-body-sm;
+        color: $color-text-grey;
+        text-decoration: none;
+
+        &:hover,
+        &:focus,
+        &:active {
+            text-decoration: underline;
+        }
+    }
 }


### PR DESCRIPTION
## One-line summary

This changeset adds in a link to the Pocket bookmarklet for browsers, which slipped through the net in the main port.

## Significant changes and points to review

Template amended, new CSS rule added  - tested locally. Hyperlink has rollover state with underline


## Screenshots

<img width="975" alt="Screenshot 2022-10-13 at 13 57 20" src="https://user-images.githubusercontent.com/101457/195602441-0681f44b-bc01-420a-b9b1-2893047280a1.png">


(Compare with https://getpocket.com/en/chrome/)

## Testing

`npm run in-pocket-mode` to start things up right

Confirm bookmarklet link appears below CTA button for
* http://localhost:8080/en/chrome/
* http://localhost:8080/en/safari/
* http://localhost:8080/en/edge/
* http://localhost:8080/en/opera/

... and ultimately links to a sensible destination page (`/add` )

And does NOT appear for

* http://localhost:8080/fr/chrome/
* http://localhost:8080/es/safari/
* http://localhost:8080/it/edge/
* http://localhost:8080/pt-BR/opera/

because it hasn't been localised just yet

And does not appear for 

* http://localhost:8080/en/ios/
* http://localhost:8080/en/android/
* http://localhost:8080/en/welcome/

