### PR TITLE
Remove platform fields from VPN waitlist form (Fixes #12590)

### DIFF
--- a/bedrock/products/forms.py
+++ b/bedrock/products/forms.py
@@ -2,21 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django import forms
-
 from bedrock.newsletter.forms import NewsletterFooterForm
 
 
 class VPNWaitlistForm(NewsletterFooterForm):
-    PLATFORM_CHOICES = (
-        ("windows", "Windows 10"),
-        ("ios", "iOS"),
-        ("android", "Android"),
-        ("mac", "Mac"),
-        ("chromebook", "Chromebook"),
-        ("linux", "Linux"),
-    )
-    fpn_platform = forms.MultipleChoiceField(required=False, choices=PLATFORM_CHOICES, widget=forms.CheckboxSelectMultiple)
-
     def __init__(self, locale, data=None, *args, **kwargs):
         super().__init__("guardian-vpn-waitlist", locale, data, *args, **kwargs)

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -67,50 +67,6 @@
           <em class="mzp-c-fieldnote">{{ ftl('vpn-landing-invite-required-label') }}</em>
         </label>
         {{ newsletter_form.lang|safe }}
-
-        <fieldset>
-          <legend>{{ ftl('vpn-landing-invite-platform-label') }}</legend>
-
-          <ul class="vpn-invite-platform-options">
-            <li>
-              <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-windows" name="fpn_platform" value="windows">
-                {{ ftl('vpn-landing-invite-platform-windows', fallback='vpn-landing-invite-platform-windows-10') }}
-              </label>
-            </li>
-            <li>
-              <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-ios" name="fpn_platform" value="ios">
-                {{ ftl('vpn-landing-invite-platform-ios') }}
-              </label>
-            </li>
-            <li>
-              <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-android" name="fpn_platform" value="android">
-                {{ ftl('vpn-landing-invite-platform-android') }}
-              </label>
-            </li>
-            <li>
-              <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-mac" name="fpn_platform" value="mac">
-                {{ ftl('vpn-landing-invite-platform-mac') }}
-              </label>
-            </li>
-            <li>
-              <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-chromebook" name="fpn_platform" value="chromebook">
-                {{ ftl('vpn-landing-invite-platform-chromebook') }}
-              </label>
-            </li>
-            <li>
-              <label class="mzp-u-inline">
-                <input type="checkbox" id="platforms-linux" name="fpn_platform" value="linux">
-                {{ ftl('vpn-landing-invite-platform-linux') }}
-              </label>
-            </li>
-          </ul>
-        </fieldset>
-
       </div>
 
       <p class="mzp-c-form-submit">

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -9,7 +9,7 @@
 {% block page_title_full %}{{ ftl('vpn-landing-invite-page-title') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 
-{% block page_desc %}{{ ftl('vpn-landing-invite-page-desc') }}{% endblock %}
+{% block page_desc %}{{ ftl('vpn-landing-invite-page-desc-v2', fallback='vpn-landing-invite-page-desc') }}{% endblock %}
 
 {% block body_id %}mozilla-vpn-invite{% endblock %}
 
@@ -30,7 +30,7 @@
 <main class="mzp-l-content mzp-t-content-md">
   <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post">
     <h1 class="mzp-c-form-header">{{ ftl('vpn-landing-invite-page-heading') }}</h1>
-    <p class="mzp-c-form-subtitle">{{ ftl('vpn-landing-invite-page-desc') }}</p>
+    <p class="mzp-c-form-subtitle">{{ ftl('vpn-landing-invite-page-desc-v2', fallback='vpn-landing-invite-page-desc') }}</p>
     <div hidden>
       {{ newsletter_form.newsletters|safe }}
     </div>

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -192,18 +192,6 @@ vpn-landing-invite-email-placeholder = yourname@example.com
 
 vpn-landing-invite-country-label = What country do you live in?
 vpn-landing-invite-language-label = Select your preferred language.
-vpn-landing-invite-platform-label = Which platforms are you interested in?
-
-vpn-landing-invite-platform-windows = { -brand-name-windows } 10/11
-
-# Outdated string
-vpn-landing-invite-platform-windows-10 = { -brand-name-windows } 10
-
-vpn-landing-invite-platform-ios = { -brand-name-ios }
-vpn-landing-invite-platform-android = { -brand-name-android }
-vpn-landing-invite-platform-mac = { -brand-name-mac-short }
-vpn-landing-invite-platform-chromebook = { -brand-name-chromebook }
-vpn-landing-invite-platform-linux = { -brand-name-linux }
 
 # Variables:
 #   $privacy (url) - link to https://www.mozilla.org/privacy/subscription-services/

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -182,7 +182,12 @@ vpn-landing-faq-link = See more FAQs
 ## Invite page https://www-dev.allizom.org/products/vpn/invite/
 
 vpn-landing-invite-page-title = Join the Waitlist: { -brand-name-mozilla-vpn }
+
+vpn-landing-invite-page-desc-v2 = Get notified when { -brand-name-mozilla-vpn } is available for your region.
+
+# Outdated string
 vpn-landing-invite-page-desc = Get notified when { -brand-name-mozilla-vpn } is available for your device and region.
+
 vpn-landing-invite-page-heading = Join the VPN Waitlist
 vpn-landing-invite-email-label = What is your email address?
 vpn-landing-invite-required-label = Required

--- a/media/js/products/vpn/invite.es6.js
+++ b/media/js/products/vpn/invite.es6.js
@@ -109,31 +109,7 @@ const WaitListForm = {
             form.querySelector('input[name="source_url"]').value
         );
 
-        // Platform interest selection (optional)
-        let platforms = '';
-        const hasPlatformInterest = form.querySelector(
-            '.vpn-invite-platform-options'
-        );
-
-        if (hasPlatformInterest) {
-            const checkedPlatforms = document.querySelectorAll(
-                'input[name="fpn_platform"]:checked'
-            );
-
-            if (checkedPlatforms.length) {
-                platforms =
-                    '&fpn_platform=' +
-                    encodeURIComponent(
-                        Array.from(checkedPlatforms)
-                            .map(function (platform) {
-                                return platform.value;
-                            })
-                            .join(',')
-                    );
-            }
-        }
-
-        return `email=${email}&newsletters=${newsletter}&fpn_country=${country}&lang=${lang}&format=H&source_url=${sourceUrl}${platforms}`;
+        return `email=${email}&newsletters=${newsletter}&fpn_country=${country}&lang=${lang}&format=H&source_url=${sourceUrl}`;
     },
 
     newsletterSubscribe: (e) => {

--- a/tests/unit/spec/products/vpn/invite.js
+++ b/tests/unit/spec/products/vpn/invite.js
@@ -70,49 +70,6 @@ describe('WaitListForm', function () {
                             <option value="en">English</option>
                             <option value="fr">Français</option>
                         </select>
-
-                        <fieldset>
-                            <legend>Which platforms are you interested in?</legend>
-
-                            <ul class="vpn-invite-platform-options">
-                                <li>
-                                    <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-windows" name="fpn_platform" value="windows">
-                                        Windows 10/11
-                                    </label>
-                                </li>
-                                <li>
-                                    <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-ios" name="fpn_platform" value="ios">
-                                        iOS
-                                    </label>
-                                </li>
-                                <li>
-                                    <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-android" name="fpn_platform" value="android">
-                                        Android
-                                    </label>
-                                </li>
-                                <li>
-                                    <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-mac" name="fpn_platform" value="mac">
-                                        Mac
-                                    </label>
-                                </li>
-                                <li>
-                                    <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-chromebook" name="fpn_platform" value="chromebook">
-                                        Chromebook
-                                    </label>
-                                </li>
-                                <li>
-                                    <label class="mzp-u-inline">
-                                        <input type="checkbox" id="platforms-linux" name="fpn_platform" value="linux">
-                                        Linux
-                                    </label>
-                                </li>
-                            </ul>
-                        </fieldset>
                     </div>
                     <p class="mzp-c-form-submit">
                         <button class="mzp-c-button mzp-t-xl" id="newsletter-submit" type="submit">Join the Waitlist</button>
@@ -310,12 +267,6 @@ describe('WaitListForm', function () {
             const data1 = WaitListForm.serialize();
             expect(data1).toEqual(
                 'email=fox%40example.com&newsletters=guardian-vpn-waitlist&fpn_country=us&lang=en&format=H&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fproducts%2Fvpn%2Finvite%2F'
-            );
-            document.getElementById('platforms-windows').click();
-            document.getElementById('platforms-android').click();
-            const data2 = WaitListForm.serialize();
-            expect(data2).toEqual(
-                'email=fox%40example.com&newsletters=guardian-vpn-waitlist&fpn_country=us&lang=en&format=H&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fproducts%2Fvpn%2Finvite%2F&fpn_platform=windows%2Candroid'
             );
         });
     });


### PR DESCRIPTION
## One-line summary

Removes the "What platforms are you interested in?" question from the VPN wait-list form.

## Issue / Bugzilla link

#12590

## Testing

http://localhost:8000/en-US/products/vpn/invite/
