### PR TITLE
Add Sales Force param to donation links (Fixes #12796)

### DIFF
--- a/bedrock/base/templates/includes/banners/fundraiser.html
+++ b/bedrock/base/templates/includes/banners/fundraiser.html
@@ -23,13 +23,14 @@
       <button type="submit" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('banner-fundraising-donate') }}</button>
     </div>
 
-    {# GA params #}
+    {# Referral params #}
     <input type="hidden" name="form" value="donate">
-    <input type="hidden" name="ref" value="home-page">
-    <input type="hidden" name="utm_campaign" value="home-page">
+    <input type="hidden" name="c_id" value="7014x000000eQOH">
+    <input type="hidden" name="ref" value="moco">
+    <input type="hidden" name="utm_campaign" value="moco">
     <input type="hidden" name="utm_source" value="mozilla.org">
     <input type="hidden" name="utm_medium" value="referral">
-    <input type="hidden" name="utm_content" value="fundraising-banner">
+    <input type="hidden" name="utm_content" value="giving2022banner">
 
   </form>
 {% endblock %}

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -25,7 +25,7 @@
           {% endif %}
             <li><a href="{{ url('careers.home') }}" data-link-type="footer" data-link-name="Careers">{{ ftl('footer-careers') }}</a></li>
             <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact">{{ ftl('footer-contact') }}</a></li>
-            <li><a href="{{ donate_url(campaign='footer', content='company') }}" data-link-type="footer" data-link-name="Donate">{{ ftl('footer-donate', fallback='navigation-donate') }}</a></li>
+            <li><a href="{{ donate_url(content='footer') }}" data-link-type="footer" data-link-name="Donate">{{ ftl('footer-donate', fallback='navigation-donate') }}</a></li>
           </ul>
         </section>
 

--- a/bedrock/foundation/templates/foundation/annualreport/2009/broadening-our-scope.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/broadening-our-scope.html
@@ -187,7 +187,7 @@
           festival="http://www.drumbeat.org/",
           movies="http://www.drumbeat.org/",
           subtitles="http://www.drumbeat.org/",
-          fund=donate_url(campaign='annualreport2009')
+          fund=donate_url(content='annualreport2009')
         %}
           <img src="{{ logo }}" width="100" height="95" align="left" alt="">
           Mozilla's work to build openness and empowerment into the Internet has historically

--- a/bedrock/foundation/templates/foundation/annualreport/2021/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2021/index.html
@@ -618,7 +618,7 @@
       {{ card(
         title='Donate',
         ga_title='Donate',
-        link_url=donate_url(campaign='annualreport2021'),
+        link_url=donate_url(content='annualreport2021'),
         image=card_third_img(filename='donate', ext='jpg'),
         aspect_ratio='mzp-has-aspect-16-9'
       ) }}

--- a/bedrock/foundation/templates/foundation/openwebfund/more.html
+++ b/bedrock/foundation/templates/foundation/openwebfund/more.html
@@ -52,7 +52,7 @@
   <ul class="mzp-u-list-styled">
     <li><a href="//www.drumbeat.org/people">Join</a> Drumbeat</li>
     <li>Get involved in a <a href="//www.drumbeat.org/projects">project</a></li>
-    <li><a href="{{ donate_url(campaign='openwebfund') }}">Donate</a> to the Mozilla Drumbeat Open Web Fund</a></li>
+    <li><a href="{{ donate_url(content='openwebfund') }}">Donate</a> to the Mozilla Drumbeat Open Web Fund</a></li>
   </ul>
 
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -28,7 +28,7 @@
 
       <ul class="mzp-u-list-styled">
         <li><a href="https://support.mozilla.org/">I’m having problems with using Firefox</a></li>
-        <li><a href="{{ donate_url(campaign='contact_us_page') }}">I want to donate to Mozilla</a></li>
+        <li><a href="{{ donate_url(content='contact_us_page') }}">I want to donate to Mozilla</a></li>
         <li><a href="{{ url('foundation.trademarks.policy') }}">I have questions about using Mozilla’s trademarks</a></li>
         <li><a href="{{ url('legal.fraud-report') }}">I’d like to report misuse of a Mozilla trademark</a></li>
         <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines">I want to hold an event in a Mozilla space</a></li>

--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -191,7 +191,7 @@
         </li>
 
         <li class="contribute-mission-card">
-          <a href="{{ donate_url(campaign='contribute-page') }}">
+          <a href="{{ donate_url(content='contribute-page') }}">
             <h3 class="contribute-mission-donate-icon">{{ ftl('contribute-donate') }}</h3>
             <p>{{ ftl('contribute-help-fund') }}</p>
           </a>

--- a/bedrock/mozorg/templates/mozorg/home/home-contentful.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-contentful.html
@@ -127,7 +127,9 @@
 
   {% if switch('homepage-ijustine-promo', ['en-US']) %}
     {{ js_bundle ('ijustine-promo')}}
-  {% elif show_fundraising_banner %}
+  {% endif %}
+
+  {% if show_fundraising_banner %}
     {{ js_bundle('fundraising-banner') }}
   {% elif show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -426,7 +426,7 @@ def press_blog_url(ctx):
 
 @library.global_function
 @jinja2.pass_context
-def donate_url(ctx, campaign="", content=""):
+def donate_url(ctx, content=""):
     """Output a formatted donation link to the donation page
 
     Examples
@@ -439,21 +439,20 @@ def donate_url(ctx, campaign="", content=""):
 
     This would output:
 
-        https://foundation.mozilla.org/?form=donate&utm_source=mozilla.org&utm_medium=referral
+        https://foundation.mozilla.org/?form=donate&utm_source=mozilla.org&utm_medium=referral&utm_campaign=moco
 
-        {{ donate(campaign='footer', content='company')}}
+        {{ donate(content='footer')}}
 
     This would output:
 
-        https://foundation.mozilla.org/?form=donate&utm_source=mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=company
+        https://foundation.mozilla.org/?form=donate&utm_source=mozilla.org&utm_medium=referral&utm_campaign=moco&utm_content=footer
 
 
     """
 
-    campaign = "&utm_campaign=" + campaign if campaign else ""
     content = "&utm_content=" + content if content else ""
 
-    return settings.DONATE_LINK.format(campaign=campaign, content=content)
+    return settings.DONATE_LINK.format(content=content)
 
 
 @library.global_function

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -315,20 +315,23 @@ class TestPressBlogUrl(TestCase):
 class TestDonateUrl(TestCase):
     rf = RequestFactory()
 
-    def _render(self, campaign="", content=""):
+    def _render(self, content=""):
         req = self.rf.get("/")
-        return render(f"{{{{ donate_url(campaign='{campaign}', content='{content}') }}}}", {"request": req})
+        return render(f"{{{{ donate_url(content='{content}') }}}}", {"request": req})
 
-    def test_donate_url_with_params(self):
+    def test_donate_url_with_content_param(self):
         """Should include campaign specific parameters when supplied"""
-        assert self._render(campaign="footer", content="company") == (
-            "https://foundation.mozilla.org/?form=donate&amp;utm_source=mozilla.org&amp;utm_medium=referral"
-            "&amp;utm_campaign=footer&amp;utm_content=company"
+        assert self._render(content="footer") == (
+            "https://foundation.mozilla.org/?form=donate&amp;c_id=7014x000000eQOH&amp;utm_source=mozilla.org&amp;utm_medium=referral"
+            "&amp;utm_campaign=moco&amp;utm_content=footer"
         )
 
     def test_donate_url_no_params(self):
         """Should exclude campaign specific parameters when not supplied"""
-        assert self._render() == ("https://foundation.mozilla.org/?form=donate&amp;utm_source=mozilla.org&amp;utm_medium=referral")
+        assert self._render() == (
+            "https://foundation.mozilla.org/?form=donate&amp;c_id=7014x000000eQOH&amp;utm_source=mozilla.org&amp;utm_medium=referral"
+            "&amp;utm_campaign=moco"
+        )
 
 
 class TestFirefoxTwitterUrl(TestCase):

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -873,7 +873,7 @@ PRESS_BLOGS = {
     "pt-BR": "press-br/",
 }
 
-DONATE_LINK = "https://foundation.mozilla.org/?form=donate&utm_source=mozilla.org&utm_medium=referral{campaign}{content}"
+DONATE_LINK = "https://foundation.mozilla.org/?form=donate&c_id=7014x000000eQOH&utm_source=mozilla.org&utm_medium=referral&utm_campaign=moco{content}"
 
 # Official Firefox Twitter accounts
 FIREFOX_TWITTER_ACCOUNTS = {


### PR DESCRIPTION
## One-line summary

- Adds `c_id` param to all donation links for Sales Force attribution.
- Alse hard codes `utm_campaign=moco` to all donation links.

## Issue / Bugzilla link

#12796

## Testing

http://localhost:8000/en-US/

- [ ] Donate link in the footer contains new params
- [ ] Fundraising form submits with new params.