### PR TITLE
Pocket jobs link fixups

### DIFF
--- a/bedrock/pocket/templates/pocket/contact-info.html
+++ b/bedrock/pocket/templates/pocket/contact-info.html
@@ -31,7 +31,7 @@
     <p class="contact-info-body-text">{{ ftl('contact-regarding-api', api_email_link='mailto:api@getpocket.com', api_email='api@getpocket.com') }}</p>
 
     <h2 class="contact-info-subheader">{{ ftl('contact-jobs') }}</h2>
-    <p class="contact-info-body-text">{{ ftl('contact-view-job-page', jobs=url('pocket.jobs')) }}</p>
+    <p class="contact-info-body-text">{{ ftl('contact-view-job-page', jobs="/en/jobs/") }}</p>
 
     <h2 class="contact-info-subheader">{{ ftl('contact-security') }}</h2>
     <p class="contact-info-body-text">{{ ftl('contact-report-security-vulnerability', security_bug='https://www.mozilla.org/en-US/about/governance/policies/security-group/bugs/') }}</p>

--- a/bedrock/pocket/templates/pocket/includes/footer.html
+++ b/bedrock/pocket/templates/pocket/includes/footer.html
@@ -31,7 +31,7 @@
                       <a href="{{ url('pocket.about') }}?src=footer_v2">{{ ftl('pocket-footer-about') }}</a>
                     </li>
                     <li>
-                      <a href="{{ url('pocket.jobs') }}?src=footer_v2">{{ ftl('pocket-footer-careers') }}</a>
+                      <a href="/en/jobs/?src=footer_v2">{{ ftl('pocket-footer-careers') }}</a>
 
                     </li>
                     <li>

--- a/bedrock/pocket/templates/pocket/includes/platform-footer.html
+++ b/bedrock/pocket/templates/pocket/includes/platform-footer.html
@@ -8,12 +8,12 @@
   <nav class="footer-navigation">
     <ul class="footer-navigation-list">
       <li class="footer-navigation-list-item"><a href="https://blog.getpocket.com/">{{ ftl('pocket-footer-blog') }}</a></li>
-      <li class="footer-navigation-list-item"><a href="https://getpocket.com/en/about/">{{ ftl('pocket-footer-about') }}</a></li>
+      <li class="footer-navigation-list-item"><a href="/{{LANG}}/about/">{{ ftl('pocket-footer-about') }}</a></li>
       <li class="footer-navigation-list-item"><a href="https://getpocket.com/explore">{{ ftl('pocket-footer-explore') }}</a></li>
       <li class="footer-navigation-list-item"><a href="https://getpocket.com/publisher/">{{ ftl('pocket-footer-publishers') }}</a></li>
       <li class="footer-navigation-list-item"><a href="https://getpocket.com/developer/">{{ ftl('pocket-footer-developers') }}</a></li>
-      <li class="footer-navigation-list-item"><a href="https://getpocket.com/en/tos/">{{ ftl('pocket-footer-terms-of-service') }}</a></li>
-      <li class="footer-navigation-list-item"><a href="https://getpocket.com/en/privacy/">{{ ftl('pocket-footer-privacy-policy') }}</a></li>
+      <li class="footer-navigation-list-item"><a href="/en/tos/">{{ ftl('pocket-footer-terms-of-service') }}</a></li>
+      <li class="footer-navigation-list-item"><a href="/en/privacy/">{{ ftl('pocket-footer-privacy-policy') }}</a></li>
       <li class="footer-navigation-list-item"><a href="https://help.getpocket.com/">{{ ftl('pocket-footer-support') }}</a></li>
       <li class="footer-navigation-list-item"><a href="/en/jobs/">{{ ftl('pocket-footer-jobs') }}</a></li>
     </ul>

--- a/bedrock/pocket/templates/pocket/includes/platform-footer.html
+++ b/bedrock/pocket/templates/pocket/includes/platform-footer.html
@@ -15,7 +15,7 @@
       <li class="footer-navigation-list-item"><a href="https://getpocket.com/en/tos/">{{ ftl('pocket-footer-terms-of-service') }}</a></li>
       <li class="footer-navigation-list-item"><a href="https://getpocket.com/en/privacy/">{{ ftl('pocket-footer-privacy-policy') }}</a></li>
       <li class="footer-navigation-list-item"><a href="https://help.getpocket.com/">{{ ftl('pocket-footer-support') }}</a></li>
-      <li class="footer-navigation-list-item"><a href="https://getpocket.com/en/jobs/">{{ ftl('pocket-footer-jobs') }}</a></li>
+      <li class="footer-navigation-list-item"><a href="/en/jobs/">{{ ftl('pocket-footer-jobs') }}</a></li>
     </ul>
     <div class="platform-footer-socials">
     <div class="footer-socials-wrapper">


### PR DESCRIPTION
## One-line summary

This changeset tidies up a few links in Pocket Mode pages

* Make sure Pocket links to /jobs/ only go to the 'en' locale (Consistent with current setup in production)ensures we only link to /en/jobs
* Make links in homepage footer relative when they are for marketing pages, so
that test-driving is easier.
* Make the /about/ path locale-sensitive, not hard-coded to /en/ (The TOS and PP have not been localised, consistent with current production, so remain under /en/ only)

## Testing

`npm run in-pocket-mode`

* Go to the homepage in a locale other than English  - eg http://localhost:8080/es/ 
* Confirm the link to the jobs page (the last one on the footer) goes to `/en/jobs` not `{YOUR_LOCALE}/jobs/`
* Follow the link to the `about` page (second footer link) - it should keep you in the same locale as you were in
* Go to `/{YOUR_LOCALE}/contact-info` an confirm the jobs link (sixth one down) goes to `/en/jobs` not `{YOUR_LOCALE}/jobs/`