### PR TITLE
Try supplying a CodeCov token to sidestep issues where the build can't be found via GHA's API

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -46,6 +46,9 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
         with:
+          # A CodeCov token is normally NOT needed for public repos, but this workaround is suggested here:
+          # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/18
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: python_coverage/coverage.xml
           fail_ci_if_error: true  # optional (default = false)
           verbose: true  # optional (default = false)


### PR DESCRIPTION
This should hopefully stabilise CI tests running on the main `mozilla` origin, but it may not work for forks of this repo.

Example of the failure we're trying to avoid https://github.com/mozilla/bedrock/actions/runs/4404509648/jobs/7714206696