### PR TITLE
Update bug bounty for highest impact (sandbox escapes)

### DIFF
--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -90,8 +90,8 @@
           <li>Bypassing WebExtension install prompts<sup>2</sup></li>
         </ul>
       </td>
-      <td>$10,000</td>
-      <td>$8,000</td>
+      <td>$20,000</td>
+      <td>$18,000</td>
     </tr>
     <tr>
       <td>High Impact


### PR DESCRIPTION
This is just a content change. None of the template questions for new Pull Requests apply.

## One-line summary

This change increases the bug bounty awards for the "Highest Impact" category. "High Quality Reports" now go up to $20k and the "Baseline" is now at $18k

## Reviews
r? @dveditz @tomrittervg 