### PR TITLE
Fix typo in Careers testimonials section

### DIFF
--- a/bedrock/careers/templates/careers/includes/testimonials.html
+++ b/bedrock/careers/templates/careers/includes/testimonials.html
@@ -43,7 +43,7 @@
         <li class="c-careers-testimonial-image four"></li>
         <li class="c-careers-testimonial-item has-modal" data-modal-id="tom-h">
           <q>
-            Mozilla is a special place that is truly cares about the people who work here&hellip;
+            Mozilla is a special place that truly cares about the people who work here&hellip;
           </q>
           <a href="#tom-h-testimonial">
           More...


### PR DESCRIPTION
## One-line summary
Removed a typo in the testimonials section:
`Mozilla is a special place that is truly cares about the people who work here…` 

👇🏽 to 

`Mozilla is a special place that truly cares about the people who work here… `

## Testing

http://localhost:8000/en-US/careers/

