### PR TITLE
add instruction to use staging instance when testing crash-stats

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -41,6 +41,9 @@
     <li>crash-reports.mozilla.com</li>
     <li>crash-stats.mozilla.org</li>
   </ul>
+  <p>
+    If you are planning to experiment with crash report payloads, please use our <a href="https://crash-stats.allizom.org/">staging instance</a> for testing.
+  </p>
 
   <h3>Downloads (Product Delivery)</h3>
   <ul class="mzp-u-list-styled">

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -42,7 +42,7 @@
     <li>crash-stats.mozilla.org</li>
   </ul>
   <p>
-    If you are planning to experiment with crash report payloads, please use our <a href="https://crash-stats.allizom.org/">staging instance</a> for testing.
+    If you are planning to experiment with crash report payloads, please use our <a href="https://crash-stats.allizom.org/">crash-stats staging instance</a> and <a href="https://crash-reports.allizom.org/">crash-reports staging instance</a> for testing.
   </p>
 
   <h3>Downloads (Product Delivery)</h3>


### PR DESCRIPTION
## One-line summary

add instruction to use staging instance when testing crash-stats.