### PR TITLE
Link on The History of Mozilla goes to an access denied webpage

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/history.html
+++ b/bedrock/mozorg/templates/mozorg/about/history.html
@@ -16,7 +16,7 @@
 
   <p>
     {{ ftl('history-the-mozilla-project-was',
-           coderush='https://air.mozilla.org/code-rush/',
+           coderush='https://www.youtube.com/watch?v=4Q7FTjhvZ7Y',
            sourcerelease='https://web.archive.org/web/20021001071727/wp.netscape.com/newsref/pr/newsrelease558.html') }}
     {{ ftl('history-it-was-intended-to-harness') }}
     {{ ftl('history-within-the-first-year-new', firstyear='http://www-archive.mozilla.org/mozilla-at-one.html') }}

--- a/l10n/en/mozorg/about/history.ftl
+++ b/l10n/en/mozorg/about/history.ftl
@@ -7,7 +7,7 @@
 history-history-of-the-mozilla-project = History of the { -brand-name-mozilla } Project
 
 # Variables:
-#   $coderush (url) - link to https://air.mozilla.org/code-rush/
+#   $coderush (url) - link to https://www.youtube.com/watch?v=4Q7FTjhvZ7Y
 #   $sourcerelease (url) - link to https://web.archive.org/web/20021001071727/wp.netscape.com/newsref/pr/newsrelease558.html'
 history-the-mozilla-project-was = The { -brand-name-mozilla } project was <a href="{ $coderush }">created in 1998</a> with the <a href="{ $sourcerelease }">release of the { -brand-name-netscape } browser suite source code</a>.
 


### PR DESCRIPTION
The situation is that the History of Mozilla Project (https://www.mozilla.org/en-US/about/history/) links to a page that currently shows access denied (an air Mozilla link). 

The missing link is Code Rush by David Winton, which according to Wikipedia, is licensed under a CC 3.0 US License: https://en.wikipedia.org/wiki/Code_Rush 

There is an youtube version which is active and provided by The Documentary Network: https://www.youtube.com/watch?v=4Q7FTjhvZ7Y which is the one I have used in the patch. 

Keep in mind that I am not familiar with Fluent.



