### PR TITLE
Fix #12705: Add system git config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-install gettext libxslt1.1 git curl
 COPY --from=python-builder /venv /venv
 
 # changes infrequently
+COPY docker/gitconfig /etc/
 COPY ./bin ./bin
 COPY ./etc ./etc
 COPY ./lib ./lib

--- a/docker/gitconfig
+++ b/docker/gitconfig
@@ -1,0 +1,7 @@
+# system git config for docker containers
+# copied to /etc/gitconfig
+
+; see https://github.com/mozilla/bedrock/issues/12705
+[safe]
+	directory = /app/data/www-l10n
+	directory = /app/data/pocket-www-l10n


### PR DESCRIPTION
Including makring the l10n git repos as "safe".
