### PR TITLE
Fix pocket intermittent scrolling issue (fixes #12677)

### DIFF
--- a/media/js/pocket/mobile-nav-init.es6.js
+++ b/media/js/pocket/mobile-nav-init.es6.js
@@ -4,6 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import init from './mobile-nav.es6';
+import {
+    mobileMenuQuery,
+    init,
+    addMediaQueryListeners
+} from './mobile-nav.es6';
 
-init();
+if (mobileMenuQuery.matches) {
+    init();
+} else {
+    addMediaQueryListeners();
+}

--- a/media/js/pocket/mobile-nav.es6.js
+++ b/media/js/pocket/mobile-nav.es6.js
@@ -4,6 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// match css/pocket/utils/_variables
+export const mobileMenuQuery = matchMedia(`(max-width: 720px)`);
+
 let navOpenBtn;
 let mobileNavWrapper;
 let mobileNav;
@@ -19,17 +22,12 @@ function detectClickOutside(event) {
     }
 }
 
-function toggleContentWrapperClass(e) {
-    if (e.target === mobileNavWrapper) {
-        contentWrapper.classList.toggle('mobile-nav-open');
-    }
-}
-
 function handleMenuOpen() {
     mobileNavWrapper.classList.add('active');
     mobileNavWrapper.style.opacity = 1;
     mobileNav.classList.add('active');
     navOpenBtn.setAttribute('aria-expanded', true);
+    contentWrapper.classList.add('mobile-nav-open');
 
     document.addEventListener('click', detectClickOutside);
     window.addEventListener('keydown', handleKeyDown);
@@ -42,6 +40,7 @@ function handleMenuClose() {
     mobileNavWrapper.classList.remove('active');
     mobileNavWrapper.style.opacity = 0;
     navOpenBtn.setAttribute('aria-expanded', false);
+    contentWrapper.classList.remove('mobile-nav-open');
 
     document.removeEventListener('click', detectClickOutside);
     window.removeEventListener('keydown', handleKeyDown);
@@ -98,7 +97,25 @@ function handleKeyDown(e) {
     }
 }
 
-const init = function () {
+export const addMediaQueryListeners = function () {
+    if (typeof mobileMenuQuery.addEventListener === 'function') {
+        // evergreen
+        mobileMenuQuery.addEventListener('change', function (event) {
+            if (event.matches) {
+                init();
+            }
+        });
+    } else if (typeof mobileMenuQuery.addListener === 'function') {
+        // IE fallback
+        mobileMenuQuery.addListener(function (event) {
+            if (event.matches) {
+                init();
+            }
+        });
+    }
+};
+
+export const init = function () {
     // set element references
     navOpenBtn = document.querySelector('.global-nav-mobile-menu-btn');
     mobileNavWrapper = document.querySelector('.mobile-nav-wrapper');
@@ -109,12 +126,4 @@ const init = function () {
     // add event listeners
     navOpenBtn.addEventListener('click', handleMenuOpen, false);
     navCloseBtn.addEventListener('click', handleMenuClose, false);
-    // this event is used both for styling and as a test condition
-    mobileNavWrapper.addEventListener(
-        'transitionend',
-        toggleContentWrapperClass,
-        { capture: true }
-    );
 };
-
-export default init;

--- a/tests/functional/pocket/test_navigation.py
+++ b/tests/functional/pocket/test_navigation.py
@@ -34,3 +34,8 @@ def test_accessible_mobile_menu_close_name(pocket_base_url, selenium_mobile):
     page.navigation.open_mobile_menu()
     string = page.navigation.mobile_menu_close_button.text
     assert len(string) > 0
+
+
+def test_mobile_menu_not_displayed_on_desktop(pocket_base_url, selenium):
+    page = AboutPage(selenium, pocket_base_url).open()
+    assert not page.navigation.is_mobile_menu_open_button_displayed

--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -65,6 +65,7 @@ class BasePage(Page):
             return (
                 "mobile-nav-open" in self.find_element(*self._content_wrapper_locator).get_attribute("class")
                 and self.mobile_menu_open_button.get_attribute("aria-expanded") == "true"
+                and self.wait.until(lambda s: self.is_mobile_menu_close_button_displayed)
             )
 
         @property

--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -76,11 +76,11 @@ class BasePage(Page):
 
         @property
         def is_mobile_menu_open_button_displayed(self):
-            return self.mobile_menu_open_button
+            return self.is_element_displayed(*self._mobile_menu_open_btn_locator)
 
         @property
         def is_mobile_menu_close_button_displayed(self):
-            return self.mobile_menu_close_button
+            return self.is_element_displayed(*self._mobile_menu_close_btn_locator)
 
         @property
         def mobile_menu_open_button(self):

--- a/tests/unit/spec/pocket/mobile-nav.js
+++ b/tests/unit/spec/pocket/mobile-nav.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import init from '../../../../media/js/pocket/mobile-nav.es6';
+import { init } from '../../../../media/js/pocket/mobile-nav.es6';
 
 describe('mobile-nav.js', () => {
     const mobileNav = `<div class="mobile-nav-wrapper" tabindex="-1">


### PR DESCRIPTION
## One-line summary

Simplifies mobile nav logic by removing the transitionend event and toggle class function.

## Significant changes and points to review

Updated test to check for button display on desktop size
Removed transitionend event listener (no obvious effect on styling, unnecessary for functional or testing, might have been left over from a previous approach)

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12677

## Testing

To test this work:

Note: I wasn't able to recreate the scroll issue locally

- [x] http://localhost:8000/en/, scroll to bottom and click About. You should be able to scroll about page
- [x] http://localhost:8000/en/about/ on desktop, resize to mobile, mobile menu button should appear and work as expected
- [x] Additional functional test passes, existing tests pass: `BASE_POCKET_URL=http://localhost:8000 py.test -m pocket_mode --driver Firefox --html tests/functional/results.html tests/functional/`
