### PR TITLE
Remove --clean from l10n update to troubleshoot GCP deployment

### DIFF
--- a/bin/cron.py
+++ b/bin/cron.py
@@ -151,7 +151,7 @@ def schedule_database_jobs():
 
 
 def schedule_file_jobs():
-    call_command("l10n_update --clean")
+    call_command("l10n_update")
 
     @scheduled_job("interval", minutes=DB_UPDATE_MINUTES)
     def update_locales():


### PR DESCRIPTION
## One-line summary

Remove `--clean` to assist in troubleshooting locales errors we are experiencing in our new GCP environment.

## Significant changes and points to review

This should probably stay only in `main` for now.

## Issue / Bugzilla link



## Screenshots

(If the changeset updates the UI, please include screenshots so reviewers know what to look for when testing)

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: (or None)

To test this work:

- [ ]
