### PR TITLE
Update firefox/browsers page title and desc (Fixes #12486)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -8,8 +8,10 @@
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import split with context %}
 
-{% block page_title %}{{ ftl('firefox-browsers-get-the-browsers-that-put') }}{% endblock %}
-{% block page_desc %}{{ ftl('firefox-browsers-get-the-privacy-you-deserve') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-browsers-page-title', fallback='firefox-browsers-get-the-browsers-that-put') }}{% endblock %}
+{% block page_title_suffix %} — Mozilla{% endblock %}
+
+{% block page_desc %}{{ ftl('firefox-browsers-page-desc', fallback='firefox-browsers-get-the-privacy-you-deserve') }}{% endblock %}
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 

--- a/l10n/en/firefox/browsers.ftl
+++ b/l10n/en/firefox/browsers.ftl
@@ -5,9 +5,15 @@
 ### URL: https://www-dev.allizom.org/firefox/browsers/
 
 # HTML page title
+firefox-browsers-page-title = Download { -brand-name-firefox } for Desktop, Mobile, or Enterprise
+
+# Outdated string
 firefox-browsers-get-the-browsers-that-put = Get the browsers that put your privacy first — and always have
 
 # HTML page description
+firefox-browsers-page-desc = Choose from Desktop, { -brand-name-ios }, { -brand-name-android }, or let us email you a mobile download link.
+
+# Outdated string
 firefox-browsers-get-the-privacy-you-deserve = Get the privacy you deserve. Enhanced Tracking Protection is automatic in every { -brand-name-firefox } browser.
 
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language


### PR DESCRIPTION
## One-line summary

Updates page title and description as per copy in the issue linked below.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/12486

## Testing

- [ ] http://localhost:8000/en-US/firefox/browsers/
