### PR TITLE
Remove duplicate Mozilla from home page title (Fixes #12488)

### DIFF
--- a/bedrock/base/templates/404-locale.html
+++ b/bedrock/base/templates/404-locale.html
@@ -8,7 +8,7 @@
 
 {%- block page_title -%}
   {%- if is_root -%}
-    Internet for people, not profit — Mozilla
+    Internet for people, not profit
   {%- else -%}
     404 - Choose your language or locale to browse Mozilla.org
   {%- endif -%}


### PR DESCRIPTION
## One-line summary

Removes duplicate "Mozilla" in page title

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/12488

## Testing

To test this locally, first remove all languages from your browser settings:

<img width="659" alt="Screenshot 2022-12-13 at 10 32 15" src="https://user-images.githubusercontent.com/400117/207294511-7bce9624-e8ca-460c-b87d-857db289957f.png">

- [ ] http://localhost:8000/ page title only contains one occurrence of "Mozilla" at the end.