### PR TITLE
Add EU disclosures to H2 2022 transparency report (Fixes #12837)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2022.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2022.html
@@ -306,6 +306,11 @@
           Homepage Experiment Ad Campaign
         </a>
       </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/pocket-eu-h2-2022.pdf">
+          Pocket European Union H2 2022 Campaign
+        </a>
+      </li>
     </ul>
 
     <h3>Firefox</h3>
@@ -319,6 +324,11 @@
       <li>
         <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/firefox-european-union-h2-2022-campaign.pdf">
           Firefox European Union H2 2022 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h2-2022/firefox-eu-campaign-2-h2-2022.pdf">
+          Firefox European Union H2 2022 Campaign 2
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## One-line summary

Adds EU disclosures to the latest transparency report.

## Issue / Bugzilla link

#12837

## Testing

http://localhost:8000/en-US/about/policy/transparency/jul-dec-2022/
