### PR TITLE
Correcting mistake in web bug bounty sites

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -159,6 +159,7 @@
   <ul class="mzp-u-list-styled">
     <li>hubs.mozilla.com</li>
     <li>reticulum.io</li>
+    <li>*.reticulum.io</li>
   </ul>
 
   <h3>Payment Subscription</h3>


### PR DESCRIPTION
## One-line summary

This changeset extends the list of web bug bounty sites in order to correct a mistaken missing set of subdomains.

## Significant changes and points to review

This is a simple text change of a list item, not a significant change

## Issue / Bugzilla link

None

## Screenshots

No UI change, just an added list item

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: None
