### PR TITLE
Lazy load images in the sticky promo

### DIFF
--- a/bedrock/base/templates/includes/sticky-promo.html
+++ b/bedrock/base/templates/includes/sticky-promo.html
@@ -17,23 +17,23 @@
       <ul class="promo-products-list">
         <li>
           <a data-link-name="Browsers" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="{{ url('firefox.browsers.index') }}">
-            <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" width="32" height="32" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" width="32" height="32" alt="" loading="lazy">
             {{ ftl('firefox-sticky-promo-browsers') }}
           </a>
           <a data-link-name="Monitor" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="https://monitor.firefox.com/{{ promo_referrals }}" rel="external noopener">
-            <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" width="32" height="32" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" width="32" height="32" alt="" loading="lazy">
             {{ ftl('firefox-sticky-promo-monitor') }}
           </a>
           <a data-link-name="Pocket" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://getpocket.com/{{ promo_referrals }}">
-            <img src="{{ static('protocol/img/logos/pocket/logo.svg') }}" width="32" height="29" alt="">
+            <img src="{{ static('protocol/img/logos/pocket/logo.svg') }}" width="32" height="29" alt="" loading="lazy">
             {{ ftl('firefox-sticky-promo-pocket') }}
           </a>
           <a data-link-name="Mozilla VPN" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="{{ url('products.vpn.landing') }}">
-            <img src="{{ static('protocol/img/logos/mozilla/vpn/logo-flat-white.svg') }}" width="32" height="35" alt="">
+            <img src="{{ static('protocol/img/logos/mozilla/vpn/logo-flat-white.svg') }}" width="32" height="35" alt="" loading="lazy">
             {{ ftl('firefox-sticky-promo-mozilla-vpn') }}
           </a>
           <a data-link-name="Relay" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://relay.firefox.com/{{ promo_referrals }}">
-            <img src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" width="32" height="32" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" width="32" height="32" alt="" loading="lazy">
             {{ ftl('firefox-sticky-promo-relay') }}
           </a>
         </li>


### PR DESCRIPTION
## One-line summary

Lazy load images in the sticky promo to improve page load experience.

## Issue / Bugzilla link

n/a

## Testing

Demo server URL: (or None)

To test this work:

Sticky promo appears on http://localhost:8000/en-US/firefox/ Watch the Dev Tools network panel to see that the images are loaded late.