### PR TITLE
Expired token error message should link to recovery form (Fixes ##12685)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -20,8 +20,14 @@
 
 {% block body_class %}newsletter-management{% endblock %}
 
+{% set recovery_href = 'href="' + url('newsletter.recovery') + '"'|escape %}
+
 {% block string_data %}
-  data-error-token-not-found="{{ ftl('newsletters-the-supplied-link-has-expired') }}"
+  {% if ftl_has_messages('newsletters-the-supplied-link-has-expired-v2') %}
+    data-error-token-not-found="{{ ftl('newsletters-the-supplied-link-has-expired-v2', recovery_href=recovery_href) }}"
+  {% else %}
+    data-error-token-not-found="{{ ftl('newsletters-the-supplied-link-has-expired') }}"
+  {% endif %}
   data-error-invalid-email="{{ ftl('newsletters-this-is-not-a-valid-email') }}"
   data-error-invalid-newsletter="{{ ftl('newsletters-is-not-a-valid-newsletter', newsletter='%newsletter%') }}"
   data-error-select-country="{{ ftl('newsletters-please-select-country') }}"

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -35,7 +35,6 @@ FTL_FILES = ["mozorg/newsletters"]
 
 general_error = ftl_lazy("newsletters-we-are-sorry-but-there", ftl_files=FTL_FILES)
 thank_you = ftl_lazy("newsletters-your-email-preferences", fallback="newsletters-thanks-for-updating-your", ftl_files=FTL_FILES)
-bad_token = ftl_lazy("newsletters-the-supplied-link-has-expired-long", ftl_files=FTL_FILES)
 invalid_email_address = ftl_lazy("newsletters-this-is-not-a-valid-email", ftl_files=FTL_FILES)
 
 UNSUB_UNSUBSCRIBED_ALL = 1

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -28,7 +28,14 @@ newsletters-please-be-sure-to-add-our-v2 = Please be sure to add our sending add
 
 # Obsolete string
 newsletters-please-be-sure-to-add-our = Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.
+
+# Variables:
+#   $recovery_href (url) - link href to https://www.mozilla.org/newsletter/recovery/
+newsletters-the-supplied-link-has-expired-v2 = The supplied link has expired. Please <a { $recovery_href }>request a new link here</a>.
+
+# Obsolete string
 newsletters-the-supplied-link-has-expired = The supplied link has expired. You will receive a new one in the next newsletter.
+
 newsletters-something-is-amiss-with = Something is amiss with our system, sorry! Please try again later.
 newsletters-youre-awesome = You’re awesome!
 newsletters-and-were-not-just-saying = And we’re not just saying that because you trusted us with your email address.
@@ -137,7 +144,6 @@ newsletters-see-where-the-web-can-take = See where the Web can take you with mon
 
 newsletters-we-are-sorry-but-there = We are sorry, but there was a problem with our system. Please try again later!
 newsletters-thanks-for-updating-your = Thanks for updating your email preferences.
-newsletters-the-supplied-link-has-expired-long = The supplied link has expired or is not valid. You will receive a new one in the next newsletter, or below you can request an email with the link.
 newsletters-success-an-email-has-been-sent = Success! An email has been sent to you with your preference center link. Thanks!
 newsletters-this-is-not-a-valid-email = This is not a valid email address. Please check the spelling.
 newsletters-you-send-too-many-emails = You send too many emails.


### PR DESCRIPTION
## One-line summary

Updates error message string to link to recovery form when newsletter token has expired.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/12685

## Testing

- [x] http://localhost:8000/en-US/newsletter/existing/f0fd014f-ae66-4a0e-a272-d45229d5963f/
