### PR TITLE
Simplify split() macro image handling (Fixes #12331)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -83,22 +83,12 @@
   block_class=None,
   block_id=None,
   body_class=None,
-  image_alt='',
-  image_height=None,
-  image_sizes=None,
-  image_sources=None,
-  image_srcset=None,
-  image_url=None,
-  image_width=None,
-  include_highres_image=False,
-  l10n_image=False,
-  loading=None,
+  image=None,
   media_after=False,
   media_class=None,
   media_include=None,
   mobile_class=None,
-  theme_class=None,
-  image=None
+  theme_class=None
 ) -%}
 <{{base_el}}{% if block_id %} id="{{ block_id }}"{% endif %} class="mzp-c-split{% if block_class %} {{ block_class }}{% endif %}{% if mobile_class %} {{ mobile_class }}{% endif %}">
   {% if theme_class %}
@@ -106,25 +96,9 @@
   {% endif %}
   <div class="mzp-c-split-container">
     {% if not media_after %}
-      {% if image_url or image %}
+      {% if image %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
-          {% if image_url %}
-            {{ image_macro(
-              alt=image_alt,
-              class='mzp-c-split-media-asset',
-              height=image_height,
-              include_highres=include_highres_image,
-              include_l10n=l10n_image,
-              loading=loading,
-              sizes=image_sizes,
-              sources=image_sources,
-              srcset=image_srcset,
-              url=image_url,
-              width=image_width
-            ) }}
-          {% else %}
-            {{ image|safe }}
-          {% endif %}
+          {{ image|safe }}
         </div>
       {% elif media_include %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
@@ -136,25 +110,9 @@
       {{ caller() }}
     </div>
     {% if media_after %}
-      {% if image_url or image %}
+      {% if image %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">
-           {% if image_url %}
-            {{ image_macro(
-            alt=image_alt,
-            class='mzp-c-split-media-asset',
-            height=image_height,
-            include_highres=include_highres_image,
-            include_l10n=l10n_image,
-            loading=loading,
-            sizes=image_sizes,
-            sources=image_sources,
-            srcset=image_srcset,
-            url=image_url,
-            width=image_width
-          ) }}
-          {% else %}
-            {{ image|safe }}
-          {% endif %}
+          {{ image|safe }}
         </div>
       {% elif media_include %}
         <div class="mzp-c-split-media{% if media_class %} {{ media_class }}{% endif %}">

--- a/bedrock/careers/templates/careers/diversity.html
+++ b/bedrock/careers/templates/careers/diversity.html
@@ -103,171 +103,206 @@
       {% call split(
         block_class=' mzp-l-split-body-wide',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/mrg-afrozilla.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/mrg-afrozilla.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>Afrozilla</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              Being a part of this group has challenged me to not just carry things on my own or pretend they don’t exist, and to show up more fully as an advocate myself.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-afrozilla-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-afrozilla-tina.png') }}" alt="Tina from Mozilla's Afrozilla MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Tina R.</cite>
-                <p>Lifecycle Marketing Manager</p>
-                <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/afrozillians-a-resource-group-for-black-mozillians-and-allies/">Read Tina's interview</a></p>
-              </div>
+      ) %}
+        <h3>Afrozilla</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            Being a part of this group has challenged me to not just carry things on my own or pretend they don’t exist, and to show up more fully as an advocate myself.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-afrozilla-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-afrozilla-tina.png') }}" alt="Tina from Mozilla's Afrozilla MRG">
             </div>
-          </blockquote>
+            <div class="c-diversity-citation-author">
+              <cite>Tina R.</cite>
+              <p>Lifecycle Marketing Manager</p>
+              <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/afrozillians-a-resource-group-for-black-mozillians-and-allies/">Read Tina's interview</a></p>
+            </div>
+          </div>
+        </blockquote>
       {% endcall %}
 
       {% call split(
         block_class=' mzp-l-split-body-wide mzp-l-split-reversed',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/mrg-disability-at-mozilla.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/mrg-disability-at-mozilla.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>Disability@</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              One value we included in our charter is that ableism is unacceptable and will not be tolerated. But it’s immediately followed by another value: We make space for growth, and we expect to make, and learn from, mistakes.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-disability-at-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-disability-kim.png') }}" alt="Kim from Mozilla's Disability@ MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Kim B.</cite>
-                <p>Head of Operations for Rally</p>
-                <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/resource-group-for-mozillians-with-disabilities/">Read Kim's interview</a></p>
-              </div>
+      ) %}
+        <h3>Disability@</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            One value we included in our charter is that ableism is unacceptable and will not be tolerated. But it’s immediately followed by another value: We make space for growth, and we expect to make, and learn from, mistakes.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-disability-at-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-disability-kim.png') }}" alt="Kim from Mozilla's Disability@ MRG">
             </div>
+            <div class="c-diversity-citation-author">
+              <cite>Kim B.</cite>
+              <p>Head of Operations for Rally</p>
+              <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/resource-group-for-mozillians-with-disabilities/">Read Kim's interview</a></p>
+            </div>
+          </div>
         </blockquote>
       {% endcall %}
 
       {% call split(
         block_class=' mzp-l-split-body-wide',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/mrg-latin-pride.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/mrg-latin-pride.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>Latin Pride</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              The more Latinx people we hire, the stronger and more dynamic Latin Pride will be. I want our members to use their voices not just within our group, but throughout all of Mozilla.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-latin-pride-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-latinpride-solana.png') }}" alt="Solana from Mozilla's Latin Pride MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Solana L.</cite>
-                <p>Editor, Internet Health Report</p>
-                <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/latin-pride-a-resource-group-for-latinx-mozillians-and-allies/">Read Solana's interview</a></p>
-              </div>
+      ) %}
+        <h3>Latin Pride</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            The more Latinx people we hire, the stronger and more dynamic Latin Pride will be. I want our members to use their voices not just within our group, but throughout all of Mozilla.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-latin-pride-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-latinpride-solana.png') }}" alt="Solana from Mozilla's Latin Pride MRG">
             </div>
+            <div class="c-diversity-citation-author">
+              <cite>Solana L.</cite>
+              <p>Editor, Internet Health Report</p>
+              <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/latin-pride-a-resource-group-for-latinx-mozillians-and-allies/">Read Solana's interview</a></p>
+            </div>
+          </div>
         </blockquote>
       {% endcall %}
 
       {% call split(
         block_class=' mzp-l-split-body-wide mzp-l-split-reversed',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/mrg-moz-api.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/mrg-moz-api.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>MozAPI</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              Our discussions have been so powerful. There’s often a tension, especially in East Asian cultures with roots in Confucianism, between speaking up and keeping a sort of stiff upper lip. So it’s good to have a forum where we can say — and our allies can hear — the things we’re usually quiet about.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-moz-api-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-mozapi-julie.png') }}" alt="Julie from Mozilla's MozAPI MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Julie H.</cite>
-                <p>Senior Manager, Data Science, Business & Metrics</p>
-                <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/mozilla-api-resource-group/">Read Julie's interview</a></p>
-              </div>
+      ) %}
+        <h3>MozAPI</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            Our discussions have been so powerful. There’s often a tension, especially in East Asian cultures with roots in Confucianism, between speaking up and keeping a sort of stiff upper lip. So it’s good to have a forum where we can say — and our allies can hear — the things we’re usually quiet about.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-moz-api-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-mozapi-julie.png') }}" alt="Julie from Mozilla's MozAPI MRG">
             </div>
+            <div class="c-diversity-citation-author">
+              <cite>Julie H.</cite>
+              <p>Senior Manager, Data Science, Business & Metrics</p>
+              <p><a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/mozilla-api-resource-group/">Read Julie's interview</a></p>
+            </div>
+          </div>
         </blockquote>
       {% endcall %}
 
       {% call split(
         block_class=' mzp-l-split-body-wide',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/pridezilla.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/pridezilla.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>Pridezilla</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              Pridezilla is important not only for Mozillians who are LGBTQ, but for all of us to better understand our colleagues from different walks of life. We’re a resource for anyone who wants to learn.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-pridezilla-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-pridezilla-damiano.png') }}" alt="Damiano from Mozilla's Pridezilla MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Damiano D.</cite>
-                <p>Senior Communications Manager</p>
-                <p>
-                  <a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/pridezilla-a-resource-group-for-lgbtqia-mozillians-and-allies/">Read Damiano's interview</a>
-                </p>
-              </div>
+      ) %}
+        <h3>Pridezilla</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            Pridezilla is important not only for Mozillians who are LGBTQ, but for all of us to better understand our colleagues from different walks of life. We’re a resource for anyone who wants to learn.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-pridezilla-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-pridezilla-damiano.png') }}" alt="Damiano from Mozilla's Pridezilla MRG">
             </div>
+            <div class="c-diversity-citation-author">
+              <cite>Damiano D.</cite>
+              <p>Senior Communications Manager</p>
+              <p>
+                <a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/pridezilla-a-resource-group-for-lgbtqia-mozillians-and-allies/">Read Damiano's interview</a>
+              </p>
+            </div>
+          </div>
         </blockquote>
       {% endcall %}
 
       {% call split(
         block_class=' mzp-l-split-body-wide mzp-l-split-reversed',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/womoz.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/womoz.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>WoMoz</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              I’ve also enjoyed being able to connect with other women at the company. Mozilla is so distributed — and I live in a very remote part of Canada and don’t have many opportunities to see people in person — so I especially appreciate having a place where I can chat with people who might have some similar experiences to me, and who I can learn from.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-womoz-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-womoz-elgin.png') }}" alt="Elgin from Mozilla's WoMoz MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Elgin-Skye M.</cite>
-                <p>Hubs Senior Product Manager</p>
-                <p>
-                  <a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/women-of-mozilla-resource-group/">Read Elgin-Skye's interview</a>
-                </p>
-              </div>
+      ) %}
+        <h3>WoMoz</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            I’ve also enjoyed being able to connect with other women at the company. Mozilla is so distributed — and I live in a very remote part of Canada and don’t have many opportunities to see people in person — so I especially appreciate having a place where I can chat with people who might have some similar experiences to me, and who I can learn from.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-womoz-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-womoz-elgin.png') }}" alt="Elgin from Mozilla's WoMoz MRG">
             </div>
+            <div class="c-diversity-citation-author">
+              <cite>Elgin-Skye M.</cite>
+              <p>Hubs Senior Product Manager</p>
+              <p>
+                <a target="_blank" rel="external noopener" href="https://blog.mozilla.org/careers/women-of-mozilla-resource-group/">Read Elgin-Skye's interview</a>
+              </p>
+            </div>
+          </div>
         </blockquote>
       {% endcall %}
 
       {% call split(
         block_class='mzp-l-split-body-wide',
         media_class='mzp-l-split-h-center',
-        image_url='img/careers/mozilla-resource-groups/mrg-yallazilla.jpg',
+        image=resp_img(
+          url='img/careers/mozilla-resource-groups/mrg-yallazilla.jpg',
+          optional_attributes={
+            'class': 'mzp-c-split-media-asset'
+          }
+        ),
         media_after=False
-        ) %}
-          <h3>Yallazilla</h3>
-          <blockquote>
-            <p class="c-careers-diversity-quote">
-              I was so happy when I learned about Yallazilla. It offers a space to connect with people from different countries and cultures and to discuss topics that affect folks from the SWANA/MENA region. I hope we are able to advocate for our people in what Mozilla does in their efforts for a more joyful internet.
-            </p>
-            <div class="c-diversity-citation">
-              <div class="c-diversity-citation-image c-yallazilla-image">
-                <img src="{{ static('img/careers/mozilla-resource-groups/mrg-yallazilla-frida.png') }}" alt="Frida from Mozilla's Yallazilla MRG">
-              </div>
-              <div class="c-diversity-citation-author">
-                <cite>Frida K.</cite>
-                <p>Senior Security Engineer, Risk Management</p>
-              </div>
+      ) %}
+        <h3>Yallazilla</h3>
+        <blockquote>
+          <p class="c-careers-diversity-quote">
+            I was so happy when I learned about Yallazilla. It offers a space to connect with people from different countries and cultures and to discuss topics that affect folks from the SWANA/MENA region. I hope we are able to advocate for our people in what Mozilla does in their efforts for a more joyful internet.
+          </p>
+          <div class="c-diversity-citation">
+            <div class="c-diversity-citation-image c-yallazilla-image">
+              <img src="{{ static('img/careers/mozilla-resource-groups/mrg-yallazilla-frida.png') }}" alt="Frida from Mozilla's Yallazilla MRG">
             </div>
+            <div class="c-diversity-citation-author">
+              <cite>Frida K.</cite>
+              <p>Senior Security Engineer, Risk Management</p>
+            </div>
+          </div>
         </blockquote>
       {% endcall %}
 

--- a/bedrock/careers/templates/careers/includes/footer.html
+++ b/bedrock/careers/templates/careers/includes/footer.html
@@ -9,10 +9,17 @@
     block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed mzp-t-split-nospace',
     media_class='mzp-l-split-h-center mzp-l-split-media-overflow',
     media_include='careers/includes/big-picture-video.html',
-    image_url='img/careers/footer-remote.png',
-    include_highres_image=True,
+    image=resp_img(
+      url='img/careers/footer-remote.png',
+      srcset={
+        'img/careers/footer-remote-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'mzp-c-split-media-asset'
+      }
+    ),
     media_after=True
-    ) %}
+  ) %}
     <h2>Feel good about your work again</h2>
     <p>We’re hiring curious and kind people across the organization. Come help write Mozilla’s next chapter.</p>
     <a href="{{ url('careers.listings') }}" class="mzp-c-button">Find your next role at Mozilla</a>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -176,8 +176,7 @@
     block_class='about-mozilla mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace',
     theme_class='mzp-t-dark',
     media_class='mzp-l-split-media-overflow mzp-l-split-h-center',
-    media_after=True,
-    loading='lazy'
+    media_after=True
   ) %}
     <h3>{{ ftl('mobile-android-about-mozilla') }}</h3>
     <p>{{ ftl('mobile-android-mozilla-exists-to') }}</p>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -341,8 +341,7 @@
   block_id='trackers',
   image=resp_img('img/firefox/privacy/book/privacy-target.png', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   block_class='mzp-t-split-nospace',
-  theme_class='mzp-t-dark mzp-t-background-secondary',
-  loading='lazy',
+  theme_class='mzp-t-dark mzp-t-background-secondary'
 ) %}
   <h3>{{ ftl('privacy-book-friendly-reminder-what') }}</h3>
   <p>{{ ftl('privacy-book-news-recommendations-are') }}</p>

--- a/bedrock/mozorg/templates/mozorg/home/includes/mr2-promo-eu.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/mr2-promo-eu.html
@@ -7,13 +7,21 @@
 {% from "macros-protocol.html" import split with context %}
 
 {% set image = 'img/home/2021/mr2-watercolor-de.png' if LANG == 'de' else 'img/home/2021/mr2-watercolor-fr.png' %}
+{% set high_res_image = 'img/home/2021/mr2-watercolor-de-high-res.png' if LANG == 'de' else 'img/home/2021/mr2-watercolor-fr-high-res.png' %}
 {% set set_the_tone = 'Gib den Ton an' if LANG == 'de' else 'Donnez le ton' %}
 {% set bring_creativity = 'Entfalte deine Kreativität mit dem anpassbarsten Firefox ever.' if LANG == 'de' else 'Soyez créatif avec le Firefox le plus personnalisable de son histoire.' %}
 {% set cta = 'Jetzt downloaden' if LANG == 'de' else 'Installer maintenant' %}
 
 {% call split(
-  image_url=image,
-  include_highres_image=True,
+  image=resp_img(
+    url=image,
+    srcset={
+      high_res_image: '2x'
+    },
+    optional_attributes={
+      'class': 'mzp-c-split-media-asset'
+    }
+  ),
   block_class='mr2-home-hero mzp-l-split-center-on-sm-md mzp-l-split-hide-media-on-sm-md',
   body_class=None,
   media_class='mzp-l-split-h-center mzp-l-split-v-center',

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1387,75 +1387,18 @@ Split
 
     Example: ``Not currently in use``
 
-- image_alt
-    Alt text for the images to be used.
-
-    Default: ``''``
-
-    Example: ``image_alt='Red Panda'``
-
-- image_height
-    Number indicating the height of an image.
+- image
+    Can pass an <img> element, `resp_img` or `picture` python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
 
     Default: ``None``
 
-    Example: ``image_height='153'``
+    Example:
 
-- image_sizes
-    The ``sizes`` attribute for a responsive image.
+    .. code-block::
 
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_sources
-    A list of ``<source>`` elements for a responsive ``<picture>`` image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_srcset
-    The ``srcset`` attribute for a responsive image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_url
-    Path to image location.
-
-    Default: ``None``
-
-    Example: ``image_url=’img/firefox/accounts/trailhead/value-respect.jpg’``
-
-- image_width
-    Number indicating the width of an image.
-
-    Default: ``None``
-
-    Example: ``image_width='153'``
-
-- include_highres_image (deprecated)
-    Boolean that determines whether the image can also appear in high res.
-
-    Default: ``False``
-
-    Example: ``include_highres_image=True``
-
-- l10n_image
-    Boolean to indicate if image has translatable text.
-
-    Default: ``False``
-
-    Example: ``l10n_image=True``
-
-- loading
-    String to provide value for image loading attribute. This will use browser default ("eager") if not set. Lazy loading defers fetching of images to a browser decision based on user scroll and connection.
-
-    Default: ``None``
-
-    Example: ``loading='lazy'``
+        image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', srcset={
+            'img/firefox/accounts/trailhead/value-respect-high-res.jpg': '2x'
+        })
 
 - media_after
     Boolean to determine if image appears before or after text when stacked on mobile size screens.
@@ -1544,13 +1487,6 @@ Billboard
     Default: ``None``
 
     Example: ``link_url=url('mozorg.about.manifesto')``
-
-- loading
-    String to provide value for image loading attribute. This will use browser default ("eager") if not set. Lazy loading defers fetching of images to a browser decision based on user scroll and connection.
-
-    Default: ``None``
-
-    Example: ``loading='lazy'``
 
 - reverse
     Uses default layout: mzp-l-billboard-right. Reverse will switch to billboard (text) left.

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1388,7 +1388,7 @@ Split
     Example: ``Not currently in use``
 
 - image
-    Can pass an <img> element, `resp_img` or `picture` python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
+    Can pass an <img> element, `resp_img` or `picture` Python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
 
     Default: ``None``
 
@@ -1503,7 +1503,7 @@ Billboard
     Example: ``title=ftl('about-the-mozilla-manifesto')``
 
 - image
-    **Required**. Image to be used in the Billboard element. Can pass an <img> element, `resp_img` or `picture` python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
+    **Required**. Image to be used in the Billboard element. Can pass an <img> element, `resp_img` or `picture` Python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
 
     Default: ``None``
 
@@ -1584,7 +1584,7 @@ Card
     Example: ``heading_level=2``
 
 - image
-    **Required**. Image to be used in the Card element. Can pass an <img> element, `resp_img` or `picture` python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
+    **Required**. Image to be used in the Card element. Can pass an <img> element, `resp_img` or `picture` Python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
 
     Default: ``None``
 


### PR DESCRIPTION
## One-line summary

Instead of passing lots of parameters through multiple macros in order to construct an image, `split()` now just takes a single `image` parameter. This can be a `resp_img()`, a `picture()`, a simple `<img>`, an inline SVG, or anything calling the template wants.

## Issue / Bugzilla link

#12331

## Testing

- [ ] No occurrences of `split()` macro left remaining using the old image parameters (e.g `image_url=`).
