### PR TITLE
Add new dlsource field to stub attribution (Fixes #12836)

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -54,6 +54,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id": "(not set)",
             "session_id": "(not set)",
+            "dlsource": "(not set)",
         }
         req = self._get_request({"dude": "abides"})
         resp = views.stub_attribution_code(req)
@@ -67,7 +68,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "5d146033839aa07dd3078a1a001864056c69baefbe7dcd95701457a0bc4c1d71",
+            "d09a7d09fa80872d3835161b0b3072332ec773753e6481306c1a7c4f1ef77216",
         )
 
     def test_no_valid_param_data(self):
@@ -78,6 +79,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "ef&bvcv",
             "client_id": "14</p>4538.1610<t>957",
             "session_id": "2w</br>123bg<u>957",
+            "dlsource": "fs<a>44fn</a>",
         }
         final_params = {
             "source": "www.mozilla.org",
@@ -89,6 +91,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id": "(not set)",
             "session_id": "(not set)",
+            "dlsource": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -102,11 +105,11 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "5d146033839aa07dd3078a1a001864056c69baefbe7dcd95701457a0bc4c1d71",
+            "d09a7d09fa80872d3835161b0b3072332ec773753e6481306c1a7c4f1ef77216",
         )
 
     def test_some_valid_param_data(self):
-        params = {"utm_source": "brandt", "utm_content": "ae<t>her"}
+        params = {"utm_source": "brandt", "utm_content": "ae<t>her", "dlsource": "mozorg"}
         final_params = {
             "source": "brandt",
             "medium": "(direct)",
@@ -117,6 +120,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id": "(not set)",
             "session_id": "(not set)",
+            "dlsource": "mozorg",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -130,7 +134,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "68b9e75f17129baa01c2baf91e635035412fc1fcd94a63fa14c1c166dacf4375",
+            "ed0705c22e56e7ed8152b08abd3df72a897ae00b30f7c802aa4a19e3a8c77503",
         )
 
     def test_campaign_data_too_long(self):
@@ -145,6 +149,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
+            "dlsource": "mozorg",
         }
         final_params = {
             "source": "brandt",
@@ -153,13 +158,14 @@ class TestStubAttributionCode(TestCase):
             "|thatThe|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe"
             "|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides"
             "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know"
-            "|about|you|but|I|take|_",
+            "|about|you|b_",
             "content": "A144_A000_0000000",
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
+            "dlsource": "mozorg",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -175,7 +181,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "22e9951d6658fab0723086be79933622e85283181b27ceae649089a1b67d140e",
+            "16010b2f9581e4ba48689125b7f35e4f4420399da1f0f245e814da071c726991",
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -203,6 +209,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
+            "dlsource": "mozorg",
         }
         final_params = {
             "source": "brandt",
@@ -214,6 +221,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
             "session_id": "1668161374",
+            "dlsource": "mozorg",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -227,7 +235,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "7b0b668edd8f374040faa0e063e3940004c5248ec5254140e24baa19220e3aa2",
+            "98c68dcf0ff6086b9e546dda753a830127afc4981745a32a6b6c3dfe81295877",
         )
 
     def test_handles_referrer(self):
@@ -242,6 +250,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id": "(not set)",
             "session_id": "(not set)",
+            "dlsource": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -255,7 +264,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "68b9e75f17129baa01c2baf91e635035412fc1fcd94a63fa14c1c166dacf4375",
+            "9657ba3bdb383411ede4c7da300712624b893e3a8f7d69e804485bec4606628f",
         )
 
     def test_handles_referrer_no_source(self):
@@ -273,6 +282,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id": "(not set)",
             "session_id": "(not set)",
+            "dlsource": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -286,7 +296,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "ef5b4cfcdf34b12142af22ecf3c69144f892a64057d0a9dbea8afe352b706cac",
+            "14670eae778afebe5f68d8e844a87717630a9264a79861f3ebe048fac09431df",
         )
 
     def test_handles_referrer_utf8(self):
@@ -307,6 +317,7 @@ class TestStubAttributionCode(TestCase):
             "ua": "(not set)",
             "client_id": "(not set)",
             "session_id": "(not set)",
+            "dlsource": "(not set)",
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -320,7 +331,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "5d146033839aa07dd3078a1a001864056c69baefbe7dcd95701457a0bc4c1d71",
+            "d09a7d09fa80872d3835161b0b3072332ec773753e6481306c1a7c4f1ef77216",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -60,6 +60,7 @@ STUB_VALUE_NAMES = [
     ("ua", "(not set)"),
     ("client_id", "(not set)"),
     ("session_id", "(not set)"),
+    ("dlsource", "(not set)"),
 ]
 STUB_VALUE_RE = re.compile(r"^[a-z0-9-.%():_]+$", flags=re.IGNORECASE)
 

--- a/docs/firefox-stub-attribution.rst
+++ b/docs/firefox-stub-attribution.rst
@@ -43,6 +43,7 @@ The full list of data values we pass to stub attribution is as follows:
 - ``variation`` (``?variation=`` query parameter)
 - ``client_id`` (``clientId`` client ID from Google Analytics (GA))
 - ``session_id`` (random 10 digit string identifier used to associate Telemetry data with GA session).
+- ``dlsource=mozorg`` (used to distinguish mozorg downloads from archive downloads)
 
 .. Note::
 

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -26,6 +26,7 @@ if (typeof window.Mozilla === 'undefined') {
 
     StubAttribution.COOKIE_CODE_ID = 'moz-stub-attribution-code';
     StubAttribution.COOKIE_SIGNATURE_ID = 'moz-stub-attribution-sig';
+    StubAttribution.DLSOURCE = 'mozorg';
 
     /**
      * Experiment name and variation globals. These values can be set directly by a
@@ -409,7 +410,8 @@ if (typeof window.Mozilla === 'undefined') {
             experiment: experiment,
             variation: variation,
             client_id: clientID,
-            session_id: clientID ? StubAttribution.createSessionID() : null
+            session_id: clientID ? StubAttribution.createSessionID() : null,
+            dlsource: StubAttribution.DLSOURCE
         };
         /* eslint-enable camelcase */
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -14,6 +14,7 @@
 describe('stub-attribution.js', function () {
     const GA_CLIENT_ID = '1456954538.1610960957';
     const STUB_SESSION_ID = '1234567890';
+    const DLSOURCE = 'mozorg';
 
     beforeEach(function () {
         window.Mozilla.dntEnabled = sinon.stub();
@@ -564,7 +565,8 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
-                session_id: jasmine.any(String)
+                session_id: jasmine.any(String),
+                dlsource: DLSOURCE
             };
             /* eslint-enable camelcase */
 
@@ -595,7 +597,8 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://www.mozilla.org/en-US/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
-                session_id: jasmine.any(String)
+                session_id: jasmine.any(String),
+                dlsource: DLSOURCE
             };
             /* eslint-enable camelcase */
 
@@ -609,7 +612,7 @@ describe('stub-attribution.js', function () {
             expect(result).toEqual(data);
         });
 
-        it('should return only UA and GA data if neither utm params and referrer are present', function () {
+        it('should return only generic data if neither utm params and referrer are present', function () {
             const referrer = '';
 
             /* eslint-disable camelcase */
@@ -626,7 +629,8 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
-                session_id: jasmine.any(String)
+                session_id: jasmine.any(String),
+                dlsource: DLSOURCE
             };
             /* eslint-enable camelcase */
 
@@ -659,7 +663,8 @@ describe('stub-attribution.js', function () {
                 experiment: 'firefox-new',
                 variation: 1,
                 client_id: GA_CLIENT_ID,
-                session_id: jasmine.any(String)
+                session_id: jasmine.any(String),
+                dlsource: DLSOURCE
             };
             /* eslint-enable camelcase */
 


### PR DESCRIPTION
## One-line summary

Adds a new `dlsource` field to stub attribution, with a value of `mozorg`.

This is requested by the Firefox team so that we can distinguish downloads that come from mozorg, and downloads that come from https://archive.mozilla.org/ (which will use`dlsource=mozillaci`).

## Significant changes and points to review

This has already been approved by Firefox QA on demo1, but I included instructions below for some additional manual testing.

## Issue / Bugzilla link

#12836

## Testing

1. On a Windows machine, open https://www-demo1.allizom.org/en-US/
2. Inspect cookies using dev tools and look for a cookie called `moz-stub-attribution-code`. The value should be a base64 string.
3. [Decode](https://www.base64decode.net/) the cookie value and verify it has both a `dlsource` parameter it's value is `mozorg`