### PR TITLE
Only bleach the HTML in the raw markdown content, not the rendered HTML

### DIFF
--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -88,8 +88,7 @@ ALLOWED_ATTRS = [
 
 
 def process_markdown(value):
-    rendered_html = markdowner.reset().convert(value)
-    return bleach.clean(rendered_html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS)
+    return markdowner.reset().convert(bleach.clean(value, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS))
 
 
 def process_notes(notes):


### PR DESCRIPTION
## One-line summary

Image embedding in Release Notes pages is broken due to a regression. This changeset fixes it by reverting an unnecessary change.

### More detail

b29693789 was an attempt to improve sanitisation of HTML from markdown, but doing so inadvertently over-escaped some of the HTML tags that were produced by rendering markdown (eg img) because they were not in the allowlist.

Revisiting this, I think it's OK to revert to only sanitising the raw markdown's HTML elements, because any rendered HTML from the markdown is only going to be adding safe HTML tags, based on the spec.

## Issue / Bugzilla link

Resolves #12558

## Screenshots

Before

<img width="1427" alt="Screenshot 2023-01-05 at 13 28 21" src="https://user-images.githubusercontent.com/101457/210791011-9391e01a-6e9b-4d39-9d9c-3bfdacdf4c8e.png">

```
  <li id="note-789315">
    <p>Processes used for background tabs now use efficiency mode on Windows 11 to limit resource use.&lt;br /&gt;
&lt;img alt="Efficiency mode on Windows 11" src="/media/img/firefox/releasenotes/note-images/108_efficiency-mode.png" /&gt;</p>
    
  </li>
```

After (locally)
<img width="1466" alt="Screenshot 2023-01-05 at 13 28 26" src="https://user-images.githubusercontent.com/101457/210790975-5c3809c2-57bb-45d7-81fe-b497d8715484.png">



```
<li id="note-789315">
    <p>Processes used for background tabs now use efficiency mode on Windows 11 to limit resource use.<br />
<img alt="Efficiency mode on Windows 11" src="[/media/img/firefox/releasenotes/note-images/108_efficiency-mode.png](view-source:http://localhost:8000/media/img/firefox/releasenotes/note-images/108_efficiency-mode.png)" /></p>
    
  </li>
```



## Testing

Demo server URL: (or None)

To test this work:

- [ ] `./manage.py update_release_notes --force`
- [ ] Confirm http://localhost:8000/en-US/firefox/108.0/releasenotes/ has image and no over-escaped HTML
