### PR TITLE
Add region1 to Pocket CSP (fixes #12608)

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -122,6 +122,7 @@ if IS_POCKET_MODE:
         "'unsafe-eval'",
         "www.googletagmanager.com",
         "www.google-analytics.com",
+        "region1.google-analytics.com",
         "cdn.cookielaw.org",
         "assets.getpocket.com",  # allow Pocket Snowplow analytics
     ]


### PR DESCRIPTION
## One-line summary

Add region1 to Pocket CSP to allow GA4 to connect and load

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12608

## Testing

`npm run in-pocket-mode`

To test this work:

- [ ] http://localhost:8000/en/ in Chrome, check console to confirm there are no GA connect errors
