### PR TITLE
Fix Firefox Relay wordmark alignment for l10n (Fixes #12317)

### DIFF
--- a/media/css/products/vpn/components/block.scss
+++ b/media/css/products/vpn/components/block.scss
@@ -554,7 +554,9 @@ $image-path: '/media/protocol/img';
 
         .mzp-c-wordmark {
             display: block;
+            height: 48px;
             margin: 0;
+            width: 220px;
         }
     }
 


### PR DESCRIPTION
## One-line summary

Removes empty space at the end of Relay wordmark.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/12317

## Testing

Note: you may need to update local translations to see the issue

- http://localhost:8000/de/products/vpn/?geo=us
