### PR TITLE
Make browser tests use whatever is set as BOUNCER_URL when checking for a download URL

### DIFF
--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -63,7 +63,7 @@ class TestDownloadButtons(TestCase):
     def test_button_force_direct(self):
         """
         If the force_direct parameter is True, all download links must be
-        directly to https://download.mozilla.org.
+        directly to https://download.mozilla.org (or whatever settings.BOUNCER_URL is set to)
         """
         rf = RequestFactory()
         get_request = rf.get("/fake")
@@ -73,10 +73,12 @@ class TestDownloadButtons(TestCase):
         # Check that the first 5 links are direct.
         links = doc(".download-list a")
 
+        assert bool(settings.BOUNCER_URL)  # Safety check that it's set to _something_
+
         for link in links[:5]:
             link = pq(link)
             href = link.attr("href")
-            assert href.startswith("https://download.mozilla.org")
+            assert href.startswith(settings.BOUNCER_URL)
             self.assertListEqual(parse_qs(urlparse(href).query)["lang"], ["fr"])
             # direct links should not have the data attr.
             assert link.attr("data-direct-link") is None
@@ -163,7 +165,7 @@ class TestDownloadButtons(TestCase):
         links = doc(".download-list a")
 
         for link in links[:8]:
-            assert pq(link).attr("data-direct-link").startswith("https://download.mozilla.org")
+            assert pq(link).attr("data-direct-link").startswith(settings.BOUNCER_URL)
 
         # The ninth link is mobile and should not have the attr
         assert pq(links[8]).attr("data-direct-link") is None
@@ -339,7 +341,7 @@ class TestDownloadThanksButton(TestCase):
         assert link.attr("data-link-type") == "download"
 
         # Direct attribute for legacy IE browsers should always be win 32bit
-        assert link.attr("data-direct-link") == "https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US"
+        assert link.attr("data-direct-link") == f"{settings.BOUNCER_URL}?product=firefox-stub&os=win&lang=en-US"
 
     def test_download_firefox_thanks_attributes(self):
         """
@@ -393,7 +395,8 @@ class TestDownloadList(TestCase):
 
     def test_firefox_desktop_list_release(self):
         """
-        All release download links must be directly to https://download.mozilla.org.
+        All release download links must be directly to https://download.mozilla.org
+        (or whatever settings.BOUNCER_URL is set to)
         """
         rf = RequestFactory()
         get_request = rf.get("/fake")
@@ -420,12 +423,13 @@ class TestDownloadList(TestCase):
         for link in links:
             link = pq(link)
             href = link.attr("href")
-            assert href.startswith("https://download.mozilla.org")
+            assert href.startswith(settings.BOUNCER_URL)
             self.assertListEqual(parse_qs(urlparse(href).query)["lang"], ["en-US"])
 
     def test_firefox_desktop_list_aurora(self):
         """
-        All aurora download links must be directly to https://download.mozilla.org.
+        All aurora download links must be directly to https://download.mozilla.org
+        (or whatever settings.BOUNCER_URL is set to)
         """
         rf = RequestFactory()
         get_request = rf.get("/fake")
@@ -449,12 +453,13 @@ class TestDownloadList(TestCase):
         for link in links:
             link = pq(link)
             href = link.attr("href")
-            assert href.startswith("https://download.mozilla.org")
+            assert href.startswith(settings.BOUNCER_URL)
             self.assertListEqual(parse_qs(urlparse(href).query)["lang"], ["en-US"])
 
     def test_firefox_desktop_list_nightly(self):
         """
-        All nightly download links must be directly to https://download.mozilla.org.
+        All nightly download links must be directly to https://download.mozilla.org
+        or whatever settings.BOUNCER_URL is set to
         """
         rf = RequestFactory()
         get_request = rf.get("/fake")
@@ -477,7 +482,7 @@ class TestDownloadList(TestCase):
         for link in links:
             link = pq(link)
             href = link.attr("href")
-            assert href.startswith("https://download.mozilla.org")
+            assert href.startswith(settings.BOUNCER_URL)
             self.assertListEqual(parse_qs(urlparse(href).query)["lang"], ["en-US"])
 
 

--- a/tests/pages/firefox/all.py
+++ b/tests/pages/firefox/all.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.conf import settings
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
@@ -51,7 +53,7 @@ class FirefoxAllPage(BasePage):
 
     @property
     def is_desktop_download_link_valid(self):
-        return "https://download.mozilla.org" in self.find_element(*self._desktop_download_button_locator).get_attribute("href")
+        return settings.BOUNCER_URL in self.find_element(*self._desktop_download_button_locator).get_attribute("href")
 
     def select_product(self, value):
         el = self.find_element(*self._product_locator)

--- a/tests/pages/firefox/new/thank_you.py
+++ b/tests/pages/firefox/new/thank_you.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.conf import settings
+
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
@@ -25,4 +27,4 @@ class ThankYouPage(BasePage):
 
     @property
     def is_direct_download_link_valid(self):
-        return "https://download.mozilla.org" in self.find_element(*self._direct_download_link_locator).get_attribute("href")
+        return settings.BOUNCER_URL in self.find_element(*self._direct_download_link_locator).get_attribute("href")


### PR DESCRIPTION
This changeset should fix CI on Dev, by making sure tests seek the download bouncer domain that is configured for the relevant enviroment (Dev, Test, Stage, Prod). Only Dev points to the Staging bouncer.

## Significant points

* JS tests pass (tested locally)
* Integration tests were run with `BOUNCER_URL` forced/hard-coded to the Staging bouncer url. All passed.

* Local commit hard-coding it: 

   `* 618fab990 (HEAD -> hotfix-failing-dev-ci-tests, mozilla/run-integration-tests) DISCARD ME LATER: TEMPORARILY FORCE BEDROCK TO USE THE STAGING BOUNCER JUST TO RUN INTEGRATION TESTS (29 minutes ago)`

* CI passing for that commit: https://gitlab.com/mozmeao/www-config/-/pipelines/786774127

* You can see that 618fab990 is not a commit in this PR, because it's been dropped from the branch

## Issue / Bugzilla link

No ticket.


## Testing

Demo server URL: (or None)

To test this work locally, you can run the integration tests that are/were failing on Dev

- [x] Shell A: `BOUNCER_URL=https://bouncer-bouncer.stage.mozaws.net/ npm start`
- [x] Shell B`BOUNCER_URL=https://bouncer-bouncer.stage.mozaws.net/ pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/test_all.py`
- [x] Also check that FF download links from a local build use the staging Bouncer url. You can then re-start a local build without the BOUNCER_URL set and those links should point to the prod bouncer again. If there are more places than firefox/new (leading to http://localhost:8000/en-US/firefox/download/thanks/) please try them and let me know what they are for future checks
