### PR TITLE
Fix up broken links in documentation

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -220,7 +220,7 @@ Recording the data
 
 .. Note::
 
-    If you are measuring installs as part of your experiment be sure to configure `custom stub attribution <https://bedrock.readthedocs.io/en/latest/stub-attribution.html#measuring-campaigns-and-experiments>`_ as well.
+    If you are measuring installs as part of your experiment be sure to configure `custom stub attribution <https://bedrock.readthedocs.io/en/latest/firefox-stub-attribution.html#measuring-campaigns-and-experiments>`_ as well.
 
 Including the ``data-ex-variant`` and ``data-ex-name`` in the analytics
 reporting will add the test to an auto generated report in :abbr:`GA (Google Analytics)`.

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -714,7 +714,7 @@ image()
 ^^^^^^^
 
 We also have an image macro, which is mainly used to encapsulate the conditional logic needed for
-`Protocol macros <https://bedrock.readthedocs.io/en/latest/coding.html#working-with-protocol>`_
+`Protocol macros <https://bedrock.readthedocs.io/en/latest/coding.html#working-with-protocol-design-system>`_
 containing images. You can also import the macro directly into a template.
 
 .. code-block:: jinja

--- a/docs/contentful.rst
+++ b/docs/contentful.rst
@@ -256,9 +256,7 @@ Adding support for a new product icon, size, folder
 ---------------------------------------------------
 
 Many content models have drop downs with identical content. For example: the Hero, Callout,
-and Wordmark models all include a "product icon". The icon can be one of any of the
-`supported logos in Protocol <https://protocol.mozilla.org/demos/logo.html>`_. Other common
-fields are width and folder.
+and Wordmark models all include a "product icon". Other common fields are width and folder.
 
 There are two ways to keep these lists up to date to reflect Protocol updates:
 
@@ -490,7 +488,7 @@ In the right-hand sidebar of the editor page in Contentful:
 * Click ``Open preview``
 
 New (non-master) Content Types
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In bedrock:
 
 * Update ``class ContentfulPreviewView(L10nTemplateView)`` in `Mozorg Views <https://github.com/mozilla/bedrock/blob/main/bedrock/mozorg/views.py>`_ with a render case for your new content type

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,7 +34,7 @@ Docker Installation
 
 .. note::
 
-    This method assumes you have `Docker installed for your platform <https://www.docker.com/community-edition#/download>`_.
+    This method assumes you have `Docker installed for your platform <https://www.docker.com/>`_.
     If not please do that now or skip to the ``Local Installation`` section.
 
 This is the simplest way to get started developing for bedrock. If you're on Linux or Mac (and possibly Windows 10 with the
@@ -433,7 +433,7 @@ To test switches locally:
 #. Enable the switch in your ``.env`` file.
 #. Restart your web server.
 
-To configure switches for a demo branch. Follow the `configuration instructions here <http://bedrock.readthedocs.io/en/latest/pipeline.html#configuration>`_.
+To configure switches/env vars for a demo branch. Follow the `demo-site instructions here <https://bedrock.readthedocs.io/en/latest/contribute.html#demo-sites>`_.
 
 Traffic Cop
 -----------

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -315,11 +315,11 @@ reliability due to any potential network flakiness.
 Headless tests
 --------------
 
-There are targeted headless tests for the `download`_ and `localized download`_ pages.
+There are targeted headless tests for the `download`_ pages.
 These tests and are run as part of the pipeline to ensure that download links constructed
 via product details are well formed and return valid 200 responses.
 
-.. _Jasmine: https://jasmine.github.io/1.3/introduction.html
+.. _Jasmine: https://jasmine.github.io/index.html
 .. _Karma: https://karma-runner.github.io/
 .. _Sinon: http://sinonjs.org/
 .. _Selenium: http://docs.seleniumhq.org/
@@ -334,7 +334,6 @@ via product details are well formed and return valid 200 responses.
 .. _expected conditions: http://seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html
 .. _Web QA style guide: https://wiki.mozilla.org/QA/Execution/Web_Testing/Docs/Automation/StyleGuide
 .. _download: https://github.com/mozilla/bedrock/blob/main/tests/functional/test_download.py
-.. _localized download: https://github.com/mozilla/bedrock/blob/main/tests/functional/test_download_l10n.py
 .. _Basket: https://github.com/mozilla/basket
 .. _geckodriver: https://github.com/mozilla/geckodriver/releases/latest
 .. _latest release: https://github.com/mozilla/geckodriver/releases/


### PR DESCRIPTION
## One-line summary

This changeset fixes up broken links in the Bedrock documentation. 

## Testing

* `cd path/to/bedrock/docs`
* `make linkcheck` - there WILL still be some 404s flagged as broken links, but these are either links to dummy URLs or to private git repos, so they are fine as they are
* `make livehtml` - and confirm the console has nothing to grumble about when starting the Sphinx server