### PR TITLE
Force client proxy server to use IPv4 (Issue #12508)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,7 @@ const cssConfig = {
 // Plugin will only start when Webpack is in watch mode.
 const browserSync = new BrowserSyncPlugin({
     port: 8000,
-    proxy: process.env.BS_PROXY_URL || 'localhost:8080',
+    proxy: process.env.BS_PROXY_URL || '0.0.0.0:8080',
     open: false,
     notify: true,
     reloadDebounce: 1000,


### PR DESCRIPTION
## One-line summary

This is a small test to see if specifying the IPv4 address of the Python server fixes #12508 for me 🤞 

## Issue / Bugzilla link

#12508 

## Testing

`npm start`
