### PR TITLE
Remove duplicate table from Transparency Report

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2022.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2022.html
@@ -401,37 +401,6 @@
   </div>
 </section>
 
-<section id="monthly-active-users" class="c-collapsible-section">
-  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">EU Monthly Active Users</h2>
-
-  <div data-accordion-role="tabpanel">
-    <table class="mzp-u-data-table">
-      <thread>
-        <th scope="col">Service</th>
-        <th scope="col">Average MAU in the European Union</th>
-      </thread>
-      <tbody>
-        <tr>
-          <th scope="row">Addons.mozilla.org</th>
-          <td>3,047,095</td>
-        </tr>
-        <tr>
-          <th scope="row">Hubs</th>
-          <td>101</td>
-        </tr>
-        <tr>
-          <th scope="row">Pocket</th>
-          <td>354,986</td>
-        </tr>
-        <tr>
-          <th scope="row">MDN</th>
-          <td>2,364,850</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
-
 <section id="supplement" class="c-collapsible-section">
   <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Supplement</h2>
 


### PR DESCRIPTION
Somehow I accidentally left in a duplicate table, which needs removing