### PR TITLE
Add recommended extensions for VSCode (Fixes #12515)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ root_files/*/sitemap.xml
 root_files/sitemap.json
 root_files/etags.json
 node_modules
-.vscode/
+.vscode/*
+!.vscode/extensions.json
 static_build
 static_final
 static

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+  "recommendations": [
+    "EditorConfig.EditorConfig",
+    "dbaeumer.vscode-eslint",
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "lextudio.restructuredtext",
+    "macabeus.vscode-fluent",
+    "mikestead.dotenv",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "samuelcolvin.jinjahtml",
+    "streetsidesoftware.code-spell-checker",
+    "trond-snekvik.simple-rst"
+  ]
+}


### PR DESCRIPTION
## One-line summary

Adds a list of recommended VSCode extensions for bedrock development.

## Issue / Bugzilla link

#12515

## Testing

VS Code prompts a user to install the recommended extensions when a workspace is opened for the first time. The user can also review the list with the `Extensions: Show Recommended Extensions` command.
