### PR TITLE
Fix 500 error on /firefox/welcome/14/

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page14.html
+++ b/bedrock/firefox/templates/firefox/welcome/page14.html
@@ -39,7 +39,7 @@
           referral_id='welcome-page14',
           link_text=ftl('welcome-page14-get-mozilla-vpn'),
           class_name='mzp-t-product mzp-t-xl',
-          page_anchor="#pricing"
+          page_anchor="#pricing",
           optional_attributes= {
                 'data-cta-text' : 'Get Mozilla VPN',
                 'data-cta-type' : 'button',

--- a/tests/functional/firefox/welcome/test_welcome_page14.py
+++ b/tests/functional/firefox/welcome/test_welcome_page14.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.welcome.page14 import FirefoxWelcomePage14
+
+
+@pytest.mark.skip_if_not_firefox(reason="Welcome pages are shown to Firefox only.")
+@pytest.mark.nondestructive
+def test_vpn_button_displayed(base_url, selenium):
+    page = FirefoxWelcomePage14(selenium, base_url).open()
+    assert page.is_get_vpn_button_displayed

--- a/tests/pages/firefox/welcome/page14.py
+++ b/tests/pages/firefox/welcome/page14.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class FirefoxWelcomePage14(BasePage):
+
+    _URL_TEMPLATE = "/{locale}/firefox/welcome/14/"
+
+    _get_vpn_button_locator = (By.CSS_SELECTOR, ".c-main-cta .mzp-c-button")
+
+    @property
+    def is_get_vpn_button_displayed(self):
+        return self.is_element_displayed(*self._get_vpn_button_locator)


### PR DESCRIPTION
## One-line summary

Fixes 500 error on https://www-dev.allizom.org/en-US/firefox/welcome/14/

## Issue / Bugzilla link

https://sentry.io/organizations/mozilla/issues/3671860684/?alert_rule_id=10555963&alert_timestamp=1665774510814&alert_type=email&environment=production&project=6260211&referrer=alert_email

## Testing

http://localhost:8000/en-US/firefox/welcome/14/

```
py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/welcome/test_welcome_page14.py
```
