### PR TITLE
Remove outdated Wiki link from firefox/privacy page (Fixes #12469)

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -97,9 +97,13 @@
       <h2>{{ ftl('firefox-privacy-hub-no-secrets') }}</h2>
       <h3 class="privacy-promise-sub-title">{{ ftl('firefox-privacy-hub-youll-always-know-where-you') }}</h3>
       <p>
-        {{ ftl('firefox-privacy-hub-theres-no-hidden-agenda-here',
-               meetings='https://wiki.mozilla.org/WeeklyUpdates?utm_source=' ~ _entrypoint ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign ~ '&entrypoint=' ~ _entrypoint,
-               privacy=url('privacy.notices.firefox')) }}
+        {% if ftl_has_messages('firefox-privacy-hub-theres-no-hidden-agenda-here-v2') %}
+          {{ ftl('firefox-privacy-hub-theres-no-hidden-agenda-here-v2', privacy=url('privacy.notices.firefox')) }}
+        {% else %}
+          {{ ftl('firefox-privacy-hub-theres-no-hidden-agenda-here',
+                meetings='https://wiki.mozilla.org/WeeklyUpdates?utm_source=' ~ _entrypoint ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign ~ '&entrypoint=' ~ _entrypoint,
+                privacy=url('privacy.notices.firefox')) }}
+        {% endif %}
       </p>
     {% endcall %}
   </div>

--- a/l10n/en/firefox/privacy-hub.ftl
+++ b/l10n/en/firefox/privacy-hub.ftl
@@ -35,6 +35,11 @@ firefox-privacy-hub-youll-always-know-where-you = You’ll always know where you
 
 # Variables:
 #   $privacy (url) - link to https://www.mozilla.org/privacy/firefox/
+firefox-privacy-hub-theres-no-hidden-agenda-here-v2 = There’s no hidden agenda here. Our business doesn’t depend on secretly abusing your trust. Our <a href="{ $privacy }">Privacy Notice</a> is actually readable. If you want to dig into every data-point we collect, our code is open. And so are we.
+
+# Obsolete string
+# Variables:
+#   $privacy (url) - link to https://www.mozilla.org/privacy/firefox/
 #   $meetings (url) - link to https://wiki.mozilla.org/
 firefox-privacy-hub-theres-no-hidden-agenda-here = There’s no hidden agenda here. Our business doesn’t depend on secretly abusing your trust. Our <a href="{ $privacy }">Privacy Notice</a> is actually readable. Anyone in the world can attend our <a href="{ $meetings }">weekly company meetings</a>. If you want to dig into every datapoint we collect, our code is open. And so are we.
 


### PR DESCRIPTION
## One-line summary

Removes an outdated link from the firefox/privacy page.

## Issue / Bugzilla link

#12469

## Testing

http://localhost:8000/en-US/firefox/privacy/