### PR TITLE
Newsletter /updated page should not POST when token is empty (Issue #12377)

### DIFF
--- a/media/js/newsletter/unsubscribed.es6.js
+++ b/media/js/newsletter/unsubscribed.es6.js
@@ -115,6 +115,7 @@ const UnsubscribedEmailForm = {
         e.preventDefault();
 
         const url = _unsubscribedForm.getAttribute('action');
+        const token = UnsubscribedEmailForm.getToken();
 
         // Disable form fields until POST has completed.
         disableFormFields(_unsubscribedForm);
@@ -125,6 +126,11 @@ const UnsubscribedEmailForm = {
         // Perform client side form field validation.
         if (!UnsubscribedEmailForm.validateFields()) {
             UnsubscribedEmailForm.handleFormError(errorList.REASON_ERROR);
+            return;
+        }
+
+        if (token === '') {
+            UnsubscribedEmailForm.handleFormError();
             return;
         }
 

--- a/tests/unit/spec/newsletter/unsubscribed.js
+++ b/tests/unit/spec/newsletter/unsubscribed.js
@@ -128,6 +128,25 @@ describe('UnsubscribedEmailForm', function () {
             ).toBeFalse();
         });
 
+        it('should handle an invalid token', function () {
+            spyOn(UnsubscribedEmailForm, 'handleFormError').and.callThrough();
+            UnsubscribedEmailForm.init();
+            document.querySelector('input[name="token"]').value = '';
+            document.getElementById('unsub0').click();
+            document.getElementById('newsletter-updated-form-submit').click();
+            expect(UnsubscribedEmailForm.handleFormError).toHaveBeenCalled();
+            expect(
+                document
+                    .getElementById('newsletter-updated-form-errors')
+                    .classList.contains('hidden')
+            ).toBeFalse();
+            expect(
+                document
+                    .querySelector('.error-try-again-later')
+                    .classList.contains('hidden')
+            ).toBeFalse();
+        });
+
         it('should handle failure', function () {
             spyOn(UnsubscribedEmailForm, 'handleFormError').and.callThrough();
             UnsubscribedEmailForm.init();


### PR DESCRIPTION
## One-line summary

Small bug fix for https://github.com/mozilla/bedrock/pull/12448

Prevents the form trying to POST to basket if the token is invalid / empty.

This scenario shouldn't normally happen, unless someone manually / accidentally alters the URL.

## Issue / Bugzilla link

#12377

## Testing

You need a newsletter token in order to view / test this page locally, which you can [get here](https://www.mozilla.org/en-US/newsletter/recovery/). Once you have a token you can view the page at:

`http://localhost:8000/en-US/newsletter/updated/?unsub=1&token={TOKEN}`

- [ ] Form POSTs successfully with your generated token.
- [ ] Form throws an error is token is invalid (e.g. http://localhost:8000/en-US/newsletter/updated/?unsub=1&token=123456789)