### PR TITLE
Add scroll offset to anchors on channel pages [fix #12751]

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -20,7 +20,7 @@
 {% block page_og_desc %}{{ self.page_desc() }}{% endblock %}
 
 {% block channels %}
-<section id="beta">
+<section id="beta" class="mzp-is-anchor-link">
   {% call call_out_compact(
     title=ftl('firefox-channel-beta'),
     desc=ftl('firefox-channel-try-the-latest-android-features'),
@@ -51,7 +51,7 @@
   </div>
 </section>
 
-<section id="nightly">
+<section id="nightly" class="mzp-is-anchor-link">
   {% call call_out_compact(
     title=ftl('firefox-channel-nightly'),
     desc=ftl('firefox-channel-check-out-new-android-features'),

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -17,7 +17,7 @@
 {% block page_og_desc %}{{ self.page_desc() }}{% endblock %}
 
 {% block channels %}
-<section id="beta">
+<section id="beta" class="mzp-is-anchor-link">
   {% call call_out_compact(
     title=ftl('firefox-channel-beta'),
     desc=ftl('firefox-channel-test-about-to-be-released'),
@@ -49,7 +49,7 @@
   </div>
 </section>
 
-<section id="developer">
+<section id="developer" class="mzp-is-anchor-link">
   {% call call_out_compact(
     title=ftl('firefox-channel-developer-edition'),
     desc=ftl('firefox-channel-build-test-scale-and-more'),
@@ -79,7 +79,7 @@
   </div>
 </section>
 
-<section id="nightly">
+<section id="nightly" class="mzp-is-anchor-link">
     {% call call_out_compact(
       title=ftl('firefox-channel-nightly'),
       desc=ftl('firefox-channel-get-a-sneak-peek-at-our', fallback='firefox-channel-test-brand-new-features'),

--- a/bedrock/firefox/templates/firefox/channel/ios.html
+++ b/bedrock/firefox/templates/firefox/channel/ios.html
@@ -17,7 +17,7 @@
 {% block page_og_desc %}{{ self.page_desc() }}{% endblock %}
 
 {% block channels %}
-<section id="testflight">
+<section id="testflight" class="mzp-is-anchor-link">
   {% call call_out_compact(
     title=ftl('firefox-channel-test-flight'),
     desc=ftl('firefox-channel-test-beta-versions-of-firefox-ios'),


### PR DESCRIPTION
## One-line summary

Adds the class `mzp-is-anchor-link` to sections on the Firefox channel pages so when we link directly to a section it gets some scroll offset to accommodate the sticky navbar.

## Issue / Bugzilla link

#12751 

## Testing

http://localhost:8000/firefox/channel/desktop/#beta
http://localhost:8000/firefox/channel/android/#beta

