### PR TITLE
Remove image macro from billboard macro

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -8,37 +8,20 @@
 
 
 {# Billboard: https://protocol.mozilla.org/patterns/organisms/billboard.html #}
+{# image attribute passed should be one of the following helpers: <img>, resp_img or picture #}
 {% macro billboard(
   desc='',
   ga_title='',
   heading_level=2,
-  image_alt='',
-  image_sizes=None,
-  image_sources=None,
-  image_srcset=None,
-  image_url='',
-  include_highres_image=False,
   link_cta=None,
   link_url=None,
-  loading=None,
   reverse=False,
-  title=''
+  title='',
+  image=None
 ) -%}
 <section class="mzp-c-billboard {% if reverse %}mzp-l-billboard-left{% else %}mzp-l-billboard-right{% endif %}">
   <div class="mzp-c-billboard-image-container">
-    {{ image(
-      alt=image_alt,
-      class='mzp-c-billboard-image',
-      height=346,
-      include_highres=include_highres_image,
-      include_l10n=l10n_image,
-      loading=loading,
-      sizes=image_sizes,
-      sources=image_sources,
-      srcset=image_srcset,
-      url=image_url,
-      width=346
-    ) }}
+    {{ image }}
   </div>
   <div class="mzp-c-billboard-content">
     <div class="mzp-c-billboard-content-container">

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -108,8 +108,10 @@
       desc=ftl('about-the-principles-we-wrote-in'),
       link_cta=ftl('about-read-the-manifesto'),
       link_url=url('mozorg.about.manifesto'),
-      image_url='img/home/2018/billboard-healthy-internet.png',
-      include_highres_image=True
+      image=resp_img(url='img/home/2018/billboard-healthy-internet.png',
+        srcset={
+          'img/home/2018/billboard-healthy-internet-high-res.png': '2x'
+        }),
   )}}
 </div>
 

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -85,8 +85,10 @@
         desc='Mozilla setzt sich für ein gesundes Internet ein – und damit für die Menschen, die es nutzen. Damals. Heute. Morgen.',
         link_cta='Erfahre mehr über Mozilla',
         link_url=url('mozorg.about.manifesto'),
-        image_url='img/home/2018/billboard-more-power.png',
-        include_highres_image=True
+        image=resp_img('img/home/2018/billboard-more-power.png',
+          srcset={
+            'img/home/2018/billboard-more-power-high-res.png': '2x'
+          })
       )}}
 
       <div class="mzp-l-card-half">
@@ -100,8 +102,10 @@
         desc='Virtual Reality, IoT und mehr.',
         link_cta='Entdecke das Web der Zukunft',
         link_url='https://labs.mozilla.org/',
-        image_url='img/home/2018/billboard-open-minds.png',
-        include_highres_image=True,
+        image=resp_img('img/home/2018/billboard-open-minds.png',
+          srcset={
+            'img/home/2018/billboard-open-minds-high-res.png': '2x'
+        }),
         reverse=True
       )}}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -85,8 +85,10 @@
         desc='Mozilla s’engage pour un Internet plus sain et plus accessible. Pour vous et pour demain.',
         link_cta='En savoir plus sur Mozilla',
         link_url=url('mozorg.about.manifesto'),
-        image_url='img/home/2018/billboard-more-power.png',
-        include_highres_image=True
+        image=resp_img('img/home/2018/billboard-more-power.png',
+          srcset={
+            'img/home/2018/billboard-more-power-high-res.png': '2x'
+          })
       )}}
 
       <div class="mzp-l-card-half">
@@ -100,8 +102,10 @@
         desc='Réalité virtuelle, IoT et plus encore.',
         link_cta='Découvrez le Web du futur',
         link_url='https://labs.mozilla.org/',
-        image_url='img/home/2018/billboard-open-minds.png',
-        include_highres_image=True,
+        image=resp_img('img/home/2018/billboard-open-minds.png',
+          srcset={
+            'img/home/2018/billboard-open-minds-high-res.png': '2x'
+        }),
         reverse=True
       )}}
 

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -66,11 +66,10 @@
 
   <div class="mzp-l-content mzp-t-mozilla">
     {{ billboard(
-    title=ftl('home-we-make-the-internet-safer'),
-    desc=ftl('home-mozilla-is-the-not-for-profit'),
-    image_url='img/home/dino.svg'
+      title=ftl('home-we-make-the-internet-safer'),
+      desc=ftl('home-mozilla-is-the-not-for-profit'),
+      image=resp_img('img/home/dino.svg', optional_attributes={"width": "346"})
     )}}
-
     <section class="c-column-container">
       <div class="c-column">
         <div class="c-column-content">

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1572,9 +1572,13 @@ Billboard
 
     Default: ``None``
 
-    Example: ``image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', srcset={
-                        'img/firefox/accounts/trailhead/value-respect-high-res.jpg': '2x'
-                    })``
+    Example:
+
+    .. code-block::
+
+        image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', srcset={
+            'img/firefox/accounts/trailhead/value-respect-high-res.jpg': '2x'
+        })
 
 Card
 ^^^^

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1532,55 +1532,6 @@ Billboard
 
     Example: ``heading_level=1``
 
-- image_alt
-    Alt text for the images to be used.
-
-    Default: ``''``
-
-    Example: ``image_alt='Red Panda'``
-
-- image_height
-    Number indicating the height of an image.
-
-    Default: ``None``
-
-    Example: ``image_height='153'``
-
-- image_sizes
-    The ``sizes`` attribute for a responsive image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_sources
-    A list of ``<source>`` elements for a responsive ``<picture>`` image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_srcset
-    The ``srcset`` attribute for a responsive image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_url
-    **Required**. Path to image location.
-
-    Default: ``''``
-
-    Example: ``image_url='img/home/2018/billboard-healthy-internet.png'``
-
-- include_highres_image (deprecated)
-    Boolean that determines whether the image can also appear in high res.
-
-    Default: ``False``
-
-    Example: ``include_highres_image=True``
-
 - link_cta
     String indicating link text (usually a translation id wrapped in an ftl function).
 
@@ -1616,6 +1567,14 @@ Billboard
 
     Example: ``title=ftl('about-the-mozilla-manifesto')``
 
+- image
+    **Required**. Image to be used in the Billboard element. Can pass an <img> element, `resp_img` or `picture` python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
+
+    Default: ``None``
+
+    Example: ``image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', srcset={
+                        'img/firefox/accounts/trailhead/value-respect-high-res.jpg': '2x'
+                    })``
 
 Card
 ^^^^


### PR DESCRIPTION
## Summary
Removed the image macro for the protocol Billboard macro to simplify the logic that exists inside the Billboard macro. The change will require that an `image` argument is passed using one of the existing python image helpers instead of the `image` macro.

## Issue / Bugzilla link
#12190 

## Testing

Demo server URL: (or None)

To test this works:
Check the following pages that the billboard element matches what is on production
- [x] http://localhost:8000/ca (rest of the world homepage - 1 billboard element)
- [x] http://localhost:8000/de (2 billboard elements)
- [x] http://localhost:8000/fr (2 billboard elements)
- [x] http://localhost:8000/about (1 billboard element)

