### PR TITLE
Use https: protocol instead of deprecated git: protocol

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,7 @@ There are two primary methods of installing bedrock: Docker and Local. Whichever
 
 .. code-block:: bash
 
-    $ git clone git://github.com/mozilla/bedrock.git
+    $ git clone https://github.com/mozilla/bedrock.git
 
 .. code-block:: bash
 


### PR DESCRIPTION
👋 This is just a small documentation fix, so hopefully should be quick. GitHub no longer supports the `git://` protocol for cloning, this will fail. Instead, use the HTTPS protocol. See the [GitHub blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/) for more information.