### PR TITLE
Bump @sentry/browser to v7.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
-        "@sentry/browser": "^7.6.0",
+        "@sentry/browser": "^7.25.0",
         "babel-loader": "^8.2.5",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
@@ -1799,13 +1799,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.11.1.tgz",
-      "integrity": "sha512-k2XHuzPfnm8VJPK5eWd1+Y5VCgN42sLveb8Qxc3prb5PSL416NWMLZaoB7RMIhy430fKrSFiosnm6QDk2M6pbA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-vBNWDv8SUtJqgw/Mg9hGxct7dzHucfxq1zfxOdFziZOA/N9l+K52roNLZjYOk1JxaBE4QsHgJJyXelHnPlzCbA==",
       "dependencies": {
-        "@sentry/core": "7.11.1",
-        "@sentry/types": "7.11.1",
-        "@sentry/utils": "7.11.1",
+        "@sentry/core": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1818,13 +1818,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-kaDSZ6VNuO4ZZdqUOOX6XM6x+kjo2bMnDQ3IJG51FPvVjr8lXYhXj1Ccxcot3pBYAIWPPby2+vNDOXllmXqoBA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-4PMuf+MsLxtbesXFBdXfRQhdxHVMi4e6z52DEdtSN9V41lT/R78qIfVopHs5gAr9j4lxCaiKSnNQDKziWLeQ8w==",
       "dependencies": {
-        "@sentry/hub": "7.11.1",
-        "@sentry/types": "7.11.1",
-        "@sentry/utils": "7.11.1",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1836,38 +1835,20 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@sentry/hub": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.11.1.tgz",
-      "integrity": "sha512-M6ClgdXdptS0lUBKB5KpXXe2qMQhsoiEN2pEGRI6+auqhfHCUQB1ZXsfjiOYexKC9fwx7TyFyZ9Jcaf2DTxEhw==",
-      "dependencies": {
-        "@sentry/types": "7.11.1",
-        "@sentry/utils": "7.11.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@sentry/types": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.11.1.tgz",
-      "integrity": "sha512-gIEhOPxC2cjrxQ0+K2SFJ1P6e/an5osSxVc9OOtekN28eHtVsXFCLB8XVWeNQnS7N2VkrVrkqORMBz1kvIcvVQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.25.0.tgz",
+      "integrity": "sha512-m/tVeuZpbYNQjp4BYOz7bBxZEWdTHdTgXg9YlztUOCf5JDDujpxYp2Pyp4+cDDulzFIixXzRH7FRiKsOJ0WF7w==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.11.1.tgz",
-      "integrity": "sha512-tRVXNT5O9ilkV31pyHeTqA1PcPQfMV/2OR6yUYM4ah+QVISovC0f0ybhByuH5nYg6x/Gsnx1o7pc8L1GE3+O7A==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.25.0.tgz",
+      "integrity": "sha512-1Wct+LvDySYgXBYHjoTzccASK4Rk/88cCifSZF7pLrix3Rzk+8QnPt4vZ/ce62nTNBDs/OeFXO1eFwiz9nCoEg==",
       "dependencies": {
-        "@sentry/types": "7.11.1",
+        "@sentry/types": "7.25.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -11114,13 +11095,13 @@
       }
     },
     "@sentry/browser": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.11.1.tgz",
-      "integrity": "sha512-k2XHuzPfnm8VJPK5eWd1+Y5VCgN42sLveb8Qxc3prb5PSL416NWMLZaoB7RMIhy430fKrSFiosnm6QDk2M6pbA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-vBNWDv8SUtJqgw/Mg9hGxct7dzHucfxq1zfxOdFziZOA/N9l+K52roNLZjYOk1JxaBE4QsHgJJyXelHnPlzCbA==",
       "requires": {
-        "@sentry/core": "7.11.1",
-        "@sentry/types": "7.11.1",
-        "@sentry/utils": "7.11.1",
+        "@sentry/core": "7.25.0",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -11132,30 +11113,12 @@
       }
     },
     "@sentry/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-kaDSZ6VNuO4ZZdqUOOX6XM6x+kjo2bMnDQ3IJG51FPvVjr8lXYhXj1Ccxcot3pBYAIWPPby2+vNDOXllmXqoBA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-4PMuf+MsLxtbesXFBdXfRQhdxHVMi4e6z52DEdtSN9V41lT/R78qIfVopHs5gAr9j4lxCaiKSnNQDKziWLeQ8w==",
       "requires": {
-        "@sentry/hub": "7.11.1",
-        "@sentry/types": "7.11.1",
-        "@sentry/utils": "7.11.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/hub": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.11.1.tgz",
-      "integrity": "sha512-M6ClgdXdptS0lUBKB5KpXXe2qMQhsoiEN2pEGRI6+auqhfHCUQB1ZXsfjiOYexKC9fwx7TyFyZ9Jcaf2DTxEhw==",
-      "requires": {
-        "@sentry/types": "7.11.1",
-        "@sentry/utils": "7.11.1",
+        "@sentry/types": "7.25.0",
+        "@sentry/utils": "7.25.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -11167,16 +11130,16 @@
       }
     },
     "@sentry/types": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.11.1.tgz",
-      "integrity": "sha512-gIEhOPxC2cjrxQ0+K2SFJ1P6e/an5osSxVc9OOtekN28eHtVsXFCLB8XVWeNQnS7N2VkrVrkqORMBz1kvIcvVQ=="
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.25.0.tgz",
+      "integrity": "sha512-m/tVeuZpbYNQjp4BYOz7bBxZEWdTHdTgXg9YlztUOCf5JDDujpxYp2Pyp4+cDDulzFIixXzRH7FRiKsOJ0WF7w=="
     },
     "@sentry/utils": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.11.1.tgz",
-      "integrity": "sha512-tRVXNT5O9ilkV31pyHeTqA1PcPQfMV/2OR6yUYM4ah+QVISovC0f0ybhByuH5nYg6x/Gsnx1o7pc8L1GE3+O7A==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.25.0.tgz",
+      "integrity": "sha512-1Wct+LvDySYgXBYHjoTzccASK4Rk/88cCifSZF7pLrix3Rzk+8QnPt4vZ/ce62nTNBDs/OeFXO1eFwiz9nCoEg==",
       "requires": {
-        "@sentry/types": "7.11.1",
+        "@sentry/types": "7.25.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",
-    "@sentry/browser": "^7.6.0",
+    "@sentry/browser": "^7.25.0",
     "babel-loader": "^8.2.5",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
## One-line summary

Bumps `@sentry/browser` to latest version.

## Issue / Bugzilla link

N/A

## Testing

- `npm install`

Set `SENTRY_FRONTEND_DSN=https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331` in your `.env` if you would like to test this locally.