### PR TITLE
Fix #12553: Enable skr locale

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -215,7 +215,7 @@ LOCALES_BY_REGION = {
         "uk",
         "uz",
     ],
-    "Middle East and Africa": ["ach", "af", "ar", "az", "fa", "ff", "gu-IN", "he", "kab", "kn", "son", "xh"],
+    "Middle East and Africa": ["ach", "af", "ar", "az", "fa", "ff", "gu-IN", "he", "kab", "kn", "skr", "son", "xh"],
 }
 
 # Our accepted production locales are the values from the above, plus an exception.


### PR DESCRIPTION
## One-line summary

Add `skr` to the localized languages.

Note: This may require a `python manage.py update_product_details_files` locally for testing to pull down the latest `product_details`.

## Testing

- Check the `locales` page includes this locale.
- Check this locale is included in the list of locales at the bottom of the page.

