### PR TITLE
Add T&C legal page for Pocket PoD raffle (Fixes #12699)

### DIFF
--- a/bedrock/legal/templates/legal/terms/peopleofdeutschland.de.html
+++ b/bedrock/legal/templates/legal/terms/peopleofdeutschland.de.html
@@ -1,0 +1,312 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}OFFIZIELLE REGELN zum People of Deutschland-Buchgewinnspiel von POCKET{% endblock %}
+
+{% block article %}
+<h1 class="mzp-c-article-title" itemprop="name">OFFIZIELLE REGELN zum People of Deutschland-Buchgewinnspiel von POCKET</h1>
+
+<ol class="mzp-u-list-styled">
+  <li>
+    <p>
+      <b>Sponsor.</b> Sponsor des People of Deutschland-Buchgewinnspiels von Pocket (im Folgenden „Gewinnspiel“)
+      ist die Mozilla Corporation, 2 Harrison St., #175, San Francisco, CA 94105, USA.
+    </p>
+
+    <p>
+      Das Gewinnspiel wird weder von Instagram gesponsert, unterstützt oder verwaltet, noch steht es mit
+      Instagram in Verbindung.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Kein Kauf erforderlich; Teilnahmeanleitung.</b> ZUR TEILNAHME IST KEIN KAUF UND KEINE ZAHLUNG
+      ERFORDERLICH. EIN KAUF STEIGERT DIE GEWINNCHANCE NICHT. Grundlage dieses Gewinnspiels ist das reine
+      Zufallsprinzip. Die Gewinnchancen beim Gewinnspiel hängen von der Anzahl der Teilnehmer ab. UNGÜLTIG,
+      WO VERBOTEN UND WO EINE REGISTRIERUNG, KAUTION ODER LOKALISIERUNG ERFORDERLICH IST.
+    </p>
+
+    <p>
+      Zur Teilnahme am Gewinnspiel ist es erforderlich, einen Kommentar unter dem Instagram-Post zur
+      Ankündigung des Gewinnspiels abzugeben. Mit der Übermittlung des Kommentars stimmen Sie diesen
+      offiziellen Regeln zu. Eine Teilnahme pro Person. Jeder Versuch eines Teilnehmers, mithilfe
+      mehrerer/verschiedener E-Mail-Adressen, Konten, Identitäten oder anderer Methoden öfter als erlaubt
+      teilzunehmen, führt zur Ungültigkeit der Teilnahme dieser Person und kann zur Disqualifikation
+      führen.
+    </p>
+
+    <p>
+      Im Falle von Streitigkeiten bezüglich eines Teilnehmers gilt der autorisierte Kontoinhaber
+      der E-Mail-Adresse oder des Instagram-Kontos, die bzw. das mit der Teilnahme verbunden ist, als
+      Teilnehmer. Der „autorisierte Kontoinhaber" ist die natürliche Person, der von einem
+      Internetzugangsanbieter, Online-Dienstanbieter oder einem anderen Unternehmen, das für die Zuweisung
+      von Konten für die mit der angegebenen E-Mail-Adresse oder dem angegebenen Instagram-Konto
+      verbundene Domain zuständig ist, ein Konto zugewiesen wurde. Potenzielle Gewinner werden evtl.
+      gebeten, nachzuweisen, dass sie der autorisierte Kontoinhaber sind. Im Falle von laufenden
+      Streitigkeiten bezüglich eines Teilnehmers ist der Sponsor befugt, in alleinigem Ermessen über
+      den/die Teilnehmer zu entscheiden.
+    </p>
+
+    <p>Alle Beiträge müssen folgende Bedingungen erfüllen:</p>
+
+    <ul>
+      <li>
+        Für jede Teilnahme ist eine kurze, schriftliche Beschreibung in einem Instagram-Kommentar
+        beizufügen.
+      </li>
+
+      <li>
+        Kommentare dürfen kein Material enthalten, das obszön, verleumderisch, beleidigend, bedrohlich,
+        pornografisch, rassistisch oder ethnisch anstößig ist oder Verhaltensweisen fördert, die als
+        Straftat gelten, eine zivilrechtliche Haftung nach sich ziehen oder gegen ein Gesetz verstoßen.
+        Die Kommentare müssen für die allgemeine Öffentlichkeit angemessen sein; die Angemessenheit wird
+        vom Sponsor bestimmt.
+      </li>
+
+      <li>Kommentare müssen in deutscher oder englischer Sprache verfasst sein.</li>
+
+      <li>Teilnehmer müssen ihren Wohnsitz in Deutschland haben.</li>
+    </ul>
+
+    <p>Der Sponsor behält sich das Recht vor, Beiträge aus beliebigen Gründen abzulehnen.</p>
+  </li>
+
+  <li>
+    <p>
+      <b>Zeitraum des Gewinnspiels.</b> Der Zeitraum des Gewinnspiels („Gewinnspielzeitraum“) erstreckt
+      sich von seinem offiziellen Start am 16. Februar 2023 um 00:01 Uhr MEZ bis zum offiziellen Ende
+      am 22. Februar 2023 um 23:59 Uhr MEZ. Der Computer des Sponsors ist das offizielle Zeitmessgerät
+      für das Gewinnspiel. Alle Beiträge müssen innerhalb des Gewinnspielzeitraums eingehen.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Teilnahmeberechtigung.</b> Um teilnahmeberechtigt zu sein, müssen die Teilnehmer in ihrem
+      Wohnsitzland volljährig sein. Mitarbeiter des Sponsors und seiner Mutter- und Tochtergesellschaften
+      sowie deren unmittelbare Familienangehörige (Ehepartner, Eltern, Geschwister und Kinder) und
+      Haushaltsmitglieder sind nicht teilnahmeberechtigt. Bevor Sie am Gewinnspiel teilnehmen, sollten
+      Sie auch überlegen, ob Sie kollidierende Verpflichtungen haben, die eine Teilnahme verhindern.
+      Wenn ein Teilnehmer Angestellter eines Unternehmens oder einer Behörde oder akademischen
+      Einrichtung oder als Schüler/Student eingeschrieben ist, liegt es in seiner alleinigen
+      Verantwortung, die Richtlinien seines Arbeitgebers bzw. seiner akademischen Einrichtung im
+      Hinblick auf die Berechtigung zur Teilnahme am Gewinnspiel zu prüfen, zu verstehen und einzuhalten.
+      Verstößt ein Teilnehmer gegen die Richtlinien seines Arbeitgebers oder seiner akademischen
+      Einrichtung, so wird er von der Teilnahme am Gewinnspiel ausgeschlossen, und das Team kann von der
+      Vergabe oder vom Erhalt eines Preises ausgeschlossen werden. Der Sponsor lehnt jegliche Haftung
+      oder Verantwortung für Streitigkeiten zwischen einem Arbeitnehmer oder Schüler/Studenten und seinem
+      Arbeitgeber bzw. seiner akademischen Einrichtung im Zusammenhang mit dem Gewinnspiel ab.
+    </p>
+
+    <p>
+      Die Teilnehmer sind nicht berechtigt, Preise zu erhalten, wenn sie auf der SDN-Liste (Specifically
+      Designated Nationals) der USA stehen oder wenn gegen das Land des Teilnehmers Sanktionen bestehen,
+      aufgrund derer Mozilla keine Zahlungen an ihn leisten darf.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Gewinner.</b> Es werden 10 Gewinner nach dem Zufallsprinzip ausgewählt. Alle 10 Gewinner erhalten
+      den unten stehenden Preis. Die Gewinner werden am oder um den 23. Februar 2023 bekanntgegeben.
+      Die Ziehung erfolgt durch den Sponsor oder von ihm beauftragte Vertreter.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Preise.</b> Jeder der 10 Gewinner erhält 1 gedrucktes Exemplar des Buchs „People of Deutschland“.
+    </p>
+
+    <p>
+      Die Preise werden kurz nach Bekanntgabe der Gewinner am oder um den 23. Februar 2023 ausgeliefert.
+    </p>
+
+    <p>
+      Der Gesamtwert aller Preise beträgt ca. 249,50 Euro. Austausch, Abtretung oder Übertragung des Preises
+      außer durch den Sponsor ist nicht gestattet. Der Sponsor hat das Recht, einen Preis durch einen anderen
+      mit vergleichbarem oder höherem Wert zu ersetzen. Der Gewinner trägt sämtliche Steuern und Gebühren,
+      die mit dem Erhalt und/oder der Nutzung des Preises verbunden sind. Ferner ist der Gewinner vor dem
+      Erhalt des Preises möglicherweise zur Vorlage von Steuerinformationen verpflichtet.
+    </p>
+
+    <p>
+      Jeder Gewinner stimmt zu, sich selbst bei den zuständigen Steuerbehörden zu melden, sofern dies geltende
+      Gesetze vorschreiben.
+    </p>
+
+    <p>
+      Einzelpersonen sollten Preise nur in Übereinstimmung mit den geltenden Richtlinien ihres Arbeitgebers bzw.
+      ihrer akademischen Einrichtung und den geltenden staatlichen Vorgaben für die Teilnahme an und den Erhalt
+      von Werbeleistungen im Zusammenhang mit dem Gewinnspiel sowie den Erhalt und auf die Aufbewahrung des
+      Preises behalten. Wenn die Richtlinien einer Regierung, eines Arbeitgebers oder einer Bildungseinrichtung
+      anzuwenden sind, liegt es in der alleinigen und letztendlichen Verantwortung des Teilnehmers, in Absprache
+      mit seiner Regierung, seinem Arbeitgeber oder seiner Bildungseinrichtung festzustellen, wie und ob der
+      Preis einbehalten und/oder verteilt und abgerechnet wird. Wir übernehmen keine Verantwortung für die
+      Entscheidungen, die von diesen Regierungen, Arbeitgebern oder Bildungseinrichtungen in dieser
+      Angelegenheit getroffen werden.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Bedingungen und Teilnahme.</b> Mit der Einreichung eines Beitrags bzw. der Teilnahme an diesem
+      Gewinnspiel erklären Sie sich damit einverstanden, diese Regeln und alle Entscheidungen des Sponsors
+      bezüglich dieses Gewinnspiels zu befolgen, die der Sponsor nach eigenem Ermessen trifft. Der Sponsor
+      behält sich das Recht vor, Teilnehmer oder Gewinner zu disqualifizieren und im größtmöglichen gesetzlich
+      zulässigen Umfang strafrechtlich zu verfolgen, wenn diese nach dem begründeten Verdacht des Sponsors die
+      Website des Sponsors oder das Teilnahmeverfahren manipulieren, absichtlich mehr als einen Beitrag
+      einreichen, gegen diese Regeln verstoßen, Betrug oder Betrugsversuche begehen oder sich unfair oder
+      störend verhalten.
+    </p>
+
+    <p>
+      Durch Ihren Beitrag bzw. durch die Teilnahme an diesem Gewinnspiel erklären Sie sich bereit, die
+      Community Participation Guidelines (Richtlinien für das Mitwirken in der Community) von Mozilla zu
+      befolgen. Jeglicher Verstoß gegen die <a href="{{ url('mozorg.about.governance.policies.participation') }}">Community Participation Guidelines</a>
+      („CPG“) durch Teilnehmer hat eine Disqualifizierung des Teilnehmers zur Folge. Die CPG finden Sie
+      hier: <a href="{{ url('mozorg.about.governance.policies.participation') }}">https://www.mozilla.org/about/governance/policies/participation/</a>
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Geistiges Eigentum.</b> Die Rechte an dem dem Beitrag zugrunde liegenden geistigen Eigentum des
+      Teilnehmers verbleiben beim Teilnehmer, vorbehaltlich der Rechte des Sponsors, den Beitrag und die
+      eingereichten Materialien und Informationen zum Zwecke der Verwaltung und Bewertung des Gewinnspiels
+      sowie für jegliche Geschäfts-, Marketing- und Werbezwecke zugunsten des Sponsors nachzudrucken,
+      darzustellen, wiederzugeben, aufzuführen, zu nutzen und zu präsentieren. Durch die Teilnahme am
+      Gewinnspiel räumt der jeweilige Teilnehmer dem Sponsor eine nicht exklusive, weltweite, vollständig
+      bezahlte, abgabenfreie, unbefristete, unwiderrufliche, übertragbare und unterlizenzierbare Lizenz
+      zum Nachdrucken, Darstellen, Wiedergeben, Aufführen, Nutzen und Präsentieren des Beitrags und der
+      Materialien und Informationen, die im Zusammenhang mit dem Gewinnspiel oder der Nutzung oder dem
+      Erhalt des Preises eingereicht wurden, (und insbesondere des Rechts auf Erstellen davon abgeleiteter
+      Werke) für sämtliche Zwecke in jedem beliebigen Medium ein. Jeder Teilnehmer garantiert hiermit, dass
+      seine Beiträge und alle anderen von ihm bereitgestellten Materialien und Informationen Originale des
+      Teilnehmers sind und dass diese nicht gegen Urheberrechte, Marken, Datenschutzrechte,
+      Persönlichkeitsrechte, moralische Rechte oder andere Rechte an geistigem Eigentum oder andere Rechte
+      natürlicher oder juristischer Personen verstoßen und gegen keine Regeln, Vorschriften oder Gesetze
+      verstoßen. Wenn der Beitrag oder die vom Teilnehmer zur Verfügung gestellten Informationen oder
+      Materialien Elemente oder Materialien enthalten, die nicht Eigentum des Teilnehmers sind und/oder
+      den Rechten Dritter unterliegen, so versichert der Teilnehmer, dass er vor der Einreichung des
+      Beitrags und der Informationen oder Materialien alle Freigaben und Zustimmungen eingeholt hat, die
+      erforderlich sind, um die Nutzung und Verwertung des Beitrags und der Informationen und Materialien
+      durch den Sponsor in der in den offiziellen Regeln dargelegten Weise zu ermöglichen, und zwar ohne
+      zusätzliche Vergütung.
+    </p>
+
+    <p>
+      Jeder Teilnehmer garantiert, dass die Einsendung und die zur Verfügung gestellten Materialien und
+      Informationen keine Informationen enthalten, die vom Teilnehmer, seinen Mitarbeitern, seinem
+      Arbeitgeber oder Personal oder anderen Dritten als vertraulich angesehen werden, und dass die
+      Einsendung der Materialien und Informationen nicht gegen Vereinbarungen mit Dritten oder Richtlinien
+      verstößt, denen der Teilnehmer unterliegt. Der Teilnehmer erklärt sich damit einverstanden, dass
+      der Sponsor das Recht hat, Eigentum und Echtheit aller Einsendungen zu prüfen, und dass der Teilnehmer
+      auf Verlangen des Sponsors eine schriftliche Kopie jeglicher Freigabe oder Genehmigung vorzulegen hat,
+      die er von Dritten erhalten hat und die ihm das Recht zur Nutzung dieses Eigentums einräumt. Der
+      Teilnehmer nimmt zur Kenntnis, dass andere Teilnehmer möglicherweise Beiträge einreichen, die den
+      seinen ähnlich sind, und dass sie oder auch der Sponsor möglicherweise bereits Inhalte oder Ideen,
+      die mit den seinen im Zusammenhang stehen oder diesen ähneln, erwägen oder entwickeln oder später
+      unabhängig vom Gewinnspiel erwägen oder entwickeln können. Sie nehmen zur Kenntnis, dass dies weder
+      für den Sponsor noch für Dritte eine Verpflichtung oder Haftung Ihnen gegenüber begründet.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Haftungsausschluss, Freistellung und Haftpflicht.</b> DER SPONSOR GIBT KEINE AUSDRÜCKLICHEN ODER
+      STILLSCHWEIGENDEN ZUSICHERUNGEN ODER GARANTIEN IN BEZUG AUF PREISE ODER IHRE TEILNAHME AN DER
+      WERBEAKTION. DURCH DIE TEILNAHME AN DER WERBEAKTION BZW. DURCH DEN ERHALT EINES PREISES ERKLÄRT SICH
+      DER JEWEILIGE TEILNEHMER DAMIT EINVERSTANDEN, DEN SPONSOR UND SEINE TOCHTERGESELLSCHAFTEN, VERBUNDENEN
+      UNTERNEHMEN, LIEFERANTEN, VERTRIEBSUNTERNEHMEN, WERBE- UND VERKAUFSFÖRDERUNGSAGENTUREN, PARTNER UND
+      PREISLIEFERANTEN SOWIE DEREN JEWEILIGE MUTTERGESELLSCHAFTEN UND DIE LEITENDEN ANGESTELLTEN, DIREKTOREN,
+      MITARBEITER UND VERTRETER DES JEWEILIGEN UNTERNEHMENS (GEMEINSAM DIE „FREIGESTELLTEN PARTEIEN“) VON
+      JEGLICHEN ANSPRÜCHEN BZW. KLAGEGRÜNDEN FREIZUSTELLEN UND SCHADLOS ZU HALTEN, U. A. VON PERSONENSCHÄDEN,
+      TOD ODER BESCHÄDIGUNG VON EIGENTUM ODER DESSEN VERLUST, DIE AUS DER TEILNAHME AN DER WERBEAKTION ODER
+      DEM ERHALT ODER DER VERWENDUNG ODER DEM MISSBRAUCH EINES PREISES ENTSTEHEN. DIE FREIGESTELLTEN PARTEIEN
+      SIND NICHT VERANTWORTLICH FÜR: (1) FEHLERHAFTE ODER UNGENAUE INFORMATIONEN, SEI ES DURCH TEILNEHMER,
+      DRUCKFEHLER ODER DURCH GERÄTE ODER PROGRAMME, DIE MIT DER WERBEAKTION IN VERBINDUNG STEHEN ODER IN IHREM
+      ZUSAMMENHANG VERWENDET WERDEN; (2) TECHNISCHE AUSFÄLLE JEGLICHER ART, Z. B. STÖRUNGEN, UNTERBRECHUNGEN
+      ODER TRENNUNG VON TELEFONLEITUNGEN ODER NETZWERKHARDWARE ODER -SOFTWARE; (3) UNBEFUGTES MENSCHLICHES
+      EINGREIFEN IN ASPEKTE DES TEILNAHMEVERFAHRENS ODER DER WERBEAKTION; (4) TECHNISCHE ODER MENSCHLICHE
+      FEHLER, DIE BEI DER VERWALTUNG DER WERBEAKTION ODER DER VERARBEITUNG DER EINSENDUNGEN AUFTRETEN KÖNNEN;
+      ODER (5) VERLETZUNGEN ODER SCHÄDEN AN PERSONEN ODER EIGENTUM, DIE DIREKT ODER INDIREKT, GANZ ODER
+      TEILWEISE, DURCH DIE TEILNAHME DES TEILNEHMERS AN DER WERBEAKTION ODER DEN ERHALT ODER DIE VERWENDUNG
+      ODER DEN MISSBRAUCH EINES PREISES VERURSACHT WERDEN KÖNNEN. Es werden nicht mehr als die angegebene
+      Anzahl von Preisen vergeben. Bei Betrug, oder wenn Viren, Softwarefehler, Bots, katastrophale Ereignisse
+      oder sonstige unvorhergesehene oder unerwartete Handlungen oder Ereignisse die Chancengleichheit und/oder
+      Integrität dieses Gewinnspiels beeinträchtigen, behält sich der Sponsor das Recht vor, dieses Gewinnspiel
+      abzubrechen, zu ändern oder auszusetzen. Dieses Recht ist sowohl bei menschlichen als auch bei
+      technischen Fehlern vorbehalten. Wenn keine Lösung gefunden werden kann, um die Integrität des
+      Gewinnspiels wiederherzustellen, behalten wir uns vor (ohne jedoch hierzu eine Verpflichtung einzugehen),
+      aus allen Einsendungen, die vor dem Abbruch, der Änderung oder Aussetzung des Gewinnspiels eingegangen
+      sind und die Teilnahmebedingungen erfüllen, die Gewinner zu ziehen.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Datenschutz und Verwendung von personenbezogenen Daten.</b> Der Sponsor erfasst personenbezogene Daten
+      zu Ihnen, wenn Sie am Gewinnspiel teilnehmen. Der Sponsor behält sich das Recht vor, jegliche im Einklang
+      mit seiner Datenschutzerklärung (zu finden unter <a href="{{ url('privacy') }}">https://www.mozilla.org/privacy</a>)
+      erfassten Daten zu nutzen.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>GELTENDES RECHT UND STREITIGKEITEN.</b> DIESE OFFIZIELLEN REGELN UND DIE WERBEAKTION UNTERLIEGEN DEN
+      GESETZEN DES US-BUNDESTAATS KALIFORNIEN UND WERDEN ENTSPRECHEND AUSGELEGT. GERICHTSSTAND FÜR ALLE
+      STREITIGKEITEN, DIE SICH AUS DIESEN OFFIZIELLEN REGELN ODER IM ZUSAMMENHANG DAMIT ERGEBEN, IST SANTA CLARA
+      COUNTY, KALIFORNIEN. WENN DIE STREITIGKEIT ODER DER ANSPRUCH NICHT DURCH DIREKTE DISKUSSIONEN ODER
+      SCHLICHTUNG GELÖST WERDEN KANN, ERFOLGT DIE LÖSUNG DURCH EIN ENDGÜLTIGES UND VERBINDLICHES SCHIEDSVERFAHREN
+      UNTER DER LEITUNG VON JUDICIAL ARBITRATION AND MEDIATION SERVICES, INC. IN ÜBEREINSTIMMUNG MIT DEN
+      VEREINFACHTEN SCHIEDSGERICHTSREGELN UND -VERFAHREN BZW. DEREN NACHFOLGENDEN VERSIONEN („JAMS-REGELN“).
+      DIE JAMS-REGELN FÜR DIE AUSWAHL EINES SCHIEDSRICHTERS SIND ZU BEFOLGEN, ABGESEHEN DAVON, DASS DER
+      SCHIEDSRICHTER ERFAHREN UND IN KALIFORNIEN ALS RECHTSANWALT ZUGELASSEN SEIN MUSS. ALLE STREITIGKEITEN ODER
+      ANSPRÜCHE DIESER ART WERDEN EINZELN GESCHLICHTET UND NICHT MIT ANSPRÜCHEN ODER STREITIGKEITEN ANDERER
+      PARTEIEN IN SCHIEDSVERFAHREN ZUSAMMENGEFASST. ALLE GEMÄSS DIESEM ABSATZ EINGELEITETEN VERFAHREN WERDEN IN
+      SANTA CLARA COUNTY, KALIFORNIEN, DURCHGEFÜHRT. DER RECHTSBEHELF FÜR ANSPRÜCHE JEDER ART IST AUF DEN
+      TATSÄCHLICHEN SCHADEN BESCHRÄNKT, UND IN KEINEM FALL HAT EINE PARTEI DAS RECHT, STRAFENDEN, EXEMPLARISCHEN,
+      FOLGE- ODER BEILÄUFIGEN SCHADENERSATZ ZU FORDERN, EINSCHLIESSLICH ANWALTSGEBÜHREN ODER ANDERE DAMIT
+      ZUSAMMENHÄNGENDE KOSTEN FÜR DIE VORBRINGUNG EINES ANSPRUCHES, ODER DIESE VEREINBARUNG AUFZULÖSEN ODER EINE
+      UNTERLASSUNGSANORDNUNG ODER EINEN ANDEREN BILLIGKEITSRECHTSBEHELF ZU FORDERN. DIE GESAMTHAFTUNG DES SPONSORS,
+      DIE SICH AUS DIESER VEREINBARUNG ERGIBT ODER DAMIT ZUSAMMENHÄNGT, DARF DEN GESAMTBETRAG DES PREISES, DER DEM
+      GEWINNER DES GEWINNSPIELS ANGEBOTEN WIRD, NICHT ÜBERSCHREITEN.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Erlaubnis zur Werbung.</b> Vorbehaltlich geltenden Rechts gilt die Teilnahme am Gewinnspiel als
+      Einverständnis des Teilnehmers, dass der Sponsor und von ihm beauftragte Personen den Namen, das Abbild,
+      die Stimme, das Bild, die Persona, die biografischen Informationen, den Beitrag und die Audio- und visuellen
+      Inhalte des Teilnehmers für beliebige Zwecke in allen Medien weltweit ohne weitere Bezahlung oder Gegenleistung
+      veröffentlichen, ausstrahlen, anzeigen, weitergeben und nutzen dürfen.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Keine Vertraulichkeit.</b> Die eingereichten Beiträge werden an Dritte weitergegeben, und Teile der Beiträge
+      können an anderer Stelle – insbesondere in Verbindung mit Werbematerialien zum Gewinnspiel – wiedergegeben werden.
+      In Ihrem Beitrag sollten Sie keine Informationen preisgeben, die urheberrechtlich geschützt oder vertraulich sind.
+      Zwischen Ihnen und dem Sponsor wird in Verbindung mit Ihrem Beitrag keine vertrauliche Beziehung hergestellt.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Gewinnerliste.</b> Natürliche Personen sind berechtigt, die Namen der Gewinner anzufordern. Hierzu müssen
+      Berechtigte vor dem 31. März 2023 einen vorfrankierten Rückumschlag an Mozilla Raffle Winners List Request,
+      Schlesische Str. 27, 10997 Berlin senden.
+    </p>
+  </li>
+</ol>
+{% endblock %}

--- a/bedrock/legal/templates/legal/terms/peopleofdeutschland.html
+++ b/bedrock/legal/templates/legal/terms/peopleofdeutschland.html
@@ -1,0 +1,268 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}POCKET People of Deutschland Book Raffle OFFICIAL RULES{% endblock %}
+
+{% block article %}
+<h1 class="mzp-c-article-title" itemprop="name">POCKET People of Deutschland Book Raffle OFFICIAL RULES</h1>
+
+<ol class="mzp-u-list-styled">
+  <li>
+    <p>
+      <b>Sponsor.</b> Sponsor of the Pocket People of Deutschland book raffle (the “raffle”) is Mozilla
+      Corporation, 2 Harrison St., #175, San Francisco, CA 94105.
+    </p>
+    <p>This raffle is in no way sponsored, endorsed or administered by, or associated with, Instagram.</p>
+  </li>
+  <li>
+    <p>
+      <b>No Purchase Necessary; Entry Instructions.</b> NO PURCHASE OR PAYMENT OF ANY MONEY IS NECESSARY
+      TO ENTER. A PURCHASE WILL NOT IMPROVE THE CHANCES OF WINNING. This is a raffle based on luck. Odds
+      of winning the raffle depend on the number of entrants. VOID WHERE PROHIBITED AND WHERE ANY
+      REGISTRATION, BONDING OR LOCALIZATION REQUIRED.
+    </p>
+    <p>
+      To enter and participate in the raffle, you must submit the required comment on the instagram post
+      announcing the raffle. By submitting your comment, you are agreeing to these Official Rules. One
+      entry per individual.  Any attempt by any participant to obtain more than the stated number of
+      entries by using multiple/different email or addresses, accounts, identities, or any other methods
+      will void that participant's entries and that participant may be disqualified.
+    </p>
+    <p>
+      In the event of a dispute as to any entrant, the authorized account holder of the email address or
+      Instagram account associated with the entry will be deemed to be the entrant.  The “authorized
+      account holder” is the natural person assigned to an account by an Internet access provider, online
+      service provider or other organization responsible for assigning accounts for the domain associated
+      with the submitted email address or Instagram account.  A potential winner may be required to show
+      proof of being the authorized account holder.  In the event of an ongoing dispute as to any entrant,
+      Sponsor has the right to make determination as to entrant(s) in its sole discretion.
+    </p>
+
+    <p>All entries must meet the following criteria:</p>
+
+    <ul>
+      <li>Each entry must include a short, written description in an Instagram comment.</li>
+      <li>
+        Comments may not contain material that is obscene, defamatory, libelous, threatening, pornographic,
+        racially or ethnically offensive, or encourages conduct that would be considered a criminal offense,
+        give rise to civil liability, or violate any law. Comments must be appropriate for viewing by the
+        general public; appropriateness will be determined by Sponsor.
+      </li>
+      <li>Comments must be written in German or English.</li>
+      <li>Participants must have their place of residence in Germany.</li>
+    </ul>
+
+    <p>Sponsor reserves the right to reject any entry for any reason.</p>
+  </li>
+
+  <li>
+    <p>
+      <b>Raffle Period.</b> This raffle begins at 12:01 am CET February 15, 2023 and ends at 11:59 pm CET
+      February 21, 2023 (the “Raffle Period”). Sponsor’s computer is the official time-keeping device for
+      the raffle. All entries must be received during the dates and times specified in the Raffle Period.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Eligibility.</b> In order to be eligible, participants must be at least the age of majority in
+      their jurisdiction of residence.  Employees of Sponsor and its parent and affiliate companies as
+      well as the immediate family (spouse, parents, siblings and children) and household members of each
+      such employee are not eligible. Before participating in the Raffle, you should also consider whether
+      you have any conflicting obligations that prevent participation. If an entrant is an employee of a
+      corporation, government or an academic institution, or enrolled as a student, it is his or her sole
+      responsibility to review, understand and abide by his or her employer’s, or academic institution’s
+      policies regarding eligibility to participate in the Raffle.  If an entrant is found to be in
+      violation of his or her employer’s or academic institution’s policies, then he or she will be, and
+      the Team may be, disqualified from participating in the Raffle and from being awarded or retaining
+      any prize. Sponsor disclaims any and all liability or responsibility for disputes arising between
+      an employee or student and his or her employer or academic institution related to the Raffle.
+    </p>
+
+    <p>
+      Contestants are not eligible to receive prizes if they are on the US Specifically Designated Nationals
+      (SDN) list or if there are sanctions against the contestant’s country such that Mozilla is prohibited
+      from paying them.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Winners.</b> There will be 10 winners randomly selected. All 10 winners will receive the prize below.
+      Winners will be announced on or about February 22, 2023. Drawing will be done by Sponsor or its designees.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Prizes.</b> Each of the 10 winners will receive 1 printed edition of the book “People of Deutschland”.
+    </p>
+
+    <p>Prizes will be delivered shortly after winners are announced on or about February 22, 2023.</p>
+
+    <p>
+      The aggregate retail value of all the prize(s) is approximately EUR 249.50. No substitution, assignment or
+      transfer of the prize is permitted, except by Sponsor, who has the right to substitute a prize with
+      another of comparable or greater value. Winner is responsible for all taxes and fees associated with the
+      receipt and/or use of the prize, and the winner may be required to provide tax information prior to
+      receiving the prize.
+    </p>
+
+    <p>
+      Each winner agrees to self-report to applicable taxing authorities, as may be required by applicable laws.
+    </p>
+
+    <p>
+      Prizes should be retained by individuals only in conformity with any applicable policies of his or her
+      employers, academic institutions, or government regarding participation in and receipt of promotional
+      consideration relating to the Raffle and receipt and retention of prize. If a government, employer’s or
+      school’s policies are applicable, it is the entrant’s sole and ultimate responsibility, in consultation
+      with his or her government, employer or school, to determine how and if prize will be retained and/or
+      distributed and accounted for and we assume no responsibility for the decisions made by such government,
+      employers or schools regarding this issue.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Conditions of Participation.</b> By submitting an entry for or participating in this Raffle, you
+      agree to abide by these rules and any decision Sponsor makes regarding this Raffle, which Sponsor
+      shall make in its sole discretion.  Sponsor reserves the right to disqualify and prosecute to the
+      fullest extent permitted by law any participant or winner who, in Sponsor’s reasonable suspicion,
+      tampers with Sponsor site, the entry process, intentionally submits more than a single entry,
+      violates these rules, engages in fraud, attempted fraud, or acts in an unsportsmanlike or disruptive
+      manner.
+    </p>
+
+    <p>
+      By submitting an entry for or participating in this Raffle, you agree to abide by Mozilla’s
+      <a href="{{ url('mozorg.about.governance.policies.participation') }}">Community Participation Guidelines</a>.
+      Violation of the Community Participation Guidelines (“CPG”) by any Entrant will result in
+      disqualification for that Entrant. The CPG is available at:
+      <a href="{{ url('mozorg.about.governance.policies.participation') }}">https://www.mozilla.org/about/governance/policies/participation/</a>
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Intellectual Property.</b> Ownership of the pre-existing underlying intellectual property of the
+      entrant remains the property of the entrant subject to Sponsor’s rights to reprint, display,
+      reproduce, perform, use, and exhibit the entry and materials and information submitted, for the
+      purpose of administering and promoting the Raffle and for any business, marketing and advertising
+      purposes for the benefit of Sponsor. By participating in the Raffle, each entrant grants to Sponsor
+      a non-exclusive, worldwide, fully paid, royalty-free, perpetual, irrevocable, transferable,
+      sub-licensable, license to reprint, display, reproduce, exploit, perform, use, and exhibit (including
+      the right to make derivative works of) the entry and materials and information submitted on and in
+      connection with the Raffle or use or receipt of the prize for any and all purposes in any medium.
+      Each participating entrant hereby warrants that any entry and other materials and information
+      provided by entrant are original with entrant and do not violate or infringe upon the copyrights,
+      trademarks, rights of privacy, publicity, moral rights or other intellectual property or other rights
+      of any person or entity, and do not violate any rules, regulations, or laws. If the entry or
+      information or materials provided by entrant contain any material or elements that are not owned by
+      entrant and/or which are subject to the rights of third parties, entrant represents he or she has
+      obtained, prior to submission of the entry and information or materials, any and all releases and
+      consents necessary to permit use and exploitation of the entry and information and materials by
+      Sponsor in the manner set forth in the Official Rules without additional compensation.
+    </p>
+
+    <p>
+      Each entrant warrants that the entry and materials and information provided do not contain information
+      considered by entrant, its employees, employer, or personnel, or any other third party to be confidential,
+      and that submission of the materials and information will not violate any agreements with third parties
+      or policies that entrant is subject to. Entrant agrees that Sponsor has the right to verify the ownership
+      and originality of all entries and that, upon Sponsor’s request, entrant must submit a written copy of
+      any release or permission entrant has received from a third party granting entrant the right to use such
+      property. Entrant acknowledges that other entrants may submit entries that are similar to yours and that
+      they, or Sponsor, may already be considering or developing, or may subsequently consider or develop
+      independent of the Raffle, content or ideas that are related or similar to yours. You acknowledge that
+      this does not create in Sponsor or others any obligation or liability to you.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Disclaimer, Release and Limit of Liability.</b> SPONSOR MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+      KIND, EXPRESS OR IMPLIED, REGARDING ANY PRIZE OR YOUR PARTICIPATION IN THE PROMOTION. BY ENTERING THE
+      PROMOTION OR RECEIPT OF ANY PRIZE, EACH ENTRANT AGREES TO RELEASE AND HOLD HARMLESS SPONSOR AND ITS
+      SUBSIDIARIES, AFFILIATES, SUPPLIERS, DISTRIBUTORS, ADVERTISING/PROMOTION AGENCIES, PARTNERS, AND PRIZE
+      SUPPLIERS, AND EACH OF THEIR RESPECTIVE PARENT COMPANIES AND EACH SUCH COMPANY’S OFFICERS, DIRECTORS,
+      EMPLOYEES AND AGENTS (COLLECTIVELY, THE “RELEASED PARTIES”) FROM AND AGAINST ANY CLAIM OR CAUSE OF ACTION,
+      INCLUDING, BUT NOT LIMITED TO, PERSONAL INJURY, DEATH, OR DAMAGE TO OR LOSS OF PROPERTY, ARISING OUT OF
+      PARTICIPATION IN THE PROMOTION OR RECEIPT OR USE OR MISUSE OF ANY PRIZE. THE RELEASED PARTIES ARE NOT
+      RESPONSIBLE FOR:  (1) ANY INCORRECT OR INACCURATE INFORMATION, WHETHER CAUSED BY ENTRANTS, PRINTING
+      ERRORS OR BY ANY OF THE EQUIPMENT OR PROGRAMMING ASSOCIATED WITH OR UTILIZED IN THE PROMOTION; (2)
+      TECHNICAL FAILURES OF ANY KIND, INCLUDING, BUT NOT LIMITED TO MALFUNCTIONS, INTERRUPTIONS, OR
+      DISCONNECTIONS IN PHONE LINES OR NETWORK HARDWARE OR SOFTWARE; (3) UNAUTHORIZED HUMAN INTERVENTION IN ANY
+      PART OF THE ENTRY PROCESS OR THE PROMOTION; (4) TECHNICAL OR HUMAN ERROR WHICH MAY OCCUR IN THE
+      ADMINISTRATION OF THE PROMOTION OR THE PROCESSING OF ENTRIES; OR (5) ANY INJURY OR DAMAGE TO PERSONS OR
+      PROPERTY WHICH MAY BE CAUSED, DIRECTLY OR INDIRECTLY, IN WHOLE OR IN PART, FROM ENTRANT’S PARTICIPATION
+      IN THE PROMOTION OR RECEIPT OR USE OR MISUSE OF ANY PRIZE.  No more than the stated number of prizes will
+      be awarded.  If someone cheats, or a virus, bug, bot, catastrophic event, or any other unforeseen or
+      unexpected action or event affects the fairness and/or integrity of this Raffle, Sponsor reserves the
+      right to cancel, change, or suspend this Raffle.  This right is reserved whether the event is due to human
+      or technical error.  If a solution cannot be found to restore the integrity of the Raffle, we reserve the
+      right, but are not required, to draw winner(s) from among all eligible entries received before we had to
+      cancel, change or suspend the Raffle.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Privacy and Use of Personal Information.</b> Sponsor collects personal information from you when you
+      enter this Raffle.  Sponsor reserves the right to use any information collected in accordance with its
+      privacy policy, which may be found at <a href="{{ url('privacy') }}">https://www.mozilla.org/privacy/</a>.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>GOVERNING LAW AND DISPUTES</b>. THESE OFFICIAL RULES AND THE PROMOTION ARE GOVERNED BY, AND WILL BE
+      CONSTRUED IN ACCORDANCE WITH, THE LAWS OF THE STATE OF CALIFORNIA, AND THE FORUM AND VENUE FOR ANY
+      DISPUTE ARISING OUT OF OR RELATING TO THESE OFFICIAL RULES SHALL BE IN SANTA CLARA COUNTY, CALIFORNIA.
+      IF THE CONTROVERSY OR CLAIM IS NOT OTHERWISE RESOLVED THROUGH DIRECT DISCUSSIONS OR MEDIATION, IT SHALL
+      THEN BE RESOLVED BY FINAL AND BINDING ARBITRATION ADMINISTERED BY JUDICIAL ARBITRATION AND MEDIATION
+      SERVICES, INC., IN ACCORDANCE WITH ITS STREAMLINED ARBITRATION RULES AND PROCEDURES OR SUBSEQUENT VERSIONS
+      THEREOF (“JAMS RULES”). THE JAMS RULES FOR SELECTION OF AN ARBITRATOR SHALL BE FOLLOWED, EXCEPT THAT THE
+      ARBITRATOR SHALL BE EXPERIENCED AND LICENSED TO PRACTICE LAW IN CALIFORNIA. ANY SUCH CONTROVERSY OR CLAIM
+      WILL BE ARBITRATED ON AN INDIVIDUAL BASIS, AND WILL NOT BE CONSOLIDATED IN ANY ARBITRATION WITH ANY CLAIM
+      OR CONTROVERSY OF ANY OTHER PARTY. ALL PROCEEDINGS BROUGHT PURSUANT TO THIS PARAGRAPH WILL BE CONDUCTED
+      IN SANTA CLARA COUNTY, CALIFORNIA. THE REMEDY FOR ANY CLAIM SHALL BE LIMITED TO ACTUAL DAMAGES, AND IN NO
+      EVENT SHALL ANY PARTY BE ENTITLED TO RECOVER PUNITIVE, EXEMPLARY, CONSEQUENTIAL, OR INCIDENTAL DAMAGES,
+      INCLUDING ATTORNEY’S FEES OR OTHER SUCH RELATED COSTS OF BRINGING A CLAIM, OR TO RESCIND THIS AGREEMENT
+      OR SEEK INJUNCTIVE OR ANY OTHER EQUITABLE RELIEF. SPONSOR’S TOTAL LIABILITY UNDER, ARISING OUT OF, OR
+      RELATED TO THIS AGREEMENT SHALL NOT EXCEED THE TOTAL AMOUNT OF THE PRIZE OFFERED TO THE WINNER OF THE
+      RAFFLE.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Publicity Grant.</b> Except where prohibited, participation in the Raffle constitutes entrant’s consent
+      to Sponsor’s and Sponsor’s designees’ publication, broadcast, display, sharing and use of entrant’s and
+      Team’s name, likeness, voice, image, persona, biographical information, entry and audio and visual content
+      shared by entrant for any purposes in any media, worldwide, without further payment or consideration.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>No Confidentiality.</b>  Submissions will be shared with others and portions of entries may be reproduced
+      elsewhere, including in connection with Raffle-related publicity materials. You should not disclose any
+      information in your entry that is proprietary or confidential. No confidential relationship is established
+      between you and Sponsor in connection with your entry.
+    </p>
+  </li>
+
+  <li>
+    <p>
+      <b>Winners List.</b>  Individuals may request the name of winners by submitting a self-addressed stamped
+      envelope prior to March 31, 2023 to Mozilla Raffle Winners List Request, Schlesische Str. 27, 10997 Berlin.
+    </p>
+  </li>
+</ol>
+{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -23,6 +23,7 @@ urlpatterns = (
     # requested in any other locale. (Bug 1248393)
     page("impressum/", "legal/impressum.html", active_locales=["de"], ftl_files=["mozorg/about/legal"]),
     path("terms/mozilla/", LegalDocView.as_view(template_name="legal/terms/mozilla.html", legal_doc_name="Websites_ToU"), name="legal.terms.mozilla"),
+    page("terms/peopleofdeutschland/", "legal/terms/peopleofdeutschland.html", active_locales=["en-US", "de"], ftl_files=["mozorg/about/legal"]),
     path(
         "terms/firefox/",
         LegalDocView.as_view(template_name="legal/terms/firefox.html", legal_doc_name="firefox_about_rights"),


### PR DESCRIPTION
## One-line summary

Adds legal pages for Pocket raffle

## Issue / Bugzilla link

#12699

## Testing

- http://localhost:8000/en-US/about/legal/terms/peopleofdeutschland/
- http://localhost:8000/de/about/legal/terms/peopleofdeutschland/