### PR TITLE
Add empty alt attribute for homepage contentful images

### DIFF
--- a/bedrock/contentful/templates/includes/contentful/all.html
+++ b/bedrock/contentful/templates/includes/contentful/all.html
@@ -108,7 +108,7 @@
         {% set loading = 'lazy' %}
       {% endif %}
 
-      {% set image = '<img class="mzp-c-split-media-asset" src="' ~ entry.image ~ '" loading="' ~ loading ~ '">' %}
+      {% set image = '<img class="mzp-c-split-media-asset" src="' ~ entry.image ~ '" loading="' ~ loading ~ '" alt="">' %}
 
       {% call split(
         block_class=entry.block_class,


### PR DESCRIPTION
## One-line summary

Add empty alt attribute for homepage Contentful images so HTML validation passes.

This is not ideal. Ideal is actual descriptive image text! But this is an incremental improvement.