### PR TITLE
Remove image macro use from split macro (pocket) (Issue #12331)

### DIFF
--- a/bedrock/pocket/templates/pocket/add.html
+++ b/bedrock/pocket/templates/pocket/add.html
@@ -20,103 +20,107 @@
 {% endblock %}
 
 {% block content %}
+  <div class="add-page">
+    <section class="add-header">
+      {% call split(
+        block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-l-split-body-narrow',
+        media_class='mzp-l-split-h-center',
+        image=resp_img(
+          url='img/pocket/add-pocket-header.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        )
+      )%}
+        <h2>{{ ftl('pocket-add-save-to-pocket') }}</h2>
+        <p>{{ ftl('pocket-add-click-the-pocket-button') }}</p>
+        <a href="https://help.getpocket.com/article/900-saving-to-pocket-and-viewing-your-list-in-firefox" class="mzp-c-button">{{ ftl('pocket-add-learn-how') }}</a>
+        <p>
+          <a href="https://help.getpocket.com/article/942-where-is-the-pocket-button-in-firefox" class="dark-inline-link rarrow">
+            {{ ftl('pocket-add-dont-see-the-pocket') }}
+          </a>
+        </p>
+      {% endcall %}
+    </section>
 
-<div class="add-page">
-   <section class="add-header">
-         {% call split(
-          block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-l-split-body-narrow',
-          media_class='mzp-l-split-h-center',
-          image_url='img/pocket/add-pocket-header.jpg',
-          )%}
-          <h2>{{ ftl('pocket-add-save-to-pocket') }}</h2>
-          <p>{{ ftl('pocket-add-click-the-pocket-button') }}</p>
-          <a href="https://help.getpocket.com/article/900-saving-to-pocket-and-viewing-your-list-in-firefox" class="mzp-c-button">{{ ftl('pocket-add-learn-how') }}</a>
-           <p>
-              <a href="https://help.getpocket.com/article/942-where-is-the-pocket-button-in-firefox" class="dark-inline-link rarrow">
-               {{ ftl('pocket-add-dont-see-the-pocket') }}
-              </a>
-          </p>
-          {% endcall %}
-   </section>
-
-   <section class="add-device">
-         <h2>{{ ftl('pocket-add-view-from-any') }}</h2>
+    <section class="add-device">
+      <h2>{{ ftl('pocket-add-view-from-any') }}</h2>
       <div class="device-context">
-         <div class="device-image">
-            <img src="{{ static('img/pocket/add-any-device.jpg') }}" alt="{{ ftl('pocket-add-different-devices') }}">
-         </div>
-         <div class="app-stores">
-            <h3>{{ ftl('pocket-add-get-pocket-for') }}</h3>
-            <ul class="app-store-list">
-               <li class="app-store-badge" aria-label="{{ ftl('pocket-add-apple-app-store') }}"><a href="https://apps.apple.com/app/read-it-later-pro/id309601447" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-apple.png') }}" alt=""></a></li>
-               <li class="app-store-badge" aria-label="{{ ftl('pocket-add-mac-app-store') }}"><a href="https://apps.apple.com/app/pocket/id568494494?ls=1&mt=12" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-mac.png') }}" alt=""></a></li>
-               <li class="app-store-badge" aria-label="{{ ftl('pocket-add-google-play-store') }}"><a href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-google.png') }}" alt=""></a></li>
-               <li class="app-store-badge" aria-label="{{ ftl('pocket-add-amazon-app-store') }}"><a href="https://www.amazon.com/dp/B0057PAY8G" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-amazon.png') }}" alt=""></a></li>
-            </ul>
-            <ul class="device-list">
-               <li><a href="https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj?hl=en" target="_blank" rel="noopener noreferrer" class="dark-inline-link rarrow">{{ ftl('pocket-add-windows') }}</a></li>
-               <li><a href="https://help.getpocket.com/article/1006-getting-started-with-kobo" class="dark-inline-link rarrow">{{ ftl('pocket-add-kobo-e-reader') }}</a></li>
-               <li><a href="https://getpocket.com/apps/windowsphone/" class="dark-inline-link rarrow">{{ ftl('pocket-add-windows-mobile') }}</a></li>
-               <li><a href="https://getpocket.com/apps/blackberry/" class="dark-inline-link rarrow">{{ ftl('pocket-add-blackberry') }}</a></li>
-               <li><a href="https://getpocket.com/apps/" class="dark-inline-link rarrow">{{ ftl('pocket-add-more-apps') }}</a></li>
-            </ul>
-         </div>
+        <div class="device-image">
+          <img src="{{ static('img/pocket/add-any-device.jpg') }}" alt="{{ ftl('pocket-add-different-devices') }}">
+        </div>
+        <div class="app-stores">
+          <h3>{{ ftl('pocket-add-get-pocket-for') }}</h3>
+          <ul class="app-store-list">
+            <li class="app-store-badge" aria-label="{{ ftl('pocket-add-apple-app-store') }}"><a href="https://apps.apple.com/app/read-it-later-pro/id309601447" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-apple.png') }}" alt=""></a></li>
+            <li class="app-store-badge" aria-label="{{ ftl('pocket-add-mac-app-store') }}"><a href="https://apps.apple.com/app/pocket/id568494494?ls=1&mt=12" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-mac.png') }}" alt=""></a></li>
+            <li class="app-store-badge" aria-label="{{ ftl('pocket-add-google-play-store') }}"><a href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-google.png') }}" alt=""></a></li>
+            <li class="app-store-badge" aria-label="{{ ftl('pocket-add-amazon-app-store') }}"><a href="https://www.amazon.com/dp/B0057PAY8G" target="_blank" rel="noopener noreferrer" class="dark-inline-link"><img src="{{ static('img/pocket/app-button-amazon.png') }}" alt=""></a></li>
+          </ul>
+          <ul class="device-list">
+            <li><a href="https://chrome.google.com/webstore/detail/save-to-pocket/niloccemoadcdkdjlinkgdfekeahmflj?hl=en" target="_blank" rel="noopener noreferrer" class="dark-inline-link rarrow">{{ ftl('pocket-add-windows') }}</a></li>
+            <li><a href="https://help.getpocket.com/article/1006-getting-started-with-kobo" class="dark-inline-link rarrow">{{ ftl('pocket-add-kobo-e-reader') }}</a></li>
+            <li><a href="https://getpocket.com/apps/windowsphone/" class="dark-inline-link rarrow">{{ ftl('pocket-add-windows-mobile') }}</a></li>
+            <li><a href="https://getpocket.com/apps/blackberry/" class="dark-inline-link rarrow">{{ ftl('pocket-add-blackberry') }}</a></li>
+            <li><a href="https://getpocket.com/apps/" class="dark-inline-link rarrow">{{ ftl('pocket-add-more-apps') }}</a></li>
+          </ul>
+        </div>
       </div>
-   </section>
+    </section>
 
-   <section class="add-save">
+    <section class="add-save">
       <div class="add-save-wrapper">
-            <h2>{{ ftl('pocket-add-unlimited-ways') }}</h2>
-         <div class="save-context">
-            <div class="save-email">
-                <h3>{{ ftl('pocket-add-save-via-email') }}</h3>
-                <p>{{ ftl('pocket-add-email-any-link', add_email='add@getpocket.com',add_email_link='mailto:add@getpocket.com', add_email_css_class='dark-inline-link') }}</p>
-                <a class="save-email-link" href="https://help.getpocket.com/customer/portal/articles/482759">
-                  <div class="save-email-card">
-                    <p class="save-email-card-line email"><span>{{ ftl('pocket-add-to') }}: </span>add@getpocket.com</p>
-                    <p class="save-email-card-line"><span>{{ ftl('pocket-add-subject') }}: </span>{{ ftl('pocket-add-cooking-tips') }}</p>
-                    <p class="save-email-card-line no-border">https://www.example.com</p>
-                  </div>
-                </a>
-                <a href="https://help.getpocket.com/article/1020-saving-to-pocket-via-email" class="dark-inline-link rarrow">{{ ftl('pocket-add-learn-more') }}</a>
+        <h2>{{ ftl('pocket-add-unlimited-ways') }}</h2>
+        <div class="save-context">
+          <div class="save-email">
+            <h3>{{ ftl('pocket-add-save-via-email') }}</h3>
+            <p>{{ ftl('pocket-add-email-any-link', add_email='add@getpocket.com',add_email_link='mailto:add@getpocket.com', add_email_css_class='dark-inline-link') }}</p>
+            <a class="save-email-link" href="https://help.getpocket.com/customer/portal/articles/482759">
+              <div class="save-email-card">
+                <p class="save-email-card-line email"><span>{{ ftl('pocket-add-to') }}: </span>add@getpocket.com</p>
+                <p class="save-email-card-line"><span>{{ ftl('pocket-add-subject') }}: </span>{{ ftl('pocket-add-cooking-tips') }}</p>
+                <p class="save-email-card-line no-border">https://www.example.com</p>
+              </div>
+            </a>
+            <a href="https://help.getpocket.com/article/1020-saving-to-pocket-via-email" class="dark-inline-link rarrow">{{ ftl('pocket-add-learn-more') }}</a>
+          </div>
+          <div class="save-apps">
+            <h3>{{ ftl('pocket-add-integrated-in') }}</h3>
+            <p>{{ ftl('pocket-add-save-to-pocket-using') }}</p>
+            <div class="app-types">
+              <ul class="app-board">
+                <li class="app-icon" aria-label="{{ ftl('pocket-add-twitter') }}">
+                  <a href="https://twitter.com" target="_blank" rel="external noopener">
+                    <img src="{{ static('img/pocket/pocket-twitter.svg') }}" alt="">
+                  </a>
+                </li>
+                <li class="app-icon" aria-label="{{ ftl('pocket-add-flipboard') }}">
+                  <a href="https://flipboard.com" target="_blank" rel="external noopener">
+                    <img src="{{ static('img/pocket/pocket-flipboard.svg') }}" alt="">
+                  </a>
+                </li>
+                <li class="app-icon" aria-label="{{ ftl('pocket-add-tweetbot') }}">
+                  <a href="https://tapbots.com/tweetbot/" target="_blank" rel="external noopener">
+                    <img src="{{ static('img/pocket/pocket-tweetbot.svg') }}" alt="">
+                  </a>
+                </li>
+                <li class="app-icon" aria-label="{{ ftl('pocket-add-feedly') }}">
+                  <a href="https://feedly.com" target="_blank" rel="external noopener">
+                    <img src="{{ static('img/pocket/pocket-feedly.svg') }}" alt="">
+                  </a>
+                </li>
+              </ul>
+              <ul class="social-apps">
+                <li><a href="https://getpocket.com/apps/twitter/" class="dark-inline-link rarrow">{{ ftl('pocket-add-twitter-apps') }}</a></li>
+                <li><a href="https://getpocket.com/apps/news/" class="dark-inline-link rarrow">{{ ftl('pocket-add-news-apps') }}</a></li>
+                <li><a href="https://getpocket.com/apps/" class="dark-inline-link rarrow">{{ ftl('pocket-add-more') }}</a></li>
+              </ul>
             </div>
-            <div class="save-apps">
-               <h3>{{ ftl('pocket-add-integrated-in') }}</h3>
-               <p>{{ ftl('pocket-add-save-to-pocket-using') }}</p>
-               <div class="app-types">
-                  <ul class="app-board">
-                     <li class="app-icon" aria-label="{{ ftl('pocket-add-twitter') }}">
-                       <a href="https://twitter.com" target="_blank" rel="external noopener">
-                         <img src="{{ static('img/pocket/pocket-twitter.svg') }}" alt="">
-                       </a>
-                     </li>
-                     <li class="app-icon" aria-label="{{ ftl('pocket-add-flipboard') }}">
-                       <a href="https://flipboard.com" target="_blank" rel="external noopener">
-                         <img src="{{ static('img/pocket/pocket-flipboard.svg') }}" alt="">
-                       </a>
-                     </li>
-                     <li class="app-icon" aria-label="{{ ftl('pocket-add-tweetbot') }}">
-                       <a href="https://tapbots.com/tweetbot/" target="_blank" rel="external noopener">
-                         <img src="{{ static('img/pocket/pocket-tweetbot.svg') }}" alt="">
-                       </a>
-                     </li>
-                     <li class="app-icon" aria-label="{{ ftl('pocket-add-feedly') }}">
-                       <a href="https://feedly.com" target="_blank" rel="external noopener">
-                         <img src="{{ static('img/pocket/pocket-feedly.svg') }}" alt="">
-                       </a>
-                     </li>
-                  </ul>
-                  <ul class="social-apps">
-                     <li><a href="https://getpocket.com/apps/twitter/" class="dark-inline-link rarrow">{{ ftl('pocket-add-twitter-apps') }}</a></li>
-                     <li><a href="https://getpocket.com/apps/news/" class="dark-inline-link rarrow">{{ ftl('pocket-add-news-apps') }}</a></li>
-                     <li><a href="https://getpocket.com/apps/" class="dark-inline-link rarrow">{{ ftl('pocket-add-more') }}</a></li>
-                  </ul>
-               </div>
-            </div>
-         </div>
+          </div>
+        </div>
       </div>
-   </section>
-</div>
+    </section>
+  </div>
 {% endblock %}
 
 {% block footer %}

--- a/bedrock/pocket/templates/pocket/base-platform.html
+++ b/bedrock/pocket/templates/pocket/base-platform.html
@@ -4,45 +4,49 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% extends "pocket/base.html" %}
+{% extends "pocket/base.html" %}
 
- {% from "macros-protocol.html" import split with context %}
+{% from "macros-protocol.html" import split with context %}
 
- {% block page_title %}self.page_title(){% endblock %}
+{% block page_title %}self.page_title(){% endblock %}
 
- {% block pocket_css %}
-   {{ css_bundle('protocol-split') }}
-   {{ css_bundle('pocket-platforms') }}
- {% endblock %}
+{% block pocket_css %}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('pocket-platforms') }}
+{% endblock %}
 
- {% block header %}
+{% block header %}
   {% include 'pocket/includes/nav-platform.html' %}
- {% endblock %}
+{% endblock %}
 
- {% block content %}
-     <div class="platform">
-         {% call split(
-           block_class='mzp-l-split-center-on-sm-md mzp-t-content-lg mzp-l-split-reversed mzp-l-split-hide-media-on-sm-md',
-           media_class='mzp-l-split-h-center',
-           image_url=platform_image,
-           )%}
-           <h1>{{ self.page_title() }}</h1>
-           <p>{{ self.page_desc() }}</p>
-           <a href="{{ self.page_url() }}" class="mzp-c-button" target="_blank" rel="external noopener">{{ self.page_cta() }}</a>
-           {% block bookmarklet %}
-           {% if ftl_has_messages('pocket-platform-install-bookmarklet') %}
-           <p>
-             <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">
-               {{ ftl('pocket-platform-install-bookmarklet') }}
-             </a>
-           </p>
-           {% endif %}
-           {% endblock bookmarklet %}
+{% block content %}
+  <div class="platform">
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-t-content-lg mzp-l-split-reversed mzp-l-split-hide-media-on-sm-md',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url=platform_image,
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h1>{{ self.page_title() }}</h1>
+      <p>{{ self.page_desc() }}</p>
+      <a href="{{ self.page_url() }}" class="mzp-c-button" target="_blank" rel="external noopener">{{ self.page_cta() }}</a>
+      {% block bookmarklet %}
+          {% if ftl_has_messages('pocket-platform-install-bookmarklet') %}
+            <p>
+              <a class="bookmarklet" href="https://getpocket.com/bookmarklets/">
+                {{ ftl('pocket-platform-install-bookmarklet') }}
+              </a>
+            </p>
+          {% endif %}
+      {% endblock bookmarklet %}
+    {% endcall %}
+  </div>
+{% endblock %}
 
-           {% endcall %}
-     </div>
- {% endblock %}
-
- {% block footer %}
+{% block footer %}
   {% include 'pocket/includes/footer-platform.html' %}
- {% endblock %}
+{% endblock %}

--- a/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
+++ b/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
@@ -9,93 +9,119 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% from "macros-protocol.html" import split with context %}
 
 {% block pocket_css %}
-{{ css_bundle('protocol-split') }}
-{{ css_bundle('pocket-new-tab') }}
+  {{ css_bundle('protocol-split') }}
+  {{ css_bundle('pocket-new-tab') }}
 {% endblock %}
 
 {% block page_title %}{{ ftl('pocket-new-tab-learn-more') }}{% endblock page_title %}
 
 {% block content %}
-<header class="new-tab-header">
-  <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-family">{{ ftl('pocket-new-tab-firefox') }}</div>
-  <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket">{{ ftl('pocket-new-tab-pocket') }}</div>
-  <p>{{ ftl('pocket-new-tab-pocket-is-part') }}</p>
-</header>
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md new-tab-section top',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/new-tab/pocket-list.png',
-  )%}
-    <span class="tagline">{{ ftl('pocket-new-tab-pocket-for-firefox') }}</span>
-    <h2 class="new-tab-section-header top">{{ ftl('pocket-new-tab-build-your-personal') }}</h2>
-    <p class="new-tab-section-body top">{{ ftl('pocket-new-tab-included-inside') }}</p>
-     {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-new-tab-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
-    <a href="https://getpocket.com/signup" class="sub-cta">{{ ftl('pocket-new-tab-more-ways-to') }}</a>
-  {% endcall %}
-</section>
-<section class="new-tab-section">
-  <h1 class="new-tab-page-header mzp-l-content">{{ ftl('pocket-new-tab-discover-the-most') }}</h1>
-  <section
-    class="mzp-c-split mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-t-split-nospace new-tab-section">
-    <div class="mzp-c-split-container">
-      <div class="mzp-c-split-media mzp-l-split-h-center mzp-l-split-media-overflow hidden-gem-media">
-        <img class="mzp-c-split-media-asset" src="/media/img/pocket/new-tab/hidden-gem.svg" alt="" loading="eager">
+  <header class="new-tab-header">
+    <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-family">{{ ftl('pocket-new-tab-firefox') }}</div>
+    <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket">{{ ftl('pocket-new-tab-pocket') }}</div>
+    <p>{{ ftl('pocket-new-tab-pocket-is-part') }}</p>
+  </header>
+
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md new-tab-section top',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/new-tab/pocket-list.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <span class="tagline">{{ ftl('pocket-new-tab-pocket-for-firefox') }}</span>
+      <h2 class="new-tab-section-header top">{{ ftl('pocket-new-tab-build-your-personal') }}</h2>
+      <p class="new-tab-section-body top">{{ ftl('pocket-new-tab-included-inside') }}</p>
+      {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-new-tab-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
+      <a href="https://getpocket.com/signup" class="sub-cta">{{ ftl('pocket-new-tab-more-ways-to') }}</a>
+    {% endcall %}
+  </section>
+
+  <section class="new-tab-section">
+    <h1 class="new-tab-page-header mzp-l-content">{{ ftl('pocket-new-tab-discover-the-most') }}</h1>
+
+    <section class="mzp-c-split mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-t-split-nospace new-tab-section">
+      <div class="mzp-c-split-container">
+        <div class="mzp-c-split-media mzp-l-split-h-center mzp-l-split-media-overflow hidden-gem-media">
+          <img class="mzp-c-split-media-asset" src="/media/img/pocket/new-tab/hidden-gem.svg" alt="" loading="eager">
+        </div>
+        <div class="mzp-c-split-body hidden-gem-body">
+          <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-finding-the') }}</h2>
+          <p class="new-tab-section-body">{{ ftl('pocket-new-tab-as-part-of', learn_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why') }}</p>
+        </div>
       </div>
-      <div class="mzp-c-split-body hidden-gem-body">
-        <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-finding-the') }}</h2>
-        <p class="new-tab-section-body">{{ ftl('pocket-new-tab-as-part-of', learn_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#why') }}</p>
+    </section>
+
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace new-tab-section',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/new-tab/fortress.svg',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-your-data') }}</h2>
+      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-in-addition-to', privacy_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#personalized') }}</p>
+    {% endcall %}
+
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-t-content-lg mzp-l-split-reversed mzp-t-split-nospace new-tab-section',
+      media_class='mzp-l-split-h-center',
+      body_class="new-tab-books-body",
+      image=resp_img(
+        url='img/pocket/new-tab/books.svg',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-fuel') }}</h2>
+      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-check-out', explore_url='https://getpocket.com/explore', hits_signup_url='https://getpocket.com/explore/pocket-hits-signup') }}</p>
+    {% endcall %}
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace new-tab-section',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/new-tab/lounge.svg',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-save-in') }}</h2>
+      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-built-right') }}</p>
+      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-activate-your-account', pocket_and_firefox=url('pocket.pocket-and-firefox')) }}</p>
+    {% endcall %}
+  </section>
+
+  <section class="mzp-l-content">
+    <img class="details-img" src="{{ static('img/pocket/new-tab/sign.svg') }}" />
+    <div>
+      <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-you-make') }}</h2>
+      <div class="helpful-links-wrapper">
+        <p class="new-tab-section-body">{{ ftl('pocket-new-tab-its-easy', dismiss_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#turn-off') }}</p>
+        <ul class="new-tab-helpful-links">
+          <li><a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq">{{ ftl('pocket-new-tab-faq') }}</a></li>
+          <li><a href="{{ url('pocket.privacy') }}">{{ ftl('pocket-new-tab-privacy-policy') }}</a></li>
+          <li><a href="{{ url('pocket.tos') }}">{{ ftl('pocket-new-tab-tos') }}</a></li>
+          <li><a href="https://getpocket.com/sponsor">{{ ftl('pocket-new-tab-sponsorship') }}</a></li>
+        </ul>
       </div>
     </div>
   </section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace new-tab-section',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/new-tab/fortress.svg',
-  )%}
-    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-your-data') }}</h2>
-    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-in-addition-to', privacy_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#personalized') }}</p>
-  {% endcall %}
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-t-content-lg mzp-l-split-reversed mzp-t-split-nospace new-tab-section',
-  media_class='mzp-l-split-h-center',
-  body_class="new-tab-books-body",
-  image_url='img/pocket/new-tab/books.svg',
-  )%}
-    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-fuel') }}</h2>
-    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-check-out', explore_url='https://getpocket.com/explore',
-    hits_signup_url='https://getpocket.com/explore/pocket-hits-signup') }}</p>
-  {% endcall %}
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace new-tab-section',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/new-tab/lounge.svg',
-  )%}
-    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-save-in') }}</h2>
-    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-built-right') }}</p>
-    <p class="new-tab-section-body">{{ ftl('pocket-new-tab-activate-your-account', pocket_and_firefox=url('pocket.pocket-and-firefox')) }}</p>
-  {% endcall %}
-</section>
-<section class="mzp-l-content">
-  <img class="details-img" src="{{ static('img/pocket/new-tab/sign.svg') }}" />
-  <div>
-    <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-you-make') }}</h2>
-    <div class="helpful-links-wrapper">
-      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-its-easy', dismiss_url='https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq#turn-off') }}</p>
-      <ul class="new-tab-helpful-links">
-        <li><a href="https://help.getpocket.com/article/1142-firefox-new-tab-recommendations-faq">{{ ftl('pocket-new-tab-faq') }}</a></li>
-        <li><a href="{{ url('pocket.privacy') }}">{{ ftl('pocket-new-tab-privacy-policy') }}</a></li>
-        <li><a href="{{ url('pocket.tos') }}">{{ ftl('pocket-new-tab-tos') }}</a></li>
-        <li><a href="https://getpocket.com/sponsor">{{ ftl('pocket-new-tab-sponsorship') }}</a></li>
-      </ul>
-    </div>
-  </div>
-</section>
-<section class="grass-graphic">
-  <img class="left-grass" src="{{ static('img/pocket/new-tab/grass-footer-left.png') }}" />
-  <img class="right-grass" src="{{ static('img/pocket/new-tab/grass-footer-right.png') }}" />
-</section>
-<footer class="new-tab-footer mzp-t-dark">
-  <span class="mzp-c-wordmark mzp-t-wordmark-xs mzp-t-product-pocket">{{ ftl('pocket-new-tab-pocket') }}</span>
-</footer>
+
+  <section class="grass-graphic">
+    <img class="left-grass" src="{{ static('img/pocket/new-tab/grass-footer-left.png') }}" />
+    <img class="right-grass" src="{{ static('img/pocket/new-tab/grass-footer-right.png') }}" />
+  </section>
+
+  <footer class="new-tab-footer mzp-t-dark">
+    <span class="mzp-c-wordmark mzp-t-wordmark-xs mzp-t-product-pocket">{{ ftl('pocket-new-tab-pocket') }}</span>
+  </footer>
 {% endblock %}

--- a/bedrock/pocket/templates/pocket/get-inspired.html
+++ b/bedrock/pocket/templates/pocket/get-inspired.html
@@ -16,54 +16,67 @@
 {% block page_title %}{{ ftl('pocket-features-pocket-and-firefox') }}{% endblock %}
 
 {% block content %}
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/save-inspirations.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h1 class="section-heading">{{ ftl('pocket-features-save-what-inspires') }}</h1>
+      <p class="section-lede">{{ ftl('pocket-features-pocket-is-your-save') }}</p>
+      <div class="app-store-badges">
+        <a href="https://apps.apple.com/us/app/pocket-save-read-grow/" target="_blank" rel="noopener noreferrer" class="apple-store"><img src="{{ static('img/pocket/app-button-apple.png') }}" alt="{{ ftl('pocket-features-apple-store') }}"></a>
+        <a href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro" target="_blank" rel="noopener noreferrer" class="google-play-store"><img src="{{ static('img/pocket/app-button-google.png') }}" alt="{{ ftl('pocket-features-google-play-store') }}"></a>
+      </div>
+    {% endcall %}
+  </section>
 
-<section>
-{% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/save-inspirations.png',
-  )%}
-  <h1 class="section-heading">{{ ftl('pocket-features-save-what-inspires') }}</h1>
-  <p class="section-lede">{{ ftl('pocket-features-pocket-is-your-save') }}</p>
-  <div class="app-store-badges">
-    <a href="https://apps.apple.com/us/app/pocket-save-read-grow/" target="_blank" rel="noopener noreferrer" class="apple-store"><img src="{{ static('img/pocket/app-button-apple.png') }}" alt="{{ ftl('pocket-features-apple-store') }}"></a>
-    <a href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro" target="_blank" rel="noopener noreferrer" class="google-play-store"><img src="{{ static('img/pocket/app-button-google.png') }}" alt="{{ ftl('pocket-features-google-play-store') }}"></a>
-  </div>
-  {% endcall %}
-</section>
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/focused-reading.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-special-features') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-use-pocket-app') }}</p>
+    {% endcall %}
+  </section>
 
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/focused-reading.png',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-special-features') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-use-pocket-app') }}</p>
-  {% endcall %}
-</section>
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/reading-nook.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-your-private') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-when-ready-to') }}</p>
+    {% endcall %}
+  </section>
 
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/reading-nook.png',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-your-private') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-when-ready-to') }}</p>
-  {% endcall %}
-</section>
+  <section class="personal-library">
+    <h2 class="section-heading">
+      {{ ftl('pocket-features-start-building') }}
+    </h2>
+    <div class="app-store-badges">
+      <a href="https://apps.apple.com/us/app/pocket-save-read-grow/" target="_blank" rel="noopener noreferrer" class="apple-store"><img src="{{ static('img/pocket/app-button-apple.png') }}" alt="{{ ftl('pocket-features-apple-store') }}"></a>
+      <a href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro" target="_blank" rel="noopener noreferrer" class="google-play-store"><img src="{{ static('img/pocket/app-button-google.png') }}" alt="{{ ftl('pocket-features-google-play-store') }}"></a>
+    </div>
+  </section>
 
-<section class="personal-library">
-  <h2 class="section-heading">
-    {{ ftl('pocket-features-start-building') }}
-  </h2>
-  <div class="app-store-badges">
-    <a href="https://apps.apple.com/us/app/pocket-save-read-grow/" target="_blank" rel="noopener noreferrer" class="apple-store"><img src="{{ static('img/pocket/app-button-apple.png') }}" alt="{{ ftl('pocket-features-apple-store') }}"></a>
-    <a href="https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro" target="_blank" rel="noopener noreferrer" class="google-play-store"><img src="{{ static('img/pocket/app-button-google.png') }}" alt="{{ ftl('pocket-features-google-play-store') }}"></a>
-  </div>
-</section>
-
-{% include 'pocket/includes/pocket-premium.html' %}
-
+  {% include 'pocket/includes/pocket-premium.html' %}
 {% endblock %}

--- a/bedrock/pocket/templates/pocket/home.html
+++ b/bedrock/pocket/templates/pocket/home.html
@@ -23,108 +23,118 @@
 {% endblock %}
 
 {% block content %}
+  <div class="pocket-homepage mzp-t-content-xl">
+    {% call split(
+      block_class='pocket-homepage-header mzp-l-split-pop',
+      media_class='mzp-l-split-media-overflow',
+      image=resp_img(
+        url='pocket/pocket-home-articles.png',
+        optional_attributes={
+          'l10n': True,
+          'class': 'mzp-c-split-media-asset'
+        }
+      ),
+      media_after=True
+    )%}
+      <div class="c-hero-badge">
+        <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket"></div>
+        <p><strong>{{ ftl('pocket-home-10-year') }}</strong></p>
+      </div>
+      <h1 class="section-heading">{{ ftl('pocket-home-get-right-to') }}</h1>
+      <p class="section-lede">{{ ftl('pocket-home-your-own-private') }}</p>
+      <div class="pocket-homepage-accounts">
+        <a href="https://getpocket.com/signup?utm_source=homepage" class="mzp-c-button">{{ ftl('pocket-home-sign-up-for-pocket') }}</a>
+        <p class="pocket-homepage-mobile-login">{{ ftl('pocket-home-already-have-an-account') }}
+          <a href="https://getpocket.com/login/?ep=1">{{ ftl('pocket-home-log-in') }}</a>
+        </p>
+      </div>
+    {% endcall %}
 
-    <div class="pocket-homepage mzp-t-content-xl">
-        {% call split(
-          block_class='pocket-homepage-header mzp-l-split-pop',
-          media_class='mzp-l-split-media-overflow',
-          l10n_image=True,
-          image_url='pocket/pocket-home-articles.png',
-          media_after=True,
-          loading='eager'
-          )%}
-          <div class="c-hero-badge">
-            <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket"></div>
-            <p><strong>{{ ftl('pocket-home-10-year') }}</strong></p>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed',
+      media_class='mzp-l-split-h-center',
+      media_after=True,
+      image=resp_img(
+        url='img/pocket/pocket-colorful-books.svg',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-home-save-interesting-stories') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-home-stop-sending-yourself-links') }}</p>
+    {% endcall %}
+
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md',
+      media_class='mzp-l-split-h-center',
+      media_after=True,
+      image=resp_img(
+        url='pocket/pocket-list-mobile.png',
+        optional_attributes={
+          'l10n': True,
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-home-great-recommendations') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-home-we-comb-the-internet') }}</p>
+    {% endcall %}
+
+    <section class="pocket-homepage-picto mzp-l-content mzp-t-content-xl">
+      <h2 class="sub-section-heading">{{ ftl('pocket-home-make-pocket-work') }}</h2>
+      <ul class="mzp-l-columns mzp-t-columns-three">
+        {% call picto(
+          title=ftl('pocket-home-tailor-text'),
+          image_url='img/pocket/pocket-text-icon.svg',
+          image_width=40
+        ) %}
+        {% endcall %}
+
+        {% call picto(
+          title=ftl('pocket-home-categorize-saves'),
+          image_url='img/pocket/pocket-tag-icon.svg',
+          image_width=40
+        ) %}
+        {% endcall %}
+
+        {% call picto(
+          title=ftl('pocket-home-listen-to-articles'),
+          image_url='img/pocket/pocket-audio-icon.svg',
+          image_width=40,
+        ) %}
+        {% endcall %}
+      </ul>
+    </section>
+
+    <section class="pocket-homepage-premium ">
+      <div class="mzp-l-content mzp-t-content-xl">
+        <div class="mzp-l-columns mzp-t-columns-two">
+          <div>
+            <h2>{{ ftl('pocket-home-start-with-the-best') }}</h2>
+            <p>{{ ftl('pocket-home-pocket-premium-is') }}</p>
           </div>
-          <h1 class="section-heading">{{ ftl('pocket-home-get-right-to') }}</h1>
-          <p class="section-lede">{{ ftl('pocket-home-your-own-private') }}</p>
-          <div class="pocket-homepage-accounts">
-            <a href="https://getpocket.com/signup?utm_source=homepage" class="mzp-c-button">{{ ftl('pocket-home-sign-up-for-pocket') }}</a>
-            <p class="pocket-homepage-mobile-login">{{ ftl('pocket-home-already-have-an-account') }}
-              <a href="https://getpocket.com/login/?ep=1">{{ ftl('pocket-home-log-in') }}</a>
-            </p>
-          </div>
-          {% endcall %}
-
-          {% call split(
-          block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed',
-          media_class='mzp-l-split-h-center',
-          media_after=True,
-          image_url='img/pocket/pocket-colorful-books.svg',
-          )%}
-          <h2 class="sub-section-heading">{{ ftl('pocket-home-save-interesting-stories') }}</h2>
-          <p class="section-lede">{{ ftl('pocket-home-stop-sending-yourself-links') }}</p>
-          {% endcall %}
-
-          {% call split(
-          block_class='mzp-l-split-center-on-sm-md',
-          media_class='mzp-l-split-h-center',
-          media_after=True,
-          l10n_image=True,
-          image_url='pocket/pocket-list-mobile.png',
-          )%}
-          <h2 class="sub-section-heading">{{ ftl('pocket-home-great-recommendations') }}</h2>
-          <p class="section-lede">{{ ftl('pocket-home-we-comb-the-internet') }}</p>
-          {% endcall %}
-
-        <section class="pocket-homepage-picto mzp-l-content mzp-t-content-xl">
-
-          <h2 class="sub-section-heading">{{ ftl('pocket-home-make-pocket-work') }}</h2>
-           <ul class="mzp-l-columns mzp-t-columns-three">
-            {% call picto(
-              title=ftl('pocket-home-tailor-text'),
-              image_url='img/pocket/pocket-text-icon.svg',
-              image_width=40
-            ) %}
-            {% endcall %}
-
-            {% call picto(
-              title=ftl('pocket-home-categorize-saves'),
-              image_url='img/pocket/pocket-tag-icon.svg',
-              image_width=40
-            ) %}
-            {% endcall %}
-
-            {% call picto(
-              title=ftl('pocket-home-listen-to-articles'),
-              image_url='img/pocket/pocket-audio-icon.svg',
-              image_width=40,
-            ) %}
-            {% endcall %}
-
+          <div>
+            <ul class="mzp-u-list-styled">
+              <li>{{ ftl('pocket-home-permanent-library') }}</li>
+              <li>{{ ftl('pocket-home-suggested-tags') }}</li>
+              <li>{{ ftl('pocket-home-full-text-search') }}</li>
+              <li>{{ ftl('pocket-home-unlimited-highlights') }}</li>
+              <li>{{ ftl('pocket-home-premium-fonts') }}</li>
             </ul>
-        </section>
-
-        <section class="pocket-homepage-premium ">
-          <div class="mzp-l-content mzp-t-content-xl">
-            <div class="mzp-l-columns mzp-t-columns-two">
-              <div>
-                <h2>{{ ftl('pocket-home-start-with-the-best') }}</h2>
-                <p>{{ ftl('pocket-home-pocket-premium-is') }}</p>
-              </div>
-              <div>
-                <ul class="mzp-u-list-styled">
-                  <li>{{ ftl('pocket-home-permanent-library') }}</li>
-                  <li>{{ ftl('pocket-home-suggested-tags') }}</li>
-                  <li>{{ ftl('pocket-home-full-text-search') }}</li>
-                  <li>{{ ftl('pocket-home-unlimited-highlights') }}</li>
-                  <li>{{ ftl('pocket-home-premium-fonts') }}</li>
-                </ul>
-                <a href="https://getpocket.com/premium#plans" class="mzp-c-button">{{ ftl('pocket-home-get-pocket-premium') }}</a>
-              </div>
-            </div>
+            <a href="https://getpocket.com/premium#plans" class="mzp-c-button">{{ ftl('pocket-home-get-pocket-premium') }}</a>
           </div>
-        </section>
+        </div>
+      </div>
+    </section>
 
-        <section class="pocket-homepage-bottom mzp-l-content">
-          <h2 class="sub-section-heading">{{ ftl('pocket-home-discover-and-save') }}</h2>
-          <div class="pocket-homepage-button-center">
-            <a href="https://getpocket.com/signup?utm_source=homepage" class="mzp-c-button">{{ ftl('pocket-home-sign-up-for-pocket') }}</a>
-          </div>
-        </section>
-
-    </div>
+    <section class="pocket-homepage-bottom mzp-l-content">
+      <h2 class="sub-section-heading">{{ ftl('pocket-home-discover-and-save') }}</h2>
+      <div class="pocket-homepage-button-center">
+        <a href="https://getpocket.com/signup?utm_source=homepage" class="mzp-c-button">{{ ftl('pocket-home-sign-up-for-pocket') }}</a>
+      </div>
+    </section>
+  </div>
 {% endblock %}
 
 {% block footer %}

--- a/bedrock/pocket/templates/pocket/pocket-and-firefox.html
+++ b/bedrock/pocket/templates/pocket/pocket-and-firefox.html
@@ -16,81 +16,98 @@
 {% block page_title %}{{ ftl('pocket-features-for-firefox') }}{% endblock %}
 
 {% block content %}
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/save-inspirations.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <span class="tagline">{{ ftl('pocket-features-pocket-and-firefox') }}</span>
+      <h1 class="section-heading">{{ ftl('pocket-features-build-your-personal') }}</h1>
+      <p class="section-lede">{{ ftl('pocket-features-included-inside') }}</p>
+      <div class="section-ctas">
+        {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-features-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
+        <a href="https://getpocket.com/signup" class="secondary-cta">{{ ftl('pocket-features-more-ways-to') }}</a>
+      </div>
+    {% endcall %}
+  </section>
 
-<section>
-{% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/save-inspirations.png',
-  )%}
-  <span class="tagline">{{ ftl('pocket-features-pocket-and-firefox') }}</span>
-  <h1 class="section-heading">{{ ftl('pocket-features-build-your-personal') }}</h1>
-  <p class="section-lede">{{ ftl('pocket-features-included-inside') }}</p>
-  <div class="section-ctas">
-    {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-features-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
-    <a href="https://getpocket.com/signup" class="secondary-cta">{{ ftl('pocket-features-more-ways-to') }}</a>
-  </div>
-  {% endcall %}
-</section>
-
-<section class="explore-stories">
-  <div class="explore-stories-wrapper mzp-l-content mzp-t-content-md">
-    <h2 class="sub-section-heading">{{ ftl('pocket-features-get-thought') }}</h2>
-    <p class="section-lede">{{ ftl('pocket-features-in-addition-to') }}</p>
-    <a href="https://getpocket.com/explore" class="black-white-cta">{{ ftl('pocket-features-discover-stories') }}</a>
-  </div>
-</section>
-
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/reading-nook.png',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-your-private') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-when-ready-to') }}</p>
-  {% endcall %}
-</section>
-
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/focused-reading.png',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-special-features') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-use-pocket-app') }}</p>
-  {% endcall %}
-</section>
-
+  <section class="explore-stories">
+    <div class="explore-stories-wrapper mzp-l-content mzp-t-content-md">
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-get-thought') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-in-addition-to') }}</p>
+      <a href="https://getpocket.com/explore" class="black-white-cta">{{ ftl('pocket-features-discover-stories') }}</a>
+    </div>
+  </section>
 
   <section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/save-button-doodle.svg',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-your-save-button') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-click-pocket-button') }}</p>
-  {% endcall %}
-</section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/reading-nook.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-your-private') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-when-ready-to') }}</p>
+    {% endcall %}
+  </section>
 
-<section class="personal-library">
-  <h2 class="section-heading">
-    {{ ftl('pocket-features-start-building') }}
-  </h2>
-  <div class="library-ctas">
-    <div>
-      {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-features-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
-      <span>
-        <a href="https://getpocket.com/signup">{{ ftl('pocket-features-more-ways-to') }}</a>
-      </span>
-    </div>
-    <a href="https://getpocket.com/explore" class="black-white-cta">{{ ftl('pocket-features-discover-stories') }}</a>
-  </div>
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/focused-reading.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-special-features') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-use-pocket-app') }}</p>
+    {% endcall %}
   </section>
 
 
-{% include 'pocket/includes/pocket-premium.html' %}
+    <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/save-button-doodle.svg',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-your-save-button') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-click-pocket-button') }}</p>
+    {% endcall %}
+  </section>
 
+  <section class="personal-library">
+    <h2 class="section-heading">
+      {{ ftl('pocket-features-start-building') }}
+    </h2>
+    <div class="library-ctas">
+      <div>
+        {{ pocket_fxa_button(entrypoint='pocket', class_name='new-tab-pocket-cta', button_text='<span class="mzp-c-logo mzp-t-logo-sm mzp-t-product-family"></span>'|safe + ftl('pocket-features-activate-pocket'), optional_parameters={'s': 'fflearnmore', 'utm_campaign': 'landing-page', 'utm_content': 'page-button'}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
+        <span>
+          <a href="https://getpocket.com/signup">{{ ftl('pocket-features-more-ways-to') }}</a>
+        </span>
+      </div>
+      <a href="https://getpocket.com/explore" class="black-white-cta">{{ ftl('pocket-features-discover-stories') }}</a>
+    </div>
+  </section>
+
+  {% include 'pocket/includes/pocket-premium.html' %}
 {% endblock %}

--- a/bedrock/pocket/templates/pocket/save-to-pocket.html
+++ b/bedrock/pocket/templates/pocket/save-to-pocket.html
@@ -17,76 +17,94 @@
 {% block page_title %}{{ ftl('pocket-features-save-to-pocket') }}{% endblock %}
 
 {% block content %}
-
-<section>
-{% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/save-inspirations.png',
-  )%}
-  <h1 class="section-heading">{{ ftl('pocket-features-build') }}</h1>
-  <p class="section-lede">{{ ftl('pocket-features-use-pocket') }}</p>
-  <div class="section-ctas">
-    <a href="https://getpocket.com/signup" class="red-cta">{{ ftl('pocket-features-get-started') }}</a>
-    <a href="https://getpocket.com/login" class="secondary-cta">{{ ftl('pocket-features-already-have') }}</a>
-  </div>
-  {% endcall %}
-</section>
-
-<hr class="pocket-features-horizontal-rule"/>
-
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/save-button-doodle.svg',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-save-from-anywhere') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-once-you', span_css_class_name='pocket-logo-inline') }}</p>
-  <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-features-start-saving') }}</a>
-  {% endcall %}
-</section>
-
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/reading-nook.png',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-absorb-content') }}</h2>
-  <p class="section-lede">{{ ftl('pocket-features-away-from') }}</p>
-  <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-features-create-your') }}</a>
-  {% endcall %}
-</section>
-
-<section>
-  {% call split(
-  block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
-  media_class='mzp-l-split-h-center',
-  image_url='img/pocket/focused-reading.png',
-  )%}
-  <h2 class="sub-section-heading">{{ ftl('pocket-features-customize-your') }}</h2>
-  <ul class="section-lede">
-    <li>{{ ftl('pocket-features-tailor-text') }}</li>
-    <li>{{ ftl('pocket-features-categorize-saves') }}</li>
-    <li>{{ ftl('pocket-features-listen-to') }}</li>
-  </ul>
-  <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-features-get-started-with') }}</a>
-  {% endcall %}
-</section>
-
-<section class="personal-library">
-  <h2 class="section-heading">
-    {{ ftl('pocket-features-start-building') }}
-  </h2>
-  <div class="library-ctas">
-    <div>
-      <a href="https://getpocket.com/signup" class="red-cta">{{ ftl('pocket-features-get-started') }}</a>
-    </div>
-    <a href="https://getpocket.com/explore" class="black-white-cta login-cta">{{ ftl('pocket-features-log-in') }}</a>
-  </div>
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/save-inspirations.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h1 class="section-heading">{{ ftl('pocket-features-build') }}</h1>
+      <p class="section-lede">{{ ftl('pocket-features-use-pocket') }}</p>
+      <div class="section-ctas">
+        <a href="https://getpocket.com/signup" class="red-cta">{{ ftl('pocket-features-get-started') }}</a>
+        <a href="https://getpocket.com/login" class="secondary-cta">{{ ftl('pocket-features-already-have') }}</a>
+      </div>
+    {% endcall %}
   </section>
 
-{% include 'pocket/includes/pocket-premium.html' %}
+  <hr class="pocket-features-horizontal-rule"/>
 
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/save-button-doodle.svg',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-save-from-anywhere') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-once-you', span_css_class_name='pocket-logo-inline') }}</p>
+      <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-features-start-saving') }}</a>
+    {% endcall %}
+  </section>
+
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/reading-nook.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-absorb-content') }}</h2>
+      <p class="section-lede">{{ ftl('pocket-features-away-from') }}</p>
+      <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-features-create-your') }}</a>
+    {% endcall %}
+  </section>
+
+  <section>
+    {% call split(
+      block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed pocket-feature-page-split',
+      media_class='mzp-l-split-h-center',
+      image=resp_img(
+        url='img/pocket/focused-reading.png',
+        optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+        }
+      )
+    )%}
+      <h2 class="sub-section-heading">{{ ftl('pocket-features-customize-your') }}</h2>
+      <ul class="section-lede">
+        <li>{{ ftl('pocket-features-tailor-text') }}</li>
+        <li>{{ ftl('pocket-features-categorize-saves') }}</li>
+        <li>{{ ftl('pocket-features-listen-to') }}</li>
+      </ul>
+      <a href="https://getpocket.com/signup" class="green-line-cta">{{ ftl('pocket-features-get-started-with') }}</a>
+    {% endcall %}
+  </section>
+
+  <section class="personal-library">
+    <h2 class="section-heading">
+      {{ ftl('pocket-features-start-building') }}
+    </h2>
+    <div class="library-ctas">
+      <div>
+        <a href="https://getpocket.com/signup" class="red-cta">{{ ftl('pocket-features-get-started') }}</a>
+      </div>
+      <a href="https://getpocket.com/explore" class="black-white-cta login-cta">{{ ftl('pocket-features-log-in') }}</a>
+    </div>
+  </section>
+
+  {% include 'pocket/includes/pocket-premium.html' %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Updates split macro image syntax for pocket pages.

Apologies for the diff - the changes are actually much smaller, but I did some white space / indentation fixes whilst I was here.

## Issue / Bugzilla link

#12331

## Testing

Run  `npm run in-pocket-mode`

- [ ] http://localhost:8000/en/
- [ ] http://localhost:8000/en/add/
- [ ] http://localhost:8000/en/get-inspired/
- [ ] http://localhost:8000/en/pocket-and-firefox/
- [ ] http://localhost:8000/en/save-to-pocket/
- [ ] http://localhost:8000/en/firefox/new_tab_learn_more/
- [ ] http://localhost:8000/en/chrome/
