### PR TITLE
Fix sitemap generation due to incompletely localised Contentful objects appearing

### DIFF
--- a/bedrock/contentful/models.py
+++ b/bedrock/contentful/models.py
@@ -148,7 +148,7 @@ class ContentfulEntry(models.Model):
     def __str__(self) -> str:
         return f"ContentfulEntry {self.content_type}:{self.contentful_id}[{self.locale}]"
 
-    def get_related_entries(self, order_by="last_modified"):
+    def get_related_entries(self, order_by="last_modified", localisation_complete=True):
         """Find ContentfulEntry records that:
         * are for the same content_type
         * are for the same classification
@@ -163,6 +163,7 @@ class ContentfulEntry(models.Model):
 
         _base_qs = ContentfulEntry.objects.filter(
             locale=self.locale,
+            localisation_complete=localisation_complete,
             content_type=self.content_type,
             classification=self.classification,  # eg same Product/project/area of the site
         ).exclude(

--- a/bedrock/sitemaps/tests/test_utils.py
+++ b/bedrock/sitemaps/tests/test_utils.py
@@ -25,6 +25,7 @@ def dummy_vrc_pages():
             slug=f"test-slug-{idx}",
             # TODO: support different locales
             locale="en-US",
+            localisation_complete=True,
             content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
             classification=CONTENT_CLASSIFICATION_VPN,
             data={},

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -165,11 +165,12 @@ def _get_vrc_urls():
     urls = defaultdict(list)
 
     for entry in ContentfulEntry.objects.filter(
+        localisation_complete=True,
         content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
         classification=CONTENT_CLASSIFICATION_VPN,
     ):
         _path = f"{VRC_ROOT_PATH}{entry.slug}/"
-        urls[_path].append(entry.locale)  # In the future one, slug may support multiple locales
+        urls[_path].append(entry.locale)  # One slug may support multiple locales
 
     return urls
 


### PR DESCRIPTION
This changeset stops ContentfulEntry records with incomplete localisation status from appearing in the sitemap

If they do, they create URLs with a slug of `.../unknown/`, which then 404s so can't be spidered by the sitemap generator

