### PR TITLE
2023-01-16 Dependency bumps

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,13 +88,13 @@ blessings==1.7 \
     --hash=sha256:b1fdd7e7a675295630f9ae71527a8ebc10bfefa236b3d6aa4932ee4462c17ba3 \
     --hash=sha256:caad5211e7ba5afe04367cdd4cfc68fa886e2e08f6f35e76b7387d2109ccea6e
     # via curtsies
-boto3==1.26.45 \
-    --hash=sha256:b1bc7db503dc49bdccf5dada080077056a32af9982afdde84578a109cd741d05 \
-    --hash=sha256:cc7f652df93e1ce818413fd82ffd645d4f92a64fec67c72946212d3750eaa80f
+boto3==1.26.50 \
+    --hash=sha256:3737d8a506f50065bb2366a6b8e7545d88034f4771527790a125e0abd307d8e8 \
+    --hash=sha256:9c434bcd02c527485c89d6efbd38b7c205e06ab06abe80e5dbf9a8be836c77c2
     # via -r requirements/prod.txt
-botocore==1.29.45 \
-    --hash=sha256:62ae03e591ff25555854aa338da35190ffe18c0b1be2ebf5cfb277164233691f \
-    --hash=sha256:a5c0e13f266ee9a74335a1e5d3e377f2baae27226ae23d78f023bae0d18f3161
+botocore==1.29.50 \
+    --hash=sha256:0e9ab19787ad7a079c00d3e40b16bc66423e54bc0e8a203b70b543bd8854d5ad \
+    --hash=sha256:5cc68b78a48217550c18b4639420b7c3b48ed9e09e749343143acbfa423ceec5
     # via
     #   -r requirements/prod.txt
     #   boto3
@@ -790,9 +790,9 @@ pathspec==0.9.0 \
     #   -r requirements/prod.txt
     #   black
     #   yamllint
-phonenumberslite==8.13.3 \
-    --hash=sha256:2b7452fe69c907b7638ff4cf7f8a773a6dfce26bf32d67ebf4dc74d5e31abb79 \
-    --hash=sha256:b7f56b77711e6b99c7890f20f1aaa705d9fe2514215446b8426c8515c198775f
+phonenumberslite==8.13.4 \
+    --hash=sha256:44cbb13581122164cd8a83b40f12db854277e8a5f9c6e22bd8dc2d8aa98e3260 \
+    --hash=sha256:469eb263160e243aa02fff643502698f99e77bcb6478e9aaa7115838006be122
     # via -r requirements/prod.txt
 pillow==9.4.0 \
     --hash=sha256:0845adc64fe9886db00f5ab68c4a8cd933ab749a87747555cec1c95acea64b0b \
@@ -1117,9 +1117,9 @@ qrcode==7.3.1 \
 querystringsafe-base64==1.1.1 \
     --hash=sha256:bad9187c0406456020ee354be7f51d2e0dfc262dadde0449cbdd1fd78d437eed
     # via -r requirements/prod.txt
-requests==2.28.1 \
-    --hash=sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983 \
-    --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
+requests==2.28.2 \
+    --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
+    --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
     # via
     #   -r requirements/prod.txt
     #   basket-client
@@ -1154,9 +1154,9 @@ selenium==4.1.3 \
 sentry-processor==0.0.1 \
     --hash=sha256:fd7a30fb57aaf05c01cd04cf7d949c628376b2b55d7a0aaa222efe58a8f122bc
     # via -r requirements/prod.txt
-sentry-sdk==1.12.1 \
-    --hash=sha256:5bbe4b72de22f9ac1e67f2a4e6efe8fbd595bb59b7b223443f50fe5802a5551c \
-    --hash=sha256:9f0b960694e2d8bb04db4ba6ac2a645040caef4e762c65937998ff06064f10d6
+sentry-sdk==1.13.0 \
+    --hash=sha256:72da0766c3069a3941eadbdfa0996f83f5a33e55902a19ba399557cfee1dddcc \
+    --hash=sha256:b7ff6318183e551145b5c4766eb65b59ad5b63ff234dffddc5fb50340cad6729
     # via -r requirements/prod.txt
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -1237,9 +1237,9 @@ trio-websocket==0.9.2 \
     --hash=sha256:5b558f6e83cc20a37c3b61202476c5295d1addf57bd65543364e0337e37ed2bc \
     --hash=sha256:a3d34de8fac26023eee701ed1e7bf4da9a8326b61a62934ec9e53b64970fd8fe
     # via selenium
-twilio==7.16.0 \
-    --hash=sha256:3c02ed1855629e3b567b613c03dfad2aade913f21897d21cd0efe6e48f06ddcf \
-    --hash=sha256:8d6fb07d42235ec60d6256c0f438f6274f601d688e550d25124a0067c4daf75c
+twilio==7.16.1 \
+    --hash=sha256:3c843fb643fe902e727081128e9fb26a3de6bdfb515c818ac5b89a6fdf7f8638 \
+    --hash=sha256:8e6602adfb878e2a52ff62b5ca9befc63c5d409262c1cbb1ad84fe7f33131927
     # via -r requirements/prod.txt
 typing-extensions==4.1.1 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -3,7 +3,7 @@ babis==0.2.4
 basket-client==1.0.0
 beautifulsoup4==4.11.1
 bleach[css]==5.0.1
-boto3==1.26.45
+boto3==1.26.50
 certifi==2022.12.7  # hard-pinned subdep for now until requests and sentry-sdk bump it
 chardet==5.0.0
 commonware==0.6.0
@@ -41,7 +41,7 @@ https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibil
 markupsafe==2.0.1
 meinheld==1.0.2
 newrelic==8.5.0
-phonenumberslite==8.13.3
+phonenumberslite==8.13.4
 Pillow==9.4.0
 PyGithub==1.57
 pyOpenSSL==23.0.0
@@ -49,11 +49,11 @@ python-memcached==1.59
 PyYAML==6.0
 qrcode==7.3.1
 querystringsafe-base64==1.1.1
-requests==2.28.1
+requests==2.28.2
 rich-text-renderer==0.2.7
-sentry-sdk==1.12.1
+sentry-sdk==1.13.0
 sentry-processor==0.0.1
 supervisor==4.2.5
 timeago==1.0.16
-twilio==7.16.0
+twilio==7.16.1
 whitenoise==6.3.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -42,13 +42,13 @@ bleach[css]==5.0.1 \
     --hash=sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a \
     --hash=sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c
     # via -r requirements/prod.in
-boto3==1.26.45 \
-    --hash=sha256:b1bc7db503dc49bdccf5dada080077056a32af9982afdde84578a109cd741d05 \
-    --hash=sha256:cc7f652df93e1ce818413fd82ffd645d4f92a64fec67c72946212d3750eaa80f
+boto3==1.26.50 \
+    --hash=sha256:3737d8a506f50065bb2366a6b8e7545d88034f4771527790a125e0abd307d8e8 \
+    --hash=sha256:9c434bcd02c527485c89d6efbd38b7c205e06ab06abe80e5dbf9a8be836c77c2
     # via -r requirements/prod.in
-botocore==1.29.45 \
-    --hash=sha256:62ae03e591ff25555854aa338da35190ffe18c0b1be2ebf5cfb277164233691f \
-    --hash=sha256:a5c0e13f266ee9a74335a1e5d3e377f2baae27226ae23d78f023bae0d18f3161
+botocore==1.29.50 \
+    --hash=sha256:0e9ab19787ad7a079c00d3e40b16bc66423e54bc0e8a203b70b543bd8854d5ad \
+    --hash=sha256:5cc68b78a48217550c18b4639420b7c3b48ed9e09e749343143acbfa423ceec5
     # via
     #   boto3
     #   s3transfer
@@ -571,9 +571,9 @@ pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
     --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
     # via yamllint
-phonenumberslite==8.13.3 \
-    --hash=sha256:2b7452fe69c907b7638ff4cf7f8a773a6dfce26bf32d67ebf4dc74d5e31abb79 \
-    --hash=sha256:b7f56b77711e6b99c7890f20f1aaa705d9fe2514215446b8426c8515c198775f
+phonenumberslite==8.13.4 \
+    --hash=sha256:44cbb13581122164cd8a83b40f12db854277e8a5f9c6e22bd8dc2d8aa98e3260 \
+    --hash=sha256:469eb263160e243aa02fff643502698f99e77bcb6478e9aaa7115838006be122
     # via -r requirements/prod.in
 pillow==9.4.0 \
     --hash=sha256:0845adc64fe9886db00f5ab68c4a8cd933ab749a87747555cec1c95acea64b0b \
@@ -771,9 +771,9 @@ qrcode==7.3.1 \
 querystringsafe-base64==1.1.1 \
     --hash=sha256:bad9187c0406456020ee354be7f51d2e0dfc262dadde0449cbdd1fd78d437eed
     # via -r requirements/prod.in
-requests==2.28.1 \
-    --hash=sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983 \
-    --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
+requests==2.28.2 \
+    --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa \
+    --hash=sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf
     # via
     #   -r requirements/prod.in
     #   basket-client
@@ -792,9 +792,9 @@ s3transfer==0.6.0 \
 sentry-processor==0.0.1 \
     --hash=sha256:fd7a30fb57aaf05c01cd04cf7d949c628376b2b55d7a0aaa222efe58a8f122bc
     # via -r requirements/prod.in
-sentry-sdk==1.12.1 \
-    --hash=sha256:5bbe4b72de22f9ac1e67f2a4e6efe8fbd595bb59b7b223443f50fe5802a5551c \
-    --hash=sha256:9f0b960694e2d8bb04db4ba6ac2a645040caef4e762c65937998ff06064f10d6
+sentry-sdk==1.13.0 \
+    --hash=sha256:72da0766c3069a3941eadbdfa0996f83f5a33e55902a19ba399557cfee1dddcc \
+    --hash=sha256:b7ff6318183e551145b5c4766eb65b59ad5b63ff234dffddc5fb50340cad6729
     # via -r requirements/prod.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
@@ -828,9 +828,9 @@ tinycss2==1.1.1 \
     --hash=sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf \
     --hash=sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8
     # via bleach
-twilio==7.16.0 \
-    --hash=sha256:3c02ed1855629e3b567b613c03dfad2aade913f21897d21cd0efe6e48f06ddcf \
-    --hash=sha256:8d6fb07d42235ec60d6256c0f438f6274f601d688e550d25124a0067c4daf75c
+twilio==7.16.1 \
+    --hash=sha256:3c843fb643fe902e727081128e9fb26a3de6bdfb515c818ac5b89a6fdf7f8638 \
+    --hash=sha256:8e6602adfb878e2a52ff62b5ca9befc63c5d409262c1cbb1ad84fe7f33131927
     # via -r requirements/prod.in
 tzdata==2021.5 \
     --hash=sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5 \


### PR DESCRIPTION
Resolves #12601 Bump boto3 from 1.26.45 to 1.26.50 in /requirements 
Resolves #12599 Bump twilio from 7.16.0 to 7.16.1 in /requirements 
Resolves #12598 Bump sentry-sdk from 1.12.1 to 1.13.0 in /requirements 
Resolves #12579 Bump phonenumberslite from 8.13.3 to 8.13.4 in /requirements 
Resolves #12597 Bump requests from 2.28.1 to 2.28.2 in /requirements
