### PR TITLE
Update input for test_spaces_menu

### DIFF
--- a/tests/functional/test_contact.py
+++ b/tests/functional/test_contact.py
@@ -19,7 +19,7 @@ def test_tab_navigation(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("slug", [("toronto/"), ("san-francisco/"), ("berlin/")])
+@pytest.mark.parametrize("slug", [("toronto/"), ("san-francisco/"), ("berlin/"), ("paris/"), ("beijing/")])
 def test_spaces_menus(slug, base_url, selenium):
     page = SpacesPage(selenium, base_url, slug=slug).open()
     space_menu = [s for s in page.spaces if s.id in slug]


### PR DESCRIPTION
## One-line summary

The most recently added Mozilla spaces (on the [contact page](https://www.mozilla.org/en-US/contact/spaces/)) are not tested by test_spaces_menus ([test_contact.py ](https://github.com/mozilla/bedrock/blob/main/tests/functional/test_contact.py)) as the input hasn't been updated with Paris and Beijing.

## Significant changes and points to review

The spaces input has been updated with Paris and Beijing.

## Issue / Bugzilla link
N/A


## Screenshots
![image](https://user-images.githubusercontent.com/76040511/222349359-3dc3bf6f-4277-489c-a05a-e35f5b6056ab.png)


## Checklist
N/A

## Testing
N/A
