### PR TITLE
Integrate updated protocol version with new SCSS module syntax

### DIFF
--- a/media/css/contentful/c-logo.scss
+++ b/media/css/contentful/c-logo.scss
@@ -2,33 +2,31 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' with ($image-path: '/media/protocol/img');
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-family';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-beta';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-developer';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-nightly';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-focus';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-monitor';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-lockwise';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-mozilla';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-relay';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-beta';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-nightly';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-focus';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-lockwise';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-family';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-beta';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-developer';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-nightly';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-focus';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-monitor';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-lockwise';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-mozilla';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-relay';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-beta';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-nightly';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-focus';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-lockwise';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';

--- a/media/css/firefox/all/all-unified.scss
+++ b/media/css/firefox/all/all-unified.scss
@@ -4,14 +4,11 @@
 
 @use 'sass:color';
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/forms/lib';
-@import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
-@import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
+@use '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
+@use '~@mozilla-protocol/core/protocol/css/components/modal';
+@use '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
 
 .c-product-select-form {
     @include clearfix;
@@ -200,7 +197,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-download-info-caption {
-    @include field-label;
+    @include forms.field-label;
     display: table-caption;
 }
 
@@ -246,9 +243,9 @@ $image-path: '/media/protocol/img';
 
     a[data-link-type='download']:focus,
     a[data-link-type='download']:active {
-        box-shadow: 0 0 0 2px $field-border-color-hover, 0 0 0 4px color.mix($color-blue-40, $color-white);
+        box-shadow: 0 0 0 2px forms.$field-border-color-hover, 0 0 0 4px color.mix($color-blue-40, $color-white);
         border-radius: 6px;
-        background-color: $field-border-color-hover;
+        background-color: forms.$field-border-color-hover;
     }
 
     img {

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -2,16 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-$brand-theme: 'firefox';
-
-@import '../protocol/components/custom-menu-list';
-@import '../protocol/components/fxa-form';
-@import './sticky-promo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/zap';
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img', $brand-theme: 'firefox');
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
+@use '~@mozilla-protocol/core/protocol/css/components/zap';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '../protocol/components/custom-menu-list';
+@use '../protocol/components/fxa-form';
+@use './sticky-promo';
 
 // Hello developer in the future! This file serves multiple different pages
 // which isn't so obvious, so make changes with care! Be sure to check the
@@ -487,7 +484,7 @@ $url-download-link-hover: svg-url($download-link-hover);
 
                 // put in fake form label to push button down height of real form label next to it
                 &::before {
-                    @include field-label;
+                    @include forms.field-label;
                     content: '.';
                     visibility: hidden;
                 }

--- a/media/css/firefox/browsers/best-browser.scss
+++ b/media/css/firefox/browsers/best-browser.scss
@@ -2,13 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 .seo-hero {
     background: $color-purple-90 url('/media/img/firefox/browsers/best-browser/hero-pattern.png') 55% 60% no-repeat;

--- a/media/css/firefox/browsers/get-ios.scss
+++ b/media/css/firefox/browsers/get-ios.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 #ios-attr-get-ios {
     .get-ios-attr-content {

--- a/media/css/firefox/browsers/mobile.scss
+++ b/media/css/firefox/browsers/mobile.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-focus';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-focus';
 
 @media #{$mq-lg} {
     .c-page-header::before {

--- a/media/css/firefox/browsers/windows-64-bit.scss
+++ b/media/css/firefox/browsers/windows-64-bit.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 .c-hero {
     background: $color-purple-90;

--- a/media/css/firefox/developer/developer.scss
+++ b/media/css/firefox/developer/developer.scss
@@ -2,18 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
-@import 'includes/engage';
-@import 'includes/features';
-@import 'includes/gallery-grid';
-@import 'includes/highlights';
-@import 'includes/intro';
-@import 'includes/newsletter';
-@import 'includes/performance';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
+@use 'includes/engage';
+@use 'includes/features';
+@use 'includes/gallery-grid';
+@use 'includes/highlights';
+@use 'includes/intro';
+@use 'includes/newsletter';
+@use 'includes/performance';
 
 // *------------------------------------------------------------------*/
 // Title and subtitles for entire page

--- a/media/css/firefox/developer/includes/performance.scss
+++ b/media/css/firefox/developer/includes/performance.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
 .t-performance .mzp-c-split-container {
     box-sizing: content-box; // add default split padding to max-width
     max-width: $content-sm;

--- a/media/css/firefox/developer/whatsnew-mdnplus.scss
+++ b/media/css/firefox/developer/whatsnew-mdnplus.scss
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/templates/multi-column';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-developer';
 
 .firefox-developer-whatsnew-mdnplus {
     h1,

--- a/media/css/firefox/enterprise/landing.scss
+++ b/media/css/firefox/enterprise/landing.scss
@@ -2,15 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/button';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '../../protocol/components/custom-menu-list';
-@import '../../protocol/components/sub-navigation';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/button';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '../../protocol/components/custom-menu-list';
+@use '../../protocol/components/sub-navigation';
 
 // * -------------------------------------------------------------------------- */
 // Generic Container Styles

--- a/media/css/firefox/facebook-container.scss
+++ b/media/css/firefox/facebook-container.scss
@@ -2,14 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-$brand-theme: 'firefox';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/video';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img', $brand-theme: 'firefox');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/video';
 
 // * -------------------------------------------------------------------------- */
 // Components

--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @use '../utils' as f3;
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 
 .no-js .c-dad-jokes-banner {

--- a/media/css/firefox/faq.scss
+++ b/media/css/firefox/faq.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 .mzp-c-split .mzp-c-logo {
     margin-left: auto;

--- a/media/css/firefox/features/safebrowser.scss
+++ b/media/css/firefox/features/safebrowser.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 .c-hero {
     background: $color-purple-90;

--- a/media/css/firefox/firstrun/firstrun.scss
+++ b/media/css/firefox/firstrun/firstrun.scss
@@ -2,14 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
 $break-large: 1305px;
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '../../protocol/components/fxa-form';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '../../protocol/components/fxa-form';
 
 // * -------------------------------------------------------------------------- */
 // Common elements & variables

--- a/media/css/firefox/flashback/flashback.scss
+++ b/media/css/firefox/flashback/flashback.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 @mixin down-arrow($color) {
     $downarrow: '<?xml version="1.0" encoding="utf-8"?><svg viewBox="0 0 50 54" width="50px" height="54px" xmlns="http://www.w3.org/2000/svg" xmlns:bx="https://boxy-svg.com"><path style="stroke: #{$color}; fill: rgba(0,0,0,0); stroke-width: 9px; stroke-linejoin: round; stroke-linecap: round;" d="M 6.76 28.842 C 8.723 30.855 25.377 48.01 25.398 48.007 C 25.398 48.007 43.025 29.144 43.419 28.8"/><path style="stroke: #{$color}; fill: rgba(0,0,0,0); stroke-width: 9px; stroke-linejoin: round; stroke-linecap: round;" d="M 6.8 5.764 C 8.763 7.777 25.417 24.932 25.438 24.929 C 25.438 24.929 43.065 6.066 43.459 5.722" bx:origin="0.48441 0.5"/></svg>';

--- a/media/css/firefox/home/master.scss
+++ b/media/css/firefox/home/master.scss
@@ -2,20 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-$brand-theme: 'firefox';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
-@import '~@mozilla-protocol/core/protocol/css/components/zap';
-@import '../../protocol/components/custom-menu-list';
-@import '../sticky-promo';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img', $brand-theme: 'firefox');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
+@use '~@mozilla-protocol/core/protocol/css/components/zap';
+@use '../../protocol/components/custom-menu-list';
+@use '../sticky-promo';
 
 // conditional content
 .js-fx-only {

--- a/media/css/firefox/mobile/get-app.scss
+++ b/media/css/firefox/mobile/get-app.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 // * -------------------------------------------------------------------------- */
 //  Main page heading

--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -2,14 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-$brand-theme: 'firefox';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img', $brand-theme: 'firefox');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/templates/multi-column';
 
 // * -------------------------------------------------------------------------- */
 

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -4,18 +4,15 @@
 
 @use 'sass:math';
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/section-heading';
-@import '~@mozilla-protocol/core/protocol/css/components/zap';
-@import '../../../protocol/components/sub-navigation';
-@import '../../sticky-promo';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/modal';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/section-heading';
+@use '~@mozilla-protocol/core/protocol/css/components/zap';
+@use '../../../protocol/components/sub-navigation';
+@use '../../sticky-promo';
 
 // --------------------------------------------------------------------------
 // Protocol over-rides

--- a/media/css/firefox/new/desktop/thanks.scss
+++ b/media/css/firefox/new/desktop/thanks.scss
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/zap';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/zap';
 
 // --------------------------------------------------------------------------
 // Protocol over-rides

--- a/media/css/firefox/pocket.scss
+++ b/media/css/firefox/pocket.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/billboard';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/billboard';
 
 .pocket-hero {
     h1 {

--- a/media/css/firefox/privacy/products.scss
+++ b/media/css/firefox/privacy/products.scss
@@ -2,16 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '../../protocol/components/fxa-form';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '../../protocol/components/fxa-form';
 
 .t-medium .mzp-l-content,
 .t-medium .mzp-c-split-container {

--- a/media/css/firefox/releases-index.scss
+++ b/media/css/firefox/releases-index.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 
 .c-release-list {
     line-height: 2;

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 
 .mzp-c-split {
     overflow: hidden;

--- a/media/css/firefox/sync.scss
+++ b/media/css/firefox/sync.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 .sync-highlights {
     margin-bottom: $layout-xl;

--- a/media/css/firefox/welcome11.scss
+++ b/media/css/firefox/welcome11.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 
 .c-page-header {
     .mzp-l-content {

--- a/media/css/firefox/welcome12.scss
+++ b/media/css/firefox/welcome12.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 
 .c-page-header {
     .mzp-l-content {

--- a/media/css/firefox/welcome13.scss
+++ b/media/css/firefox/welcome13.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 
 .c-page-header {
     .mzp-l-content {

--- a/media/css/firefox/whatsnew/includes/_dark-mode.scss
+++ b/media/css/firefox/whatsnew/includes/_dark-mode.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
 @media (prefers-color-scheme: dark) {
     html,
     body,

--- a/media/css/firefox/whatsnew/whatsnew-110-eu.scss
+++ b/media/css/firefox/whatsnew/whatsnew-110-eu.scss
@@ -2,15 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import 'includes/base';
-@import 'includes/dark-mode';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use 'includes/base';
+@use 'includes/dark-mode';
 
 .wnp-content-main {
     .mzp-c-wordmark {

--- a/media/css/firefox/whatsnew/whatsnew-account.scss
+++ b/media/css/firefox/whatsnew/whatsnew-account.scss
@@ -2,15 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import 'includes/base';
-@import 'includes/dark-mode';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use 'includes/base';
+@use 'includes/dark-mode';
 
 // * -------------------------------------------------------------------------- */
 // Main content

--- a/media/css/firefox/whatsnew/whatsnew.scss
+++ b/media/css/firefox/whatsnew/whatsnew.scss
@@ -2,15 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import 'includes/base';
-@import 'includes/dark-mode';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use 'includes/base';
+@use 'includes/dark-mode';
 
 // * -------------------------------------------------------------------------- */
 // Main content

--- a/media/css/landing/landing-shared.scss
+++ b/media/css/landing/landing-shared.scss
@@ -2,18 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
 
 .c-navigation-container {
     .sem-landing-nav-icon {

--- a/media/css/legal/legal.scss
+++ b/media/css/legal/legal.scss
@@ -2,14 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 
 /* -------------------------------------------------------------------------- */
 // Article

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
-@import '~@mozilla-protocol/core/protocol/css/components/billboard';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
+@use '~@mozilla-protocol/core/protocol/css/components/billboard';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
 
 .mzp-c-split .mzp-u-title-md {
     @include font-firefox;

--- a/media/css/mozorg/santa-locator.scss
+++ b/media/css/mozorg/santa-locator.scss
@@ -2,12 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 
 $santa-red: #e83d53;
 

--- a/media/css/newsletter/newsletter-knowledge-is-power.scss
+++ b/media/css/newsletter/newsletter-knowledge-is-power.scss
@@ -2,16 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
 
 .section-subscribe {
     .mzp-l-content:first-child {

--- a/media/css/newsletter/newsletter-management.scss
+++ b/media/css/newsletter/newsletter-management.scss
@@ -5,6 +5,7 @@
 $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
 
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
@@ -29,7 +30,7 @@ main {
     }
 
     .mzp-c-field {
-        padding-bottom: $label-v-spacing;
+        padding-bottom: forms.$label-v-spacing;
     }
 }
 

--- a/media/css/newsletter/newsletter-opt-out-confirmation.scss
+++ b/media/css/newsletter/newsletter-opt-out-confirmation.scss
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 
 /* -------------------------------------------------------------------------- */
 // Common elements
@@ -43,6 +44,7 @@ header {
 .mzp-c-form-errors {
     @include border-box;
     max-width: $content-xs;
+    padding-bottom: forms.$label-v-spacing;
 }
 
 .mzp-c-button-container {

--- a/media/css/newsletter/newsletter-recovery.scss
+++ b/media/css/newsletter/newsletter-recovery.scss
@@ -2,20 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 /* stylelint-disable declaration-no-important */
 
 .newsletter-recovery-form {
     .mzp-c-field {
-        padding-bottom: $label-v-spacing;
+        padding-bottom: forms.$label-v-spacing;
     }
 
     .mzp-c-form-errors {

--- a/media/css/pocket/components/add.scss
+++ b/media/css/pocket/components/add.scss
@@ -4,37 +4,37 @@
 
 @use 'sass:color';
 
-@import '../utils/variables';
-@import '../includes/platform-nav';
-@import '../includes/platform-footer';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/button';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/button';
+@use '../utils/variables';
+@use '../includes/platform-nav';
+@use '../includes/platform-footer';
 
 // Header section
 .add-page {
     .add-header {
-        background-color: $color-background-grey;
+        background-color: variables.$color-background-grey;
         padding: 5px;
     }
 
     h2 {
-        color: $color-text-dark-grey;
+        color: variables.$color-text-dark-grey;
         margin: 0 auto;
         max-width: 62.5rem;
-        padding: $spacing100;
-        font-size: $size150;
+        padding: variables.$spacing100;
+        font-size: variables.$size150;
         text-align: center;
 
         @media #{$mq-md} {
-            font-size: $size200;
+            font-size: variables.$size200;
             text-align: left;
         }
     }
 
     h3,
     p {
-        color: $color-text-grey;
+        color: variables.$color-text-grey;
     }
 }
 
@@ -44,14 +44,14 @@
 
 .add-header {
     .mzp-c-button {
-        background-color: $color-button-red;
-        border: 2px solid $color-button-red;
+        background-color: variables.$color-button-red;
+        border: 2px solid variables.$color-button-red;
 
         &:hover,
         &:focus,
         &:active {
-            background-color: color.adjust($color-button-red, $lightness: -10%);
-            border: 2px solid color.adjust($color-button-red, $lightness: -10%);
+            background-color: color.adjust(variables.$color-button-red, $lightness: -10%);
+            border: 2px solid color.adjust(variables.$color-button-red, $lightness: -10%);
             color: $color-white;
         }
     }
@@ -60,8 +60,8 @@
 // Device section
 .add-device {
     margin: 0 auto;
-    max-width: 62.5rem;
-    padding: $spacing100;
+    max-width: 62.5em;
+    padding: variables.$spacing100;
     width: 100%;
 
     @media #{$mq-md} {
@@ -106,11 +106,11 @@
 
 .app-store-list,
 .device-list {
-    margin-bottom: $spacing050;
+    margin-bottom: variables.$spacing050;
     padding: 0;
 
     li {
-        margin: $spacing050 0;
+        margin: variables.$spacing050 0;
     }
 }
 
@@ -131,7 +131,7 @@
 
 // Save section
 .add-save {
-    background-color: $color-background-grey;
+    background-color: variables.$color-background-grey;
 
     @media #{$mq-md} {
         .save-context {
@@ -150,8 +150,8 @@
 
 .add-save-wrapper {
     margin: 0 auto;
-    max-width: 62.5rem;
-    padding: $spacing100;
+    max-width: 62.5em;
+    padding: variables.$spacing100;
     width: 100%;
 }
 
@@ -169,7 +169,7 @@
 .save-email-link {
     display: block;
     max-width: 400px;
-    margin-bottom: $spacing100;
+    margin-bottom: variables.$spacing100;
     text-decoration: none;
     padding: $spacing-md $spacing-md 0;
     overflow: hidden;
@@ -183,13 +183,13 @@
         .save-email-card-line {
             @include font-size(15px);
             font-weight: 300;
-            color: $color-text-dark-grey;
-            border-bottom: 1px solid $color-light-grey;
+            color: variables.$color-text-dark-grey;
+            border-bottom: 1px solid variables.$color-light-grey;
             padding-bottom: $spacing-sm;
 
             &.email {
                 font-weight: 400;
-                color: $color-text-cyan;
+                color: variables.$color-text-cyan;
                 margin-top: 0;
             }
 
@@ -201,7 +201,7 @@
 
             span {
                 font-weight: 100;
-                color: $color-text-grey;
+                color: variables.$color-text-grey;
             }
         }
     }
@@ -269,12 +269,12 @@ $icon-gap: 1rem;
 
 .dark-inline-link {
     font-weight: 700;
-    color: $color-text-grey;
+    color: variables.$color-text-grey;
     text-decoration: none;
 
     &:hover,
     &:focus,
     &:active {
-        color: $color-text-cyan;
+        color: variables.$color-text-cyan;
     }
 }

--- a/media/css/pocket/components/error-page.scss
+++ b/media/css/pocket/components/error-page.scss
@@ -2,21 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '../utils/variables';
-@import '../includes/platform-nav';
-@import '../includes/platform-footer';
+@use '../utils/variables';
+@use '../includes/platform-nav';
+@use '../includes/platform-footer';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/base/elements/containers';
 
 a {
-    color: $color-action-primary;
+    color: variables.$color-action-primary;
     text-decoration: underline;
     transition: color 0.1s ease-out;
 
     &:hover,
     &:active,
     &:focus {
-        color: $color-action-primary-hover;
+        color: variables.$color-action-primary-hover;
     }
 }

--- a/media/css/pocket/components/home.scss
+++ b/media/css/pocket/components/home.scss
@@ -29,7 +29,7 @@
 
         p {
             align-self: center;
-            font-family: $font-sans;
+            font-family: variables.$font-sans;
             font-weight: 600;
             margin: 0 $spacing-md;
         }
@@ -61,7 +61,7 @@
 
     p {
         margin: 0;
-        font-family: $font-sans;
+        font-family: variables.$font-sans;
     }
 
     @media #{$mq-md} {

--- a/media/css/pocket/components/home.scss
+++ b/media/css/pocket/components/home.scss
@@ -4,16 +4,15 @@
 
 @use 'sass:color';
 
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/base/elements/containers';
+@use '~@mozilla-protocol/core/protocol/css/components/button';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
-@import '~@mozilla-protocol/core/protocol/css/components/button';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
-@import '../utils/variables';
-@import '../includes/platform-nav';
-@import '../includes/platform-footer';
+@use '../utils/variables';
+@use '../includes/platform-nav';
+@use '../includes/platform-footer';
 
 .c-banner {
     $dark-blue: #00256d;
@@ -87,8 +86,8 @@ $image-path: '/media/protocol/img';
 }
 
 .pocket-homepage {
-    color: $color-text-primary;
-    font-family: $font-sans;
+    color: variables.$color-text-primary;
+    font-family: variables.$font-sans;
 
     .pocket-homepage-header {
         .mzp-l-split-media-overflow {
@@ -117,7 +116,7 @@ $image-path: '/media/protocol/img';
 
     .section-heading {
         @include text-title-lg;
-        font-family: $font-sans-alt;
+        font-family: variables.$font-sans-alt;
         font-weight: 500;
         line-height: 1.1;
     }
@@ -146,13 +145,13 @@ $image-path: '/media/protocol/img';
 
         a {
             font-weight: 600;
-            color: $color-text-primary;
+            color: variables.$color-text-primary;
             text-decoration-thickness: 1.5px;
 
             &:hover,
             &:focus,
             &:active {
-                color: $color-button-red;
+                color: variables.$color-button-red;
             }
         }
 
@@ -184,7 +183,7 @@ $image-path: '/media/protocol/img';
         position: relative;
 
         h2 {
-            font-family: $font-sans-alt;
+            font-family: variables.$font-sans-alt;
             @include text-title-md;
             font-weight: 500;
             text-align: center;
@@ -244,14 +243,14 @@ $image-path: '/media/protocol/img';
     }
 
     .mzp-c-button {
-        background-color: $color-button-red;
+        background-color: variables.$color-button-red;
         border: 0;
 
         &:hover,
         &:focus,
         &:active {
-            background-color: color.adjust($color-button-red, $lightness: -10%);
-            color: $color-white;
+            background-color: color.adjust(variables.$color-button-red, $lightness: -10%);
+            color: variables.$color-white;
         }
     }
 

--- a/media/css/pocket/components/new-tab-learn-more.scss
+++ b/media/css/pocket/components/new-tab-learn-more.scss
@@ -2,19 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/base/elements/containers';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-family';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-family';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-pocket';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-
-@import '../utils/variables';
-@import '../includes/nav';
-@import '../includes/footer';
+@use '../utils/variables';
+@use '../includes/nav';
+@use '../includes/footer';
 
 // * -------------------------------------------------------------------------- */
 // Page Header
@@ -22,10 +20,10 @@ $image-path: '/media/protocol/img';
 .new-tab-header {
     @include text-body-xs;
     align-items: center;
-    background-color: $color-black;
-    color: $color-white-10;
+    background-color: variables.$color-black;
+    color: variables.$color-white-10;
     display: flex;
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
     height: 50px;
     justify-content: center;
     padding: 0 $spacing-md;
@@ -61,10 +59,10 @@ $image-path: '/media/protocol/img';
 // * -------------------------------------------------------------------------- */
 // Styles for sections + overriding some protocol styles to work well with pocket images
 .new-tab-section {
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
 
     &.top {
-        background-color: $color-background-grey-10;
+        background-color: variables.$color-background-grey-10;
     }
 
     &.mzp-t-split-nospace {
@@ -74,7 +72,7 @@ $image-path: '/media/protocol/img';
 
 .tagline {
     @include text-body-sm;
-    color: $color-text-grey;
+    color: variables.$color-text-grey;
     margin-bottom: $spacing-xs;
     margin-top: 0;
     text-align: center;
@@ -87,12 +85,12 @@ $image-path: '/media/protocol/img';
 
 .new-tab-section-header {
     @include text-title-2xs;
-    font-family: $font-sans-alt;
+    font-family: variables.$font-sans-alt;
     text-align: left;
 
     &.top {
         @include text-title-sm;
-        font-family: $font-sans-alt;
+        font-family: variables.$font-sans-alt;
         font-weight: 500;
         margin-bottom: $spacing-xs;
         margin-top: 0;
@@ -127,22 +125,22 @@ $image-path: '/media/protocol/img';
     }
 
     a {
-        color: $color-button-red-10;
+        color: variables.$color-button-red-10;
         cursor: pointer;
         text-decoration: underline;
 
         &:hover,
         &:focus {
-            color: $color-text-primary;
+            color: variables.$color-text-primary;
         }
     }
 }
 
 .new-tab-pocket-cta {
     @include text-body-xl;
-    background-color: $color-button-red-10;
+    background-color: variables.$color-button-red-10;
     border-radius: $border-radius-sm;
-    color: $color-white;
+    color: variables.$color-white;
     cursor: pointer;
     display: inline-block;
     line-height: 1;
@@ -168,7 +166,7 @@ $image-path: '/media/protocol/img';
 
 .sub-cta {
     @include text-body-sm;
-    color: $color-text-primary;
+    color: variables.$color-text-primary;
     cursor: pointer;
     display: block;
     margin-top: $spacing-sm;
@@ -178,7 +176,7 @@ $image-path: '/media/protocol/img';
     &:hover,
     &:focus,
     &:active {
-        color: $color-action-primary;
+        color: variables.$color-action-primary;
     }
 
     @media #{$mq-lg} {
@@ -188,7 +186,7 @@ $image-path: '/media/protocol/img';
 
 .new-tab-page-header {
     @include text-title-sm;
-    font-family: $font-sans-alt;
+    font-family: variables.$font-sans-alt;
     font-weight: 500;
     margin-bottom: 0;
     padding-bottom: 0;
@@ -224,14 +222,14 @@ $image-path: '/media/protocol/img';
     padding: 0;
 
     li a {
-        color: $color-button-red-10;
+        color: variables.$color-button-red-10;
         cursor: pointer;
-        font-family: $font-sans;
+        font-family: variables.$font-sans;
         text-decoration: underline;
 
         &:hover,
         &:focus {
-            color: $color-text-primary;
+            color: variables.$color-text-primary;
         }
     }
 
@@ -244,7 +242,7 @@ $image-path: '/media/protocol/img';
 // Footer
 .new-tab-footer {
     align-items: center;
-    background-color: $color-black;
+    background-color: variables.$color-black;
     display: flex;
     height: 50px;
     padding: 0 $spacing-lg;

--- a/media/css/pocket/components/platforms.scss
+++ b/media/css/pocket/components/platforms.scss
@@ -49,7 +49,7 @@
 
     .bookmarklet {
         @include text-body-sm;
-        color: $color-text-grey;
+        color: variables.$color-text-grey;
         text-decoration: none;
 
         &::after {

--- a/media/css/pocket/components/platforms.scss
+++ b/media/css/pocket/components/platforms.scss
@@ -4,21 +4,21 @@
 
 @use 'sass:color';
 
-@import '../utils/variables';
-@import '../utils/tokens';
-@import '../includes/platform-footer';
-@import '../includes/platform-nav';
+@use '../utils/variables';
+@use '../utils/tokens';
+@use '../includes/platform-footer';
+@use '../includes/platform-nav';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/button';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/button';
 
 .platform {
-    background-color: $color-background-grey;
+    background-color: variables.$color-background-grey;
 
     .mzp-c-split-container {
-        background: $color-white;
+        background: variables.$color-white;
         border-radius: 10px;
-        border: 1px solid $color-divider;
+        border: 1px solid variables.$color-divider;
         padding-bottom: $spacing-lg;
 
         @media #{$mq-md} {
@@ -31,18 +31,18 @@
 
         p {
             @include text-body-xl;
-            color: $color-text-grey;
+            color: variables.$color-text-grey;
         }
 
         .mzp-c-button {
-            background-color: $color-button-red;
+            background-color: variables.$color-button-red;
             border: 0;
 
             &:hover,
             &:focus,
             &:active {
-                background-color: color.adjust($color-button-red, $lightness: -10%);
-                color: $color-white;
+                background-color: color.adjust(variables.$color-button-red, $lightness: -10%);
+                color: variables.$color-white;
             }
         }
     }

--- a/media/css/pocket/components/pocket-features.scss
+++ b/media/css/pocket/components/pocket-features.scss
@@ -2,17 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/base/elements/containers';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-family';
+
+@use '../utils/variables';
+@use '../includes/nav';
+@use '../includes/footer';
+@use '../includes/pocket-premium';
+
 $image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/base/elements/containers';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-family';
-
-@import '../utils/variables';
-@import '../includes/nav';
-@import '../includes/footer';
-@import '../includes/pocket-premium';
 
 .pocket-feature-page-split {
     padding: $layout-lg 0;
@@ -29,26 +29,26 @@ $image-path: '/media/protocol/img';
 
 .section-heading {
     @include text-title-sm;
-    font-family: $font-sans-alt;
+    font-family: variables.$font-sans-alt;
     font-weight: 500;
     margin-top: $spacing-sm;
 }
 
 .sub-section-heading {
     @include text-title-xs;
-    font-family: $font-sans-alt;
+    font-family: variables.$font-sans-alt;
     font-weight: 500;
 }
 
 .tagline {
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
     @include text-body-sm;
     text-transform: uppercase;
 }
 
 .section-lede {
     @include text-body-xl;
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
 
     li {
         list-style: disc;
@@ -118,12 +118,12 @@ $image-path: '/media/protocol/img';
 
     .secondary-cta {
         @include text-body-sm;
-        color: $color-text-primary;
+        color: variables.$color-text-primary;
 
         &:hover,
         &:focus,
         &:active {
-            color: $color-action-primary;
+            color: variables.$color-action-primary;
         }
     }
 }
@@ -131,12 +131,12 @@ $image-path: '/media/protocol/img';
 .new-tab-pocket-cta,
 .red-cta {
     @include text-body-lg;
-    background-color: $color-button-red-10;
+    background-color: variables.$color-button-red-10;
     border-radius: $border-radius-sm;
-    color: $color-white;
+    color: variables.$color-white;
     cursor: pointer;
     display: inline-block;
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
     line-height: 1;
     padding: 10px 36px 10px $spacing-lg;
     text-align: center;
@@ -157,7 +157,7 @@ $image-path: '/media/protocol/img';
     &:focus,
     &:active {
         background-color: #901424;
-        color: $color-white;
+        color: variables.$color-white;
     }
 }
 
@@ -184,12 +184,12 @@ $image-path: '/media/protocol/img';
 
 .black-white-cta {
     @include text-body-md;
-    border: 2px solid $color-text-primary;
+    border: 2px solid variables.$color-text-primary;
     border-radius: $border-radius-sm;
-    color: $color-text-primary;
+    color: variables.$color-text-primary;
     cursor: pointer;
     display: inline-block;
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
     line-height: 1;
     padding: 12px 36px;
     text-align: center;
@@ -201,8 +201,8 @@ $image-path: '/media/protocol/img';
     &:hover,
     &:focus,
     &:active {
-        color: $color-white;
-        background-color: $color-text-primary;
+        color: variables.$color-white;
+        background-color: variables.$color-text-primary;
     }
 }
 
@@ -222,12 +222,12 @@ $image-path: '/media/protocol/img';
             margin-left: $spacing-sm;
 
             a {
-                color: $color-text-primary;
+                color: variables.$color-text-primary;
 
                 &:hover,
                 &:focus,
                 &:active {
-                    color: $color-action-primary;
+                    color: variables.$color-action-primary;
                 }
             }
         }
@@ -254,25 +254,25 @@ $image-path: '/media/protocol/img';
 
 .green-line-cta {
     @include text-body-lg;
-    box-shadow: inset 0 0 $color-white, inset 0 -3px #00b2a8;
-    color: $color-text-primary;
-    font-family: $font-sans;
+    box-shadow: inset 0 0 variables.$color-white, inset 0 -3px #00b2a8;
+    color: variables.$color-text-primary;
+    font-family: variables.$font-sans;
     font-weight: 500;
     padding-bottom: 6.4px;
     text-decoration: none;
-    text-shadow: -0.126em 0.063em 0 $color-white, -0.063em 0.063em 0 $color-white, 0 0.063em 0 $color-white, 0.063em 0.063em 0 $color-white, 0.126em 0.063em 0 $color-white, -0.126em 0 0 $color-white;
+    text-shadow: -0.126em 0.063em 0 variables.$color-white, -0.063em 0.063em 0 variables.$color-white, 0 0.063em 0 variables.$color-white, 0.063em 0.063em 0 variables.$color-white, 0.126em 0.063em 0 variables.$color-white, -0.126em 0 0 variables.$color-white;
     transition: 0.15s;
 
     &:hover,
     &:focus,
     &:active {
-        color: $color-action-primary;
-        box-shadow: inset 0 -6px $color-white, inset 0 -8px $color-action-primary;
+        color: variables.$color-action-primary;
+        box-shadow: inset 0 -6px variables.$color-white, inset 0 -8px variables.$color-action-primary;
     }
 }
 
 .pocket-features-horizontal-rule {
-    background-color: $color-divider;
+    background-color: variables.$color-divider;
     border: 0;
     height: 1px;
     padding: 0 80px;

--- a/media/css/pocket/includes/_platform-footer.scss
+++ b/media/css/pocket/includes/_platform-footer.scss
@@ -2,13 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '../utils/variables';
 
 .platform-footer {
     background-color: #f9f9fa;
-    font-family: $font-sans;
+    font-family: variables.$font-sans;
     padding-top: $spacing-xl;
 
     .footer-navigation {
@@ -28,7 +27,7 @@ $image-path: '/media/protocol/img';
 
         .footer-navigation-list {
             @include text-body-md;
-            color: $color-text-primary;
+            color: variables.$color-text-primary;
             display: flex;
             flex-flow: column wrap;
             height: 300px;
@@ -43,7 +42,7 @@ $image-path: '/media/protocol/img';
 
                 a,
                 #ot-sdk-btn {
-                    color: $color-text-primary;
+                    color: variables.$color-text-primary;
                     display: inline-block;
                     text-decoration: none;
                     margin: $spacing-sm $spacing-xs;
@@ -103,7 +102,7 @@ $image-path: '/media/protocol/img';
                 .svg-social {
                     fill: currentColor;
                     display: block;
-                    color: $color-text-primary;
+                    color: variables.$color-text-primary;
                     width: 30px;
                     height: 30px;
                     transition: color 100ms ease-in-out;
@@ -112,7 +111,7 @@ $image-path: '/media/protocol/img';
                         &:hover,
                         &:focus,
                         &:active {
-                            color: $color-twitter-blue;
+                            color: variables.$color-twitter-blue;
                         }
                     }
 
@@ -120,7 +119,7 @@ $image-path: '/media/protocol/img';
                         &:hover,
                         &:focus,
                         &:active {
-                            color: $color-facebook-blue;
+                            color: variables.$color-facebook-blue;
                         }
                     }
                 }
@@ -138,7 +137,7 @@ $image-path: '/media/protocol/img';
 
     .platform-footer-copyright {
         @include text-body-md;
-        color: $color-text-primary;
+        color: variables.$color-text-primary;
         font-weight: 300;
         text-align: left;
 

--- a/media/css/pocket/includes/_platform-nav.scss
+++ b/media/css/pocket/includes/_platform-nav.scss
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '../utils/variables';
 
 .pocket-header.platform {
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.15);
@@ -56,10 +57,10 @@
 
                 .header-navigation-list-item-link {
                     @include text-body-sm;
-                    font-family: $font-sans;
+                    font-family: variables.$font-sans;
                     margin: $spacing-lg $spacing-xs;
                     text-decoration: none;
-                    color: $color-text-primary;
+                    color: variables.$color-text-primary;
 
                     &:hover,
                     &:focus,
@@ -70,10 +71,10 @@
 
                     &.log-in-cta {
                         @include text-body-xs;
-                        background-color: $color-text-primary;
+                        background-color: variables.$color-text-primary;
                         border-radius: $border-radius-xs;
-                        border: 2px solid $color-text-primary;
-                        color: $color-white;
+                        border: 2px solid  variables.$color-text-primary;
+                        color: variables.$color-white;
                         font-weight: 500;
                         padding: 3px $spacing-md;
                         transition: all 100ms ease-in-out;
@@ -86,7 +87,7 @@
                         &:focus,
                         &:active {
                             background-color: transparent;
-                            color: $color-text-primary;
+                            color: variables.$color-text-primary;
                             text-decoration: none;
                         }
                     }

--- a/media/css/pocket/utils/_tokens.scss
+++ b/media/css/pocket/utils/_tokens.scss
@@ -2,18 +2,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'variables';
+
 .main-container {
     overflow: hidden;
 
     .about-section a {
-        color: $color-action-primary;
+        color: variables.$color-action-primary;
         text-decoration: underline;
         transition: color 0.1s ease-out;
 
         &:hover,
         &:active,
         &:focus {
-            color: $color-action-primary-hover;
+            color: variables.$color-action-primary-hover;
         }
     }
 }

--- a/media/css/products/vpn/components/pricing-basic.scss
+++ b/media/css/products/vpn/components/pricing-basic.scss
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
 
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '../includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '../includes/lib';
 
 // * -------------------------------------------------------------------------- */
 // Pricing Blocks
@@ -102,7 +100,7 @@ main {
 
     .vpn-pricing-variable-plan-tag {
         @include border-box;
-        background: $color-vpn-brand-purple;
+        background: lib.$color-vpn-brand-purple;
         color: $color-white;
         font-weight: bold;
         left: 0;
@@ -123,7 +121,7 @@ main {
 
     .vpn-pricing-variable-saving {
         @include text-title-2xs;
-        color: $color-vpn-brand-purple;
+        color: lib.$color-vpn-brand-purple;
         font-weight: bold;
         margin-bottom: $spacing-sm;
     }

--- a/media/css/products/vpn/landing.scss
+++ b/media/css/products/vpn/landing.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/inline-list';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/inline-list';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
 
 // * -------------------------------------------------------------------------- */
 // Smooth Scroll

--- a/media/css/products/vpn/resource-center.scss
+++ b/media/css/products/vpn/resource-center.scss
@@ -2,16 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
+@use '~@mozilla-protocol/core/protocol/css/components/inline-list';
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/breadcrumb';
+
 $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/inline-list';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/breadcrumb';
 
 .resource-center-page-header {
     .mzp-l-content {

--- a/media/css/protocol/basic-article.scss
+++ b/media/css/protocol/basic-article.scss
@@ -2,14 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/article';
+@use '~@mozilla-protocol/core/protocol/css/components/newsletter-form';
+@use '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
+@use '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
+
 $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/components/article';
-@import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
-@import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
-@import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
-@import 'components/newsletter-form';
 
 .side-reference {
     border-bottom: 2px solid #ddd;

--- a/media/css/protocol/components/_fxa-form.scss
+++ b/media/css/protocol/components/_fxa-form.scss
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
 
 .fxa-email-form {
     margin: 0 auto;
@@ -31,7 +29,7 @@ $image-path: '/media/protocol/img';
 
 .fxa-signin {
     @include text-body-xs;
-    color: $form-text;
+    color: forms.$form-text;
     margin-bottom: 0;
 
     .mzp-t-dark & {

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
 // * -------------------------------------------------------------------------- */
 // Should be replaced by https://github.com/mozilla/protocol/issues/471
 

--- a/media/css/protocol/components/send-to-device.scss
+++ b/media/css/protocol/components/send-to-device.scss
@@ -2,16 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 
 .send-to-device {
-    color: $form-text;
+    color: forms.$form-text;
     max-width: 500px;
     @include clearfix;
 
@@ -20,7 +20,7 @@ $image-path: '/media/protocol/img';
     }
 
     .mzp-c-field {
-        padding-bottom: $label-v-spacing;
+        padding-bottom: forms.$label-v-spacing;
     }
 
     .mzp-c-button-container {
@@ -77,7 +77,7 @@ $image-path: '/media/protocol/img';
 
                     // put in fake form label to push button down height of real form label next to it
                     &::before {
-                        @include field-label;
+                        @include forms.field-label;
                         content: '.';
                         visibility: hidden;
                     }

--- a/media/css/protocol/protocol-firefox.scss
+++ b/media/css/protocol/protocol-firefox.scss
@@ -2,32 +2,37 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$brand-theme: 'firefox';
-$type-scale: 'standard';
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
+// Import protocol lib and set
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with (
+    $font-path: '/media/protocol/fonts',
+    $image-path: '/media/protocol/img',
+    $brand-theme: 'firefox'
+);
+
+// SCSS variables for forms
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
 
 // These are general styles for elements/components that occur on every page.
 // Individual pages may include additional component styles as needed.
 
 // Fonts
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
 
 // Base elements - general HTML elements
-@import '~@mozilla-protocol/core/protocol/css/base/elements';
+@use '~@mozilla-protocol/core/protocol/css/base/elements';
 
 // Base includes - animations
-@import '~@mozilla-protocol/core/protocol/css/base/includes';
+@use '~@mozilla-protocol/core/protocol/css/base/includes';
 
 // Utility includes
-@import '~@mozilla-protocol/core/protocol/css/base/utilities/backgrounds';
-@import '~@mozilla-protocol/core/protocol/css/base/utilities/titles';
+@use '~@mozilla-protocol/core/protocol/css/base/utilities/backgrounds';
+@use '~@mozilla-protocol/core/protocol/css/base/utilities/titles';
 
 // Global components
-@import '~@mozilla-protocol/core/protocol/css/components/button';
-@import '~@mozilla-protocol/core/protocol/css/components/footer';
-@import '~@mozilla-protocol/core/protocol/css/components/language-switcher';
+@use '~@mozilla-protocol/core/protocol/css/components/button';
+@use '~@mozilla-protocol/core/protocol/css/components/footer';
+@use '~@mozilla-protocol/core/protocol/css/components/language-switcher';
 @import 'components/download-button';
 
 // Custom global components for nav and footer
@@ -61,8 +66,8 @@ $image-path: '/media/protocol/img';
 .errorlist,
 .error-msg {
     @include light-links;
-    background-color: $form-red;
-    border-radius: $field-border-radius;
+    background-color: forms.$form-red;
+    border-radius: forms.$field-border-radius;
     color: $color-white;
     padding: $spacing-sm;
     margin-bottom: $spacing-xl;

--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -2,32 +2,35 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$brand-theme: 'mozilla';
-$type-scale: 'standard';
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
 // These are general styles for elements/components that occur on every page.
 // Individual pages may include additional component styles as needed.
 
-// Fonts
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/zilla-slab';
+// Import protocol lib and set font and image path
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with (
+    $font-path: '/media/protocol/fonts',
+    $image-path: '/media/protocol/img'
+);
+
+// SCSS variables for forms
+@use '~@mozilla-protocol/core/protocol/css/includes/forms';
+
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/zilla-slab';
 
 // Base elements - general HTML elements
-@import '~@mozilla-protocol/core/protocol/css/base/elements';
+@use '~@mozilla-protocol/core/protocol/css/base/elements';
 
 // Base includes - animations
-@import '~@mozilla-protocol/core/protocol/css/base/includes';
+@use '~@mozilla-protocol/core/protocol/css/base/includes';
 
 // Utility includes
-@import '~@mozilla-protocol/core/protocol/css/base/utilities/backgrounds';
-@import '~@mozilla-protocol/core/protocol/css/base/utilities/titles';
+@use '~@mozilla-protocol/core/protocol/css/base/utilities/backgrounds';
+@use '~@mozilla-protocol/core/protocol/css/base/utilities/titles';
 
 // Global components
-@import '~@mozilla-protocol/core/protocol/css/components/button';
-@import '~@mozilla-protocol/core/protocol/css/components/footer';
-@import '~@mozilla-protocol/core/protocol/css/components/language-switcher';
+@use '~@mozilla-protocol/core/protocol/css/components/button';
+@use '~@mozilla-protocol/core/protocol/css/components/footer';
+@use '~@mozilla-protocol/core/protocol/css/components/language-switcher';
 @import 'components/download-button';
 
 // Custom global components for nav and footer
@@ -61,8 +64,8 @@ $image-path: '/media/protocol/img';
 // style classes automatically added by python to match Protocol form error styles
 .errorlist {
     @include white-links;
-    background-color: $form-red;
-    border-radius: $field-border-radius;
+    background-color: forms.$form-red;
+    border-radius: forms.$field-border-radius;
     color: $color-white;
     padding: $spacing-sm;
     margin-bottom: $spacing-xl;
@@ -70,8 +73,8 @@ $image-path: '/media/protocol/img';
 
 .error-msg {
     @include light-links;
-    background-color: $form-red;
-    border-radius: $field-border-radius;
+    background-color: forms.$form-red;
+    border-radius: forms.$field-border-radius;
     color: $color-white;
     padding: $spacing-sm;
     margin-bottom: $spacing-xl;


### PR DESCRIPTION
ℹ️ Was able to make a much less complex PR with minimal changes here:  #13146 ℹ️ 

## One-line summary

[Sass](https://sass-lang.com/) (the language that we use for protocol and our styles) recommended that the @import` syntax be depreciated in favor of `@use` and `@forward` - for this to work correctly with protocol, files needed to be updated so that bedrock would still work correctly with our protocol design system. The partner PR for protocol is [here](https://github.com/mozilla/protocol/pull/821)

## Significant changes and points to review

Most of the changes are in files that needed to update font, theme and brand variables

## Issue / Bugzilla link
Issue from protocol's repo: mozilla/protocol/issues/755

## Checklist

- [ ] All pages' stylesheets should load and compile correctly
- [ ] Theming and branding should work as it did before

## Testing

To test that these changes are working I suggest using `npm link`([article on npm-link](https://medium.com/dailyjs/how-to-use-npm-link-7375b6219557)) since we haven't pushed any of the changes in protocol to the npm package. Directions below:

To test this works: (you will need a local version of both protocol and bedrock to test these changes)

**In local protocol directory**
- [ ]  `git checkout import-migration`
- [ ] `npm run build-package` (this will build the package)
- [ ] `cd package && npm link`

**In local bedrock**
- [ ] `git checkout protocol-scss-module-integration`
- [ ] `npm link @mozilla-protocol/core` (This will use the linked protocol package that was just built instead of using the NPM package)
- [ ] `npm run start`
- [ ] the server should start without any compilation errors, and there shouldnt be any style differences between prod and what you are viewing locally
