### PR TITLE
Fix Taskcluster pull requests policy

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: collaborators_quiet
+    pullRequests: public
 tasks:
     - $let:
           trustDomain: "bedrock"


### PR DESCRIPTION
Contrary to the docs, the initial policy I used [doesn't exist](https://github.com/mozilla/bedrock/commit/0dba90ddaf9b792f3fa3aa0d53ed8f04a2b82958#commitcomment-106445698).