### PR TITLE
Follow-up to incomplete fix of leaking HTML in newsletter prefs page

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -20,7 +20,7 @@
 
 {% block body_class %}newsletter-management{% endblock %}
 
-{% set recovery_href = 'href="' + url('newsletter.recovery') + '"'|escape %}
+{% set recovery_href = 'href="' + url('newsletter.recovery') + '"' %}
 
 {% block string_data %}
   {#


### PR DESCRIPTION
Please see https://github.com/mozilla/bedrock/pull/12790 for context. That PR didn't completely fix things, as it still resulted in some broken HTML in the JS-rendered dialog box when the token had expired. 

Specifically: `<li>The supplied link has expired. Please <a href="" en-us="" newsletter="" recovery="" ""="">request a new link here</a>.</li>` which we suspect is down to the string being over-escaped to be:
`data-error-token-not-found='The supplied link has expired. Please <a href="&#34;/en-US/newsletter/recovery/&#34;">request a new link here</a>.'` but it's a bit hard to repro/test locally.

This change makes sure the expired-link URL is not over-escaped, resulting in:
`data-error-token-not-found='The supplied link has expired. Please <a href="/en-US/newsletter/recovery/">request a new link here</a>.'`


## Issue / Bugzilla link

Resolves #12789 

## Testing

This is fiddly to test but the prefs page should have no HTML leakage as featured in the source Issue AND when the JS dialogs are triggered, they should all work correctly, including the one for an expire link, which contains the hyperlink which is broken without this PR's change 