### PR TITLE
Prevent overflow on parent tips (Fix #12586)

### DIFF
--- a/media/css/firefox/family/components/_pro-tip.scss
+++ b/media/css/firefox/family/components/_pro-tip.scss
@@ -28,6 +28,7 @@
 .c-pro-tip {
     background-color: f3.$black;
     font-weight: bold;
+    overflow-y: hidden;
 
     .mzp-l-content {
         padding-top: $spacing-md;

--- a/media/css/firefox/family/components/_pro-tip.scss
+++ b/media/css/firefox/family/components/_pro-tip.scss
@@ -28,7 +28,7 @@
 .c-pro-tip {
     background-color: f3.$black;
     font-weight: bold;
-    overflow-y: hidden;
+    overflow-x: hidden;
 
     .mzp-l-content {
         padding-top: $spacing-md;


### PR DESCRIPTION
## One-line summary

Add overflow-y: hidden to parental tips to prevent horizontal scroll

## Issue / Bugzilla link

Fix #12586

## Testing

http://localhost:8000/en-US/firefox/family/

To test this work:

- [ ] load page, try to scroll horizontally before scrolling down
