### PR TITLE
Fix Pocket about illustration overlap (fixes #12371)

### DIFF
--- a/media/css/pocket/components/about.scss
+++ b/media/css/pocket/components/about.scss
@@ -221,6 +221,10 @@ $pocket-image-path: '/media/img/pocket';
             width: 100vw;
         }
 
+        @media (min-width: 450px) {
+            padding-bottom: 875px;
+        }
+
         @media (min-width: 599px) {
             padding-bottom: 1020px;
 


### PR DESCRIPTION
## One-line summary

Fixes overlap on awkward breakpoint

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12371

## Screenshots

https://getpocket.com/en/about/ around 570px wide
<img width="555" alt="overlap" src="https://user-images.githubusercontent.com/19650432/202697202-b128a23b-9435-4305-a18d-f6dd84da5d70.png">

## Testing

- [ ] http://localhost:8000/en/about/ should be readable on Use Pocket Your Way section at all screen sizes (particularly 450-600px wide)
<img width="569" alt="overlap-fix" src="https://user-images.githubusercontent.com/19650432/202697301-fa78ea5c-2738-4720-8945-942201b47768.png">

