### PR TITLE
Simplify picto macro image handling (Fixes #12513)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -189,7 +189,7 @@
 <section class="mzp-c-card {% if class %}{{ class }}{% endif %} {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if media_icon %}{{ media_icon }}{% endif %} {% if youtube_id %}mzp-has-video has-video-embed{% endif %}" {% if attributes %}{{attributes|safe}}{% endif %}>
   <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}  {% if link_target %}target="{{ link_target }}"{% endif %} {% if link_rel %}rel="{{ link_rel }}"{% endif %} {% if link_title %}title="{{ link_title }}"{% endif %}>
     {% if image %}
-      <div class="mzp-c-card-media-wrapper">{{ image | safe }}</div>
+      <div class="mzp-c-card-media-wrapper">{{ image|safe }}</div>
     {% endif %}
     <div class="mzp-c-card-content">
     {% if tag_label %}
@@ -245,34 +245,13 @@
   body=False,
   class=None,
   heading_level=3,
-  image_alt='',
-  image_height=None,
-  image_sizes=None,
-  image_sources=None,
-  image_srcset=None,
-  image_url='',
-  image_width=64,
-  include_highres_image=False,
-  l10n_image=False,
+  image=None,
   loading=None,
   title=None
 ) -%}
 <{{ base_el }} class="mzp-c-picto{% if class %} {{ class }}{% endif %}">
-  {% if image_url %}
-  {{ image_macro(
-      alt=image_alt,
-      class='mzp-c-picto-image',
-      height=image_height,
-      include_highres=include_highres_image,
-      include_l10n=l10n_image,
-      loading=loading,
-      sizes=image_sizes,
-      sources=image_sources,
-      srcset=image_srcset,
-      url=image_url,
-      url=image_url,
-      width=image_width
-    ) }}
+  {% if image %}
+    {{ image|safe }}
   {% endif %}
   {% if title %}<h{{ heading_level }} class="mzp-c-picto-heading">{{ title }}</h{{ heading_level }}>{% endif %}
   {% if body %}

--- a/bedrock/careers/templates/careers/benefits.html
+++ b/bedrock/careers/templates/careers/benefits.html
@@ -41,7 +41,13 @@
         {% call picto(
           base_el='li',
           title='Health and wellness',
-          image_url='img/careers/icons/mozilla-theme/careers-items.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-items.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -56,7 +62,13 @@
         {% call picto(
           base_el='li',
           title='Mental wellness',
-          image_url='img/careers/icons/mozilla-theme/careers-watering.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-watering.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -70,7 +82,13 @@
         {% call picto(
           base_el='li',
           title='Time away',
-          image_url='img/careers/icons/mozilla-theme/careers-camp.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-camp.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -86,7 +104,13 @@
         {% call picto(
           base_el='li',
           title='Parental leave',
-          image_url='img/careers/icons/mozilla-theme/careers-dino-egg.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-dino-egg.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -100,7 +124,13 @@
         {% call picto(
           base_el='li',
           title='Financial',
-          image_url='img/careers/icons/mozilla-theme/careers-charts.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-charts.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -116,7 +146,13 @@
         {% call picto(
           base_el='li',
           title='Learning and development',
-          image_url='img/careers/icons/mozilla-theme/careers-chat.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-chat.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -132,7 +168,13 @@
         {% call picto(
           base_el='li',
           title='Help when you need it',
-          image_url='img/careers/icons/mozilla-theme/careers-dino-help.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-dino-help.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
           ) %}
           <p>
@@ -146,7 +188,13 @@
           {% call picto(
             base_el='li',
             title='Plus a bit more',
-            image_url='img/careers/icons/mozilla-theme/careers-more.svg',
+            image=resp_img(
+              url='img/careers/icons/mozilla-theme/careers-more.svg',
+              optional_attributes={
+                'class': 'mzp-c-picto-image',
+                'loading': 'lazy'
+              }
+            ),
             body=True,
             ) %}
             <p>

--- a/bedrock/careers/templates/careers/home.html
+++ b/bedrock/careers/templates/careers/home.html
@@ -69,7 +69,13 @@
       {% call picto(
         base_el='li',
         title='We welcome differences',
-        image_url='img/careers/icons/mozilla-theme/careers-rainbow.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-rainbow.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -82,7 +88,13 @@
       {% call picto(
         base_el='li',
         title='We are relationship-minded',
-        image_url='img/careers/icons/mozilla-theme/careers-dino-help.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-dino-help.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -97,7 +109,13 @@
       {% call picto(
         base_el='li',
         title='We practice responsible participation',
-        image_url='img/careers/icons/mozilla-theme/careers-participation.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-participation.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -111,7 +129,13 @@
       {% call picto(
         base_el='li',
         title='We have grit',
-        image_url='img/careers/icons/mozilla-theme/careers-target.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-target.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -170,7 +194,13 @@
       {% call picto(
         base_el='li',
         title='Health and wellness',
-        image_url='img/careers/icons/mozilla-theme/careers-items.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-items.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -183,7 +213,13 @@
       {% call picto(
         base_el='li',
         title='Mental health',
-        image_url='img/careers/icons/mozilla-theme/careers-watering.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-watering.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -196,7 +232,13 @@
       {% call picto(
         base_el='li',
         title='Time away',
-        image_url='img/careers/icons/mozilla-theme/careers-camp.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-camp.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -211,7 +253,13 @@
       {% call picto(
         base_el='li',
         title='Parental leave',
-        image_url='img/careers/icons/mozilla-theme/careers-dino-egg.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-dino-egg.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -258,7 +306,13 @@
       {% call picto(
         base_el='li',
         title='Product Engineering',
-        image_url='img/careers/icons/mozilla-theme/careers-web.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-web.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -272,7 +326,13 @@
       {% call picto(
         base_el='li',
         title='Data Organization',
-        image_url='img/careers/icons/mozilla-theme/careers-charts.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-charts.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -287,7 +347,13 @@
       {% call picto(
         base_el='li',
         title='Marketing',
-        image_url='img/careers/icons/mozilla-theme/careers-webpage.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-webpage.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>
@@ -300,7 +366,13 @@
       {% call picto(
         base_el='li',
         title='Innovation',
-        image_url='img/careers/icons/mozilla-theme/careers-connection.svg',
+        image=resp_img(
+          url='img/careers/icons/mozilla-theme/careers-connection.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>

--- a/bedrock/careers/templates/careers/teams.html
+++ b/bedrock/careers/templates/careers/teams.html
@@ -42,7 +42,13 @@
         {% call picto(
           base_el='li',
           title='Engineering',
-          image_url='img/careers/icons/mozilla-theme/careers-web.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-web.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -57,7 +63,13 @@
         {% call picto(
           base_el='li',
           title='Product Design / UX',
-          image_url='img/careers/icons/mozilla-theme/careers-webpage.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-webpage.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -71,7 +83,13 @@
         {% call picto(
           base_el='li',
           title='Innovation Ecosystems',
-          image_url='img/careers/icons/mozilla-theme/careers-rainbow.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-rainbow.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -91,7 +109,13 @@
         {% call picto(
           base_el='li',
           title='Data Organization',
-          image_url='img/careers/icons/mozilla-theme/careers-participation.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-participation.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -107,7 +131,13 @@
         {% call picto(
           base_el='li',
           title='Marketing',
-          image_url='img/careers/icons/mozilla-theme/careers-chat.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-chat.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -124,7 +154,13 @@
         {% call picto(
           base_el='li',
           title='Trust & Security',
-          image_url='img/careers/icons/mozilla-theme/careers-birdsnest.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-birdsnest.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -138,7 +174,13 @@
         {% call picto(
           base_el='li',
           title='Global Policy',
-          image_url='img/careers/icons/mozilla-theme/careers-global.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-global.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -152,7 +194,13 @@
         {% call picto(
           base_el='li',
           title='Legal',
-          image_url='img/careers/icons/mozilla-theme/careers-swords.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-swords.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -166,7 +214,13 @@
         {% call picto(
           base_el='li',
           title='People',
-          image_url='img/careers/icons/mozilla-theme/careers-watering.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-watering.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>
@@ -180,7 +234,13 @@
         {% call picto(
           base_el='li',
           title='Finance and Business Ops',
-          image_url='img/careers/icons/mozilla-theme/careers-charts.svg',
+          image=resp_img(
+            url='img/careers/icons/mozilla-theme/careers-charts.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>

--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -108,8 +108,13 @@
       <ul class="mzp-l-content {{ entry.layout_class }}">
       {% for picto_data in entry.pictos -%}
         {% call picto(
-          image_url=picto_data.image_url,
-          image_width=entry.image_width,
+          image=resp_img(
+            url=picto_data.image_url,
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': entry.image_width
+            }
+          ),
           title=picto_data.heading,
           heading_level=entry.heading_level,
           body=picto_data.body,

--- a/bedrock/firefox/templates/firefox/browsers/quantum.html
+++ b/bedrock/firefox/templates/firefox/browsers/quantum.html
@@ -42,7 +42,14 @@
     <ul class="mzp-l-columns mzp-t-columns-three">
       {% call picto(
         title=ftl('privacy-first'),
-        image_url='img/firefox/new/desktop/privacy.svg',
+        image=resp_img(
+          url='img/firefox/new/desktop/privacy.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('firefox-doesnt-spy') }}</p>
@@ -50,7 +57,14 @@
 
       {% call picto(
         title=ftl('super-fast'),
-        image_url='img/icons/speedometer.svg',
+        image=resp_img(
+          url='img/icons/speedometer.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('get-speed-and') }}</p>
@@ -58,7 +72,14 @@
 
       {% call picto(
         title=ftl('always-evolving'),
-        image_url='img/firefox/new/desktop/highlights.svg',
+        image=resp_img(
+          url='img/firefox/new/desktop/highlights.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('find-out-about', url=url('firefox.features.index')) }}</p>

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -61,9 +61,15 @@
 
   <aside class="mzp-t-picto-center">
   {% call picto(
-    image_url='img/icons/warning.svg',
+    image=resp_img(
+      url='img/icons/warning.svg',
+      optional_attributes={
+        'class': 'mzp-c-picto-image',
+        'width': '44',
+        'loading': 'lazy'
+      }
+    ),
     heading_level=2,
-    image_width=44,
     title=ftl('firefox-channel-see-something-that-isnt-working'),
     body=True,
     ) %}

--- a/bedrock/firefox/templates/firefox/developer/includes/engage.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/engage.html
@@ -10,7 +10,14 @@
   {% call picto(
     title=ftl('firefox-developer-speak-up'),
     body=True,
-    image_url='img/firefox/developer/icon-speak.svg'
+    image=resp_img(
+      url='img/firefox/developer/icon-speak.svg',
+      optional_attributes={
+        'class': 'mzp-c-picto-image',
+        'width': '64',
+        'loading': 'lazy'
+      }
+    ),
   ) %}
     <p>{{ ftl('firefox-developer-feedback-makes-us') }}</p>
     <p><a class="mzp-c-cta-link" href="https://discourse.mozilla.org/c/devtools">{{ ftl('firefox-developer-join-the-convo') }}</a></p>
@@ -18,7 +25,14 @@
   {% call picto(
     title=ftl('firefox-developer-get-involved'),
     body=True,
-    image_url='img/firefox/developer/icon-involved.svg'
+    image=resp_img(
+      url='img/firefox/developer/icon-involved.svg',
+      optional_attributes={
+        'class': 'mzp-c-picto-image',
+        'width': '64',
+        'loading': 'lazy'
+      }
+    ),
   ) %}
     <p>{{ ftl('firefox-developer-help-build-the-last') }}</p>
     <p><a class="mzp-c-cta-link" href="https://firefox-dev.tools/">{{ ftl('firefox-developer-start-now') }}</a></p>

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -76,8 +76,14 @@
       <ul class="mzp-l-columns mzp-t-columns-three">
         {% call picto(
           title=ftl('firefox-enterprise-your-data-stays-your-business'),
-          image_url='img/firefox/enterprise/icon-data-privacy.svg',
-          image_width='44',
+          image=resp_img(
+            url='img/firefox/enterprise/icon-data-privacy.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '44',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           {% if LANG == 'en-US' %}
@@ -89,8 +95,14 @@
 
         {% call picto(
           title=ftl('firefox-enterprise-deploy-when-and-how-you-want'),
-          image_url='img/firefox/enterprise/icon-deploy.svg',
-          image_width='53',
+          image=resp_img(
+            url='img/firefox/enterprise/icon-deploy.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '53',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('firefox-enterprise-with-install-packages-and') }}</p>
@@ -98,8 +110,14 @@
 
         {% call picto(
           title=ftl('firefox-enterprise-choose-your-release-cadence'),
-          image_url='img/firefox/enterprise/icon-release.svg',
-          image_width='49',
+          image=resp_img(
+            url='img/firefox/enterprise/icon-release.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '49',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('firefox-enterprise-get-rapid-releases-to-make') }}</p>

--- a/bedrock/firefox/templates/firefox/features/includes/features-content.html
+++ b/bedrock/firefox/templates/firefox/features/includes/features-content.html
@@ -12,8 +12,14 @@
   <ul class="mzp-l-columns mzp-t-columns-three">
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/orange/speedometer.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/orange/speedometer.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.fast') }}">{{ ftl('features-shared-browse-faster') }}</a></p>
@@ -21,8 +27,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/orange/feature-extensions-puzzle.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/orange/feature-extensions-puzzle.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="https://addons.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=firefox-features" rel="external">{{ ftl('features-shared-your-favorite-extensions') }}</a></p>
@@ -30,8 +42,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/orange/microchip.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/orange/microchip.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.memory') }}">{{ ftl('features-shared-balanced-memory') }}</a></p>
@@ -39,8 +57,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/violet/feature-private-browsing-mask.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/violet/feature-private-browsing-mask.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.private-browsing') }}">{{ ftl('features-shared-more-powerful-private-browsing') }}</a></p>
@@ -48,8 +72,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/violet/feature-tracking-protection-shield.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/violet/feature-tracking-protection-shield.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.adblocker') }}">{{ ftl('features-shared-ad-tracker-blocking') }}</a></p>
@@ -57,8 +87,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/violet/password.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/violet/password.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.password-manager') }}">{{ ftl('features-shared-password-manager') }}</a></p>
@@ -66,8 +102,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/pink/paintbrush.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/pink/paintbrush.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="https://addons.mozilla.org/firefox/themes/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=firefox-features" rel="external">{{ ftl('features-shared-customize-your-browser') }}</a></p>
@@ -75,8 +117,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/pink/feature-sync-arrows.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/pink/feature-sync-arrows.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.sync') }}">{{ ftl('features-shared-sync-between-devices') }}</a></p>
@@ -84,8 +132,14 @@
 
     {% call picto(
       base_el='li',
-      image_url='protocol/img/icons/brand/pink/feature-bookmarks-star.svg',
-      image_width='32',
+      image=resp_img(
+        url='protocol/img/icons/brand/pink/feature-bookmarks-star.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.bookmarks') }}">{{ ftl('features-shared-better-bookmarks') }}</a></p>
@@ -94,8 +148,14 @@
   {% if ftl_has_messages('features-shared-fingerprinter-blocking') %}
     {% call picto(
       base_el='li',
-      image_url='img/firefox/features/index/feature_icons/fingerprint_blue.svg',
-      image_width='32',
+      image=resp_img(
+        url='img/firefox/features/index/feature_icons/fingerprint_blue.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.fingerprinting') }}">{{ ftl('features-shared-fingerprinter-blocking') }}</a></p>
@@ -105,8 +165,14 @@
   {% if ftl_has_messages('features-shared-translate-the-web') %}
     {% call picto(
       base_el='li',
-      image_url='img/firefox/features/index/feature_icons/language_blue.svg',
-      image_width='32',
+      image=resp_img(
+        url='img/firefox/features/index/feature_icons/language_blue.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.translate') }}">{{ ftl('features-shared-translate-the-web') }}</a></p>
@@ -116,8 +182,14 @@
   {% if ftl_has_messages('features-shared-picture-in-picture') %}
     {% call picto(
       base_el='li',
-      image_url='img/firefox/features/index/feature_icons/picture-in-picture_blue.svg',
-      image_width='32',
+      image=resp_img(
+        url='img/firefox/features/index/feature_icons/picture-in-picture_blue.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '32',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
     ) %}
       <p><a href="{{ url('firefox.features.picture-in-picture') }}">{{ ftl('features-shared-picture-in-picture') }}</a></p>

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -45,7 +45,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-browse-faster'),
-        image_url='protocol/img/icons/brand/orange/speedometer.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/orange/speedometer.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-use-less-memory') }}</p>
@@ -55,7 +62,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-your-favorite-extensions'),
-        image_url='protocol/img/icons/brand/orange/feature-extensions-puzzle.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/orange/feature-extensions-puzzle.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-add-powerful-functions') }}</p>
@@ -65,7 +79,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-balanced-memory'),
-        image_url='protocol/img/icons/brand/orange/microchip.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/orange/microchip.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-just-enough') }}</p>
@@ -75,7 +96,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-more-powerful-private-browsing'),
-        image_url='protocol/img/icons/brand/violet/feature-private-browsing-mask.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/violet/feature-private-browsing-mask.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-private-browsing-mode') }}</p>
@@ -85,7 +113,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-ad-tracker-blocking'),
-        image_url='protocol/img/icons/brand/violet/feature-tracking-protection-shield.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/violet/feature-tracking-protection-shield.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-firefox-automatically') }}</p>
@@ -95,7 +130,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-password-manager'),
-        image_url='protocol/img/icons/brand/violet/password.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/violet/password.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-access-all-passwords') }}</p>
@@ -105,7 +147,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-customize-your-browser'),
-        image_url='protocol/img/icons/brand/pink/paintbrush.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/pink/paintbrush.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-give-your-browser') }}</p>
@@ -115,7 +164,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-sync-between-devices'),
-        image_url='protocol/img/icons/brand/pink/feature-sync-arrows.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/pink/feature-sync-arrows.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-important-stuff') }}</p>
@@ -125,7 +181,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-shared-better-bookmarks'),
-        image_url='protocol/img/icons/brand/pink/feature-bookmarks-star.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/pink/feature-bookmarks-star.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-use-the-bookmark') }}</p>
@@ -136,7 +199,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-index-fingerprinter-blocking'),
-        image_url='img/firefox/features/index/feature_icons/fingerprint_blue.svg',
+        image=resp_img(
+          url='img/firefox/features/index/feature_icons/fingerprint_blue.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-fingerprinting-is-a') }}</p>
@@ -148,7 +218,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-index-translate-the-web'),
-        image_url='img/firefox/features/index/feature_icons/language_blue.svg',
+        image=resp_img(
+          url='img/firefox/features/index/feature_icons/language_blue.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-translate-more-than') }}</p>
@@ -160,7 +237,14 @@
       {% call picto(
         base_el='li',
         title=ftl('features-index-picture-in-picture'),
-        image_url='img/firefox/features/index/feature_icons/picture-in-picture_blue.svg',
+        image=resp_img(
+          url='img/firefox/features/index/feature_icons/picture-in-picture_blue.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('features-index-got-things-to-do') }}</p>
@@ -178,8 +262,14 @@
         {% call picto(
           base_el='li',
           title=ftl('features-index-open-source-minds'),
-          image_url='img/firefox/features/index/benefit_icons/opensource.svg',
-          image_width='24',
+          image=resp_img(
+            url='img/firefox/features/index/benefit_icons/opensource.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '24',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('features-index-mozilla-creates') }}</p>
@@ -189,8 +279,14 @@
         {% call picto(
           base_el='li',
           title=ftl('features-index-by-not-for-profit-mozilla', fallback='features-index-by-non-profit-mozilla'),
-          image_url='img/firefox/features/index/benefit_icons/mozilla.svg',
-          image_width='24',
+          image=resp_img(
+            url='img/firefox/features/index/benefit_icons/mozilla.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '24',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('features-index-on-a-mission') }}</p>
@@ -200,8 +296,14 @@
         {% call picto(
           base_el='li',
           title=ftl('features-index-keep-corporate-power'),
-          image_url='img/firefox/features/index/benefit_icons/mountain.svg',
-          image_width='24',
+          image=resp_img(
+            url='img/firefox/features/index/benefit_icons/mountain.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '24',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('features-index-independent-browser') }}</p>
@@ -211,8 +313,14 @@
         {% call picto(
           base_el='li',
           title=ftl('features-index-private-by-default'),
-          image_url='img/firefox/features/index/benefit_icons/lock.svg',
-          image_width='24',
+          image=resp_img(
+            url='img/firefox/features/index/benefit_icons/lock.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '24',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('features-index-opted-in-to-privacy-so-you') }}</p>
@@ -222,8 +330,14 @@
         {% call picto(
           base_el='li',
           title=ftl('features-index-enhanced-tracking'),
-          image_url='img/firefox/features/index/benefit_icons/shield.svg',
-          image_width='24',
+          image=resp_img(
+            url='img/firefox/features/index/benefit_icons/shield.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '24',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('features-index-we-dont-sell-access-to-your') }}</p>
@@ -233,8 +347,14 @@
         {% call picto(
           base_el='li',
           title=ftl('features-index-firefox-vs'),
-          image_url='img/firefox/features/index/benefit_icons/browser.svg',
-          image_width='24',
+          image=resp_img(
+            url='img/firefox/features/index/benefit_icons/browser.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '24',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('features-index-stack-up') }}</p>

--- a/bedrock/firefox/templates/firefox/features/picture-in-picture.html
+++ b/bedrock/firefox/templates/firefox/features/picture-in-picture.html
@@ -68,9 +68,39 @@
       <h3 class="content-extra-title">{{ ftl('features-pip-3-more-ways-to-use-picture', fallback='features-pip-3-ways-to-use-picture') }}</h3>
 
       <div class="mzp-l-columns mzp-t-columns-three mzp-t-picto-center">
-        {{ picto(title=ftl('features-pip-watch-a-lecture-or-meeting'), heading_level=4, image_url='img/firefox/features/pip/pip-lecture.svg', image_width=None,) }}
-        {{ picto(title=ftl('features-pip-keep-a-tutorial-video-open'), heading_level=4, image_url='img/firefox/features/pip/pip-cook.svg', image_width=None,) }}
-        {{ picto(title=ftl('features-pip-entertain-cats-dogs-and-kids'), heading_level=4, image_url='img/firefox/features/pip/pip-entertain.svg', image_width=None,) }}
+        {{ picto(
+          title=ftl('features-pip-watch-a-lecture-or-meeting'),
+          heading_level=4,
+          image=resp_img(
+            url='img/firefox/features/pip/pip-lecture.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          )
+        ) }}
+        {{ picto(
+          title=ftl('features-pip-keep-a-tutorial-video-open'),
+          heading_level=4,
+          image=resp_img(
+            url='img/firefox/features/pip/pip-cook.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          )
+        ) }}
+        {{ picto(
+          title=ftl('features-pip-entertain-cats-dogs-and-kids'),
+          heading_level=4,
+          image=resp_img(
+            url='img/firefox/features/pip/pip-entertain.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'loading': 'lazy'
+            }
+          )
+        ) }}
       </div>
 
       <aside class="secondary-cta">

--- a/bedrock/firefox/templates/firefox/more/misinformation.html
+++ b/bedrock/firefox/templates/firefox/more/misinformation.html
@@ -139,9 +139,14 @@
     <ul class="mzp-l-content mzp-l-columns mzp-t-columns-two mzp-t-picto-center">
       {% call picto(
         title=ftl('misinformation-why-trust-firefox'),
-        image_url='img/icons/mountain-purple.svg',
-        image_width='153px',
-        loading="lazy",
+        image=resp_img(
+          url='img/icons/mountain-purple.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '153',
+            'loading': 'lazy'
+          }
+        ),
         class='trust',
         body=True,
         base_el='li'
@@ -154,9 +159,14 @@
 
       {% call picto(
         title=ftl('misinformation-your-privacy-by-the-product'),
-        image_url='img/icons/privacy-shield.svg',
-        image_width='146px',
-        loading="lazy",
+        image=resp_img(
+          url='img/icons/privacy-shield.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '146',
+            'loading': 'lazy'
+          }
+        ),
         class='privacy',
         body=True,
         base_el='li',

--- a/bedrock/firefox/templates/firefox/new/basic/base_platform.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_platform.html
@@ -34,8 +34,13 @@
       <ul class="mzp-l-content mzp-l-columns mzp-t-columns-three mzp-t-picto-center">
         {% call picto(
           title=card1_title,
-          image_url=card1_image_url,
-          image_width=96,
+          image=resp_img(
+            url=card1_image_url,
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '96'
+            }
+          ),
           body=True,
           base_el='li'
         ) %}
@@ -43,8 +48,13 @@
         {% endcall %}
         {% call picto(
           title=card2_title,
-          image_url=card2_image_url,
-          image_width=96,
+          image=resp_img(
+            url=card2_image_url,
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '96'
+            }
+          ),
           body=True,
           base_el='li'
         ) %}
@@ -52,8 +62,13 @@
         {% endcall %}
         {% call picto(
           title=card3_title,
-          image_url=card3_image_url,
-          image_width=96,
+          image=resp_img(
+            url=card3_image_url,
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '96'
+            }
+          ),
           body=True,
           base_el='li'
         ) %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -47,7 +47,12 @@
           heading_level=3,
           class='test',
           body=True,
-          image_url='img/firefox/firstrun/test.png',
+          image=resp_img(
+            url='img/firefox/firstrun/test.png',
+            optional_attributes={
+              'class': 'mzp-c-picto-image'
+            }
+          ),
           base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-find-and-file-bugs') }}</p>
@@ -59,7 +64,12 @@
           heading_level=3,
           class='code',
           body=True,
-          image_url='img/firefox/firstrun/code.png',
+          image=resp_img(
+            url='img/firefox/firstrun/code.png',
+            optional_attributes={
+              'class': 'mzp-c-picto-image'
+            }
+          ),
           base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-file-bugs-and-work') }}</p>
@@ -71,7 +81,12 @@
           heading_level=3,
           class='localize',
           body=True,
-          image_url='img/firefox/firstrun/localize.png',
+          image=resp_img(
+            url='img/firefox/firstrun/localize.png',
+            optional_attributes={
+              'class': 'mzp-c-picto-image'
+            }
+          ),
           base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-make-firefox-available') }}</p>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -141,7 +141,14 @@
       title=ftl('privacy-book-search-engine-title'),
       heading_level=4,
       body=True,
-      image_url='img/firefox/privacy/book/privacy-icon-search.svg',
+      image=resp_img(
+        url='img/firefox/privacy/book/privacy-icon-search.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '64',
+          'loading': 'lazy'
+        }
+      )
     ) %}
       <p>{{ ftl('privacy-book-search-engine-duckduckgo') }}</p>
     {% endcall %}
@@ -150,7 +157,14 @@
       title=ftl('privacy-book-email-have-title'),
       heading_level=4,
       body=True,
-      image_url='img/firefox/privacy/book/privacy-icon-email.svg',
+      image=resp_img(
+        url='img/firefox/privacy/book/privacy-icon-email.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '64',
+          'loading': 'lazy'
+        }
+      )
     ) %}
       <p>{{ ftl('privacy-book-email-have-you') }}</p>
     {% endcall %}
@@ -159,7 +173,14 @@
       title=ftl('privacy-book-browser-while-title'),
       heading_level=4,
       body=True,
-      image_url='img/firefox/privacy/book/privacy-icon-browser.svg',
+      image=resp_img(
+        url='img/firefox/privacy/book/privacy-icon-browser.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '64',
+          'loading': 'lazy'
+        }
+      )
     ) %}
       <p>{{ ftl('privacy-book-browser-while-many') }}</p>
     {% endcall %}
@@ -168,7 +189,14 @@
       title=ftl('privacy-book-messenger-signal-title'),
       heading_level=4,
       body=True,
-      image_url='img/firefox/privacy/book/privacy-icon-messenger.svg',
+      image=resp_img(
+        url='img/firefox/privacy/book/privacy-icon-messenger.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '64',
+          'loading': 'lazy'
+        }
+      )
     ) %}
       <p>{{ ftl('privacy-book-messenger-signal-is') }}</p>
     {% endcall %}

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -113,8 +113,14 @@
       {% call picto(
         title=ftl('firefox-privacy-hub-why-trust-firefox'),
         body=True,
-        image_url='img/icons/mountain-purple.svg',
-        image_width=150,
+        image=resp_img(
+          url='img/icons/mountain-purple.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '150',
+            'loading': 'lazy'
+          }
+        ),
         base_el='li'
       ) %}
         <p>
@@ -127,8 +133,14 @@
       {% call picto(
         title=ftl('firefox-privacy-hub-your-privacy-by-the-product'),
         body=True,
-        image_url='img/icons/privacy-shield.svg',
-        image_width=150,
+        image=resp_img(
+          url='img/icons/privacy-shield.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '150',
+            'loading': 'lazy'
+          }
+        ),
         base_el='li'
       ) %}
         <p>{{ ftl('firefox-privacy-hub-firefox-products-work-differently') }}</p>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -74,7 +74,14 @@
     <ul class="mzp-l-content mzp-l-columns mzp-t-columns-three">
       {% call picto(
         title=ftl('firefox-privacy-hub-invisible-to-the-top-trackers'),
-        image_url='img/firefox/privacy/products/icon-invisible.svg',
+        image=resp_img(
+          url='img/firefox/privacy/products/icon-invisible.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         base_el='li',
         body=True
       ) %}
@@ -82,7 +89,14 @@
       {% endcall %}
       {% call picto(
         title=ftl('firefox-privacy-hub-always-in-your-control'),
-        image_url='img/firefox/privacy/products/icon-control.svg',
+        image=resp_img(
+          url='img/firefox/privacy/products/icon-control.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         base_el='li',
         body=True
       ) %}
@@ -90,7 +104,14 @@
       {% endcall %}
       {% call picto(
         title=ftl('firefox-privacy-hub-protection-beyond-tracking'),
-        image_url='img/firefox/privacy/products/icon-protection.svg',
+        image=resp_img(
+          url='img/firefox/privacy/products/icon-protection.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         base_el='li',
         body=True
       ) %}

--- a/bedrock/firefox/templates/firefox/set-as-default/landing.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/landing.html
@@ -53,7 +53,14 @@
     <ul class="mzp-l-columns mzp-t-columns-three mzp-l-content mzp-t-content-lg">
       {% call picto(
         title=ftl('set-as-default-landing-choose-automatic-privacy'),
-        image_url='protocol/img/icons/brand/violet/no-eye.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/violet/no-eye.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=true,
       ) %}
         <p>{{ ftl('set-as-default-landing-companies-keep-finding') }}</p>
@@ -61,7 +68,14 @@
 
       {% call picto(
         title=ftl('set-as-default-landing-choose-freedom-on-every'),
-        image_url='protocol/img/icons/brand/orange/devices.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/orange/devices.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=true,
       ) %}
         <p>{{ ftl('set-as-default-landing-firefox-is-fast-and') }}</p>
@@ -69,7 +83,14 @@
 
       {% call picto(
         title=ftl('set-as-default-landing-choose-corporate-independence'),
-        image_url='protocol/img/icons/brand/blue/mountain.svg',
+        image=resp_img(
+          url='protocol/img/icons/brand/blue/mountain.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=true,
       ) %}
         <p>{{ ftl('set-as-default-landing-firefox-is-the-only') }}</p>

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -71,7 +71,14 @@
     <ul class="mzp-l-columns mzp-t-columns-three">
       {% call picto(
         title=ftl('firefox-sync-privacy-made-easy'),
-        image_url='img/firefox/new/desktop/privacy.svg',
+        image=resp_img(
+          url='img/firefox/new/desktop/privacy.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('firefox-sync-all-you-need') }}</p>
@@ -79,7 +86,14 @@
 
       {% call picto(
         title=ftl('firefox-sync-encrypt-your-data'),
-        image_url='img/icons/speedometer.svg',
+        image=resp_img(
+          url='img/icons/speedometer.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('firefox-sync-your-encryption-key') }}</p>
@@ -87,7 +101,14 @@
 
       {% call picto(
         title=ftl('firefox-sync-feel-safe'),
-        image_url='img/firefox/new/desktop/highlights.svg',
+        image=resp_img(
+          url='img/firefox/new/desktop/highlights.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'width': '64',
+            'loading': 'lazy'
+          }
+        ),
         body=True,
       ) %}
         <p>{{ ftl('firefox-sync-we-store-your') }}</p>

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -122,9 +122,17 @@
     <section class="externals">
       <ul class="mzp-l-content mzp-l-columns mzp-t-columns-three mzp-t-picto-center">
           {% call picto(
-            image_url='img/home/extensions.png',
-            image_width=100,
-            include_highres_image=True,
+            image=resp_img(
+              url='img/home/extensions.png',
+              srcset={
+                'img/home/extensions-high-res.png': '2x'
+              },
+              optional_attributes={
+                'class': 'mzp-c-picto-image',
+                'width': '100',
+                'loading': 'lazy'
+              }
+            ),
             body=True,
             base_el='li'
           ) %}
@@ -135,9 +143,17 @@
           {% endcall %}
 
           {% call picto(
-            image_url='img/home/careers.png',
-            image_width=100,
-            include_highres_image=True,
+            image=resp_img(
+              url='img/home/careers.png',
+              srcset={
+                'img/home/careers-high-res.png': '2x'
+              },
+              optional_attributes={
+                'class': 'mzp-c-picto-image',
+                'width': '100',
+                'loading': 'lazy'
+              }
+            ),
             body=True,
             base_el='li'
           ) %}
@@ -148,9 +164,17 @@
           {% endcall %}
 
           {% call picto(
-            image_url='img/home/help.png',
-            image_width=100,
-            include_highres_image=True,
+            image=resp_img(
+              url='img/home/help.png',
+              srcset={
+                'img/home/help-high-res.png': '2x'
+              },
+              optional_attributes={
+                'class': 'mzp-c-picto-image',
+                'width': '100',
+                'loading': 'lazy'
+              }
+            ),
             body=True,
             base_el='li'
           ) %}

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -50,8 +50,14 @@
     {% call picto(
       title='Track I: Foundational Technology',
       heading_level=3,
-      image_url='img/mozorg/moss/foundational-technology.svg',
-      image_width=200,
+      image=resp_img(
+        url='img/mozorg/moss/foundational-technology.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '200',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
       base_el='li'
     ) %}
@@ -65,8 +71,14 @@
     {% call picto(
       title='Track II: Mission Partners',
       heading_level=3,
-      image_url='img/mozorg/moss/mission-partners.svg',
-      image_width=200,
+      image=resp_img(
+        url='img/mozorg/moss/mission-partners.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '200',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
       base_el='li'
     ) %}
@@ -80,8 +92,14 @@
     {% call picto(
       title='Track III: Secure Open Source Fund',
       heading_level=3,
-      image_url='img/mozorg/moss/secure-open-source.svg',
-      image_width=200,
+      image=resp_img(
+        url='img/mozorg/moss/secure-open-source.svg',
+        optional_attributes={
+          'class': 'mzp-c-picto-image',
+          'width': '200',
+          'loading': 'lazy'
+        }
+      ),
       body=True,
       base_el='li'
     ) %}

--- a/bedrock/pocket/templates/pocket/home.html
+++ b/bedrock/pocket/templates/pocket/home.html
@@ -86,22 +86,40 @@
       <ul class="mzp-l-columns mzp-t-columns-three">
         {% call picto(
           title=ftl('pocket-home-tailor-text'),
-          image_url='img/pocket/pocket-text-icon.svg',
-          image_width=40
+          image=resp_img(
+            url='img/pocket/pocket-text-icon.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '40',
+              'loading': 'lazy'
+            }
+          )
         ) %}
         {% endcall %}
 
         {% call picto(
           title=ftl('pocket-home-categorize-saves'),
-          image_url='img/pocket/pocket-tag-icon.svg',
-          image_width=40
+          image=resp_img(
+            url='img/pocket/pocket-tag-icon.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '40',
+              'loading': 'lazy'
+            }
+          )
         ) %}
         {% endcall %}
 
         {% call picto(
           title=ftl('pocket-home-listen-to-articles'),
-          image_url='img/pocket/pocket-audio-icon.svg',
-          image_width=40,
+          image=resp_img(
+            url='img/pocket/pocket-audio-icon.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '40',
+              'loading': 'lazy'
+            }
+          )
         ) %}
         {% endcall %}
       </ul>

--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -52,8 +52,14 @@
         {% call picto(
           base_el='li',
           title=ftl('vpn-download-for-windows'),
-          image_url='img/products/vpn/download/platform-windows-black.svg',
-          image_width=100,
+          image=resp_img(
+            url='img/products/vpn/download/platform-windows-black.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '100',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
@@ -65,8 +71,14 @@
         {% call picto(
           base_el='li',
           title=ftl('vpn-download-for-mac'),
-          image_url='img/products/vpn/download/platform-mac-black.svg',
-          image_width=100,
+          image=resp_img(
+            url='img/products/vpn/download/platform-mac-black.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '100',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('vpn-download-version-requirements', version='10.14') }}</p>
@@ -78,8 +90,14 @@
         {% call picto(
           base_el='li',
           title=ftl('vpn-download-for-linux'),
-          image_url='img/products/vpn/download/platform-linux-black.svg',
-          image_width=100,
+          image=resp_img(
+            url='img/products/vpn/download/platform-linux-black.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '100',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('vpn-download-for-linux-requirements', version='18.04') }}</p>
@@ -91,8 +109,14 @@
         {% call picto(
           base_el='li',
           title=ftl('vpn-download-for-android'),
-          image_url='img/products/vpn/download/platform-android-black.svg',
-          image_width=100,
+          image=resp_img(
+            url='img/products/vpn/download/platform-android-black.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '100',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
@@ -104,8 +128,14 @@
         {% call picto(
           base_el='li',
           title=ftl('vpn-download-for-ios'),
-          image_url='img/products/vpn/download/platform-ios-black.svg',
-          image_width=100,
+          image=resp_img(
+            url='img/products/vpn/download/platform-ios-black.svg',
+            optional_attributes={
+              'class': 'mzp-c-picto-image',
+              'width': '100',
+              'loading': 'lazy'
+            }
+          ),
           body=True,
         ) %}
           <p>{{ ftl('vpn-download-version-requirements', version='13.0') }}</p>

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -1207,75 +1207,18 @@ Picto
 
     Example: ``heading_level=2``
 
-- image_alt
-    Alt text for the images to be used.
-
-    Default: ``''``
-
-    Example: ``image_alt='Red Panda'``
-
-- image_height
-    Number indicating the height of an image.
+- image
+    Can pass an <img> element, `resp_img` or `picture` Python helpers. For information on Bedrock's image helpers, `look here <https://bedrock.readthedocs.io/en/latest/coding.html?highlight=resp_img#primary-image-helpers>`_
 
     Default: ``None``
 
-    Example: ``image_height='153'``
+    Example:
 
-- image_sizes
-    The ``sizes`` attribute for a responsive image.
+    .. code-block::
 
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_sources
-    A list of ``<source>`` elements for a responsive ``<picture>`` image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_srcset
-    The ``srcset`` attribute for a responsive image.
-
-    Default: ``None``
-
-    Example: See responsive images docs above.
-
-- image_url
-    The default image to be used. Start it off with ``img/``.
-
-    Default: ``''``
-
-    Example: ``image_url='img/icons/mountain-purple.svg'``
-
-- image_width
-    Number indicating the width of an image.
-
-    Default: ``64``
-
-    Example: ``image_width='153'``
-
-- include_highres_image (deprecated)
-    Boolean that determines whether the image can also appear in high res.
-
-    Default: ``False``
-
-    Example: ``include_highres_image=True``
-
-- l10n_image
-    Boolean to indicate if image has translatable text.
-
-    Default: ``False``
-
-    Example: ``l10n_image=True``
-
-- loading
-    String to provide value for image loading attribute. This will use browser default ("eager") if not set. Lazy loading defers fetching of images to a browser decision based on user scroll and connection.
-
-    Default: ``None``
-
-    Example: ``loading='lazy'``
+        image=resp_img('img/firefox/accounts/trailhead/value-respect.jpg', srcset={
+            'img/firefox/accounts/trailhead/value-respect-high-res.jpg': '2x'
+        })
 
 - title
     String indicating heading text (usually a translation id wrapped in ftl function)


### PR DESCRIPTION
## One-line summary

Simplifies `picto()` macro image handling, so we now pass a single `image` param (as opposed to passing multiple parameters through multiple macros to decide which type of image to render).

## Issue / Bugzilla link

#12513

## Testing

`npm start`

- [x] http://localhost:8000/en-US/careers/benefits/
- [x] http://localhost:8000/en-US/careers/
- [x] http://localhost:8000/en-US/careers/teams/
- [x] http://localhost:8000/en-US/firefox/browsers/quantum/
- [x] http://localhost:8000/en-US/firefox/channel/desktop/
- [x] http://localhost:8000/en-US/firefox/developer/
- [x] http://localhost:8000/en-US/firefox/enterprise/
- [x] http://localhost:8000/en-US/firefox/features/
- [x] http://localhost:8000/en-US/firefox/features/bookmarks/
- [x] http://localhost:8000/en-US/firefox/features/picture-in-picture/
- [x] http://localhost:8000/en-US/firefox/more/misinformation/
- [x] http://localhost:8000/en-US/firefox/windows/
- [x] http://localhost:8000/en-US/firefox/nightly/firstrun/
- [x] http://localhost:8000/en-US/firefox/privacy/book/
- [x] http://localhost:8000/en-US/firefox/privacy/
- [x] http://localhost:8000/en-US/firefox/privacy/products/
- [x] http://localhost:8000/en-US/firefox/set-as-default/
- [x] http://localhost:8000/en-US/firefox/sync/
- [x] http://localhost:8000/es-ES/
- [x] http://localhost:8000/en-US/moss/
- [x] http://localhost:8000/en-US/products/vpn/download/

`npm run in-pocket-mode`

- [x] http://localhost:8000/en/