### PR TITLE
Move region1 to correct Pocket CSP setting

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -122,7 +122,6 @@ if IS_POCKET_MODE:
         "'unsafe-eval'",
         "www.googletagmanager.com",
         "www.google-analytics.com",
-        "region1.google-analytics.com",
         "cdn.cookielaw.org",
         "assets.getpocket.com",  # allow Pocket Snowplow analytics
     ]
@@ -136,6 +135,7 @@ if IS_POCKET_MODE:
     _csp_connect_src = [
         "www.googletagmanager.com",
         "www.google-analytics.com",
+        "region1.google-analytics.com",
         "o1069899.sentry.io",
         "o1069899.ingest.sentry.io",
         "cdn.cookielaw.org",


### PR DESCRIPTION
## One-line summary

Fixes placement of region1 in Pocket CSP (currently under **script**, should be **connect**)

Follow up for https://github.com/mozilla/bedrock/pull/12611

## Testing

https://dev.tekcopteg.com/en/ shows region1 connect error in console

local does not show error
`npm run in-pocket-mode`
http://localhost:8000/en/ 
