### PR TITLE
Bump @sentry/browser to v7.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
-        "@sentry/browser": "^7.25.0",
+        "@sentry/browser": "^7.31.0",
         "babel-loader": "^9.1.2",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
@@ -1909,13 +1909,14 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.25.0.tgz",
-      "integrity": "sha512-vBNWDv8SUtJqgw/Mg9hGxct7dzHucfxq1zfxOdFziZOA/N9l+K52roNLZjYOk1JxaBE4QsHgJJyXelHnPlzCbA==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.31.0.tgz",
+      "integrity": "sha512-1ui2rbR6lNPXUOZOCLpa2+YZXhx0AbPgBD/RoC/OHVus3sAs+CyyMR1wBzmI5H3ZhA5jwwzelh4ivt+gQZ24rw==",
       "dependencies": {
-        "@sentry/core": "7.25.0",
-        "@sentry/types": "7.25.0",
-        "@sentry/utils": "7.25.0",
+        "@sentry/core": "7.31.0",
+        "@sentry/replay": "7.31.0",
+        "@sentry/types": "7.31.0",
+        "@sentry/utils": "7.31.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1928,12 +1929,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/core": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.25.0.tgz",
-      "integrity": "sha512-4PMuf+MsLxtbesXFBdXfRQhdxHVMi4e6z52DEdtSN9V41lT/R78qIfVopHs5gAr9j4lxCaiKSnNQDKziWLeQ8w==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.31.0.tgz",
+      "integrity": "sha512-IZS1MZznyBOPw7UEpZwq3t3aaaVhFB+r3KM4JYFSJRr7Ky9TjldXA3hadNUTztjYGgEC3u8kB9jXoRvNXM2hqA==",
       "dependencies": {
-        "@sentry/types": "7.25.0",
-        "@sentry/utils": "7.25.0",
+        "@sentry/types": "7.31.0",
+        "@sentry/utils": "7.31.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1945,20 +1946,33 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@sentry/replay": {
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.31.0.tgz",
+      "integrity": "sha512-/Vb/EcAdvb9zZbNyaAaYjaHXK9XWDoo2lFf7A6DfV+yVf4yaHHraex3pAv0mNs/99LNr55V5eIiwMGhkfeDORg==",
+      "dependencies": {
+        "@sentry/core": "7.31.0",
+        "@sentry/types": "7.31.0",
+        "@sentry/utils": "7.31.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@sentry/types": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.25.0.tgz",
-      "integrity": "sha512-m/tVeuZpbYNQjp4BYOz7bBxZEWdTHdTgXg9YlztUOCf5JDDujpxYp2Pyp4+cDDulzFIixXzRH7FRiKsOJ0WF7w==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.0.tgz",
+      "integrity": "sha512-nFqo7wyMnapdSEdw1MD+cavDtD9x5QQmh/bwLEOb/euM0cHFJHYyD7CveY/mQng4HyEVWY+DCtX/7E3GcQ7Bdw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.25.0.tgz",
-      "integrity": "sha512-1Wct+LvDySYgXBYHjoTzccASK4Rk/88cCifSZF7pLrix3Rzk+8QnPt4vZ/ce62nTNBDs/OeFXO1eFwiz9nCoEg==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.0.tgz",
+      "integrity": "sha512-B1KkvdfwlaqM7sDp3/yk2No7WsbMuLEywGRVOLzXeTqTLSBRBWyyYIudqPtx2LDds9anlUHj21zs9FKY+S3eiA==",
       "dependencies": {
-        "@sentry/types": "7.25.0",
+        "@sentry/types": "7.31.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -11801,13 +11815,14 @@
       }
     },
     "@sentry/browser": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.25.0.tgz",
-      "integrity": "sha512-vBNWDv8SUtJqgw/Mg9hGxct7dzHucfxq1zfxOdFziZOA/N9l+K52roNLZjYOk1JxaBE4QsHgJJyXelHnPlzCbA==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.31.0.tgz",
+      "integrity": "sha512-1ui2rbR6lNPXUOZOCLpa2+YZXhx0AbPgBD/RoC/OHVus3sAs+CyyMR1wBzmI5H3ZhA5jwwzelh4ivt+gQZ24rw==",
       "requires": {
-        "@sentry/core": "7.25.0",
-        "@sentry/types": "7.25.0",
-        "@sentry/utils": "7.25.0",
+        "@sentry/core": "7.31.0",
+        "@sentry/replay": "7.31.0",
+        "@sentry/types": "7.31.0",
+        "@sentry/utils": "7.31.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -11819,12 +11834,12 @@
       }
     },
     "@sentry/core": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.25.0.tgz",
-      "integrity": "sha512-4PMuf+MsLxtbesXFBdXfRQhdxHVMi4e6z52DEdtSN9V41lT/R78qIfVopHs5gAr9j4lxCaiKSnNQDKziWLeQ8w==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.31.0.tgz",
+      "integrity": "sha512-IZS1MZznyBOPw7UEpZwq3t3aaaVhFB+r3KM4JYFSJRr7Ky9TjldXA3hadNUTztjYGgEC3u8kB9jXoRvNXM2hqA==",
       "requires": {
-        "@sentry/types": "7.25.0",
-        "@sentry/utils": "7.25.0",
+        "@sentry/types": "7.31.0",
+        "@sentry/utils": "7.31.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -11835,17 +11850,27 @@
         }
       }
     },
+    "@sentry/replay": {
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.31.0.tgz",
+      "integrity": "sha512-/Vb/EcAdvb9zZbNyaAaYjaHXK9XWDoo2lFf7A6DfV+yVf4yaHHraex3pAv0mNs/99LNr55V5eIiwMGhkfeDORg==",
+      "requires": {
+        "@sentry/core": "7.31.0",
+        "@sentry/types": "7.31.0",
+        "@sentry/utils": "7.31.0"
+      }
+    },
     "@sentry/types": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.25.0.tgz",
-      "integrity": "sha512-m/tVeuZpbYNQjp4BYOz7bBxZEWdTHdTgXg9YlztUOCf5JDDujpxYp2Pyp4+cDDulzFIixXzRH7FRiKsOJ0WF7w=="
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.31.0.tgz",
+      "integrity": "sha512-nFqo7wyMnapdSEdw1MD+cavDtD9x5QQmh/bwLEOb/euM0cHFJHYyD7CveY/mQng4HyEVWY+DCtX/7E3GcQ7Bdw=="
     },
     "@sentry/utils": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.25.0.tgz",
-      "integrity": "sha512-1Wct+LvDySYgXBYHjoTzccASK4Rk/88cCifSZF7pLrix3Rzk+8QnPt4vZ/ce62nTNBDs/OeFXO1eFwiz9nCoEg==",
+      "version": "7.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.31.0.tgz",
+      "integrity": "sha512-B1KkvdfwlaqM7sDp3/yk2No7WsbMuLEywGRVOLzXeTqTLSBRBWyyYIudqPtx2LDds9anlUHj21zs9FKY+S3eiA==",
       "requires": {
-        "@sentry/types": "7.25.0",
+        "@sentry/types": "7.31.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",
-    "@sentry/browser": "^7.25.0",
+    "@sentry/browser": "^7.31.0",
     "babel-loader": "^9.1.2",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
## One-line summary

Bumps `@sentry/browser` to latest version

## Issue / Bugzilla link

N/A

## Testing

- `npm install`

Set `SENTRY_FRONTEND_DSN=https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331` in your `.env` if you would like to test that Sentry initializes locally. You'll also need a browser with DNT disabled.
