### PR TITLE
Revert "Fix #12667: Change to using a setting to determine if in prod"

### DIFF
--- a/bedrock/base/geo.py
+++ b/bedrock/base/geo.py
@@ -14,8 +14,9 @@ def valid_country_code(country):
 
 
 def get_country_from_param(request):
+    is_prod = request.get_host() == "www.mozilla.org"
     country_code = valid_country_code(request.GET.get("geo"))
-    return country_code if not settings.IS_PROD else None
+    return country_code if not is_prod else None
 
 
 def get_country_from_header(request):

--- a/bedrock/base/tests/test_context_processors.py
+++ b/bedrock/base/tests/test_context_processors.py
@@ -56,9 +56,8 @@ class TestContext(TestCase):
         assert self.render("{{ country_code }}", req) == "FR"
 
         # should use header if at prod domain
-        with override_settings(IS_PROD=True):
-            req = self.factory.get("/", data={"geo": "fr"}, HTTP_CF_IPCOUNTRY="de")
-            assert self.render("{{ country_code }}", req) == "DE"
+        req = self.factory.get("/", data={"geo": "fr"}, HTTP_CF_IPCOUNTRY="de", HTTP_HOST="www.mozilla.org")
+        assert self.render("{{ country_code }}", req) == "DE"
 
     @override_settings(DEV=False)
     def test_invalid_geo_param(self):

--- a/bedrock/base/tests/test_geo.py
+++ b/bedrock/base/tests/test_geo.py
@@ -39,9 +39,8 @@ class TestGeo(TestCase):
         assert get_country_from_request(req) == "FR"
 
         # should use header if at prod domain
-        with override_settings(IS_PROD=True):
-            req = self.factory.get("/", data={"geo": "fr"}, HTTP_CF_IPCOUNTRY="de")
-            assert get_country_from_request(req) == "DE"
+        req = self.factory.get("/", data={"geo": "fr"}, HTTP_CF_IPCOUNTRY="de", HTTP_HOST="www.mozilla.org")
+        assert get_country_from_request(req) == "DE"
 
     @override_settings(DEV=False)
     def test_invalid_geo_param(self):

--- a/bedrock/mozorg/templates/mozorg/robots.txt
+++ b/bedrock/mozorg/templates/mozorg/robots.txt
@@ -7,4 +7,4 @@ disallow: /*/newsletter/existing/
 disallow: /*/whatsnew/
 disallow: /*/etc/
 {% endif -%}
-Sitemap: https://{{ hostname }}/sitemap.xml
+Sitemap: {{ request.scheme }}://{{ request.get_host() }}/sitemap.xml

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -7,7 +7,6 @@ from unittest.mock import ANY, Mock, patch
 
 from django.core import mail
 from django.http.response import HttpResponse
-from django.test import override_settings
 from django.test.client import RequestFactory
 
 import pytest
@@ -43,18 +42,16 @@ class TestRobots(TestCase):
         self.rf = RequestFactory()
         self.view = views.Robots()
 
-    @override_settings(IS_PROD=True)
     def test_production_disallow_all_is_false(self):
-        self.view.request = self.rf.get("/")
+        self.view.request = self.rf.get("/", HTTP_HOST="www.mozilla.org")
         self.assertFalse(self.view.get_context_data()["disallow_all"])
 
     def test_non_production_disallow_all_is_true(self):
         self.view.request = self.rf.get("/", HTTP_HOST="www.allizom.org")
         self.assertTrue(self.view.get_context_data()["disallow_all"])
 
-    @override_settings(IS_PROD=True)
     def test_robots_no_redirect(self):
-        response = self.client.get("/robots.txt")
+        response = self.client.get("/robots.txt", HTTP_HOST="www.mozilla.org")
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context_data["disallow_all"])
         self.assertEqual(response.get("Content-Type"), "text/plain")

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -65,12 +65,7 @@ class Robots(RequireSafeMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         hostname = self.request.get_host()
-        disallow_all = True
-        if settings.IS_PROD:
-            disallow_all = False
-            hostname = "www.mozilla.org"
-
-        return {"disallow_all": disallow_all, "hostname": hostname}
+        return {"disallow_all": not hostname == "www.mozilla.org"}
 
 
 NAMESPACES = {

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -543,9 +543,6 @@ APP_NAME = config("APP_NAME", default=get_app_name(HOSTNAME))
 CLUSTER_NAME = config("CLUSTER_NAME", default="")
 ENABLE_HOSTNAME_MIDDLEWARE = config("ENABLE_HOSTNAME_MIDDLEWARE", default=str(bool(APP_NAME)), parser=bool)
 ENABLE_VARY_NOCACHE_MIDDLEWARE = config("ENABLE_VARY_NOCACHE_MIDDLEWARE", default="true", parser=bool)
-# this will be True when the site is running in production
-# in either mozorg or pocket mode
-IS_PROD = APP_NAME == "bedrock-prod"
 # set this to enable basic auth for the entire site
 # e.g. BASIC_AUTH_CREDS="thedude:thewalrus"
 BASIC_AUTH_CREDS = config("BASIC_AUTH_CREDS", default="")


### PR DESCRIPTION
@bkochendorfer has fixed the CDN for us so that it will send the proper Host header for the original behavior to work. We'd like the original behavior back for two reasons:

1. When you access the prod website from the origin domain the robots.txt currently allows crawling because it's the prod infra, but the old way would disallow crawling except at the real prod domain. Blocking crawling of all non-prod domains is best.
2. Some of our integration tests rely on using the `?geo=XX` param for testing against the origin domains, but we don't allow that param to work in prod for security reasons. Allowing the tests to pass on prod infra and non-prod domains is preferable. 

This reverts commit 320e674b6d81a4bbab9c410f28cd4d19ad04154f.
