### PR TITLE
Family: fix horizontal spacing in hero CTA (fixes #12691)

### DIFF
--- a/media/css/firefox/family/components/_hero.scss
+++ b/media/css/firefox/family/components/_hero.scss
@@ -79,6 +79,7 @@ $image-path: '/media/protocol/img';
 
         @media #{$mq-md} {
             display: flex; // allow logo to share same line as text
+            gap: $spacing-sm;
         }
     }
 


### PR DESCRIPTION
## One-line summary

Adds gap between text and logo on larger screens in Family page Hero CTA

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12691


## Screenshots
issue
<img width="451" alt="Screen Shot 2023-02-02 at 3 01 30 PM" src="https://user-images.githubusercontent.com/19650432/216363555-e7d9a975-6578-4d8d-b434-dc3df32f3449.png">

fix
<img width="603" alt="Screen Shot 2023-02-02 at 3 13 57 PM" src="https://user-images.githubusercontent.com/19650432/216363618-53c786d7-5e92-4114-8474-32275099b120.png">

## Testing

To test this work:

- [ ] http://localhost:8000/en-US/firefox/family/
horizontal space creates gap between text and logo
