### PR TITLE
Fix broken styles in /new-tab-learn-more

### DIFF
--- a/bedrock/pocket/templates/pocket/includes/footer.html
+++ b/bedrock/pocket/templates/pocket/includes/footer.html
@@ -85,7 +85,7 @@
             {{ ftl('pocket-footer-pocket-is-part-of-mozilla-family',
             mozorgabout='https://www.mozilla.org/about/') }}</p>
             <div class="legal" aria-label="{{ ftl('pocket-footer-aria-label-legal') }}">
-              <span>© 2021 {{ ftl ('pocket-footer-read-it-later-brand-name') }}</span>
+              <span>© {{ thisyear()}} {{ ftl ('pocket-footer-read-it-later-brand-name') }}</span>
               <a href="{{ url('pocket.privacy') }}?src=footer_v2">{{ ftl ('pocket-footer-privacy-policy') }}</a>
               <a href="{{ url('pocket.tos') }}?src=footer_v2">{{ ftl ('pocket-footer-terms-of-service') }}</a>
               <button id="ot-sdk-btn" class="ot-sdk-show-settings">{{ ftl ('pocket-footer-cookie-preferences') }}</button>

--- a/media/css/pocket/components/new-tab-learn-more.scss
+++ b/media/css/pocket/components/new-tab-learn-more.scss
@@ -13,6 +13,8 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
 
 @import '../utils/variables';
+@import '../includes/nav';
+@import '../includes/footer';
 
 // * -------------------------------------------------------------------------- */
 // Page Header


### PR DESCRIPTION
## One-line summary
Fixes broken style on the new tab learn more page and updates the year in the footer
## Testing
http://localhost:8000/en/firefox/new_tab_learn_more/
