### PR TITLE
Fix fundraising banner destination

### DIFF
--- a/bedrock/base/templates/includes/banners/fundraiser.html
+++ b/bedrock/base/templates/includes/banners/fundraiser.html
@@ -18,7 +18,7 @@
     <p>{{ ftl('banner-fundraising-body') }}</p>
   {% endif %}
 
-  <form id="fundraiser-form" class="c-fundraiser-form" method="get" action="https://donate.mozilla.org/">
+  <form id="fundraiser-form" class="c-fundraiser-form" method="get" action="https://donate.mozilla.org/help-mozilla-fight-for-a-better-internet-this-holiday-season/">
     <fieldset class="c-fundraiser-recurring">
       <label for="onetime">
         <input type="radio" value="single" id="onetime" name="frequency" checked> {{ ftl('banner-fundraising-one-time') }}

--- a/media/css/base/banners/fundraiser.scss
+++ b/media/css/base/banners/fundraiser.scss
@@ -142,12 +142,6 @@ $image-path: '/media/protocol/img';
             }
         }
     }
-
-    @media #{$mq-xl} {
-        .mzp-c-button.mzp-t-secondary {
-            width: auto;
-        }
-    }
 }
 
 .c-fundraiser-submit .mzp-c-button {
@@ -170,14 +164,6 @@ $image-path: '/media/protocol/img';
 
         @media #{$mq-xl} {
             grid-template: 1fr / repeat(4, 1fr);
-        }
-    }
-
-    .c-fundraiser-donation-choice {
-        @media #{$mq-xl} {
-            display: grid;
-            grid-column-gap: $spacing-xl;
-            grid-template-columns: max-content 1fr;
         }
     }
 


### PR DESCRIPTION
## One-line summary

Changes the form action so it submits to the campaign page on donate.mozilla.org rather than the front page. 

Also makes some small style tweaks because in languages where the submit button label is more than one word it tends to wrap and look wonky, and/or causes some overflow issues.

## Issue / Bugzilla link
#12373 

## Testing
Make sure the form submits to `https://donate.mozilla.org/help-mozilla-fight-for-a-better-internet-this-holiday-season/` and that the form on the other end still reflects the right selections.