### PR TITLE
Add trailing slash to builders challenge t&c URL

### DIFF
--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -25,7 +25,7 @@ urlpatterns = (
     path("terms/mozilla/", LegalDocView.as_view(template_name="legal/terms/mozilla.html", legal_doc_name="Websites_ToU"), name="legal.terms.mozilla"),
     page("terms/peopleofdeutschland/", "legal/terms/peopleofdeutschland.html", active_locales=["en-US", "de"], ftl_files=["mozorg/about/legal"]),
     # Builders AI Challenge - Terms and Conditions
-    page("terms/builders-challenge", "legal/terms/builders-challenge.html"),
+    page("terms/builders-challenge/", "legal/terms/builders-challenge.html"),
     path(
         "terms/firefox/",
         LegalDocView.as_view(template_name="legal/terms/firefox.html", legal_doc_name="firefox_about_rights"),


### PR DESCRIPTION
Not urgent, but makes things consistent.