### PR TITLE
Remove duplicate JS bundle from static-bundles.json

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1898,13 +1898,6 @@
     {
       "files": [
         "protocol/js/protocol-modal.js",
-        "js/careers/hero-video.js"
-      ],
-      "name": "careers-hero-video"
-    },
-    {
-      "files": [
-        "protocol/js/protocol-modal.js",
         "js/careers/testimonials-modal.es6.js"
       ],
       "name": "careers-testimonials"


### PR DESCRIPTION
## One-line summary

Removes duplicate bundle that was accidentally added in https://github.com/mozilla/bedrock/pull/12767

## Issue / Bugzilla link

N/A

## Testing

- [x] video still loads in modal on http://localhost:8000/en-US/careers/