### PR TITLE
Migrate snowplow to v3 for pocket marketing pages

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -110,7 +110,7 @@ if IS_POCKET_MODE:
     COOKIE_CONSENT_DATA_DOMAIN = "a7ff9c31-9f59-421f-9a8e-49b11a3eb24e-test" if DEV else "a7ff9c31-9f59-421f-9a8e-49b11a3eb24e"
 
     SNOWPLOW_APP_ID = "pocket-web-mktg-dev" if DEV else "pocket-web-mktg"
-    SNOWPLOW_SCRIPT_SRC = "https://assets.getpocket.com/web-utilities/public/static/te-2.18.js"
+    SNOWPLOW_SCRIPT_SRC = "https://assets.getpocket.com/web-utilities/public/static/te-3.1.2.js"
     SNOWPLOW_CONNECT_URL = "com-getpocket-prod1.mini.snplow.net" if DEV else "getpocket.com"
 
     # CSP settings for POCKET, expanded upon later:

--- a/media/js/pocket/analytics.es6.js
+++ b/media/js/pocket/analytics.es6.js
@@ -135,18 +135,20 @@ const PocketAnalytics = {
 
         const data = getUserData();
         if (data) {
-            window.snowplow('addGlobalContexts', [
-                {
-                    schema: `iglu:com.pocket/user/jsonschema/1-0-0`,
-                    data
-                }
-            ]);
+            window.snowplow('addGlobalContexts', {
+                context: [
+                    {
+                        schema: `iglu:com.pocket/user/jsonschema/1-0-0`,
+                        data
+                    }
+                ]
+            });
         }
-        window.snowplow(
-            'enableActivityTracking',
-            10, // heartbeat delay
-            10 // heartbeat interval
-        );
+        window.snowplow('enableActivityTracking', {
+            // integers are in seconds
+            minimumVisitLength: 10,
+            heartbeatDelay: 10
+        });
         window.snowplow('enableLinkClickTracking');
         window.snowplow('enableFormTracking');
         window.snowplow('trackPageView');


### PR DESCRIPTION
## One-line summary

Updated the Pocket Marketing pages to use v3 of Snowplow analytics 

## Issue / Bugzilla link
#12727 

## Testing
- Run tests locally with `npm run test` to ensure the unit tests pass
- http://localhost:8000 and see that snowplow has been loaded
