### PR TITLE
Fix Best of Pocket link for German (Issue #12406)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/pocket-best-2022-promo.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/pocket-best-2022-promo.html
@@ -10,7 +10,7 @@
   {% set promo_title = 'Die besten Artikel <br>des Jahres'|safe %}
   {% set promo_desc = 'In einem Jahr voller Höhen und Tiefen gab es Artikel, die uns geholfen haben, die Ereignisse besser zu verstehen und Inspiration zu finden.' %}
   {% set promo_cta = 'Entdecke das Best of 2022' %}
-  {% set promo_url = 'https://getpocket.com/de/collections/besten-artikel-2022' %}
+  {% set promo_url = 'https://getpocket.com/de/collections/die-besten-artikel-2022' %}
 {% else %}
   {% set promo_title = 'Don’t miss the best <br>articles of 2022'|safe %}
   {% set promo_desc = 'In a year of ups and downs, these articles helped us make sense of it all. See what made the list.' %}


### PR DESCRIPTION
We were previously given the incorrect link for German best of pocket collection. This updated URL should fix things