### PR TITLE
Mark Pocket and Family pages tests as non-destructive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ per-file-ignores=
 # Hiding warnings for now, the noise is making test fixes harder
 addopts = --showlocals -r a --ignore=node_modules -p no:warnings
 DJANGO_SETTINGS_MODULE = bedrock.settings.test
-sensitive_url = (mozilla\.(com|org)|bedrock-prod)
+sensitive_url = (mozilla\.(com|org)|bedrock-prod|bedrock\.prod)
 testpaths =
     bedrock
     lib

--- a/tests/functional/firefox/family/test_family.py
+++ b/tests/functional/firefox/family/test_family.py
@@ -8,18 +8,21 @@ from pages.firefox.family.landing import FamilyPage
 
 
 @pytest.mark.skip_if_firefox(reason="Nav download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
 def test_firefox_nav_download_button_is_displayed(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert page.is_firefox_nav_download_button_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason="Nav CTA is only hidden for Firefox users")
+@pytest.mark.nondestructive
 def test_firefox_nav_cta_is_displayed(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert not page.is_firefox_nav_cta_displayed
 
 
 @pytest.mark.skip_if_firefox(reason="Download CTA is only shown for non-Firefox users")
+@pytest.mark.nondestructive
 def test_firefox_desktop_download_button_is_displayed(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert page.is_firefox_desktop_download_button_displayed
@@ -27,17 +30,20 @@ def test_firefox_desktop_download_button_is_displayed(base_url, selenium):
 
 
 @pytest.mark.skip_if_not_firefox(reason="Make Default CTA is only shown for (non-default) Firefox users")
+@pytest.mark.nondestructive
 def test_firefox_make_default_button_is_displayed(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert page.is_firefox_make_default_button_displayed
     assert not page.is_firefox_desktop_download_button_displayed
 
 
+@pytest.mark.nondestructive
 def test_firefox_pdf_download_button_is_displayed(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert page.is_firefox_pdf_download_button_displayed
 
 
+@pytest.mark.nondestructive
 def test_h1_has_accessible_title(base_url, selenium):
     page = FamilyPage(selenium, base_url).open()
     assert page.h1_title == "The Tech Talk"

--- a/tests/functional/pocket/test_navigation.py
+++ b/tests/functional/pocket/test_navigation.py
@@ -22,6 +22,7 @@ def test_mobile_menu(pocket_base_url, selenium_mobile):
     assert not page.navigation.is_mobile_menu_nav_list_displayed
 
 
+@pytest.mark.nondestructive
 def test_accessible_mobile_menu_open_name(pocket_base_url, selenium_mobile):
     page = AboutPage(selenium_mobile, pocket_base_url).open()
     button_label_reference = page.navigation.mobile_menu_open_button.get_attribute("aria-labelledby")
@@ -29,6 +30,7 @@ def test_accessible_mobile_menu_open_name(pocket_base_url, selenium_mobile):
     assert len(string) > 0
 
 
+@pytest.mark.nondestructive
 def test_accessible_mobile_menu_close_name(pocket_base_url, selenium_mobile):
     page = AboutPage(selenium_mobile, pocket_base_url).open()
     page.navigation.open_mobile_menu()
@@ -36,6 +38,7 @@ def test_accessible_mobile_menu_close_name(pocket_base_url, selenium_mobile):
     assert len(string) > 0
 
 
+@pytest.mark.nondestructive
 def test_mobile_menu_not_displayed_on_desktop(pocket_base_url, selenium):
     page = AboutPage(selenium, pocket_base_url).open()
     assert not page.navigation.is_mobile_menu_open_button_displayed


### PR DESCRIPTION
Spotted a few tests that were missing the `nondestructive` pytest mark and are still OK to be run against prod.

This PR also updates `sensitive_url` so we can distinguish the [new infra](https://prod.bedrock.prod.webservices.mozgcp.net/en-US/) in tests that might be considered sensitive should we need/want to (I don't think we currently have any though).