### PR TITLE
Update resp_img() helper to support absolute URLs (Fixes #12625)

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -225,7 +225,7 @@ def high_res_img(ctx, url, optional_attributes=None):
 
 @library.global_function
 @jinja2.pass_context
-def resp_img(ctx, url, srcset=None, sizes=None, optional_attributes=None):
+def resp_img(ctx={}, url=None, srcset=None, sizes=None, optional_attributes=None):
     alt = ""
     attrs = ""
     final_sizes = ""

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -240,14 +240,16 @@ def resp_img(ctx, url, srcset=None, sizes=None, optional_attributes=None):
             attrs = " " + " ".join(f'{attr}="{val}"' for attr, val in optional_attributes.items())
 
     # default src
-    url = l10n_img(ctx, url) if l10n else static(url)
+    if not url.startswith("https://"):
+        url = l10n_img(ctx, url) if l10n else static(url)
 
     if srcset:
         srcset_last_item = list(srcset)[-1]
         for image, size in srcset.items():
             postfix = "" if image == srcset_last_item else ","
-            img = l10n_img(ctx, image) if l10n else static(image)
-            final_srcset = final_srcset + img + " " + size + postfix
+            if not image.startswith("https://"):
+                image = l10n_img(ctx, image) if l10n else static(image)
+            final_srcset = final_srcset + image + " " + size + postfix
 
     if sizes:
         sizes_last_item = list(sizes)[-1]

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -270,7 +270,7 @@ def resp_img(ctx={}, url=None, srcset=None, sizes=None, optional_attributes=None
 
 @library.global_function
 @jinja2.pass_context
-def picture(ctx, url, sources, optional_attributes=None):
+def picture(ctx={}, url=None, sources=[], optional_attributes=None):
     alt = ""
     attrs = ""
     final_sources = []
@@ -284,7 +284,8 @@ def picture(ctx, url, sources, optional_attributes=None):
             attrs = " " + " ".join(f'{attr}="{val}"' for attr, val in optional_attributes.items())
 
     # default src
-    url = l10n_img(ctx, url) if l10n else static(url)
+    if not url.startswith("https://"):
+        url = l10n_img(ctx, url) if l10n else static(url)
 
     # sources
     for source in sources:
@@ -300,11 +301,12 @@ def picture(ctx, url, sources, optional_attributes=None):
             srcset_last_item = list(source_srcset)[-1]
             for image, descriptor in source_srcset.items():
                 postfix = "" if image == srcset_last_item else ","
-                img = l10n_img(ctx, image) if l10n else static(image)
+                if not url.startswith("https://"):
+                    image = l10n_img(ctx, image) if l10n else static(image)
                 if descriptor == "default":
-                    final_srcset = final_srcset + img + postfix
+                    final_srcset = final_srcset + image + postfix
                 else:
-                    final_srcset = final_srcset + img + " " + descriptor + postfix
+                    final_srcset = final_srcset + image + " " + descriptor + postfix
 
         # sizes
         if source_sizes:

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -662,6 +662,24 @@ class TestPicture(TestCase):
         )
         self.assertEqual(markup, expected)
 
+    def test_picture_absolute_urls(self):
+        """Should return expected markup when absolute image urls are passed"""
+        expected = (
+            "<picture>"
+            '<source media="(max-width: 799px)" srcset="https://www.example.com/img/panda-mobile.png">'
+            '<source media="(min-width: 800px)" srcset="https://www.example.com/img/panda-desktop.png">'
+            '<img src="https://www.example.com/img/panda-mobile.png" alt="">'
+            "</picture>"
+        )
+        markup = self._render(
+            "https://www.example.com/img/panda-mobile.png",
+            [
+                {"media": "(max-width: 799px)", "srcset": {"https://www.example.com/img/panda-mobile.png": "default"}},
+                {"media": "(min-width: 800px)", "srcset": {"https://www.example.com/img/panda-desktop.png": "default"}},
+            ],
+        )
+        self.assertEqual(markup, expected)
+
     def test_picture_media_multiple_srcset_sizes(self):
         """Should return expected markup when specifying media with multiple srcset and sizes"""
         expected = (

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -548,6 +548,20 @@ class TestRespImg(TestCase):
         )
         self.assertEqual(markup, expected)
 
+    def test_resp_img_absolute_urls(self):
+        """Should return expected markup when absolute image URLs are passed"""
+        expected = (
+            '<img src="https://www.example.com/img/panda-500.png" '
+            'srcset="https://www.example.com/img/panda-500.png 500w,https://www.example.com/img/panda-1000.png 1000w" '
+            'sizes="(min-width: 1000px) calc(50vw - 200px),calc(100vw - 50px)" alt="">'
+        )
+        markup = self._render(
+            "https://www.example.com/img/panda-500.png",
+            {"https://www.example.com/img/panda-500.png": "500w", "https://www.example.com/img/panda-1000.png": "1000w"},
+            {"(min-width: 1000px)": "calc(50vw - 200px)", "default": "calc(100vw - 50px)"},
+        )
+        self.assertEqual(markup, expected)
+
     def test_resp_img_with_optional_attributes(self):
         """Should return expected markup with optional attributes"""
         expected = (


### PR DESCRIPTION
## One-line summary

Updates `resp_img()` helper to support absolute image URLs.

## Issue / Bugzilla link

#12625

## Testing

I added tests but please give this a try locally as well.