### PR TITLE
Add cursor declaration for F3 page banner

### DIFF
--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -101,6 +101,7 @@
 
         button {
             transition: opacity 0.5s;
+            cursor: pointer;
 
             &[disabled] {
                 opacity: 0;


### PR DESCRIPTION
## One-line summary
The `Accept all dad jokes` banner's button didn't have a pointed cursor on hover, so I changed that to include it, just to enhance it's clicking feature.

## Testing

Demo server URL: (or None)

To test this work:

- [ ] http://localhost:8000/en-US/firefox/family/
