### PR TITLE
Stop CodeCov failing CI if it errors out

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -50,5 +50,5 @@ jobs:
           # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/18
           token: ${{ secrets.CODECOV_TOKEN }}
           files: python_coverage/coverage.xml
-          fail_ci_if_error: true  # optional (default = false)
+          fail_ci_if_error: false  # optional (default = false)
           verbose: true  # optional (default = false)


### PR DESCRIPTION
This should stop things like https://github.com/reemhamz/bedrock/actions/runs/4527910198/jobs/7974199028 I am hoping, but there's commentary around in other issues that suggests it might not be a silver bullet.