### PR TITLE
[Oct 25] Update Hubs privacy/legal notices (Fixes #12260)

### DIFF
--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -53,7 +53,7 @@ urlpatterns = (
     ),
     path(
         "terms/hubs/",
-        LegalDocView.as_view(template_name="legal/terms/hubs.html", legal_doc_name="mozilla_hubs_tos"),
+        LegalDocView.as_view(template_name="legal/terms/hubs.html", legal_doc_name="hubs_tos"),
         name="legal.terms.hubs",
     ),
     path(

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -62,7 +62,7 @@ firefox_reality_notices = PrivacyDocView.as_view(
     template_name="privacy/notices/firefox-reality.html", legal_doc_name="firefox_reality_privacy_notice"
 )
 
-hubs_notices = PrivacyDocView.as_view(template_name="privacy/notices/hubs.html", legal_doc_name="mozilla_hubs_privacy_notice")
+hubs_notices = PrivacyDocView.as_view(template_name="privacy/notices/hubs.html", legal_doc_name="hubs_privacy_notice")
 
 thunderbird_notices = PrivacyDocView.as_view(template_name="privacy/notices/thunderbird.html", legal_doc_name="thunderbird_privacy_policy")
 


### PR DESCRIPTION
## One-line summary

Updates Hubs legal docs sources to point to new markdown files.

**Do not merge until Oct 25**

## Issue / Bugzilla link

#12260

## Testing

Run `./manage.py update_legal_docs`

- http://localhost:8000/en-US/privacy/hubs/
- http://localhost:8000/en-US/about/legal/terms/hubs/