### PR TITLE
Pocket: update /my-list and "My List" to /saves and "Saves"

### DIFF
--- a/bedrock/pocket/templates/pocket/includes/mobile-nav.html
+++ b/bedrock/pocket/templates/pocket/includes/mobile-nav.html
@@ -14,7 +14,7 @@
                 <a class="mobile-nav-list-link home" href="https://getpocket.com/home?src=navbar">{{ ftl('pocket-nav-home') }}<span class="beta">{{ ftl('pocket-mobile-nav-beta') }}</span></a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link my-list" href="https://getpocket.com/my-list?src=navbar">{{ ftl('pocket-nav-my-list') }}</a>
+                <a class="mobile-nav-list-link my-list" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}?src=navbar">{% if switch('pocket-rename-my-list-to-saves') %}{{ ftl('pocket-nav-saves') }}{% else %}{{ ftl('pocket-nav-my-list') }}{% endif %}</a>
             </li>
             <li class="mobile-nav-list-item">
                 <a class="mobile-nav-list-link discover" href="https://getpocket.com/explore?src=navbar">{{ ftl('pocket-nav-discover') }}</a>
@@ -23,22 +23,22 @@
                 <a class="mobile-nav-list-link collections" href="https://getpocket.com/collections?src=navbar">{{ ftl('pocket-nav-collections') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link archive" href="https://getpocket.com/my-list/archive">{{ ftl('pocket-nav-archive') }}</a>
+                <a class="mobile-nav-list-link archive" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/archive">{{ ftl('pocket-nav-archive') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link favorites" href="https://getpocket.com/my-list/favorites">{{ ftl('pocket-nav-favorites') }}</a>
+                <a class="mobile-nav-list-link favorites" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/favorites">{{ ftl('pocket-nav-favorites') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link highlights" href="https://getpocket.com/my-list/highlights">{{ ftl('pocket-nav-highlights') }}</a>
+                <a class="mobile-nav-list-link highlights" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/highlights">{{ ftl('pocket-nav-highlights') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link articles" href="https://getpocket.com/my-list/articles">{{ ftl('pocket-nav-articles') }}</a>
+                <a class="mobile-nav-list-link articles" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/articles">{{ ftl('pocket-nav-articles') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link videos" href="https://getpocket.com/my-list/videos">{{ ftl('pocket-nav-videos') }}</a>
+                <a class="mobile-nav-list-link videos" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/videos">{{ ftl('pocket-nav-videos') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link tags" href="https://getpocket.com/my-list/tags">{{ ftl('pocket-nav-all-tags') }}</a>
+                <a class="mobile-nav-list-link tags" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/tags">{{ ftl('pocket-nav-all-tags') }}</a>
             </li>
         </ul>
     </nav>

--- a/bedrock/pocket/templates/pocket/includes/nav.html
+++ b/bedrock/pocket/templates/pocket/includes/nav.html
@@ -35,9 +35,9 @@
             <ul class="page-navigation-list links">
                 <li class="page-navigation-list-item"><a id="global-nav-discover-link" class="page-navigation-list-item-link selected nav-link" href="https://getpocket.com/explore?src=navbar">{{ ftl('pocket-nav-discover') }}</a></li>
                 {% if switch('pocket-rename-my-list-to-saves') %}
-                <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/saves?src=navbar">{{ ftl('pocket-nav-saves') }}</a></li>
+                  <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/saves?src=navbar">{{ ftl('pocket-nav-saves') }}</a></li>
                 {% else %}
-                <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/my-list?src=navbar">{{ ftl('pocket-nav-my-list') }}</a></li>
+                  <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/my-list?src=navbar">{{ ftl('pocket-nav-my-list') }}</a></li>
                 {% endif %}
               </ul>
         </div>

--- a/bedrock/pocket/templates/pocket/includes/nav.html
+++ b/bedrock/pocket/templates/pocket/includes/nav.html
@@ -34,8 +34,12 @@
         <div class="page-navigation" aria-label="{{ ftl('pocket-nav-aria-label') }}">
             <ul class="page-navigation-list links">
                 <li class="page-navigation-list-item"><a id="global-nav-discover-link" class="page-navigation-list-item-link selected nav-link" href="https://getpocket.com/explore?src=navbar">{{ ftl('pocket-nav-discover') }}</a></li>
-                <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/login?src=navbar">{{ ftl('pocket-nav-my-list') }}</a></li>
-            </ul>
+                {% if switch('pocket-rename-my-list-to-saves') %}
+                <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/saves?src=navbar">{{ ftl('pocket-nav-saves') }}</a></li>
+                {% else %}
+                <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/my-list?src=navbar">{{ ftl('pocket-nav-my-list') }}</a></li>
+                {% endif %}
+              </ul>
         </div>
         <div>
             <a class="login-link nav-link" href="https://getpocket.com/login?src=navbar" id="global-nav-login-link">{{ ftl('pocket-nav-log-in') }}</a>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -178,7 +178,11 @@
         <li>getpocket.com/account</li>
         <li>getpocket.com/discover</li>
         <li>getpocket.com/collections</li>
+        {% if switch('pocket-rename-my-list-to-saves') %}
+        <li>getpocket.com/saves/*</li>
+        {% else %}
         <li>getpocket.com/my-list/*</li>
+        {% endif %}
         <li>getpocket.com/read/*</li>
         <li>getpocket.com/premium/*</li>
       </ul>

--- a/l10n-pocket/en/nav.ftl
+++ b/l10n-pocket/en/nav.ftl
@@ -17,6 +17,8 @@ pocket-nav-sign-up = Sign up
 
 pocket-nav-home = Home
 pocket-nav-my-list = My List
+# "Saves" refers to a list of links saved by the user. It is a replacement for "My List"
+pocket-nav-saves = Saves
 pocket-nav-discover = Discover
 pocket-nav-collections = Collections
 pocket-nav-archive = Archive

--- a/tests/functional/pocket/test_navigation.py
+++ b/tests/functional/pocket/test_navigation.py
@@ -15,13 +15,11 @@ def test_mobile_menu(pocket_base_url, selenium_mobile):
     page = AboutPage(selenium_mobile, pocket_base_url).open()
     assert page.navigation.is_mobile_menu_open_button_displayed
     page.navigation.open_mobile_menu()
-    assert page.navigation.is_mobile_menu_home_link_displayed
-    assert page.navigation.is_mobile_menu_my_list_link_displayed
+    assert page.navigation.is_mobile_menu_nav_link_displayed
 
     assert page.navigation.is_mobile_menu_close_button_displayed
     page.navigation.close_mobile_menu()
-    assert not page.navigation.is_mobile_menu_home_link_displayed
-    assert not page.navigation.is_mobile_menu_my_list_link_displayed
+    assert not page.navigation.is_mobile_menu_nav_link_displayed
 
 
 def test_accessible_mobile_menu_open_name(pocket_base_url, selenium_mobile):

--- a/tests/functional/pocket/test_navigation.py
+++ b/tests/functional/pocket/test_navigation.py
@@ -15,11 +15,11 @@ def test_mobile_menu(pocket_base_url, selenium_mobile):
     page = AboutPage(selenium_mobile, pocket_base_url).open()
     assert page.navigation.is_mobile_menu_open_button_displayed
     page.navigation.open_mobile_menu()
-    assert page.navigation.is_mobile_menu_nav_link_displayed
+    assert page.navigation.is_mobile_menu_nav_list_displayed
 
     assert page.navigation.is_mobile_menu_close_button_displayed
     page.navigation.close_mobile_menu()
-    assert not page.navigation.is_mobile_menu_nav_link_displayed
+    assert not page.navigation.is_mobile_menu_nav_list_displayed
 
 
 def test_accessible_mobile_menu_open_name(pocket_base_url, selenium_mobile):

--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -51,11 +51,11 @@ class BasePage(Page):
         _mobile_menu_close_btn_locator = (By.CLASS_NAME, "mobile-nav-close-btn")
         _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav")
         _mobile_menu_wrapper_locator = (By.CLASS_NAME, "mobile-nav-wrapper")
-        _mobile_menu_link_locator = (By.CSS_SELECTOR, ".mobile-nav-list-link")
+        _mobile_menu_nav_list_locator = (By.CSS_SELECTOR, ".mobile-nav-list")
 
         @property
-        def is_mobile_menu_nav_link_displayed(self):
-            return self.is_element_displayed(*self._mobile_menu_link_locator)
+        def is_mobile_menu_nav_list_displayed(self):
+            return self.is_element_displayed(*self._mobile_menu_nav_list_locator)
 
         @property
         def is_mobile_menu_open(self):

--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -51,16 +51,11 @@ class BasePage(Page):
         _mobile_menu_close_btn_locator = (By.CLASS_NAME, "mobile-nav-close-btn")
         _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav")
         _mobile_menu_wrapper_locator = (By.CLASS_NAME, "mobile-nav-wrapper")
-        _home_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/home?src=navbar"]')
-        _my_list_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/saves?src=navbar"]')
+        _mobile_menu_link_locator = (By.CSS_SELECTOR, ".mobile-nav-list-link")
 
         @property
-        def is_mobile_menu_home_link_displayed(self):
-            return self.is_element_displayed(*self._home_mobile_menu_locator)
-
-        @property
-        def is_mobile_menu_my_list_link_displayed(self):
-            return self.is_element_displayed(*self._my_list_mobile_menu_locator)
+        def is_mobile_menu_nav_link_displayed(self):
+            return self.is_element_displayed(*self._mobile_menu_link_locator)
 
         @property
         def is_mobile_menu_open(self):

--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -52,7 +52,7 @@ class BasePage(Page):
         _mobile_menu_locator = (By.CLASS_NAME, "mobile-nav")
         _mobile_menu_wrapper_locator = (By.CLASS_NAME, "mobile-nav-wrapper")
         _home_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/home?src=navbar"]')
-        _my_list_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/my-list?src=navbar"]')
+        _my_list_mobile_menu_locator = (By.CSS_SELECTOR, '.mobile-nav-list-link[href="https://getpocket.com/saves?src=navbar"]')
 
         @property
         def is_mobile_menu_home_link_displayed(self):


### PR DESCRIPTION
## One-line summary

This changeset is designed to match in-app wording change for main Pocket, where My List will be rephrased as Saves.


## Significant changes and points to review

The switchover is scheduled for 31 October, but we need to get a new string ("Saves") translated before then, so getting the changes in to main now, behind a switch, lets us move ahead now and test what we can.

The wording and URL change is overseen by a switch, which has NOT yet been added to `www-config`.

`SWITCH_POCKET_RENAME_MY_LIST_TO_SAVES`

A follow-up task is required to clean this up after go-live. It would have been possible to do this without switches (add the new fluent string now, get it translated in Smartling, then swap it in), but switches give us extra latitude.

NOT IN THIS PR: there's also an image change needed for the homepage, to replace the mocked-up mobile screenshot that features "My List". This has been requested from Pocket and is en route. We can merge this PR and get the L10N strings (well, string) updated first, then circle back to make the image switch-swappable, too.

## Issue / Bugzilla link

Resolves #12266 

## Screenshots

Switch OFF

<img width="563" alt="Screenshot 2022-10-20 at 20 45 19" src="https://user-images.githubusercontent.com/101457/197053735-3617df6c-ecd0-415d-9f99-3f502f576c63.png">
<img width="373" alt="Screenshot 2022-10-20 at 20 45 04" src="https://user-images.githubusercontent.com/101457/197053741-e6b1a017-fc36-4368-93da-9a475b60f59c.png">


Switch ON 

<img width="517" alt="Screenshot 2022-10-20 at 20 54 33" src="https://user-images.githubusercontent.com/101457/197053773-fec1f413-c6b0-4c42-8f51-9634da1a9d4c.png">
<img width="411" alt="Screenshot 2022-10-20 at 20 54 44" src="https://user-images.githubusercontent.com/101457/197053780-2358d388-7c96-4a13-b61b-71d2d795717b.png">


## Checklist

If relevant:

- [ ] Tests added
- [x] STILL TO DO Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: (or None)

To test this work:

- [x] Enable the switch and confirm that the nav contains "Saves" and links to /saves in both desktop and mobile viewports. Note that the mobile nav contains multiple links to /saves
- [x] Disable the switch and confirm that the nav contains "My List" and links to /my-list in both desktop and mobile viewports. Note that the mobile nav contains multiple links to /my-list

`BASE_POCKET_URL=http://localhost:8000 py.test -m pocket_mode --driver Firefox --html tests/functional/results.html tests/functional/`
