### PR TITLE
Fix leakage of HTML for JS errors into the main newsletter prefs page

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -23,10 +23,18 @@
 {% set recovery_href = 'href="' + url('newsletter.recovery') + '"'|escape %}
 
 {% block string_data %}
+  {#
+  Note the outer single quotes wrapping data-error-token-not-found, not
+  doubles - this is critical to avoiding some over-escaping of quotes
+  in `recovery_href` when we bleach during the ftl() call
+  See: https://github.com/mozilla/bedrock/issues/12789
+  #}
+
+  #}
   {% if ftl_has_messages('newsletters-the-supplied-link-has-expired-v2') %}
-    data-error-token-not-found="{{ ftl('newsletters-the-supplied-link-has-expired-v2', recovery_href=recovery_href) }}"
+    data-error-token-not-found='{{ ftl("newsletters-the-supplied-link-has-expired-v2", recovery_href=recovery_href) }}'
   {% else %}
-    data-error-token-not-found="{{ ftl('newsletters-the-supplied-link-has-expired') }}"
+    data-error-token-not-found='{{ ftl("newsletters-the-supplied-link-has-expired") }}'
   {% endif %}
   data-error-invalid-email="{{ ftl('newsletters-this-is-not-a-valid-email') }}"
   data-error-invalid-newsletter="{{ ftl('newsletters-is-not-a-valid-newsletter', newsletter='%newsletter%') }}"


### PR DESCRIPTION
## One-line summary

Fix HTML leaking into the prefs page

## Significant changes and points to review

This appears to be a subtle regression via https://github.com/mozilla/bedrock/pull/12730 where we introduced sanitisation of strings sourced by `ftl()` using the `bleach` library. UPDATE: I think it's actually `html5lib`, used by `bleach` that is doing the "fixing" of the markup.

I've tried to keep the fix as light as possible, retaining calls to `|escape`.

## Issue / Bugzilla link

Resolves #12789 

## Screenshots

Before/Broken
<img width="1436" alt="Screenshot 2023-02-22 at 23 39 18" src="https://user-images.githubusercontent.com/101457/220788359-ea733965-3840-45af-8a43-35a7392a508d.png">



After/Fixed

<img width="1436" alt="Screenshot 2023-02-22 at 23 39 06" src="https://user-images.githubusercontent.com/101457/220788382-a76b1d01-e2e3-4a25-93ab-d5cf302fd340.png">


(If the changeset updates the UI, please include screenshots so reviewers know what to look for when testing)


## Testing

- [ ] On localhost, go to email prefs page using a valid token - DM @stevejalim or @robhudson for one if you don't have one