### PR TITLE
2023-02-27 Dependency bumps

### DIFF
--- a/bin/compile-requirements.sh
+++ b/bin/compile-requirements.sh
@@ -12,9 +12,9 @@ export CUSTOM_COMPILE_COMMAND="$ make compile-requirements"
 # We need this installed, but we don't want it to live in the main requirements
 # We will need to periodically review this pinning
 
-pip install -U pip==23.0
+pip install -U pip==23.0.1
 pip install pip-tools==6.12.2
 
-pip-compile --generate-hashes -r requirements/prod.in --resolver=backtracking
-pip-compile --generate-hashes -r requirements/dev.in --resolver=backtracking
-pip-compile --generate-hashes -r requirements/docs.in --resolver=backtracking
+pip-compile --generate-hashes -r requirements/prod.in --resolver=backtracking --rebuild
+pip-compile --generate-hashes -r requirements/dev.in --resolver=backtracking --rebuild
+pip-compile --generate-hashes -r requirements/docs.in --resolver=backtracking --rebuild

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -89,13 +89,13 @@ blessed==1.20.0 \
     --hash=sha256:0c542922586a265e699188e52d5f5ac5ec0dd517e5a1041d90d2bbf23f906058 \
     --hash=sha256:2cdd67f8746e048f00df47a2880f4d6acbcdb399031b604e34ba8f71d5787680
     # via curtsies
-boto3==1.26.74 \
-    --hash=sha256:57f1696cbf5927180521ddabc37f10eb6650ccedc2b784dfb04502193bb65df9 \
-    --hash=sha256:a3cf126d18194e5d350ec46f99f1fff15beacdf091d1979e8471681688e14ba1
+boto3==1.26.79 \
+    --hash=sha256:049de631cc03726a14b8eb24ac9ec2a48b0624197796f36166da809fdc9b9a7f \
+    --hash=sha256:73d7bd1f16118ef0dfe936e0420cd76b02d1aedb75330ebda51168458ab752ac
     # via -r requirements/prod.txt
-botocore==1.29.74 \
-    --hash=sha256:bf1515908c8ffdffa249e112fd9bbb54d919ce8fb5ee88baf9c198dda6172fd5 \
-    --hash=sha256:cb1e1a584c0bea3b1bcf39710eb7b2e58add56945598d95356bf9f6d4cc8b6ae
+botocore==1.29.79 \
+    --hash=sha256:5f254f019e8641f8b2ba6dddc1f7541e8c6d25d976802392710b2fc4bac925b1 \
+    --hash=sha256:c7ded44062bed3b928944cfb09e1578ed3fed0e4c98de4f233f3c2056a8d491e
     # via
     #   -r requirements/prod.txt
     #   boto3
@@ -353,9 +353,9 @@ django-allow-cidr==0.6.0 \
     --hash=sha256:24b71f70257e97bab9fdb5ad8342c96eeea1d45bc06a36332978574252219401 \
     --hash=sha256:6709f4581dfd2a00476a134741a738a7f67714ec4f8596c55b22cf3b2ac5a12e
     # via -r requirements/prod.txt
-django-cors-headers==3.13.0 \
-    --hash=sha256:37e42883b5f1f2295df6b4bba96eb2417a14a03270cb24b2a07f021cd4487cf4 \
-    --hash=sha256:f9dc6b4e3f611c3199700b3e5f3398c28757dcd559c2f82932687f3d0443cfdf
+django-cors-headers==3.14.0 \
+    --hash=sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739 \
+    --hash=sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e
     # via -r requirements/prod.txt
 django-crum==0.7.9 \
     --hash=sha256:037cc8b822975bb1d41cd24269b59a512cc77448fadc3f34ab9a17b229b4b471 \
@@ -1247,9 +1247,9 @@ trio-websocket==0.9.2 \
     --hash=sha256:5b558f6e83cc20a37c3b61202476c5295d1addf57bd65543364e0337e37ed2bc \
     --hash=sha256:a3d34de8fac26023eee701ed1e7bf4da9a8326b61a62934ec9e53b64970fd8fe
     # via selenium
-twilio==7.16.3 \
-    --hash=sha256:56697433bb695b7e2885a9fb84672f75cacd6158a2d656d304775d232a57ad01 \
-    --hash=sha256:c72cabacfd392b2fd2dae609ec984787cfa004cd510c0861475b5c20983570cb
+twilio==7.16.4 \
+    --hash=sha256:594b2b594d2181e6f765e8af37f1d28277fa54b0f651ca7e5c0f54aa45797fd3 \
+    --hash=sha256:7dead87cf3b92fae5db07ce553b571b315a1bfff2cc6a13bdf5bdfc4675409e5
     # via -r requirements/prod.txt
 types-toml==0.10.8.3 \
     --hash=sha256:a2286a053aea6ab6ff814659272b1d4a05d86a1dd52b807a87b23511993b46c5 \
@@ -1296,9 +1296,9 @@ webencodings==0.5.1 \
     #   bleach
     #   html5lib
     #   tinycss2
-whitenoise==6.3.0 \
-    --hash=sha256:cf8ecf56d86ba1c734fdb5ef6127312e39e92ad5947fef9033dc9e43ba2777d9 \
-    --hash=sha256:fe0af31504ab08faa1ec7fc02845432096e40cc1b27e6a7747263d7b30fb51fa
+whitenoise==6.4.0 \
+    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
+    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
     # via -r requirements/prod.txt
 wrapt==1.14.0 \
     --hash=sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b \

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -2,6 +2,7 @@ certifi==2022.12.7  # hard-pinned subdep for now until sphinx bump it
 chardet==5.0.0
 fluent.pygments==1.0
 fluent.syntax==0.18.1
+markdown-it-py>=2.2.0
 markupsafe==2.0.1
 myst-parser==0.18.0
 Sphinx==5.1.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,10 +8,6 @@ alabaster==0.7.12 \
     --hash=sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359 \
     --hash=sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02
     # via sphinx
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
-    # via markdown-it-py
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
@@ -73,10 +69,11 @@ livereload==2.6.3 \
     --hash=sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869 \
     --hash=sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4
     # via sphinx-autobuild
-markdown-it-py==2.0.1 \
-    --hash=sha256:31974138ca8cafbcb62213f4974b29571b940e78364584729233f59b8dfdb8bd \
-    --hash=sha256:7b5c153ae1ab2cde00a33938bce68f3ad5d68fbe363f946de7d28555bed4e08a
+markdown-it-py==2.2.0 \
+    --hash=sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30 \
+    --hash=sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1
     # via
+    #   -r requirements/docs.in
     #   mdit-py-plugins
     #   myst-parser
 markupsafe==2.0.1 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -3,7 +3,7 @@ babis==0.2.4
 basket-client==1.0.0
 beautifulsoup4==4.11.2
 bleach[css]==6.0.0
-boto3==1.26.74
+boto3==1.26.79
 chardet==5.1.0
 commonware==0.6.0
 contentful==1.13.1
@@ -11,7 +11,7 @@ contextlib2==21.6.0
 cryptography==39.0.1
 dirsync==2.2.5
 django-allow-cidr==0.6.0
-django-cors-headers==3.13.0
+django-cors-headers==3.14.0
 django-crum==0.7.9
 django-csp==3.7
 django-extensions==3.2.1
@@ -53,5 +53,5 @@ sentry-sdk==1.15.0
 sentry-processor==0.0.1
 supervisor==4.2.5
 timeago==1.0.16
-twilio==7.16.3
-whitenoise==6.3.0
+twilio==7.16.4
+whitenoise==6.4.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -42,13 +42,13 @@ bleach[css]==6.0.0 \
     --hash=sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414 \
     --hash=sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4
     # via -r requirements/prod.in
-boto3==1.26.74 \
-    --hash=sha256:57f1696cbf5927180521ddabc37f10eb6650ccedc2b784dfb04502193bb65df9 \
-    --hash=sha256:a3cf126d18194e5d350ec46f99f1fff15beacdf091d1979e8471681688e14ba1
+boto3==1.26.79 \
+    --hash=sha256:049de631cc03726a14b8eb24ac9ec2a48b0624197796f36166da809fdc9b9a7f \
+    --hash=sha256:73d7bd1f16118ef0dfe936e0420cd76b02d1aedb75330ebda51168458ab752ac
     # via -r requirements/prod.in
-botocore==1.29.74 \
-    --hash=sha256:bf1515908c8ffdffa249e112fd9bbb54d919ce8fb5ee88baf9c198dda6172fd5 \
-    --hash=sha256:cb1e1a584c0bea3b1bcf39710eb7b2e58add56945598d95356bf9f6d4cc8b6ae
+botocore==1.29.79 \
+    --hash=sha256:5f254f019e8641f8b2ba6dddc1f7541e8c6d25d976802392710b2fc4bac925b1 \
+    --hash=sha256:c7ded44062bed3b928944cfb09e1578ed3fed0e4c98de4f233f3c2056a8d491e
     # via
     #   boto3
     #   s3transfer
@@ -191,9 +191,9 @@ django-allow-cidr==0.6.0 \
     --hash=sha256:24b71f70257e97bab9fdb5ad8342c96eeea1d45bc06a36332978574252219401 \
     --hash=sha256:6709f4581dfd2a00476a134741a738a7f67714ec4f8596c55b22cf3b2ac5a12e
     # via -r requirements/prod.in
-django-cors-headers==3.13.0 \
-    --hash=sha256:37e42883b5f1f2295df6b4bba96eb2417a14a03270cb24b2a07f021cd4487cf4 \
-    --hash=sha256:f9dc6b4e3f611c3199700b3e5f3398c28757dcd559c2f82932687f3d0443cfdf
+django-cors-headers==3.14.0 \
+    --hash=sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739 \
+    --hash=sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e
     # via -r requirements/prod.in
 django-crum==0.7.9 \
     --hash=sha256:037cc8b822975bb1d41cd24269b59a512cc77448fadc3f34ab9a17b229b4b471 \
@@ -824,9 +824,9 @@ tinycss2==1.1.1 \
     --hash=sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf \
     --hash=sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8
     # via bleach
-twilio==7.16.3 \
-    --hash=sha256:56697433bb695b7e2885a9fb84672f75cacd6158a2d656d304775d232a57ad01 \
-    --hash=sha256:c72cabacfd392b2fd2dae609ec984787cfa004cd510c0861475b5c20983570cb
+twilio==7.16.4 \
+    --hash=sha256:594b2b594d2181e6f765e8af37f1d28277fa54b0f651ca7e5c0f54aa45797fd3 \
+    --hash=sha256:7dead87cf3b92fae5db07ce553b571b315a1bfff2cc6a13bdf5bdfc4675409e5
     # via -r requirements/prod.in
 typing-extensions==4.4.0 \
     --hash=sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa \
@@ -854,9 +854,9 @@ webencodings==0.5.1 \
     #   bleach
     #   html5lib
     #   tinycss2
-whitenoise==6.3.0 \
-    --hash=sha256:cf8ecf56d86ba1c734fdb5ef6127312e39e92ad5947fef9033dc9e43ba2777d9 \
-    --hash=sha256:fe0af31504ab08faa1ec7fc02845432096e40cc1b27e6a7747263d7b30fb51fa
+whitenoise==6.4.0 \
+    --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
+    --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
     # via -r requirements/prod.in
 wrapt==1.14.0 \
     --hash=sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b \


### PR DESCRIPTION
## Bedrock

#12810  Bump boto3 from 1.26.74 to 1.26.79 in /requirements
#12808  Bump whitenoise from 6.3.0 to 6.4.0 in /requirements
#12807  Bump twilio from 7.16.3 to 7.16.4 in /requirements
#12805  Bump django-cors-headers from 3.13.0 to 3.14.0 in /requirements


## Docs
#12799  Bump markdown-it-py from 2.0.1 to 2.2.0 in /requirements