### PR TITLE
Add GA session_id to stub attribution data (Fixes #12355)

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -53,6 +53,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "visit_id": "(not set)",
+            "session_id": "(not set)",
         }
         req = self._get_request({"dude": "abides"})
         resp = views.stub_attribution_code(req)
@@ -66,7 +67,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "135b2245f6b70978bc8142a91521facdb31d70a1bfbdefdc1bd1dee92ce21a22",
+            "28afcdd9797a76edcb19ffa11e0e65f48103720bc4b43de5707132e8c0cff4eb",
         )
 
     def test_no_valid_param_data(self):
@@ -76,6 +77,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "dfb</p>s",
             "variation": "ef&bvcv",
             "visit_id": "14</p>4538.1610<t>957",
+            "session_id": "2w</br>123bg<u>957",
         }
         final_params = {
             "source": "www.mozilla.org",
@@ -86,6 +88,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "visit_id": "(not set)",
+            "session_id": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -99,7 +102,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "135b2245f6b70978bc8142a91521facdb31d70a1bfbdefdc1bd1dee92ce21a22",
+            "28afcdd9797a76edcb19ffa11e0e65f48103720bc4b43de5707132e8c0cff4eb",
         )
 
     def test_some_valid_param_data(self):
@@ -113,6 +116,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "visit_id": "(not set)",
+            "session_id": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -126,7 +130,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "b53097f17741b75cdd5b737d3c8ba03349a6093148adeada2ee69adf4fe87322",
+            "c89753ed9f16dc339fc20565b7fa204f6f4e2c8c3fde8e125298fbbcfe40bc89",
         )
 
     def test_campaign_data_too_long(self):
@@ -140,6 +144,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "chrome",
             "visit_id": "1456954538.1610960957",
+            "session_id": "1668161374",
         }
         final_params = {
             "source": "brandt",
@@ -148,12 +153,13 @@ class TestStubAttributionCode(TestCase):
             "|thatThe|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe"
             "|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides"
             "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know"
-            "|about|you|but|I|take|comfort|in|thatT_",
+            "|about|you|but|I|take|_",
             "content": "A144_A000_0000000",
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
             "visit_id": "1456954538.1610960957",
+            "session_id": "1668161374",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -169,7 +175,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "3c1611db912c51a96418eb7806fbaf1400b8d05fbf6ee4f2f1fb3c0ba74a89f4",
+            "f74cd1a77b2f9e05f396ee7d2a682750e8b8e6f7f127b32619a4b545e13cca45",
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -196,6 +202,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "1",
             "ua": "chrome",
             "visit_id": "1456954538.1610960957",
+            "session_id": "1668161374",
         }
         final_params = {
             "source": "brandt",
@@ -206,6 +213,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "1",
             "ua": "chrome",
             "visit_id": "1456954538.1610960957",
+            "session_id": "1668161374",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -219,7 +227,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "b2dc555b2914fdec9f9a1247d244520392e4f888961a6fb57a74a1cdf041261f",
+            "55ad3322efce0df69562b715b1d835aeca80c50bef20a83abba353c65e8f814e",
         )
 
     def test_handles_referrer(self):
@@ -233,6 +241,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "visit_id": "(not set)",
+            "session_id": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -246,7 +255,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "b53097f17741b75cdd5b737d3c8ba03349a6093148adeada2ee69adf4fe87322",
+            "c89753ed9f16dc339fc20565b7fa204f6f4e2c8c3fde8e125298fbbcfe40bc89",
         )
 
     def test_handles_referrer_no_source(self):
@@ -263,6 +272,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "visit_id": "(not set)",
+            "session_id": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -276,7 +286,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "d075cbcbae3bcef5bda3650a259863151586e3a4709d53886ab3cc83a6963d00",
+            "846c42e5569023d4c77f9671096151432432ce0903469e46eeae7873bd9927fb",
         )
 
     def test_handles_referrer_utf8(self):
@@ -296,6 +306,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "visit_id": "(not set)",
+            "session_id": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -309,7 +320,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "135b2245f6b70978bc8142a91521facdb31d70a1bfbdefdc1bd1dee92ce21a22",
+            "28afcdd9797a76edcb19ffa11e0e65f48103720bc4b43de5707132e8c0cff4eb",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -52,7 +52,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "visit_id": "(not set)",
+            "client_id": "(not set)",
             "session_id": "(not set)",
         }
         req = self._get_request({"dude": "abides"})
@@ -67,7 +67,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "28afcdd9797a76edcb19ffa11e0e65f48103720bc4b43de5707132e8c0cff4eb",
+            "5d146033839aa07dd3078a1a001864056c69baefbe7dcd95701457a0bc4c1d71",
         )
 
     def test_no_valid_param_data(self):
@@ -76,7 +76,7 @@ class TestStubAttributionCode(TestCase):
             "utm_medium": "ae<t>her",
             "experiment": "dfb</p>s",
             "variation": "ef&bvcv",
-            "visit_id": "14</p>4538.1610<t>957",
+            "client_id": "14</p>4538.1610<t>957",
             "session_id": "2w</br>123bg<u>957",
         }
         final_params = {
@@ -87,7 +87,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "visit_id": "(not set)",
+            "client_id": "(not set)",
             "session_id": "(not set)",
         }
         req = self._get_request(params)
@@ -102,7 +102,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "28afcdd9797a76edcb19ffa11e0e65f48103720bc4b43de5707132e8c0cff4eb",
+            "5d146033839aa07dd3078a1a001864056c69baefbe7dcd95701457a0bc4c1d71",
         )
 
     def test_some_valid_param_data(self):
@@ -115,7 +115,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "visit_id": "(not set)",
+            "client_id": "(not set)",
             "session_id": "(not set)",
         }
         req = self._get_request(params)
@@ -130,7 +130,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "c89753ed9f16dc339fc20565b7fa204f6f4e2c8c3fde8e125298fbbcfe40bc89",
+            "68b9e75f17129baa01c2baf91e635035412fc1fcd94a63fa14c1c166dacf4375",
         )
 
     def test_campaign_data_too_long(self):
@@ -143,7 +143,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
-            "visit_id": "1456954538.1610960957",
+            "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
         }
         final_params = {
@@ -158,7 +158,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
-            "visit_id": "1456954538.1610960957",
+            "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
         }
         req = self._get_request(params)
@@ -175,7 +175,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "f74cd1a77b2f9e05f396ee7d2a682750e8b8e6f7f127b32619a4b545e13cca45",
+            "22e9951d6658fab0723086be79933622e85283181b27ceae649089a1b67d140e",
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -201,7 +201,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "firefox-new",
             "variation": "1",
             "ua": "chrome",
-            "visit_id": "1456954538.1610960957",
+            "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
         }
         final_params = {
@@ -212,7 +212,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "firefox-new",
             "variation": "1",
             "ua": "chrome",
-            "visit_id": "1456954538.1610960957",
+            "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
         }
         req = self._get_request(params)
@@ -227,7 +227,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "55ad3322efce0df69562b715b1d835aeca80c50bef20a83abba353c65e8f814e",
+            "7b0b668edd8f374040faa0e063e3940004c5248ec5254140e24baa19220e3aa2",
         )
 
     def test_handles_referrer(self):
@@ -240,7 +240,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "visit_id": "(not set)",
+            "client_id": "(not set)",
             "session_id": "(not set)",
         }
         req = self._get_request(params)
@@ -255,7 +255,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "c89753ed9f16dc339fc20565b7fa204f6f4e2c8c3fde8e125298fbbcfe40bc89",
+            "68b9e75f17129baa01c2baf91e635035412fc1fcd94a63fa14c1c166dacf4375",
         )
 
     def test_handles_referrer_no_source(self):
@@ -271,7 +271,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "visit_id": "(not set)",
+            "client_id": "(not set)",
             "session_id": "(not set)",
         }
         req = self._get_request(params)
@@ -286,7 +286,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "846c42e5569023d4c77f9671096151432432ce0903469e46eeae7873bd9927fb",
+            "ef5b4cfcdf34b12142af22ecf3c69144f892a64057d0a9dbea8afe352b706cac",
         )
 
     def test_handles_referrer_utf8(self):
@@ -305,7 +305,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "visit_id": "(not set)",
+            "client_id": "(not set)",
             "session_id": "(not set)",
         }
         req = self._get_request(params)
@@ -320,7 +320,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "28afcdd9797a76edcb19ffa11e0e65f48103720bc4b43de5707132e8c0cff4eb",
+            "5d146033839aa07dd3078a1a001864056c69baefbe7dcd95701457a0bc4c1d71",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -59,6 +59,7 @@ STUB_VALUE_NAMES = [
     ("variation", "(not set)"),
     ("ua", "(not set)"),
     ("visit_id", "(not set)"),
+    ("session_id", "(not set)"),
 ]
 STUB_VALUE_RE = re.compile(r"^[a-z0-9-.%():_]+$", flags=re.IGNORECASE)
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -58,7 +58,7 @@ STUB_VALUE_NAMES = [
     ("experiment", "(not set)"),
     ("variation", "(not set)"),
     ("ua", "(not set)"),
-    ("visit_id", "(not set)"),
+    ("client_id", "(not set)"),
     ("session_id", "(not set)"),
 ]
 STUB_VALUE_RE = re.compile(r"^[a-z0-9-.%():_]+$", flags=re.IGNORECASE)

--- a/docs/firefox-stub-attribution.rst
+++ b/docs/firefox-stub-attribution.rst
@@ -41,7 +41,8 @@ The full list of data values we pass to stub attribution is as follows:
 - ``ua`` (simplified browser name parsed from UA string, e.g. ``chrome``, ``safari``, ``firefox``).
 - ``experiment`` (``?experiment=`` query parameter)
 - ``variation`` (``?variation=`` query parameter)
-- ``visit_id`` (``clientId`` from Google Analytics)
+- ``visit_id`` (``clientId`` client ID from Google Analytics)
+- ``session_id`` (``_gt`` session ID from Google Analytics)
 
 .. Note::
 
@@ -71,7 +72,7 @@ that is used to sign the attribution code must be set via an environment variabl
 
 .. code-block:: html
 
-    STUB_ATTRIBUTION_HMAC_KEY='thedude'
+    STUB_ATTRIBUTION_HMAC_KEY=thedude
 
 .. Note::
 

--- a/docs/firefox-stub-attribution.rst
+++ b/docs/firefox-stub-attribution.rst
@@ -41,7 +41,7 @@ The full list of data values we pass to stub attribution is as follows:
 - ``ua`` (simplified browser name parsed from UA string, e.g. ``chrome``, ``safari``, ``firefox``).
 - ``experiment`` (``?experiment=`` query parameter)
 - ``variation`` (``?variation=`` query parameter)
-- ``visit_id`` (``clientId`` client ID from Google Analytics)
+- ``client_id`` (``clientId`` client ID from Google Analytics)
 - ``session_id`` (``_gt`` session ID from Google Analytics)
 
 .. Note::

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -326,12 +326,29 @@ if (typeof window.Mozilla === 'undefined') {
      * Gets the client ID from the GA object.
      * @returns {String} client ID.
      */
-    StubAttribution.getGAVisitID = function () {
+    StubAttribution.getGAClientID = function () {
         try {
             var clientID = window.ga.getAll()[0].get('clientId');
 
             if (clientID && typeof clientID === 'string' && clientID !== '') {
                 return clientID;
+            }
+            return null;
+        } catch (e) {
+            return null;
+        }
+    };
+
+    /**
+     * Gets the session ID from the GA object.
+     * @returns {String} session ID.
+     */
+    StubAttribution.getGASessionID = function () {
+        try {
+            var sessionID = window.ga.getAll()[0].get('_gt');
+
+            if (sessionID && typeof sessionID === 'number') {
+                return sessionID.toString();
             }
             return null;
         } catch (e) {
@@ -352,9 +369,10 @@ if (typeof window.Mozilla === 'undefined') {
 
         function _checkGA() {
             clearTimeout(timeout);
-            var clientID = StubAttribution.getGAVisitID();
+            var clientID = StubAttribution.getGAClientID();
+            var sessionID = StubAttribution.getGASessionID();
 
-            if (clientID) {
+            if (clientID && sessionID) {
                 callback(true);
             } else {
                 if (pollRetry <= limit) {
@@ -383,7 +401,8 @@ if (typeof window.Mozilla === 'undefined') {
             params.get('variation') || StubAttribution.experimentVariation;
         var referrer = typeof ref !== 'undefined' ? ref : document.referrer;
         var ua = StubAttribution.getUserAgent();
-        var visitID = StubAttribution.getGAVisitID();
+        var clientID = StubAttribution.getGAClientID();
+        var sessionID = StubAttribution.getGASessionID();
 
         /* eslint-disable camelcase */
         var data = {
@@ -395,7 +414,8 @@ if (typeof window.Mozilla === 'undefined') {
             ua: ua,
             experiment: experiment,
             variation: variation,
-            visit_id: visitID
+            visit_id: clientID, // passed through as visit_id as was originally named incorrectly
+            session_id: sessionID
         };
         /* eslint-enable camelcase */
 

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -414,7 +414,7 @@ if (typeof window.Mozilla === 'undefined') {
             ua: ua,
             experiment: experiment,
             variation: variation,
-            visit_id: clientID, // passed through as visit_id as was originally named incorrectly
+            client_id: clientID,
             session_id: sessionID
         };
         /* eslint-enable camelcase */

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -259,7 +259,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -275,7 +275,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -289,7 +289,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta:dUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -303,7 +303,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -317,7 +317,7 @@ describe('stub-attribution.js', function () {
                 utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -333,7 +333,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -347,7 +347,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta:cm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -361,7 +361,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -375,7 +375,7 @@ describe('stub-attribution.js', function () {
                 utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -393,7 +393,7 @@ describe('stub-attribution.js', function () {
                 )}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -409,7 +409,7 @@ describe('stub-attribution.js', function () {
                 )}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -425,7 +425,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID
+                client_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -542,7 +542,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID,
+                client_id: GA_CLIENT_ID,
                 session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -573,7 +573,7 @@ describe('stub-attribution.js', function () {
             const data = {
                 referrer: 'https://www.mozilla.org/en-US/',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID,
+                client_id: GA_CLIENT_ID,
                 session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -604,7 +604,7 @@ describe('stub-attribution.js', function () {
             const data = {
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_CLIENT_ID,
+                client_id: GA_CLIENT_ID,
                 session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -637,7 +637,7 @@ describe('stub-attribution.js', function () {
                 ua: 'chrome',
                 experiment: 'firefox-new',
                 variation: 1,
-                visit_id: GA_CLIENT_ID,
+                client_id: GA_CLIENT_ID,
                 session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -1068,7 +1068,7 @@ describe('stub-attribution.js', function () {
     });
 
     describe('getGAClientID', function () {
-        it('should return a valid Google Analytics visit ID', function () {
+        it('should return a valid Google Analytics client ID', function () {
             window.ga = sinon.stub();
             window.ga.getAll = sinon.stub().returns([
                 {

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -12,7 +12,8 @@
 /* eslint new-cap: [2, {"capIsNewExceptions": ["Deferred"]}] */
 
 describe('stub-attribution.js', function () {
-    const GA_VISIT_ID = '1456954538.1610960957';
+    const GA_CLIENT_ID = '1456954538.1610960957';
+    const GA_SESSION_ID = 1668161374;
 
     beforeEach(function () {
         window.Mozilla.dntEnabled = sinon.stub();
@@ -37,8 +38,11 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'updateBouncerLinks');
 
             // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
-                GA_VISIT_ID
+            spyOn(Mozilla.StubAttribution, 'getGAClientID').and.returnValue(
+                GA_CLIENT_ID
+            );
+            spyOn(Mozilla.StubAttribution, 'getGASessionID').and.returnValue(
+                GA_SESSION_ID
             );
         });
 
@@ -255,7 +259,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -271,7 +275,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -285,7 +289,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta:dUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -299,7 +303,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -313,7 +317,7 @@ describe('stub-attribution.js', function () {
                 utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -329,7 +333,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -343,7 +347,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta:cm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -357,7 +361,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -371,7 +375,7 @@ describe('stub-attribution.js', function () {
                 utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -389,7 +393,7 @@ describe('stub-attribution.js', function () {
                 )}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -405,7 +409,7 @@ describe('stub-attribution.js', function () {
                 )}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -421,7 +425,7 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID
             };
             /* eslint-enable camelcase */
 
@@ -491,12 +495,15 @@ describe('stub-attribution.js', function () {
     describe('waitForGoogleAnalytics', function () {
         beforeEach(function () {
             // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
-                GA_VISIT_ID
+            spyOn(Mozilla.StubAttribution, 'getGAClientID').and.returnValue(
+                GA_CLIENT_ID
+            );
+            spyOn(Mozilla.StubAttribution, 'getGASessionID').and.returnValue(
+                GA_SESSION_ID
             );
         });
 
-        it('should fire a callback with the GA visit ID', function () {
+        it('should fire a callback when GA visitor ID and session ID are found', function () {
             const callback = jasmine.createSpy('callback');
 
             Mozilla.StubAttribution.waitForGoogleAnalytics(callback);
@@ -507,8 +514,11 @@ describe('stub-attribution.js', function () {
     describe('getAttributionData', function () {
         beforeEach(function () {
             // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getGAVisitID').and.returnValue(
-                GA_VISIT_ID
+            spyOn(Mozilla.StubAttribution, 'getGAClientID').and.returnValue(
+                GA_CLIENT_ID
+            );
+            spyOn(Mozilla.StubAttribution, 'getGASessionID').and.returnValue(
+                GA_SESSION_ID
             );
         });
 
@@ -532,7 +542,8 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID,
+                session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
 
@@ -562,7 +573,8 @@ describe('stub-attribution.js', function () {
             const data = {
                 referrer: 'https://www.mozilla.org/en-US/',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID,
+                session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
 
@@ -592,7 +604,8 @@ describe('stub-attribution.js', function () {
             const data = {
                 referrer: '',
                 ua: 'chrome',
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID,
+                session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
 
@@ -624,7 +637,8 @@ describe('stub-attribution.js', function () {
                 ua: 'chrome',
                 experiment: 'firefox-new',
                 variation: 1,
-                visit_id: GA_VISIT_ID
+                visit_id: GA_CLIENT_ID,
+                session_id: GA_SESSION_ID
             };
             /* eslint-enable camelcase */
 
@@ -1053,19 +1067,21 @@ describe('stub-attribution.js', function () {
         });
     });
 
-    describe('getGAVisitID', function () {
+    describe('getGAClientID', function () {
         it('should return a valid Google Analytics visit ID', function () {
             window.ga = sinon.stub();
             window.ga.getAll = sinon.stub().returns([
                 {
-                    get: () => GA_VISIT_ID
+                    get: () => GA_CLIENT_ID
                 }
             ]);
 
-            expect(Mozilla.StubAttribution.getGAVisitID()).toEqual(GA_VISIT_ID);
+            expect(Mozilla.StubAttribution.getGAClientID()).toEqual(
+                GA_CLIENT_ID
+            );
         });
 
-        it('should return a null if Google Analytics visit ID is invalid', function () {
+        it('should return a null if Google Analytics visitor ID is invalid', function () {
             window.ga = sinon.stub();
             window.ga.getAll = sinon.stub().returns([
                 {
@@ -1073,14 +1089,47 @@ describe('stub-attribution.js', function () {
                 }
             ]);
 
-            expect(Mozilla.StubAttribution.getGAVisitID()).toBeNull();
+            expect(Mozilla.StubAttribution.getGAClientID()).toBeNull();
         });
 
         it('should return a null if accessing Google Analytics object throws an error', function () {
             window.ga = sinon.stub().throws(function () {
                 return new Error();
             });
-            expect(Mozilla.StubAttribution.getGAVisitID()).toBeNull();
+            expect(Mozilla.StubAttribution.getGAClientID()).toBeNull();
+        });
+    });
+
+    describe('getGASessionID', function () {
+        it('should return a valid Google Analytics session ID', function () {
+            window.ga = sinon.stub();
+            window.ga.getAll = sinon.stub().returns([
+                {
+                    get: () => GA_SESSION_ID
+                }
+            ]);
+
+            expect(Mozilla.StubAttribution.getGASessionID()).toEqual(
+                GA_SESSION_ID.toString()
+            );
+        });
+
+        it('should return a null if Google Analytics session ID is invalid', function () {
+            window.ga = sinon.stub();
+            window.ga.getAll = sinon.stub().returns([
+                {
+                    get: () => ''
+                }
+            ]);
+
+            expect(Mozilla.StubAttribution.getGASessionID()).toBeNull();
+        });
+
+        it('should return a null if accessing Google Analytics object throws an error', function () {
+            window.ga = sinon.stub().throws(function () {
+                return new Error();
+            });
+            expect(Mozilla.StubAttribution.getGASessionID()).toBeNull();
         });
     });
 });

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -503,7 +503,7 @@ describe('stub-attribution.js', function () {
             );
         });
 
-        it('should fire a callback when GA visitor ID and session ID are found', function () {
+        it('should fire a callback when GA client ID and session ID are found', function () {
             const callback = jasmine.createSpy('callback');
 
             Mozilla.StubAttribution.waitForGoogleAnalytics(callback);

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -1081,7 +1081,7 @@ describe('stub-attribution.js', function () {
             );
         });
 
-        it('should return a null if Google Analytics visitor ID is invalid', function () {
+        it('should return a null if Google Analytics client ID is invalid', function () {
             window.ga = sinon.stub();
             window.ga.getAll = sinon.stub().returns([
                 {


### PR DESCRIPTION
## One-line summary

- Adds a new `session_id` parameter to stub attribution that contains the GA session ID.
- Renames `visit_id` to `client_id` as to be more technically correct / less confusing.

## Significant changes and points to review

This change has already been tested end-to-end by QA against demo3, so code-level review should be all that's really required here. If you would like to manually test things still, there are testing steps below for the bedrock side of things.

## Issue / Bugzilla link

#12355

## Testing

1. On a Windows machine, open https://www-demo3.allizom.org/en-US/
2. Inspect cookies using dev tools and look for a cookie called `moz-stub-attribution-code`. The value should be a base64 string.
3. [Decode](https://www.base64decode.net/) the cookie value and verify it has both a `client_id` and `session_id` parameter.