### PR TITLE
Pocket mode: improve line spacing of headers

### DIFF
--- a/media/css/pocket/components/about.scss
+++ b/media/css/pocket/components/about.scss
@@ -35,8 +35,12 @@ $pocket-image-path: '/media/img/pocket';
         z-index: 2;
 
         .about-section-heading {
+            @include font-size(28px);
             font-family: $font-sans-alt;
             font-weight: 500;
+
+            // need to increase line-height here to remove visual bug on non EN locales (mainly an issues with the letter 'j'
+            line-height: 60px;
             margin-top: 0;
             margin-bottom: 8px;
             font-size: 28px;
@@ -56,8 +60,7 @@ $pocket-image-path: '/media/img/pocket';
             max-width: 50%;
 
             .about-section-heading {
-                font-size: 32px;
-                line-height: 40px;
+                @include font-size(32px);
             }
         }
     }

--- a/media/css/pocket/components/about.scss
+++ b/media/css/pocket/components/about.scss
@@ -40,7 +40,7 @@ $pocket-image-path: '/media/img/pocket';
             font-weight: 500;
 
             // need to increase line-height here to remove visual bug on non EN locales (mainly an issues with the letter 'j'
-            line-height: 60px;
+            line-height: 1.2;
             margin-top: 0;
             margin-bottom: 8px;
             font-size: 28px;


### PR DESCRIPTION
## One-line summary

Updated the line height for pocket/{locale}/about to fix a visual bug in the heading when the letter j is used

## Significant changes and points to review
This is more of a band-aid, but not sure how to deal with this as it could pop up in others areas. Do we change line-height for all heading elements that use that font family?

## Issue / Bugzilla link
#12265 

## Testing

To test this work:

start server in pocket mode (you may have to run `manage.py l10n_update` to update the strings)

- [ ] http://localhost:8000/fr-ca/about
