### PR TITLE
Fix intermittent test failure on /leadership page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/index.html
@@ -148,7 +148,7 @@
     </div>
   </article>
 
-  <article id="eric-muhlheim" data-id="eric-mulheim" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
+  <article id="eric-muhlheim" data-id="eric-muhlheim" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       {{ high_res_img('img/mozorg/about/leadership/eric-muhlheim.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
       <figcaption><h4 class="fn" itemprop="name">Eric Muhlheim</h4></figcaption>
@@ -158,7 +158,7 @@
       <p class="title" itemprop="jobTitle">Chief Financial Officer</p>
 
       <ul class="utility">
-        <li><a class="link" href="{{ url('mozorg.about.leadership.index') }}#eric-mulheim">Link to this bio</a></li>
+        <li><a class="link" href="{{ url('mozorg.about.leadership.index') }}#eric-muhlheim">Link to this bio</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Fixes https://gitlab.com/mozmeao/www-config/-/jobs/3395498449

The reason for the failure was Eric's surname was misspelt in the `data-id` attribute, so it was not matching up to `id`.

The test failure report gave the clue:

![image](https://user-images.githubusercontent.com/400117/204576736-ed9e8204-7435-4d7e-bdda-a50aef3315de.png)

## Testing

- [ ] http://localhost:8000/en-US/about/leadership/ should still work as expected when clicking Eric's bio
