### PR TITLE
Grammar and linting fixes for Santa Locator page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/santa-locator.html
+++ b/bedrock/mozorg/templates/mozorg/santa-locator.html
@@ -40,7 +40,7 @@
             <circle cx="15" cy="21.7" r="1.5" fill-rule="evenodd" clip-rule="evenodd"/>
         </svg>
         <p class="err">Unable to locate Santa.</p>
-        <p class="desc">Looks like Santa has activated his VPN and gone into stealth mode. That means he must be getting closer to you. Here’s a red panda to keep you company till he gets there.</p>
+        <p class="desc">Looks like Santa has activated his VPN and gone into stealth mode. That means he must be getting closer to you. Here’s a red panda to keep you company ’til he gets there.</p>
       </div>
 
       <div id="panda">

--- a/media/css/mozorg/santa-locator.scss
+++ b/media/css/mozorg/santa-locator.scss
@@ -13,9 +13,9 @@ $santa-red: #e83d53;
 
 // Scrolling stripes
 @keyframes stripes {
-	to {
-		transform: translateX(57px);
-	}
+    to {
+        transform: translateX(57px);
+    }
 }
 
 // Fake progress bar


### PR DESCRIPTION
## One-line summary

- Changes till to 'til
- Converts tabs to spaces (tabs got pasted from whatever StackOverflow post I copied)