### PR TITLE
Update meta data on home page when 'Choose your own language' is displayed (Fixes #12468)

### DIFF
--- a/bedrock/base/templates/404-locale.html
+++ b/bedrock/base/templates/404-locale.html
@@ -6,11 +6,21 @@
 
 {% extends "base-protocol-mozilla.html" %}
 
-{% block page_title %}{% if not is_root %}404 - {% endif %}Choose your language or locale to browse Mozilla.org{% endblock %}
+{%- block page_title -%}
+  {%- if is_root -%}
+    Internet for people, not profit — Mozilla
+  {%- else -%}
+    404 - Choose your language or locale to browse Mozilla.org
+  {%- endif -%}
+{%- endblock -%}
 
-{% block page_desc -%}
-  Select your country or region to indicate your preferred language.
-{%- endblock %}
+{%- block page_desc -%}
+  {%- if is_root -%}
+    Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.
+  {%- else -%}
+    Select your country or region to indicate your preferred language.
+  {%- endif -%}
+{%- endblock -%}
 
 {% block canonical_urls %}
 {% if is_root %}


### PR DESCRIPTION
## One-line summary

Sets `page_title` and `page_desc` to match the English [home page](https://www.mozilla.org/en-US/) when the `404-locale.html` template is served at the site root.

## Issue / Bugzilla link

#12468

## Testing

To test this locally, first remove all languages from your browser settings:

<img width="659" alt="Screenshot 2022-12-13 at 10 32 15" src="https://user-images.githubusercontent.com/400117/207294511-7bce9624-e8ca-460c-b87d-857db289957f.png">

- [ ] http://localhost:8000/ contains a page title and description that match the English home page.
- [ ] http://localhost:8000/404-locale/ still contains the existing title / description.