### PR TITLE
Show price + tax for VPN in US and Canada (Fixes #12589)

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -15,6 +15,9 @@ FTL_FILES = ["products/vpn/shared"]
 
 VPN_12_MONTH_PLAN = "12-month"
 
+# Show price "+ tax" in countries such as US & Canada.
+TAX_NOT_INCLUDED = ["US", "CA"]
+
 
 def _vpn_get_available_plans(country_code, lang, bundle_relay=False):
     """
@@ -122,7 +125,11 @@ def vpn_monthly_price(ctx, plan=VPN_12_MONTH_PLAN, country_code=None, lang=None,
     available_plans = _vpn_get_available_plans(country_code, lang, bundle_relay)
     selected_plan = available_plans.get(plan, VPN_12_MONTH_PLAN)
     amount = selected_plan.get("price")
-    price = ftl("vpn-shared-pricing-monthly", amount=amount, ftl_files=FTL_FILES)
+
+    if country_code in TAX_NOT_INCLUDED:
+        price = ftl("vpn-shared-pricing-monthly-plus-tax", fallback="vpn-shared-pricing-monthly", amount=amount, ftl_files=FTL_FILES)
+    else:
+        price = ftl("vpn-shared-pricing-monthly", amount=amount, ftl_files=FTL_FILES)
 
     markup = f'<span class="vpn-monthly-price-display">{price}</span>'
 
@@ -147,7 +154,11 @@ def vpn_total_price(ctx, country_code=None, lang=None, bundle_relay=False):
     available_plans = _vpn_get_available_plans(country_code, lang, bundle_relay)
     selected_plan = available_plans.get(VPN_12_MONTH_PLAN)
     amount = selected_plan.get("total")
-    price = ftl("vpn-shared-pricing-total", amount=amount, ftl_files=FTL_FILES)
+
+    if country_code in TAX_NOT_INCLUDED:
+        price = ftl("vpn-shared-pricing-total-plus-tax", fallback="vpn-shared-pricing-total", amount=amount, ftl_files=FTL_FILES)
+    else:
+        price = ftl("vpn-shared-pricing-total", amount=amount, ftl_files=FTL_FILES)
 
     markup = price
 

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -572,7 +572,13 @@ class TestVPNMonthlyPrice(TestCase):
     def test_vpn_monthly_price_usd(self):
         """Should return expected markup"""
         markup = self._render(plan="monthly", country_code="US", lang="en-US")
-        expected = '<span class="vpn-monthly-price-display">US$9.99<span>/month</span></span>'
+        expected = '<span class="vpn-monthly-price-display">US$9.99<span>/month + tax</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_usd_ca(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="CA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">US$9.99<span>/month + tax</span></span>'
         self.assertEqual(markup, expected)
 
     def test_vpn_monthly_price_euro(self):
@@ -590,7 +596,13 @@ class TestVPNMonthlyPrice(TestCase):
     def test_vpn_12_month_price_usd(self):
         """Should return expected markup"""
         markup = self._render(plan="12-month", country_code="US", lang="en-US")
-        expected = '<span class="vpn-monthly-price-display">US$4.99<span>/month</span></span>'
+        expected = '<span class="vpn-monthly-price-display">US$4.99<span>/month + tax</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_usd_ca(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="CA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">US$4.99<span>/month + tax</span></span>'
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_price_euro(self):
@@ -621,7 +633,13 @@ class TestVPNTotalPrice(TestCase):
     def test_vpn_12_month_total_price_usd(self):
         """Should return expected markup"""
         markup = self._render(country_code="US", lang="en-US")
-        expected = "US$59.88 total"
+        expected = "US$59.88 total + tax"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_usd_ca(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="US", lang="en-US")
+        expected = "US$59.88 total + tax"
         self.assertEqual(markup, expected)
 
     def test_vpn_12_month_total_price_euro(self):
@@ -639,13 +657,13 @@ class TestVPNTotalPrice(TestCase):
     def test_vpn_relay_bundle_12_month_total_price_usd(self):
         """Should return expected markup"""
         markup = self._render(country_code="US", lang="en-US", bundle_relay=True)
-        expected = "US$83.88 total"
+        expected = "US$83.88 total + tax"
         self.assertEqual(markup, expected)
 
     def test_vpn_relay_bundle_12_month_total_price_ca(self):
         """Should return expected markup"""
         markup = self._render(country_code="CA", lang="en-CA", bundle_relay=True)
-        expected = "US$83.88 total"
+        expected = "US$83.88 total + tax"
         self.assertEqual(markup, expected)
 
 

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -638,7 +638,7 @@ class TestVPNTotalPrice(TestCase):
 
     def test_vpn_12_month_total_price_usd_ca(self):
         """Should return expected markup"""
-        markup = self._render(country_code="US", lang="en-US")
+        markup = self._render(country_code="CA", lang="en-US")
         expected = "US$59.88 total + tax"
         self.assertEqual(markup, expected)
 

--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -97,6 +97,11 @@ vpn-shared-pricing-plan-monthly = Monthly
 #   $amount (string) - a string containing the monthly subscription price together with the appropriate currency symbol e.g. 'US$4.99' or '6,99 €'.
 vpn-shared-pricing-monthly = { $amount }<span>/month</span>
 
+# Monthly price plus tax (shown in US and Canada).
+# Variables:
+#   $amount (string) - a string containing the monthly subscription price together with the appropriate currency symbol e.g. 'US$4.99' or '6,99 €'.
+vpn-shared-pricing-monthly-plus-tax = { $amount }<span>/month + tax</span>
+
 # Outdated string
 vpn-shared-pricing-get-6-month = Get 6 month plan
 
@@ -123,6 +128,11 @@ vpn-shared-when-you-subscribe = *when you subscribe to a 12-month plan
 # Variables:
 #   $amount (string) - a string containing the total annual subscription price together with the appropriate currency symbol e.g. '35,94 €'
 vpn-shared-pricing-total = { $amount } total
+
+# total price plus tax (shown in US and Canada).
+# Variables:
+#   $amount (string) - a string containing the total annual subscription price together with the appropriate currency symbol e.g. '35,94 €'
+vpn-shared-pricing-total-plus-tax = { $amount } total + tax
 
 # Platform subpage shared strings
 


### PR DESCRIPTION
## One-line summary

In US and Canada where tax is typically not included in the price shown to consumers, show "+ tax" after monthly / total VPN subscription prices.

## Issue / Bugzilla link

#12589

## Testing

- [ ] Shows price + tax: http://localhost:8000/en-US/products/vpn/?geo=us
- [ ] Shows price + tax: http://localhost:8000/en-US/products/vpn/?geo=ca
- [ ] Shows price only: http://localhost:8000/en-US/products/vpn/?geo=gb
