### PR TITLE
Remove pocket saves switch (fixes #12284)

### DIFF
--- a/bedrock/pocket/templates/pocket/includes/mobile-nav.html
+++ b/bedrock/pocket/templates/pocket/includes/mobile-nav.html
@@ -14,7 +14,7 @@
                 <a class="mobile-nav-list-link home" href="https://getpocket.com/home?src=navbar">{{ ftl('pocket-nav-home') }}<span class="beta">{{ ftl('pocket-mobile-nav-beta') }}</span></a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link my-list" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}?src=navbar">{% if switch('pocket-rename-my-list-to-saves') %}{{ ftl('pocket-nav-saves') }}{% else %}{{ ftl('pocket-nav-my-list') }}{% endif %}</a>
+                <a class="mobile-nav-list-link my-list" href="https://getpocket.com/saves?src=navbar">{{ ftl('pocket-nav-saves') }}</a>
             </li>
             <li class="mobile-nav-list-item">
                 <a class="mobile-nav-list-link discover" href="https://getpocket.com/explore?src=navbar">{{ ftl('pocket-nav-discover') }}</a>
@@ -23,22 +23,22 @@
                 <a class="mobile-nav-list-link collections" href="https://getpocket.com/collections?src=navbar">{{ ftl('pocket-nav-collections') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link archive" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/archive">{{ ftl('pocket-nav-archive') }}</a>
+                <a class="mobile-nav-list-link archive" href="https://getpocket.com/saves/archive">{{ ftl('pocket-nav-archive') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link favorites" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/favorites">{{ ftl('pocket-nav-favorites') }}</a>
+                <a class="mobile-nav-list-link favorites" href="https://getpocket.com/saves/favorites">{{ ftl('pocket-nav-favorites') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link highlights" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/highlights">{{ ftl('pocket-nav-highlights') }}</a>
+                <a class="mobile-nav-list-link highlights" href="https://getpocket.com/saves/highlights">{{ ftl('pocket-nav-highlights') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link articles" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/articles">{{ ftl('pocket-nav-articles') }}</a>
+                <a class="mobile-nav-list-link articles" href="https://getpocket.com/saves/articles">{{ ftl('pocket-nav-articles') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link videos" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/videos">{{ ftl('pocket-nav-videos') }}</a>
+                <a class="mobile-nav-list-link videos" href="https://getpocket.com/saves/videos">{{ ftl('pocket-nav-videos') }}</a>
             </li>
             <li class="mobile-nav-list-item">
-                <a class="mobile-nav-list-link tags" href="https://getpocket.com{% if switch('pocket-rename-my-list-to-saves') %}/saves{% else %}/my-list{% endif %}/tags">{{ ftl('pocket-nav-all-tags') }}</a>
+                <a class="mobile-nav-list-link tags" href="https://getpocket.com/saves/tags">{{ ftl('pocket-nav-all-tags') }}</a>
             </li>
         </ul>
     </nav>

--- a/bedrock/pocket/templates/pocket/includes/nav.html
+++ b/bedrock/pocket/templates/pocket/includes/nav.html
@@ -34,11 +34,7 @@
         <div class="page-navigation" aria-label="{{ ftl('pocket-nav-aria-label') }}">
             <ul class="page-navigation-list links">
                 <li class="page-navigation-list-item"><a id="global-nav-discover-link" class="page-navigation-list-item-link selected nav-link" href="https://getpocket.com/explore?src=navbar">{{ ftl('pocket-nav-discover') }}</a></li>
-                {% if switch('pocket-rename-my-list-to-saves') %}
-                  <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/saves?src=navbar">{{ ftl('pocket-nav-saves') }}</a></li>
-                {% else %}
-                  <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/my-list?src=navbar">{{ ftl('pocket-nav-my-list') }}</a></li>
-                {% endif %}
+                <li class="page-navigation-list-item"><a id="global-nav-my-list-link" class="page-navigation-list-item-link nav-link" href="https://getpocket.com/saves?src=navbar">{{ ftl('pocket-nav-saves') }}</a></li>
               </ul>
         </div>
         <div>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -182,11 +182,7 @@
         <li>getpocket.com/account</li>
         <li>getpocket.com/discover</li>
         <li>getpocket.com/collections</li>
-        {% if switch('pocket-rename-my-list-to-saves') %}
         <li>getpocket.com/saves/*</li>
-        {% else %}
-        <li>getpocket.com/my-list/*</li>
-        {% endif %}
         <li>getpocket.com/read/*</li>
         <li>getpocket.com/premium/*</li>
       </ul>


### PR DESCRIPTION
## One-line summary

We created a switch to have a wording change ready for Oct. 31, 2022. We no longer have need for this logic.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12284

## Checklist

If relevant:

- [ ] Feature flags removed from www-config: https://github.com/mozmeao/www-config/pull/509

## Testing

<img width="247" alt="Screenshot 2023-02-20 at 5 06 41 PM" src="https://user-images.githubusercontent.com/19650432/220166607-31816733-0095-4eff-bf08-5d4a17eac409.png">

To test this work:

POCKET MODE
- [ ] http://localhost:8000/en/about/ desktop menu shows "saves"
- [ ] any former "my list" link in desktop or mobile menu now shows "saves" in url path
MOZORG MODE
- [ ] http://localhost:8000/en-US/security/bug-bounty/web-eligible-sites/ lists "saves/*"
