### PR TITLE
Update link to Pocket's press page

### DIFF
--- a/bedrock/pocket/templates/pocket/contact-info.html
+++ b/bedrock/pocket/templates/pocket/contact-info.html
@@ -21,7 +21,7 @@
     <p class="contact-info-body-text">To get help with Pocket or to request features, please visit our <a href="https://help.getpocket.com">support page</a>.</p>
 
     <h2 class="contact-info-subheader">Press</h2>
-    <p class="contact-info-body-text">For press inquiries or media assets, please visit our <a href="https://getpocket.com/press">press page</a>.</p>
+    <p class="contact-info-body-text">For press inquiries or media assets, please visit our <a href="https://blog.getpocket.com/press/">press page</a>.</p>
 
     <h2 class="contact-info-subheader">Sponsorships/Business</h2>
     <p class="contact-info-body-text">For questions related to business, please contact us at <a href="mailto:business@getpocket.com">business@getpocket.com</a>.</p>


### PR DESCRIPTION
Nano-sized fix. Noticed the link to press from /contact-info was wrong. Swapping in a link that works, with Pocket's blessing.