### PR TITLE
Fixes for pocket add page (fixes #12494)

### DIFF
--- a/bedrock/pocket/templates/pocket/add.html
+++ b/bedrock/pocket/templates/pocket/add.html
@@ -21,27 +21,28 @@
 
 {% block content %}
   <div class="add-page">
-    <section class="add-header">
-      {% call split(
-        block_class='mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-l-split-body-narrow',
-        media_class='mzp-l-split-h-center',
-        image=resp_img(
-          url='img/pocket/add-pocket-header.jpg',
-          optional_attributes={
-            'class': 'mzp-c-split-media-asset'
-          }
-        )
-      )%}
-        <h2>{{ ftl('pocket-add-save-to-pocket') }}</h2>
-        <p>{{ ftl('pocket-add-click-the-pocket-button') }}</p>
-        <a href="https://help.getpocket.com/article/900-saving-to-pocket-and-viewing-your-list-in-firefox" class="mzp-c-button">{{ ftl('pocket-add-learn-how') }}</a>
-        <p>
-          <a href="https://help.getpocket.com/article/942-where-is-the-pocket-button-in-firefox" class="dark-inline-link rarrow">
-            {{ ftl('pocket-add-dont-see-the-pocket') }}
-          </a>
-        </p>
-      {% endcall %}
-    </section>
+  <section class="add-header mzp-c-split mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-l-split-body-narrow">
+    <h2>{{ ftl('pocket-add-save-to-pocket') }}</h2>
+    <div class="mzp-c-split-container">
+        <div class="mzp-c-split-body ">
+          <p>{{ ftl('pocket-add-click-the-pocket-button') }}</p>
+          <a href="https://help.getpocket.com/article/900-saving-to-pocket-and-viewing-your-list-in-firefox" class="mzp-c-button">{{ ftl('pocket-add-learn-how') }}</a>
+          <p>
+            <a href="https://help.getpocket.com/article/942-where-is-the-pocket-button-in-firefox" class="dark-inline-link rarrow">
+              {{ ftl('pocket-add-dont-see-the-pocket') }}
+            </a>
+          </p>
+        </div>
+        <div class="mzp-c-split-media ">
+          {{ resp_img(
+            url='img/pocket/add-pocket-header.jpg',
+            optional_attributes={
+              'class': 'mzp-c-split-media-asset'
+            }
+          ) }}
+        </div>
+    </div>
+  </section> <!-- .add-header -->
 
     <section class="add-device">
       <h2>{{ ftl('pocket-add-view-from-any') }}</h2>

--- a/l10n-pocket/en/pocket/add.ftl
+++ b/l10n-pocket/en/pocket/add.ftl
@@ -38,8 +38,8 @@ pocket-add-subject = Subject
 pocket-add-cooking-tips = Cooking Tips
 pocket-add-learn-more = Learn more
 
-# The + denotes more than, alt: "Integreated in more than 1500 Apps"
-pocket-add-integrated-in = Integreated in 1500+ Apps
+# The + denotes more than, alt: "Integrated in more than 1500 Apps"
+pocket-add-integrated-in = Integrated in 1500+ Apps
 pocket-add-save-to-pocket-using = Save to { -brand-name-pocket } using your favorite apps, such as:
 pocket-add-twitter = { -brand-name-twitter }
 pocket-add-flipboard = { -brand-name-flipboard }

--- a/media/css/pocket/components/add.scss
+++ b/media/css/pocket/components/add.scss
@@ -20,7 +20,9 @@
 
     h2 {
         color: $color-text-dark-grey;
-        margin-bottom: $spacing100;
+        margin: 0 auto;
+        max-width: 62.5rem;
+        padding: $spacing100;
         font-size: $size150;
         text-align: center;
 
@@ -58,13 +60,11 @@
 // Device section
 .add-device {
     margin: 0 auto;
-    max-width: 62.5em;
+    max-width: 62.5rem;
     padding: $spacing100;
     width: 100%;
 
     @media #{$mq-md} {
-        width: 70%;
-
         .device-context {
             flex-direction: row;
         }
@@ -136,7 +136,6 @@
     @media #{$mq-md} {
         .save-context {
             flex-direction: row;
-            align-items: center;
         }
 
         .save-email {
@@ -151,7 +150,7 @@
 
 .add-save-wrapper {
     margin: 0 auto;
-    max-width: 62.5em;
+    max-width: 62.5rem;
     padding: $spacing100;
     width: 100%;
 }
@@ -213,44 +212,54 @@
     display: flex;
     flex-direction: column;
 
+    h3 + * {
+        margin-top: 0;
+    }
+
     @media #{$mq-md} {
         width: 45%;
     }
 }
 
 .app-types {
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-start;
-    width: 100%;
+    ul {
+        padding-left: 0;
+    }
+
+    @media #{$mq-md} {
+        display: flex;
+        align-items: flex-start;
+        justify-content: flex-start;
+        width: 100%;
+        gap: $layout-sm;
+    }
 }
+
+$icon-size: 64px;
+$icon-gap: 1rem;
 
 .app-board {
     display: flex;
-    flex-wrap: wrap;
-    padding: 0;
-    width: 60%;
+    gap: $icon-gap;
+
+    @media #{$mq-md} {
+        flex-wrap: wrap;
+        padding: 0;
+        max-width: calc((#{$icon-size} * 2) + #{$icon-gap});
+    }
 }
 
 .app-icon {
-    height: $layout-lg;
-    margin: $spacing-sm;
-    width: $layout-lg;
-
     img {
-        height: 100%;
-        width: 100%;
-        display: block;
+        width: $icon-size;
+        height: $icon-size;
     }
 }
 
 .social-apps {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
     padding: 0;
-    margin-left: $spacing-lg;
 
     li {
         margin: $spacing-sm;

--- a/media/css/pocket/components/add.scss
+++ b/media/css/pocket/components/add.scss
@@ -212,7 +212,7 @@
     display: flex;
     flex-direction: column;
 
-    h3 + * {
+    h3 + p {
         margin-top: 0;
     }
 


### PR DESCRIPTION
## One-line summary

Updates to better match the prod /add page


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/12494

## Testing

Run in pocket mode

To test this work:

- [ ] http://localhost:8000/en/add/

top headline should go across section
app integration section
- should have typo fixed
- sets 2 icons per row on larger screens, as we only have 4 working links
