### PR TITLE
Typo fix

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -304,7 +304,7 @@
         {% if loop.first %}
           <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left" id="known">
             <img class="sidebar-icon" alt="" src="{{ static('protocol/img/icons/stop.svg') }}" width="30" height="30">
-            <div class="mzp-l-sidebar"><h3>unresolved</h3></div>
+            <div class="mzp-l-sidebar"><h3>Unresolved</h3></div>
             <div class="mzp-l-main mzp-l-article">
               <ul>
         {% endif %}


### PR DESCRIPTION
The Unresolved section should start with a capital letter, like other sections of release notes.
