### PR TITLE
Remove token from newsletter URLs (Fixes #12389)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/confirm.html
+++ b/bedrock/newsletter/templates/newsletter/confirm.html
@@ -13,20 +13,26 @@
 
 {% block page_title %}{{ ftl('newsletters-newsletter-confirm') }}{% endblock page_title %}
 
+{% block page_css %}
+  {{ css_bundle('newsletter-confirm') }}
+{% endblock %}
+
 {% block content %}
 <main role="main">
   <div class="mzp-l-content mzp-t-content-md">
-    {% if success %}
+    {% if token_error %}
+      <div class="mzp-c-notification-bar mzp-t-error">
+        {{ ftl('newsletters-the-supplied-link-has-expired') }}
+      </div>
+    {% elif generic_error %}
+      <div class="mzp-c-notification-bar mzp-t-error">
+        {{ ftl('newsletters-something-is-amiss-with') }}
+      </div>
+    {% else %}
       <h1>{{ ftl('newsletters-thanks-for-subscribing') }}</h1>
       <p>{{ ftl('newsletters-your-newsletter-subscription') }}</p>
       <p>{{ ftl('newsletters-please-be-sure-to-add-our-v2') }}</p>
-    {% elif token_error %}
-      <p>{{ ftl('newsletters-the-supplied-link-has-expired') }}</p>
-    {% elif generic_error %}
-      <p>{{ ftl('newsletters-something-is-amiss-with') }}</p>
     {% endif %}
   </div>
 </main>
 {% endblock %}
-
-{% block site_footer %}{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/country.html
+++ b/bedrock/newsletter/templates/newsletter/country.html
@@ -35,7 +35,7 @@
         <p>We've pre-filled what we think is correct, but make sure to check that it's right
           before clicking the button. Thanks!</p>
         </p>
-        <form id="country-newsletter-form" class="country-newsletter-form" method="post" action="{{ action }}">
+        <form id="country-newsletter-form" class="country-newsletter-form" method="post" action="{{ action }}" data-recovery-url="{{ recovery_url }}">
           <div class="mzp-c-form-errors hidden" id="country-newsletter-errors">
             <ul class="mzp-u-list-styled">
               <li class="error-try-again-later hidden">

--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -75,10 +75,10 @@
     <form method="post"
       action="{{ action }}"
       class="newsletter-management-form"
-      data-token="{{ token }}"
       data-newsletters-url="{{ newsletters_url }}"
       data-strings-url="{{ strings_url }}"
       data-updated-url="{{ updated_url }}"
+      data-recovery-url="{{ recovery_url }}"
       data-unsubscribe-url="{{ unsubscribe_url }}">
 
       {# noscript warning to enable JavaScript #}

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -39,7 +39,6 @@
           </header>
 
           <form id="newsletter-updated-form" action="{{ action }}" method="post" class="c-updated-block-content c-updated-form">
-            <input type="hidden" name="token" value="{{ token }}" />
 
             <div class="mzp-c-form-errors hidden" id="newsletter-updated-form-errors">
               <ul class="mzp-u-list-styled">
@@ -184,11 +183,8 @@
   </main>
 {% endblock %}
 
-{# Don't display the footer if there is a token present. bug 1247446 #}
 {% block site_footer %}
-  {% if not token %}
-    {{ super() }}
-  {% endif %}
+  {{ super() }}
 {% endblock %}
 
 {% block js %}

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -21,8 +21,9 @@ urlpatterns = (
     path("newsletter/updated/", views.updated, name="newsletter.updated"),
     # Confirm subscriptions
     re_path("^newsletter/confirm/(?P<token>%s)/$" % uuid_regex, views.confirm, name="newsletter.confirm"),
+    path("newsletter/confirm/thanks/", views.confirm_thanks, name="newsletter.confirm.thanks"),
     # Update country
-    re_path("^newsletter/country/(?P<token>%s)/$" % uuid_regex, views.set_country, name="newsletter.country"),
+    re_path("^newsletter/country/(?P<token>[^/]*)/?$", views.set_country, name="newsletter.country"),
     # Request recovery message with link to manage subscriptions
     path("newsletter/recovery/", views.recovery, name="newsletter.recovery"),
     # Receives POSTs from all subscribe forms

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -52,7 +52,7 @@ def set_country(request, token):
     if countrycode:
         initial["country"] = countrycode.lower()
 
-    form = CountrySelectForm("en-US", None, initial=initial)
+    form = CountrySelectForm("en-US", initial=initial)
 
     context = {
         "action": f"{settings.BASKET_URL}/news/user-meta/",
@@ -108,8 +108,8 @@ def confirm(request, token):
 
 
 def confirm_thanks(request):
-    generic_error = request.GET.get("error", None) == "1"
-    token_error = request.GET.get("error", None) == "2"
+    generic_error = request.GET.get("error") == "1"
+    token_error = request.GET.get("error") == "2"
 
     return l10n_utils.render(request, "newsletter/confirm.html", {"token_error": token_error, "generic_error": generic_error}, ftl_files=FTL_FILES)
 
@@ -142,7 +142,7 @@ def existing(request, token=None):
         "strings_url": reverse("newsletter.strings"),
         "updated_url": reverse("newsletter.updated"),
         "recovery_url": reverse("newsletter.recovery"),
-        "did_confirm": request.GET.get("confirm", None) == "1",
+        "did_confirm": request.GET.get("confirm") == "1",
         "form": form,
     }
 

--- a/docs/newsletters.rst
+++ b/docs/newsletters.rst
@@ -24,8 +24,8 @@ Features
 - Whole pages devoted to subscribing to one newsletter, often with custom
   text, branding, and layout.
 
-- Newsletter preference center - allow user to change their email address,
-  preferences (e.g. language, HTML vs. text), which newsletters they're
+- Newsletter preference center - allow user to change their email preferences
+  (e.g. language, HTML vs. text), as well as which newsletters they're
   subscribed to, etc. Access is limited by requiring a user-specific
   token in the URL (it's a UUID).  The full URL is included as a link in
   each newsletter sent to the user. Users can also recover a link to their
@@ -112,6 +112,14 @@ Bedrock came along, and so are unlikely to be changed.
 - ``/newsletter/recovery/`` - Allows users to recover a link containing their token so they can manage their subscriptions.
 
 - ``/newsletter/updated/`` - A page users are redirected to after updating their details, or unsubscribing.
+
+.. note::
+
+    URLs that contain ``{USERTOKEN}`` will have their path rewritten on page load
+    so that they no longer contain the token e.g. ``/newsletter/existing/{USERTOKEN}/``
+    will be rewritten to just ``/newsletter/existing/``. This helps to prevent
+    accidental sharing of user tokens in URLS and also against referral
+    information leakage.
 
 Footer sign-up
 --------------

--- a/media/css/newsletter/newsletter-confirm.scss
+++ b/media/css/newsletter/newsletter-confirm.scss
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+
+main {
+    min-height: 500px;
+}

--- a/media/css/newsletter/newsletter-confirm.scss
+++ b/media/css/newsletter/newsletter-confirm.scss
@@ -8,6 +8,8 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
+// there's not much content on this page, so min-height
+// ensures a bit of breathing space before the footer.
 main {
     min-height: 500px;
 }

--- a/media/js/base/send-to-device.es6.js
+++ b/media/js/base/send-to-device.es6.js
@@ -5,13 +5,7 @@
  */
 
 import Spinner from '../libs/spin.min';
-import {
-    checkEmailValidity,
-    clearFormErrors,
-    errorList,
-    postToBasket,
-    serialize
-} from '../newsletter/form-utils.es6';
+import FormUtils from '../newsletter/form-utils.es6';
 
 const SendToDevice = function (id) {
     this.formId = typeof id !== 'undefined' ? id : 'send-to-device';
@@ -127,8 +121,8 @@ SendToDevice.prototype.disableForm = function () {
 
 SendToDevice.prototype.validateFields = function () {
     // Really basic client side email validity check.
-    if (!checkEmailValidity(this.input.value)) {
-        this.onFormError(errorList.EMAIL_INVALID_ERROR);
+    if (!FormUtils.checkEmailValidity(this.input.value)) {
+        this.onFormError(FormUtils.errorList.EMAIL_INVALID_ERROR);
         return false;
     }
 
@@ -142,20 +136,20 @@ SendToDevice.prototype.onFormSubmit = function (e) {
     e.preventDefault();
 
     const url = this.form.getAttribute('action');
-    const params = serialize(this.form);
+    const params = FormUtils.serialize(this.form);
 
     // Disable form fields until POST has completed.
     this.disableForm();
 
     // Clear any prior messages that might have been displayed.
-    clearFormErrors(this.form);
+    FormUtils.clearFormErrors(this.form);
 
     // Perform client side form field validation.
     if (!this.validateFields()) {
         return;
     }
 
-    postToBasket(
+    FormUtils.postToBasket(
         this.input.value,
         params,
         url,
@@ -191,7 +185,7 @@ SendToDevice.prototype.onFormError = function (msg) {
     this.form.querySelector('.mzp-c-form-errors').classList.remove('hidden');
 
     switch (msg) {
-        case errorList.EMAIL_INVALID_ERROR:
+        case FormUtils.errorList.EMAIL_INVALID_ERROR:
             error = this.form.querySelector('.error-email-invalid');
             break;
         default:

--- a/media/js/newsletter/country.es6.js
+++ b/media/js/newsletter/country.es6.js
@@ -4,19 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-    clearFormErrors,
-    disableFormFields,
-    enableFormFields,
-    postToBasket
-} from './form-utils.es6';
+import FormUtils from './form-utils.es6';
 
 let _form;
 let _countrySelect;
 
 const CountryForm = {
     handleFormError: () => {
-        enableFormFields(_form);
+        FormUtils.enableFormFields(_form);
         _form.querySelector('.mzp-c-form-errors').classList.remove('hidden');
         _form
             .querySelector('.error-try-again-later')
@@ -30,6 +25,14 @@ const CountryForm = {
         document
             .querySelector('.country-newsletter-thanks')
             .classList.remove('hidden');
+    },
+
+    redirectToRecoveryPage: () => {
+        const recoveryUrl = _form.getAttribute('data-recovery-url');
+
+        if (FormUtils.isWellFormedURL(recoveryUrl)) {
+            window.location.href = recoveryUrl;
+        }
     },
 
     serialize: () => {
@@ -46,17 +49,22 @@ const CountryForm = {
         return true;
     },
 
+    getFormActionURL: () => {
+        const token = FormUtils.getUserToken();
+        return `${_form.getAttribute('action')}${token}/`;
+    },
+
     subscribe: (e) => {
-        const url = _form.getAttribute('action');
+        const url = CountryForm.getFormActionURL();
 
         e.preventDefault();
         e.stopPropagation();
 
         // Disable form fields until POST has completed.
-        disableFormFields(_form);
+        FormUtils.disableFormFields(_form);
 
         // Clear any prior messages that might have been displayed.
-        clearFormErrors(_form);
+        FormUtils.clearFormErrors(_form);
 
         // Perform client side form field validation.
         if (!CountryForm.validateFields()) {
@@ -65,7 +73,7 @@ const CountryForm = {
 
         const params = CountryForm.serialize();
 
-        postToBasket(
+        FormUtils.postToBasket(
             null,
             params,
             url,
@@ -80,6 +88,21 @@ const CountryForm = {
 
         if (!_form) {
             return;
+        }
+
+        const urlToken = FormUtils.getURLToken(window.location);
+
+        // If the page URL contains a token, grab it and replace history.
+        if (urlToken) {
+            FormUtils.setUserToken(urlToken);
+            FormUtils.removeTokenFromURL(window.location, urlToken);
+        }
+
+        const token = FormUtils.getUserToken();
+
+        // if there's no locally stored token, redirect to recovery page.
+        if (!token) {
+            CountryForm.redirectToRecoveryPage();
         }
 
         _form.addEventListener('submit', CountryForm.subscribe, false);

--- a/media/js/newsletter/country.es6.js
+++ b/media/js/newsletter/country.es6.js
@@ -32,6 +32,8 @@ const CountryForm = {
 
         if (FormUtils.isWellFormedURL(recoveryUrl)) {
             window.location.href = recoveryUrl;
+        } else {
+            CountryForm.handleFormError();
         }
     },
 
@@ -90,22 +92,13 @@ const CountryForm = {
             return;
         }
 
-        const urlToken = FormUtils.getURLToken(window.location);
-
-        // If the page URL contains a token, grab it and replace history.
-        if (urlToken) {
-            FormUtils.setUserToken(urlToken);
-            FormUtils.removeTokenFromURL(window.location, urlToken);
-        }
-
-        const token = FormUtils.getUserToken();
-
-        // if there's no locally stored token, redirect to recovery page.
-        if (!token) {
-            CountryForm.redirectToRecoveryPage();
-        }
-
         _form.addEventListener('submit', CountryForm.subscribe, false);
+
+        // Look for a valid user token before rendering the page.
+        // If not found, redirect to /newsletter/recovery/.
+        return FormUtils.checkForUserToken().catch(
+            CountryForm.redirectToRecoveryPage
+        );
     }
 };
 

--- a/media/js/newsletter/form-utils.es6.js
+++ b/media/js/newsletter/form-utils.es6.js
@@ -51,6 +51,32 @@ const FormUtils = {
     },
 
     /**
+     * Looks for UUID token in the page URL. If found, removes token
+     * from the URL and stores in a cookie. If not found, look for an
+     * existing cookie with a token. If still not found, reject.
+     * @returns {Promise}
+     */
+    checkForUserToken: () => {
+        return new window.Promise((resolve, reject) => {
+            const urlToken = FormUtils.getURLToken(window.location);
+
+            // If the page URL contains a token, grab it and replace history.
+            if (urlToken) {
+                FormUtils.setUserToken(urlToken);
+                FormUtils.removeTokenFromURL(window.location, urlToken);
+            }
+
+            const token = FormUtils.getUserToken();
+
+            if (!token) {
+                reject();
+            } else {
+                resolve();
+            }
+        });
+    },
+
+    /**
      * Add disabled property to all form fields.
      * @param {HTMLFormElement} form
      */
@@ -119,13 +145,7 @@ const FormUtils = {
             return false;
         }
 
-        const matches = token.match(UUID_REGEX);
-
-        if (matches && matches[0]) {
-            return true;
-        } else {
-            return false;
-        }
+        return UUID_REGEX.test(token);
     },
 
     /**

--- a/media/js/newsletter/form-utils.es6.js
+++ b/media/js/newsletter/form-utils.es6.js
@@ -4,6 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+const BASKET_COOKIE_ID = 'nl-token';
+
+const UUID_REGEX =
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
 const errorList = {
     COUNTRY_ERROR: 'Country not selected',
     EMAIL_INVALID_ERROR: 'Invalid email address',
@@ -16,135 +21,265 @@ const errorList = {
     REASON_ERROR: 'Reason not selected'
 };
 
-/**
- * Really primitive validation (e.g a@a)
- * matches built-in validation in Firefox
- * @param {String} email
- * @returns {Boolean}
- */
-function checkEmailValidity(email) {
-    return /\S+@\S+/.test(email);
-}
+let _userToken;
 
-/**
- * Hide all visible form error labels.
- * @param {HTMLFormElement} form
- */
-function clearFormErrors(form) {
-    const errorMsgs = form.querySelectorAll('.mzp-c-form-errors li');
+const FormUtils = {
+    errorList,
 
-    form.querySelector('.mzp-c-form-errors').classList.add('hidden');
+    /**
+     * Really primitive validation (e.g a@a)
+     * matches built-in validation in Firefox
+     * @param {String} email
+     * @returns {Boolean}
+     */
+    checkEmailValidity: (email) => {
+        return /\S+@\S+/.test(email);
+    },
 
-    for (let i = 0; i < errorMsgs.length; i++) {
-        errorMsgs[i].classList.add('hidden');
-    }
-}
+    /**
+     * Hide all visible form error labels.
+     * @param {HTMLFormElement} form
+     */
+    clearFormErrors: (form) => {
+        const errorMsgs = form.querySelectorAll('.mzp-c-form-errors li');
 
-/**
- * Add disabled property to all form fields.
- * @param {HTMLFormElement} form
- */
-function disableFormFields(form) {
-    const formFields = form.querySelectorAll('input, button, select');
+        form.querySelector('.mzp-c-form-errors').classList.add('hidden');
 
-    for (let i = 0; i < formFields.length; i++) {
-        formFields[i].disabled = true;
-    }
-}
+        for (let i = 0; i < errorMsgs.length; i++) {
+            errorMsgs[i].classList.add('hidden');
+        }
+    },
 
-/**
- * Remove disabled property to all form fields.
- * @param {HTMLFormElement} form
- */
-function enableFormFields(form) {
-    const formFields = form.querySelectorAll('input, button, select');
+    /**
+     * Add disabled property to all form fields.
+     * @param {HTMLFormElement} form
+     */
+    disableFormFields: (form) => {
+        const formFields = form.querySelectorAll('input, button, select');
 
-    for (let i = 0; i < formFields.length; i++) {
-        formFields[i].disabled = false;
-    }
-}
+        for (let i = 0; i < formFields.length; i++) {
+            formFields[i].disabled = true;
+        }
+    },
 
-function postToBasket(email, params, url, successCallback, errorCallback) {
-    const xhr = new XMLHttpRequest();
+    /**
+     * Remove disabled property to all form fields.
+     * @param {HTMLFormElement} form
+     */
+    enableFormFields: (form) => {
+        const formFields = form.querySelectorAll('input, button, select');
 
-    // Emails used in automation for page-level integration tests
-    // should avoid hitting basket directly.
-    if (email === 'success@example.com') {
-        successCallback();
-        return;
-    } else if (email === 'failure@example.com') {
-        errorCallback();
-        return;
-    }
+        for (let i = 0; i < formFields.length; i++) {
+            formFields[i].disabled = false;
+        }
+    },
 
-    xhr.onload = function (e) {
-        let response = e.target.response || e.target.responseText;
+    getURLToken: (location) => {
+        const token = location.pathname.match(UUID_REGEX);
 
-        if (typeof response !== 'object') {
-            response = JSON.parse(response);
+        if (token && token.length) {
+            return token[0];
         }
 
-        if (response) {
-            if (
-                response.status === 'ok' &&
-                e.target.status >= 200 &&
-                e.target.status < 300
-            ) {
-                successCallback();
-            } else if (response.status === 'error' && response.desc) {
-                errorCallback(response.desc);
+        return '';
+    },
+
+    /**
+     * Gets the user's UUID token.
+     * Looks to cookie first, falling back to local variable.
+     * Will return an empty string if token is not a valid format.
+     * @returns {String}
+     */
+    getUserToken: () => {
+        let token;
+
+        const cookiesEnabled =
+            typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
+
+        if (cookiesEnabled) {
+            token = Mozilla.Cookies.getItem(BASKET_COOKIE_ID);
+        } else {
+            token = _userToken;
+        }
+
+        if (FormUtils.isValidToken(token)) {
+            return token;
+        } else {
+            return '';
+        }
+    },
+
+    /**
+     * Validates the supplied token matches the expected UUID format.
+     * @param {String} token
+     * @returns {Boolean}
+     */
+    isValidToken: (token) => {
+        if (typeof token !== 'string') {
+            return false;
+        }
+
+        const matches = token.match(UUID_REGEX);
+
+        if (matches && matches[0]) {
+            return true;
+        } else {
+            return false;
+        }
+    },
+
+    /**
+     * Returns true if URL string starts with http(s) or a relative path.
+     * @param {String} url
+     * @returns {Boolean}
+     */
+    isWellFormedURL: (url) => {
+        const absolute = /^https?:\/\//;
+        const relative = /^\//;
+        return absolute.test(url) || relative.test(url);
+    },
+
+    /**
+     * Perform an AJAX POST to Basket
+     * @param {String} email
+     * @param {String} params (URI encoded query string)
+     * @param {String} url (Basket API endpoint)
+     * @param {Function} successCallback
+     * @param {Function} errorCallback
+     */
+    postToBasket: (email, params, url, successCallback, errorCallback) => {
+        const xhr = new XMLHttpRequest();
+
+        // Emails used in automation for page-level integration tests
+        // should avoid hitting basket directly.
+        if (email === 'success@example.com') {
+            successCallback();
+            return;
+        } else if (email === 'failure@example.com') {
+            errorCallback();
+            return;
+        }
+
+        xhr.onload = function (e) {
+            let response = e.target.response || e.target.responseText;
+
+            if (typeof response !== 'object') {
+                response = JSON.parse(response);
+            }
+
+            if (response) {
+                if (
+                    response.status === 'ok' &&
+                    e.target.status >= 200 &&
+                    e.target.status < 300
+                ) {
+                    successCallback();
+                } else if (response.status === 'error' && response.desc) {
+                    errorCallback(response.desc);
+                } else {
+                    errorCallback();
+                }
             } else {
                 errorCallback();
             }
-        } else {
-            errorCallback();
-        }
-    };
+        };
 
-    xhr.onerror = errorCallback;
-    xhr.open('POST', url, true);
-    xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-    xhr.timeout = 5000;
-    xhr.ontimeout = errorCallback;
-    xhr.responseType = 'json';
-    xhr.send(params);
-}
+        xhr.onerror = errorCallback;
+        xhr.open('POST', url, true);
+        xhr.setRequestHeader(
+            'Content-type',
+            'application/x-www-form-urlencoded'
+        );
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        xhr.timeout = 5000;
+        xhr.ontimeout = errorCallback;
+        xhr.responseType = 'json';
+        xhr.send(params);
+    },
 
-/**
- * Helper function to serialize form data for XHR request.
- * @param {HTMLElement} form
- * @returns {String} query string
- */
-function serialize(form) {
-    const q = [];
-    for (let i = 0; i < form.elements.length; i++) {
-        const elem = form.elements[i];
-        if (elem.name) {
-            q.push(elem.name + '=' + encodeURIComponent(elem.value));
+    /**
+     * Removes Basket UUID token from page URL path and updates browser history.
+     * Note: this function will remove *everything* from the path *after* the token.
+     * Only query parameters will be preserved.
+     * @param {Object} location (e.g. window.location)
+     * @param {String} token
+     */
+    removeTokenFromURL: (location, token) => {
+        if (
+            typeof token === 'string' &&
+            location.pathname.lastIndexOf(token) !== -1
+        ) {
+            const url =
+                location.pathname.substring(
+                    0,
+                    location.pathname.lastIndexOf(token)
+                ) + location.search;
+
+            try {
+                window.history.replaceState(null, null, url);
+            } catch (e) {
+                // do nothing
+            }
         }
+    },
+
+    /**
+     * Sets a cookie with the user's UUID token. If cookies are disabled,
+     * then falls back to storing the token to a variable in memory.
+     * @param {String} token
+     */
+    setUserToken: (token) => {
+        if (FormUtils.isValidToken(token)) {
+            const cookiesEnabled =
+                typeof Mozilla.Cookies !== 'undefined' &&
+                Mozilla.Cookies.enabled();
+
+            if (cookiesEnabled) {
+                const date = new Date();
+                date.setTime(date.getTime() + 1 * 3600 * 1000); // expiry in 1 hour.
+                const expires = date.toUTCString();
+
+                Mozilla.Cookies.setItem(
+                    BASKET_COOKIE_ID,
+                    token,
+                    expires,
+                    '/',
+                    undefined,
+                    false,
+                    'lax'
+                );
+            } else {
+                _userToken = token;
+            }
+        }
+    },
+
+    /**
+     * Helper function to serialize form data for XHR request.
+     * @param {HTMLElement} form
+     * @returns {String} query string
+     */
+    serialize: (form) => {
+        const q = [];
+        for (let i = 0; i < form.elements.length; i++) {
+            const elem = form.elements[i];
+            if (elem.name) {
+                q.push(elem.name + '=' + encodeURIComponent(elem.value));
+            }
+        }
+        return q.join('&');
+    },
+
+    /**
+     * Helper function that strips HTML tags from text form input.
+     * @param {String} text
+     * @returns {String}
+     */
+    stripHTML: (text) => {
+        const div = document.createElement('div');
+        div.innerHTML = decodeURIComponent(text);
+        return div.textContent;
     }
-    return q.join('&');
-}
-
-/**
- * Helper function that strips HTML tags from text form input.
- * @param {String} text
- * @returns {String}
- */
-function stripHTML(text) {
-    const div = document.createElement('div');
-    div.innerHTML = decodeURIComponent(text);
-    return div.textContent;
-}
-
-export {
-    checkEmailValidity,
-    clearFormErrors,
-    errorList,
-    disableFormFields,
-    enableFormFields,
-    postToBasket,
-    serialize,
-    stripHTML
 };
+
+export default FormUtils;

--- a/media/js/newsletter/management.es6.js
+++ b/media/js/newsletter/management.es6.js
@@ -6,14 +6,7 @@
 
 import Spinner from '../libs/spin.min';
 
-import {
-    checkEmailValidity,
-    clearFormErrors,
-    disableFormFields,
-    enableFormFields,
-    errorList,
-    postToBasket
-} from './form-utils.es6';
+import FormUtils from './form-utils.es6';
 
 const FXA_NEWSLETTERS = [
     'firefox-accounts-journey',
@@ -140,7 +133,26 @@ const NewsletterManagementForm = {
      * @returns {String}
      */
     getUserDataURL: () => {
-        return _form.getAttribute('action');
+        const token = FormUtils.getUserToken();
+        return `${_form.getAttribute('action')}${token}/`;
+    },
+
+    /**
+     * Get Basket URL for unsubscribing to all newsletters.
+     * @returns {String}
+     */
+    getUnsubscribeURL: () => {
+        const token = FormUtils.getUserToken();
+        return `${_form.getAttribute('data-unsubscribe-url')}${token}/`;
+    },
+
+    /**
+     * Get Basket URL for updating user preferences.
+     * @returns {String}
+     */
+    getFormActionURL: () => {
+        const token = FormUtils.getUserToken();
+        return `${_form.getAttribute('action')}${token}/`;
     },
 
     /**
@@ -176,17 +188,6 @@ const NewsletterManagementForm = {
      */
     isFxANewsletter: (newsletter) => {
         return FXA_NEWSLETTERS.includes(newsletter);
-    },
-
-    /**
-     * Returns true if URL string starts with http(s) or a relative path.
-     * @param {String} url
-     * @returns {Boolean}
-     */
-    isWellFormedURL: (url) => {
-        const absolute = /^https?:\/\//;
-        const relative = /^\//;
-        return absolute.test(url) || relative.test(url);
     },
 
     /**
@@ -479,7 +480,7 @@ const NewsletterManagementForm = {
         const list = errorContainer.querySelector('.mzp-c-form-errors ul');
 
         // clear any previously displayed errors.
-        clearFormErrors(_form);
+        FormUtils.clearFormErrors(_form);
 
         errors.forEach((error) => {
             const item = `<li>${error}</li>`;
@@ -489,7 +490,7 @@ const NewsletterManagementForm = {
         errorContainer.classList.remove('hidden');
         window.scrollTo(0, 0); // Scroll to top of page for error visibility.
 
-        enableFormFields(_form);
+        FormUtils.enableFormFields(_form);
     },
 
     /**
@@ -498,7 +499,7 @@ const NewsletterManagementForm = {
     onFormSuccess: () => {
         const url = _form.getAttribute('data-updated-url');
 
-        if (NewsletterManagementForm.isWellFormedURL(url)) {
+        if (FormUtils.isWellFormedURL(url)) {
             window.location.href = url;
         } else {
             NewsletterManagementForm.onDataError();
@@ -507,15 +508,14 @@ const NewsletterManagementForm = {
 
     /**
      * Redirects for `/newsletter/updated/` page on successful unsubscribe
-     * from all newsletters. The `?unsub` and `?token` params are required
-     * to display the unsubscription survey form.
+     * from all newsletters. The `?unsub` param is required to display the
+     * unsubscription survey form.
      */
     onUnsubscribeAll: () => {
-        const token = _form.getAttribute('data-token');
         const updated = _form.getAttribute('data-updated-url');
-        const url = `${updated}?unsub=${UNSUB_UNSUBSCRIBED_ALL}&token=${token}`;
+        const url = `${updated}?unsub=${UNSUB_UNSUBSCRIBED_ALL}`;
 
-        if (NewsletterManagementForm.isWellFormedURL(url)) {
+        if (FormUtils.isWellFormedURL(url)) {
             window.location.href = url;
         } else {
             NewsletterManagementForm.onDataError();
@@ -546,13 +546,13 @@ const NewsletterManagementForm = {
         let error;
 
         switch (msg) {
-            case errorList.NOT_FOUND:
+            case FormUtils.errorList.NOT_FOUND:
                 error = strings.getAttribute('data-error-token-not-found');
                 break;
-            case errorList.EMAIL_INVALID_ERROR:
+            case FormUtils.errorList.EMAIL_INVALID_ERROR:
                 error = strings.getAttribute('data-error-invalid-email');
                 break;
-            case errorList.NEWSLETTER_ERROR:
+            case FormUtils.errorList.NEWSLETTER_ERROR:
                 error = strings.getAttribute('data-error-invalid-newsletter');
 
                 // replace '%newsletter%' placeholder with actual newsletter ID.
@@ -560,10 +560,10 @@ const NewsletterManagementForm = {
                     error = error.replace('%newsletter%', newsletterId);
                 }
                 break;
-            case errorList.COUNTRY_ERROR:
+            case FormUtils.errorList.COUNTRY_ERROR:
                 error = strings.getAttribute('data-error-select-country');
                 break;
-            case errorList.LANGUAGE_ERROR:
+            case FormUtils.errorList.LANGUAGE_ERROR:
                 error = strings.getAttribute('data-error-select-lang');
                 break;
             default:
@@ -600,10 +600,10 @@ const NewsletterManagementForm = {
 
         // Basic email validation
         const email = NewsletterManagementForm.getUserEmail();
-        if (!checkEmailValidity(email)) {
+        if (!FormUtils.checkEmailValidity(email)) {
             errors.push(
                 NewsletterManagementForm.handleFormError(
-                    errorList.EMAIL_INVALID_ERROR
+                    FormUtils.errorList.EMAIL_INVALID_ERROR
                 )
             );
         }
@@ -613,7 +613,7 @@ const NewsletterManagementForm = {
         if (unexpected.length > 0) {
             errors.push(
                 NewsletterManagementForm.handleFormError(
-                    errorList.NEWSLETTER_ERROR,
+                    FormUtils.errorList.NEWSLETTER_ERROR,
                     unexpected[0]
                 )
             );
@@ -624,7 +624,7 @@ const NewsletterManagementForm = {
         if (!country) {
             errors.push(
                 NewsletterManagementForm.handleFormError(
-                    errorList.COUNTRY_ERROR
+                    FormUtils.errorList.COUNTRY_ERROR
                 )
             );
         }
@@ -634,7 +634,7 @@ const NewsletterManagementForm = {
         if (!lang) {
             errors.push(
                 NewsletterManagementForm.handleFormError(
-                    errorList.LANGUAGE_ERROR
+                    FormUtils.errorList.LANGUAGE_ERROR
                 )
             );
         }
@@ -669,7 +669,7 @@ const NewsletterManagementForm = {
     onSubmit: (e) => {
         e.preventDefault();
 
-        disableFormFields(_form);
+        FormUtils.disableFormFields(_form);
 
         // Perform client side form field validation.
         const errors = NewsletterManagementForm.validateFields();
@@ -684,19 +684,20 @@ const NewsletterManagementForm = {
         if (unsubscribeAll) {
             // Do opt-out from all newsletters.
             const email = NewsletterManagementForm.getUserEmail();
-            postToBasket(
+
+            FormUtils.postToBasket(
                 email,
                 `email=${email}&optout=Y`,
-                _form.getAttribute('data-unsubscribe-url'),
+                NewsletterManagementForm.getUnsubscribeURL(),
                 NewsletterManagementForm.onUnsubscribeAll,
                 NewsletterManagementForm.onDataError
             );
         } else {
             // Update user data to reflect form changes.
-            postToBasket(
+            FormUtils.postToBasket(
                 NewsletterManagementForm.getUserEmail(),
                 NewsletterManagementForm.serialize(),
-                _form.getAttribute('action'),
+                NewsletterManagementForm.getFormActionURL(),
                 NewsletterManagementForm.onFormSuccess,
                 NewsletterManagementForm.onDataError
             );
@@ -711,17 +712,70 @@ const NewsletterManagementForm = {
         );
     },
 
+    showUpdateBrowserCopy: () => {
+        document
+            .querySelector('.js-outdated-browser-msg')
+            .classList.add('show');
+    },
+
+    showIntroCopy: () => {
+        const intro = document.querySelector('.js-intro-msg');
+
+        // Intro copy is conditional on ?confirm=1, so
+        // check that it exists in the DOM before trying
+        // to display it.
+        if (intro) {
+            intro.classList.add('show');
+        }
+    },
+
+    /**
+     * Perform a client side redirect to the /newsletter/recovery/ page.
+     */
+    redirectToRecoveryPage: () => {
+        const recoveryUrl = _form.getAttribute('data-recovery-url');
+
+        if (FormUtils.isWellFormedURL(recoveryUrl)) {
+            window.location.href = recoveryUrl;
+        }
+    },
+
+    /**
+     * Looks for UUID token in the page URL. If found, removes token
+     * from the URL and stores in a cookie. If not found, look for an
+     * existing cookie with a token. If still not found, redirect
+     * the user back to the /recovery/ page.
+     */
+    checkForUserToken: () => {
+        const urlToken = FormUtils.getURLToken(window.location);
+
+        // If the page URL contains a token, grab it and replace history.
+        if (urlToken) {
+            FormUtils.setUserToken(urlToken);
+            FormUtils.removeTokenFromURL(window.location, urlToken);
+        }
+
+        const token = FormUtils.getUserToken();
+
+        // if there's no locally stored token, redirect to recovery page.
+        if (!token) {
+            NewsletterManagementForm.redirectToRecoveryPage();
+        }
+    },
+
     init: () => {
         if (!NewsletterManagementForm.meetsRequirements()) {
-            document
-                .querySelector('.js-outdated-browser-msg')
-                .classList.add('show');
+            NewsletterManagementForm.showUpdateBrowserCopy();
             return window.Promise.reject();
         } else {
-            document.querySelector('.js-intro-msg').classList.add('show');
+            NewsletterManagementForm.showIntroCopy();
         }
 
         _form = document.querySelector('.newsletter-management-form');
+
+        // Grab user token from URL and add to cookie
+        NewsletterManagementForm.checkForUserToken();
+
         const userData = NewsletterManagementForm.getUserData();
         const newsletterData = NewsletterManagementForm.getNewsletterData();
         const newsletterStrings =

--- a/media/js/newsletter/newsletter.es6.js
+++ b/media/js/newsletter/newsletter.es6.js
@@ -4,14 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-    checkEmailValidity,
-    clearFormErrors,
-    errorList,
-    disableFormFields,
-    enableFormFields,
-    postToBasket
-} from './form-utils.es6';
+import FormUtils from './form-utils.es6';
 
 let form;
 
@@ -19,29 +12,29 @@ const NewsletterForm = {
     handleFormError: (msg) => {
         let error;
 
-        enableFormFields(form);
+        FormUtils.enableFormFields(form);
 
         form.querySelector('.mzp-c-form-errors').classList.remove('hidden');
 
         switch (msg) {
-            case errorList.EMAIL_INVALID_ERROR:
+            case FormUtils.errorList.EMAIL_INVALID_ERROR:
                 error = form.querySelector('.error-email-invalid');
                 break;
-            case errorList.NEWSLETTER_ERROR:
+            case FormUtils.errorList.NEWSLETTER_ERROR:
                 form.querySelector(
                     '.error-newsletter-checkbox'
                 ).classList.remove('hidden');
                 break;
-            case errorList.COUNTRY_ERROR:
+            case FormUtils.errorList.COUNTRY_ERROR:
                 error = form.querySelector('.error-select-country');
                 break;
-            case errorList.LANGUAGE_ERROR:
+            case FormUtils.errorList.LANGUAGE_ERROR:
                 error = form.querySelector('.error-select-language');
                 break;
-            case errorList.PRIVACY_POLICY_ERROR:
+            case FormUtils.errorList.PRIVACY_POLICY_ERROR:
                 error = form.querySelector('.error-privacy-policy');
                 break;
-            case errorList.LEGAL_TERMS_ERROR:
+            case FormUtils.errorList.LEGAL_TERMS_ERROR:
                 error = form.querySelector('.error-terms');
                 break;
             default:
@@ -116,38 +109,46 @@ const NewsletterForm = {
         const terms = form.querySelector('input[name="terms"]');
 
         // Really basic client side email validity check.
-        if (!checkEmailValidity(email)) {
-            NewsletterForm.handleFormError(errorList.EMAIL_INVALID_ERROR);
+        if (!FormUtils.checkEmailValidity(email)) {
+            NewsletterForm.handleFormError(
+                FormUtils.errorList.EMAIL_INVALID_ERROR
+            );
             return false;
         }
 
         // Check for country selection value.
         if (countrySelect && !countrySelect.value) {
-            NewsletterForm.handleFormError(errorList.COUNTRY_ERROR);
+            NewsletterForm.handleFormError(FormUtils.errorList.COUNTRY_ERROR);
             return false;
         }
 
         // Check for language selection value.
         if (!lang) {
-            NewsletterForm.handleFormError(errorList.LANGUAGE_ERROR);
+            NewsletterForm.handleFormError(FormUtils.errorList.LANGUAGE_ERROR);
             return false;
         }
 
         // Confirm at least one newsletter is checked
         if (newsletters.length === 0) {
-            NewsletterForm.handleFormError(errorList.NEWSLETTER_ERROR);
+            NewsletterForm.handleFormError(
+                FormUtils.errorList.NEWSLETTER_ERROR
+            );
             return false;
         }
 
         // Confirm privacy policy is checked
         if (!privacy) {
-            NewsletterForm.handleFormError(errorList.PRIVACY_POLICY_ERROR);
+            NewsletterForm.handleFormError(
+                FormUtils.errorList.PRIVACY_POLICY_ERROR
+            );
             return false;
         }
 
         // Terms checkbox only appears on /firefox/ios/testflight/ page.
         if (terms && !terms.checked) {
-            NewsletterForm.handleFormError(errorList.LEGAL_TERMS_ERROR);
+            NewsletterForm.handleFormError(
+                FormUtils.errorList.LEGAL_TERMS_ERROR
+            );
             return false;
         }
 
@@ -162,10 +163,10 @@ const NewsletterForm = {
         e.stopPropagation();
 
         // Disable form fields until POST has completed.
-        disableFormFields(form);
+        FormUtils.disableFormFields(form);
 
         // Clear any prior messages that might have been displayed.
-        clearFormErrors(form);
+        FormUtils.clearFormErrors(form);
 
         // Perform client side form field validation.
         if (!NewsletterForm.validateFields()) {
@@ -174,7 +175,7 @@ const NewsletterForm = {
 
         const params = NewsletterForm.serialize();
 
-        postToBasket(
+        FormUtils.postToBasket(
             email,
             params,
             url,

--- a/media/js/newsletter/recovery.es6.js
+++ b/media/js/newsletter/recovery.es6.js
@@ -4,14 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-    checkEmailValidity,
-    clearFormErrors,
-    errorList,
-    disableFormFields,
-    enableFormFields,
-    postToBasket
-} from './form-utils.es6';
+import FormUtils from './form-utils.es6';
 
 let _recoveryForm;
 
@@ -26,19 +19,19 @@ const RecoveryEmailForm = {
     },
 
     handleFormError: (msg) => {
-        enableFormFields(_recoveryForm);
+        FormUtils.enableFormFields(_recoveryForm);
 
         _recoveryForm
             .querySelector('.mzp-c-form-errors')
             .classList.remove('hidden');
 
         switch (msg) {
-            case errorList.EMAIL_INVALID_ERROR:
+            case FormUtils.errorList.EMAIL_INVALID_ERROR:
                 _recoveryForm
                     .querySelector('.error-email-invalid')
                     .classList.remove('hidden');
                 break;
-            case errorList.EMAIL_UNKNOWN_ERROR:
+            case FormUtils.errorList.EMAIL_UNKNOWN_ERROR:
                 _recoveryForm
                     .querySelector('.error-email-not-found')
                     .classList.remove('hidden');
@@ -54,9 +47,11 @@ const RecoveryEmailForm = {
         const email = document.getElementById('id_email').value;
 
         // Really basic client side email validity check.
-        if (!checkEmailValidity(email)) {
-            RecoveryEmailForm.handleFormError(errorList.EMAIL_INVALID_ERROR);
-            enableFormFields(_recoveryForm);
+        if (!FormUtils.checkEmailValidity(email)) {
+            RecoveryEmailForm.handleFormError(
+                FormUtils.errorList.EMAIL_INVALID_ERROR
+            );
+            FormUtils.enableFormFields(_recoveryForm);
             return false;
         }
 
@@ -71,17 +66,17 @@ const RecoveryEmailForm = {
         const url = _recoveryForm.getAttribute('action');
 
         // Disable form fields until POST has completed.
-        disableFormFields(_recoveryForm);
+        FormUtils.disableFormFields(_recoveryForm);
 
         // Clear any prior messages that might have been displayed.
-        clearFormErrors(_recoveryForm);
+        FormUtils.clearFormErrors(_recoveryForm);
 
         // Perform client side form field validation.
         if (!RecoveryEmailForm.validateFields()) {
             return;
         }
 
-        postToBasket(
+        FormUtils.postToBasket(
             email,
             params,
             url,

--- a/media/js/newsletter/unsubscribed.es6.js
+++ b/media/js/newsletter/unsubscribed.es6.js
@@ -4,14 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-    clearFormErrors,
-    errorList,
-    disableFormFields,
-    enableFormFields,
-    postToBasket,
-    stripHTML
-} from './form-utils.es6';
+import FormUtils from './form-utils.es6';
 
 let _unsubscribedForm;
 
@@ -25,7 +18,7 @@ const UnsubscribedEmailForm = {
             _unsubscribedForm.querySelectorAll(
                 '.c-updated-form input[type="checkbox"]:checked'
             )
-        ).map((reason) => stripHTML(reason.value));
+        ).map((reason) => FormUtils.stripHTML(reason.value));
     },
 
     /**
@@ -36,28 +29,20 @@ const UnsubscribedEmailForm = {
         const text = _unsubscribedForm.querySelector(
             'textarea[name="reason-text"'
         ).value;
-        return stripHTML(text);
-    },
-
-    /**
-     * Get hidden token field value from the form.
-     * @returns  {String}
-     */
-    getToken: () => {
-        return _unsubscribedForm.querySelector('input[name="token"]').value;
+        return FormUtils.stripHTML(text);
     },
 
     handleFormError: (msg) => {
         let error;
 
-        enableFormFields(_unsubscribedForm);
+        FormUtils.enableFormFields(_unsubscribedForm);
 
         _unsubscribedForm
             .querySelector('.mzp-c-form-errors')
             .classList.remove('hidden');
 
         switch (msg) {
-            case errorList.REASON_ERROR:
+            case FormUtils.errorList.REASON_ERROR:
                 error = _unsubscribedForm.querySelector('.error-reason');
                 break;
             default:
@@ -97,7 +82,7 @@ const UnsubscribedEmailForm = {
     serialize: () => {
         const reasons = UnsubscribedEmailForm.getCheckedReasons();
         const text = UnsubscribedEmailForm.getReasonText();
-        const token = UnsubscribedEmailForm.getToken();
+        const token = FormUtils.getUserToken();
 
         if (text !== '') {
             reasons.push(text);
@@ -115,17 +100,19 @@ const UnsubscribedEmailForm = {
         e.preventDefault();
 
         const url = _unsubscribedForm.getAttribute('action');
-        const token = UnsubscribedEmailForm.getToken();
+        const token = FormUtils.getUserToken();
 
         // Disable form fields until POST has completed.
-        disableFormFields(_unsubscribedForm);
+        FormUtils.disableFormFields(_unsubscribedForm);
 
         // Clear any prior messages that might have been displayed.
-        clearFormErrors(_unsubscribedForm);
+        FormUtils.clearFormErrors(_unsubscribedForm);
 
         // Perform client side form field validation.
         if (!UnsubscribedEmailForm.validateFields()) {
-            UnsubscribedEmailForm.handleFormError(errorList.REASON_ERROR);
+            UnsubscribedEmailForm.handleFormError(
+                FormUtils.errorList.REASON_ERROR
+            );
             return;
         }
 
@@ -136,7 +123,7 @@ const UnsubscribedEmailForm = {
 
         const params = UnsubscribedEmailForm.serialize();
 
-        postToBasket(
+        FormUtils.postToBasket(
             null,
             params,
             url,

--- a/media/js/products/vpn/invite.es6.js
+++ b/media/js/products/vpn/invite.es6.js
@@ -4,14 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-    checkEmailValidity,
-    clearFormErrors,
-    errorList,
-    disableFormFields,
-    enableFormFields,
-    postToBasket
-} from '../../newsletter/form-utils.es6';
+import FormUtils from '../../newsletter/form-utils.es6';
 
 let form;
 
@@ -19,18 +12,18 @@ const WaitListForm = {
     handleFormError: (msg) => {
         let error;
 
-        enableFormFields(form);
+        FormUtils.enableFormFields(form);
 
         form.querySelector('.mzp-c-form-errors').classList.remove('hidden');
 
         switch (msg) {
-            case errorList.EMAIL_INVALID_ERROR:
+            case FormUtils.errorList.EMAIL_INVALID_ERROR:
                 error = form.querySelector('.error-email-invalid');
                 break;
-            case errorList.COUNTRY_ERROR:
+            case FormUtils.errorList.COUNTRY_ERROR:
                 error = form.querySelector('.error-select-country');
                 break;
-            case errorList.LANGUAGE_ERROR:
+            case FormUtils.errorList.LANGUAGE_ERROR:
                 error = form.querySelector('.error-select-language');
                 break;
             default:
@@ -67,20 +60,20 @@ const WaitListForm = {
         const lang = form.querySelector('#id_lang').value;
 
         // Really basic client side email validity check.
-        if (!checkEmailValidity(email)) {
-            form.handleFormError(errorList.EMAIL_INVALID_ERROR);
+        if (!FormUtils.checkEmailValidity(email)) {
+            form.handleFormError(FormUtils.errorList.EMAIL_INVALID_ERROR);
             return false;
         }
 
         // Check for country selection value.
         if (countrySelect && !countrySelect.value) {
-            WaitListForm.handleFormError(errorList.COUNTRY_ERROR);
+            WaitListForm.handleFormError(FormUtils.errorList.COUNTRY_ERROR);
             return false;
         }
 
         // Check for language selection value.
         if (!lang) {
-            WaitListForm.handleFormError(errorList.LANGUAGE_ERROR);
+            WaitListForm.handleFormError(FormUtils.errorList.LANGUAGE_ERROR);
             return false;
         }
 
@@ -120,10 +113,10 @@ const WaitListForm = {
         e.stopPropagation();
 
         // Disable form fields until POST has completed.
-        disableFormFields(form);
+        FormUtils.disableFormFields(form);
 
         // Clear any prior messages that might have been displayed.
-        clearFormErrors(form);
+        FormUtils.clearFormErrors(form);
 
         // Perform client side form field validation.
         if (!WaitListForm.validateFields()) {
@@ -132,7 +125,7 @@ const WaitListForm = {
 
         const params = WaitListForm.serialize();
 
-        postToBasket(
+        FormUtils.postToBasket(
             email,
             params,
             url,

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -523,6 +523,12 @@
     },
     {
       "files": [
+        "css/newsletter/newsletter-confirm.scss"
+      ],
+      "name": "newsletter-confirm"
+    },
+    {
+      "files": [
         "css/newsletter/newsletter-updated.scss"
       ],
       "name": "newsletter-updated"

--- a/tests/unit/spec/newsletter/country.js
+++ b/tests/unit/spec/newsletter/country.js
@@ -4,13 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import FormUtils from '../../../../media/js/newsletter/form-utils.es6';
 import CountryForm from '../../../../media/js/newsletter/country.es6';
+
+const TOKEN_MOCK = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
 
 describe('CountryForm', function () {
     beforeEach(async function () {
         const form = `<div id="country-newsletter-test-form">
             <div class="country-newsletter-content">
-                <form id="country-newsletter-form" class="country-newsletter-form" method="post" action="https://basket.mozilla.org/news/user-meta/c3e6c6b9-daf1-43ed-a560-51160e15b360/">
+                <form id="country-newsletter-form" class="country-newsletter-form" method="post" action="https://basket.mozilla.org/news/user-meta/">
                     <div class="mzp-c-form-errors hidden" id="country-newsletter-errors">
                         <ul class="mzp-u-list-styled">
                             <li class="error-try-again-later hidden">
@@ -48,6 +51,8 @@ describe('CountryForm', function () {
         let xhrRequests = [];
 
         beforeEach(function () {
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
+
             xhr = sinon.useFakeXMLHttpRequest();
             xhr.onCreate = (req) => {
                 xhrRequests.push(req);
@@ -69,6 +74,9 @@ describe('CountryForm', function () {
                 '{"status": "ok"}'
             );
 
+            expect(xhrRequests[0].url).toEqual(
+                `https://basket.mozilla.org/news/user-meta/${TOKEN_MOCK}/`
+            );
             expect(CountryForm.handleFormSuccess).toHaveBeenCalled();
             expect(
                 document

--- a/tests/unit/spec/newsletter/form-utils.js
+++ b/tests/unit/spec/newsletter/form-utils.js
@@ -6,6 +6,8 @@
 
 import FormUtils from '../../../../media/js/newsletter/form-utils.es6';
 
+const TOKEN_MOCK = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+
 describe('checkEmailValidity', function () {
     it('should return true for primitive email format', function () {
         expect(FormUtils.checkEmailValidity('a@a')).toBeTruthy();
@@ -26,11 +28,10 @@ describe('checkEmailValidity', function () {
 
 describe('getURLToken', function () {
     it('should return a UUID token from a URL', function () {
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
         const location = {
-            pathname: `/en-US/newsletter/existing/${token}/`
+            pathname: `/en-US/newsletter/existing/${TOKEN_MOCK}/`
         };
-        expect(FormUtils.getURLToken(location)).toEqual(token);
+        expect(FormUtils.getURLToken(location)).toEqual(TOKEN_MOCK);
     });
 
     it('should return an empty string if a valid token is not found', function () {
@@ -43,9 +44,8 @@ describe('getURLToken', function () {
 
 describe('getUserToken', function () {
     it('should return a UUID token from cookie', function () {
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
-        spyOn(Mozilla.Cookies, 'getItem').and.returnValue(token);
-        expect(FormUtils.getUserToken()).toEqual(token);
+        spyOn(Mozilla.Cookies, 'getItem').and.returnValue(TOKEN_MOCK);
+        expect(FormUtils.getUserToken()).toEqual(TOKEN_MOCK);
     });
 
     it('should return an empty string if token is invalid', function () {
@@ -57,8 +57,7 @@ describe('getUserToken', function () {
 
 describe('isValidToken', function () {
     it('should return true for a valid token', function () {
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
-        expect(FormUtils.isValidToken(token)).toBeTrue();
+        expect(FormUtils.isValidToken(TOKEN_MOCK)).toBeTrue();
     });
 
     it('should return false if a token is too long', function () {
@@ -115,12 +114,11 @@ describe('isWellFormedURL', function () {
 describe('removeTokenFromURL', function () {
     it('should remove token from URL path name', function () {
         spyOn(window.history, 'replaceState');
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
         const location = {
-            pathname: `/en-US/newsletter/existing/${token}/`,
+            pathname: `/en-US/newsletter/existing/${TOKEN_MOCK}/`,
             search: ''
         };
-        FormUtils.removeTokenFromURL(location, token);
+        FormUtils.removeTokenFromURL(location, TOKEN_MOCK);
         expect(window.history.replaceState).toHaveBeenCalledWith(
             null,
             null,
@@ -130,12 +128,11 @@ describe('removeTokenFromURL', function () {
 
     it('should maintain existing query parameters', function () {
         spyOn(window.history, 'replaceState');
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
         const location = {
-            pathname: `/en-US/newsletter/existing/${token}/`,
+            pathname: `/en-US/newsletter/existing/${TOKEN_MOCK}/`,
             search: '?fxa=1'
         };
-        FormUtils.removeTokenFromURL(location, token);
+        FormUtils.removeTokenFromURL(location, TOKEN_MOCK);
         expect(window.history.replaceState).toHaveBeenCalledWith(
             null,
             null,
@@ -143,25 +140,23 @@ describe('removeTokenFromURL', function () {
         );
     });
 
-    it('should not update the URL is a token is not present', function () {
+    it('should not update the URL if a token is not present', function () {
         spyOn(window.history, 'replaceState');
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
         const location = {
             pathname: '/en-US/newsletter/existing/'
         };
-        FormUtils.removeTokenFromURL(location, token);
+        FormUtils.removeTokenFromURL(location, TOKEN_MOCK);
         expect(window.history.replaceState).not.toHaveBeenCalled();
     });
 });
 
 describe('setUserToken', function () {
     it('should set a cookie with a valid UUID token', function () {
-        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
         spyOn(Mozilla.Cookies, 'setItem');
-        FormUtils.setUserToken(token);
+        FormUtils.setUserToken(TOKEN_MOCK);
         expect(Mozilla.Cookies.setItem).toHaveBeenCalledOnceWith(
             'nl-token',
-            token,
+            TOKEN_MOCK,
             jasmine.any(String),
             '/',
             undefined,

--- a/tests/unit/spec/newsletter/form-utils.js
+++ b/tests/unit/spec/newsletter/form-utils.js
@@ -4,25 +4,177 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-    checkEmailValidity,
-    serialize,
-    stripHTML
-} from '../../../../media/js/newsletter/form-utils.es6';
+import FormUtils from '../../../../media/js/newsletter/form-utils.es6';
 
 describe('checkEmailValidity', function () {
     it('should return true for primitive email format', function () {
-        expect(checkEmailValidity('a@a')).toBeTruthy();
-        expect(checkEmailValidity('example@example.com')).toBeTruthy();
+        expect(FormUtils.checkEmailValidity('a@a')).toBeTruthy();
+        expect(
+            FormUtils.checkEmailValidity('example@example.com')
+        ).toBeTruthy();
     });
 
     it('should return false for anything else', function () {
-        expect(checkEmailValidity(1234567890)).toBeFalsy();
-        expect(checkEmailValidity('aaa')).toBeFalsy();
-        expect(checkEmailValidity(null)).toBeFalsy();
-        expect(checkEmailValidity(undefined)).toBeFalsy();
-        expect(checkEmailValidity(true)).toBeFalsy();
-        expect(checkEmailValidity(false)).toBeFalsy();
+        expect(FormUtils.checkEmailValidity(1234567890)).toBeFalsy();
+        expect(FormUtils.checkEmailValidity('aaa')).toBeFalsy();
+        expect(FormUtils.checkEmailValidity(null)).toBeFalsy();
+        expect(FormUtils.checkEmailValidity(undefined)).toBeFalsy();
+        expect(FormUtils.checkEmailValidity(true)).toBeFalsy();
+        expect(FormUtils.checkEmailValidity(false)).toBeFalsy();
+    });
+});
+
+describe('getURLToken', function () {
+    it('should return a UUID token from a URL', function () {
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        const location = {
+            pathname: `/en-US/newsletter/existing/${token}/`
+        };
+        expect(FormUtils.getURLToken(location)).toEqual(token);
+    });
+
+    it('should return an empty string if a valid token is not found', function () {
+        const location = {
+            pathname: `/en-US/newsletter/existing/`
+        };
+        expect(FormUtils.getURLToken(location)).toEqual('');
+    });
+});
+
+describe('getUserToken', function () {
+    it('should return a UUID token from cookie', function () {
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        spyOn(Mozilla.Cookies, 'getItem').and.returnValue(token);
+        expect(FormUtils.getUserToken()).toEqual(token);
+    });
+
+    it('should return an empty string if token is invalid', function () {
+        const token = 'some invalid string';
+        spyOn(Mozilla.Cookies, 'getItem').and.returnValue(token);
+        expect(FormUtils.getUserToken()).toEqual('');
+    });
+});
+
+describe('isValidToken', function () {
+    it('should return true for a valid token', function () {
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        expect(FormUtils.isValidToken(token)).toBeTrue();
+    });
+
+    it('should return false if a token is too long', function () {
+        expect(
+            FormUtils.isValidToken(
+                'ffa1a2a3a4-abgc1-1g2ab-a12f3-12345a12345bgf'
+            )
+        ).toBeFalse();
+    });
+
+    it('should return false if a token is too short', function () {
+        expect(FormUtils.isValidToken('a1-abc1-12ab-a123-12345a')).toBeFalse();
+    });
+
+    it('should return false for everything else', function () {
+        expect(FormUtils.isValidToken('some-string')).toBeFalse();
+        expect(FormUtils.isValidToken(true)).toBeFalse();
+        expect(FormUtils.isValidToken(null)).toBeFalse();
+        expect(FormUtils.isValidToken(undefined)).toBeFalse();
+        expect(FormUtils.isValidToken()).toBeFalse();
+        expect(FormUtils.isValidToken(123456789)).toBeFalse();
+    });
+});
+
+describe('isWellFormedURL', function () {
+    it('should return true for absolute URLs', function () {
+        expect(
+            FormUtils.isWellFormedURL(
+                'http://localhost:8000/en-US/newsletter/updated/'
+            )
+        ).toBeTrue();
+        expect(
+            FormUtils.isWellFormedURL(
+                'https://www.mozilla.org/en-US/newsletter/updated/'
+            )
+        ).toBeTrue();
+    });
+
+    it('should return true for relative URLs', function () {
+        expect(
+            FormUtils.isWellFormedURL('/en-US/newsletter/updated/')
+        ).toBeTrue();
+    });
+
+    it('should return false for anything else', function () {
+        expect(
+            FormUtils.isWellFormedURL('undefined?unsub=1&token=null')
+        ).toBeFalse();
+        expect(FormUtils.isWellFormedURL(undefined)).toBeFalse();
+        expect(FormUtils.isWellFormedURL(null)).toBeFalse();
+    });
+});
+
+describe('removeTokenFromURL', function () {
+    it('should remove token from URL path name', function () {
+        spyOn(window.history, 'replaceState');
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        const location = {
+            pathname: `/en-US/newsletter/existing/${token}/`,
+            search: ''
+        };
+        FormUtils.removeTokenFromURL(location, token);
+        expect(window.history.replaceState).toHaveBeenCalledWith(
+            null,
+            null,
+            '/en-US/newsletter/existing/'
+        );
+    });
+
+    it('should maintain existing query parameters', function () {
+        spyOn(window.history, 'replaceState');
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        const location = {
+            pathname: `/en-US/newsletter/existing/${token}/`,
+            search: '?fxa=1'
+        };
+        FormUtils.removeTokenFromURL(location, token);
+        expect(window.history.replaceState).toHaveBeenCalledWith(
+            null,
+            null,
+            '/en-US/newsletter/existing/?fxa=1'
+        );
+    });
+
+    it('should not update the URL is a token is not present', function () {
+        spyOn(window.history, 'replaceState');
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        const location = {
+            pathname: '/en-US/newsletter/existing/'
+        };
+        FormUtils.removeTokenFromURL(location, token);
+        expect(window.history.replaceState).not.toHaveBeenCalled();
+    });
+});
+
+describe('setUserToken', function () {
+    it('should set a cookie with a valid UUID token', function () {
+        const token = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+        spyOn(Mozilla.Cookies, 'setItem');
+        FormUtils.setUserToken(token);
+        expect(Mozilla.Cookies.setItem).toHaveBeenCalledOnceWith(
+            'nl-token',
+            token,
+            jasmine.any(String),
+            '/',
+            undefined,
+            false,
+            'lax'
+        );
+    });
+
+    it('should not set a cookie if token is invalid', function () {
+        const token = 'some invalid string';
+        spyOn(Mozilla.Cookies, 'setItem');
+        FormUtils.setUserToken(token);
+        expect(Mozilla.Cookies.setItem).not.toHaveBeenCalled();
     });
 });
 
@@ -50,7 +202,7 @@ describe('serialize', function () {
         </form>`;
         document.body.insertAdjacentHTML('beforeend', form);
         expect(
-            serialize(document.querySelector('.send-to-device-form'))
+            FormUtils.serialize(document.querySelector('.send-to-device-form'))
         ).toEqual(
             'newsletters=download-firefox-mobile-reco&source-url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Ffirefox%2Fbrowsers%2Fmobile%2Fios%2F&email=example%40example.com'
         );
@@ -60,23 +212,23 @@ describe('serialize', function () {
         const form = `<form class="send-to-device-form" action="https://basket.mozilla.org/news/subscribe/" method="post"></form>`;
         document.body.insertAdjacentHTML('beforeend', form);
         expect(
-            serialize(document.querySelector('.send-to-device-form'))
+            FormUtils.serialize(document.querySelector('.send-to-device-form'))
         ).toEqual('');
     });
 });
 
 describe('stripHTML', function () {
     it('should strip HTML tags from strings as expected', function () {
-        expect(stripHTML('This string should not contain HTML.')).toEqual(
-            'This string should not contain HTML.'
-        );
         expect(
-            stripHTML(
+            FormUtils.stripHTML('This string should not contain HTML.')
+        ).toEqual('This string should not contain HTML.');
+        expect(
+            FormUtils.stripHTML(
                 'This string<script></script> should <strong>not</strong> contain <br>HTML<img src="/img/placeholder.png" />.'
             )
         ).toEqual('This string should not contain HTML.');
         expect(
-            stripHTML(
+            FormUtils.stripHTML(
                 'This%20string%3Cscript%3E%3C%2Fscript%3E%20should%20%3Cstrong%3Enot%3C%2Fstrong%3E%20contain%20%3Cbr%3EHTML%3Cimg%20src%3D%22%2Fimg%2Fplaceholder.png%22%20%2F%3E.'
             )
         ).toEqual('This string should not contain HTML.');

--- a/tests/unit/spec/newsletter/unsubscribed.js
+++ b/tests/unit/spec/newsletter/unsubscribed.js
@@ -4,13 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import FormUtils from '../../../../media/js/newsletter/form-utils.es6';
 import UnsubscribedEmailForm from '../../../../media/js/newsletter/unsubscribed.es6';
+
+const TOKEN_MOCK = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
 
 describe('UnsubscribedEmailForm', function () {
     beforeEach(async function () {
         const form = `<section class="c-updated-block">
             <form id="newsletter-updated-form" action="https://basket.mozilla.org/news/custom_unsub_reason/" method="post" class="c-updated-block-content c-updated-form">
-            <input type="hidden" name="token" value="1234567890">
 
             <div class="mzp-c-form-errors hidden" id="newsletter-updated-form-errors">
                 <ul class="mzp-u-list-styled">
@@ -86,6 +88,7 @@ describe('UnsubscribedEmailForm', function () {
 
         it('should handle success', function () {
             spyOn(UnsubscribedEmailForm, 'handleFormSuccess').and.callThrough();
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
             UnsubscribedEmailForm.init();
             document.getElementById('unsub0').click();
             document.getElementById('unsub99').click();
@@ -98,7 +101,7 @@ describe('UnsubscribedEmailForm', function () {
             );
 
             expect(xhrRequests[0].requestBody).toEqual(
-                'token=1234567890&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6%0A%0ATest'
+                'token=a1a2a3a4-abc1-12ab-a123-12345a12345b&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6%0A%0ATest'
             );
             expect(UnsubscribedEmailForm.handleFormSuccess).toHaveBeenCalled();
             expect(
@@ -115,6 +118,7 @@ describe('UnsubscribedEmailForm', function () {
 
         it('should handle an incomplete form', function () {
             spyOn(UnsubscribedEmailForm, 'handleFormError').and.callThrough();
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
             UnsubscribedEmailForm.init();
             document.getElementById('newsletter-updated-form-submit').click();
             expect(UnsubscribedEmailForm.handleFormError).toHaveBeenCalled();
@@ -132,8 +136,8 @@ describe('UnsubscribedEmailForm', function () {
 
         it('should handle an invalid token', function () {
             spyOn(UnsubscribedEmailForm, 'handleFormError').and.callThrough();
+            spyOn(FormUtils, 'getUserToken').and.returnValue('');
             UnsubscribedEmailForm.init();
-            document.querySelector('input[name="token"]').value = '';
             document.getElementById('unsub0').click();
             document.getElementById('newsletter-updated-form-submit').click();
             expect(UnsubscribedEmailForm.handleFormError).toHaveBeenCalled();
@@ -151,6 +155,7 @@ describe('UnsubscribedEmailForm', function () {
 
         it('should handle failure', function () {
             spyOn(UnsubscribedEmailForm, 'handleFormError').and.callThrough();
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
             UnsubscribedEmailForm.init();
             document.getElementById('unsub0').click();
             document.getElementById('newsletter-updated-form-submit').click();
@@ -176,32 +181,33 @@ describe('UnsubscribedEmailForm', function () {
 
     describe('serialize', function () {
         it('should serialize form data as expected', function () {
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
             UnsubscribedEmailForm.init();
             document.getElementById('unsub0').click();
 
             const data1 = UnsubscribedEmailForm.serialize();
             expect(data1).toEqual(
-                'token=1234567890&reason=You%20send%20too%20many%20emails.'
+                'token=a1a2a3a4-abc1-12ab-a123-12345a12345b&reason=You%20send%20too%20many%20emails.'
             );
 
             document.getElementById('unsub99').click();
             const data2 = UnsubscribedEmailForm.serialize();
             expect(data2).toEqual(
-                'token=1234567890&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6'
+                'token=a1a2a3a4-abc1-12ab-a123-12345a12345b&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6'
             );
 
             document.querySelector('textarea[name="reason-text"]').value =
                 'Testing';
             const data3 = UnsubscribedEmailForm.serialize();
             expect(data3).toEqual(
-                'token=1234567890&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6%0A%0ATesting'
+                'token=a1a2a3a4-abc1-12ab-a123-12345a12345b&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6%0A%0ATesting'
             );
 
             document.querySelector('textarea[name="reason-text"]').value =
                 'Testing <script>123</script>';
             const data4 = UnsubscribedEmailForm.serialize();
             expect(data4).toEqual(
-                'token=1234567890&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6%0A%0ATesting%20123'
+                'token=a1a2a3a4-abc1-12ab-a123-12345a12345b&reason=You%20send%20too%20many%20emails.%0A%0AOther%E2%80%A6%0A%0ATesting%20123'
             );
         });
     });


### PR DESCRIPTION
## One-line summary

Removes UUID tokens from basket newsletter URLs. Pages that rely on such URLs will now remove the tokens from the URL path on page load (via the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)). Tokens are also now stored in a cookie for the front end code to reference instead.

## Significant changes and points to review

Why make this change? Whilst the token URLs allow people to easily update their newsletter preferences without requiring a frustrating login process, it is possible for users to accidentally leak their own token by sharing the URL. Clicking links to external sites from our pages can also leak the token via `document.referrer` in site analytics. This PR hopefully makes it much harder for users to accidentally share their token.

Given the above is quite a large change, it needs to be tested carefully.

## Issue / Bugzilla link

#12389

## Testing

Note: this branch is also up on https://www-demo2.allizom.org/en-US/

First get your token here: https://www.mozilla.org/en-US/newsletter/recovery/

- [x] `http://localhost:8000/en-US/newsletter/existing/YOUR_TOKEN_HERE/`
  - [x] Token is removed from the URL on page load.
    - [x] Once loaded, cookie is set successfully with a 1 hr expiry.
    - [x] Refreshing the page should still work as expected.
    - [x] Clearing the cookie and then refreshing the page should get you redirected back to the /recovery/ page.
  - [x] Preferences can still be updated as normal.
  - [x] Unsubscribing from all newsletters still works as normal.
    - [x] When filling out the survey form on `/updated/` the page should use the token from the cookie.
  - [x] Token should no longer be visible anywhere in the HTML source.
- [x] `http://localhost:8000/en-US/newsletter/country/YOUR_TOKEN_HERE/`
  - [x] Token is removed from the URL on page load.
    - [x] Once loaded, cookie is set successfully with a 1 hr expiry.
    - [x] Refreshing the page should still work as expected.
    - [x] Clearing the cookie and then refreshing the page should get you redirected back to the /recovery/ page.
  - [x] Country can still be updated as per normal.
  - [x] Token should no longer be visible anywhere in the HTML source.
- [x] `http://localhost:8000/en-US/newsletter/confirm/YOUR_TOKEN_HERE/`
  - Normally this URL should redirect to /existing/. However if there's an issue with Basket (e.g. it's down), then URL will render a template instead. The only way I could force this locally was by setting `success = False` [here](https://github.com/mozilla/bedrock/blob/main/bedrock/newsletter/views.py#L95).
  - [x] The template does not need a token at all, so now it should simply redirect to http://localhost:8000/en-US/newsletter/confirm/thanks/

