### PR TITLE
chore: Force supervisord to log to stdout

### DIFF
--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -1,4 +1,6 @@
 [supervisord]
+logfile = /dev/stdout
+logfile_maxbytes = 0
 nodaemon = true
 
 [program:bedrock]


### PR DESCRIPTION
## One-line summary

Currently running with the supervisor creates a log, we are unable to create a log in this location and we should probably be logging to stdout anyways.

This is only applicable, as far as I can tell, for when we run in the `test` environment.
