### PR TITLE
Fix 500ing releasenotes shortcut page for FF mobile

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -87,6 +87,8 @@ urlpatterns = (
     re_path(f"^firefox/(?:{platform_re}/)?(?:{channel_re}/)?notes/$", bedrock.releasenotes.views.latest_notes, name="firefox.notes"),
     path("firefox/nightly/notes/feed/", bedrock.releasenotes.views.nightly_feed, name="firefox.nightly.notes.feed"),
     re_path("firefox/(?:latest/)?releasenotes/$", bedrock.releasenotes.views.latest_notes, {"product": "firefox"}),
+    re_path("firefox/android/releasenotes/$", bedrock.releasenotes.views.latest_notes, {"product": "Firefox for Android"}),
+    re_path("firefox/ios/releasenotes/$", bedrock.releasenotes.views.latest_notes, {"product": "Firefox for iOS"}),
     re_path(
         f"^firefox/(?:{platform_re}/)?(?:{channel_re}/)?system-requirements/$",
         bedrock.releasenotes.views.latest_sysreq,

--- a/tests/redirects/test_urls.py
+++ b/tests/redirects/test_urls.py
@@ -68,6 +68,8 @@ def test_301_urls(url, base_url, follow_redirects=False):
         "/firefox/nightly/firstrun/",
         "/firefox/releases/",
         "/firefox/unsupported-systems/",
+        "/firefox/android/releasenotes/",
+        "/firefox/ios/releasenotes/",
     ],
 )
 def test_302_urls(url, base_url, follow_redirects=False):


### PR DESCRIPTION
## One-line summary

Fix 500 when trying to access releasenotes for Android and iOS using the same URL structure as for FF desktop

## Significant changes and points to review

If a user goes to https://www.mozilla.org/en-US/firefox/releasenotes/ they get redirected to the latest release notes URL for Firefox - eg currently https://www.mozilla.org/en-US/firefox/108.0.1/releasenotes/

However, prior to this changeset, that behaviour didn't exist for mobile FF's release notes - eg the following two links triggered a 500

* https://www.mozilla.org/en-US/firefox/android/releasenotes/
* https://www.mozilla.org/en-US/firefox/ios/releasenotes/

This changeset updates that, so that the URLs for mobile Firefox now redirect to the latest releasenotes for the relevant mobile platform



## Issue / Bugzilla link

Resolves #12536 


## Checklist

If relevant:

- [X] Tests added

## Testing

Demo server URL: (or None)

To test this work:

* `npm start`
* Go to the following URLs and confirm they now redirect to the latest release notes for each browser
  - [ ] http://localhost:8080/en-US/firefox/android/releasenotes/
  - [ ] http://localhost:8080/en-US/firefox/ios/releasenotes/
