### PR TITLE
Contribute card fix overflow (fixes #12343)

### DIFF
--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -98,6 +98,54 @@ $image-path: '/media/protocol/img';
             flex-wrap: wrap;
         }
 
+        // protocol override to avoid over-frequent word breaks
+        &.mzp-l-card-quarter .mzp-c-card {
+            @media #{$mq-lg} {
+                @include bidi((
+                    (float, left, right),
+                    (margin-left, 0, $spacing-xl),
+                    (margin-right, $spacing-xl, 0),
+                ));
+                width: calc(50% - (#{$spacing-xl} * 0.5));
+
+                &.mzp-c-card-extra-small,
+                &,
+                &.mzp-c-card-medium,
+                &.mzp-c-card-large {
+                    max-width: 100%;
+                }
+
+                &:nth-child(even) {
+                    margin-left: 0;
+                    margin-right: 0;
+                }
+            }
+            @media (min-width: 1100px) {
+                @include bidi((
+                    (margin-left, 0, $spacing-xl),
+                    (margin-right, $spacing-xl, 0),
+                ));
+                width: calc(25% - (#{$spacing-xl} - (#{$spacing-xl} * 0.25)));
+
+                &:nth-child(even) {
+                    @include bidi((
+                        (margin-left, 0, $spacing-xl),
+                        (margin-right, $spacing-xl, 0),
+                    ));
+                }
+
+                &:nth-child(4n) {
+                    @include bidi(((margin-right, 0, margin-left, 0),));
+                }
+
+                &:nth-child(4n+1) {
+                    @include bidi(((clear, left, right),));
+                }
+            }
+        }
+
+        // end override
+
         .contribute-card {
             display: flex;
             flex: 1 0 45%;

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -101,6 +101,7 @@ $image-path: '/media/protocol/img';
         .contribute-card {
             display: flex;
             flex: 1 0 45%;
+            overflow-wrap: break-word;
 
             @media #{$mq-md} {
                 flex: auto;
@@ -110,6 +111,7 @@ $image-path: '/media/protocol/img';
         .contribute-card-wrapper {
             display: flex;
             flex-direction: column;
+            max-width: 100%;
         }
 
         .contribute-card-content {

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -149,7 +149,6 @@ $image-path: '/media/protocol/img';
         .contribute-card {
             display: flex;
             flex: 1 0 45%;
-            overflow-wrap: break-word;
 
             @media #{$mq-md} {
                 flex: auto;
@@ -164,7 +163,21 @@ $image-path: '/media/protocol/img';
 
         .contribute-card-content {
             flex: 1;
+
+            // fallback when hyphens aren't supported
+            overflow-wrap: break-word;
             word-wrap: break-word; // IE specific overflow-wrap fix
+        }
+
+        @supports (hyphens: auto) {
+            .contribute-card-content {
+                overflow-wrap: unset;
+                word-wrap: unset;
+            }
+
+            .mzp-c-card-title {
+                hyphens: auto;
+            }
         }
     }
 }

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -116,6 +116,7 @@ $image-path: '/media/protocol/img';
 
         .contribute-card-content {
             flex: 1;
+            word-wrap: break-word; // IE specific overflow-wrap fix
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Sets overflow-wrap to break words that would otherwise overflow container.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12343


## Screenshots
<img width="1252" alt="headline-hyphens" src="https://user-images.githubusercontent.com/19650432/200812830-8cca3941-9d98-4eb4-8056-b39003f85b5c.png">



## Testing

Demo server URL: (or None)

To test this work:

- [ ] http://localhost:8000/de/contribute/
