### PR TITLE
Fix intermittent test failure for pocket/test_navigation.py

### DIFF
--- a/tests/pages/pocket/base.py
+++ b/tests/pages/pocket/base.py
@@ -73,6 +73,7 @@ class BasePage(Page):
             return (
                 "mobile-nav-open" not in self.find_element(*self._content_wrapper_locator).get_attribute("class")
                 and self.mobile_menu_open_button.get_attribute("aria-expanded") == "false"
+                and self.wait.until(lambda s: not self.is_mobile_menu_nav_list_displayed)
             )
 
         @property


### PR DESCRIPTION
## One-line summary

Fixes: https://gitlab.com/mozmeao/www-config/-/jobs/3896135830

## Issue / Bugzilla link

N/A

## Testing

Note: failure only happens in Chrome, so you'll need [chrome driver](https://chromedriver.chromium.org/home) installed to test locally

`BASE_POCKET_URL=http://localhost:8000 py.test -m pocket_mode --driver Chrome --html tests/functional/results.html tests/functional/pocket/test_navigation.py`