### PR TITLE
Fix #12398: Fix grouping of jobs in RSS feed

### DIFF
--- a/bedrock/careers/feeds.py
+++ b/bedrock/careers/feeds.py
@@ -31,7 +31,7 @@ class LatestPositionsFeed(Feed):
         return Position.categories()
 
     def items(self):
-        return [list(g)[0] for k, g in groupby(Position.objects.all().order_by("job_id"), key=lambda p: p.internal_job_id)]
+        return [list(g)[0] for k, g in groupby(Position.objects.all().order_by("internal_job_id", "job_id"), key=lambda p: p.internal_job_id)]
 
     def item_title(self, item):
         return item.title


### PR DESCRIPTION
## One-line summary

This pre-sorts the list so `groupby` can find the groupings of the jobs by `internal_job_id`.
