### PR TITLE
Add light smoke/integration test for the VRC landing page to confirm it's OK

### DIFF
--- a/bedrock/products/templates/products/vpn/resource-center/landing.html
+++ b/bedrock/products/templates/products/vpn/resource-center/landing.html
@@ -43,7 +43,7 @@
     {# </div> #}
     {# {% endif %} #}
 
-  <div class="mzp-l-card-third">
+  <div class="mzp-l-card-third resource-center-articles">
     {% for article in first_article_group %}
       {% include "products/vpn/resource-center/includes/vpn-article-card.html" %}
     {% endfor %}

--- a/tests/functional/products/vpn/test_resource_center.py
+++ b/tests/functional/products/vpn/test_resource_center.py
@@ -22,3 +22,6 @@ def test_vpn_available_in_country(locale, base_url, selenium):
 
     # Light test that the VRC page renders at all
     assert page.is_resource_center_header_displayed
+
+    # ...and that it has at least one article
+    assert page.is_article_card_with_link_displayed

--- a/tests/functional/products/vpn/test_resource_center.py
+++ b/tests/functional/products/vpn/test_resource_center.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.products.vpn.resource_center import VPNResourceCenterHomePage
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize(
+    "locale",
+    [
+        ("en-US"),
+    ],
+)
+def test_vpn_available_in_country(locale, base_url, selenium):
+    page = VPNResourceCenterHomePage(
+        selenium,
+        base_url,
+    ).open()
+
+    # Light test that the VRC page renders at all
+    assert page.is_resource_center_header_displayed

--- a/tests/pages/products/vpn/resource_center.py
+++ b/tests/pages/products/vpn/resource_center.py
@@ -14,6 +14,13 @@ class VPNResourceCenterHomePage(BasePage):
     # Header unit
     _resource_center_header_locator = (By.CSS_SELECTOR, ".mzp-c-call-out.resource-center-page-header.resource-center-hero")
 
+    # Article link
+    _resource_center_article_link_locator = (By.CSS_SELECTOR, ".mzp-c-card a.mzp-c-card-block-link")
+
     @property
     def is_resource_center_header_displayed(self):
         return self.is_element_displayed(*self._resource_center_header_locator)
+
+    @property
+    def is_article_card_with_link_displayed(self):
+        return self.is_element_displayed(*self._resource_center_article_link_locator)

--- a/tests/pages/products/vpn/resource_center.py
+++ b/tests/pages/products/vpn/resource_center.py
@@ -15,7 +15,7 @@ class VPNResourceCenterHomePage(BasePage):
     _resource_center_header_locator = (By.CSS_SELECTOR, ".mzp-c-call-out.resource-center-page-header.resource-center-hero")
 
     # Article link
-    _resource_center_article_link_locator = (By.CSS_SELECTOR, ".mzp-c-card a.mzp-c-card-block-link")
+    _resource_center_article_link_locator = (By.CSS_SELECTOR, ".resource-center-articles .mzp-c-card a.mzp-c-card-block-link")
 
     @property
     def is_resource_center_header_displayed(self):

--- a/tests/pages/products/vpn/resource_center.py
+++ b/tests/pages/products/vpn/resource_center.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class VPNResourceCenterHomePage(BasePage):
+
+    _URL_TEMPLATE = "/{locale}/products/vpn/resource-center/"
+
+    # Header unit
+    _resource_center_header_locator = (By.CSS_SELECTOR, ".mzp-c-call-out.resource-center-page-header.resource-center-hero")
+
+    @property
+    def is_resource_center_header_displayed(self):
+        return self.is_element_displayed(*self._resource_center_header_locator)


### PR DESCRIPTION
## One-line summary

This will help keep an eye on the Contentful-powered VRC listing page post-rollout. 

However it's not foolproof because if the page breaks due to bad data, that might be triggered many minutes/hours after the tests are run.

## Checklist

If relevant:

- [X] Tests added

## Testing

To test this work:

- [ ] `npm start`
- [ ] `pytest -k test_resource_center --base-url=http://localhost:8080 --driver=Firefox` 
