### PR TITLE
Support sanitisation of Fluent strings before rendering

### DIFF
--- a/lib/l10n_utils/templatetags/fluent.py
+++ b/lib/l10n_utils/templatetags/fluent.py
@@ -11,19 +11,20 @@ from lib.l10n_utils import fluent
 
 TAGS_ALLOWED_IN_FLUENT_STRINGS = {
     "a",
-    "strong",
-    "span",
+    "abbr",
     "br",
     "em",
-    "abbr",
+    "i",
+    "span",
+    "strong",
 }
 
 ATTRS_ALLOWED_IN_FLUENT_STRINGS = [
-    "href",
     "class",
+    "href",
     "id",
-    "title",
     "rel",
+    "title",
 ]
 
 

--- a/lib/l10n_utils/templatetags/fluent.py
+++ b/lib/l10n_utils/templatetags/fluent.py
@@ -2,17 +2,36 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import bleach
 import jinja2
 from django_jinja import library
 from markupsafe import Markup
 
 from lib.l10n_utils import fluent
 
+TAGS_ALLOWED_IN_FLUENT_STRINGS = {
+    "a",
+    "strong",
+    "span",
+    "br",
+    "em",
+    "abbr",
+}
+
+ATTRS_ALLOWED_IN_FLUENT_STRINGS = [
+    "href",
+    "class",
+    "id",
+    "title",
+    "rel",
+]
+
 
 @library.global_function
 @jinja2.pass_context
 def ftl(ctx, message_id, fallback=None, locale=None, **kwargs):
-    """Return the translated string.
+    """Return the translated string, after sanitising any _disallowed_ HTML
+    markup. (Allowed HTML is left unchanged.)
 
     :param ctx: the context from the template (automatically included)
     :param str message_id: the ID of the message
@@ -26,10 +45,18 @@ def ftl(ctx, message_id, fallback=None, locale=None, **kwargs):
         <p>{{ ftl('greeting', name='The Dude') }}
     """
     if locale:
-        return Markup(fluent.ftl(message_id, fallback, locale=locale, ftl_files=ctx["fluent_files"], **kwargs))
+        localised_string = fluent.ftl(message_id, fallback, locale=locale, ftl_files=ctx["fluent_files"], **kwargs)
+    else:
+        l10n = ctx["fluent_l10n"]
+        localised_string = fluent.translate(l10n, message_id, fallback, **kwargs)
 
-    l10n = ctx["fluent_l10n"]
-    return Markup(fluent.translate(l10n, message_id, fallback, **kwargs))
+    bleached_localised_string = bleach.clean(
+        localised_string,
+        tags=TAGS_ALLOWED_IN_FLUENT_STRINGS,
+        attributes=ATTRS_ALLOWED_IN_FLUENT_STRINGS,
+    )
+
+    return Markup(bleached_localised_string)
 
 
 @library.global_function

--- a/lib/l10n_utils/tests/test_templatetags.py
+++ b/lib/l10n_utils/tests/test_templatetags.py
@@ -101,14 +101,14 @@ def test_ftl_bleach_allowlists_are_comprehensive():
                 if attr_matches := re.findall(attr_re, line):
                     attrs_found.update(_clean_attr_matches(attr_matches))
 
-    assert TAGS_ALLOWED_IN_FLUENT_STRINGS == tags_found, (
-        "DANGER! HTML tags were detected in en-US source FTL strings that are not in "
-        "lib.l10n_utils.templatetags.fluent.fluent.TAGS_ALLOWED_IN_FLUENT_STRINGS. "
+    assert TAGS_ALLOWED_IN_FLUENT_STRINGS.issuperset(tags_found), (
+        "DANGER! HTML tags were detected in source FTL strings that are not in "
+        "lib.l10n_utils.templatetags.fluent.TAGS_ALLOWED_IN_FLUENT_STRINGS. "
         f"Unexpected tag(s) found: {tags_found.difference(TAGS_ALLOWED_IN_FLUENT_STRINGS)}"
     )
 
-    assert sorted(ATTRS_ALLOWED_IN_FLUENT_STRINGS) == sorted(attrs_found), (
-        "DANGER! HTML attributes were detected in en-US source FTL strings that are not in "
-        "lib.l10n_utils.templatetags.fluent.fluent.ATTRS_ALLOWED_IN_FLUENT_STRINGS. "
+    assert set(ATTRS_ALLOWED_IN_FLUENT_STRINGS).issuperset(attrs_found), (
+        "DANGER! HTML attributes were detected in source FTL strings that are not in "
+        "lib.l10n_utils.templatetags.fluent.ATTRS_ALLOWED_IN_FLUENT_STRINGS. "
         f"Unexpected attribute(s) found: {set(attrs_found).difference(set(ATTRS_ALLOWED_IN_FLUENT_STRINGS))}"
     )

--- a/lib/l10n_utils/tests/test_templatetags.py
+++ b/lib/l10n_utils/tests/test_templatetags.py
@@ -1,0 +1,114 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import re
+from typing import List, MutableSet
+from unittest.mock import patch
+
+import pytest
+
+from lib.l10n_utils.templatetags.fluent import (
+    ATTRS_ALLOWED_IN_FLUENT_STRINGS,
+    TAGS_ALLOWED_IN_FLUENT_STRINGS,
+    ftl,
+)
+
+
+@pytest.mark.parametrize(
+    "mock_return_value, expected",
+    (
+        (
+            '<strong>bolder</strong>and <a href="{ $mailto }">test@example.com</a>.<br><span>spanned</span> <em>emphasised</em> <abbr>abbreviation</abbr>',  # noqa: E501
+            '<strong>bolder</strong>and <a href="{ $mailto }">test@example.com</a>.<br><span>spanned</span> <em>emphasised</em> <abbr>abbreviation</abbr>',  # noqa: E501
+        ),
+        (
+            'test attrs <a href="https://www.mozilla.org/" class="test-link" id="target-for-link" rel="nofollow" title="test title">test</a>',
+            'test attrs <a href="https://www.mozilla.org/" class="test-link" id="target-for-link" rel="nofollow" title="test title">test</a>',
+        ),
+        (
+            "some string with a sneaky <script>alert('pwned');</script>",
+            "some string with a sneaky &lt;script&gt;alert('pwned');&lt;/script&gt;",
+        ),
+        (
+            'some string with disallowed attrs <a onclick="injectedScript()">test</a>',
+            "some string with disallowed attrs <a>test</a>",
+        ),
+        ("String with no markup in it", "String with no markup in it"),
+    ),
+    ids=[
+        "Tag test, no changes expected via sanitization",
+        "Attr test, no changes expected via sanitization",
+        "Proof that bleach is escaping tags that are not in the allowlists",
+        "Proof that bleach is stripping attrs that are not in the allowlists",
+        "String with no markup in it",
+    ],
+)
+@patch("lib.l10n_utils.templatetags.fluent.fluent.translate")
+@patch("lib.l10n_utils.templatetags.fluent.fluent.ftl")
+def test_ftl_bleaches_string(mock_ftl, mock_translate, mock_return_value, expected):
+    # Ensure the ftl() templatetag call bleaches the output of Markup
+    mock_ftl.return_value = mock_return_value
+    mock_translate.return_value = mock_return_value
+    dummy_ctx = {
+        "fluent_l10n": "dummy_fluent_l10n_in_ctx",
+        "fluent_files": "dummy_fluent_files_in_ctx",
+    }
+    assert ftl(dummy_ctx, "dummy") == expected
+
+
+def test_ftl_bleach_allowlists_are_comprehensive():
+    """This is a canary test to confirm our bleach() settings for
+    calls to the ftl() helper are appropriate for the content we expect.
+
+    FTL strings in `en-US` are our default, so ensure the bleaching call
+    expects all the _trusted_ markup that we can currently find in those
+    en-US strings. If non-en-US strings contain disallowed markup, it will
+    be escaped at runtime"""
+
+    # Build a list of the tags and attrs we find in our fluent strings and
+    # compare them with what's in our allowlists.
+
+    tag_re = re.compile(r"<\w+")
+    attr_re = re.compile(r"\s\w+=")
+
+    filepaths = set()
+
+    tags_found = set()
+    attrs_found = set()
+
+    def _clean_tag_matches(tag_matches: List) -> MutableSet:
+        return set([x.replace("<", "") for x in tag_matches])
+
+    def _clean_attr_matches(attr_matches: List) -> MutableSet:
+        return set([x.replace("=", "").strip() for x in attr_matches if "?" not in x])
+
+    for starting_dir in [
+        "l10n/",
+        "l10n-pocket",
+    ]:
+        for root, _, files in os.walk(starting_dir):
+            for file in files:
+                if file.endswith(".ftl"):
+                    filepaths.add(os.path.join(root, file))
+
+    for filepath in filepaths:
+        with open(filepath) as fp:
+            for line in fp.readlines():
+                if tag_matches := re.findall(tag_re, line):
+                    tags_found.update(_clean_tag_matches(tag_matches))
+                if attr_matches := re.findall(attr_re, line):
+                    attrs_found.update(_clean_attr_matches(attr_matches))
+
+    assert TAGS_ALLOWED_IN_FLUENT_STRINGS == tags_found, (
+        "DANGER! HTML tags were detected in en-US source FTL strings that are not in "
+        "lib.l10n_utils.templatetags.fluent.fluent.TAGS_ALLOWED_IN_FLUENT_STRINGS. "
+        f"Unexpected tag(s) found: {tags_found.difference(TAGS_ALLOWED_IN_FLUENT_STRINGS)}"
+    )
+
+    assert sorted(ATTRS_ALLOWED_IN_FLUENT_STRINGS) == sorted(attrs_found), (
+        "DANGER! HTML attributes were detected in en-US source FTL strings that are not in "
+        "lib.l10n_utils.templatetags.fluent.fluent.ATTRS_ALLOWED_IN_FLUENT_STRINGS. "
+        f"Unexpected attribute(s) found: {set(attrs_found).difference(set(ATTRS_ALLOWED_IN_FLUENT_STRINGS))}"
+    )


### PR DESCRIPTION
This changeset adds a layer of protection against unexpected markup being introduced via Fluent strings as part of the localisation process.

## Significant changes and points to review

We now use `bleach` to sanitise each Fluent string's content before declaring it as safe for Django to render without further escaping (which we do via `Markup`).

The sanitisation only allows a specific, small, set of HTML tags and attributes to be allowed through; everything else will be escaped.

We've drawn our initial set of allowed tags and attributes from the current en-US fluent templates in the repo, following the logic that: a) we trust these because we added them; and b) if someone tries to add in malevolent markup via a Fluent string in a particular locale, we _should_ be sanitising that because the translation should use the same tags and elements that the source does.

There is a test added to show the sanitisation working, plus a test that inspects the current state of the Fluent files in the l10n/ and l10n-pocket/ directories and ensures they do not contain any tags that are not currently in the relevant allowlist. If we want to support another tag or attr in our Fluent strings, that's fine - we just expand the allowlist, and a test will fail to warn us that we haven't updated the allowlist.

## Issue / Bugzilla link

Resolves #12719

If relevant:

- [X] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

- [ ] Please extensively test-drive a locale and look for broken markup that's being over-escaped. There should be none, of course
- [ ] If you want to test the 'canary test' , comment out an item from `TAGS_ALLOWED_IN_FLUENT_STRINGS` then, separately `ATTRS_ALLOWED_IN_FLUENT_STRINGS` and run `pytest -k test_ftl_bleach_allowlists_are_comprehensive`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203291192319248