### PR TITLE
Add English WNP for Firefox 107 [fix #12229]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/fx107/vpn-shopping.svg
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/fx107/vpn-shopping.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="543" height="238" viewBox="0 0 543 238">
+  <style>
+    .st0,.st3,.st6{fill:none;stroke:#000;stroke-width:2.2095}
+    .st0{stroke-miterlimit:10}
+    .st3,.st6{stroke-linecap:round;stroke-linejoin:round}
+    .st6{fill-rule:evenodd;clip-rule:evenodd;stroke-width:2.2095}
+    .invert-stroke { stroke: #000; }
+    .invert-fill { fill: #fff; }
+  </style>
+  <path d="M364.4 121V83.8c0-9.4 3.8-18.5 10.4-25.1 6.7-6.7 15.7-10.4 25.2-10.4 9.4 0 18.5 3.7 25.2 10.4 6.7 6.7 10.4 15.7 10.4 25.1V121h20.2V85.5c0-14.8-5.9-28.9-16.4-39.4C429 35.6 414.8 29.8 400 29.8c-14.8 0-29 5.9-39.5 16.3s-16.4 24.6-16.4 39.4V121h20.3z" class="st0 invert-stroke"/>
+  <path fill="#6f4ae7" class="invert-stroke" stroke-miterlimit="10" stroke-width="2.2095" d="M468.4 114.9H331.6c-5.8 0-10.5 4.7-10.5 10.5v99.5c0 5.8 4.7 10.5 10.5 10.5h136.9c5.8 0 10.5-4.7 10.5-10.5v-99.5c0-5.8-4.7-10.5-10.6-10.5zM415 174.1c-1.4 2.5-3.4 4.7-5.9 6.2v12.1c0 2.4-1 4.7-2.7 6.4-1.7 1.7-4 2.7-6.4 2.7-2.4 0-4.7-1-6.4-2.7-1.7-1.7-2.7-4-2.7-6.4v-12.1c-2.5-1.6-4.6-3.8-6-6.4-1.4-2.6-2.1-5.6-2-8.5.1-3 .9-5.9 2.5-8.4 1.5-2.5 3.7-4.6 6.3-6 2.6-1.4 5.5-2.2 8.5-2.1 3 0 5.9.9 8.4 2.4 2.6 1.5 4.7 3.7 6.2 6.2 1.5 2.6 2.2 5.5 2.2 8.5.1 2.8-.6 5.6-2 8.1z"/>
+  <path fill="#a77ffa" d="M108.5 236.1V81.7h126v154.6l-126-.2z"/>
+  <path d="M200 80.4V61.1c0-13.9-11.3-25.2-25.2-25.2-14 0-25.2 11.3-25.2 25.2v19.3" class="st3 invert-stroke"/>
+  <path d="M174.8 80.4V61.1c0-13.9-11.3-25.2-25.2-25.2-14 0-25.2 11.3-25.2 25.2v19.3" class="st3 invert-stroke"/>
+  <path d="M85.7 80.4 86.8 215 66 235.8V80.4h169.9v101.1" class="st3 invert-stroke"/>
+  <path d="m86.8 215 21.1 21.1V80.4" class="st3 invert-stroke"/>
+  <path d="M300.6 133.8v-15c0-15.1-12.2-27.3-27.3-27.3-15.1 0-27.3 12.2-27.3 27.3v15" class="st3 invert-stroke"/>
+  <path class="invert-fill" d="M336.2 140.8v-6.4h-125v6.4"/>
+  <path d="M336.2 140.8v-6.4h-125v6.4" class="st3 invert-stroke"/>
+  <path fill="#b5b5ff" d="m357 236.3-16-95.1H205.4l-16 95.1"/>
+  <path d="m357 236.3-16-95.1H205.4l-16 95.1" class="st0 invert-stroke"/>
+  <path d="m216.7 236.3 16.5-95.1" class="st0 invert-stroke"/>
+  <path d="M2 236.3h519.9" class="st3 invert-stroke"/>
+  <path d="M136.2 1.1v12" class="st3 invert-stroke"/>
+  <path d="M142.2 7.1h-12" class="st3 invert-stroke"/>
+  <path d="M23.5 128.5v12" class="st3 invert-stroke"/>
+  <path d="M29.5 134.5h-12" class="st3 invert-stroke"/>
+  <path d="M291.9 36.6c3.4 0 6.2-2.8 6.2-6.2s-2.8-6.2-6.2-6.2c-3.4 0-6.2 2.8-6.2 6.2s2.7 6.2 6.2 6.2z" class="st0 invert-stroke"/>
+  <path d="m505 124 14.8-16" class="st6 invert-stroke"/>
+  <path d="m518.8 146 20.8-6.6" class="st6 invert-stroke"/>
+  <path d="m519.8 171.6 21.6 4.6" class="st6 invert-stroke"/>
+  <path d="m508 194.5 16 14.9" class="st6 invert-stroke"/>
+</svg>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx107-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx107-en.html
@@ -42,20 +42,25 @@
     }}
   </p>
 
-  <aside class="c-coupon">
-    <h3>Use code at checkout for 20% off</h3>
-    <p>
-      <strong class="c-coupon-code">VPNHOLIDAY20</strong>
-      <button type="button" class="c-coupon-copy" id="code-copy" data-code="VPNHOLIDAY20" data-success="Code copied!">Copy code</button>
-    </p>
+  {% if switch('firefox_whatsnew_107_en_coupon') %}
+    <aside class="c-coupon">
+      <h3>Use code at checkout for 20% off</h3>
+      <p>
+        <strong class="c-coupon-code">VPNHOLIDAY20</strong>
+        <button type="button" class="c-coupon-copy" id="code-copy" data-cta-type="button" data-cta-text="Copy code" data-code="VPNHOLIDAY20" data-success="Code copied!">Copy code</button>
+      </p>
 
-    <p class="c-disclaimer">Available for annual plan subscribers.</p>
-  </aside>
+      <p class="c-disclaimer">Available for annual plan subscribers.</p>
+    </aside>
+  {% endif %}
 
 </section>
 {% endblock %}
 
 {% block js %}
   {{ js_bundle('firefox_whatsnew') }}
-  {{ js_bundle('firefox_whatsnew_107_en') }}
+
+  {% if switch('firefox_whatsnew_107_en_coupon') %}
+    {{ js_bundle('firefox_whatsnew_107_en') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx107-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx107-en.html
@@ -1,0 +1,61 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_107_en') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+<section class="wnp-content-main mzp-l-content mzp-t-content-lg">
+  <div class="wnp-main-img">
+    {% include 'firefox/whatsnew/includes/fx107/vpn-shopping.svg' %}
+  </div>
+
+  <h2 class="wnp-main-title">Privacy is the gift of the season</h2>
+  <h3 class="wnp-sub-title">Get Mozilla VPN</h3>
+
+  <p class="wnp-main-tagline">
+    With travel logistics, holiday parties and gift ideas — you have too much on
+    your plate to worry about privacy. Mozilla VPN protects your location and
+    browsing activity when you’re online, so you can have peace of mind.
+  </p>
+
+  <p class="wnp-main-cta">
+    {{ vpn_product_referral_link(
+      referral_id='whatsnew-107-en',
+      link_text='Get Mozilla VPN',
+      class_name='mzp-t-product',
+      optional_attributes= {
+          'data-cta-text' : 'Get Mozilla VPN',
+          'data-cta-type' : 'button'
+      })
+    }}
+  </p>
+
+  <aside class="c-coupon">
+    <h3>Use code at checkout for 20% off</h3>
+    <p>
+      <strong class="c-coupon-code">VPNHOLIDAY20</strong>
+      <button type="button" class="c-coupon-copy" id="code-copy" data-code="VPNHOLIDAY20" data-success="Code copied!">Copy code</button>
+    </p>
+
+    <p class="c-disclaimer">Available for annual plan subscribers.</p>
+  </aside>
+
+</section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew') }}
+  {{ js_bundle('firefox_whatsnew_107_en') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -871,6 +871,28 @@ class TestWhatsNew(TestCase):
 
     # end 105.0 whatsnew tests
 
+    # begin 107.0 whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_107_0_0_en(self, render_mock):
+        """Should use whatsnew-fx105-en template for en-US locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-US"
+        self.view(req, version="107.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx107-en.html"]
+
+    @override_settings(DEV=False)
+    def test_fx_107_0_0_default(self, render_mock):
+        """Should use default whatsnew template for other locales"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "es-ES"
+        self.view(req, version="107.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/index.html"]
+
+    # end 107.0 whatsnew tests
+
 
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
 class TestFirstRun(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -492,6 +492,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx105-fr.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx105-de-1.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx105-de-2.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx107-en.html": ["firefox/whatsnew/whatsnew"],
     }
 
     # specific templates that should not be rendered in
@@ -510,6 +511,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx104-vpn-de-coupon.html",
         "firefox/whatsnew/whatsnew-fx104-vpn-fr.html",
         "firefox/whatsnew/whatsnew-fx104-vpn-fr-coupon.html",
+        "firefox/whatsnew/whatsnew-fx107-en.html",
     ]
 
     # place expected ?v= values in this list
@@ -582,6 +584,11 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/developer/whatsnew.html"
             elif show_57_dev_whatsnew(version):
                 template = "firefox/developer/whatsnew.html"
+            else:
+                template = "firefox/whatsnew/index.html"
+        elif version.startswith("107."):
+            if locale.startswith("en-"):
+                template = "firefox/whatsnew/whatsnew-fx107-en.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("105."):

--- a/media/css/firefox/whatsnew/whatsnew-107-en.scss
+++ b/media/css/firefox/whatsnew/whatsnew-107-en.scss
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/components/section-heading';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import 'includes/base';
+@import 'includes/dark-mode';
+
+// * -------------------------------------------------------------------------- */
+// Main content
+.wnp-content-main {
+    padding-top: $spacing-md;
+    text-align: center;
+}
+
+.wnp-main-title {
+    @include text-title-md;
+}
+
+.wnp-sub-title {
+    @include text-title-md;
+    color: #a77ffa;
+}
+
+.wnp-main-img {
+    max-width: $content-md;
+    margin: $layout-sm auto $layout-lg;
+
+    svg {
+        width: 100%;
+        height: auto;
+    }
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+    max-width: $content-md;
+    margin: $spacing-xl auto;
+}
+
+.wnp-main-cta {
+    margin-top: $spacing-xl;
+}
+
+.c-coupon {
+    background: #c3c4fd;
+    border-radius: $border-radius-sm;
+    color: $color-black;
+    margin: $layout-lg auto 0;
+    max-width: $content-md;
+    padding: $spacing-xl;
+
+    h3 {
+        @include text-title-2xs;
+        color: $color-black;
+        margin-bottom: $spacing-lg;
+    }
+
+    .c-disclaimer {
+        @include text-body-xs;
+        margin-bottom: 0;
+    }
+
+    .c-coupon-code {
+        @include text-body-xl;
+        border-radius: $border-radius-sm;
+        border: 1px solid $color-black;
+        display: inline-block;
+        font-weight: normal;
+        padding: $spacing-sm $spacing-md;
+    }
+
+    .c-coupon-copy {
+        @include text-body-sm;
+        appearance: none;
+        background: transparent none;
+        border: 0;
+        cursor: pointer;
+        display: block;
+        margin: 0 auto;
+        text-decoration: underline;
+
+        &:hover,
+        &:focus {
+            font-weight: bold;
+            text-decoration: underline;
+        }
+    }
+}
+
+// * -------------------------------------------------------------------------- */
+// For dark mode
+@media (prefers-color-scheme: dark) {
+    .wnp-main-title {
+        color: get-theme('title-text-color-inverse');
+    }
+
+    .wnp-sub-title {
+        color: #a77ffa;
+    }
+
+    .wnp-main-img {
+        .invert-stroke {
+            stroke: #fff;
+        }
+
+        .invert-fill {
+            fill: $color-violet-60;
+        }
+    }
+}

--- a/media/css/firefox/whatsnew/whatsnew-107-en.scss
+++ b/media/css/firefox/whatsnew/whatsnew-107-en.scss
@@ -82,7 +82,7 @@ $image-path: '/media/protocol/img';
         border: 0;
         cursor: pointer;
         display: block;
-        margin: 0 auto;
+        margin: $spacing-xs auto 0;
         text-decoration: underline;
 
         &:hover,

--- a/media/js/firefox/whatsnew/whatsnew-107-en.js
+++ b/media/js/firefox/whatsnew/whatsnew-107-en.js
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+(function () {
+    'use strict';
+
+    var copyButton = document.getElementById('code-copy');
+
+    copyButton.addEventListener('click', copyCouponCode);
+
+    async function copyCouponCode() {
+        let couponCode = copyButton.dataset.code;
+        let successMsg = copyButton.dataset.success;
+
+        try {
+            await navigator.clipboard.writeText(couponCode);
+            copyButton.textContent = successMsg;
+        } catch (e) {
+            //do nothing
+        }
+    }
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -505,6 +505,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-107-en.scss"
+      ],
+      "name": "firefox_whatsnew_107_en"
+    },
+    {
+      "files": [
         "css/firefox/privacy/common.scss"
       ],
       "name": "firefox-privacy-common"
@@ -1639,6 +1645,12 @@
         "js/firefox/whatsnew/whatsnew-104-vpn-coupon.js"
       ],
       "name": "firefox_whatsnew_104_vpn_coupon"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-107-en.js"
+      ],
+      "name": "firefox_whatsnew_107_en"
     },
     {
       "files": [


### PR DESCRIPTION
## One-line summary
Adds the English what's new page for Firefox 107 (I'm not sure if the EU team wants a different page shown in the UK, but I'm assuming for now this one is for all Englishes and not just US and CA). @maureenlholland is working on the EU pages.

## Issue / Bugzilla link
#12229 

## Testing
http://localhost:8000/en-US/firefox/107.0/whatsnew/