### PR TITLE
WNP 112 EU (Fixes #12905)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-privacy.de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-privacy.de.html
@@ -1,0 +1,52 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_112_eu_privacy') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="mzp-l-content">
+      <div class="wnp-main-wrapper">
+        <h1 class="wnp-main-title">
+          <span class="part1">Privatsphäre</span>
+          <span class="part2">für alle</span>
+        </h1>
+
+        <p class="wnp-main-tagline">Du musst nicht in verschachtelten Einstellungen danach suchen – Privatsphäre ist unser Standard.</p>
+
+        <p class="wnp-cta-default">
+          <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.set-as-default.thanks') }}" data-cta-text="Set Firefox as default" data-cta-type="button">
+            Firefox als Standardbrowser festlegen
+          </a>
+        </p>
+
+        <p class="wnp-cta-protections">
+          <button type="button" class="mzp-c-button mzp-t-product">
+            Sieh dir deinen Schutz an
+          </button>
+        </p>
+
+        <p class="wnp-sign-off">
+          <strong>Powered by Mozilla.</strong> Für dich und das Web. Schon seit 1998.
+        </p>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_112_eu_privacy') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-privacy.fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-privacy.fr.html
@@ -1,0 +1,52 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_112_eu_privacy') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="mzp-l-content">
+      <div class="wnp-main-wrapper">
+        <h1 class="wnp-main-title">
+          <span class="part1">Confidentialité</span>
+          <span class="part2">pour tou·tes</span>
+        </h1>
+
+        <p class="wnp-main-tagline">Inutile de fouiller dans les paramètres de sécurité. Le respect de la vie privée est notre norme par défaut.</p>
+
+        <p class="wnp-cta-default">
+          <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.set-as-default.thanks') }}" data-cta-text="Set Firefox as default" data-cta-type="button">
+            Choisir Firefox comme navigateur par défaut
+          </a>
+        </p>
+
+        <p class="wnp-cta-protections">
+          <button type="button" class="mzp-c-button mzp-t-product">
+            Voir comment Firefox me protège
+          </button>
+        </p>
+
+        <p class="wnp-sign-off">
+          <strong>Conçu par Mozilla.</strong> I Pensé pour vous depuis 1998.
+        </p>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_112_eu_privacy') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-privacy.uk.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-privacy.uk.html
@@ -1,0 +1,53 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_112_eu_privacy') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="mzp-l-content">
+      <div class="wnp-main-wrapper">
+        <h1 class="wnp-main-title">
+          <span class="part1">Power and</span>
+          <span class="part2">privacy</span>
+          <span class="part3">to the people</span>
+        </h1>
+
+        <p class="wnp-main-tagline">No need to dig into your security settings. Fierce privacy is our default.</p>
+
+        <p class="wnp-cta-default">
+          <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.set-as-default.thanks') }}" data-cta-text="Set Firefox as default" data-cta-type="button">
+            Set Firefox as default
+          </a>
+        </p>
+
+        <p class="wnp-cta-protections">
+          <button type="button" class="mzp-c-button mzp-t-product">
+            See how Firefox protects you
+          </button>
+        </p>
+
+        <p class="wnp-sign-off">
+          <strong>Powered by Mozilla.</strong> Putting people before profits since 1998.
+        </p>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_112_eu_privacy') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-translate.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx112-eu-translate.html
@@ -10,7 +10,7 @@
 {% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
 
 {% block page_css %}
-  {{ css_bundle('firefox_whatsnew_111_eu') }}
+  {{ css_bundle('firefox_whatsnew_112_eu_translate') }}
 {% endblock %}
 
 {% block site_header %}{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -965,6 +965,73 @@ class TestWhatsNew(TestCase):
 
     # end 111.0 whatsnew tests
 
+    # begin 112.0 whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_de(self, render_mock):
+        """Should use whatsnew-fx112-eu-privacy.de template for de locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "de"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-privacy.de.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_fr(self, render_mock):
+        """Should use whatsnew-fx112-eu-privacy.fr template for fr locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "fr"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-privacy.fr.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_gb(self, render_mock):
+        """Should use whatsnew-fx112-eu-privacy.uk template for en-GB locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-GB"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-privacy.uk.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_en_us_gb(self, render_mock):
+        """Should use whatsnew-fx112-eu-privacy.uk template for en-US locale in GB"""
+        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="GB")
+        req.locale = "en-US"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-privacy.uk.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_es(self, render_mock):
+        """Should use whatsnew-fx112-eu-translate template for es-ES locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "es-ES"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-translate.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_it(self, render_mock):
+        """Should use whatsnew-fx112-eu-translate template for it locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "it"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-translate.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_112_0_0_pt(self, render_mock):
+        """Should use whatsnew-fx112-eu-translate template for pt-PT locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "pt-PT"
+        self.view(req, version="112.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx112-eu-translate.html"]
+
+    # end 112.0 whatsnew tests
+
 
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
 class TestFirstRun(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -490,6 +490,9 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx111-eu-translate.de.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx111-eu-translate.fr.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx112-eu-translate.html": ["firefox/whatsnew/whatsnew-112-translate", "firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx112-eu-privacy.uk.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx112-eu-privacy.de.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx112-eu-privacy.fr.html": ["firefox/whatsnew/whatsnew"],
     }
 
     # specific templates that should not be rendered in
@@ -581,8 +584,17 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("112."):
-            if settings.DEV and locale in ["es-ES", "it", "pt-PT"]:
+            if locale in ["es-ES", "it", "pt-PT"] and ftl_file_is_active("firefox/whatsnew/whatsnew-112-translate"):
                 template = "firefox/whatsnew/whatsnew-fx112-eu-translate.html"
+            elif locale == "de":
+                template = "firefox/whatsnew/whatsnew-fx112-eu-privacy.de.html"
+            elif locale == "fr":
+                template = "firefox/whatsnew/whatsnew-fx112-eu-privacy.fr.html"
+            elif locale.startswith("en-"):
+                if country == "GB" or locale == "en-GB":
+                    template = "firefox/whatsnew/whatsnew-fx112-eu-privacy.uk.html"
+                else:
+                    template = "firefox/whatsnew/index.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("111."):

--- a/media/css/firefox/whatsnew/whatsnew-112-eu-privacy.scss
+++ b/media/css/firefox/whatsnew/whatsnew-112-eu-privacy.scss
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import 'includes/base';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+
+$off-black: #333336;
+
+@keyframes blur {
+    0% {
+        color: $off-black;
+        text-shadow: 0;
+    }
+
+    100% {
+        color: transparent;
+        text-shadow: 0 0 10px $off-black;
+    }
+}
+
+.wnp-content-main {
+    background: $color-yellow-20;
+    color: $color-black;
+    margin: $layout-xs 0 0;
+    min-height: 50vh;
+    padding-top: 0;
+    text-align: center;
+
+    h1 span {
+        display: block;
+    }
+}
+
+.wnp-main-wrapper {
+    margin: 0 auto;
+    max-width: 550px;
+}
+
+.wnp-main-title {
+    @include text-title-lg;
+    color: $off-black;
+    letter-spacing: -0.025em;
+    line-height: 0.95;
+
+    .part1 {
+        animation: blur 500ms 1250ms ease forwards;
+    }
+
+    html[lang^='en'] & {
+        .part1 {
+            animation: none;
+        }
+
+        .part2 {
+            animation: blur 500ms 1250ms ease forwards;
+        }
+
+        @media #{$mq-md} {
+            .part1 {
+                text-align: left;
+            }
+
+            .part2 {
+                text-align: center;
+            }
+
+            .part3 {
+                text-align: right;
+            }
+        }
+    }
+
+    @media #{$mq-md} {
+        @include text-title-2xl;
+    }
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+    margin: $spacing-xl auto;
+    max-width: $content-sm;
+}
+
+.no-js .wnp-cta-default {
+    display: block;
+}
+
+.no-js .wnp-cta-protections {
+    display: none;
+}
+
+.js .wnp-cta-default,
+.js .wnp-cta-protections {
+    display: none;
+
+    &.show {
+        display: block;
+    }
+
+    &.hide {
+        display: none;
+    }
+}
+
+.wnp-sign-off {
+    @include text-body-sm;
+    grid-column: 1 / span 2;
+    grid-row: 5;
+    margin-top: $spacing-2xl;
+
+    strong {
+        display: block;
+
+        @media #{$mq-md} {
+            display: inline;
+        }
+    }
+}

--- a/media/css/firefox/whatsnew/whatsnew-112-eu-translate.scss
+++ b/media/css/firefox/whatsnew/whatsnew-112-eu-translate.scss
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import 'includes/base';
+@import 'includes/dark-mode';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+
+.wnp-content-main {
+    text-align: center;
+    padding-top: $spacing-2xl;
+}
+
+.wnp-main-image {
+    margin-bottom: $spacing-2xl;
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+    text-align: center;
+    color: $color-black;
+    padding: $spacing-sm;
+}
+
+// Dark mode support
+@media (prefers-color-scheme: dark) {
+    .wnp-main-title,
+    .wnp-main-tagline {
+        color: $color-white;
+    }
+}

--- a/media/js/firefox/whatsnew/whatsnew-112-eu-privacy.js
+++ b/media/js/firefox/whatsnew/whatsnew-112-eu-privacy.js
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function defaultTrue() {
+    'use strict';
+
+    document.querySelector('.wnp-cta-default').classList.add('hide');
+    document.querySelector('.wnp-cta-protections').classList.add('show');
+
+    // Open about:protections using UITour when button is clicked.
+    document
+        .querySelector('.wnp-cta-protections > .mzp-c-button')
+        .addEventListener(
+            'click',
+            (e) => {
+                e.preventDefault();
+
+                Mozilla.UITour.showProtectionReport();
+
+                window.dataLayer.push({
+                    event: 'in-page-interaction',
+                    eAction: 'button click',
+                    eLabel: 'See how Firefox protects you'
+                });
+            },
+            false
+        );
+
+    window.dataLayer.push({
+        event: 'non-interaction',
+        eAction: 'whatsnew-112-eu',
+        eLabel: 'default-true'
+    });
+}
+
+function defaultFalse() {
+    'use strict';
+
+    document.querySelector('.wnp-cta-default').classList.add('show');
+    document.querySelector('.wnp-cta-protections').classList.add('hide');
+
+    window.dataLayer.push({
+        event: 'non-interaction',
+        eAction: 'whatsnew-112-eu',
+        eLabel: 'default-false'
+    });
+}
+
+function init() {
+    'use strict';
+
+    // If UITour is slow to respond, fallback to assuming Fx is not default.
+    const requestTimeout = window.setTimeout(defaultFalse, 2000);
+
+    Mozilla.UITour.getConfiguration(
+        'appinfo',
+        (details) => {
+            // Clear timeout as soon as we get a response.
+            window.clearTimeout(requestTimeout);
+
+            // If Firefox is already the default, show alternate call to action.
+            if (details.defaultBrowser) {
+                defaultTrue();
+                return;
+            }
+
+            defaultFalse();
+        },
+        false
+    );
+}
+
+if (
+    typeof window.Mozilla.Client !== 'undefined' &&
+    typeof window.Mozilla.UITour !== 'undefined' &&
+    window.Mozilla.Client.isFirefoxDesktop
+) {
+    init();
+} else {
+    document.querySelector('.wnp-cta-default').classList.add('show');
+    document.querySelector('.wnp-cta-protections').classList.add('hide');
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -505,9 +505,21 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-112-eu-translate.scss"
+      ],
+      "name": "firefox_whatsnew_112_eu_translate"
+    },
+    {
+      "files": [
         "css/firefox/whatsnew/whatsnew-111-en.scss"
       ],
       "name": "firefox_whatsnew_111_en"
+    },
+    {
+      "files": [
+        "css/firefox/whatsnew/whatsnew-112-eu-privacy.scss"
+      ],
+      "name": "firefox_whatsnew_112_eu_privacy"
     },
     {
       "files": [
@@ -1685,6 +1697,12 @@
         "js/firefox/whatsnew/whatsnew-111-en.js"
       ],
       "name": "firefox_whatsnew_111_en"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-112-eu-privacy.js"
+      ],
+      "name": "firefox_whatsnew_112_eu_privacy"
     },
     {
       "files": [

--- a/tests/functional/firefox/whatsnew/test_whatsnew_112.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_112.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.whatsnew.whatsnew_112 import FirefoxWhatsNew112Page
+
+
+@pytest.mark.skip_if_not_firefox(reason="Whatsnew pages are shown to Firefox only.")
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("locale", [("de"), ("fr"), ("en-GB")])
+def test_set_default_button_displayed(locale, base_url, selenium):
+    page = FirefoxWhatsNew112Page(selenium, base_url, locale=locale).open()
+    assert page.is_firefox_set_default_button_displayed
+    assert not page.is_firefox_protection_report_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_112.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_112.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+from pages.base import BasePage
+
+
+class FirefoxWhatsNew112Page(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/112.0/whatsnew/"
+
+    _set_default_button_locator = (By.CSS_SELECTOR, ".wnp-cta-default .mzp-c-button")
+    _protection_report_button_locator = (By.CSS_SELECTOR, ".wnp-cta-protections .mzp-c-button")
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.seed_url in s.current_url)
+        el = self.find_element(By.TAG_NAME, "html")
+        self.wait.until(lambda s: "loaded" in el.get_attribute("class"))
+        self.wait.until(expected.visibility_of_element_located(self._set_default_button_locator))
+        return self
+
+    @property
+    def is_firefox_set_default_button_displayed(self):
+        return self.is_element_displayed(*self._set_default_button_locator)
+
+    @property
+    def is_firefox_protection_report_button_displayed(self):
+        return self.is_element_displayed(*self._protection_report_button_locator)


### PR DESCRIPTION
## One-line summary

Adds WNP 112 for EU.

## Issue / Bugzilla link

#12905

## Testing

Note: you'll need [UITour](https://bedrock.readthedocs.io/en/latest/uitour.html#local-development) set up for local dev for the conditional CTAs to work.

"Set Firefox as default" CTA, or Protection Report CTA if Firefox is already default.

- [x] http://localhost:8000/de/firefox/112.0/whatsnew/
- [x] http://localhost:8000/fr/firefox/112.0/whatsnew/
- [x] http://localhost:8000/en-GB/firefox/112.0/whatsnew/
- [x] http://localhost:8000/en-US/firefox/112.0/whatsnew/?geo=gb

Firefox Translate add-on CTA:

- [x] http://localhost:8000/es-ES/firefox/112.0/whatsnew/
- [x] http://localhost:8000/it/firefox/112.0/whatsnew/
- [x] http://localhost:8000/pt-PT/firefox/112.0/whatsnew/