### PR TITLE
fix(careers/listings): use job_locations as filter

### DIFF
--- a/bedrock/careers/templates/careers/listings.html
+++ b/bedrock/careers/templates/careers/listings.html
@@ -64,7 +64,7 @@
       <tr class="position"
           data-team="{{ position.department.strip() }},"
           data-type="{{ position.position_type.strip() }},"
-          data-location="{{ position.location.strip() }},">
+          data-location="{{ position.job_locations.strip() }},">
         <td class="title"><a href="{{ position.get_absolute_url() }}">{{ position.title }}</a></td>
         <td class="location">{{ position.job_locations }}</td>
         <td class="name">{{ position.department }}</td>


### PR DESCRIPTION
## One-line summary

Fixes the Careers listings filter, which did not show all locations and did not show all jobs for a selected location.

## Significant changes and points to review

Reuses a position's `job_locations` attribute as `data-location` instead of `location`.

Note: `job_locations` comes from Greenhouse's `location` field, whereas `location` is derived from Greenhouse's `offices` field (that seems to be incomplete):

https://github.com/mozilla/bedrock/blob/67fd925b4d621dde0e48e27738c4b9c397ac5169/bedrock/careers/management/commands/sync_greenhouse.py#L125-L131

## Issue / Bugzilla link



## Screenshots

(If the changeset updates the UI, please include screenshots so reviewers know what to look for when testing)

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: (or None)

To test this work:

- [ ]
