### PR TITLE
Fix Firefox Nightly Atom feed to start with XML declaration

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
+++ b/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
 {#
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:webfeeds="http://webfeeds.org/rss/1.0">
   <title>Firefox Nightly Notes</title>
   <subtitle>Firefox Nightly gets a new version every day and as a consequence, the release notes for the Nightly channel are updated continuously to reflect features that have reached sufficient maturity to benefit from community feedback and bug reports.</subtitle>


### PR DESCRIPTION
## Fix Firefox Nightly Atom feed to start with XML declaration

Whitespace before the XML declaration isn't allowed. Feed readers using a strict XML parser won't load the feed.

Current state: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Ffirefox%2Fnightly%2Fnotes%2Ffeed%2F

To test this work:
- Use the W3C's feed validator: https://validator.w3.org/feed/
