### PR TITLE
Add EN whatsnew 109 templates to the VPN excluded list [#12541, #12583]

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -495,6 +495,8 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx104-vpn-fr.html",
         "firefox/whatsnew/whatsnew-fx104-vpn-fr-coupon.html",
         "firefox/whatsnew/whatsnew-fx107-en.html",
+        "firefox/whatsnew/whatsnew-fx109-en.html",
+        "firefox/whatsnew/whatsnew-fx109-en-features.html",
     ]
 
     # place expected ?v= values in this list


### PR DESCRIPTION
## One-line summary

English whatsnew pages for Firefox 109 promote VPN, which we don't advertise in certain countries. Countries on that list should see the standard WNP page instead.

## Testing

http://localhost:8000/en-US/firefox/109.0/whatsnew/?geo=us should show the VPN promo
http://localhost:8000/en-US/firefox/109.0/whatsnew/?geo=cn should show the default page