### PR TITLE
Update VPN & Relay bundle IDs (Issue #11781)

### DIFF
--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -111,7 +111,7 @@ TEST_VPN_RELAY_BUNDLE_PRODUCT_ID = "prod_MIex7Q079igFZJ"
 TEST_VPN_RELAY_BUNDLE_PLAN_ID_MATRIX = {
     "usd": {
         "en": {
-            "12-month": {"id": "price_1La3d7JNcmPzuWtRn0cg2EyH", "price": "US$6.99", "total": "US$83.88", "saving": 50},
+            "12-month": {"id": "price_1LwoSDJNcmPzuWtR6wPJZeoh", "price": "US$6.99", "total": "US$83.88", "saving": 50},
         }
     },
 }
@@ -205,7 +205,7 @@ class TestVPNSubscribeLink(TestCase):
             lang="en-US",
             bundle_relay=True,
         )
-        self.assertIn("/prod_MIex7Q079igFZJ?plan=price_1La3d7JNcmPzuWtRn0cg2EyH", markup)
+        self.assertIn("/prod_MIex7Q079igFZJ?plan=price_1LwoSDJNcmPzuWtR6wPJZeoh", markup)
 
     def test_vpn_relay_bundle_subscribe_link_variable_12_month_ca_en(self):
         """Should return expected markup for variable 12-month plan link"""
@@ -215,7 +215,7 @@ class TestVPNSubscribeLink(TestCase):
             lang="en-CA",
             bundle_relay=True,
         )
-        self.assertIn("/prod_MIex7Q079igFZJ?plan=price_1La3d7JNcmPzuWtRn0cg2EyH", markup)
+        self.assertIn("/prod_MIex7Q079igFZJ?plan=price_1LwoSDJNcmPzuWtR6wPJZeoh", markup)
 
     def test_vpn_subscribe_link_variable_12_month_us_en(self):
         """Should contain expected 12-month plan ID (US / en-US)"""

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1550,7 +1550,7 @@ VPN_RELAY_BUNDLE_PLAN_ID_MATRIX = {
     "usd": {
         "en": {
             "12-month": {
-                "id": "price_1LhJGWKb9q6OnNsLuCurigPk" if DEV else "price_1La3d7JNcmPzuWtRn0cg2EyH",
+                "id": "price_1Lwp7uKb9q6OnNsLQYzpzUs5" if DEV else "price_1LwoSDJNcmPzuWtR6wPJZeoh",
                 "price": "US$6.99",
                 "total": "US$83.88",
                 "saving": 50,


### PR DESCRIPTION
## One-line summary

The VPN product team need to update the price IDs for the VPN / Relay bundle as below.

## Issue / Bugzilla link

#11781

## Testing

http://localhost:8000/en-US/products/vpn/

- [x] Clicking the "Get VPN + Relay" button should redirect to a checkout page that matches the total price displayed on the landing page.