### PR TITLE
Fix error string on newsletter/country/ page (Issue #12376)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/country.html
+++ b/bedrock/newsletter/templates/newsletter/country.html
@@ -35,7 +35,9 @@
         <form id="country-newsletter-form" class="country-newsletter-form" method="post" action="{{ action }}">
           <div class="mzp-c-form-errors hidden" id="country-newsletter-errors">
             <ul class="mzp-u-list-styled">
-              <li class="error-try-again-later hidden">{{ ftl('newsletters-we-are-sorry-but-there') }}</li>
+              <li class="error-try-again-later hidden">
+                We are sorry, but there was a problem with our system. Please try again later!
+              </li>
             </ul>
           </div>
 

--- a/tests/unit/spec/newsletter/country.js
+++ b/tests/unit/spec/newsletter/country.js
@@ -13,7 +13,9 @@ describe('CountryForm', function () {
                 <form id="country-newsletter-form" class="country-newsletter-form" method="post" action="https://basket.mozilla.org/news/user-meta/c3e6c6b9-daf1-43ed-a560-51160e15b360/">
                     <div class="mzp-c-form-errors hidden" id="country-newsletter-errors">
                         <ul class="mzp-u-list-styled">
-                            <li class="error-try-again-later hidden">newsletters-we-are-sorry-but-there</li>
+                            <li class="error-try-again-later hidden">
+                                We are sorry, but there was a problem with our system. Please try again later!
+                            </li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
## One-line summary

Small follow up bug fix for https://github.com/mozilla/bedrock/pull/12421

The page is `en-US` only and has no FTL file associated with it, so the error string should be hard-coded.

## Issue / Bugzilla link

#12376

## Testing

You need a newsletter token in order to view / test this page locally, which you can [get here](https://www.mozilla.org/en-US/newsletter/recovery/). Once you have a token you can view the page at:

`http://localhost:8000/en-US/newsletter/country/{TOKEN}/`
