### PR TITLE
Fix picture helper (Fixes #12633)

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -301,7 +301,7 @@ def picture(ctx={}, url=None, sources=[], optional_attributes=None):
             srcset_last_item = list(source_srcset)[-1]
             for image, descriptor in source_srcset.items():
                 postfix = "" if image == srcset_last_item else ","
-                if not url.startswith("https://"):
+                if not image.startswith("https://"):
                     image = l10n_img(ctx, image) if l10n else static(image)
                 if descriptor == "default":
                     final_srcset = final_srcset + image + postfix


### PR DESCRIPTION
Fixes: https://github.com/mozilla/bedrock/issues/12633

Regression was due to a some copy pasta, which didn't show up locally since there `static()` resolves to a relative path, whereas when deployed image URLs are absolute.

Demo: https://www-demo1.allizom.org/en-US/products/vpn/