### PR TITLE
Fix Mastodon icon to be white in WNP's dark mode

### DIFF
--- a/media/css/firefox/whatsnew/includes/_dark-mode.scss
+++ b/media/css/firefox/whatsnew/includes/_dark-mode.scss
@@ -70,6 +70,10 @@
                 background-image: url('/media/img/logos/social/spotify-white.svg');
             }
 
+            a.mastodon {
+                background-image: url('/media/img/logos/social/mastodon-white.svg');
+            }
+
             a:hover,
             a:focus,
             a:active {


### PR DESCRIPTION
## One-line summary

Updated the icon to be white in the WNP dark mode footer.

## Issue / Bugzilla link
#12569 

## Testing

To test this work:

- [ ] http://localhost:8000/en-US/firefox/whatsnew/ and scroll to the socials section in the footer
