### PR TITLE
Make greenhouse metadata checking more resilient

### DIFF
--- a/bedrock/careers/management/commands/sync_greenhouse.py
+++ b/bedrock/careers/management/commands/sync_greenhouse.py
@@ -141,7 +141,7 @@ class Command(BaseCommand):
             # (no-brake space). I ♥ regex
             description = re.sub(r"<(p|h4)>([ ]*|(\xa0)+)</(p|h4)>", "", description)
 
-            for metadata in job.get("metadata", []):
+            for metadata in job.get("metadata", []) or []:
                 if metadata.get("name", "") == "Employment Type":
                     position_type = metadata["value"] or ""
                     break

--- a/bedrock/careers/tests/test_commands.py
+++ b/bedrock/careers/tests/test_commands.py
@@ -148,3 +148,21 @@ class SyncGreenhouseTests(TestCase):
             requests.get().json.return_value = jobs_response
             call_command("sync_greenhouse", stdout=StringIO())
         self.assertEqual(Position.objects.all().count(), 1)
+
+    def test_metadata_is_none(self):
+        jobs_response = {
+            "jobs": [
+                {
+                    "id": "xxx",
+                    "internal_job_id": 99,
+                    "title": "Web Fox",
+                    "metadata": None,
+                    "absolute_url": "http://example.com/foo",
+                    "updated_at": "2016-07-25T14:45:57-04:00",
+                },
+            ]
+        }
+        with patch(REQUESTS) as requests:
+            requests.get().json.return_value = jobs_response
+            call_command("sync_greenhouse", stdout=StringIO())
+        self.assertEqual(Position.objects.all().count(), 1)


### PR DESCRIPTION
## One-line summary

The Greenhouse API started sending `metadata: null` for a job, rather than the expected `metadata: []`. This works around this so it can accept either and still complete the import.