### PR TITLE
Update pocket hits newsletter link to de locale if viewing /de

### DIFF
--- a/bedrock/pocket/templates/pocket/about.html
+++ b/bedrock/pocket/templates/pocket/about.html
@@ -37,7 +37,11 @@
             <h3 class="about-section-heading">{{ ftl('pocket-about-find-hidden-gems')}}</h3>
             <p class="about-section-body">{{ ftl('pocket-about-internet-filled-with-buried-treasures') }}</p>
             <p class="about-section-body">
-
+              {% if LANG == 'de' %}
+                {% set pocket_newsletter_attrs = 'id="daily-newsletter" href="https://getpocket.com/de/explore/pocket-hits-signup"'%}
+              {% else %}
+                {% set pocket_newsletter_attrs = 'id="daily-newsletter" href="https://getpocket.com/en/explore/pocket-hits-signup"'%}
+              {% endif %}
               {% set pocket_and_firefox_attrs = 'id="pocket-and-firefox" href="'|safe ~ url('pocket.pocket-and-firefox') ~ '"'|safe %}
               {% set pocket_app_attrs = 'id="bottom-pocket-app" href="'|safe ~ url('pocket.add') ~ '"'|safe %}
               {{ ftl(
@@ -45,7 +49,7 @@
                 pocket_home_attrs='id="home-page" href="/"',
                 pocket_home_domain='GetPocket.com',
                 pocket_and_firefox_attrs=pocket_and_firefox_attrs,
-                pocket_daily_newsletter_attrs='id="daily-newsletter" href="https://getpocket.com/explore/pocket-hits-signup"',
+                pocket_daily_newsletter_attrs=pocket_newsletter_attrs,
                 pocket_app_attrs=pocket_app_attrs)
               }}
             </p>

--- a/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
+++ b/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
@@ -15,6 +15,12 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block page_title %}{{ ftl('pocket-new-tab-learn-more') }}{% endblock page_title %}
 
+{% if LANG == 'de' %}
+  {% set pocket_newsletter_href = 'https://getpocket.com/de/explore/pocket-hits-signup' %}
+{% else %}
+  {% set pocket_newsletter_href = 'https://getpocket.com/en/explore/pocket-hits-signup' %}
+{% endif %}
+
 {% block content %}
   <header class="new-tab-header">
     <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-family">{{ ftl('pocket-new-tab-firefox') }}</div>
@@ -82,7 +88,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       )
     )%}
       <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-fuel') }}</h2>
-      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-check-out', explore_url='https://getpocket.com/explore', hits_signup_url='https://getpocket.com/explore/pocket-hits-signup') }}</p>
+      <p class="new-tab-section-body">{{ ftl('pocket-new-tab-check-out', explore_url='https://getpocket.com/explore', hits_signup_url=pocket_newsletter_href ) }}</p>
     {% endcall %}
     {% call split(
       block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-t-split-nospace new-tab-section',

--- a/bedrock/pocket/templates/pocket/includes/footer.html
+++ b/bedrock/pocket/templates/pocket/includes/footer.html
@@ -4,6 +4,12 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% if LANG == 'de' %}
+  {% set pocket_newsletter_href = 'https://getpocket.com/de/explore/pocket-hits-signup?src=footer_v2'%}
+{% else %}
+  {% set pocket_newsletter_href = 'https://getpocket.com/en/explore/pocket-hits-signup?src=footer_v2'%}
+{% endif %}
+
 <footer class="pocket-footer-container">
     <div class="pocket-footer-content">
         <nav class="pocket-footer-primary">
@@ -14,7 +20,7 @@
                         <a href="https://getpocket.com/explore/must-reads?src=footer_v2">{{ ftl('pocket-footer-must-read-articles') }}</a>
                     </li>
                     <li>
-                        <a href="https://getpocket.com/explore/pocket-hits?src=footer_v2">{{ ftl('pocket-footer-daily-newsletter')}}</a>
+                        <a href="{{ pocket_newsletter_href }}">{{ ftl('pocket-footer-daily-newsletter')}}</a>
                     </li>
                     <li>
                         <a href="https://getpocket.com/premium?src=footer_v2">{{ ftl('pocket-footer-pocket-premium') }}</a>


### PR DESCRIPTION
## One-line summary

Updated the logic for the newsletter signup link on /about to navigate to the /de page if viewing from /de/about

## Testing

view /about in pocket mode and inspect the link with `id="daily-newsletter"`

- [x] lf viewing on /en/about the link should be: `https://getpocket.com/en/explore/pocket-hits-signup`
- [x] if viewing on /de/about the link should be: `https://getpocket.com/de/explore/pocket-hits-signup`
