### PR TITLE
Support <del></del> in Release Notes markup

### DIFF
--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -69,7 +69,8 @@ ALLOWED_ATTRS = [
 
 
 def process_markdown(value):
-    return markdowner.reset().convert(bleach.clean(value, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS))
+    rendered_html = markdowner.reset().convert(value)
+    return bleach.clean(rendered_html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS)
 
 
 def process_notes(notes):

--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -5,6 +5,7 @@
 import codecs
 import json
 import os
+import xml.etree.ElementTree as etree
 from glob import glob
 from operator import attrgetter
 
@@ -18,10 +19,26 @@ from django.utils.functional import cached_property
 import bleach
 import markdown
 from django_extensions.db.fields.json import JSONField
+from markdown.extensions import Extension
+from markdown.inlinepatterns import InlineProcessor
 from product_details.version_compare import Version
 
 from bedrock.base.urlresolvers import reverse
 from bedrock.releasenotes.utils import memoize
+
+
+class StrikethroughInlineProcessor(InlineProcessor):
+    def handleMatch(self, m, data):
+        el = etree.Element("del")
+        el.text = m.group(1)
+        return el, m.start(0), m.end(0)
+
+
+class StrikethroughExtension(Extension):
+    def extendMarkdown(self, md):
+        STRIKETHROUGH_PATTERN = r"~~(.*?)~~"  # like ~~elided~~
+        md.inlinePatterns.register(StrikethroughInlineProcessor(STRIKETHROUGH_PATTERN, md), "del", 175)
+
 
 LONG_RN_CACHE_TIMEOUT = 7200  # 2 hours
 cache = caches["release-notes"]
@@ -32,6 +49,7 @@ markdowner = markdown.Markdown(
         "markdown.extensions.fenced_code",
         "markdown.extensions.toc",
         "markdown.extensions.nl2br",
+        StrikethroughExtension(),
     ]
 )
 # based on bleach.sanitizer.ALLOWED_TAGS
@@ -43,6 +61,7 @@ ALLOWED_TAGS = [
     "blockquote",
     "code",
     "div",
+    "del",
     "em",
     "h1",
     "h2",

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -2,12 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+
 from itertools import chain
 from pathlib import Path
 from unittest.mock import call, patch
 
 from django.core.cache import caches
 from django.test.utils import override_settings
+
+import markdown
 
 from bedrock.mozorg.tests import TestCase
 from bedrock.releasenotes import models
@@ -174,3 +177,18 @@ class TestGetLatestRelease(TestCase):
         # non public release
         # should NOT raise multiple objects error
         assert models.get_release("firefox for android", "56.0.3", include_drafts=True)
+
+
+class StrikethroughExtensionTestCase(TestCase):
+    def test_strikethrough_rendered_to_del(self):
+        # Show the StrikethroughExtension works
+        self.assertEqual(
+            markdown.markdown("*hello~~test~~*", extensions=[models.StrikethroughExtension()]),
+            "<p><em>hello<del>test</del></em></p>",
+        )
+
+        # And without strikethough extension - no transformation
+        self.assertEqual(
+            markdown.markdown("*hello~~test~~*"),
+            "<p><em>hello~~test~~</em></p>",
+        )


### PR DESCRIPTION
**Not critical, so marking as Do Not Merge until after the code freeze**

## One-line summary

This changeset:

1) Fixes a bug in our bleaching of release notes
2) adds support for transforming `~~` into `<del>`


## Significant changes and points to review

Please check the logic of the change made to `render_markdown` (the first commit in this PR) in case I'm overlooking something and introducing a subtle regression

## Issue / Bugzilla link

Resolves https://github.com/mozilla/nucleus/issues/665

## Screenshots

<img width="377" alt="Screenshot 2022-12-15 at 18 10 28" src="https://user-images.githubusercontent.com/101457/208077580-d94875c3-dbe5-4d8d-9e44-a7cfb32094fc.png">


## Testing

Testing is hard because it requires getting in releasenotes data that has `~~` in the markdown. I can a database file with that directly if you want it, with installation instructions

Assuming you've got it

- [ ] go to http://localhost:8080/en-US/firefox/109.0beta/releasenotes/ and scroll down the third note for 109.0beta - you 
should see ~~test test test~~ in the middle of that message, as per the screenshot above
