### PR TITLE
Add missing cookie preferences link to pocket platform footer (Fixes #12678)

### DIFF
--- a/bedrock/pocket/templates/pocket/includes/footer-platform.html
+++ b/bedrock/pocket/templates/pocket/includes/footer-platform.html
@@ -14,6 +14,7 @@
       <li class="footer-navigation-list-item"><a href="https://getpocket.com/developer/">{{ ftl('pocket-footer-developers') }}</a></li>
       <li class="footer-navigation-list-item"><a href="{{ url('pocket.tos') }}">{{ ftl('pocket-footer-terms-of-service') }}</a></li>
       <li class="footer-navigation-list-item"><a href="{{ url('pocket.privacy') }}">{{ ftl('pocket-footer-privacy-policy') }}</a></li>
+      <li class="footer-navigation-list-item"><button id="ot-sdk-btn" class="ot-sdk-show-settings">{{ ftl ('pocket-footer-cookie-preferences') }}</button></li>
       <li class="footer-navigation-list-item"><a href="https://help.getpocket.com/">{{ ftl('pocket-footer-support') }}</a></li>
       <li class="footer-navigation-list-item"><a href="{{ url('pocket.jobs') }}">{{ ftl('pocket-footer-jobs') }}</a></li>
     </ul>

--- a/media/css/pocket/includes/_platform-footer.scss
+++ b/media/css/pocket/includes/_platform-footer.scss
@@ -15,7 +15,7 @@ $image-path: '/media/protocol/img';
         display: flex;
         flex-flow: column-reverse wrap;
         margin: 0 auto;
-        max-width: $screen-lg;
+        max-width: $screen-xl;
         width: 100%;
         height: auto;
 
@@ -31,7 +31,7 @@ $image-path: '/media/protocol/img';
             color: $color-text-primary;
             display: flex;
             flex-flow: column wrap;
-            height: 220px;
+            height: 300px;
             justify-content: center;
             margin: 0 auto $layout-xs;
             max-width: 500px;
@@ -41,10 +41,12 @@ $image-path: '/media/protocol/img';
                 margin: 0 0 $spacing-md;
                 cursor: pointer;
 
-                a {
+                a,
+                #ot-sdk-btn {
                     color: $color-text-primary;
+                    display: inline-block;
                     text-decoration: none;
-                    margin: $spacing-lg $spacing-xs;
+                    margin: $spacing-sm $spacing-xs;
 
                     &:hover,
                     &:active,


### PR DESCRIPTION
## One-line summary

Ensures all pocket marketing pages have a "Cookie preferences" link, as per: https://help.getpocket.com/article/1163-pocket-website-cookies-faq

## Significant changes and points to review

The footer here could really use a larger CSS refactor to make it more scalable for adding new links. I had to tweak a few things to make it play nice. But then I started down the path of why we even have two footers and not just one, so for now I think this is the quickest fix.

## Issue / Bugzilla link

#12678

## Testing

`npm run in-pocket-mode`

http://localhost:8000/en/
