### PR TITLE
Update protocol/core to v16.1.0 (Fixes #12759)

### DIFF
--- a/media/css/protocol/common-old-ie.scss
+++ b/media/css/protocol/common-old-ie.scss
@@ -36,10 +36,6 @@ label {
     display: block;
 }
 
-[hidden] {
-    display: none;
-}
-
 .visually-hidden {
     @include visually-hidden;
 }

--- a/media/css/protocol/protocol-firefox.scss
+++ b/media/css/protocol/protocol-firefox.scss
@@ -38,10 +38,6 @@ $image-path: '/media/protocol/img';
 @import 'components/menu-item';
 @import 'components/sub-navigation';
 
-[hidden] {
-    display: none;
-}
-
 // Temporary styling until the newsletter component is updated in Protocol
 // https://github.com/mozilla/protocol/issues/578
 .mzp-c-newsletter-subtitle {

--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -41,10 +41,6 @@ $image-path: '/media/protocol/img';
 // Temporary styling until the newsletter component is updated in Protocol
 // https://github.com/mozilla/protocol/issues/578
 
-[hidden] {
-    display: none;
-}
-
 .mzp-c-newsletter-subtitle {
     @include text-title-xs;
 }

--- a/media/js/careers/testimonials-modal.es6.js
+++ b/media/js/careers/testimonials-modal.es6.js
@@ -182,16 +182,6 @@ for (let i = 0; i < modalContainers.length; i++) {
 
                 // set next/prev listeners
                 modalInit();
-
-                // temporary workaround for https://github.com/mozilla/protocol/issues/829 to keep modal focussed
-                const modal = document.querySelector('.mzp-c-modal');
-                modal.addEventListener(
-                    'animationend',
-                    (e) => {
-                        e.target.focus();
-                    },
-                    false
-                );
             },
             onDestroy: function () {
                 if (window.history) {

--- a/media/js/foundation/annual-report-modal.es6.js
+++ b/media/js/foundation/annual-report-modal.es6.js
@@ -164,16 +164,6 @@ for (let i = 0; i < modalContainers.length; i++) {
 
                 // set next/prev listeners
                 modalInit();
-
-                // temporary workaround for https://github.com/mozilla/protocol/issues/829
-                const modal = document.querySelector('.mzp-c-modal');
-                modal.addEventListener(
-                    'animationend',
-                    (e) => {
-                        e.target.focus();
-                    },
-                    false
-                );
             },
             onDestroy: () => {
                 if (window.history) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
-        "@mozilla-protocol/core": "16.0.0",
+        "@mozilla-protocol/core": "^16.1.0",
         "@mozilla/glean": "^1.3.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
@@ -1839,9 +1839,9 @@
       "dev": true
     },
     "node_modules/@mozilla-protocol/core": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-16.0.0.tgz",
-      "integrity": "sha512-2eICrBcKvm9GpKy7yv90YIVbR/iscyVpjfaeMt+n25lj0svNknDBPmQJR0njgOemzEr8IFdnqL8oj0+JhMGj8g=="
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-16.1.0.tgz",
+      "integrity": "sha512-M9Omsb8/J+yT42nESsZk3ENPB8TVOpGjjGOK364ufDK6bT5cUhazxvIVF1EGOi46rLsv7QBH9POku01kd+Xb7Q=="
     },
     "node_modules/@mozilla/glean": {
       "version": "1.3.0",
@@ -11761,9 +11761,9 @@
       "dev": true
     },
     "@mozilla-protocol/core": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-16.0.0.tgz",
-      "integrity": "sha512-2eICrBcKvm9GpKy7yv90YIVbR/iscyVpjfaeMt+n25lj0svNknDBPmQJR0njgOemzEr8IFdnqL8oj0+JhMGj8g=="
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-16.1.0.tgz",
+      "integrity": "sha512-M9Omsb8/J+yT42nESsZk3ENPB8TVOpGjjGOK364ufDK6bT5cUhazxvIVF1EGOi46rLsv7QBH9POku01kd+Xb7Q=="
     },
     "@mozilla/glean": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
-    "@mozilla-protocol/core": "16.0.0",
+    "@mozilla-protocol/core": "^16.1.0",
     "@mozilla/glean": "^1.3.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",


### PR DESCRIPTION
## One-line summary

Change log https://github.com/mozilla/protocol/blob/main/CHANGELOG.md

## Significant changes and points to review

- Removes redundant `[hidden]` selectors which are now in protocol's base style sheets
- Removes modal focus workarounds which have since been fixes 

## Issue / Bugzilla link

#12759

## Testing

Demo: https://www-demo3.allizom.org/en-US/

Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/779927308