### PR TITLE
Add Transparency Report H2 2022 (Fixes #12748)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,7 @@
 <nav class="prev-reports-nav">
   <h3>Previous Reports</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2022') }}">January-June 2022</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2021') }}">July-December 2021</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2021') }}">January-June 2021</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2020') }}">July-December 2020</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -15,7 +15,7 @@
     </li>
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2022') }}">January-June 2022 Report</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2022') }}">July-December 2022 Report</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2022.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2022.html
@@ -1,0 +1,505 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}Transparency Report - July-December 2022{% endblock %}
+
+{% block report_title %}
+<h1>Transparency Report <span>Reporting Period: July 1, 2022 to December 31, 2022</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for User Data</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received the following.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Legal Processes</th>
+          <th scope="col">Received</th>
+          <th scope="col">User Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">Search Warrants</a>
+          </th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">Subpoenas</a>
+          </th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">Court Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">Wiretap Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">Pen Register Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">Emergency Requests</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">National Security Requests</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>0-249</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p id="footnote-1">
+        <sup>1</sup> We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for Content Removal</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received no government request for content removal from our services.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Requesting Country</th>
+          <th scope="col">Requests Received</th>
+          <th scope="col">Items Removed</th>
+          <th scope="col">Items Geographically Restricted</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">None</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Copyright</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received four Copyright Takedown Notices and one Counter Notice (note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>4</td>
+          <td>1</td>
+          <td>4</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Trademark</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received one Trademark Takedown Notice (note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>1</td>
+          <td>0</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="other-content" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Other Takedown Requests By Companies or Individuals</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received one private takedown notice invoking laws other than copyright or trademark (note that takedown notices can target more than one item). Where takedown requests are made pursuant to national laws removal might be limited to the relevant jurisdiction.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>1</td>
+          <td>0</td>
+          <td>10</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="personal-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Personal Data Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 21,066 requests.</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Received</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Mozilla</th>
+          <td>16,583</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>4,483</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="targeted-advertising" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Targeted Advertising Disclosures</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, and during the time we started targeted advertising, we have placed the following targeted advertisements.</p>
+
+    <h3>Mozilla</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/mradi-h2-2022-campaign.pdf">
+          Mradi H2 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/rally-2022-campaign.pdf">
+          Rally H2 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/homepage-experiment-ad-campaign.pdf">
+          Homepage Experiment Ad Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Firefox</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/firefox-north-america-h2-2022-campaign.pdf">
+          Firefox North America H2 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/firefox-european-union-h2-2022-campaign.pdf">
+          Firefox European Union H2 2022 Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Mozilla Foundation Ads</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/common-voice-competition-campaign.pdf">
+          Common Voice Competition Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/youtube-regrets-reporter-h2-2022.pdf">
+          Youtube Regrets Reporter H2 2022
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/transparency-democracy-campaign.pdf">
+          Transparency & Democracy Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/privacy-not-included-campaign.pdf">
+          Privacy Not Included Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/mozfest-2023-campaign.pdf">
+          Mozfest 2023 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/mozilla-irl.pdf">
+          Mozilla IRL Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/data-futures-lab.pdf">
+          Data Futures Lab Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/ai-act-campaign.pdf">
+          AI Act Campaign
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section id="monthly-active-users" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">EU Monthly Active Users</h2>
+
+  <div data-accordion-role="tabpanel">
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Average MAU in the European Union</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Addons.mozilla.org</th>
+          <td>3,047,095</td>
+        </tr>
+        <tr>
+          <th scope="row">Hubs</th>
+          <td>&lt;50,000</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>354,986</td>
+        </tr>
+        <tr>
+          <th scope="row">MDN</th>
+          <td>2,364,850</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="monthly-active-users" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">EU Monthly Active Users</h2>
+
+  <div data-accordion-role="tabpanel">
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Average MAU in the European Union</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Addons.mozilla.org</th>
+          <td>3,047,095</td>
+        </tr>
+        <tr>
+          <th scope="row">Hubs</th>
+          <td>101</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>354,986</td>
+        </tr>
+        <tr>
+          <th scope="row">MDN</th>
+          <td>2,364,850</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Supplement</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      During the course of this reporting period, Mozilla maintained its efforts to protect the privacy and security of our users
+      through public policy engagements. In the European Union, we continued our work on the eIDAS legislation, which threatens
+      web security by placing a ceiling on the security standards. This included holding an
+      <a href="https://www.linkedin.com/posts/security-risk-ahead_securityriskahead-qwacs-eidas-activity-6998306415274565632-koIu">event</a>
+      with a Member of European Parliament, engaging with civil society allies, and continuing our public
+      <a href="https://securityriskahead.eu/">campaign</a> to drive awareness of the risks posed by the issue. We also
+      <a href="https://www.stiftung-nv.de/de/veranstaltung/cyber-diplomacy-workshop-governments-role-increasing-software-supply-chain-security">engaged</a>
+      in the role governments can play in software supply chain security.
+    </p>
+
+    <p>
+      In the United Kingdom, we continued our work on privacy preserving advertising and mitigating online tracking via
+      conversations with the Competition and Markets Authority (CMA) and the Information Commissioner's Office (ICO). We also
+      spoke on panels on adtech regulations and privacy in <a href="https://www.youtube.com/watch?v=qI6vuRgixjs">Amsterdam</a>
+      and on the nexus between privacy and competition in <a href="https://www.le-foundation.com/app/uploads/2022/11/22.-November-Flyer-und-Programm-V2.pdf">St. Gallen</a>.
+    </p>
+
+    <p>
+      In the United States, we submitted <a href="https://blog.mozilla.org/netpolicy/2022/11/15/mozilla-comments-on-ftcs-commercial-surveillance-and-data-security-advance-notice-of-proposed-rulemaking/">comments</a>
+      in the FTC’s “Commercial Surveillance and Data Security” advance notice of proposed rulemaking (where we also
+      <a href="https://www.ftc.gov/news-events/events/2022/09/commercial-surveillance-data-security-anpr-public-forum">spoke</a> at the Public Forum),
+      <a href="https://blog.mozilla.org/netpolicy/2022/07/27/mozilla-submits-comments-in-ostp-consultation-on-privacy-preserving-data-sharing/">commented</a>
+      on the White House Office of Science and Technology Policy’s consultation on privacy-preserving data sharing, and
+      responded to a US Government <a href="https://www.federalregister.gov/documents/2022/03/17/2022-05683/request-for-information-on-federal-priorities-for-information-integrity-research-and-development">Request for Information</a>
+      on Federal Priorities for Information Integrity Research & Development. We also
+      <a href="https://blog.mozilla.org/netpolicy/2022/08/24/its-time-to-pass-u-s-federal-privacy-legislation/">endorsed</a>
+      the American Data Privacy and Protection Act (ADPPA) and held an <a href="https://blog.mozilla.org/netpolicy/2022/08/29/save-the-date-the-long-road-to-federal-privacy-protections-are-we-there-yet/">event</a>
+      with experts to discuss the legislation, and supported the Platform Accountability and Transparency Act
+      (<a href="https://www.coons.senate.gov/news/press-releases/coons-portman-klobuchar-announce-legislation-to-ensure-transparency-at-social-media-platforms">PATA</a>).
+    </p>
+
+    <p>
+      In India, we <a href="https://www.youtube.com/watch?v=sYrU2H52-9Q">spoke</a> on algorithmic accountability and personal
+      data protection, organised technical <a href="https://www.medianama.com/2022/10/223-privacynama-2022-workshop-privacy-preserving-advertising-october-11/">workshops</a>
+      on privacy preserving advertising, and <a href="https://www.medianama.com/2022/09/223-privacynama-session-geopolitics-data-segmentation-and-cross-border-data-flows-october-6/">engaged</a>
+      on the latest iteration of India’s data protection law. In Kenya, we launched a course on Lean Data Practices focused on
+      Small and Medium Enterprises (<a href="https://www.capitalfm.co.ke/business/2022/06/mozilla-unveils-data-privacy-course-for-smes-in-kenya/">SMEs</a>)
+      to increase their awareness and capabilities in managing data responsibly.
+    </p>
+
+    <h3>Voluntary Threat Indicators & Data Disclosures</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Type of Disclosure</th>
+          <th scope="col">Number of Disclosures</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">Cybersecurity Threat Indicator</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            Other <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-specific-user' }}">Specific User</a> Data Disclosure
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -83,6 +83,7 @@ urlpatterns = (
     page("about/policy/transparency/jan-jun-2021/", "mozorg/about/policy/transparency/jan-jun-2021.html"),
     page("about/policy/transparency/jul-dec-2021/", "mozorg/about/policy/transparency/jul-dec-2021.html"),
     page("about/policy/transparency/jan-jun-2022/", "mozorg/about/policy/transparency/jan-jun-2022.html"),
+    page("about/policy/transparency/jul-dec-2022/", "mozorg/about/policy/transparency/jul-dec-2022.html"),
     page("contact/", "mozorg/contact/contact-landing.html"),
     page("contact/spaces/", "mozorg/contact/spaces/spaces-landing.html"),
     page("contact/spaces/beijing/", "mozorg/contact/spaces/beijing.html"),


### PR DESCRIPTION
## One-line summary

Adds Transparency Report page for H2 2022. The EU MAU numbers have a hard legal deadline, so this needs to go live tomorrow (Friday 17th Feb).

## Issue / Bugzilla link

#12748

## Testing

http://localhost:8000/en-US/about/policy/transparency/jul-dec-2022/