### PR TITLE
Stub out WNP 111 page for EU locales [#12720]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx111-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx111-eu.html
@@ -1,0 +1,32 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_111_eu') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+
+  <section class="wnp-content-main mzp-l-content mzp-t-content-md">
+    <h1>{{ ftl('whatsnew-111-pdf-title') }}</h1>
+    <p class="wnp-main-tagline">{{ ftl('whatsnew-111-pdf-its-spring-cleaning-season') }}</p>
+    <p class="wnp-main-tagline">{{ ftl('whatsnew-111-pdf-try-it-out-now-and-say') }}</p>
+
+    <p><a class="mzp-c-button mzp-t-product" href="https://assets.mozilla.net/wnp109-eu/wnp-fx109-uk.pdf" data-cta-type="button" data-cta-text="Try it now">{{ ftl('whatsnew-111-pdf-cta') }}</a></p>
+  </section>
+
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+{% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -484,6 +484,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx110-de-v1.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx110-de-v2.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx110-fr.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx111-eu.html": ["firefox/whatsnew/whatsnew-111-pdf", "firefox/whatsnew/whatsnew"],
     }
 
     # specific templates that should not be rendered in
@@ -572,6 +573,11 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/developer/whatsnew.html"
             elif show_57_dev_whatsnew(version):
                 template = "firefox/developer/whatsnew.html"
+            else:
+                template = "firefox/whatsnew/index.html"
+        elif version.startswith("111.0"):
+            if settings.DEV and locale in ["es-ES", "it", "pl", "pt-PT", "nl"] and ftl_file_is_active("firefox/whatsnew/whatsnew-111-pdf"):
+                template = "firefox/whatsnew/whatsnew-fx111-eu.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("110.0"):

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -210,6 +210,16 @@ locales = [
         "pl",
     ]
 [[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-111-pdf.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-111-pdf.ftl"
+    locales = [
+        "es-ES",
+        "it",
+        "pl",
+        "pt-PT",
+        "nl",
+    ]
+[[paths]]
     reference = "en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl"
     l10n = "{locale}/firefox/whatsnew/whatsnew-developer-mdnplus.ftl"
 [[paths]]

--- a/l10n/en/firefox/whatsnew/whatsnew-111-pdf.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-111-pdf.ftl
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/111.0/whatsnew/
+
+# Line break for visual formatting
+whatsnew-111-pdf-title = A letter to<br> your printer
+
+# An alternative title without a line break, to use as an accessible label
+whatsnew-111-pdf-title-alt = A letter to your printer
+
+whatsnew-111-pdf-its-spring-cleaning-season = It’s spring cleaning season: time to get rid of all the things that you don’t need anymore ⁠— like your printer. Edit documents easily with { -brand-name-firefox }’s built-in PDF editor.
+whatsnew-111-pdf-try-it-out-now-and-say = Try it out now and say one last goodbye to paper jams.
+
+# Call to action button
+whatsnew-111-pdf-cta = Try it now
+

--- a/media/css/firefox/whatsnew/whatsnew-111-eu.scss
+++ b/media/css/firefox/whatsnew/whatsnew-111-eu.scss
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import 'includes/base';
+@import 'includes/dark-mode';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+
+.wnp-content-main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding-top: $spacing-2xl;
+
+    h1 {
+        padding: $spacing-sm;
+    }
+
+    .wnp-main-img-light {
+        display: block;
+    }
+
+    .wnp-main-img-dark {
+        display: none;
+    }
+
+    .wnp-main-tagline {
+        @include text-body-lg;
+        text-align: center;
+        color: $color-black;
+        padding: $spacing-sm;
+    }
+
+    @media #{$mq-md} {
+        h1 {
+            padding: 0;
+        }
+    }
+}
+
+// Dark mode support
+@media (prefers-color-scheme: dark) {
+    .wnp-content-main {
+        .wnp-main-img-light {
+            display: none;
+        }
+
+        .wnp-main-img-dark {
+            display: block;
+        }
+
+        .wnp-main-tagline {
+            color: $color-white;
+        }
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -487,6 +487,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-111-eu.scss"
+      ],
+      "name": "firefox_whatsnew_111_eu"
+    },
+    {
+      "files": [
         "css/firefox/privacy/common.scss"
       ],
       "name": "firefox-privacy-common"


### PR DESCRIPTION
## One-line summary

This is just a stub page in order to get strings ready for l10n ahead of the release of Firefox 111 on March 14. Localized PDFs are forthcoming and we'll eventually need to update the CTA to link to the correct PDF for each locale. We may end up doing something different with the title as well. It could be an image for each language (hence the separate string for alt), but I'm hoping to keep it live text (hence the string with the line break for layout).

The page should only be visible in dev mode so we can merge it ahead of time.

## Issue / Bugzilla link

#12720 

## Testing

http://localhost:8000/es-ES/firefox/111.0/whatsnew/

- [x] The stub page loads for the locales es-ES, it, pl, pt-PT, nl.
- [x] The default page loads for other locales.
- [x] The stub page loads when in dev mode.
- [x] The standard page loads when in prod mode.
