### PR TITLE
Sanitise entire rendered output of Markdown-sourced Release Notes

### DIFF
--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -59,6 +59,7 @@ ALLOWED_TAGS = [
     "acronym",
     "b",
     "blockquote",
+    "br",
     "code",
     "div",
     "del",
@@ -69,7 +70,9 @@ ALLOWED_TAGS = [
     "h4",
     "h5",
     "h6",
+    "hr",
     "i",
+    "img",
     "li",
     "ol",
     "p",
@@ -83,12 +86,14 @@ ALLOWED_ATTRS = [
     "class",
     "href",
     "id",
+    "src",
     "title",
 ]
 
 
 def process_markdown(value):
-    return markdowner.reset().convert(bleach.clean(value, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS))
+    rendered_html = markdowner.reset().convert(value)
+    return bleach.clean(rendered_html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRS)
 
 
 def process_notes(notes):


### PR DESCRIPTION
This changeset amends our sanitisation of the Release Notes Markdown so that we Bleach the final rendered HTML from the Markdown, not just any HTML elements in the pre-rendered markdown. 

This will give us extra protection, especially if custom Markdown extensions are added in the future that might generate more risky HTML elements.

Changing the order of sanitisation did initially result in over-escaping or stripping of some HTML elements that were not written verbose in Markdown but instead were generated from the native Markdown syntax (eg the `<img>` tag from `![foo.png]`). That was because these elements were not in the allowlist, as the allowlist was tuned only to sanitise the HTML in the _raw_ Markdown.

Therefore, we add `br`, `hr`,`img` (and its `src` attr) to the allowlist. The `src` attr is low risk, IMO, given we do not allow `script` or `link` tags.

----

I'd welcome a sceptical take on this PR, to help avoid any breakage to Release Notes (eg if there's another tag that should be added to the allowlist but has not)

In terms of checking/validating that these changes won't create regressions, here's what I did to check our data:

Check 1. Identifying what inline HTML we had in Release Notes markdown - this content was already being bleached:

* Sync latest release notes commits from the repo
* Search for anything that looks like a HTML tag:

`ag '(<\w+\s*(:?.*)\/*>)' --nofilename --nogroup --nonumbers -o data/release_notes > /tmp/relnotes_tags.txt`

After de-duplicating, stripping back and sorting `relnotes_tags.txt`, the resulting tags are:

```
<a>
<blink>
<br>  # added to this allowlist in this changeset
<code>
<em>
<form>
<h2>
<h6>
<li>
<link>
<meta>
<p>
<small>
<strike>
<ul>
```

Four of these are not in the allowlist - and they are OK to be disallowed (and therefore escaped) because they're used as examples/text, not as an actual tag:

```
<blink>
<form>
<meta>
<link>
```

Note that no `<script>` tag is allowed, either.

Check 2. Spot-checking for escaped HTML in the output on various pages where we know we have markdown-sourced elements - eg `----` -> `hr` or `![image.png]` -> `img`.

I haven't done an exhaustive check of every single Markdown markup directive, but am pretty comfortable that I've checked enough pages, incl the most recent ones, and seen things like ~strikthrough~ working OK, and of course images.

Resolves #12560 

## To test

* `./manage.py update_release_notes --force`
* Check a few URLs - eg http://localhost:8000/en-US/firefox/108.0/releasenotes/ and http://localhost:8000/en-US/firefox/106.0/releasenotes/ (which has a bunch of images, strikethroughs etc)