### PR TITLE
Remove mozilla-technology newsletter data and strings

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -140,10 +140,6 @@
     "description": "{{ ftl('newsletters-email-updates-from-vouched')|striptags }}",
     "title": "{{ ftl('newsletters-mozillians')|striptags }}"
   },
-  "mozilla-technology": {
-    "description": "{{ ftl('newsletters-were-building-the-technology')|striptags }}",
-    "title": "{{ ftl('newsletters-mozilla-labs')|striptags }}"
-  },
   "os": {
       "description": "{{ ftl('newsletters-firefox-os-news')|striptags }}",
       "title": "{{ ftl('newsletters-firefox-os')|striptags }}"

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -404,12 +404,6 @@ newsletters-mozilla-learning-network = { -brand-name-mozilla } Learning Network
 newsletters-updates-from-our-global = Updates from our global community, helping people learn the most important skills of our age: the ability to read, write and participate in the digital world.
 
 # Name for the newsletter in Newsletter subscription page
-newsletters-mozilla-labs = { -brand-name-mozilla-labs }
-
-# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
-newsletters-were-building-the-technology = We’re building the technology of the future. Come explore with us.
-
-# Name for the newsletter in Newsletter subscription page
 newsletters-webmaker = { -brand-name-webmaker }
 
 # Description for the newsletter in Newsletter subscription page (Webmaker)

--- a/tests/unit/spec/newsletter/data.js
+++ b/tests/unit/spec/newsletter/data.js
@@ -209,21 +209,6 @@ const newsletterData = {
         is_mofo: true,
         order: 12
     },
-    'mozilla-technology': {
-        title: 'Mozilla Labs',
-        description:
-            "We're building the technology of the future. Come explore with us.",
-        show: false,
-        active: true,
-        private: false,
-        indent: false,
-        vendor_id: 'Sub_Mozilla_Tech__c',
-        languages: ['en'],
-        requires_double_optin: true,
-        firefox_confirm: false,
-        is_mofo: false,
-        order: 13
-    },
     'mixed-reality': {
         title: 'Mixed Reality',
         description:
@@ -946,11 +931,6 @@ const stringData = {
     'mozilla-phone': {
         description: 'Email updates for vouched Mozillians on mozillians.org.',
         title: 'Mozillians'
-    },
-    'mozilla-technology': {
-        description:
-            'We’re building the technology of the future. Come explore with us.',
-        title: 'Mozilla Labs'
     },
     os: {
         description:


### PR DESCRIPTION
We need to update the name and description of the newsletter. We'll do
that via basket. These data need to be removed in order for bedrock to
use the basket data.
