### PR TITLE
Bug Fix for 12370 and 12487

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -31,7 +31,6 @@
 
   <div class="l-notes mzp-l-content">
     <ul>
-      <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ ftl('firefox-channel-release-notes') }}</a></li>
       <li>
         <a href="{{ firefox_url('android', 'all', 'beta') }}">
           {{ ftl('firefox-channel-all-languages-and-platforms', fallback='firefox-channel-all-languages-and-builds') }}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -8,20 +8,20 @@
 
 {% block page_title_prefix %}{{ ftl('firefox-desktop-download-meta-title-prefix') }} — {% endblock %}
 
-{%- block page_title -%}{{ ftl('firefox-desktop-download-meta-title') }}{%- endblock -%}
+{%- block page_title -%}{{ ftl('firefox-desktop-download-meta-title-v2', fallback='firefox-desktop-download-meta-title') }}{%- endblock -%}
 
 {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
 {%- block page_title_full -%}
   {% if LANG == 'en-CA' %}
-    Download Firefox — Fast, Private & Free — from Mozilla (CA)
+    Download Firefox for Desktop — from Mozilla (CA)
   {% elif LANG == 'en-GB' %}
-    Download Firefox — Fast, Private & Free — from Mozilla (UK)
+    Download Firefox for Desktop — from Mozilla (UK)
   {% else %}
-    {{ ftl('firefox-desktop-download-meta-title') }}
+    {{ ftl('firefox-desktop-download-meta-title-v2', fallback='firefox-desktop-download-meta-title') }}
   {% endif %}
 {%- endblock -%}
 
-{% block page_desc %}{{ ftl('firefox-desktop-download-meta-desc') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-desktop-download-meta-desc-v2', fallback='firefox-desktop-download-meta-desc') }}{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}{{ ftl('firefox-desktop-download-og-title') }}{% endblock %}

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -8,8 +8,8 @@
 # the em dash is used in English to show a change of thought and
 # the em dash is used in meta titles to separate the title of a page from the title of the whole site
 # this title could also be written as "Download Firefox (Fast, Private & Free) — Mozilla"
-firefox-desktop-download-meta-title = Download { -brand-name-firefox-browser } — Fast, Private & Free — from { -brand-name-mozilla }
-firefox-desktop-download-meta-desc = Get { -brand-name-firefox }, a free web browser backed by { -brand-name-mozilla }, a non-profit dedicated to internet health and privacy. Available now on { -brand-name-windows }, { -brand-name-mac-short }, { -brand-name-linux }, { -brand-name-android } and { -brand-name-ios }.
+firefox-desktop-download-meta-title = Download { -brand-name-firefox } for Desktop — from { -brand-name-mozilla }
+firefox-desktop-download-meta-desc = Get { -brand-name-firefox } for { -brand-name-windows }, { -brand-name-mac-short } or { -brand-name-linux }. { -brand-name-firefox } is a free web browser backed by { -brand-name-mozilla }, a non-profit dedicated to internet health and privacy.
 firefox-desktop-download-og-title = Download the fastest { -brand-name-firefox } ever
 firefox-desktop-download-og-desc = Faster page loading, less memory usage and packed with features, the new { -brand-name-firefox } is here.
 firefox-desktop-download-firefox = { -brand-name-firefox-browser }

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -8,8 +8,10 @@
 # the em dash is used in English to show a change of thought and
 # the em dash is used in meta titles to separate the title of a page from the title of the whole site
 # this title could also be written as "Download Firefox (Fast, Private & Free) — Mozilla"
-firefox-desktop-download-meta-title = Download { -brand-name-firefox } for Desktop — from { -brand-name-mozilla }
-firefox-desktop-download-meta-desc = Get { -brand-name-firefox } for { -brand-name-windows }, { -brand-name-mac-short } or { -brand-name-linux }. { -brand-name-firefox } is a free web browser backed by { -brand-name-mozilla }, a non-profit dedicated to internet health and privacy.
+firefox-desktop-download-meta-title = Download { -brand-name-firefox-browser } — Fast, Private & Free — from { -brand-name-mozilla }
+firefox-desktop-download-meta-title-v2 = Download { -brand-name-firefox } for Desktop — from { -brand-name-mozilla }
+firefox-desktop-download-meta-desc = Get { -brand-name-firefox }, a free web browser backed by { -brand-name-mozilla }, a non-profit dedicated to internet health and privacy. Available now on { -brand-name-windows }, { -brand-name-mac-short }, { -brand-name-linux }, { -brand-name-android } and { -brand-name-ios }.
+firefox-desktop-download-meta-desc-v2 = Get { -brand-name-firefox } for { -brand-name-windows }, { -brand-name-mac-short } or { -brand-name-linux }. { -brand-name-firefox } is a free web browser backed by { -brand-name-mozilla }, a non-profit dedicated to internet health and privacy.
 firefox-desktop-download-og-title = Download the fastest { -brand-name-firefox } ever
 firefox-desktop-download-og-desc = Faster page loading, less memory usage and packed with features, the new { -brand-name-firefox } is here.
 firefox-desktop-download-firefox = { -brand-name-firefox-browser }


### PR DESCRIPTION
## One-line summary

Change in title and description at path /en-US/firefox/new/ 

## Significant changes and points to review

Title and Description for download page at /firefox/new.
Removed release notes link from Android beta on page https://www.mozilla.org/en-US/firefox/channel/android/#beta.


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12370
https://github.com/mozilla/bedrock/issues/12487


