### PR TITLE
Fix newsletter management error in chrome/safari (Fixes #12595)

### DIFF
--- a/media/js/newsletter/management.es6.js
+++ b/media/js/newsletter/management.es6.js
@@ -77,11 +77,7 @@ function _fetch(url, method) {
                 }
             })
             .then((resp) => {
-                if (
-                    resp.statusText === 'OK' &&
-                    resp.status >= 200 &&
-                    resp.status < 300
-                ) {
+                if (resp.status >= 200 && resp.status < 300) {
                     resolve(resp.json());
                 } else {
                     reject(resp);


### PR DESCRIPTION
## One-line summary

Removes the check for `resp.statusText === 'OK'` as this is returned as an empty string in production (only) in Chrome / Safari. We still check for a successful status code, which should hopefully be enough.

## Issue / Bugzilla link

#12595

## Testing
This is only reproducible on demo.

https://www.mozilla.org/en-US/newsletter/recovery/

`https://www-demo5.allizom.org/en-GB/newsletter/existing/YOUR_TOKEN_HERE/`
