### PR TITLE
Add comment re Bouncer URL (mostly to trigger a new build)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -729,6 +729,7 @@ BASKET_API_KEY = config("BASKET_API_KEY", default="")
 BASKET_TIMEOUT = config("BASKET_TIMEOUT", parser=int, default="10")
 BASKET_SUBSCRIBE_URL = BASKET_URL + "/news/subscribe/"
 
+# Note that this may not always be the default - eg www-dev may be set to something else
 BOUNCER_URL = config("BOUNCER_URL", default="https://download.mozilla.org/")
 
 # reCAPTCHA keys


### PR DESCRIPTION
## One-line summary

This changeset is needed to trigger www-dev's CI pipeline, which can't be fired manually
