### PR TITLE
Add missing word to Builders Challenge T&C

### DIFF
--- a/bedrock/legal/templates/legal/terms/builders-challenge.html
+++ b/bedrock/legal/templates/legal/terms/builders-challenge.html
@@ -152,7 +152,7 @@
         <p><strong>Winners List.</strong> Individuals may request the name of winners by submitting a self-addressed stamped envelope prior to August 31, 2023 to Mozilla Challenge Winners List Request, 2 Harrison St. #175, San Francisco, CA 94105. Vermont residents may omit postage.</p>
       </li>
       <li>
-        <p><strong>Winner Notification/Validation.</strong> The winning Teams will be notified by email and/or (i) of their selection in the First Phase on or about May 8, 2023, and (ii) which prize they have won (if they have won a prize in the Second Phase) on or about May 31, 2023. Winners will also be announced on the Challenge Site. Members of winning Teams may be required to sign and return to Sponsor an affidavit of eligibility, a liability release and/or a publicity release where permitted by law, as well as provide information necessary for compliance with any applicable tax laws. Failure to comply may result in disqualification and the selection of an alternate winner.</p>
+        <p><strong>Winner Notification/Validation.</strong> The winning Teams will be notified by email and/or phone (i) of their selection in the First Phase on or about May 8, 2023, and (ii) which prize they have won (if they have won a prize in the Second Phase) on or about May 31, 2023. Winners will also be announced on the Challenge Site. Members of winning Teams may be required to sign and return to Sponsor an affidavit of eligibility, a liability release and/or a publicity release where permitted by law, as well as provide information necessary for compliance with any applicable tax laws. Failure to comply may result in disqualification and the selection of an alternate winner.</p>
       </li>
     </ol>
   </div>


### PR DESCRIPTION
## One-line summary

I forgot to add the word `phone` in the last point (point 15)

## Testing

Demo server URL: (or None)

To test this work:

- [ ] http://localhost:8000/en-US/about/legal/terms/builders-challenge
