### PR TITLE
Fix French string on /new page [bug #1799474]

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -111,7 +111,7 @@
     {% set features_section_title = 'Les <strong>dernières</strong> fonctionnalités de Firefox' %}
     {% set feature1_title = 'Reprenez où vous en étiez' %}
     {% set feature1_body = 'Firefox View vous permet de voir vos onglets ouverts sur d’autres appareils  et votre historique récent.' %}
-    {% set feature2_title = 'Éditez vos PDFs dans Firefox' %}
+    {% set feature2_title = 'Éditez vos PDF dans Firefox' %}
     {% set feature2_body = 'Finie l’impression des PDF. Modifiez vos formulaires directement dans Firefox.' %}
     {% set feature3_title = 'Naviguez en toute sécurité' %}
     {% set feature3_body = 'La protection totale contre les cookies de Firefox vous offre une confidentialité hors pair par défaut.' %}


### PR DESCRIPTION
## One-line summary
Acronyms aren’t pluralized with “s” in French.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1799474

## Testing
http://localhost:8000/fr/firefox/new/ 