### PR TITLE
Move footnote under heading (Fix #12713)

### DIFF
--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -66,13 +66,13 @@
       {% block sections %}
       {% endblock %}
     </main>
+    {% if self.footnote()|trim|length %}
     <footer class="privacy-footnote">
       <div>
-        {% if self.footnote()|trim|length %}
           {% block footnote%}{% endblock %}
-        {% endif %}
       </div>
     </footer>
+    {% endif %}
     {% endblock %}
   </article>
   <aside class="mzp-l-sidebar">

--- a/bedrock/privacy/templates/privacy/notices/base-notice-headings.html
+++ b/bedrock/privacy/templates/privacy/notices/base-notice-headings.html
@@ -32,7 +32,7 @@
 
 {% set footnote = doc.body.select('#footnote') %}
 {% if footnote %}
-  {% set footnote = footnote[0].extract() %}
+  {% set footnote = footnote[0].find_parent('section').extract() %}
 {% endif %}
 
 {% block page_title %}{{ title.get_text()|join }}{% endblock %}

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -194,6 +194,8 @@ $border: 2px solid $color-marketing-gray-20;
 
 .privacy-footnote {
     @include text-body-md;
+    border-top: $border;
+    margin-top: $spacing-2xl;
     padding: $spacing-2xl 0;
 
     h3 {


### PR DESCRIPTION
## One-line summary

Tweak the beautiful soup parsing to move the footnote on the Firefox privacy page into the footnote section.

## Significant changes and points to review

- only add footer element to page if it will not be empty
- extract the full footer section from the body of the privacy notice
- add a visual separator between the footer and other sections  

## Issue / Bugzilla link

Fix #12713

## Screenshots

See screenshot in #12713 

## Testing

Check here is a proper footer on:

- http://localhost:8000/en-US/privacy/firefox/

Check I did not break other privacy notices using the same template:

http://localhost:8000/en-US/privacy/firefox-reality/
http://localhost:8000/en-US/privacy/subscription-services/
http://localhost:8000/en-US/privacy/mdn-plus/
http://localhost:8000/en-US/privacy/firefox-reality/
http://localhost:8000/en-US/privacy/hubs/
