### PR TITLE
Update Markdown to 3.4.1, using related change/bump to mdx_outline

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -650,9 +650,9 @@ lxml==4.9.1 \
     #   -r requirements/prod.txt
     #   pyquery
     #   translate-toolkit
-markdown==3.3.6 \
-    --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
-    --hash=sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3
+markdown==3.4.1 \
+    --hash=sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186 \
+    --hash=sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff
     # via
     #   -r requirements/prod.txt
     #   django-jinja-markdown
@@ -736,8 +736,8 @@ mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
     # via flake8
-mdx_outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz \
-    --hash=sha256:c37385f222866684a0a92e3b38588003c6d8c3dbcf55aea854cf543baae425c5
+mdx_outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibility.tar.gz \
+    --hash=sha256:a78e112f80628246dd45858fe18404aaa8efb8dc81949bb1fbb87e91f9654afa
     # via -r requirements/prod.txt
 meinheld==1.0.2 \
     --hash=sha256:008c76937ac2117cc69e032dc69cea9f85fc605de9bac1417f447c41c16a56d6

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -35,8 +35,8 @@ html5lib==1.1
 jinja2==3.1.2  # Moved to top-level dep to control its upgrade, to avoid breaking changes later if glean-parser updates it
 jq==1.3.0
 lxml==4.9.1  # Needed as a top-level dep so that it's available for BeautifulSoup, which doesn't explicitly pull it in
-Markdown==3.3.6
-https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz#egg=mdx_outline
+Markdown==3.4.1
+https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibility.tar.gz#egg=mdx_outline
 markupsafe==2.0.1
 meinheld==1.0.2
 newrelic==8.4.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -451,9 +451,9 @@ lxml==4.9.1 \
     --hash=sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8 \
     --hash=sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f
     # via -r requirements/prod.in
-markdown==3.3.6 \
-    --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
-    --hash=sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3
+markdown==3.4.1 \
+    --hash=sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186 \
+    --hash=sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff
     # via
     #   -r requirements/prod.in
     #   django-jinja-markdown
@@ -533,8 +533,8 @@ markupsafe==2.0.1 \
     #   django-jinja-markdown
     #   glean-parser
     #   jinja2
-mdx_outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/python-3.9-compat.tar.gz \
-    --hash=sha256:c37385f222866684a0a92e3b38588003c6d8c3dbcf55aea854cf543baae425c5
+mdx_outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibility.tar.gz \
+    --hash=sha256:a78e112f80628246dd45858fe18404aaa8efb8dc81949bb1fbb87e91f9654afa
     # via -r requirements/prod.in
 meinheld==1.0.2 \
     --hash=sha256:008c76937ac2117cc69e032dc69cea9f85fc605de9bac1417f447c41c16a56d6


### PR DESCRIPTION
This changeset upgrades Bedrock to Markdown 3.4, which had breaking changes in it that required patching the mdx_outline library (which we've forked). 

## Significant changes and points to review

We're still using our fork of mdx_outline, so have just made it work with 3.4.x as a potentially breaking change, rather than also support <3.4


## Issue / Bugzilla link

Resolves #11936 (dependabot PR)

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [X] If new dependencies are added, I've checked their license is appropriate

## Testing
To test this work:

- [ ] Remove all python packages from your virtualenv: `pip uninstall mdx_outline -y && pip freeze | xargs pip uninstall -y`
- [ ] Install fresh deps: `make install-local-python-deps`
- [ ] `./manage.py update_legal_docs --force` -- confirm all is well
- [ ] browse legal docs and confirm they are all rendered OK -- this is hard to eyeball, but I can't see any regressions myself.
