### PR TITLE
Ensure WNP update notification has consistent padding (Fixes #12465)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/header.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/header.html
@@ -7,11 +7,13 @@
 <header class="c-page-header">
   <div class="mzp-l-content c-page-header-inner">
     <h2 class="c-page-header-logo-fx">{{ ftl('whatsnew-firefox') }}</h2>
-    <div class="mzp-c-notification-bar mzp-t-success up-to-date">
-      <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
-    </div>
-    <div class="mzp-c-notification-bar out-of-date">
-      <p>{{ ftl('whatsnew-out-of-date-notification-v2', fallback='whatsnew-out-of-date-notification') }}</p>
+    <div class="c-page-header-notification">
+      <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+        <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
+      </div>
+      <div class="mzp-c-notification-bar out-of-date">
+        <p>{{ ftl('whatsnew-out-of-date-notification-v2', fallback='whatsnew-out-of-date-notification') }}</p>
+      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## One-line summary

Fix missing bottom padding on WNP out-of-date browser notification.

## Issue / Bugzilla link

#12465

## Testing

You may need to use an out of date Firefox confirm the fix looks as expected, but I've also included a screenshot below.

http://localhost:8000/en-US/firefox/108.0/whatsnew/

![image](https://user-images.githubusercontent.com/400117/207056159-3408d8ea-885c-43b4-a4a2-38e89c485202.png)