### PR TITLE
Add content poilicy page for mozilla.social (Fixes #12865)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/policies.html
@@ -21,6 +21,7 @@
   <li><a href="{{ url('mozorg.about.governance.policies.module-ownership') }}">Mozilla Modules and Module Ownership</a></li>
   <li><a href="//wiki.mozilla.org/Modules">Module Owners List</a></li>
   <li><a href="{{ url('mozorg.about.governance.policies.participation') }}">Mozilla Community Participation Guidelines</a></li>
+  <li><a href="{{ url('mozorg.about.governance.policies.social-content-policies') }}">Mozilla.Social Content Policies</a></li>
 </ul>
 
 <p>For additional information on Mozilla’s governance structure, see <a href="{{ url('mozorg.about.governance.roles') }}">the Roles and Responsibilities</a> page.</p>

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
@@ -1,0 +1,639 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block page_title %}Mozilla.Social Content Policies{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('social-content-policies') }}
+{% endblock %}
+
+{% block article %}
+<h1 class="mzp-c-article-title">Mozilla.Social Content Policies</h1>
+
+<nav>
+  <ol class="mzp-u-list-styled">
+    <li><a href="#copyright">Copyright</a></li>
+    <li><a href="#trademark">Trademark</a></li>
+    <li><a href="#impersonation">Impersonation</a></li>
+    <li><a href="#harassment">Harassment</a></li>
+    <li><a href="#violent-content">Violent content</a></li>
+    <li><a href="#self-harm">Self-Harm</a></li>
+    <li><a href="#sexualized-content">Sexualized content</a></li>
+    <li><a href="#child-sexual-abuse">Child Sexual Abuse</a></li>
+    <li><a href="#third-party-violations">Violations of Third Party Privacy</a></li>
+    <li><a href="#misinformation">Misinformation</a></li>
+    <li><a href="#illegal-goods">Promotion of illegal goods</a></li>
+    <li><a href="#fraud-counterfeit-goods">Fraud/Counterfeit goods</a></li>
+    <li><a href="#extremist-content">Terrorist and Violent Extremist Content</a></li>
+    <li><a href="#hate-speech">Hate Speech</a></li>
+  </ul>
+</nav>
+
+<section id="copyright" class="mzp-is-anchor-link">
+  <h2>Copyright</h2>
+
+  <h3>How to submit a copyright notice</h3>
+
+  <p>
+    Mozilla will respond to takedown requests that comply with the Digital Millennium Copyright Act (DMCA).
+    If you believe that content shared on the Mozilla.Social server infringes a copyright owned by you, or
+    by someone that you legally represent, you may submit a takedown notice, using the procedures outlined
+    on <a href="{{ url('legal.report-infringement') }}">Mozilla’s copyright page</a>.
+  </p>
+
+  <h3>What happens next?</h3>
+
+  <p>
+    Filing a DMCA notice will commence a structured process.  Your complaint will be reviewed for accuracy,
+    validity, and completeness.  If any of the required DMCA elements are missing, we will be unable to
+    process your takedown request.
+  </p>
+
+  <p>
+    If your complaint appears to satisfy the requirements and we remove the material in question, we will
+    notify the affected user, and provide them with a copy of your complaint (which may include your personal
+    information that is contained there).  If you do not wish to have your information shared, you may wish to
+    consider having an agent submit the complaint on your behalf.  We will also provide the user with
+    information about how to file a counter-notice, if they wish to contest your claims.
+  </p>
+
+  <p>
+    If we remove material from Mozilla.social in response to your infringement notice, you will receive
+    confirmation that the material has been removed.  If we decide not to act on your infringement report,
+    you also will receive a notification of that decision.
+  </p>
+
+  <p>Mozilla has a policy of terminating access for accounts that are repeat infringers.</p>
+
+  <h3>What can I do if I think my content should not have been removed?</h3>
+
+  <p>
+    If something you shared was removed due to a mistake or misidentification by the copyright owner, you
+    can file a DMCA counter-notice, using the process described on
+    <a href="{{ url('legal.report-infringement') }}">Mozilla’s copyright page</a>.
+  </p>
+</section>
+
+<section id="trademark" class="mzp-is-anchor-link">
+  <h2>Trademark</h2>
+
+  <h3>How to notify us of trademark infringement</h3>
+
+  <p>
+    A trademark is a word, name, logo, brand, catchphrase, or similar device used to identify the goods or
+    services provided by a specific rightsholder.  Users on our platform may not use a third party’s
+    trademark in a way that is likely to confuse or mislead others about their (or a third party’s)
+    affiliation with the trademark owner.
+  </p>
+
+  <p>
+    Referencing or discussing a third party’s trademark may not, on its own, violate this policy. Mozilla
+    will not remove posts for using a trademark to accurately identify something, or where an exception
+    to trademark law, such as fair use, applies.
+  </p>
+
+  <p>
+    If you are a trademark owner or a trademark owner’s authorized agent, and you believe that content
+    posted on Mozilla.Social infringes one or more of your trademarks, please send us a
+    “<strong>Trademark Notice</strong>”. We handle Trademark Notices similarly to how we handle notices of
+    copyright infringement, and require that they contain each of the following items:
+  </p>
+
+  <ol class="mzp-u-list-styled">
+    <li>
+      A physical or electronic signature from the trademark owner or its authorized representative;
+    </li>
+
+    <li>
+      Identification of the word, name, logo, brand, catchphrase, or other mark that you claim has been
+      infringed;
+    </li>
+
+    <li>
+      Sufficient information to allow us to determine the location of the infringement (for example, the
+      URL where the infringing material is located, or the portion of a particular image that contains
+      the infringed mark);
+    </li>
+
+    <li>
+      Your name, address, telephone number, and an email address where you can be reached;
+    </li>
+
+    <li>
+      A statement that you have a good faith belief that the use of the material in the manner complained
+      of is not authorized by the trademark owner; and
+    </li>
+
+    <li>
+      A statement that the information in your Trademark Notice is accurate, and under penalty of perjury,
+      that you are the trademark owner or are authorized to act on the owner’s behalf.
+    </li>
+  </ol>
+
+  <h3>What can I do if my post was removed for trademark infringement?</h3>
+
+  <p>
+    If material that you posted was removed for trademark infringement, and you believe that it did not
+    infringe, you can file a counter-notice to contest the removal of that content.  If you wish to file a
+    counter-notice, you can submit one at the following address:
+    <a href="mailto:dmcanotice@mozilla.co">dmcanotice@mozilla.com</a>.
+  </p>
+
+  <p>Your counter-notice must include:</p>
+
+  <ol class="mzp-u-list-styled">
+    <li>
+      A physical or electronic signature
+    </li>
+
+    <li>
+      Identification of the material that has been removed or to which access has been disabled and the
+      location at which the material appeared before it was removed or access to it was disabled (the
+      description from the takedown notice, or the URL where the content was previously posted, are
+      acceptable).
+    </li>
+
+    <li>
+      A statement under penalty of perjury that you have a good faith belief that the material was removed
+      or disabled as a result of mistake or misidentification of the material to be removed or disabled;
+    </li>
+
+    <li>
+      Your name, physical address, and telephone number;
+    </li>
+
+    <li>
+      A statement that you consent to the jurisdiction of Federal District Court for the judicial district
+      in which your address is located, or if your address is outside of the United States, for any judicial
+      district in which Mozilla may be found, and that you will accept service of process from the person who
+      provided the takedown Notice or an agent of such person; and
+    </li>
+
+    <li>
+      A brief explanation of the factual or legal basis of your counter-notice (for example, that you believe
+      you are the trademark owner, or that you posted it for nominative or fair use purposes).
+    </li>
+  </ol>
+</section>
+
+<section id="impersonation" class="mzp-is-anchor-link">
+  <h2>Impersonation</h2>
+
+  <p>
+    Users should be able to trust that the person or organization indicated by another account’s name or profile
+    is authentic, and genuinely represents the account’s owner.  You therefore may not impersonate others, and
+    may not post material intended to deceive others about your identity, or about your authority to speak or
+    act on behalf of a third party. However, clear parody or satire accounts are not considered violations of
+    this policy.
+  </p>
+
+  <p>
+    While your profile is not required to display your own name or picture, you also may not use it to pose as
+    a third party - whether real or imagined - in order to deceive others.
+  </p>
+
+  <p>
+    Violations of this policy may include accounts posing as an authorized representative of a particular business,
+    accounts offering misleading investment, employment, or financial deals, or other accounts displaying
+    counterfeit identities, or offering unauthorized or counterfeit goods or services.
+  </p>
+
+  <p>
+    If you discover an account that you believe is impersonating another person, or is purporting to represent a
+    person or entity that it is not entitled to represent, you can report that account to us via the reporting
+    tools available to you on Mozilla.Social.  Please identify the specific account in question, as well as the
+    account, individual, or entity that you believe is being impersonated without authorization.
+  </p>
+
+  <p>
+    If further information is likely to help clarify your concerns (for example, if the impersonation was done
+    in a specific post), please also share those details.  You will also be asked to provide your contact
+    information, so that we can contact you with further questions, and with updates on your complaint. For more
+    information about how we store your information, see the Mozilla.social Privacy Policy.
+  </p>
+</section>
+
+<section id="harassment" class="mzp-is-anchor-link">
+  <h2>Harassment</h2>
+
+  <p>
+    Mozilla.Social users should be able to express their opinions, and to engage in passionate and open dialogue
+    without becoming subject (or subjecting others) to bullying or harassment.  With that in mind, Mozilla will
+    remove posts that appear to be shared for the purpose of diminishing, degrading or shaming others, causing
+    them fear, or otherwise tormenting them.  Egregious or repeated violations of this policy may result in
+    permanent suspension of the user’s account.
+  </p>
+
+  <p>
+    This does not mean that we will remove posts, or accounts, simply for stating controversial ideas. Mozilla
+    believes that the best discussions occur in an environment where people feel comfortable sharing diverse
+    points of view, and will not label something as harassment simply because it includes unpopular viewpoints.
+    That said, it will remove posts that appear to be targeted at a particular individual or group, that contain
+    personal abuse, or that appear to be shared in order to cause others discomfort.
+  </p>
+
+  <p>
+    Mozilla is committed to making Mozilla.Social a space that reflects our
+    <a href="{{ url('mozorg.about.manifesto') }}">values</a>. The line between forcefully expressed opinion and
+    harassment can be hard to judge. If you are not sure whether a behavior would constitute harassment, it’s
+    best to avoid that behavior. We may sometimes make moderation decisions that you feel err on the side of
+    removing content but we will always try to strike a balance that promotes healthy community and constructive
+    debate. If you are looking for a social network that permits all speech, without limitation, Mozilla.Social
+    may not be the right place for you.
+  </p>
+
+  <p>
+    Harassment can come in many forms, and is not just at the level of person to person interaction. On
+    Mozilla.Social, we will remove posts or accounts who incite or encourage harassment against other people
+    (e.g. <a href="https://en.wikipedia.org/wiki/Dogpiling_(Internet)">dogpiling</a>), public shaming, doxxing
+    and/or releasing other forms of private and identifying information, and
+    <a href="https://en.wikipedia.org/wiki/Swatting">swatting</a>. Mozilla will also disable posts that contain
+    explicit or veiled threats, or that appear to target an individual based on that person’s membership in a
+    particular social, cultural, political, or other class, such as their race, gender, sexual identity, sexual
+    orientation, gender identity, familial status, national or regional origin, language, education level,
+    income level, or equivalent.
+  </p>
+
+  <p>
+    Messages sent to a single individual may constitute harassment, depending on the wording of the message and
+    the context in which it was sent.  While uninvited or controversial private posts may not, on their own,
+    constitute harassment, one that appears intended to belittle or intimidate the receiver, that is sent as
+    part of a coordinated or ongoing campaign, or that is sent after a request to cease contact, is more likely
+    to be a violation. Similarly, persistent and repeated sexual pressure or badgering in private or public
+    posts may also violate our harassment policy.
+  </p>
+
+  <p>
+    If you find that someone makes upsetting comments or statements that may not rise to the level of “harassment,”
+    you can <a href="https://docs.joinmastodon.org/user/moderating/">choose not to see their posts</a>, and/or to
+    block direct messages from them.
+  </p>
+</section>
+
+<section id="violent-content" class="mzp-is-anchor-link">
+  <h2>Violent content</h2>
+
+  <p>
+    Mozilla.Social users may not use the platform to glorify or promote terrorism or violence. We will remove
+    accounts owned by the perpetrators of violent or terrorist acts (explained more in our policy on terrorism
+    and violent organizations), as well as those accounts that coordinate, incite, mock, or celebrate violence
+    against any individuals, groups, entities, or others.
+  </p>
+
+  <p>
+    Users may not share content that depicts abuse of humans or animals, or that includes excessively gory or
+    violent imagery that, even if meant to be “informational” (e.g. graphic images of death, visible wounds,
+    mutilation, etc.), can disturb other users.  We will remove content that incites or facilitates violence,
+    or appears intended to do so, and will suspend accounts that post or share such content.  Users also may
+    not use the platform to advocate for, or to attempt to encourage others to commit violent acts.  We will
+    remove, and encourage users to report, content indicating a user or third party’s intent to cause real-world
+    injuries to others.  Where we believe there is a serious risk of harm to individuals or to public safety,
+    we may also report such content to law enforcement, and will work with law enforcement agencies as necessary
+    to investigate and address the threat.
+  </p>
+
+  <p>
+    When enforcing this policy, we will consider the context in which a post is shared, in determining whether
+    a violation has occurred.  For example, media that depicts violence by state actors or other newsworthy
+    violent events will typically be permitted for informational purposes, but not for the purpose of glorifying
+    or promoting the violence in question. While not required, if your posts contain such material, we strongly
+    encourage you to use the Content Warning feature available to you as a Mozilla.Social user so that other
+    users can choose whether or not to view your post.
+  </p>
+</section>
+
+<section id="self-harm" class="mzp-is-anchor-link">
+  <h2>Self-Harm</h2>
+
+  <p>
+    Users may not use the platform to glorify or promote self-harm. This includes deliberate self-harm, such as
+    suicide, cutting, ingesting dangerous substances, and similar activities.  It also includes promotion of
+    content that is inherently harmful, such as content that encourages, or aims to foster eating disorders and
+    body dysmorphia.
+  </p>
+
+  <p>
+    Content that would otherwise be forbidden under this policy may be allowed for news purposes, or when shared
+    to facilitate healthy discussion and education.  Content also will not be automatically deemed to violate
+    this policy simply because it discusses nutrition or weight loss, or because it includes images of a
+    particular body type.  Rather, such content will be analyzed holistically, based on the content in which it
+    was presented.
+  </p>
+</section>
+
+<section id="sexualized-content" class="mzp-is-anchor-link">
+  <h2>Sexualized content</h2>
+
+  <p>
+    Under the sexualized content policy, Mozilla.Social users may not share pornographic materials; images,
+    posts, and videos depicting sexual violence; advocate or glorify non-consensual sexual acts.  Users are
+    also prohibited from “outing” victims of sexual assault, and may not use the platform to advertise for
+    or to solicit sexual acts and/or encounters. Deep fakes and altered images that depict people in sexual
+    acts will be removed, and can fall under some of our other policies (<strong>impersonation</strong> and
+    <strong>harassment</strong>, in particular)
+  </p>
+
+  <p>
+    Content that involves, encourages, or facilitates the sexualization and sexual abuse of minors is also
+    prohibited (see <strong>Child Sexual Abuse</strong> policy) and may result in criminal action against
+    you.
+  </p>
+
+  <p>
+    Posts that contain partial nudity (e.g. bathing suits, lingerie, revealing clothing, breastfeeding, etc.)
+    are not prohibited under this policy. Posts that contain images or video of bare breasts that show
+    nipples - regardless of gender identity - are allowed as long as they are (a) being shared with the
+    consent of, and/or by the person depicted in the images (b) not a part of a post that is depicting an
+    explicit sexual act (e.g. pornography) and (c) is not depicting a minor (since minors cannot give
+    consent, and content involving them generally falls under the Child Sexual Exploitation Policy).
+  </p>
+
+  <p>
+    Conversations about sex, sexual acts, reproductive healthcare, childbirth, etc. are also allowed and do
+    not fall under the sexualized content policy. Conversations that glorify or describe violent sexual acts,
+    name victims of sexual assault without their consent, or harass other users for their sexual orientation,
+    reproductive healthcare choices, etc. are prohibited.
+  </p>
+</section>
+
+<section id="child-sexual-abuse" class="mzp-is-anchor-link">
+  <h2>Child Sexual Abuse</h2>
+
+  <p>
+    Mozilla.Social does not permit any content that includes, promotes, depicts, or advocates for any form of
+    child sexual exploitation. Such content may include media, text, illustrations, or links to third party
+    websites that host child sexual exploitation materials.  It includes any actual or implied depiction of,
+    or support for children engaging in sexual activity, as well as discussion of a user’s participation in
+    or desire for such activity.
+  </p>
+
+  <p>
+    Any attempt to solicit Child Sexual Abuse Material (CSAM), nude or sexualized images of children, or
+    real-world sexual encounters with a child (an individual under age 18) is a violation of this policy.
+    This policy also prohibits any attempts to engage in sexually-explicit conversations with, to exchange
+    sexually-explicit information or media with a child on the platform, or to promote or normalize sexual
+    attraction to minors.
+  </p>
+
+  <p>
+    It is also a violation of this policy to name or share images of any alleged victim of child sexual
+    exploitation, except where such information or images is shared by the victim themself. (Explicit
+    photographs of a minor are prohibited, even when shared by the minor subject.)  However, this policy
+    does not prohibit discussion of, or advocacy for a minor’s access to birth control or sexual health
+    services, as long as such services are not aimed at facilitating or concealing a sexual relationship
+    between an adult and a minor.
+  </p>
+
+  <p>
+    Violation of this policy will result in immediate deactivation of the offending account. Most
+    violations will also be reported to law enforcement and/or to the National Center for Missing and
+    Exploited Children (NCMEC). When this occurs, violators may not be immediately notified of the
+    action against their account.
+  </p>
+</section>
+
+<section id="third-party-violations" class="mzp-is-anchor-link">
+  <h2>Violations of Third Party Privacy</h2>
+
+  <p>
+    Protection of individual privacy is one of Mozilla’s core values. We do not allow users to post
+    confidential information about others, except in certain cases where that information is a subject
+    of public concern (such as when it has appeared in a major news outlet or public document and is
+    important to the related news coverage or discussion).
+  </p>
+
+  <p>
+    We may remove content that provides a third party’s contact information, details about their
+    location or residence, or their medical, familial, sexual or other private background details,
+    as well as content that shares copies of identification, financial, educational or medical
+    documents. We also will not permit content in which a user threatens to expose another’s personal
+    information, whether or not such exposure actually occurs.
+  </p>
+
+  <p>
+    We also do not allow users to post their own personal information where sharing that information
+    is likely to cause significant harm to the user who shared it (for example, a Social Security
+    Number or National ID number, address, a bank pin code, or a website or computer password).
+    Relatedly, we do not allow posts or links that seek to obtain other users’ financial, medical or
+    personal information. We will remove such posts when they are brought to our attention.
+  </p>
+</section>
+
+<section id="misinformation" class="mzp-is-anchor-link">
+  <h2>Misinformation</h2>
+
+  <p>
+    Misinformation and deliberate falsehoods are dangerous and threaten the fabric of a healthy
+    democratic society. Many of us have seen firsthand the dangers of such falsehoods becoming
+    normalized and mainstreamed within our societies, as well as the violence that it can cause.
+  </p>
+
+  <p>
+    On Mozilla.Social, we want to encourage healthy conversations and debates, but want to ensure
+    that this is done without spreading misinformation and disinformation on our platform -
+    misinformation is content that the person sharing may or may not be aware that it is false,
+    whereas disinformation is deliberately false and meant to create chaos, uncertainty, and in
+    many cases, radicalize.
+  </p>
+
+  <p>
+    Both misinformation and disinformation are not allowed on Mozilla.Social. Posts containing
+    demonstrably false information and/or conspiracy theories that can cause real-world harm,
+    or that appear likely to radicalize others or encourage violent acts against disenfranchised communities, or to encourage political and social violence, will be removed.
+  </p>
+
+  <p>
+    Posts that speculate about mainstream cultural events or public figures (e.g. celebrity
+    gossip or equivalent thereof) are not prohibited under this policy, unless the posts appear
+    to be spreading deliberate falsehoods to impact or influence public opinion, or to encourage
+    harassment or harm of individuals.
+  </p>
+
+  <p>
+    Accounts that repeatedly violate this policy will be suspended. Before sharing information,
+    double check its source and practice good digital literacy measures. If you think that
+    anything is in violation of this policy, please report it to the admins.
+  </p>
+</section>
+
+<section id="illegal-goods" class="mzp-is-anchor-link">
+  <h2>Promotion of illegal goods</h2>
+
+  <p>
+    Users may not use Mozilla’s platform to traffic in, purchase, sell, or trade illegal or goods
+    and services that are legally restricted, under applicable law. A non-exhaustive list of such
+    goods includes
+  </p>
+
+  <ol class="mzp-u-list-styled">
+    <li>
+      Weapons, firearms, ammunitions, explosives, or instructions on how to create or build these
+      items
+    </li>
+
+    <li>
+      Medications, drugs, and controlled substances, including cigarettes, marijuana, and alcohol
+    </li>
+
+    <li>
+      Sexual services
+    </li>
+
+    <li>
+      Products made from endangered animals
+    </li>
+
+    <li>
+      Human blood, organs, body parts, or skeletal remains
+    </li>
+
+    <li>
+      Gambling (with real money)
+    </li>
+
+    <li>
+      Services that involve trafficking in, trading, or or enslaving human beings
+    </li>
+  </ol>
+
+  <p>
+    Users may discuss the use or trade of such items, or debate the merits of legally restricting such
+    items, without running afoul of this policy. However, users may not instruct other users on where
+    such items can be obtained or sold, nor can they attempt to facilitate or advertise their own
+    involvement in related transactions.
+  </p>
+</section>
+
+<section id="fraud-counterfeit-goods" class="mzp-is-anchor-link">
+  <h2>Fraud/Counterfeit goods</h2>
+
+  <p>
+    Mozilla does not permit any activity that appears intended to deceive or defraud others, or to
+    misrepresent the source and authenticity of goods, in order to obtain money, property, or other
+    material gains.  It also does not permit any activity in which a user seeks to pass off a third
+    party’s goods or services (including digital goods and services), as their own, or misleadingly
+    purports to be trading on behalf of someone else.  This policy prohibits (among other things) the
+    offer or promotion of fraudulent or misleading investments, loans, jobs, or business opportunities,
+    as well as the solicitation of charitable donations for any purpose other than that for which
+    they are advertised.
+  </p>
+
+  <p>
+    Similarly, we do not allow users to coordinate with each other for the purpose of defrauding or
+    deceiving third parties. This includes any attempts to trade in fake identity, financial, business,
+    educational, or other documents and records; unauthorized exchanges of third party property or
+    personal information; and efforts to mislead third party businesses or individuals.
+  </p>
+
+  <p>
+    Violators of this rule will be suspended from Mozilla.Social.
+  </p>
+
+  <p>
+    This rule does not prohibit discussion of fraudulent activity, nor does it prohibit individuals
+    from discussing or promoting legitimate businesses, charities, or investments.
+  </p>
+</section>
+
+<section id="extremist-content" class="mzp-is-anchor-link">
+  <h2>Terrorist and Violent Extremist Content</h2>
+
+  <p>
+    Mozilla.Social prohibits content and/or accounts posted by or belonging to terrorist organizations
+    and individuals, as defined by applicable law. This also includes the promotion and glorification
+    of terrorist individuals, organizations, and acts. Content that is meant to spread extremist
+    ideology is also prohibited. Violent organizations that may or may not be classified formally as
+    terrorist groups also will be banned from the platform.
+  </p>
+
+  <p>
+    Any accounts that are being maintained by perpetrators of violent extremist, terrorist, or mass
+    violent attacks will be removed, regardless of the account owner’s membership in recognized
+    terrorist or violent organizations.
+  </p>
+
+  <p>
+    Since we want Mozilla.Social to be a safe space, we will also prohibit the sharing of hateful or
+    violent manifestos or similar content produced by perpetrators of violent and/or terrorist attacks.
+    Although manifestos are often shared following these kinds of tragedies, even by news organizations,
+    this continues to indirectly assist in the spread of these violent and extremist ideologies and
+    centers the perpetrators of these attacks rather than the victims of such violence.
+  </p>
+
+  <p>
+    Because of this, posts containing manifestos in any form (including outside links, excerpts,
+    full-length manifestos, videos, screenshots and images) or other content created by perpetrators
+    of terrorist and violent attacks will be removed. Even if the intention of the post is not meant
+    to glorify the ideology or the perpetrator, we will aim to ensure that hateful ideologies are not
+    being promoted or shared on our platform.
+  </p>
+</section>
+
+<section id="hate-speech" class="mzp-is-anchor-link">
+  <h2>Hate Speech</h2>
+
+  <p>
+    To ensure an inclusive and safe environment, hate speech and derogatory language is not permitted
+    on Mozilla.Social. Aligned with Mozilla’s values as well as Mastodon’s Server Covenant to actively
+    moderate against hateful speech, posts (this includes text, audio, video, and images) that contain
+    derogatory and/or hateful language about the following will be removed:
+  </p>
+
+  <ul class="mzp-u-list-styled">
+    <li>Family status</li>
+    <li>Gender</li>
+    <li>Gender identity or expression</li>
+    <li>Marital status</li>
+    <li>Sex</li>
+    <li>Sexual orientation</li>
+    <li>Native language</li>
+    <li>Age</li>
+    <li>Ability</li>
+    <li>Race and/or ethnicity</li>
+    <li>Caste</li>
+    <li>National origin</li>
+    <li>Socioeconomic status</li>
+    <li>Religion</li>
+    <li>Geographic location</li>
+    <li>Other physical, social or cultural attributes or classifications</li>
+  </ul>
+
+  <p>
+    Posts that target and/or attack other users containing hateful language focusing on the above are
+    not acceptable. This includes deliberately referring to someone by a gender that they do not identify
+    with, and/or questioning the legitimacy of an individual’s gender identity. Although more considered
+    along the lines of potential bullying and harassment, posts that engage in outing an LGBTQIA+ person
+    without their consent will also be removed.
+  </p>
+
+  <p>
+    Simply put, if you’re unsure if a word is derogatory, don’t use it. Under this policy, phrases, words,
+    images, memes, videos, and/or emojis that are
+    <a href="https://en.wikipedia.org/wiki/Dog_whistle_(politics)">dog whistles</a> meant to encourage
+    hatred toward a certain group or individual based on the above characteristics will also be removed.
+  </p>
+
+  <p>
+    Angry posts, or posts that criticize a specific group based on that group’s opinions or similar
+    characteristics, will not be forbidden under this policy.  Similarly, certain things that might be
+    considered hate speech may not be removed if the context in which they were shared, indicates that
+    the post itself was not intended to attack or inspire enmity against another group (for example, a news
+    photograph of a hateful symbol painted on a building might be permitted, even if the same hateful symbol
+    was forbidden in other contexts).  Similarly, posts may be permitted where the writer refers to
+    themself in a way that might seem hateful when used to refer to others (as long as the post does not
+    violate one of our other policies, such as the policy against Self-Harm).  Words with multiple meanings
+    may be removed in one context, but permitted in another.
+  </p>
+
+  <p>
+    People who violate this policy repeatedly, or who violate it in an egregious manner, will be removed
+    from the platform.
+  </p>
+</section>
+
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
@@ -31,7 +31,7 @@
     <li><a href="#fraud-counterfeit-goods">Fraud/Counterfeit goods</a></li>
     <li><a href="#extremist-content">Terrorist and Violent Extremist Content</a></li>
     <li><a href="#hate-speech">Hate Speech</a></li>
-  </ul>
+  </ol>
 </nav>
 
 <section id="copyright" class="mzp-is-anchor-link">

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -68,6 +68,7 @@ urlpatterns = (
     ),
     page("about/governance/policies/module-ownership/", "mozorg/about/governance/policies/module-ownership.html"),
     page("about/governance/policies/regressions/", "mozorg/about/governance/policies/regressions.html"),
+    page("about/governance/policies/social-content-policies/", "mozorg/about/governance/policies/social-content-policies.html"),
     page("about/policy/transparency/", "mozorg/about/policy/transparency/index.html"),
     page("about/policy/transparency/jan-dec-2015/", "mozorg/about/policy/transparency/jan-dec-2015.html"),
     page("about/policy/transparency/jan-jun-2016/", "mozorg/about/policy/transparency/jan-jun-2016.html"),

--- a/media/css/mozorg/social-content-policies.scss
+++ b/media/css/mozorg/social-content-policies.scss
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.mzp-c-article h2 {
+    margin: $layout-lg 0 $layout-sm;
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -56,6 +56,12 @@
     },
     {
       "files": [
+        "css/mozorg/social-content-policies.scss"
+      ],
+      "name": "social-content-policies"
+    },
+    {
+      "files": [
         "css/mozorg/mpl-differences.scss"
       ],
       "name": "mpl-differences"


### PR DESCRIPTION
## One-line summary

Adds content policy page for mozilla.social

## Issue / Bugzilla link

#12865

## Testing

http://localhost:8000/en-US/about/governance/policies/social-content-policies/
