### PR TITLE
Family page: Scope private mode browser color styles

### DIFF
--- a/media/css/firefox/family/components/modules/_private-mode.scss
+++ b/media/css/firefox/family/components/modules/_private-mode.scss
@@ -153,25 +153,27 @@
             }
         }
 
-        .c-browser-content {
-            background-color: f3.$white;
+        .c-private-mode {
+            .c-browser-content {
+                background-color: f3.$white;
 
-            .c-subtitle,
-            p {
-                color: f3.$black;
+                .c-subtitle,
+                p {
+                    color: f3.$black;
+                }
             }
-        }
 
-        .c-browser-content.mzp-t-dark {
-            background-color: f3.$violet-extra-dark;
-            transition-property: color, background-color;
-            transition-delay: 1s;
-            transition-duration: 1s;
+            .c-browser-content.mzp-t-dark {
+                background-color: f3.$violet-extra-dark;
+                transition-property: color, background-color;
+                transition-delay: 1s;
+                transition-duration: 1s;
 
-            .c-subtitle,
-            p {
-                color: f3.$white;
-                transition: color 1s 1s;
+                .c-subtitle,
+                p {
+                    color: f3.$white;
+                    transition: color 1s 1s;
+                }
             }
         }
     }


### PR DESCRIPTION
## One-line summary

Regression in Passwords section after Private mode section color change


## Screenshots

on www-dev
<img width="553" alt="Screen Shot 2022-10-17 at 3 31 47 PM" src="https://user-images.githubusercontent.com/19650432/196205255-e68a888e-6825-4f59-8ff1-5c1ce1e8d233.png">

on localhost

<img width="548" alt="Screen Shot 2022-10-17 at 3 31 56 PM" src="https://user-images.githubusercontent.com/19650432/196205360-5e8dbc81-ddc7-4eb1-95f8-aba787ea0868.png">


## Testing

https://www-dev.allizom.org/en-US/firefox/family/#private-mode
See color change, scroll back to password section, ENTER text is black

http://localhost:8000/en-US/firefox/family/#private-mode
see color change, scroll back to password section, ENTER text is still white
