### PR TITLE
Fix typo in mailto address for DMCA contact

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
@@ -141,7 +141,7 @@
     If material that you posted was removed for trademark infringement, and you believe that it did not
     infringe, you can file a counter-notice to contest the removal of that content.  If you wish to file a
     counter-notice, you can submit one at the following address:
-    <a href="mailto:dmcanotice@mozilla.co">dmcanotice@mozilla.com</a>.
+    <a href="mailto:dmcanotice@mozilla.com">dmcanotice@mozilla.com</a>.
   </p>
 
   <p>Your counter-notice must include:</p>


### PR DESCRIPTION
## One-line summary

Fixes a typo in the mailto: part of an email address (`mozilla.co` instead of `mozilla.com`)

Spotted with www-site-checker

## Significant changes and points to review

Resolves https://github.com/mozmeao/www-site-checker/issues/172

## Screenshots

Before


<img width="1299" alt="Screenshot 2023-03-15 at 10 57 52" src="https://user-images.githubusercontent.com/101457/225290316-d83d4914-967d-4747-8329-d143bb7666f8.png">


After


<img width="1280" alt="Screenshot 2023-03-15 at 10 51 20" src="https://user-images.githubusercontent.com/101457/225290306-9bf3852e-88c5-4199-a7c5-62d1e856e907.png">

## Testing

To test this work:
- [ ] view source on http://localhost:8000/en-US/about/governance/policies/social-content-policies/ and search for dmca to find the email