### PR TITLE
Add SUMO link to /whatsnew page update notification (Fixes #12444)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/header.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/header.html
@@ -12,7 +12,11 @@
         <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
       </div>
       <div class="mzp-c-notification-bar out-of-date">
-        <p>{{ ftl('whatsnew-out-of-date-notification-v2', fallback='whatsnew-out-of-date-notification') }}</p>
+        {% if ftl_has_messages('whatsnew-out-of-date-notification-v3') %}
+          <p>{{ ftl('whatsnew-out-of-date-notification-v3', url='https://support.mozilla.org/kb/update-firefox-latest-release?' + utm_params) }}</p>
+        {% else %}
+          <p>{{ ftl('whatsnew-out-of-date-notification-v2') }}</p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/l10n/en/firefox/whatsnew/whatsnew.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew.ftl
@@ -14,10 +14,13 @@ whatsnew-up-to-date-notification-v2 = Congrats! You’re using the latest versio
 
 # Obsolete string
 whatsnew-up-to-date-notification = Congrats! You’re using the latest version of { -brand-name-firefox-browser }.
-whatsnew-out-of-date-notification-v2 = An even newer { -brand-name-firefox } is available. Restart to update.
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/update-firefox-latest-release
+whatsnew-out-of-date-notification-v3 = An even newer { -brand-name-firefox } is available. <a href="{ $url }">Update to the latest version</a>
 
 # Obsolete string
-whatsnew-out-of-date-notification = An even newer { -brand-name-firefox-browser } is available. Restart to update.
+whatsnew-out-of-date-notification-v2 = An even newer { -brand-name-firefox } is available. Restart to update.
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/firefox/notes/


### PR DESCRIPTION
## One-line summary

Updates a string on the WNP that's shown when someone's Firefox browser is out of date to include a SUMO help link.

## Issue / Bugzilla link

#12444

## Testing

You may need to use an out of date Firefox confirm the fix looks as expected, but I've also included a screenshot below.

http://localhost:8000/en-US/firefox/whatsnew/

![image](https://user-images.githubusercontent.com/400117/207323482-7ddb0ecc-18cf-4a53-a3e7-227a238b0779.png)