### PR TITLE
Add 'make preflight' command to make it easier to keep local installs ready for work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ help:
 	@echo "  check-requirements         - get a report on stale/old Python dependencies in use"
 	@echo "  install-local-python-deps  - install Python dependencies for local development"
 	@echo "  install-local-docs-deps  	- install Python dependencies for documentation building"
+	@echo "  preflight  				- refresh installed dependencies and fetch latest DB ahead of local dev"
 
 .env:
 	@if [ ! -f .env ]; then \
@@ -175,4 +176,9 @@ install-local-python-deps:
 install-local-docs-deps: install-local-python-deps
 	pip install -r requirements/docs.txt
 
-.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod run-pocket run-pocket-prod build-prod test-cdn compile-requirements check-requirements install-local-python-deps install-local-docs-deps
+preflight:
+	${MAKE} install-local-python-deps
+	$ npm install
+	$ bin/sync-all.sh
+
+.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod run-pocket run-pocket-prod build-prod test-cdn compile-requirements check-requirements install-local-python-deps install-local-docs-deps preflight

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -225,6 +225,12 @@ credits, release notes, localizations, legal-docs etc::
 
 .. _run-python-tests:
 
+.. note::
+
+    As a convenience, there is a ``make preflight`` command which automatically brings your installed Python and NPM
+    dependencies up to date and also fetches the latest DB containing the latest site
+    content. This is a good thing to run after pulling latest changes from the ``main`` branch.
+
 Run the tests
 =============
 


### PR DESCRIPTION
## One-line summary

This changeset adds `make preflight` as a new Makefile command so it just takes one command to bring a local install up to latest state.


* installs latest Python deps
* installs latestJS deps
* gets latest DB and l10n files