### PR TITLE
Pocket: fix mobile nav JS

### DIFF
--- a/bedrock/pocket/templates/pocket/contact-info.html
+++ b/bedrock/pocket/templates/pocket/contact-info.html
@@ -53,3 +53,7 @@
 </section>
 {% include 'pocket/includes/footer.html' %}
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/get-inspired.html
+++ b/bedrock/pocket/templates/pocket/get-inspired.html
@@ -71,3 +71,7 @@
 {% include 'pocket/includes/footer.html' %}
 
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/jobs.html
+++ b/bedrock/pocket/templates/pocket/jobs.html
@@ -68,3 +68,7 @@
   </div>
   {% include 'pocket/includes/footer.html' %}
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/pocket-and-firefox.html
+++ b/bedrock/pocket/templates/pocket/pocket-and-firefox.html
@@ -98,3 +98,7 @@
 {% include 'pocket/includes/footer.html' %}
 
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/privacy.html
+++ b/bedrock/pocket/templates/pocket/privacy.html
@@ -21,3 +21,7 @@
   </div>
   {% include 'pocket/includes/footer.html' %}
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/save-to-pocket.html
+++ b/bedrock/pocket/templates/pocket/save-to-pocket.html
@@ -94,3 +94,7 @@
 {% include 'pocket/includes/footer.html' %}
 
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/tos.html
+++ b/bedrock/pocket/templates/pocket/tos.html
@@ -21,3 +21,7 @@
   </div>
   {% include 'pocket/includes/footer.html' %}
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('pocket-nav') }}
+{% endblock %}


### PR DESCRIPTION
## One-line summary

Pages that import the nav need a corresponding nav JS block

## Issue / Bugzilla link
NO BUG

## Checklist

## Testing

live pages are missing mobile nav JS bundle: https://getpocket.com/en/contact-info/

local pages should be working as expected `npm run in-pocket-mode`

http://localhost:8000/en/contact-info/
http://localhost:8000/en/get-inspired/
http://localhost:8000/en/jobs/
http://localhost:8000/en/pocket-and-firefox/
http://localhost:8000/en/privacy/
http://localhost:8000/en/save-to-pocket/
http://localhost:8000/en/tos/
