### PR TITLE
Add functional tests for VPN / Relay bundle offer (Fixes #12424)

### DIFF
--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -33,7 +33,7 @@ def vpn_landing_page(request):
     vpn_available_in_country = country in settings.VPN_COUNTRY_CODES
     attribution_available_in_country = country in settings.VPN_AFFILIATE_COUNTRIES
     vpn_affiliate_attribution_enabled = vpn_available_in_country and attribution_available_in_country and switch("vpn-affiliate-attribution")
-    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES and switch("vpn-relay-bundle")
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
 
     context = {
         "vpn_available": vpn_available_in_country,

--- a/tests/functional/products/vpn/test_landing.py
+++ b/tests/functional/products/vpn/test_landing.py
@@ -26,6 +26,12 @@ def test_vpn_available_in_country(country, base_url, selenium):
     assert page.is_get_vpn_monthly_button_displayed
     assert page.is_get_vpn_12_months_button_displayed
 
+    # VPN + Relay bundle is only available in US & Canada.
+    if country in ["us", "ca"]:
+        assert page.is_get_vpn_relay_button_displayed
+    else:
+        assert not page.is_get_vpn_relay_button_displayed
+
     # Waitlist features section
     assert not page.is_join_waitlist_features_button_displayed
 
@@ -52,6 +58,7 @@ def test_vpn_not_available_in_country(base_url, selenium):
     # Pricing section
     assert not page.is_get_vpn_monthly_button_displayed
     assert not page.is_get_vpn_12_months_button_displayed
+    assert not page.is_get_vpn_relay_button_displayed
 
     # Waitlist features section
     assert page.is_join_waitlist_features_button_displayed

--- a/tests/pages/products/vpn/landing.py
+++ b/tests/pages/products/vpn/landing.py
@@ -22,6 +22,7 @@ class VPNLandingPage(BasePage):
     # Pricing section
     _get_vpn_monthly_button_locator = (By.CSS_SELECTOR, ".vpn-pricing-monthly .mzp-c-button")
     _get_vpn_12_months_button_locator = (By.CSS_SELECTOR, ".vpn-pricing-12-months .mzp-c-button")
+    _get_vpn_relay_button_locator = (By.CSS_SELECTOR, ".vpn-pricing-12-months .vpn-pricing-add-on-bundle .mzp-c-button")
 
     # Waitlist features section
     _join_waitlist_features_button_locator = (By.CSS_SELECTOR, '.vpn-waitlist-feature-block .mzp-c-button[data-cta-text="Join the VPN Waitlist"]')
@@ -66,6 +67,10 @@ class VPNLandingPage(BasePage):
     @property
     def is_get_vpn_12_months_button_displayed(self):
         return self.is_element_displayed(*self._get_vpn_12_months_button_locator)
+
+    @property
+    def is_get_vpn_relay_button_displayed(self):
+        return self.is_element_displayed(*self._get_vpn_relay_button_locator)
 
     # Waitlist Features section
 


### PR DESCRIPTION
## One-line summary

Removes the VPN / Relay bundle feature switch (now that it has launched), and adds functional tests to make sure the button shows in the right countries.

## Issue / Bugzilla link

#12424

## Testing

```
py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/products/vpn/test_landing.py
```