### PR TITLE
remove image macro from protocol card macro

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -246,20 +246,28 @@
   <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}>
     {% if image_url %}
     <div class="mzp-c-card-media-wrapper">
-      {{ image(
-        alt=image_alt,
-        class='mzp-c-card-image',
-        height=image_height,
-        highres_image_url=highres_image_url,
-        include_highres=include_highres_image,
-        include_l10n=l10n_image,
-        loading='lazy',
-        sizes=image_sizes,
-        sources=image_sources,
-        srcset=image_srcset,
+      {% set unclean = {
+        'alt': image_alt,
+        'class': 'mzp-c-card-image',
+        'width': image_width,
+        'height': image_height,
+        'loading': 'lazy',
+        'l10n': l10n_image
+      } %}
+      {% set optional_attributes = dict() %}
+      {% for key, value in unclean.items() %}
+        {% if value is not none and value is not false %}{{ optional_attributes.update({ key: value }) }}{% endif %}
+      {% endfor %}
+      {% if include_highres_image %}
+        {% set filename, ext = image_url.split('.') %}
+        {% set srcset = {"".join([filename, "-", "high-res", ".", ext]): "1.5x"} %}
+      {% endif %}
+      {{ resp_img(
         url=image_url,
-        width=image_width
-      ) }}
+        sizes=image_sizes or None,
+        srcset=image_srcset or srcset or None,
+        optional_attributes=optional_attributes
+        )}}
     </div>
     {% endif %}
     <div class="mzp-c-card-content">


### PR DESCRIPTION
## Summary
Removed the image macro from the protocol card macro - it will now use the resp_img helper. Went about this PR different than #12299 since there were so many instances of the `card` macro being used, although I think I prefer the way I handed the image in Billboard more than how I did it here.

## Issue / Bugzilla link
#12190 

## Testing

To test this works:
A few pages that use card, but we use `card` 150+ times in bedrock
- [ ] http://localhost:8000/en-US/firefox/more
- [ ] http://localhost:8000/en-US/firefox/pocket
- [ ] http://localhost:8000/en-US/about
