### PR TITLE
Fix typo in ftl identifier (fixes #12374)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -50,7 +50,7 @@
           class='mzp-c-card-medium',
           title=ftl('about-pioneers-of-the-open-web'),
           ga_title='Pioneers of The Open Web',
-          desc=ftl('about-our-purple-bghip-has-been-at'),
+          desc=ftl('about-our-leadership-has-been-at'),
           image=resp_img('img/mozorg/about/leaders.jpg', srcset={"img/mozorg/about/leaders-high-res.jpg": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           aspect_ratio='mzp-has-aspect-3-2',
           link_url=url('mozorg.about.leadership.index')


### PR DESCRIPTION
## One-line summary

Resets raw About FTL string to match existing identifier
(correct identifier from https://github.com/mozilla/bedrock/commit/22be7e5d2f99899942a751e5a5a81d5af97a36b2#diff-6f93ef0c7277f9a5ff49759371026eab00606433975db2d340373bf792119d25R48)

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12374


## Testing

localhost:8000/en-US/about/
