### PR TITLE
Add width to images in /firefox

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -54,7 +54,7 @@
 
     {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
 
-    <img src="{{ static('img/firefox/browsers/browser-history/browser-history-a.png') }}" alt="" class="c-article-image">
+    <img src="{{ static('img/firefox/browsers/browser-history/browser-history-a.png') }}" alt="" class="c-article-image" width="954" height="372">
 
     <h2 class="c-section-title">{{ ftl('browser-history-before-web-era') }}</h2>
 
@@ -86,7 +86,7 @@
 
     <p>{{ ftl('browser-history-other-competitors') }}</p>
 
-    <img src="{{ static('img/firefox/browsers/browser-history/browser-history-b.png') }}" alt="" class="c-article-image">
+    <img src="{{ static('img/firefox/browsers/browser-history/browser-history-b.png') }}" alt="" class="c-article-image" width="954" height="372">
 
     <h2 class="mzp-c-article-title">{{ ftl('browser-history-browsing-the-web') }}</h2>
 

--- a/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
@@ -29,7 +29,7 @@
 
     {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
 
-    <img src="{{ static('img/firefox/browsers/incognito-browser/incognito-browser-a.png') }}" alt="" class="c-article-image">
+    <img src="{{ static('img/firefox/browsers/incognito-browser/incognito-browser-a.png') }}" alt="" class="c-article-image" width="954" height="372">
 
     <h2 class="c-section-title">What Incognito/Private Mode Does</h2>
 
@@ -95,7 +95,7 @@
       which is how some ads follow you into social media.
     </p>
 
-    <img src="{{ static('img/firefox/browsers/incognito-browser/incognito-browser-b.png') }}" alt="" class="c-article-image">
+    <img src="{{ static('img/firefox/browsers/incognito-browser/incognito-browser-b.png') }}" alt="" class="c-article-image" width="954" height="361">
 
     <h2 class="c-section-title-large">Going Incognito</h2>
 

--- a/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
@@ -395,7 +395,7 @@
   {% else %}
     <p>{{ ftl('mobile-compare-scan-the-qr-code-to-get-started') }}</p>
     <div class="qr-code-wrapper">
-      <img src="{{ static('img/firefox/browsers/mobile/qr-firefox.png') }}" id="firefox-qr" data-mozillaonline-link="{{ static('img/firefox/browsers/mobile/qr-firefox-mozillaonline.png') }}" alt="{{ ftl('mobile-compare-scan-alt-text') }}">
+      <img src="{{ static('img/firefox/browsers/mobile/qr-firefox.png') }}" id="firefox-qr" data-mozillaonline-link="{{ static('img/firefox/browsers/mobile/qr-firefox-mozillaonline.png') }}" alt="{{ ftl('mobile-compare-scan-alt-text') }}" width="350" height="350">
     </div>
   {% endif %}
   </section>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -112,7 +112,7 @@
     </div>
 
     <div class="c-landing-grid-item">
-      <img src="{{ static('img/firefox/browsers/mobile/index/compare-mobile-browsers.svg') }}" alt="" class="c-landing-grid-img" width="350" height=""350>
+      <img src="{{ static('img/firefox/browsers/mobile/index/compare-mobile-browsers.svg') }}" alt="" class="c-landing-grid-img" width="350" height="350">
       <h2 class="c-landing-grid-title">
         <a href="{{ url('firefox.browsers.mobile.compare') }}" data-cta-type="link" data-cta-text="Compare Mobile Browsers">{{ ftl('browsers-mobile-compare-mobile-browsers') }}</a>
       </h2>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -112,7 +112,7 @@
     </div>
 
     <div class="c-landing-grid-item">
-      <img src="{{ static('img/firefox/browsers/mobile/index/compare-mobile-browsers.svg') }}" alt="" class="c-landing-grid-img">
+      <img src="{{ static('img/firefox/browsers/mobile/index/compare-mobile-browsers.svg') }}" alt="" class="c-landing-grid-img" width="350" height=""350>
       <h2 class="c-landing-grid-title">
         <a href="{{ url('firefox.browsers.mobile.compare') }}" data-cta-type="link" data-cta-text="Compare Mobile Browsers">{{ ftl('browsers-mobile-compare-mobile-browsers') }}</a>
       </h2>

--- a/bedrock/firefox/templates/firefox/browsers/update-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/update-browser.html
@@ -56,7 +56,7 @@
     {% endwith %}
     </p>
 
-    <img src="{{ static('img/firefox/browsers/update-browser/device.png') }}" alt="" class="c-article-image">
+    <img src="{{ static('img/firefox/browsers/update-browser/device.png') }}" alt="" class="c-article-image" width="1232" height="806">
     <h1 class="mzp-c-article-title">Why Firefox?</h1>
     <p>
         Firefox is independent and a part of the not-for-profit Mozilla, which fights for your online rights, keeps corporate powers in check and makes the internet accessible to everyone, everywhere. We believe the internet is for people, not profit. Unlike other companies, we don’t sell access to your data. You’re in control over who sees your search and browsing history. All that and exceptional performance too.

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -44,7 +44,7 @@
 
     {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
 
-    <img src="{{ static('img/firefox/browsers/what-is-a-browser/illo-browser.png') }}" alt="" class="c-article-image">
+    <img src="{{ static('img/firefox/browsers/what-is-a-browser/illo-browser.png') }}" alt="" class="c-article-image" width="954" height="446">
 
     <p>{{ ftl('what-is-a-browser-the-web-is-a-vast') }}</p>
 

--- a/bedrock/firefox/templates/firefox/developer/includes/features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/features.html
@@ -11,7 +11,7 @@
 
   <ul class="c-gallery-grid">
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-inspector.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-inspector.svg') }}" alt="" width="202" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-inspector') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-inspect-and-refine') }}
@@ -26,7 +26,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-console.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-console.svg') }}" alt="" width="182" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-console') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-track-css') }}
@@ -41,7 +41,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-debugger.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-debugger.svg') }}" alt="" width="202" height="110">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-debugger') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-powerful-javascript') }}
@@ -56,7 +56,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-network.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-network.svg') }}" alt="" width="202" height="108">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-network') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-monitor-network-requests') }}
@@ -71,7 +71,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-storage.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-storage.svg') }}" alt="" width="134" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-storage-panel') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-add-modify-remove') }}
@@ -86,7 +86,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-responsive-mode.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-responsive-mode.svg') }}" alt="" width="194" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-responsive-design-mode') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-test-sites-emulated') }}
@@ -101,7 +101,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-visual-editing.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-visual-editing.svg') }}" alt="" width="112" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-visual-editing') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-fine-tuning-animations') }}
@@ -116,7 +116,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-performance.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-performance.svg') }}" alt="" width="202" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-performance') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-unblock-bottlenecks') }}
@@ -131,7 +131,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-memory.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-memory.svg') }}" alt="" width="116" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-memory') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-find-memory-leaks') }}
@@ -146,7 +146,7 @@
     </li>
 
     <li class="c-gallery-item">
-      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-style-editor.svg') }}" alt="">
+      <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-style-editor.svg') }}" alt="" width="126" height="124">
       <h3 class="c-feature-name">{{ ftl('firefox-developer-style-editor') }}</h3>
       <p class="c-feature-desc">
         {{ ftl('firefox-developer-edit-and-manage') }}

--- a/bedrock/firefox/templates/firefox/developer/includes/highlights.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/highlights.html
@@ -8,7 +8,7 @@
   <div class="c-gallery-grid">
     {% if ftl_has_messages('firefox-developer-new-tools', 'firefox-developer-firefox-devtools-now-grays-out') %}
       <div class="c-gallery-item" id="devtools">
-        <a href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools" rel="external">
+        <a href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools" rel="external" width="416" height="208">
           {{ high_res_img('img/firefox/developer/hero-inactive-css.png', {'alt': ftl('firefox-developer-inactive-css'), 'class': 'highlight-image'}) }}
         </a>
         <h2 class="c-title">{{ ftl('firefox-developer-new-tools') }}</h2>
@@ -23,7 +23,7 @@
     {% endif %}
     <div class="c-gallery-item" id="devtools">
       <a href="https://mozilladevelopers.github.io/playground/debugger/" rel="external">
-        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-debugger-ani.gif') }}" alt="{{ ftl('firefox-developer-firefox-devtools') }}">
+        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-debugger-ani.gif') }}" alt="{{ ftl('firefox-developer-firefox-devtools') }}" width="416" height="208">
       </a>
       <h2 class="c-title">{{ ftl('firefox-developer-new-tools') }}</h2>
       <h3 class="c-subtitle">{{ ftl('firefox-developer-firefox-devtools') }}</h3>
@@ -37,7 +37,7 @@
 
     <div class="c-gallery-item" id="cssgrid">
       <a href="https://mozilladevelopers.github.io/playground/css-grid/" rel="external">
-        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-cssgrid-ani.gif') }}" alt="{{ ftl('firefox-developer-master-css-grid') }}">
+        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-cssgrid-ani.gif') }}" alt="{{ ftl('firefox-developer-master-css-grid') }}" width="416" height="208">
       </a>
       <h2 class="c-title">{{ ftl('firefox-developer-master-innovative-features') }}</h2>
       <h3 class="c-subtitle">{{ ftl('firefox-developer-master-css-grid') }}</h3>
@@ -53,7 +53,7 @@
       {% if not ftl_has_messages('firefox-developer-new-tools', 'firefox-developer-firefox-devtools-now-grays-out') %}
         <div class="c-gallery-item">
           <a rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/">
-            <img class="highlight-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="{{ ftl('firefox-developer-shapes-editor') }}">
+            <img class="highlight-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="{{ ftl('firefox-developer-shapes-editor') }}" width="416" height="208">
           </a>
           <h2 class="c-title">{{ ftl('firefox-developer-convenient-features') }}</h2>
           <h3 class="c-subtitle">{{ ftl('firefox-developer-shapes-editor') }}</h3>
@@ -66,7 +66,7 @@
 
       <div class="c-gallery-item">
         <a rel="external" href="https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_fonts/">
-          <img class="highlight-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="{{ ftl('firefox-developer-fonts-panel') }}">
+          <img class="highlight-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="{{ ftl('firefox-developer-fonts-panel') }}" width="416" height="208">
         </a>
         <h2 class="c-title">{{ ftl('firefox-developer-faster-innovation') }}</h2>
         <h3 class="c-subtitle">{{ ftl('firefox-developer-fonts-panel') }}</h3>

--- a/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
@@ -6,17 +6,17 @@
 
 <ul class="c-gallery-grid">
   <li class="c-gallery-item">
-    <img class="icon" src="{{ static('img/firefox/developer/devtools-icon.svg') }}" alt="">
+    <img class="icon" src="{{ static('img/firefox/developer/devtools-icon.svg') }}" alt="" width="96" height="96">
     <h3 class="c-title">{{ ftl('firefox-developer-firefox-devtools') }}</h3>
     <p><a href="#devtools" class="mzp-c-cta-link">{{ ftl('ui-learn-more') }}</a></p>
   </li>
   <li class="c-gallery-item">
-    <img class="icon" src="{{ static('img/firefox/developer/css-grid-icon.svg') }}" alt="">
+    <img class="icon" src="{{ static('img/firefox/developer/css-grid-icon.svg') }}" alt="" width="96" height="96">
     <h3 class="c-title">{{ ftl('firefox-developer-master-css-grid') }}</h3>
     <p><a href="#cssgrid" class="mzp-c-cta-link">{{ ftl('ui-learn-more') }}</a></p>
   </li>
   <li class="c-gallery-item">
-    <img class="icon" src="{{ static('img/firefox/developer/next-gen-icon.svg') }}" alt="">
+    <img class="icon" src="{{ static('img/firefox/developer/next-gen-icon.svg') }}" alt="" width="96" height="96">
     <h3 class="c-title">{{ ftl('firefox-developer-built-for-developers', fallback='firefox-developer-next-gen-css-engine') }}</h3>
     <p><a href="#fordevs" class="mzp-c-cta-link">{{ ftl('ui-learn-more')}}</a></p>
   </li>

--- a/bedrock/firefox/templates/firefox/family/includes/download-firefox.html
+++ b/bedrock/firefox/templates/firefox/family/includes/download-firefox.html
@@ -8,7 +8,7 @@
   <div class="mzp-l-content mzp-t-content-md">
     <div class="mzp-c-wordmark mzp-t-wordmark-lg mzp-t-product-firefox">Firefox</div>
 
-    <h2 class="c-download-firefox-title">We <img src="{{ static('img/firefox/family/icon-heart-outline.svg') }}" alt="heart"> <br>all families</h2>
+    <h2 class="c-download-firefox-title">We <img src="{{ static('img/firefox/family/icon-heart-outline.svg') }}" alt="heart" width="68" height="68"> <br>all families</h2>
     <p>Firefox is made in part by lots of real-life, tired yet strangely optimistic
       parents, and we’re backed by an awesome non-profit too.</p>
 

--- a/bedrock/firefox/templates/firefox/features/bookmarks.html
+++ b/bedrock/firefox/templates/firefox/features/bookmarks.html
@@ -26,7 +26,7 @@
 {% block content %}
   <header class="c-hero">
     <div class="mzp-l-content c-hero-content">
-      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/pink/feature-bookmarks-star.svg')}}" alt="">
+      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/pink/feature-bookmarks-star.svg')}}" alt="" width="64" height="64">
       <h1 class="c-hero-title">{{ ftl('features-bookmarks-better-bookmarks')}}</h1>
       <p class="c-hero-desc">{{ ftl('features-bookmarks-dont-agonize-lovers-of')}}</p>
       <div class="c-hero-cta">

--- a/bedrock/firefox/templates/firefox/features/fast.html
+++ b/bedrock/firefox/templates/firefox/features/fast.html
@@ -26,7 +26,7 @@
 {% block content %}
   <header class="c-hero">
     <div class="mzp-l-content c-hero-content">
-      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/orange/speedometer.svg')}}" alt="">
+      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/orange/speedometer.svg')}}" alt="" width="64" height="64">
       <h1 class="c-hero-title">{{ ftl('features-fast-firefox-is-now-faster-and-leaner') }}</h1>
       <p class="c-hero-desc">{{ ftl('features-fast-weve-been-working-out-so-you') }}</p>
       <div class="c-hero-cta">

--- a/bedrock/firefox/templates/firefox/features/includes/pip-video.html
+++ b/bedrock/firefox/templates/firefox/features/includes/pip-video.html
@@ -12,7 +12,7 @@
     </video>
   {% else %}
     <a class="video-play js-video-play" href="https://youtu.be/F-nFQryDB0s" data-id="F-nFQryDB0s" data-video-title="Red Panda Cubs - Firefox + Woodland Park Zoo" title="{{ ftl('features-pip-play-the-video') }}">
-      <img src="{{ static('img/firefox/features/pip/video-poster.jpg') }}" alt="">
+      <img src="{{ static('img/firefox/features/pip/video-poster.jpg') }}" alt="" width="1024" height="576">
     </a>
   {% endif %}
 </div>

--- a/bedrock/firefox/templates/firefox/features/memory.html
+++ b/bedrock/firefox/templates/firefox/features/memory.html
@@ -26,7 +26,7 @@
 {% block content %}
   <header class="c-hero">
     <div class="mzp-l-content c-hero-content">
-      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/orange/microchip.svg')}}" alt="">
+      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/orange/microchip.svg')}}" alt="" width="64" height="64">
       <h1 class="c-hero-title">{{ ftl('features-memory-less-memory-usage-than-chrome') }}</h1>
       <p class="c-hero-desc">{{ ftl('features-memory-if-your-web-browser-uses') }}</p>
       <div class="c-hero-cta">

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -27,7 +27,7 @@
 {% block content %}
   <header class="c-hero">
     <div class="mzp-l-content c-hero-content">
-      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/violet/password.svg')}}" alt="">
+      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/violet/password.svg')}}" alt="" width="64" height="64">
       <h1 class="c-hero-title">{{ ftl('password-manager-password-manager') }}</h1>
       <p class="c-hero-desc">{{ ftl('password-manager-give-up-the-memory') }}</p>
       <div class="c-hero-cta">

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -26,7 +26,7 @@
 {% block content %}
   <header class="c-hero">
     <div class="mzp-l-content c-hero-content">
-      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/violet/feature-private-browsing-mask.svg')}}" alt="">
+      <img class="c-hero-icon" src="{{ static('protocol/img/icons/brand/violet/feature-private-browsing-mask.svg')}}" alt="" width="64" height="64">
       <h1 class="c-hero-title">{{ ftl('features-private-browsing-firefox-more-protection') }}</h1>
       <p class="c-hero-desc">{{ ftl('features-private-browsing-were-obsessed-with') }}</p>
       <div class="c-hero-cta">

--- a/bedrock/firefox/templates/firefox/features/safebrowser.html
+++ b/bedrock/firefox/templates/firefox/features/safebrowser.html
@@ -40,7 +40,7 @@ You have the right to internet safety. That’s why Firefox has features and add
     <p class="mzp-c-article-intro">
       Building a safe browser is an art and a science because there are no set rules. At Firefox, we believe you have the right to privacy on the internet. After all, the web is your home away from home, your workspace or your storage unit.
     </p>
-    <img src="{{ static('img/firefox/features/safebrowser-lock.png')}}" alt="">
+    <img src="{{ static('img/firefox/features/safebrowser-lock.png')}}" alt="" width="580" height="350">
     <p>
       When stepping inside a home or office, it’s your right to be comfortable, safe and secure. There’s no looking over your shoulder. You can shut the blinds or choose not to answer the door. The web should be no different.
     </p>

--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -53,7 +53,7 @@
     <p><a class="mzp-c-button mzp-t-product" href="https://addons.mozilla.org/firefox/addon/to-google-translate/" rel="external noopener">{{ ftl('features-translate-get-the-extension') }}</a></p>
     <p>{{ ftl('features-translate-once-installed-simply') }}</p>
 
-    <img src="{{ static('img/firefox/features/translate/translation.png') }}" alt="">
+    <img src="{{ static('img/firefox/features/translate/translation.png') }}" alt="" width="1230" height="797">
 
     <h2>{{ ftl('features-translate-switch-languages-in') }}</h2>
     <p>{{ ftl('features-translate-if-you-are', attrs='href="https://support.mozilla.org/kb/use-firefox-another-language" rel="external noopener" ') }}</p>

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -64,7 +64,7 @@
             </p>
           </aside>
           <div class="hero-image">
-            <img class="hero-photo" src="{{ static('img/firefox/firstrun/deviceSwoosh.gif') }}" alt="">
+            <img class="hero-photo" src="{{ static('img/firefox/firstrun/deviceSwoosh.gif') }}" alt="" width="600" height="400">
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -40,7 +40,7 @@
     {% else %}
       <p>{{ ftl('firefox-mobile-scan-the-qr-code-to-get-started') }}</p>
       <div class="qr-code-wrapper">
-        <img src="{{ static('img/firefox/browsers/mobile/qr-firefox.png') }}" id="firefox-qr" data-mozillaonline-link="{{ static('img/firefox/browsers/mobile/qr-firefox-mozillaonline.png') }}" alt="">
+        <img src="{{ static('img/firefox/browsers/mobile/qr-firefox.png') }}" id="firefox-qr" data-mozillaonline-link="{{ static('img/firefox/browsers/mobile/qr-firefox-mozillaonline.png') }}" alt="" width="350" height="350">
       </div>
     {% endif %}
   </section>

--- a/bedrock/firefox/templates/firefox/mobile/includes/s2d-hero.html
+++ b/bedrock/firefox/templates/firefox/mobile/includes/s2d-hero.html
@@ -17,7 +17,9 @@
     <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}"
         id="firefox-qr"
         data-mozillaonline-link="{{ static('img/firefox/mobile/protocol/qr-firefox-mozillaonline.png') }}"
-        alt="{{ ftl('firefox-mobile-scan-alt-text') }}">
+        alt="{{ ftl('firefox-mobile-scan-alt-text') }}"
+        width="330"
+        height="330">
   </div>
 {% endif %}
 </div>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -161,7 +161,9 @@
               <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}"
                   id="firefox-qr"
                   data-mozillaonline-link="{{ static('img/firefox/mobile/protocol/qr-firefox-mozillaonline.png') }}"
-                  alt="{{ ftl('firefox-mobile-scan-alt-text') }}">
+                  alt="{{ ftl('firefox-mobile-scan-alt-text') }}"
+                  width="350"
+                  height="350">
             </div>
           {% endif %}
           </div>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -256,14 +256,14 @@
       <li>{{ ftl('privacy-book-there-are-many') }}</li>
     </ol>
 
-    <img src="{{ static('img/firefox/privacy/book/privacy-devices.png') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-devices.png') }}" alt="" width="930" height="465" loading="lazy">
   </div>
 
   <div id="safer-connections" class="mzp-l-content mzp-t-content-md">
     <h3>{{ ftl('privacy-book-safer-connections-public') }}</h3>
     <p>{{ ftl('privacy-book-public-wifi') }}</p>
 
-    <img src="{{ static('img/firefox/privacy/book/privacy-coffee.png') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-coffee.png') }}" alt="" width="300" height="250" loading="lazy">
     <ol>
       <li>{{ ftl('privacy-book-ideally-avoid-publicly') }}</li>
       <li>{{ ftl('privacy-book-perhaps-you-just') }}</li>
@@ -275,19 +275,19 @@
   <div id="bluetooth" class="mzp-l-content mzp-t-content-md">
     <h3>{{ ftl('privacy-book-how-about-your') }}</h3>
     <p>{{ ftl('privacy-book-bluetooth-is-a') }}</p>
-    <img src="{{ static('img/firefox/privacy/book/privacy-joystick-sonos.png') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-joystick-sonos.png') }}" alt="" width="930" height="431" loading="lazy">
   </div>
 
   <div id="https" class="mzp-l-content mzp-t-content-md">
     <h3>{{ ftl('privacy-book-the-secure-site') }}</h3>
     <p>{{ ftl('privacy-book-its-not-unusual') }}</p>
-    <img src="{{ static('img/firefox/privacy/book/privacy-keys.jpg') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-keys.jpg') }}" alt="" width="2064" height="1479" loading="lazy">
   </div>
 
   <div id="email" class="mzp-l-content mzp-t-content-md">
     <h3>{{ ftl('privacy-book-email-accounts-and') }}</h3>
     <p>{{ ftl('privacy-book-your-email-address') }}</p>
-    <img src="{{ static('img/firefox/privacy/book/privacy-identities.jpg') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-identities.jpg') }}" width="2064" height="2100" alt="" loading="lazy">
   </div>
 
   <div id="click-bait" class="mzp-l-content mzp-t-content-md">
@@ -297,7 +297,7 @@
 
   {% call split(
     image=resp_img('img/firefox/privacy/book/privacy-caution.jpg',
-      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy', 'width': '1584', 'height': '1176' }
     ),
   ) %}
     <ol>
@@ -329,7 +329,7 @@
 
   {% call split(
     image=resp_img('img/firefox/privacy/book/privacy-globe.jpg',
-      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy' }
+      optional_attributes={ 'class': 'mzp-c-split-media-asset', 'loading': 'lazy', 'width': '1596', 'height': '948' }
     ),
     block_class='mzp-l-split-reversed',
   ) %}
@@ -344,7 +344,7 @@
     <h3>{{ ftl('privacy-book-dont-need-it') }}</h3>
     <p>{{ ftl('privacy-book-even-if-you') }}</p>
 
-    <img src="{{ static('img/firefox/privacy/book/privacy-chains.png') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-chains.png') }}" alt="" width="2064" height="1050" loading="lazy">
 
     <ol>
       <li>
@@ -358,7 +358,7 @@
       </li>
     </ol>
 
-    <img src="{{ static('img/firefox/privacy/book/privacy-cleaning.png') }}" alt="" loading="lazy">
+    <img src="{{ static('img/firefox/privacy/book/privacy-cleaning.png') }}" alt="" width="1929" height="2150" loading="lazy">
   </div>
 </section>
 

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -12,12 +12,12 @@
   {% set product_name = release.product %}
   {% set download_button_primary %}
     <a id="download-ios-primary" rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}">
+      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
     </a>
   {% endset %}
   {% set download_button_secondary %}
     <a id="download-ios-secondary" rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}">
+      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
     </a>
   {% endset %}
 {% elif release.product == 'Firefox for Android' %}


### PR DESCRIPTION
## One-line summary

Add width to images in to improve rendering speed.

## Issue / Bugzilla link

n/a

## Testing

http://localhost:8000/en-US/firefox/browsers/browser-history/
http://localhost:8000/en-US/firefox/browsers/incognito-browser/
http://localhost:8000/en-US/firefox/browsers/mobile/
http://localhost:8000/en-US/firefox/browsers/mobile/compare/
http://localhost:8000/en-US/firefox/browsers/update-your-browser/
http://localhost:8000/en-US/firefox/developer/
http://localhost:8000/en-US/firefox/family/
http://localhost:8000/en-US/firefox/features/bookmarks/
http://localhost:8000/en-US/firefox/features/fast/
http://localhost:8000/en-US/firefox/features/memory/
http://localhost:8000/en-US/firefox/features/password-manager/
http://localhost:8000/en-US/firefox/features/safebrowser/
http://localhost:8000/en-US/firefox/features/translate/
http://localhost:8000/en-US/firefox/firstrun/
http://localhost:8000/en-US/firefox/ios/109.0/releasenotes/
http://localhost:8000/en-US/firefox/privacy/book/
http://localhost:8000/zh-CN/firefox/features/picture-in-picture/