### PR TITLE
Add a link to jobs RSS feed on /careers/listings/ page #12422

### DIFF
--- a/bedrock/careers/templates/careers/listings.html
+++ b/bedrock/careers/templates/careers/listings.html
@@ -78,6 +78,7 @@
       </tr>
     </tbody>
   </table>
+  <a href="/en-US/careers/feed/">Subscribe to our open positions RSS feed</a>
 </section>
 {% endblock %}
 


### PR DESCRIPTION
## One-line summary

Added link to RSS feed

## Issue / Bugzilla link
#12422


## Screenshots
<img width="1192" alt="Snímek obrazovky 2022-11-30 v 23 56 49" src="https://user-images.githubusercontent.com/90466277/204925944-bd8851b9-4018-42e6-a15e-744ad1fa7dc4.png">

## Testing

Demo server URL: http://localhost:8080/en-US/careers/listings/
To test this work:

- [ ]
