### PR TITLE
Remove background video on careers (#12619)

### DIFF
--- a/bedrock/careers/templates/careers/diversity.html
+++ b/bedrock/careers/templates/careers/diversity.html
@@ -10,10 +10,6 @@
   <header class="c-careers-video-hero t-hero-diversity">
     <div class="c-video-wrapper">
       <div class="overlay"></div>
-      <video class="c-background-video" autoplay loop muted>
-        <source src="https://assets.mozilla.net/video/careers/careers-diversity-page-video.mp4" type="video/mp4">
-      </video>
-
       {% call split(
         media_class='mzp-l-split-h-center',
         media_include='careers/includes/diversity-video.html',

--- a/bedrock/careers/templates/careers/home.html
+++ b/bedrock/careers/templates/careers/home.html
@@ -13,10 +13,6 @@
   <header class="c-careers-video-hero t-hero-home">
     <div class="c-video-wrapper">
       <div class="overlay"></div>
-      <video class="c-background-video" autoplay loop muted>
-        <source src="https://assets.mozilla.net/video/careers/careers-homepage-optimized1.mp4" type="video/mp4">
-      </video>
-
       {% call split(
         block_class='mzp-l-split-center-on-sm-md',
         media_class='mzp-l-split-h-center',

--- a/media/css/careers/components/hero-video.scss
+++ b/media/css/careers/components/hero-video.scss
@@ -19,22 +19,6 @@
         justify-content: center;
         position: relative;
 
-        .c-background-video {
-            bottom: 0;
-            display: none;
-            height: 100%;
-            left: 0;
-            object-fit: cover;
-            position: absolute;
-            right: 0;
-            top: 0;
-            width: 100%;
-
-            @media (prefers-reduced-motion: no-preference) {
-                display: block;
-            }
-        }
-
         .overlay {
             background-color: rgba(0, 256, 256, 0.8);
             content: '';


### PR DESCRIPTION
Remove background video on careers to decrease distraction for users.

## Significant changes and points to review

(Outline the main things changed, and if there are particular parts that need extra scrutiny.)

## Issue / Bugzilla link

See #12619 

## Testing

http://localhost:8000/en-US/careers/
http://localhost:8000/en-US/careers/diversity/

- [x] video behind blue heros no longer loads and plays
- [x] background images still appear
- [x] video on right side still plays in modal
