### PR TITLE
Remove image macro from split (/firefox)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import image with context %}
+{% from "macros.html" import image as image_macro with context %}
 
 
 {# Billboard: https://protocol.mozilla.org/patterns/organisms/billboard.html #}
@@ -64,7 +64,7 @@
   </div>
   {% if image_url %}
     <div class="mzp-c-hero-image">
-      {{ image(
+      {{ image_macro(
         url=image_url,
         alt=image_alt,
         loading=loading,
@@ -97,7 +97,8 @@
   media_class=None,
   media_include=None,
   mobile_class=None,
-  theme_class=None
+  theme_class=None,
+  image=None
 ) -%}
 <{{base_el}}{% if block_id %} id="{{ block_id }}"{% endif %} class="mzp-c-split{% if block_class %} {{ block_class }}{% endif %}{% if mobile_class %} {{ mobile_class }}{% endif %}">
   {% if theme_class %}
@@ -105,21 +106,25 @@
   {% endif %}
   <div class="mzp-c-split-container">
     {% if not media_after %}
-      {% if image_url %}
+      {% if image_url or image %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
-          {{ image(
-            alt=image_alt,
-            class='mzp-c-split-media-asset',
-            height=image_height,
-            include_highres=include_highres_image,
-            include_l10n=l10n_image,
-            loading=loading,
-            sizes=image_sizes,
-            sources=image_sources,
-            srcset=image_srcset,
-            url=image_url,
-            width=image_width
-          ) }}
+          {% if image_url %}
+            {{ image_macro(
+              alt=image_alt,
+              class='mzp-c-split-media-asset',
+              height=image_height,
+              include_highres=include_highres_image,
+              include_l10n=l10n_image,
+              loading=loading,
+              sizes=image_sizes,
+              sources=image_sources,
+              srcset=image_srcset,
+              url=image_url,
+              width=image_width
+            ) }}
+          {% else %}
+            {{ image }}
+          {% endif %}
         </div>
       {% elif media_include %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
@@ -131,9 +136,10 @@
       {{ caller() }}
     </div>
     {% if media_after %}
-      {% if image_url %}
+      {% if image_url or image %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
-          {{ image(
+           {% if image_url %}
+            {{ image_macro(
             alt=image_alt,
             class='mzp-c-split-media-asset',
             height=image_height,
@@ -146,6 +152,9 @@
             url=image_url,
             width=image_width
           ) }}
+          {% else %}
+            {{ image }}
+          {% endif %}
         </div>
       {% elif media_include %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
@@ -292,7 +301,7 @@
 ) -%}
 <{{ base_el }} class="mzp-c-picto{% if class %} {{ class }}{% endif %}">
   {% if image_url %}
-  {{ image(
+  {{ image_macro(
       alt=image_alt,
       class='mzp-c-picto-image',
       height=image_height,

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -27,7 +27,10 @@
 
 {% block content %}
   {% call split(
-    image=resp_img('img/firefox/browsers/quantum/browser.jpg', srcset={ 'img/firefox/browsers/quantum/browser.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+    image=resp_img('img/firefox/browsers/quantum/browser.jpg',
+      srcset={ 'img/firefox/browsers/quantum/browser-high-res.jpg': '2x' },
+      optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+    ),
     media_after=True,
     block_class='mzp-l-split-hide-media-on-sm-md',
     media_class='mzp-l-split-h-center'
@@ -58,7 +61,10 @@
   <section>
     <h2 class="mzp-c-section-heading">{{ ftl('browsers-chromebook-why-get-firefox') }}</h2>
     {% call split(
-      image=resp_img('img/firefox/browsers/chromebook/shield.png', srcset={ 'img/firefox/browsers/chromebook/shield.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+      image=resp_img('img/firefox/browsers/chromebook/shield.png',
+        srcset={ 'img/firefox/browsers/chromebook/shield-high-res.png': '2x' },
+        optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+      ),
     ) %}
       <p>{{ ftl('browsers-chromebook-while-a-chromebook') }}</p>
       <ul class="mzp-u-list-styled">

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -27,8 +27,7 @@
 
 {% block content %}
   {% call split(
-    image_url='img/firefox/browsers/quantum/browser.jpg',
-    include_highres_image=True,
+    image=resp_img('img/firefox/browsers/quantum/browser.jpg', srcset={ 'img/firefox/browsers/quantum/browser.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     media_after=True,
     block_class='mzp-l-split-hide-media-on-sm-md',
     media_class='mzp-l-split-h-center'
@@ -59,8 +58,7 @@
   <section>
     <h2 class="mzp-c-section-heading">{{ ftl('browsers-chromebook-why-get-firefox') }}</h2>
     {% call split(
-      image_url='img/firefox/browsers/chromebook/shield.png',
-      include_highres_image=True
+      image=resp_img('img/firefox/browsers/chromebook/shield.png', srcset={ 'img/firefox/browsers/chromebook/shield.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     ) %}
       <p>{{ ftl('browsers-chromebook-while-a-chromebook') }}</p>
       <ul class="mzp-u-list-styled">

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -60,21 +60,23 @@
 {% block content %}
 <main role="main">
   {% call split(
-    image_url='img/firefox/browsers/hero-700.jpg',
-    image_srcset={
+    image=resp_img('img/firefox/browsers/hero-700.jpg',
+    srcset={
       'img/firefox/browsers/hero-500.jpg': '500w',
       'img/firefox/browsers/hero-700.jpg': '700w',
       'img/firefox/browsers/hero-900.jpg': '900w',
       'img/firefox/browsers/hero-1100.jpg': '1100w',
       'img/firefox/browsers/hero-1300.jpg': '1300w',
     },
-    image_sizes={
+    sizes={
       '(min-width: 768px)': 'calc(50vw - 192px)',
       'default': 'calc(100vw - 48px)'
     },
-    image_width='680',
-    image_height='420',
-    include_highres_image=True,
+    optional_attributes={
+      'class': 'mzp-c-split-media-asset',
+      'height': '420',
+      'width': '680'
+    }),
     block_class='c-landing-banner mzp-l-split-center-on-sm-md',
     media_class='mzp-l-split-media-overflow',
     media_after=True

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -61,22 +61,23 @@
 <main role="main">
   {% call split(
     image=resp_img('img/firefox/browsers/hero-700.jpg',
-    srcset={
-      'img/firefox/browsers/hero-500.jpg': '500w',
-      'img/firefox/browsers/hero-700.jpg': '700w',
-      'img/firefox/browsers/hero-900.jpg': '900w',
-      'img/firefox/browsers/hero-1100.jpg': '1100w',
-      'img/firefox/browsers/hero-1300.jpg': '1300w',
-    },
-    sizes={
-      '(min-width: 768px)': 'calc(50vw - 192px)',
-      'default': 'calc(100vw - 48px)'
-    },
-    optional_attributes={
-      'class': 'mzp-c-split-media-asset',
-      'height': '420',
-      'width': '680'
-    }),
+      srcset={
+        'img/firefox/browsers/hero-500.jpg': '500w',
+        'img/firefox/browsers/hero-700.jpg': '700w',
+        'img/firefox/browsers/hero-900.jpg': '900w',
+        'img/firefox/browsers/hero-1100.jpg': '1100w',
+        'img/firefox/browsers/hero-1300.jpg': '1300w',
+      },
+      sizes={
+        '(min-width: 768px)': 'calc(50vw - 192px)',
+        'default': 'calc(100vw - 48px)'
+      },
+      optional_attributes={
+        'class': 'mzp-c-split-media-asset',
+        'height': '420',
+        'width': '680'
+      }
+    ),
     block_class='c-landing-banner mzp-l-split-center-on-sm-md',
     media_class='mzp-l-split-media-overflow',
     media_after=True

--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -81,7 +81,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/fast-and-private.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/fast-and-private.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -90,7 +90,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/one-tap-to-private-mode.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/one-tap-to-private-mode.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-android-one-tap-to') }}</h3>
@@ -98,7 +98,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/search-your-own-way.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/search-your-own-way.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -107,7 +107,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/save-power-with-dark-mode.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/save-power-with-dark-mode.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-android-save-power-with') }}</h3>
@@ -115,7 +115,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/easily-organize-your-tabs.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/easily-organize-your-tabs.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -124,7 +124,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/supercharge-firefox-with-add-ons.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/supercharge-firefox-with-add-ons.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-android-supercharge-firefox-with') }}</h3>
@@ -132,7 +132,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/pick-up-where-you-left-off.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/pick-up-where-you-left-off.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -141,7 +141,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/search-from-your-phones-home-screen.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/search-from-your-phones-home-screen.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-android-search-from-your') }}</h3>
@@ -149,7 +149,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/android/pin-videos-to-your-screen.svg',
+    image=resp_img('img/firefox/browsers/mobile/android/pin-videos-to-your-screen.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -158,19 +158,21 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/about-hero-800.png',
-    image_srcset={
+    image=resp_img('img/firefox/browsers/mobile/about-hero-800.png',
+    srcset={
       'img/firefox/browsers/mobile/about-hero-500.png': '500w',
       'img/firefox/browsers/mobile/about-hero-800.png': '800w',
       'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
     },
-    image_sizes={
+    sizes={
       '(min-width: 768px)': '760px',
       'default': '250px'
     },
-    image_width='760',
-    image_height='664',
-    include_highres_image=True,
+    optional_attributes={
+      'class': 'mzp-c-split-media-asset',
+      'height': '664',
+      'width': '760'
+    }),
     block_class='about-mozilla mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-h-center',

--- a/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
@@ -27,7 +27,7 @@
 
 {% block content %}
 {% call split(
-  image_url='img/firefox/browsers/mobile/index/compare-mobile-browsers.svg',
+  image=resp_img('img/firefox/browsers/mobile/index/compare-mobile-browsers.svg', optional_attributes={  'class': 'mzp-c-split-media-asset' }),
   media_after=True,
   media_class='mzp-l-split-h-center'
 ) %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
@@ -127,25 +127,26 @@
 
   {% call split(
     image=resp_img('img/firefox/browsers/mobile/about-hero-800.png',
-    srcset={
-      'img/firefox/browsers/mobile/about-hero-500.png': '500w',
-      'img/firefox/browsers/mobile/about-hero-800.png': '800w',
-      'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
-    },
-    image_sizes={
-      '(min-width: 768px)': '760px',
-      'default': '250px'
-    },
-    optional_attributes={
-      'class': 'mzp-c-split-media-asset',
-      'height': '664',
-      'width': '760'
-    }),
+      srcset={
+        'img/firefox/browsers/mobile/about-hero-500.png': '500w',
+        'img/firefox/browsers/mobile/about-hero-800.png': '800w',
+        'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
+      },
+      image_sizes={
+        '(min-width: 768px)': '760px',
+        'default': '250px'
+      },
+      optional_attributes={
+        'class': 'mzp-c-split-media-asset',
+        'height': '664',
+        'width': '760'
+        'loading': 'lazy'
+      }
+    ),
     block_class='about-mozilla mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-h-center',
     media_after=True,
-    loading='lazy'
   ) %}
     <h3>{{ ftl('mobile-focus-made-by-mozilla') }}</h3>
     <p>{{ ftl('mobile-focus-we-believe-everyone') }}</p>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
@@ -83,7 +83,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/focus/disappear-your-history.svg',
+    image=resp_img('img/firefox/browsers/mobile/focus/disappear-your-history.svg', { 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -92,7 +92,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/focus/take-private-mode-to-the-next-level.svg',
+    image=resp_img('img/firefox/browsers/mobile/focus/take-private-mode-to-the-next-level.svg', { 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-focus-take-private-mode') }}</h3>
@@ -100,7 +100,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/focus/tracking-protection.svg',
+    image=resp_img('img/firefox/browsers/mobile/focus/tracking-protection.svg', { 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -109,7 +109,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/focus/ad-blocking.svg',
+    image=resp_img('img/firefox/browsers/mobile/focus/ad-blocking.svg', { 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl',
   ) %}
     <h3>{{ ftl('mobile-focus-ad-blocking') }}</h3>
@@ -117,7 +117,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/focus/see-it-all-faster.svg',
+    image=resp_img('img/firefox/browsers/mobile/focus/see-it-all-faster.svg', { 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -126,8 +126,8 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/about-hero-800.png',
-    image_srcset={
+    image=resp_img('img/firefox/browsers/mobile/about-hero-800.png',
+    srcset={
       'img/firefox/browsers/mobile/about-hero-500.png': '500w',
       'img/firefox/browsers/mobile/about-hero-800.png': '800w',
       'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
@@ -136,9 +136,11 @@
       '(min-width: 768px)': '760px',
       'default': '250px'
     },
-    image_width='760',
-    image_height='664',
-    include_highres_image=True,
+    optional_attributes={
+      'class': 'mzp-c-split-media-asset',
+      'height': '664',
+      'width': '760'
+    }),
     block_class='about-mozilla mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-h-center',

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -44,22 +44,23 @@
 <main role="main">
   {% call split(
     image=resp_img('img/firefox/browsers/hero-500.jpg',
-    srcset={
-      'img/firefox/browsers/hero-500.jpg': '500w',
-      'img/firefox/browsers/hero-700.jpg': '700w',
-      'img/firefox/browsers/hero-900.jpg': '900w',
-      'img/firefox/browsers/hero-1100.jpg': '1100w',
-      'img/firefox/browsers/hero-1300.jpg': '1300w',
-    },
-    sizes={
-      '(min-width: 768px)': 'calc(50vw - 192px)',
-      'default': 'calc(100vw - 48px)'
-    },
-    optional_attributes={
-      'class': 'mzp-c-split-media-asset',
-      'height': '420',
-      'width': '680'
-    }),
+      srcset={
+        'img/firefox/browsers/hero-500.jpg': '500w',
+        'img/firefox/browsers/hero-700.jpg': '700w',
+        'img/firefox/browsers/hero-900.jpg': '900w',
+        'img/firefox/browsers/hero-1100.jpg': '1100w',
+        'img/firefox/browsers/hero-1300.jpg': '1300w',
+      },
+      sizes={
+        '(min-width: 768px)': 'calc(50vw - 192px)',
+        'default': 'calc(100vw - 48px)'
+      },
+      optional_attributes={
+        'class': 'mzp-c-split-media-asset',
+        'height': '420',
+        'width': '680'
+      }
+    ),
     block_class='mzp-has-media-hide mzp-l-split-center-on-sm-md',
     body_class='mzp-l-v-center',
     media_class='mzp-l-fit-flush mzp-l-constrain-height'
@@ -122,7 +123,10 @@
 
     <div class="c-landing-grid-item c-landing-grid-wide">
       {% call split(
-        image=resp_img('img/firefox/browsers/dev.png', srcset={ 'img/firefox/browsers/dev.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+        image=resp_img('img/firefox/browsers/dev.png',
+          srcset={ 'img/firefox/browsers/dev-high-res.png': '2x' },
+          optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+        ),
         block_class='t-compare'
       ) %}
         <h2>{{ ftl('browsers-mobile-see-how-firefox-for-desktop-compare') }}</h2>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -43,20 +43,23 @@
 {% block content %}
 <main role="main">
   {% call split(
-    image_url='img/firefox/browsers/hero-500.jpg',
-    image_srcset={
+    image=resp_img('img/firefox/browsers/hero-500.jpg',
+    srcset={
       'img/firefox/browsers/hero-500.jpg': '500w',
       'img/firefox/browsers/hero-700.jpg': '700w',
       'img/firefox/browsers/hero-900.jpg': '900w',
       'img/firefox/browsers/hero-1100.jpg': '1100w',
       'img/firefox/browsers/hero-1300.jpg': '1300w',
     },
-    image_sizes={
+    sizes={
       '(min-width: 768px)': 'calc(50vw - 192px)',
       'default': 'calc(100vw - 48px)'
     },
-    image_width='680',
-    image_height='420',
+    optional_attributes={
+      'class': 'mzp-c-split-media-asset',
+      'height': '420',
+      'width': '680'
+    }),
     block_class='mzp-has-media-hide mzp-l-split-center-on-sm-md',
     body_class='mzp-l-v-center',
     media_class='mzp-l-fit-flush mzp-l-constrain-height'
@@ -119,8 +122,7 @@
 
     <div class="c-landing-grid-item c-landing-grid-wide">
       {% call split(
-        image_url='img/firefox/browsers/dev.png',
-        include_highres_image=True,
+        image=resp_img('img/firefox/browsers/dev.png', srcset={ 'img/firefox/browsers/dev.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
         block_class='t-compare'
       ) %}
         <h2>{{ ftl('browsers-mobile-see-how-firefox-for-desktop-compare') }}</h2>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -134,26 +134,26 @@
 
   {% call split(
     image=resp_img('img/firefox/browsers/mobile/about-hero-800.png',
-    srcset={
-      'img/firefox/browsers/mobile/about-hero-500.png': '500w',
-      'img/firefox/browsers/mobile/about-hero-800.png': '800w',
-      'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
-    },
-    sizes={
-      '(min-width: 768px)': '760px',
-      'default': '250px'
-    },
-    optional_attributes={
-      'class': 'mzp-c-split-media-asset',
-      'height': '664',
-      'width': '760'
-
-    }),
+      srcset={
+        'img/firefox/browsers/mobile/about-hero-500.png': '500w',
+        'img/firefox/browsers/mobile/about-hero-800.png': '800w',
+        'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
+      },
+      sizes={
+        '(min-width: 768px)': '760px',
+        'default': '250px'
+      },
+      optional_attributes={
+        'class': 'mzp-c-split-media-asset',
+        'height': '664',
+        'width': '760',
+        'loading': 'lazy'
+      }
+    ),
     block_class='about-mozilla mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-h-center',
-    media_after=True,
-    loading='lazy'
+    media_after=True
   ) %}
     <h3>{{ ftl('mobile-ios-about-mozilla') }}</h3>
     <p>{{ ftl('mobile-ios-mozilla-exists-to') }}</p>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -65,7 +65,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/make-firefox-your-default-browser.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/make-firefox-your-default-browser.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -74,7 +74,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/fast-private-secure.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/fast-private-secure.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl'
   ) %}
     <h3>{{ ftl('mobile-ios-fast-private-secure') }}</h3>
@@ -82,7 +82,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/stay-private-online.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/stay-private-online.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -91,7 +91,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/your-browser-history-is-history.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/your-browser-history-is-history.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl'
   ) %}
     <h3>{{ ftl('mobile-ios-your-browsing-history') }}</h3>
@@ -99,7 +99,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/get-more-firefox-in-your-life.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/get-more-firefox-in-your-life.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -108,7 +108,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/find-it-all-faster.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/find-it-all-faster.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl'
   ) %}
     <h3>{{ ftl('mobile-ios-find-it-all') }}</h3>
@@ -116,7 +116,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/keep-tabs-on-all-those-tabs.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/keep-tabs-on-all-those-tabs.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-background-secondary'
   ) %}
@@ -125,7 +125,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/ios/discover-more-of-what-you-love.svg',
+    image=resp_img('img/firefox/browsers/mobile/ios/discover-more-of-what-you-love.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl'
   ) %}
     <h3>{{ ftl('mobile-ios-discover-more-of') }}</h3>
@@ -133,19 +133,22 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/browsers/mobile/about-hero-800.png',
-    image_srcset={
+    image=resp_img('img/firefox/browsers/mobile/about-hero-800.png',
+    srcset={
       'img/firefox/browsers/mobile/about-hero-500.png': '500w',
       'img/firefox/browsers/mobile/about-hero-800.png': '800w',
       'img/firefox/browsers/mobile/about-hero-1100.png': '1100w'
     },
-    image_sizes={
+    sizes={
       '(min-width: 768px)': '760px',
       'default': '250px'
     },
-    image_width='760',
-    image_height='664',
-    include_highres_image=True,
+    optional_attributes={
+      'class': 'mzp-c-split-media-asset',
+      'height': '664',
+      'width': '760'
+
+    }),
     block_class='about-mozilla mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-h-center',

--- a/bedrock/firefox/templates/firefox/browsers/quantum.html
+++ b/bedrock/firefox/templates/firefox/browsers/quantum.html
@@ -21,8 +21,7 @@
 {% block content %}
 
 {% call split(
-    image_url='img/firefox/browsers/quantum/browser.jpg',
-    include_highres_image=True,
+    image=resp_img('img/firefox/browsers/quantum/browser.jpg', srcset={ 'img/firefox/browsers/quantum/browser.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
     media_after=True,
     media_class='mzp-l-split-h-center',
     block_class='mzp-l-split-hide-media-on-sm-md'

--- a/bedrock/firefox/templates/firefox/browsers/quantum.html
+++ b/bedrock/firefox/templates/firefox/browsers/quantum.html
@@ -21,7 +21,10 @@
 {% block content %}
 
 {% call split(
-    image=resp_img('img/firefox/browsers/quantum/browser.jpg', srcset={ 'img/firefox/browsers/quantum/browser.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
+    image=resp_img('img/firefox/browsers/quantum/browser.jpg',
+      srcset={ 'img/firefox/browsers/quantum/browser-high-res.jpg': '2x' },
+      optional_attributes={ 'class': 'mzp-c-split-media-asset' }
+    ),
     media_after=True,
     media_class='mzp-l-split-h-center',
     block_class='mzp-l-split-hide-media-on-sm-md'

--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -8,7 +8,7 @@
 
 {% call split(
   block_id='fordevs',
-  image_url='img/firefox/developer/stylo-engine.svg',
+  image=resp_img('img/firefox/developer/stylo-engine.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   block_class='t-performance'
 ) %}
   <h2 class="c-title">{{ ftl('firefox-developer-firefox-browser') }}</h2>

--- a/bedrock/firefox/templates/firefox/developer/includes/nightly.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/nightly.html
@@ -7,9 +7,10 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% call split(
-  image=resp_img('img/firefox/developer/browser-nightly.png', srcset={ 'img/firefox/developer/browser-nightly.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'})
-  image_url='img/firefox/developer/browser-nightly.png',
-  include_highres_image=True,
+  image=resp_img('img/firefox/developer/browser-nightly.png',
+    srcset={ 'img/firefox/developer/browser-nightly-high-res.png': '2x' },
+    optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+  ),
   block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md',
   media_after=True
 ) %}

--- a/bedrock/firefox/templates/firefox/developer/includes/nightly.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/nightly.html
@@ -7,6 +7,7 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% call split(
+  image=resp_img('img/firefox/developer/browser-nightly.png', srcset={ 'img/firefox/developer/browser-nightly.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'})
   image_url='img/firefox/developer/browser-nightly.png',
   include_highres_image=True,
   block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md',

--- a/bedrock/firefox/templates/firefox/developer/includes/performance.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/performance.html
@@ -8,7 +8,7 @@
 
 {% call split(
   block_id='fordevs',
-  image_url='img/firefox/developer/stylo-engine.svg',
+  image=resp_img('img/firefox/developer/stylo-engine.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   block_class='t-performance'
 ) %}
   <h2 class="c-title">{{ ftl('firefox-developer-faster-performance') }}</h2>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -85,7 +85,7 @@
     {% include '/firefox/developer/includes/engage.html' %}
 
     {% call split(
-      image_url='img/firefox/developer/browser.png',
+      image=resp_img('img/firefox/developer/browser.png', srcset={ 'img/firefox/developer/browser.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
       include_highres_image=True,
       block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md',
       media_after=True

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -85,8 +85,10 @@
     {% include '/firefox/developer/includes/engage.html' %}
 
     {% call split(
-      image=resp_img('img/firefox/developer/browser.png', srcset={ 'img/firefox/developer/browser.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset' }),
-      include_highres_image=True,
+      image=resp_img('img/firefox/developer/browser.png',
+        srcset={ 'img/firefox/developer/browser-high-res.png': '2x' },
+        optional_attributes={ 'class': 'mzp-c-split-media-asset' }
+      ),
       block_class='mzp-l-split-reversed mzp-l-split-center-on-sm-md',
       media_after=True
     ) %}

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -51,7 +51,7 @@
 {% block content %}
 <main role="main">
   {% call split(
-    image_url='img/firefox/enterprise/fx-browser-img.svg',
+    image=resp_img('img/firefox/enterprise/fx-browser-img.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-dark t-enterprise mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
     media_class='mzp-l-split-v-start mzp-l-split-h-start',
     media_after=True

--- a/bedrock/firefox/templates/firefox/features/bookmarks.html
+++ b/bedrock/firefox/templates/firefox/features/bookmarks.html
@@ -36,7 +36,7 @@
   </header>
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/bookmarks.png',
+    image=resp_img('img/firefox/features/thumbnails/bookmarks.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}
@@ -45,7 +45,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/bookmarks/bookmarks-sync.png',
+    image=resp_img('img/firefox/features/thumbnails/bookmarks/bookmarks-sync.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
   ) %}
     <h2>{{ ftl('features-bookmarks-fly-with-that-bookmark') }}</h2>
@@ -53,7 +53,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/bookmarks/bookmarks-addons.png',
+    image=resp_img('img/firefox/features/thumbnails/bookmarks/bookmarks-addons.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}

--- a/bedrock/firefox/templates/firefox/features/fast.html
+++ b/bedrock/firefox/templates/firefox/features/fast.html
@@ -36,7 +36,7 @@
   </header>
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/fast/low-memory.jpg',
+    image=resp_img('img/firefox/features/thumbnails/fast/low-memory.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}
@@ -45,7 +45,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/fast/multi-tabs.jpg',
+    image=resp_img('img/firefox/features/thumbnails/fast/multi-tabs.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
   ) %}
     <h2>{{ ftl('features-fast-get-all-the-tabs-without-lags') }}</h2>
@@ -53,7 +53,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/fast/gaming.jpg',
+    image=resp_img('img/firefox/features/thumbnails/fast/gaming.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}

--- a/bedrock/firefox/templates/firefox/features/fingerprinting.html
+++ b/bedrock/firefox/templates/firefox/features/fingerprinting.html
@@ -28,7 +28,10 @@
     block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
-    image=resp_img('img/firefox/features/fingerprinting/fingerprint.png', srcset={ 'img/firefox/features/fingerprinting/fingerprint-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'})
+    image=resp_img('img/firefox/features/fingerprinting/fingerprint.png',
+      srcset={ 'img/firefox/features/fingerprinting/fingerprint-high-res.png': '2x' },
+      optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+    )
   ) %}
     <span class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></span>
     <h1 class="mzp-u-title-xl">{{ ftl('features-fingerprinting-firefox-blocks-fingerprinting') }}</h1>

--- a/bedrock/firefox/templates/firefox/features/fingerprinting.html
+++ b/bedrock/firefox/templates/firefox/features/fingerprinting.html
@@ -28,8 +28,7 @@
     block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
-    image_url='img/firefox/features/fingerprinting/fingerprint.png',
-    include_highres_image=True,
+    image=resp_img('img/firefox/features/fingerprinting/fingerprint.png', srcset={ 'img/firefox/features/fingerprinting/fingerprint-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'})
   ) %}
     <span class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></span>
     <h1 class="mzp-u-title-xl">{{ ftl('features-fingerprinting-firefox-blocks-fingerprinting') }}</h1>

--- a/bedrock/firefox/templates/firefox/features/independent.html
+++ b/bedrock/firefox/templates/firefox/features/independent.html
@@ -36,7 +36,7 @@
   </header>
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/independent/no-strings.jpg',
+    image=resp_img('img/firefox/features/thumbnails/independent/no-strings.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}
@@ -45,7 +45,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/independent/what-you-see.jpg',
+    image=resp_img('img/firefox/features/thumbnails/independent/what-you-see.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
   ) %}
     <h2>{{ ftl('features-independent-what-you-see-is-what') }}</h2>
@@ -53,7 +53,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/independent/mission.jpg',
+    image=resp_img('img/firefox/features/thumbnails/independent/mission.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -26,7 +26,10 @@
       block_class='mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
       theme_class='',
       media_class='mzp-l-split-h-center',
-      image=resp_img('img/firefox/features/index/features-hero.png', srcset={ 'img/firefox/features/index/features-hero-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+      image=resp_img('img/firefox/features/index/features-hero.png',
+        srcset={ 'img/firefox/features/index/features-hero-high-res.png': '2x' },
+        optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+      ),
     ) %}
       <h1 class="mzp-u-title-xl">{{ ftl('features-index-firefox-features') }}</h1>
       <div class="c-hero-desc">

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -26,8 +26,7 @@
       block_class='mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
       theme_class='',
       media_class='mzp-l-split-h-center',
-      image_url='img/firefox/features/index/features-hero.png',
-      include_highres_image=True,
+      image=resp_img('img/firefox/features/index/features-hero.png', srcset={ 'img/firefox/features/index/features-hero-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     ) %}
       <h1 class="mzp-u-title-xl">{{ ftl('features-index-firefox-features') }}</h1>
       <div class="c-hero-desc">

--- a/bedrock/firefox/templates/firefox/features/memory.html
+++ b/bedrock/firefox/templates/firefox/features/memory.html
@@ -36,7 +36,7 @@
   </header>
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/memory/fast.png',
+    image=resp_img('img/firefox/features/thumbnails/memory/fast.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}
@@ -45,7 +45,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/memory.png',
+    image=resp_img('img/firefox/features/thumbnails/memory.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
   ) %}
     <h2>{{ ftl('features-memory-stop-running-out-of-memory') }}</h2>
@@ -53,7 +53,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/private-browsing.jpg',
+    image=resp_img('img/firefox/features/thumbnails/private-browsing.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -37,7 +37,7 @@
   </header>
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/password-manager.png',
+    image=resp_img('img/firefox/features/thumbnails/password-manager.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}
@@ -46,7 +46,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/password-manager/firefox-account.png',
+    image=resp_img('img/firefox/features/thumbnails/password-manager/firefox-account.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
   ) %}
     <h2>{{ ftl('password-manager-password-magician', fallback='password-manager-password-ninja') }}</h2>
@@ -54,7 +54,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/password-manager/addons.png',
+    image=resp_img('img/firefox/features/thumbnails/password-manager/addons.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}

--- a/bedrock/firefox/templates/firefox/features/picture-in-picture.html
+++ b/bedrock/firefox/templates/firefox/features/picture-in-picture.html
@@ -38,7 +38,7 @@
     block_class='mzp-l-split-center-on-sm-md mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-constrain-height mzp-l-split-media-overflow mzp-l-split-h-center',
-    image_url='img/firefox/features/pip/pip-hero.jpg',
+    image=resp_img('img/firefox/features/pip/pip-hero.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     media_after=True,
   ) %}
     <h1 class="c-hero-pretitle">{{ ftl('features-pip-new-feature-firefox-multi-picture', fallback='features-pip-cool-feature-picture-in-picture') }}</h1>

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -36,7 +36,7 @@
   </header>
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/private/no-trace.jpg',
+    image=resp_img('img/firefox/features/thumbnails/private/no-trace.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}
@@ -45,7 +45,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/private/zero-chill.jpg',
+    image=resp_img('img/firefox/features/thumbnails/private/zero-chill.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
   ) %}
     <h2>{{ ftl('features-private-browsing-catch-those-hidden') }}</h2>
@@ -53,7 +53,7 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/features/thumbnails/private/baggage.jpg',
+    image=resp_img('img/firefox/features/thumbnails/private/baggage.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='mzp-t-split-nospace',
     theme_class='mzp-l-split-reversed',
   ) %}

--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -28,8 +28,7 @@
     block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
-    image_url='img/firefox/features/translate/translate.png',
-    include_highres_image=True,
+    image=resp_img('img/firefox/features/translate/translate.png', srcset={ 'img/firefox/features/translate/translate-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   ) %}
     <span class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></span>
     <h1 class="mzp-u-title-xl">{{ ftl('features-translate-translate-the-web') }}</h1>

--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -28,7 +28,10 @@
     block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
-    image=resp_img('img/firefox/features/translate/translate.png', srcset={ 'img/firefox/features/translate/translate-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+    image=resp_img('img/firefox/features/translate/translate.png',
+      srcset={ 'img/firefox/features/translate/translate-high-res.png': '2x' },
+      optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+    ),
   ) %}
     <span class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></span>
     <h1 class="mzp-u-title-xl">{{ ftl('features-translate-translate-the-web') }}</h1>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -119,7 +119,7 @@
     </div>
 
     {% call split(
-      image_url='img/firefox/home/master/browsers-mr1.jpg',
+      image=resp_img('img/firefox/home/master/browsers-mr1.jpg', srcset={ 'img/firefox/home/master/browsers-mr1-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       include_highres_image=True,
       block_class='t-browsers',
       media_class='mzp-l-split-h-center',
@@ -148,7 +148,7 @@
     {% endcall %}
 
     {% call split(
-      image_url='img/firefox/home/master/monitor-mr1.svg',
+      image=resp_img('img/firefox/home/master/monitor-mr1.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='t-monitor mzp-l-split-reversed',
       media_class='mzp-l-split-h-center',
       media_after=True
@@ -162,7 +162,7 @@
 
   {% if ftl_has_messages('firefox-home-protection-for-your-whole') %}
     {% call split(
-        image_url='img/firefox/home/master/vpn.svg',
+        image=resp_img('img/firefox/home/master/vpn.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
         block_class='t-mozvpn',
         media_class='mzp-l-split-h-center',
         media_after=True
@@ -190,7 +190,7 @@
   </div>
 
     {% call split(
-      image_url='img/firefox/home/master/pocket-mr1.svg',
+      image=resp_img('img/firefox/home/master/pocket-mr1.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='t-pocket',
       media_class='mzp-l-split-h-center',
       media_after=True
@@ -210,7 +210,7 @@
     {% endcall %}
 
     {% call split(
-      image_url='img/firefox/home/master/firefox-relay.jpg',
+      image=resp_img('img/firefox/home/master/firefox-relay.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='t-monitor mzp-l-split-reversed',
       media_class='mzp-l-split-h-center',
       media_after=True

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -119,8 +119,10 @@
     </div>
 
     {% call split(
-      image=resp_img('img/firefox/home/master/browsers-mr1.jpg', srcset={ 'img/firefox/home/master/browsers-mr1-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
-      include_highres_image=True,
+      image=resp_img('img/firefox/home/master/browsers-mr1.jpg',
+        srcset={ 'img/firefox/home/master/browsers-mr1-high-res.jpg': '2x' },
+        optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+      ),
       block_class='t-browsers',
       media_class='mzp-l-split-h-center',
       media_after=True

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -104,7 +104,7 @@
 
     <section class="t-account">
       {% call split(
-        image_url='img/firefox/mobile/protocol/account.svg',
+        image=resp_img('img/firefox/mobile/protocol/account.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
         block_class='mzp-l-split-reversed mzp-t-split-nospace',
         theme_class='mzp-t-background-secondary',
         media_class='mzp-l-split-h-center',
@@ -120,7 +120,7 @@
         <div class="t-extend">
           {% set extend_title = '<span>'|safe + ftl('firefox-mobile-android-only') + '</span><br>'|safe + ftl('firefox-mobile-make-android-your-own') %}
           {% call split(
-            image_url='img/firefox/mobile/protocol/screen-frame.svg',
+            image=resp_img('img/firefox/mobile/protocol/screen-frame.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
             block_class='mzp-l-split-reversed',
             media_class='mzp-l-split-h-center',
           ) %}
@@ -132,7 +132,7 @@
       <div class="t-theme">
         {% set theme_title = '<span>'|safe + ftl('firefox-mobile-android-only') + '</span><br>'|safe + ftl('firefox-mobile-find-it-fast-with-a-smart') %}
         {% call split(
-          image_url='img/firefox/mobile/protocol/screen-frame.svg',
+          image=resp_img('img/firefox/mobile/protocol/screen-frame.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
           media_class='mzp-l-split-h-center'
         ) %}
         <h2>{{ theme_title }}</h2>

--- a/bedrock/firefox/templates/firefox/more.html
+++ b/bedrock/firefox/templates/firefox/more.html
@@ -20,8 +20,9 @@
 {% block content %}
 <main>
   {% call split(
-    image_url='img/firefox/privacy/promise/privacy-hero-700.png',
-    image_sources=[
+    image=picture(
+      'img/firefox/privacy/promise/privacy-hero-700.png',
+      sources=[
       {
         'media': '(min-width: 768px)',
         'srcset': {
@@ -40,9 +41,13 @@
           'img/placeholder.png': 'default'
         }
       }
-    ],
-    image_width='680',
-    image_height='626',
+      ],
+      optional_attributes={
+        'height': '626',
+        'width': '680',
+        'class': 'mzp-c-split-media-asset'
+      }
+    ),
     block_class='page-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-v-end'

--- a/bedrock/firefox/templates/firefox/more/misinformation.html
+++ b/bedrock/firefox/templates/firefox/more/misinformation.html
@@ -23,7 +23,10 @@
 {% block content %}
 
 {% call split(
-  image=resp_img('img/firefox/more/misinformation/hero.jpg', srcset={ 'img/firefox/more/misinformation/hero-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+  image=resp_img('img/firefox/more/misinformation/hero.jpg',
+    srcset={ 'img/firefox/more/misinformation/hero-high-res.jpg': '2x' },
+    optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+  ),
   block_class='c-hero mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md mzp-t-split-nospace t-mobile-nospace',
   media_class='mzp-l-split-media-overflow',
   theme_class='mzp-t-dark'

--- a/bedrock/firefox/templates/firefox/more/misinformation.html
+++ b/bedrock/firefox/templates/firefox/more/misinformation.html
@@ -23,8 +23,7 @@
 {% block content %}
 
 {% call split(
-  image_url='img/firefox/more/misinformation/hero.jpg',
-  include_highres_image=True,
+  image=resp_img('img/firefox/more/misinformation/hero.jpg', srcset={ 'img/firefox/more/misinformation/hero-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   block_class='c-hero mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md mzp-t-split-nospace t-mobile-nospace',
   media_class='mzp-l-split-media-overflow',
   theme_class='mzp-t-dark'
@@ -106,7 +105,7 @@
     <h2 class="misinformation-firefox-helps-heading">{{ ftl('misinformation-how-firefox-helps-heading') }}</h2>
 
     {% call split(
-      image_url='img/firefox/more/misinformation/tracking-protection.svg',
+      image=resp_img('img/firefox/more/misinformation/tracking-protection.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='mzp-l-split-reversed'
     ) %}
       <h2>{{ ftl('misinformation-firefox-keeps-trackers-heading') }}</h2>
@@ -114,7 +113,7 @@
     {% endcall %}
 
     {% call split(
-      image_url='img/firefox/more/misinformation/facebook-container.svg',
+      image=resp_img('img/firefox/more/misinformation/facebook-container.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='mzp-l-split-reversed'
     ) %}
       <h2>{{ ftl('misinformation-social-media-clean-heading') }}</h2>
@@ -124,7 +123,7 @@
     {# Pocket recommendations in Firefox are currently shown to English and German audiences only. #}
     {% if LANG.startswith('en-') or LANG == 'de' %}
       {% call split(
-        image_url='img/firefox/more/misinformation/pocket.svg',
+        image=resp_img('img/firefox/more/misinformation/pocket.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
         block_class='mzp-l-split-reversed'
       ) %}
         <h2>{{ ftl('misinformation-surface-content-heading') }}</h2>

--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -33,8 +33,7 @@
 <main class="mzp-t-firefox">
   {% call split(
     block_id='pocket-hero',
-    image_url='img/firefox/pocket/pocket-hero.png',
-    include_highres_image=True,
+    image=resp_img('img/firefox/pocket/pocket-hero.png', srcset={'img/firefox/pocket/pocket-hero-high-res.png': '2x'}, optional_attributes={'class': 'mzp-c-split-media-asset'}),
     block_class='pocket-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace mzp-l-split-pop-bottom',
     media_class='mzp-l-split-media-overflow mzp-l-split-v-end',
     theme_class='mzp-t-dark'
@@ -49,8 +48,7 @@
 
   {% call split(
     block_id='pocket-popularity',
-    image_url='img/firefox/pocket/pocket-illo-reading.png',
-    include_highres_image=True,
+    image=resp_img('img/firefox/pocket/pocket-illo-reading.png', srcset={'img/firefox/pocket/pocket-illo-reading-high-res.png': '2x'}, optional_attributes={'class': 'mzp-c-split-media-asset'}),
     block_class='pocket-popularity mzp-l-split-reversed mzp-l-split-body-narrow'
   ) %}
     <h2>Capture What Fascinates You</h2>

--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -33,7 +33,10 @@
 <main class="mzp-t-firefox">
   {% call split(
     block_id='pocket-hero',
-    image=resp_img('img/firefox/pocket/pocket-hero.png', srcset={'img/firefox/pocket/pocket-hero-high-res.png': '2x'}, optional_attributes={'class': 'mzp-c-split-media-asset'}),
+    image=resp_img('img/firefox/pocket/pocket-hero.png',
+      srcset={'img/firefox/pocket/pocket-hero-high-res.png': '2x'},
+      optional_attributes={'class': 'mzp-c-split-media-asset'}
+    ),
     block_class='pocket-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace mzp-l-split-pop-bottom',
     media_class='mzp-l-split-media-overflow mzp-l-split-v-end',
     theme_class='mzp-t-dark'
@@ -48,7 +51,10 @@
 
   {% call split(
     block_id='pocket-popularity',
-    image=resp_img('img/firefox/pocket/pocket-illo-reading.png', srcset={'img/firefox/pocket/pocket-illo-reading-high-res.png': '2x'}, optional_attributes={'class': 'mzp-c-split-media-asset'}),
+    image=resp_img('img/firefox/pocket/pocket-illo-reading.png',
+      srcset={'img/firefox/pocket/pocket-illo-reading-high-res.png': '2x'},
+      optional_attributes={'class': 'mzp-c-split-media-asset'}
+    ),
     block_class='pocket-popularity mzp-l-split-reversed mzp-l-split-body-narrow'
   ) %}
     <h2>Capture What Fascinates You</h2>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -39,10 +39,9 @@
 </section>
 
 {% call split(
-  image_url='img/firefox/privacy/book/privacy-healthy-internet.jpg',
+  image=resp_img('img/firefox/privacy/book/privacy-healthy-internet.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
   block_class='mzp-l-split-reversed',
   media_class='mzp-l-split-v-start',
-  loading='lazy',
 ) %}
   <h2>{{ ftl('privacy-book-a-healthy-private') }}</h2>
   <p>{{ ftl('privacy-book-we-believe-that') }}</p>
@@ -56,9 +55,8 @@
 
 <div id="data-breaches" class="data-breaches">
   {% call split(
-    image_url='img/firefox/privacy/book/privacy-book-arrow-on-face.jpg',
+    image=resp_img('img/firefox/privacy/book/privacy-book-arrow-on-face.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
     media_class='mzp-l-split-v-start',
-    loading='lazy',
   ) %}
     <h3>{{ ftl('privacy-book-data-breaches') }}</h3>
     <p>{{ ftl('privacy-book-even-when-organizations') }}</p>
@@ -68,10 +66,9 @@
   {% endcall %}
 
   {% call split(
-    image_url='img/firefox/privacy/book/privacy-troll.jpg',
+    image=resp_img('img/firefox/privacy/book/privacy-troll.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
     block_class='mzp-l-split-reversed',
     media_class='mzp-l-split-v-start',
-    loading='lazy',
   ) %}
     <h3>{{ ftl('privacy-book-trackers-everywhere-') }}</h3>
     <p>{{ ftl('privacy-book-trackers-cookies-youve') }}</p>
@@ -84,11 +81,10 @@
 
 {% call split(
   block_id='fake-news',
-  image_url='img/firefox/privacy/book/privacy-callouts.png',
+  image=resp_img('img/firefox/privacy/book/privacy-callouts.png', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
   theme_class='mzp-t-dark mzp-t-background-secondary',
   block_class='mzp-t-split-nospace',
   media_class='mzp-l-split-v-start',
-  loading='lazy',
 ) %}
   <h3>{{ ftl('privacy-book-fake-news-and') }}</h3>
   <p>{{ ftl('privacy-book-news-recommendations-are') }}</p>
@@ -99,9 +95,8 @@
 
 <section id="tips" class="c-tips">
   {% call split(
-    image_url='img/firefox/privacy/book/privacy-digital-life-growing.jpg',
+    image=resp_img('img/firefox/privacy/book/privacy-digital-life-growing.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
     block_class='c-tips-title mzp-l-split-reversed',
-    loading='lazy',
   ) %}
     <h2>{{ ftl('privacy-book-tips-for') }}</h2>
   {% endcall %}
@@ -190,9 +185,8 @@
   </div>
 
   {% call split(
-    image_url='img/firefox/privacy/book/privacy-magnify.png',
+    image=resp_img('img/firefox/privacy/book/privacy-magnify.png', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
     block_class='c-tips-magnify mzp-l-split-reversed',
-    loading='lazy',
   ) %}
     <ol>
       <li>{{ ftl('privacy-book-search-your-name') }}</li>
@@ -265,8 +259,7 @@
   </div>
 
   {% call split(
-    image_url='img/firefox/privacy/book/privacy-caution.jpg',
-    loading='lazy',
+    image=resp_img('img/firefox/privacy/book/privacy-caution.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
   ) %}
     <ol>
       <li>{{ ftl('privacy-book-from-time-to') }}</li>
@@ -296,9 +289,8 @@
   </div>
 
   {% call split(
-    image_url='img/firefox/privacy/book/privacy-globe.jpg',
+    image=resp_img('img/firefox/privacy/book/privacy-globe.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
     block_class='mzp-l-split-reversed',
-    loading='lazy',
   ) %}
     <ol>
       <li>{{ ftl('privacy-book-many-social-media') }}</li>
@@ -331,7 +323,7 @@
 
 {% call split(
   block_id='trackers',
-  image_url='img/firefox/privacy/book/privacy-target.png',
+  image=resp_img('img/firefox/privacy/book/privacy-target.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   block_class='mzp-t-split-nospace',
   theme_class='mzp-t-dark mzp-t-background-secondary',
   loading='lazy',

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -39,7 +39,9 @@
 </section>
 
 {% call split(
-  image=resp_img('img/firefox/privacy/book/privacy-healthy-internet.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
+  image=resp_img('img/firefox/privacy/book/privacy-healthy-internet.jpg',
+    optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }
+  ),
   block_class='mzp-l-split-reversed',
   media_class='mzp-l-split-v-start',
 ) %}
@@ -55,7 +57,9 @@
 
 <div id="data-breaches" class="data-breaches">
   {% call split(
-    image=resp_img('img/firefox/privacy/book/privacy-book-arrow-on-face.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
+    image=resp_img('img/firefox/privacy/book/privacy-book-arrow-on-face.jpg',
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}
+    ),
     media_class='mzp-l-split-v-start',
   ) %}
     <h3>{{ ftl('privacy-book-data-breaches') }}</h3>
@@ -66,7 +70,9 @@
   {% endcall %}
 
   {% call split(
-    image=resp_img('img/firefox/privacy/book/privacy-troll.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
+    image=resp_img('img/firefox/privacy/book/privacy-troll.jpg',
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }
+    ),
     block_class='mzp-l-split-reversed',
     media_class='mzp-l-split-v-start',
   ) %}
@@ -81,7 +87,9 @@
 
 {% call split(
   block_id='fake-news',
-  image=resp_img('img/firefox/privacy/book/privacy-callouts.png', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
+  image=resp_img('img/firefox/privacy/book/privacy-callouts.png',
+    optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}
+  ),
   theme_class='mzp-t-dark mzp-t-background-secondary',
   block_class='mzp-t-split-nospace',
   media_class='mzp-l-split-v-start',
@@ -95,7 +103,9 @@
 
 <section id="tips" class="c-tips">
   {% call split(
-    image=resp_img('img/firefox/privacy/book/privacy-digital-life-growing.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
+    image=resp_img('img/firefox/privacy/book/privacy-digital-life-growing.jpg',
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}
+    ),
     block_class='c-tips-title mzp-l-split-reversed',
   ) %}
     <h2>{{ ftl('privacy-book-tips-for') }}</h2>
@@ -185,7 +195,9 @@
   </div>
 
   {% call split(
-    image=resp_img('img/firefox/privacy/book/privacy-magnify.png', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}),
+    image=resp_img('img/firefox/privacy/book/privacy-magnify.png',
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy'}
+    ),
     block_class='c-tips-magnify mzp-l-split-reversed',
   ) %}
     <ol>
@@ -259,7 +271,9 @@
   </div>
 
   {% call split(
-    image=resp_img('img/firefox/privacy/book/privacy-caution.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
+    image=resp_img('img/firefox/privacy/book/privacy-caution.jpg',
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }
+    ),
   ) %}
     <ol>
       <li>{{ ftl('privacy-book-from-time-to') }}</li>
@@ -289,7 +303,9 @@
   </div>
 
   {% call split(
-    image=resp_img('img/firefox/privacy/book/privacy-globe.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }),
+    image=resp_img('img/firefox/privacy/book/privacy-globe.jpg',
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }
+    ),
     block_class='mzp-l-split-reversed',
   ) %}
     <ol>

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -25,29 +25,29 @@
 {% block hub_content %}
 
   {% call split(
-    image_url='img/firefox/privacy/promise/privacy-hero-700.png',
-    image_sources=[
-      {
-        'media': '(min-width: 768px)',
-        'srcset': {
-          'img/firefox/privacy/promise/privacy-hero-500.png': '500w',
-          'img/firefox/privacy/promise/privacy-hero-700.png': '700w',
-          'img/firefox/privacy/promise/privacy-hero-900.png': '900w',
-          'img/firefox/privacy/promise/privacy-hero-1100.png': '1100w',
+    image=picture('img/firefox/privacy/promise/privacy-hero-700.png',
+      sources=[
+        {
+          'media': '(min-width: 768px)',
+          'srcset': {
+            'img/firefox/privacy/promise/privacy-hero-500.png': '500w',
+            'img/firefox/privacy/promise/privacy-hero-700.png': '700w',
+            'img/firefox/privacy/promise/privacy-hero-900.png': '900w',
+            'img/firefox/privacy/promise/privacy-hero-1100.png': '1100w',
+          },
+          'sizes': {
+            'default': 'calc(50vw - 192px)'
+          }
         },
-        'sizes': {
-          'default': 'calc(50vw - 192px)'
+        {
+          'media': '(max-width: 767px)',
+          'srcset': {
+            'img/placeholder.png': 'default'
+          }
         }
-      },
-      {
-        'media': '(max-width: 767px)',
-        'srcset': {
-          'img/placeholder.png': 'default'
-        }
-      }
-    ],
-    image_width='680',
-    image_height='626',
+      ],
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'height': '626', 'width': '680' }
+    ),
     block_class='privacy-promise-hero mzp-l-split-hide-media-on-sm-md mzp-t-split-nospace t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-v-end'
@@ -63,8 +63,7 @@
 
   <div>
     {% call split(
-      image_url='img/firefox/privacy/promise/less.jpg',
-      include_highres_image=True,
+      image=resp_img('img/firefox/privacy/promise/less.jpg', srcset={ 'img/firefox/privacy/promise/less-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='privacy-promise-feature mzp-l-split-reversed'
     ) %}
       <h2>{{ ftl('firefox-privacy-hub-take-less') }}</h2>
@@ -73,8 +72,7 @@
     {% endcall %}
 
     {% call split(
-      image_url='img/firefox/privacy/promise/safe.jpg',
-      include_highres_image=True,
+      image=resp_img('img/firefox/privacy/promise/safe.jpg', srcset={ 'img/firefox/privacy/promise/safe-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='privacy-promise-feature'
     ) %}
       <h2>{{ ftl('firefox-privacy-hub-keep-it-safe') }}</h2>
@@ -93,8 +91,7 @@
     {% endcall %}
 
     {% call split(
-      image_url='img/firefox/privacy/promise/secrets.jpg',
-      include_highres_image=True,
+      image=resp_img('img/firefox/privacy/promise/secrets.jpg', srcset={ 'img/firefox/privacy/promise/secrets-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='privacy-promise-feature mzp-l-split-reversed'
     ) %}
       <h2>{{ ftl('firefox-privacy-hub-no-secrets') }}</h2>

--- a/bedrock/firefox/templates/firefox/privacy/passwords.html
+++ b/bedrock/firefox/templates/firefox/privacy/passwords.html
@@ -26,7 +26,8 @@
     block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
-    image_url='img/firefox/privacy/passwords/passwords.png',
+    image=resp_img('img/firefox/privacy/passwords/passwords.png', srcset={ 'img/firefox/privacy/passwords/passwords.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+
     include_highres_image=True,
   ) %}
     <span class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></span>

--- a/bedrock/firefox/templates/firefox/privacy/passwords.html
+++ b/bedrock/firefox/templates/firefox/privacy/passwords.html
@@ -26,9 +26,10 @@
     block_class='mzp-t-split-nospace mzp-l-split-hide-media-on-sm-md mzp-l-split-center-on-sm-md t-mobile-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-media-constrain-height',
-    image=resp_img('img/firefox/privacy/passwords/passwords.png', srcset={ 'img/firefox/privacy/passwords/passwords.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
-
-    include_highres_image=True,
+    image=resp_img('img/firefox/privacy/passwords/passwords.png',
+      srcset={ 'img/firefox/privacy/passwords/passwords-high-res.png': '2x' },
+      optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+    ),
   ) %}
     <span class="mzp-c-logo mzp-t-logo-lg mzp-t-product-firefox"></span>
     <h1 class="mzp-u-title-xl">{{ ftl('privacy-passwords-a-security-guide') }}</h1>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -161,7 +161,10 @@
   {% set block_class = 'mzp-l-split-reversed' %}
   {% endif %}
     {% call split(
-      image=resp_img('img/firefox/privacy/products/pocket.png', srcset={ 'img/firefox/privacy/products/pocket-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+      image=resp_img('img/firefox/privacy/products/pocket.png',
+        srcset={ 'img/firefox/privacy/products/pocket-high-res.png': '2x' },
+        optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+      ),
       block_class=block_class,
       media_class='mzp-l-split-h-center'
     ) %}

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -32,8 +32,7 @@
   }}
 
   {% call split(
-    image_url='img/firefox/privacy/products/report.svg',
-    l10n_image=True,
+    image=resp_img('img/firefox/privacy/products/report.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset', 'l10n': 'true'}),
     block_class='privacy-products-hero mzp-t-dark mzp-l-split-hide-media-on-sm-md',
     media_class='mzp-l-split-media-overflow'
   ) %}
@@ -124,7 +123,7 @@
 
   <div class="privacy-products-list t-medium">
     {% call split(
-      image_url='img/firefox/privacy/products/monitor.svg',
+      image=resp_img('img/firefox/privacy/products/monitor.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       media_class='mzp-l-split-h-center'
     ) %}
       <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-monitor">
@@ -140,7 +139,7 @@
 
   {% if ftl_has_messages('firefox-privacy-hub-surf-stream-and-get-work') %}
     {% call split(
-      image_url='img/firefox/privacy/products/vpn.svg',
+      image=resp_img('img/firefox/privacy/products/vpn.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class='mzp-l-split-reversed',
       media_class='mzp-l-split-h-center'
     ) %}
@@ -162,8 +161,7 @@
   {% set block_class = 'mzp-l-split-reversed' %}
   {% endif %}
     {% call split(
-      image_url='img/firefox/privacy/products/pocket.png',
-      include_highres_image=True,
+      image=resp_img('img/firefox/privacy/products/pocket.png', srcset={ 'img/firefox/privacy/products/pocket-high-res.png': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       block_class=block_class,
       media_class='mzp-l-split-h-center'
     ) %}

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -37,8 +37,7 @@
 {% block content %}
 <main role="main">
   {% call split(
-    image_url='img/firefox/products/hero.jpg',
-    include_highres_image=True,
+    image=resp_img('img/firefox/products/hero.jpg', srcset={ 'img/firefox/products/hero-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
     block_class='c-landing-banner t-products mzp-l-split-center-on-sm-md',
     media_class='mzp-l-split-media-overflow',
   ) %}

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -37,7 +37,10 @@
 {% block content %}
 <main role="main">
   {% call split(
-    image=resp_img('img/firefox/products/hero.jpg', srcset={ 'img/firefox/products/hero-high-res.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+    image=resp_img('img/firefox/products/hero.jpg',
+      srcset={ 'img/firefox/products/hero-high-res.jpg': '2x' },
+      optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+    ),
     block_class='c-landing-banner t-products mzp-l-split-center-on-sm-md',
     media_class='mzp-l-split-media-overflow',
   ) %}

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -21,7 +21,10 @@
 {% block content %}
 <main>
   {% call split(
-      image=resp_img('img/firefox/switch/switch.png', srcset={'img/firefox/switch/switch-high-res.png': '2x'}, optional_attributes={'class': 'mzp-c-split-media-asset'}),
+      image=resp_img('img/firefox/switch/switch.png',
+        srcset={'img/firefox/switch/switch-high-res.png': '2x'},
+        optional_attributes={'class': 'mzp-c-split-media-asset'}
+      ),
       media_after=True,
       media_class='mzp-l-split-h-center',
       block_class='mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md'

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -21,8 +21,7 @@
 {% block content %}
 <main>
   {% call split(
-      image_url='img/firefox/switch/switch.png',
-      include_highres_image=True,
+      image=resp_img('img/firefox/switch/switch.png', srcset={'img/firefox/switch/switch-high-res.png': '2x'}, optional_attributes={'class': 'mzp-c-split-media-asset'}),
       media_after=True,
       media_class='mzp-l-split-h-center',
       block_class='mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md'

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -39,7 +39,10 @@
 
 {% block content %}
   {% call split(
-  image=resp_img('img/firefox/accounts/trailhead/value-knowledge.jpg', srcset={ 'img/firefox/accounts/trailhead/value-knowledge.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
+  image=resp_img('img/firefox/accounts/trailhead/value-knowledge.jpg',
+    srcset={ 'img/firefox/accounts/trailhead/value-knowledge-high-res.jpg': '2x' },
+    optional_attributes={ 'class': 'mzp-c-split-media-asset'}
+  ),
   media_after=True,
   block_class='mzp-l-split-center-on-sm-md',
   media_class='mzp-l-split-h-center'

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -39,8 +39,7 @@
 
 {% block content %}
   {% call split(
-  image_url='img/firefox/accounts/trailhead/value-knowledge.jpg',
-  include_highres_image=True,
+  image=resp_img('img/firefox/accounts/trailhead/value-knowledge.jpg', srcset={ 'img/firefox/accounts/trailhead/value-knowledge.jpg': '2x' }, optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   media_after=True,
   block_class='mzp-l-split-center-on-sm-md',
   media_class='mzp-l-split-h-center'
@@ -96,7 +95,7 @@
 </div>
 <section>
   {% call split(
-  image_url='img/firefox/accounts/trailhead/value-respect.jpg',
+  image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   media_after=False,
   block_class='mzp-l-split-reversed',
   media_class='mzp-l-split-h-center'


### PR DESCRIPTION
## One-line summary

Removing the image macro from the split calls in the /firefox templates (Part 1)

## Issue / Bugzilla link
#12331 


## Testing

The following pages should render the same as as what is on production

- [ ] http://localhost:8000/firefox/more
- [ ] http://localhost:8000/firefox/pocket
- [ ] http://localhost:8000/firefox/switch 
- [ ] http://localhost:8000/firefox/sync
- [ ] http://localhost:8000/firefox/browsers/chromebook
- [ ] http://localhost:8000/firefox/browsers
- [ ] http://localhost:8000/firefox/browsers/quantum
- [ ] http://localhost:8000/firefox/browsers/mobile/android
- [ ] http://localhost:8000/firefox/browsers/mobile/compare
- [ ] http://localhost:8000/firefox/browsers/mobile
- [ ] http://localhost:8000/firefox/browsers/mobile/ios
- [ ] http://localhost:8000/firefox/developer
- [ ] http://localhost:8000/firefox/enterprise
- [ ] http://localhost:8000/firefox/features/bookmark
- [ ] http://localhost:8000/en-US/firefox/features/fast/
- [ ] http://localhost:8000/en-US/firefox/features/block-fingerprinting/
- [ ] http://localhost:8000/en-US/firefox/features/independent/
- [ ] http://localhost:8000/en-US/firefox/features/memory/
- [ ] http://localhost:8000/en-US/firefox/features/password-manager/
- [ ] http://localhost:8000/en-US/firefox/features/picture-in-picture/
- [ ] http://localhost:8000/en-US/firefox/features/private-browsing/
- [ ] http://localhost:8000/en-US/firefox/features/translate/
- [ ] http://localhost:8000/en-US/firefox/
- [ ] http://localhost:8000/en-US/firefox/mobile
- [ ] http://localhost:8000/en-US/firefox/privacy/book/
- [ ] http://localhost:8000/en-US/firefox/privacy/
- [ ] http://localhost:8000/en-US/firefox/privacy/safe-passwords/
- [ ] http://localhost:8000/en-US/firefox/privacy/products/
- [ ] http://localhost:8000/en-US/firefox/products/