### PR TITLE
Fix intermittent DNT test failure

### DIFF
--- a/tests/unit/spec/base/mozilla-pixel.js
+++ b/tests/unit/spec/base/mozilla-pixel.js
@@ -10,9 +10,11 @@
  */
 
 describe('mozilla-pixel.js', function () {
-    afterEach(function () {
+    beforeEach(function () {
         window.Mozilla.dntEnabled = sinon.stub();
+    });
 
+    afterEach(function () {
         document.querySelectorAll('.moz-px').forEach((e) => {
             e.parentNode.removeChild(e);
         });


### PR DESCRIPTION
Fixes intermittent failure:

```
Chrome 107.0.0.0 (Mac OS 10.15.7) mozilla-pixel.js init should add one pixel to document body FAILED
        Error: <spyOn> : dntEnabled() method does not exist
        Usage: spyOn(<object>, <methodName>)
            at <Jasmine>
            at UserContext.<anonymous> (/var/folders/sy/tzj820zd5vb4nv6wfgxcl2rr0000gn/T/_karma_webpack_116104/commons.js:12084:13)
            at <Jasmine>
```