### PR TITLE
Remove image from card macro (Fixes #12300)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -209,6 +209,7 @@
   ga_title='',
   heading_level=2,
   highres_image_url=None,
+  image=None,
   image_alt='',
   image_height=None,
   image_sizes=None,
@@ -227,23 +228,8 @@
 ) -%}
 <section class="mzp-c-card {% if class %}{{ class }}{% endif %} {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if media_icon %}{{ media_icon }}{% endif %} {% if youtube_id %}mzp-has-video has-video-embed{% endif %}" {% if attributes %}{{attributes|safe}}{% endif %}>
   <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}>
-    {% if image_url %}
-    <div class="mzp-c-card-media-wrapper">
-      {{ image(
-        alt=image_alt,
-        class='mzp-c-card-image',
-        height=image_height,
-        highres_image_url=highres_image_url,
-        include_highres=include_highres_image,
-        include_l10n=l10n_image,
-        loading='lazy',
-        sizes=image_sizes,
-        sources=image_sources,
-        srcset=image_srcset,
-        url=image_url,
-        width=image_width
-      ) }}
-    </div>
+    {% if image_url or image %}
+    <div class="mzp-c-card-media-wrapper">{{ image }}</div>
     {% endif %}
     <div class="mzp-c-card-content">
     {% if tag_label %}
@@ -280,19 +266,12 @@
 {% macro content_card(name, content_cards=None) -%}
   {% set card_data = get_content_card(content_cards or page_content_cards, name) -%}
   {% if card_data -%}
+    {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '" srcset="' ~ card_data.highres_image_url ~ ' 1.5x">' %}
+    {% do card_data.pop('image_url') %}
+    {% do card_data.pop('highres_image_url') %}
+    {% do card_data.update({'image': image}) %}
     {{ card(**card_data) }}
   {% endif %}
-{%- endmacro %}
-
-
-{% macro content_card_layout(layout_data) -%}
-  {% if layout_data -%}
-    <div class="mzp-l-card-{{ layout_data.class }}">
-      {% for card_data in layout_data.cards %}
-        {{ card(**card_data) }}
-      {% endfor %}
-    </div>
-  {%- endif %}
 {%- endmacro %}
 
 

--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -209,7 +209,6 @@
   ga_title='',
   heading_level=2,
   image=None,
-  l10n_image=None,
   link_url='',
   media_icon=None,
   meta=None,
@@ -220,7 +219,7 @@
 <section class="mzp-c-card {% if class %}{{ class }}{% endif %} {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if media_icon %}{{ media_icon }}{% endif %} {% if youtube_id %}mzp-has-video has-video-embed{% endif %}" {% if attributes %}{{attributes|safe}}{% endif %}>
   <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}>
     {% if image %}
-    <div class="mzp-c-card-media-wrapper">{{ image }}</div>
+    <div class="mzp-c-card-media-wrapper">{{ image | safe }}</div>
     {% endif %}
     <div class="mzp-c-card-content">
     {% if tag_label %}
@@ -259,7 +258,9 @@
   {% if card_data -%}
     {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '" srcset="' ~ card_data.highres_image_url ~ ' 1.5x">' %}
     {% do card_data.pop('image_url') %}
-    {% do card_data.pop('highres_image_url') %}
+    {% if card_data.highres_image_url %}
+      {% do card_data.pop('highres_image_url') %}
+    {% endif %}
     {% do card_data.update({'image': image}) %}
     {{ card(**card_data) }}
   {% endif %}

--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -208,16 +208,7 @@
   desc=None,
   ga_title='',
   heading_level=2,
-  highres_image_url=None,
   image=None,
-  image_alt='',
-  image_height=None,
-  image_sizes=None,
-  image_sources=None,
-  image_srcset=None,
-  image_url='',
-  image_width=None,
-  include_highres_image=False,
   l10n_image=None,
   link_url='',
   media_icon=None,
@@ -228,7 +219,7 @@
 ) -%}
 <section class="mzp-c-card {% if class %}{{ class }}{% endif %} {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if media_icon %}{{ media_icon }}{% endif %} {% if youtube_id %}mzp-has-video has-video-embed{% endif %}" {% if attributes %}{{attributes|safe}}{% endif %}>
   <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}>
-    {% if image_url or image %}
+    {% if image %}
     <div class="mzp-c-card-media-wrapper">{{ image }}</div>
     {% endif %}
     <div class="mzp-c-card-content">

--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -256,11 +256,13 @@
 {% macro content_card(name, content_cards=None) -%}
   {% set card_data = get_content_card(content_cards or page_content_cards, name) -%}
   {% if card_data -%}
-    {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '" srcset="' ~ card_data.highres_image_url ~ ' 1.5x">' %}
-    {% do card_data.pop('image_url') %}
     {% if card_data.highres_image_url %}
+      {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '" srcset="' ~ card_data.highres_image_url ~ ' 1.5x">' %}
       {% do card_data.pop('highres_image_url') %}
+    {% else %}
+      {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '">' %}
     {% endif %}
+    {% do card_data.pop('image_url') %}
     {% do card_data.update({'image': image}) %}
     {{ card(**card_data) }}
   {% endif %}

--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -79,14 +79,19 @@
               {% set size_class = 'mzp-c-card-medium' %}
             {% endif %}
 
+            {% if card_data.highres_image_url %}
+             {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '" srcset="' ~ card_data.highres_image_url ~ ' 1.5x">' %}
+            {% else %}
+               {% set image = '<img class="mzp-c-card-image" src="' ~ card_data.image_url ~ '">' %}
+            {% endif %}
+
             {{ card(
               class=size_class,
               tag_label=card_data.tag,
               title=card_data.heading,
               desc=card_data.body|external_html,
               ga_title='ga_title',
-              highres_image_url=card_data.highres_image_url,
-              image_url=card_data.image_url,
+              image=image,
               aspect_ratio=card_data.aspect_ratio,
               link_url=card_data.link,
               youtube_id=card_data.youtube_id,

--- a/bedrock/firefox/templates/firefox/features/tips/tips.html
+++ b/bedrock/firefox/templates/firefox/features/tips/tips.html
@@ -59,7 +59,7 @@
         class='mzp-c-card-large',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='aHpCLDQ_2ns',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_send-tabs_hilda.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_send-tabs_hilda.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#send-tabs'
       )}}
 
@@ -71,7 +71,7 @@
         desc='Sign up for things you might not want. Firefox Relay helps you keep your real email address private and your inbox uncluttered.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='hZersfIccWE',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_email_luke.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_email_luke.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://relay.firefox.com/'
       )}}
 
@@ -83,7 +83,7 @@
         desc='Take a quick picture of something online to save or share before the moment passes.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='-Rv5MKSBNUM',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_screenshot_mj.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_screenshot_mj.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#screenshots'
       )}}
 
@@ -95,7 +95,7 @@
         desc='Make sure the websites you visit are secure and encrypted so you can surf and shop with confidence.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='D6tFXSFFkfY',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_https_chris.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_https_chris.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/security/2021/08/10/firefox-91-introduces-https-by-default-in-private-browsing/'
       )}}
 
@@ -107,7 +107,7 @@
         desc='Accidentally closed your browser? No problem. Here’s an easy way to bring all your tabs back to life.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='XyusbCSAQg8',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_restore_mei.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_restore_mei.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#restore-session'
       )}}
     </div>
@@ -122,7 +122,7 @@
         class='mzp-c-card-large',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='X6dTBZR3Heo',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_PIP_tina.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_PIP_tina.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url=url('firefox.features.picture-in-picture')
       )}}
 
@@ -134,7 +134,7 @@
         desc='See a summary of all the trackers and cookies Firefox is blocking for you.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='0cmea25xl6E',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_privacy-report_roux.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_privacy-report_roux.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url=url('firefox.privacy.products')
       )}}
 
@@ -146,7 +146,7 @@
         desc='Create a privacy fence around Facebook to keep it from tracking you around the web.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='M9DK-taZsrw',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_facebook-steve.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_facebook-steve.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url=url('firefox.facebookcontainer.index')
       )}}
 
@@ -158,7 +158,7 @@
         desc='Automatically generate strong, complex passwords that you don’t have to remember.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='CqGZtCZVDZ0',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_password_nneka.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_password_nneka.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#password-generator'
       )}}
 
@@ -170,7 +170,7 @@
         desc='Find out the exact hex color of anything you see online and duplicate it in other applications.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='NXomgmnfU_Y',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_eyedropper_bram.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_eyedropper_bram.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#eyedropper-tool'
       )}}
     </div>
@@ -184,7 +184,7 @@
         desc='Rearrange your browser tabs any way you want with ease.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='uyuBOpjPFws',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_floating-tabs_natalie.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_floating-tabs_natalie.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#tab-tips'
       )}}
 
@@ -196,7 +196,7 @@
         desc='A quick way to delete your Firefox history and cookies for the last 5 minutes, or 2 hours or 24 hours in a flash.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='sn9dib80w3c',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_forget_damiano.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_forget_damiano.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#forget'
       )}}
 
@@ -208,7 +208,7 @@
         desc='Save articles, videos and more to consume later, even when you’re offline.',
         aspect_ratio='mzp-has-aspect-16-9',
         youtube_id='MGHFog9F48A',
-        image_url='img/firefox/features/tips/fx_video-thumb_secret-menu_pocket_amy.jpg',
+        image=resp_img('img/firefox/features/tips/fx_video-thumb_secret-menu_pocket_amy.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url='https://blog.mozilla.org/products/firefox/firefox-tips/firefox-secret-tips/#pocket'
       )}}
     </div>

--- a/bedrock/firefox/templates/firefox/more.html
+++ b/bedrock/firefox/templates/firefox/more.html
@@ -56,7 +56,7 @@
       {{ card(
         title=ftl('firefox-fights-for'),
         ga_title='Firefox Windows',
-        image_url='img/firefox/more/firefox-windows.jpg',
+        image=resp_img('img/firefox/more/firefox-windows.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('easy-migration-of'),
         link_url=url('firefox.windows')
       )}}
@@ -64,7 +64,7 @@
       {{ card(
         title=ftl('firefox-respects-your'),
         ga_title='Firefox Mac',
-        image_url='img/firefox/more/firefox-mac.jpg',
+        image=resp_img('img/firefox/more/firefox-mac.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-doesnt-spy'),
         link_url=url('firefox.mac')
       )}}
@@ -72,7 +72,7 @@
       {{ card(
         title=ftl('firefox-for-linux'),
         ga_title='Firefox Linux',
-        image_url='img/firefox/more/firefox-linux.jpg',
+        image=resp_img('img/firefox/more/firefox-linux.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('new-school-meets'),
         link_url=url('firefox.linux')
       )}}
@@ -80,7 +80,7 @@
       {{ card(
         title=ftl('firefox-for-windows'),
         ga_title='Firefox Win 64',
-        image_url='img/firefox/more/firefox-64-bit.jpg',
+        image=resp_img('img/firefox/more/firefox-64-bit.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('we-worry-about'),
         link_url=url('firefox.browsers.windows-64-bit')
       )}}
@@ -89,7 +89,7 @@
       {{ card(
         title=ftl('the-history-of'),
         ga_title='Browser History',
-        image_url='img/firefox/more/browser-history.jpg',
+        image=resp_img('img/firefox/more/browser-history.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-has-been'),
         link_url=url('firefox.browsers.browser-history')
       )}}
@@ -97,24 +97,24 @@
       {{ card(
         title=ftl('what-is-a'),
         ga_title='What is a browser',
-        image_url='img/firefox/more/what-is-a-browser.jpg',
+        image=resp_img('img/firefox/more/what-is-a-browser.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('a-web-browser'),
-        link_url=url('firefox.browsers.what-is-a-browser')
+        link_url=url('firefox.browsers.what-is-a-browser'),
       )}}
 
       {{ card(
         title=ftl('update-your-browser'),
         ga_title='Update Browser',
-        image_url='img/firefox/more/update-browser.jpg',
+        image=resp_img('img/firefox/more/update-browser.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('the-firefox-browser'),
-        link_url=url('firefox.browsers.update-browser')
+        link_url=url('firefox.browsers.update-browser'),
       )}}
     </div>
     <div class="mzp-l-card-third">
       {{ card(
         title=ftl('choose-which-firefox'),
         ga_title='Firefox All',
-        image_url='img/firefox/more/firefox-all.jpg',
+        image=resp_img('img/firefox/more/firefox-all.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('we-believe-everyone'),
         link_url=url('firefox.all')
       )}}
@@ -122,15 +122,15 @@
       {{ card(
         title=ftl('firefox-more-firefox-chromebook'),
         ga_title='Firefox Products',
-        image_url='img/firefox/more/firefox-chromebook.jpg',
+        image=resp_img('img/firefox/more/firefox-chromebook.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-more-while-on-chromebook'),
-        link_url=url('firefox.browsers.chromebook')
+        link_url=url('firefox.browsers.chromebook'),
       )}}
 
       {{ card(
         title=ftl('firefox-more-firefox-quantum'),
         ga_title='Firefox Browsers',
-        image_url='img/firefox/more/firefox-quantum.jpg',
+        image=resp_img('img/firefox/more/firefox-quantum.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-more-quantum-was-revolution'),
         link_url=url('firefox.browsers.quantum')
       )}}
@@ -139,15 +139,15 @@
       {{ card(
         title=ftl('firefox-rebel-with'),
         ga_title="Independent",
-        image_url='img/firefox/more/independent.jpg',
-        desc= ftl('firefox-is-independent'),
+        image=resp_img('img/firefox/more/independent.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
+        desc=ftl('firefox-is-independent'),
         link_url=url('firefox.features.independent')
       )}}
 
       {{ card(
         title=ftl('firefox-more-little-book'),
         ga_title='Features Private Browsing',
-        image_url='img/firefox/more/little-book-of-privacy.jpg',
+        image=resp_img('img/firefox/more/little-book-of-privacy.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc= ftl('firefox-more-you-can-reclaim'),
         link_url=url('firefox.privacy.book')
       )}}
@@ -155,7 +155,7 @@
       {{ card(
         title=ftl('incognito-browser-what'),
         ga_title='Features Private Browsing',
-        image_url='img/firefox/more/incognito-browser.jpg',
+        image=resp_img('img/firefox/more/incognito-browser.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-calls-it'),
         link_url=url('firefox.browsers.incognito-browser')
       )}}
@@ -164,15 +164,15 @@
       {{ card(
         title=ftl('the-ad-blocker'),
         ga_title='Featires Adblocker',
-        image_url='img/firefox/more/firefox-adblocker.jpg',
+        image=resp_img('img/firefox/more/firefox-adblocker.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('so-many-ads'),
-        link_url=url('firefox.features.adblocker')
+        link_url=url('firefox.features.adblocker'),
       )}}
 
       {{ card(
         title=ftl('firefox-more-protection'),
         ga_title='Features Private Browsing',
-        image_url='img/firefox/more/private-browsing.jpg',
+        image=resp_img('img/firefox/more/private-browsing.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('were-obsessed-with'),
         link_url=url('firefox.features.private-browsing')
       )}}
@@ -180,7 +180,7 @@
       {{ card(
         title=ftl('take-the-stress'),
         ga_title='Features Safe Browser',
-        image_url='img/firefox/more/safe-browser.jpg',
+        image=resp_img('img/firefox/more/safe-browser.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('building-a-safe'),
         link_url=url('firefox.features.safebrowser')
       )}}
@@ -188,7 +188,7 @@
       {{ card(
         title=ftl('firefox-more-firefox-sync'),
         ga_title='Features Safe Browser',
-        image_url='img/firefox/more/firefox-sync.jpg',
+        image=resp_img('img/firefox/more/firefox-sync.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-more-access-your-sync'),
         link_url=url('firefox.sync')
       )}}
@@ -197,7 +197,7 @@
       {{ card(
         title=ftl('seven-of-the'),
         ga_title='Compare',
-        image_url='img/firefox/more/compare-browsers.jpg',
+        image=resp_img('img/firefox/more/compare-browsers.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('we-compare-firefox'),
         link_url=url('firefox.browsers.compare.index')
       )}}
@@ -205,7 +205,7 @@
       {{ card(
         title=ftl('comparing-firefox-chrome'),
         ga_title='Compare Chrome',
-        image_url='img/firefox/more/firefox-chrome.jpg',
+        image=resp_img('img/firefox/more/firefox-chrome.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('big-isnt-always'),
         link_url=url('firefox.browsers.compare.chrome')
       )}}
@@ -213,7 +213,7 @@
       {{ card(
         title=ftl('comparing-firefox-brave'),
         ga_title='Compare Brave',
-        image_url='img/firefox/more/firefox-brave.jpg',
+        image=resp_img('img/firefox/more/firefox-brave.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('be-bold-and'),
         link_url=url('firefox.browsers.compare.brave')
       )}}
@@ -222,7 +222,7 @@
       {{ card(
         title=ftl('comparing-firefox-edge'),
         ga_title='Compare Edge',
-        image_url='img/firefox/more/firefox-edge.jpg',
+        image=resp_img('img/firefox/more/firefox-edge.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('youll-never-guess'),
         link_url=url('firefox.browsers.compare.edge')
       )}}
@@ -230,7 +230,7 @@
       {{ card(
         title=ftl('comparing-firefox-ie'),
         ga_title='Compare IE',
-        image_url='img/firefox/more/firefox-ie.jpg',
+        image=resp_img('img/firefox/more/firefox-ie.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('old-habits-that'),
         link_url=url('firefox.browsers.compare.ie')
       )}}
@@ -239,14 +239,14 @@
         title=ftl('comparing-firefox-safari'),
         ga_title='Compare Safari',
         desc=ftl('you-dont-have'),
-        image_url='img/firefox/more/firefox-safari.jpg',
+        image=resp_img('img/firefox/more/firefox-safari.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url=url('firefox.browsers.compare.safari')
       )}}
 
       {{ card(
         title=ftl('comparing-firefox-opera'),
         ga_title='Compare Opera',
-        image_url='img/firefox/more/firefox-opera.jpg',
+        image=resp_img('img/firefox/more/firefox-opera.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('be-free-to'),
         link_url=url('firefox.browsers.compare.opera')
       )}}
@@ -256,7 +256,7 @@
       {{ card(
         title=ftl('firefox-more-fingerprinter-blocking'),
         ga_title='Fingerprinter Blocking',
-        image_url='img/firefox/more/fingerprint.png',
+        image=resp_img('img/firefox/more/fingerprint.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-more-fingerprinting-is-a'),
         link_url=url('firefox.features.fingerprinting')
       )}}
@@ -264,7 +264,7 @@
       {{ card(
         title=ftl('firefox-more-translate-the-web'),
         ga_title='Translate',
-        image_url='img/firefox/more/firefox-all.jpg',
+        image=resp_img('img/firefox/more/firefox-all.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-more-translate-more-than'),
         link_url=url('firefox.features.translate')
       )}}
@@ -273,7 +273,7 @@
         title=ftl('firefox-more-a-guide-to'),
         ga_title='Safe Passwords',
         desc=ftl('firefox-more-more-and-more'),
-        image_url='img/firefox/more/passwords.png',
+        image=resp_img('img/firefox/more/passwords.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         link_url=url('firefox.privacy.passwords')
       )}}
     </div>
@@ -282,7 +282,7 @@
       {{ card(
         title=ftl('firefox-more-avoid-misinformation-heading'),
         ga_title='Avoid Misinformation',
-        image_url='img/firefox/more/avoid-misinformation.jpg',
+        image=resp_img('img/firefox/more/avoid-misinformation.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         desc=ftl('firefox-more-avoid-misinformation-desc'),
         link_url=url('firefox.more.misinformation')
       )}}

--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -71,8 +71,7 @@
         title='Save It Fast',
         ga_title='Save It Fast',
         desc='One click on the Pocket icon and content is saved to read later on any device, online or off. With your Firefox Account, logins and preferences travel with you.',
-        image_url='img/firefox/pocket/pocket-save.png',
-        include_highres_image=True,
+        image=resp_img('img/firefox/pocket/pocket-save.png', srcset={'img/firefox/pocket/pocket-save-high-res.png': '2x' }, optional_attributes={'loading': 'lazy', 'class': 'mzp-c-card-image'}),
         aspect_ratio='mzp-has-aspect-3-2',
         link_url='https://support.mozilla.org/kb/save-web-pages-later-pocket-firefox',
       )}}
@@ -82,8 +81,7 @@
         title='Get Great Recommendations',
         ga_title='Get Great Recommendations',
         desc='Every new Firefox tab is a chance to discover quality content that compels you, selected by real people who have their pulse on the web.',
-        image_url='img/firefox/pocket/pocket-discover.png',
-        include_highres_image=True,
+        image=resp_img('img/firefox/pocket/pocket-discover.png', srcset={'img/firefox/pocket/pocket-discover-high-res.png': '2x' }, optional_attributes={'loading': 'lazy', 'class': 'mzp-c-card-image'}),
         aspect_ratio='mzp-has-aspect-3-2',
         link_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations',
       )}}

--- a/bedrock/foundation/templates/foundation/annualreport/2020/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2020/index.html
@@ -73,7 +73,7 @@
         class='has-modal',
         attributes='data-modal-id="mitchell-baker-letter"',
         link_url='#mitchell-baker-letter',
-        image_url='img/foundation/annualreport/2019/leadership-mitchell.jpg',
+        image=resp_img('img/foundation/annualreport/2019/leadership-mitchell.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
       {{ card(
@@ -84,7 +84,7 @@
         class='has-modal',
         attributes='data-modal-id="mark-surman-letter"',
         link_url='#mark-surman-letter',
-        image_url='img/foundation/annualreport/2019/leadership-mark.jpg',
+        image=resp_img('img/foundation/annualreport/2019/leadership-mark.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
       {{ card(
@@ -95,7 +95,7 @@
         class='has-modal',
         attributes='data-modal-id="angela-eric-letter"',
         link_url='#angela-eric-letter',
-        image_url='img/foundation/annualreport/2020/leadership-angela-eric.jpg',
+        image=resp_img('img/foundation/annualreport/2020/leadership-angela-eric.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
     </div>
   </div>
@@ -277,7 +277,7 @@
           attributes='data-modal-id="firefox-mobile-redesign"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#firefox-mobile-redesign',
-          image_url='img/foundation/annualreport/2020/firefox-android.png',
+          image=resp_img('img/foundation/annualreport/2020/firefox-android.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -288,7 +288,7 @@
           attributes='data-modal-id="firefox-suggest"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#firefox-suggest',
-          image_url='img/foundation/annualreport/2020/firefox-blog-header.jpg',
+          image=resp_img('img/foundation/annualreport/2020/firefox-blog-header.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -299,7 +299,7 @@
           attributes='data-modal-id="picture-in-picture"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#picture-in-picture',
-          image_url='img/foundation/annualreport/2020/blog-header-pip.jpg',
+          image=resp_img('img/foundation/annualreport/2020/blog-header-pip.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -310,7 +310,7 @@
           attributes='data-modal-id="firefox-colorways"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#firefox-colorways',
-          image_url='img/foundation/annualreport/2020/firefox-colorways-header.png',
+          image=resp_img('img/foundation/annualreport/2020/firefox-colorways-header.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
       </div>
 
@@ -334,7 +334,7 @@
           attributes='data-modal-id="pocket-slate-partnership"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-slate-partnership',
-          image_url='img/foundation/annualreport/2020/pocket-slate-podcast.jpg',
+          image=resp_img('img/foundation/annualreport/2020/pocket-slate-podcast.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -345,7 +345,7 @@
           attributes='data-modal-id="pocket-hercampus"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-hercampus',
-          image_url='img/foundation/annualreport/2020/hercampus-blog-header.png',
+          image=resp_img('img/foundation/annualreport/2020/hercampus-blog-header.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -356,7 +356,7 @@
           attributes='data-modal-id="pocket-best-of-2021"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-best-of-2021',
-          image_url='img/foundation/annualreport/2020/pocket-best-of-2021.jpg',
+          image=resp_img('img/foundation/annualreport/2020/pocket-best-of-2021.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
       </div>
     </section>
@@ -399,7 +399,7 @@
             attributes='data-modal-id="mofo-letter-privacy"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#mofo-letter-privacy',
-            image_url='img/foundation/annualreport/2020/mofo-privacy-header.png',
+            image=resp_img('img/foundation/annualreport/2020/mofo-privacy-header.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
 
           {{ card(
@@ -410,7 +410,7 @@
             attributes='data-modal-id="doh-canada"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#doh-canada',
-            image_url='img/foundation/annualreport/2020/doh-canada-rollout.png',
+            image=resp_img('img/foundation/annualreport/2020/doh-canada-rollout.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
 
           {{ card(
@@ -421,7 +421,7 @@
             attributes='data-modal-id="apple-idfa"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#apple-idfa',
-            image_url='img/foundation/annualreport/2020/apple-idfa-campaign.jpg',
+            image=resp_img('img/foundation/annualreport/2020/apple-idfa-campaign.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
 
@@ -434,7 +434,7 @@
             attributes='data-modal-id="total-cookie-protection"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#total-cookie-protection',
-            image_url='img/foundation/annualreport/2020/total-cookie-protection.jpg',
+            image=resp_img('img/foundation/annualreport/2020/total-cookie-protection.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
 
           {{ card(
@@ -445,7 +445,7 @@
             attributes='data-modal-id="vpn-expansion"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#vpn-expansion',
-            image_url='img/foundation/annualreport/2020/vpn-blog-header.jpg',
+            image=resp_img('img/foundation/annualreport/2020/vpn-blog-header.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
 
@@ -458,7 +458,7 @@
             attributes='data-modal-id="privacy-control"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#privacy-control',
-            image_url='img/foundation/annualreport/2020/firefox-asset.png',
+            image=resp_img('img/foundation/annualreport/2020/firefox-asset.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
 
           {{ card(
@@ -469,7 +469,7 @@
             attributes='data-modal-id="venmo-privacy"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#venmo-privacy',
-            image_url='img/foundation/annualreport/2020/venmo-privacy.png',
+            image=resp_img('img/foundation/annualreport/2020/venmo-privacy.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
 
           {{ card(
@@ -480,7 +480,7 @@
             attributes='data-modal-id="firefox-relay-premium"',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url='#firefox-relay-premium',
-            image_url='img/foundation/annualreport/2020/firefox-relay-premium.jpg',
+            image=resp_img('img/foundation/annualreport/2020/firefox-relay-premium.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
       </div>
@@ -522,7 +522,7 @@
           attributes='data-modal-id="youtube-regrets"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#youtube-regrets',
-          image_url='img/foundation/annualreport/2020/youtube-regrets.png',
+          image=resp_img('img/foundation/annualreport/2020/youtube-regrets.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -533,7 +533,7 @@
           attributes='data-modal-id="tiktok-research"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#tiktok-research',
-          image_url='img/foundation/annualreport/2020/tiktok-research.png',
+          image=resp_img('img/foundation/annualreport/2020/tiktok-research.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
       </div>
 
@@ -557,7 +557,7 @@
           attributes='data-modal-id="ad-transparency"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#ad-transparency',
-          image_url='img/foundation/annualreport/2020/ad-transparency.jpg',
+          image=resp_img('img/foundation/annualreport/2020/ad-transparency.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
 
         {{ card(
@@ -568,7 +568,7 @@
           attributes='data-modal-id="kenya-research"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#kenya-research',
-          image_url='img/foundation/annualreport/2020/kenya-disinformation.jpg',
+          image=resp_img('img/foundation/annualreport/2020/kenya-disinformation.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         )}}
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -50,9 +50,8 @@
           class='mzp-c-card-medium',
           title=ftl('about-pioneers-of-the-open-web'),
           ga_title='Pioneers of The Open Web',
-          desc=ftl('about-our-leadership-has-been-at'),
-          image_url='img/mozorg/about/leaders.jpg',
-          include_highres_image=True,
+          desc=ftl('about-our-purple-bghip-has-been-at'),
+          image=resp_img('img/mozorg/about/leaders.jpg', srcset={"img/mozorg/about/leaders-high-res.jpg": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           aspect_ratio='mzp-has-aspect-3-2',
           link_url=url('mozorg.about.leadership.index')
       )}}
@@ -61,8 +60,7 @@
           title=ftl('about-firefox-fast-for-good'),
           ga_title='Firefox: Fast for Good',
           desc=ftl('about-when-you-use-the-new-firefox'),
-          image_url='img/mozorg/about/firefox.jpg',
-          include_highres_image=True,
+          image=resp_img('img/mozorg/about/firefox.jpg', srcset={"img/mozorg/about/firefox-high-res.jpg": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           aspect_ratio='mzp-has-aspect-3-2',
           link_url=url('firefox.new')
       )}}
@@ -71,7 +69,7 @@
           title=ftl('vision-for-the-web'),
           ga_title='Mozilla’s vision for the Web',
           desc=ftl('read-about-our-vision'),
-          image_url='img/mozorg/about/purple-bg.jpg',
+          image=resp_img('img/mozorg/about/purple-bg.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           aspect_ratio='mzp-has-aspect-3-2',
           link_url=url('mozorg.about.webvision.summary')
       )}}
@@ -80,8 +78,7 @@
           title=ftl('about-talking-internet-issues-irl'),
           ga_title='Talking Internet Issues IRL',
           desc=ftl('about-in-mozillas-irl-podcast-host'),
-          image_url='img/mozorg/about/irl.jpg',
-          include_highres_image=True,
+          image=resp_img('img/mozorg/about/irl.jpg', srcset={"img/mozorg/about/irl-high-res.jpg": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           aspect_ratio='mzp-has-aspect-3-2',
           link_url='https://irlpodcast.org/'
       )}}
@@ -148,8 +145,7 @@
         title=ftl('about-work-at-mozilla'),
         ga_title='Work at Mozilla',
         desc=ftl('about-join-a-mission-driven-organization'),
-        image_url='img/mozorg/about/careers.jpg',
-        include_highres_image=True,
+        image=resp_img('img/mozorg/about/careers.jpg', srcset={"img/mozorg/about/careers-high-res.jpg": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         aspect_ratio='mzp-has-aspect-3-2',
         link_url=url('careers.home'),
         cta=ftl('about-mozilla-careers')
@@ -159,8 +155,7 @@
         title=ftl('about-how-you-can-help'),
         ga_title='How You Can Help',
         desc=ftl('about-your-voice-your-code-your'),
-        image_url='img/mozorg/about/involved.jpg',
-        include_highres_image=True,
+        image=resp_img('img/mozorg/about/involved.jpg', srcset={"img/mozorg/about/involved-high-res.jpg": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
         aspect_ratio='mzp-has-aspect-3-2',
         link_url=url('mozorg.contribute'),
         cta=ftl('about-get-involved')

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/beyond-products.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/beyond-products.html
@@ -29,7 +29,7 @@
           attributes='data-modal-id="common-voice"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#common-voice',
-          image_url='img/mozorg/diversity/2021/card-images/mozilla-common-voice.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/mozilla-common-voice.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Artificial intelligence for humanity - World Economic Forum',
@@ -38,7 +38,7 @@
           attributes='data-modal-id="ai-humanity"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#ai-humanity',
-          image_url='img/mozorg/diversity/2021/card-images/weforum.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/weforum.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='African tech festivals, conferences, and events',
@@ -47,7 +47,7 @@
           attributes='data-modal-id="african-tech"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#african-tech',
-          image_url='img/mozorg/diversity/2021/card-images/african-digital-divide.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/african-digital-divide.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
       </div>
@@ -61,7 +61,7 @@
           attributes='data-modal-id="mozfest"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#mozfest',
-          image_url='img/mozorg/diversity/2021/card-images/mozilla-festival.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/mozilla-festival.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Dialogues & debates',
@@ -70,7 +70,7 @@
           attributes='data-modal-id="dialogues-debates"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#dialogues-debates',
-          image_url='img/mozorg/diversity/2021/card-images/mozfest-dialogues-and-debates.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/mozfest-dialogues-and-debates.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           </div>
           <div class="mzp-l-card-half">
@@ -81,7 +81,7 @@
           attributes='data-modal-id="creative-media"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#creative-media',
-          image_url='img/mozorg/diversity/2021/card-images/creative-awards.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/creative-awards.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Investments with Precursor Ventures',
@@ -90,7 +90,7 @@
           attributes='data-modal-id="precursor-ventures"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#precursor-ventures',
-          image_url='img/mozorg/diversity/2021/card-images/precursor-ventures.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/precursor-ventures.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
       </div>
@@ -107,7 +107,7 @@
           attributes='data-modal-id="computing-playbook"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#computing-playbook',
-          image_url='img/mozorg/diversity/2021/card-images/computing-summit.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/computing-summit.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Teaching responsible computing summit 2021',
@@ -116,7 +116,7 @@
           attributes='data-modal-id="computing-summit"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#computing-summit',
-          image_url='img/mozorg/diversity/2021/card-images/teaching-summit.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/teaching-summit.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
       </div>
@@ -131,7 +131,7 @@
           attributes='data-modal-id="hbcu-collaborative-curriculum"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#hbcu-collaborative-curriculum',
-          image_url='img/mozorg/diversity/2021/card-images/hbcu-collab.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/hbcu-collab.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Centering the experiences of black women',
@@ -140,7 +140,7 @@
           attributes='data-modal-id="centering-black-women"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#centering-black-women',
-          image_url='img/mozorg/diversity/2021/card-images/black-women-experiences.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/black-women-experiences.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='The future is intersectional: black women interrogating technology',
@@ -149,7 +149,7 @@
           attributes='data-modal-id="intersectional-future"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#intersectional-future',
-          image_url='img/mozorg/diversity/2021/card-images/black-women-technology.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/black-women-technology.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
         <div class="mzp-l-card-half">
@@ -160,7 +160,7 @@
           attributes='data-modal-id="spelman-presents"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#spelman-presents',
-          image_url='img/mozorg/diversity/2021/card-images/spelman-header.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/spelman-header.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Atlanta University Center Data Science Initiative: Trustworthy AI design thinking challenge',
@@ -169,7 +169,7 @@
           attributes='data-modal-id="atlanta-uni"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#atlanta-uni',
-          image_url='img/mozorg/diversity/2021/card-images/auc-data-science.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/auc-data-science.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
       </div>

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/index.html
@@ -175,21 +175,21 @@
       ga_title='Mozilla Foundation data',
       aspect_ratio='mzp-has-aspect-16-9',
       link_url=url('mozorg.diversity.2021.mofo-data'),
-      image_url='img/mozorg/diversity/2021/card-images/mofo-data-card.jpg',
+      image=resp_img('img/mozorg/diversity/2021/card-images/mofo-data-card.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       )}}
       {{ card(
       title='Mozilla Corporation data',
       ga_title='Mozilla Corporation data',
       aspect_ratio='mzp-has-aspect-16-9',
       link_url=url('mozorg.diversity.2021.moco-data'),
-      image_url='img/mozorg/diversity/2021/card-images/moco-data-card.jpg',
+      image=resp_img('img/mozorg/diversity/2021/card-images/moco-data-card.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       )}}
       {{ card(
       title='Racial justice commitments',
       ga_title='Racial justice commitments',
       aspect_ratio='mzp-has-aspect-16-9',
       link_url=url('mozorg.diversity.2021.racial-justice'),
-      image_url='img/mozorg/diversity/2021/card-images/racial-justice-card.jpg',
+      image=resp_img('img/mozorg/diversity/2021/card-images/racial-justice-card.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       )}}
     </div>
     <div class="mzp-l-card-third">
@@ -199,7 +199,7 @@
       desc='Our employee base and our communities',
       aspect_ratio='mzp-has-aspect-16-9',
       link_url=url('mozorg.diversity.2021.who-we-are'),
-      image_url='img/mozorg/diversity/2021/card-images/who-we-are-card.jpg',
+      image=resp_img('img/mozorg/diversity/2021/card-images/who-we-are-card.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       )}}
       {{ card(
       title='What we build',
@@ -207,7 +207,7 @@
       desc='Our outreach with our products',
       aspect_ratio='mzp-has-aspect-16-9',
       link_url=url('mozorg.diversity.2021.what-we-build'),
-      image_url='img/mozorg/diversity/2021/card-images/what-we-build-card.jpg',
+      image=resp_img('img/mozorg/diversity/2021/card-images/what-we-build-card.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       )}}
       {{ card(
       title='Beyond our products',
@@ -215,7 +215,7 @@
       desc='Our broader engagement with the world',
       aspect_ratio='mzp-has-aspect-16-9',
       link_url=url('mozorg.diversity.2021.beyond-products'),
-      image_url='img/mozorg/diversity/2021/card-images/beyond-our-products.jpg',
+      image=resp_img('img/mozorg/diversity/2021/card-images/beyond-our-products.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       )}}
     </div>
   </section>

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/what-we-build.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/what-we-build.html
@@ -34,7 +34,7 @@
           attributes='data-modal-id="pocket-latinx-publications"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-latinx-publications',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-latin-publications.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-latin-publications.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Celebrating the history of HBCU homecoming',
@@ -43,7 +43,7 @@
           attributes='data-modal-id="pocket-hbcu-homecoming"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-hbcu-homecoming',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-hbcu-homecoming.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-hbcu-homecoming.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           </div>
           <div class="mzp-l-card-third">
@@ -54,7 +54,7 @@
           attributes='data-modal-id="pocket-migrant-experience"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-migrant-experience',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-migrant-experience.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-migrant-experience.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='How to make the most of time off',
@@ -63,7 +63,7 @@
           attributes='data-modal-id="pocket-time-off"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-time-off',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-taking-time-off.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-taking-time-off.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Latinos, language, and identity: the evolution of Hispanic Heritage month',
@@ -72,7 +72,7 @@
           attributes='data-modal-id="pocket-hispanic-heritage"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-hispanic-heritage',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-latinx.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-latinx.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
         <div class="mzp-l-card-half">
@@ -83,7 +83,7 @@
           attributes='data-modal-id="pocket-mental-health"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-mental-health',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-wellbeing.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-wellbeing.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Remembering and honouring Dr. Martin Luther King Jr.',
@@ -92,7 +92,7 @@
           attributes='data-modal-id="pocket-mlk"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-mlk',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-mlk.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-mlk.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           </div>
           <div class="mzp-l-card-third">
@@ -103,7 +103,7 @@
           attributes='data-modal-id="pocket-anti-asian-hate"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-anti-asian-hate',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-anti-asian-hate.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-anti-asian-hate.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='Talking to kids about gentrification, social justice, and activism',
@@ -112,7 +112,7 @@
           attributes='data-modal-id="pocket-talking-to-kids"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-talking-to-kids',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-kids-gentrification.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-kids-gentrification.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
           {{ card(
           title='The women who powered the Civil Rights Movement',
@@ -121,7 +121,7 @@
           attributes='data-modal-id="pocket-women-of-the-movement"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-women-of-the-movement',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-women-of-the-movement.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-women-of-the-movement.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
           )}}
         </div>
         <div class="mzp-l-card-half">
@@ -133,7 +133,7 @@
           attributes='data-modal-id="pocket-slate"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-slate',
-          image_url='img/mozorg/diversity/2021/card-images/pocket-slate-podcast.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/pocket-slate-podcast.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
           )}}
           {{ card(
           title='Coming of Age in a Hyper-online World',
@@ -143,7 +143,7 @@
           attributes='data-modal-id="pocket-hercampus"',
           aspect_ratio='mzp-has-aspect-16-9',
           link_url='#pocket-hercampus',
-          image_url='img/mozorg/diversity/2021/card-images/hercampus.jpg',
+          image=resp_img('img/mozorg/diversity/2021/card-images/hercampus.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           )}}
         </div>
       </div>

--- a/bedrock/mozorg/templates/mozorg/diversity/2021/who-we-are.html
+++ b/bedrock/mozorg/templates/mozorg/diversity/2021/who-we-are.html
@@ -38,7 +38,7 @@
                attributes='data-modal-id="afrozilla"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#afrozilla',
-               image_url='img/mozorg/diversity/2021/card-images/afrozilla.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/afrozilla.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='Disability@Mozilla',
@@ -47,7 +47,7 @@
                attributes='data-modal-id="disability-at-mozilla"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#disability-at-mozilla',
-               image_url='img/mozorg/diversity/2021/card-images/disability-at-mozilla.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/disability-at-mozilla.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
             </div>
             <div class="mzp-l-card-half">
@@ -58,7 +58,7 @@
                attributes='data-modal-id="latin-pride"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#latin-pride',
-               image_url='img/mozorg/diversity/2021/card-images/mozilla-resource-groups-latin-pride.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/mozilla-resource-groups-latin-pride.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                )}}
                {{ card(
                title='MozAPI',
@@ -67,7 +67,7 @@
                attributes='data-modal-id="moz-api"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#moz-api',
-               image_url='img/mozorg/diversity/2021/card-images/moz-api.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/moz-api.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
             </div>
             <div class="mzp-l-card-half">
@@ -78,7 +78,7 @@
                attributes='data-modal-id="pridezilla"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#pridezilla',
-               image_url='img/mozorg/diversity/2021/card-images/pridezilla.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/pridezilla.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='WoMoz',
@@ -87,7 +87,7 @@
                attributes='data-modal-id="womoz"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#womoz',
-               image_url='img/mozorg/diversity/2021/card-images/womoz.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/womoz.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
             </div>
             <h4>Celebratory months</h4>
@@ -101,7 +101,7 @@
                attributes='data-modal-id="black-history-month"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#black-history-month',
-               image_url='img/mozorg/diversity/2021/card-images/black-history-month.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/black-history-month.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='Women’s history month',
@@ -111,7 +111,7 @@
                attributes='data-modal-id="womens-history-month"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#womens-history-month',
-               image_url='img/mozorg/diversity/2021/card-images/womens-history-month.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/womens-history-month.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='AAPI Month',
@@ -121,7 +121,7 @@
                attributes='data-modal-id="aapi-month"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#aapi-month',
-               image_url='img/mozorg/diversity/2021/card-images/api-month.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/api-month.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
             </div>
             <div class="mzp-l-card-third">
@@ -133,7 +133,7 @@
                attributes='data-modal-id="pride-month"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#pride-month',
-               image_url='img/mozorg/diversity/2021/card-images/pride2021.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/pride2021.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='Hispanic heritage month',
@@ -143,7 +143,7 @@
                attributes='data-modal-id="hispanic-month"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#hispanic-month',
-               image_url='img/mozorg/diversity/2021/card-images/hispanic-heritage-month.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/hispanic-heritage-month.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='Holidays, awareness days, and acknowledgements',
@@ -153,7 +153,7 @@
                attributes='data-modal-id="holidays-and-awareness"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#holidays-and-awareness',
-               image_url='img/mozorg/diversity/2021/card-images/mosaic.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/mosaic.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
             </div>
          </div>
@@ -174,7 +174,7 @@
                attributes='data-modal-id="rjaag"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#rjaag',
-               image_url='img/mozorg/diversity/2021/card-images/moz-inclusion.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/moz-inclusion.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='Inclusion Champions Pilot Program',
@@ -183,7 +183,7 @@
                attributes='data-modal-id="inclusion-champions"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#inclusion-champions',
-               image_url='img/mozorg/diversity/2021/card-images/inclusion-champions.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/inclusion-champions.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                </div>
                <div class="mzp-l-card-third">
@@ -194,7 +194,7 @@
                attributes='data-modal-id="dei-council"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#dei-council',
-               image_url='img/mozorg/diversity/2021/card-images/zoom-group-photo.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/zoom-group-photo.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='Gather@',
@@ -203,7 +203,7 @@
                attributes='data-modal-id="gather-at"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#gather-at',
-               image_url='img/mozorg/diversity/2021/card-images/gather-at.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/gather-at.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
                {{ card(
                title='MoFo’s Racial Equity and Belonging Audit',
@@ -212,7 +212,7 @@
                attributes='data-modal-id="mofo-reba"',
                aspect_ratio='mzp-has-aspect-16-9',
                link_url='#mofo-reba',
-               image_url='img/mozorg/diversity/2021/card-images/mmg-mofo.jpg',
+               image=resp_img('img/mozorg/diversity/2021/card-images/mmg-mofo.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"})
                )}}
             </div>
          </div>

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -127,8 +127,7 @@
       title='Tor ($152,500)',
       ga_title='Tor',
       desc='Tor is free software and an open network that helps you defend against network surveillance.',
-      image_url='img/mozorg/moss/tor.png',
-      include_highres_image=True,
+      image=resp_img('img/mozorg/moss/tor.png', srcset={'img/mozorg/moss/tor-high-res.png': '2x'}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       aspect_ratio='mzp-has-aspect-16-9',
       link_url='https://www.torproject.org/',
     )}}
@@ -138,8 +137,7 @@
       title='Tails ($77,000)',
       ga_title='Tails',
       desc='Tails is a live operating system that you can start on almost any computer from a DVD, USB stick, or SD card.',
-      image_url='img/mozorg/moss/tails.png',
-      include_highres_image=True,
+      image=resp_img('img/mozorg/moss/tails.png', srcset={'img/mozorg/moss/tails-high-res.png': '2x'}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       aspect_ratio='mzp-has-aspect-16-9',
       link_url='https://tails.boum.org/',
     )}}
@@ -149,8 +147,7 @@
       title='Caddy ($50,000)',
       ga_title='Caddy',
       desc='Caddy is an alternative web server that is easy to configure and use.',
-      image_url='img/mozorg/moss/caddy.png',
-      include_highres_image=True,
+      image=resp_img('img/mozorg/moss/caddy.png', srcset={'img/mozorg/moss/caddy-high-res.png': '2x'}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       aspect_ratio='mzp-has-aspect-16-9',
       link_url='https://caddyserver.com/',
     )}}
@@ -160,8 +157,7 @@
       title='Godot ($20,000)',
       ga_title='Save It Fast',
       desc='Godot is an advanced, feature-packed, multi-platform 2D and 3D open source game engine.',
-      image_url='img/mozorg/moss/godot.png',
-      include_highres_image=True,
+      image=resp_img('img/mozorg/moss/godot.png', srcset={'img/mozorg/moss/godot-high-res.png': '2x'}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       aspect_ratio='mzp-has-aspect-16-9',
       link_url='https://godotengine.org/',
     )}}
@@ -171,8 +167,7 @@
       title='SecureDrop ($250,000)',
       ga_title='SecureDrop',
       desc='SecureDrop is a free and open source whistleblower submission system originally created by the late Aaron Swartz.',
-      image_url='img/mozorg/moss/securedrop.png',
-      include_highres_image=True,
+      image=resp_img('img/mozorg/moss/securedrop.png', srcset={'img/mozorg/moss/securedrop-high-res.png': '2x'}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       aspect_ratio='mzp-has-aspect-16-9',
       link_url='https://securedrop.org/',
     )}}
@@ -182,8 +177,7 @@
       title='NVDA ($15,000)',
       ga_title='NVDA',
       desc='NVDA (NonVisual Desktop Access) is a free “screen reader” which enables blind and vision impaired people to use computers.',
-      image_url='img/mozorg/moss/nvaccess.png',
-      include_highres_image=True,
+      image=resp_img('img/mozorg/moss/nvaccess.png', srcset={'img/mozorg/moss/nvaccess-high-res.png': '2x'}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
       aspect_ratio='mzp-has-aspect-16-9',
       link_url='http://www.nvaccess.org/',
     )}}

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -89,7 +89,7 @@
                   ga_title='Take your privacy with you',
                   desc=ftl('newsletters-travel-the-internet'),
                   cta=ftl('newsletters-download-the-app'),
-                  image_url='img/newsletter/confirm/mobile.png',
+                  image=resp_img('img/newsletter/confirm/mobile.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('firefox.browsers.mobile.index'),
                 )}}
@@ -99,7 +99,7 @@
                   ga_title='Check for data breaches',
                   desc=ftl('newsletters-firefox-monitor-is-a-free'),
                   cta=ftl('newsletters-sign-in-to-monitor'),
-                  image_url='img/newsletter/confirm/monitor.png',
+                  image=resp_img('img/newsletter/confirm/monitor.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url='https://monitor.firefox.com/',
                 )}}
@@ -109,7 +109,7 @@
                   ga_title='Meet our parent brand',
                   desc=ftl('newsletters-mozilla-the-non-for-profit'),
                   cta=ftl('ui-learn-more'),
-                  image_url='img/newsletter/confirm/mozilla.png',
+                  image=resp_img('img/newsletter/confirm/mozilla.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('mozorg.about.index'),
                 )}}
@@ -125,7 +125,7 @@
                   ga_title='Get up and go',
                   desc=ftl('newsletters-its-your-web-anywhere-you'),
                   cta=ftl('newsletters-get-firefox-for-mobile'),
-                  image_url='img/newsletter/confirm/mobile.png',
+                  image=resp_img('img/newsletter/confirm/mobile.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('firefox.browsers.mobile.index'),
                 )}}
@@ -135,7 +135,7 @@
                   ga_title='Added extras',
                   desc=ftl('newsletters-make-firefox-do-more-with'),
                   cta=ftl('newsletters-find-out-how'),
-                  image_url='img/newsletter/confirm/addons.png',
+                  image=resp_img('img/newsletter/confirm/addons.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url='https://addons.mozilla.org/',
                 )}}
@@ -145,7 +145,7 @@
                   ga_title='About us',
                   desc=ftl('newsletters-whats-mozilla-all-about'),
                   cta=ftl('newsletters-were-glad-you-asked'),
-                  image_url='img/newsletter/confirm/mozilla.png',
+                  image=resp_img('img/newsletter/confirm/mozilla.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('mozorg.about.index'),
                 )}}

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1648,75 +1648,18 @@ Card
 
     Example: ``heading_level=2``
 
-- highres_image_url
-    A string for Contentful to provide a high resolution image URL.
+- image
+    **Required**. Image to be used in the Card element. Can pass an <img> element, `resp_img` or `picture` python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
 
     Default: ``None``
 
-    Example: ``https://example.com/path/to/some/highres-image.png``
+    Example:
 
-- image_alt
-    Alt text for the images to be used.
+    .. code-block::
 
-    Default: ``''``
-
-    Example: ``image_alt='Red Panda'``
-
-- image_height
-    Number indicating the height of an image.
-
-    Default: ``None``
-
-    Example: ``image_height='153'``
-
-- image_sizes
-    The ``sizes`` attribute for a responsive image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_sources
-    A list of ``<source>`` elements for a responsive ``<picture>`` image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_srcset
-    The ``srcset`` attribute for a responsive image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_url
-    **Required**. Path to image location.
-
-    Default: ``''``
-
-    Example: ``image_url='img/home/2018/billboard-healthy-internet.png'``
-
-- image_width
-    Number indicating the width of an image.
-
-    Default: ``None``
-
-    Example: ``image_width='153'``
-
-- include_highres_image (deprecated)
-    Boolean that determines whether the image can also appear in high res.
-
-    Default: ``False``
-
-    Example: ``include_highres_image=True``
-
-- l10n_image
-    Boolean to indicate if image has translatable text.
-
-    Default: ``False``
-
-    Example: ``l10n_image=True``
+        image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', srcset={
+            'img/firefox/accounts/trailhead/value-respect-high-res.jpg': '2x'
+        })
 
 - link_url
     **Required**. String or url helper function provides href value for cta link.


### PR DESCRIPTION
## One-line summary

This PR removes the `image` macro from the protocol card macro and replaces it with a single `image` argument where we can pass an image using one of the image helpers


## Issue / Bugzilla link

#12300 

## Testing

The following pages had the call to card updated:

To test this works:

- [ ] http://localhost:8000/firefox/features/tips
- [ ] http://localhost:8000/about
- [ ] http://localhost:8000/en-US/foundation/annualreport/2020/
- [ ] http://localhost:8000/en-US/diversity/2021/
- [ ] http://localhost:8000/en-US/diversity/2021/beyond-our-products/
- [ ] http://localhost:8000/en-US/diversity/2021/what-we-build/
- [ ] http://localhost:8000/en-US/diversity/2021/who-we-are/
- [ ] http://localhost:8000/en-US/moss/
- [ ] http://localhost:8000/en-US/newsletter/updated/
- [ ] http://localhost:8000/en-US/firefox/more/
- [ ] http://localhost:8000/en-US/firefox/pocket/
