### PR TITLE
Dependency updates, incl security bump

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,13 +88,13 @@ blessings==1.7 \
     --hash=sha256:b1fdd7e7a675295630f9ae71527a8ebc10bfefa236b3d6aa4932ee4462c17ba3 \
     --hash=sha256:caad5211e7ba5afe04367cdd4cfc68fa886e2e08f6f35e76b7387d2109ccea6e
     # via curtsies
-boto3==1.26.17 \
-    --hash=sha256:bb40a9788dd2234851cdd1110eec0e3f6b3af6b98280924fa44c25199ced5737 \
-    --hash=sha256:c39b7e87b27b00dcf452b2fc80252d311e275036f3d48464af34d0123077f985
+boto3==1.26.22 \
+    --hash=sha256:a4cf7fe649b0202f2f2307eb982ca215edcf9c87b6e65f5b3405f66c289603f2 \
+    --hash=sha256:f16c3aef1432c5083a9e1c36ac08b70b9072e87205e970f8d7520b10b964858f
     # via -r requirements/prod.txt
-botocore==1.29.19 \
-    --hash=sha256:917807ee4ccca34a2f2848eb4fcf878d9e97a44a911a6965ff556d0830c471fd \
-    --hash=sha256:a54561e591f5d8e653657ce04dcad09c10ebca9dbefba73471976e522abf038a
+botocore==1.29.26 \
+    --hash=sha256:2ca26983156fe0846a87b9325205af6bc56268fb99b8b4b9decccf50203ff3b4 \
+    --hash=sha256:f71220fe5a5d393c391ed81a291c0d0985f147568c56da236453043f93727a34
     # via
     #   -r requirements/prod.txt
     #   boto3
@@ -107,9 +107,9 @@ braceexpand==0.1.7 \
     --hash=sha256:91332d53de7828103dcae5773fb43bc34950b0c8160e35e0f44c4427a3b85014 \
     --hash=sha256:e6e539bd20eaea53547472ff94f4fb5c3d3bf9d0a89388c4b56663aba765f705
     # via -r requirements/dev.in
-certifi==2021.10.8 \
-    --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
-    --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
     # via
     #   -r requirements/prod.txt
     #   requests
@@ -1222,9 +1222,9 @@ trio-websocket==0.9.2 \
     --hash=sha256:5b558f6e83cc20a37c3b61202476c5295d1addf57bd65543364e0337e37ed2bc \
     --hash=sha256:a3d34de8fac26023eee701ed1e7bf4da9a8326b61a62934ec9e53b64970fd8fe
     # via selenium
-twilio==7.15.3 \
-    --hash=sha256:805b3e880b20757726a38f0f4e0ea6f91f7ce68ecb8f75ba263dccc480a7fd26 \
-    --hash=sha256:f64f2106c2c8705ac84c01cb0cdb6157dc8b5d32b5eecbaec70e60cdbf774758
+twilio==7.15.4 \
+    --hash=sha256:13a9eca9e1f06b5f01b8745274a233143198afba19cacd4522ae9e571916dfe5 \
+    --hash=sha256:699c5723d87141e0af3a8f79076b1f97acbdcf3287d384f2adf921e780e419df
     # via -r requirements/prod.txt
 typing-extensions==4.1.1 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,3 +1,4 @@
+certifi==2022.12.7  # hard-pinned subdep for now until sphinx bump it
 chardet==5.0.0
 fluent.pygments==0.1.0
 fluent.syntax==0.17.0  # hard-pinned subdep to avoid compatibility issues

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,10 +16,12 @@ babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
     # via sphinx
-certifi==2021.10.8 \
-    --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
-    --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569
-    # via requests
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+    # via
+    #   -r requirements/docs.in
+    #   requests
 chardet==5.0.0 \
     --hash=sha256:0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa \
     --hash=sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557
@@ -214,9 +216,9 @@ pyyaml==6.0 \
     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via myst-parser
-requests==2.27.1 \
-    --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
-    --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
+requests==2.28.1 \
+    --hash=sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983 \
+    --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
     # via sphinx
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -3,7 +3,8 @@ babis==0.2.4
 basket-client==1.0.0
 beautifulsoup4==4.11.1
 bleach[css]==5.0.1
-boto3==1.26.17
+boto3==1.26.22
+certifi==2022.12.7  # hard-pinned subdep for now until requests and sentry-sdk bump it
 chardet==5.0.0
 commonware==0.6.0
 contentful==1.13.1
@@ -54,5 +55,5 @@ sentry-sdk==1.11.1
 sentry-processor==0.0.1
 supervisor==4.2.4
 timeago==1.0.16
-twilio==7.15.3
+twilio==7.15.4
 whitenoise==6.2.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -42,20 +42,21 @@ bleach[css]==5.0.1 \
     --hash=sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a \
     --hash=sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c
     # via -r requirements/prod.in
-boto3==1.26.17 \
-    --hash=sha256:bb40a9788dd2234851cdd1110eec0e3f6b3af6b98280924fa44c25199ced5737 \
-    --hash=sha256:c39b7e87b27b00dcf452b2fc80252d311e275036f3d48464af34d0123077f985
+boto3==1.26.22 \
+    --hash=sha256:a4cf7fe649b0202f2f2307eb982ca215edcf9c87b6e65f5b3405f66c289603f2 \
+    --hash=sha256:f16c3aef1432c5083a9e1c36ac08b70b9072e87205e970f8d7520b10b964858f
     # via -r requirements/prod.in
-botocore==1.29.19 \
-    --hash=sha256:917807ee4ccca34a2f2848eb4fcf878d9e97a44a911a6965ff556d0830c471fd \
-    --hash=sha256:a54561e591f5d8e653657ce04dcad09c10ebca9dbefba73471976e522abf038a
+botocore==1.29.26 \
+    --hash=sha256:2ca26983156fe0846a87b9325205af6bc56268fb99b8b4b9decccf50203ff3b4 \
+    --hash=sha256:f71220fe5a5d393c391ed81a291c0d0985f147568c56da236453043f93727a34
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8 \
-    --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872 \
-    --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
     # via
+    #   -r requirements/prod.in
     #   requests
     #   sentry-sdk
 cffi==1.15.0 \
@@ -812,9 +813,9 @@ tinycss2==1.1.1 \
     --hash=sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf \
     --hash=sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8
     # via bleach
-twilio==7.15.3 \
-    --hash=sha256:805b3e880b20757726a38f0f4e0ea6f91f7ce68ecb8f75ba263dccc480a7fd26 \
-    --hash=sha256:f64f2106c2c8705ac84c01cb0cdb6157dc8b5d32b5eecbaec70e60cdbf774758
+twilio==7.15.4 \
+    --hash=sha256:13a9eca9e1f06b5f01b8745274a233143198afba19cacd4522ae9e571916dfe5 \
+    --hash=sha256:699c5723d87141e0af3a8f79076b1f97acbdcf3287d384f2adf921e780e419df
     # via -r requirements/prod.in
 tzdata==2021.5 \
     --hash=sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5 \


### PR DESCRIPTION
Bumps dependencies, incl a security fixup due to a SSL Certificate Authority being revoked - [source](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/oxX69KFvsm4/m/yLohoVqtCgAJ)

#12454 Bump certifi from 2021.10.8 to 2022.12.7 in /requirements - security 
#12446 Bump twilio from 7.15.3 to 7.15.4 in /requirements \
#12445 Bump boto3 from 1.26.17 to 1.26.22 in /requirements
