### PR TITLE
Add documentation for CI refactoring

### DIFF
--- a/docs/architecture/decisions/0010-move-ci-cd-to-github-actions.md
+++ b/docs/architecture/decisions/0010-move-ci-cd-to-github-actions.md
@@ -1,0 +1,43 @@
+# 10. Move CI to Github Actions for Unit and Integration tests
+
+Date: 2023-04-06
+
+## Status
+
+Accepted
+
+## Context
+
+Prior to this work, Bedrock's CI/CD pipeline involved Github, Gitlab and CircleCI. We were mirroring from Github to Gitlab to benefit from Gitlab's CI tooling for our functional integration tests, including private (i.e. Mozilla-managed) runners.
+
+Additionally, we were using a third party (CircleCI) to run our Python and JS unit tests.
+
+Since then, two things have changed:
+
+1. Github Actions (GHA) have arrived
+2. We are now able to use private runners with GHA
+
+## Decision
+
+We will move our CI/CD pipeline from being a combination of Github + Gitlab + CircleCI to just Github, using GHA.
+
+This will mean:
+
+1. The mirroring to Gitlab will no longer be necessary.
+2. Unit tests move from CircleCI to GHA. They will continue to be run on every PR raised against `mozilla/bedrock`.
+3. Functional/integration tests move from Gitlab to GHA. They will still be triggered by a successful deployment to dev/test/stage/prod.
+
+This work will be carried out in parallel with changes to how our deployment pipeline works, as that side is also being moved out of Gitlab and into GHA + GCP. When a deployment succeeds, a GHA in the deployment repo will trigger a GHA in `mozilla/bedrock`, which will then run the functional integration tests.
+
+## Consequences
+
+### Pros
+
+* We're no longer mirroring from Github to Gitlab, which will make understanding the deployment pipeline easier for new (and current) developers
+* We will no longer have Gitlab in our pipeline, removing a potential point of failure that could block releases
+* We can still use private runners for our functional integration tests and more (just via GHA instead of Gitlab), giving us control over security and machine resource spec
+
+### Cons
+
+* There's a risk that there will still be new race conditions or CI kick-off failures if the webhook from the deployment repo to mozilla/bedrock fails.
+* We will not all get visibility of a failed webhook ping from the deployment repo's GHA, because that's locked down to be private. We can mitigate this risk with a sensible pattern of Slack notifications (e.g. Start, Success, Failure), so a missing notification will itself be a significant thing.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -271,14 +271,6 @@ To test a single app, specify the app by name in the command above. e.g.::
 
     $ py.test bedrock/firefox
 
-.. note::
-
-    If your local tests run fine, but when you submit a pull-request the tests fail in
-    `CircleCI <https://circleci.com/gh/mozilla/bedrock>`_, it could be due to the
-    difference in settings between what you have in ``.env``
-    and what CircleCI uses: ``docker/envfiles/demo.env``. You can run tests as close to Circle
-    as possible by moving your ``.env`` file to another name (e.g. ``.env-backup``), then
-    copying ``docker/envfiles/demo.env`` to ``.env``, and running tests again.
 
 Make it run
 ===========

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -37,7 +37,7 @@ Once a pull request is submitted, a `Unit Tests Github Action`_ will run both th
 unit tests, as well as the suite of redirect headless HTTP(s) response checks.
 
 Push to main branch
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 Whenever a change is pushed to the main branch, a new image is built and deployed to the
 dev environment, and the full suite of headless and UI tests are run. This is handled by the
@@ -56,6 +56,26 @@ Note that now we have Mozorg mode and Pocket mode, we actually stand up two dev,
 and two test deployments and we run the appropriate integration tests against each deployment:
 most tests are written for Mozorg, but there are some for Pocket mode that also get run.
 
+.. note::
+
+    **The deployment workflow runs like this**
+
+    1. A push to the ``main``/``stage``/``prod``/``run-integration-tests`` branch
+    of ``mozilla/bedrock`` triggers a webhook ping to the (private)
+    ``mozilla-sre-deploy/deploy-bedrock`` repo.
+
+    2. A Github Action (GHA) in ``mozilla-sre-deploy/deploy-bedrock`` builds a
+    "release"-ready Bedrock container image, which it stores in a private container
+    registry (private because our infra requires container-image
+    access to be locked down). Using the same commit, the workflow also builds
+    an equivalent set of public Bedrock container images, which are pushed to
+    Docker Hub.
+
+    3. The GHA deploys the relevant container image to the appropriate environment.
+
+    4. The GHA pings a webhook back in ``mozilla/bedrock`` to run integration
+    tests against the environment that has just been deployed.
+
 Push to stage branch
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,13 +89,11 @@ download tests`.
 Push to prod branch (tagged)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a tagged commit is pushed to the prod branch, a production docker image is built and published
-to Google Container Registry (privately because our infra requires it to be locked down) and also as a
-public image to `Docker Hub`_ if needed (usually this will have already happened as a result of a
-push to the ``main`` or ``stage`` branch), and deployed to each `production`_ deployment.
-
-After each deployment is complete, the full suite of UI tests is
-run again (the same as for stage). As with untagged pushes, this is all handled by the pipeline.
+When a tagged commit is pushed to the ``prod`` branch, a production container image
+(private, see above) is built, and a set of public images is also built and
+pushed to `Docker Hub`_ if needed (usually this will have already happened as
+a result of a push to the ``main`` or ``stage`` branch). The production image
+is deployed to each `production`_ deployment.
 
 **Push to prod cheat sheet**
 

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -9,7 +9,7 @@ Continuous Integration & Deployment
 ===================================
 
 Bedrock runs a series of automated tests as part of continuous integration workflow and
-`Deployment Pipeline`_. You can learn more about each of the individual test suites
+deployment pipeline. You can learn more about each of the individual test suites
 by reading their respective pieces of documentation:
 
 * Python unit tests (see :ref:`run-python-tests`).
@@ -33,7 +33,7 @@ much faster than running the full test suite locally.
 Pull request
 ~~~~~~~~~~~~
 
-Once a pull request is submitted, `CircleCI`_ will run both the Python and JavaScript
+Once a pull request is submitted, a `Unit Tests Github Action`_ will run both the Python and JavaScript
 unit tests, as well as the suite of redirect headless HTTP(s) response checks.
 
 Push to main branch
@@ -41,8 +41,8 @@ Push to main branch
 
 Whenever a change is pushed to the main branch, a new image is built and deployed to the
 dev environment, and the full suite of headless and UI tests are run. This is handled by the
-pipeline, and is subject to change according to the settings in the `.gitlab-ci.yml file
-in the www-config repository`_.
+pipeline, and is subject to change according to the settings in the Github Action workflow
+defined in ``bedrock/.github/workflows/integration_tests.yml``.
 
 The tests for the dev environment are currently configured as follows:
 
@@ -51,11 +51,6 @@ The tests for the dev environment are currently configured as follows:
 - Internet Explorer 11 (smoke tests) via `Sauce Labs`_.
 - Internet Explorer 9 (sanity tests) via `Sauce Labs`_.
 - Headless tests.
-
-If you view a job's `pipeline configuration`_, you will also notice there are manual tests
-that can be run via SauceLabs for Firefox, Chrome, Edge, and Download tests. These tests
-aren't run automatically and will not block a deployment, but they can be useful if you
-want to run an extra set of checks should you see a test failure and want some verification.
 
 Note that now we have Mozorg mode and Pocket mode, we actually stand up two dev, two stage
 and two test deployments and we run the appropriate integration tests against each deployment:
@@ -75,17 +70,20 @@ Push to prod branch (tagged)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a tagged commit is pushed to the prod branch, a production docker image is built and published
-to `Docker Hub`_ if needed (usually this will have already happened as a result of a push to the stage branch),
-and deployed to each `production`_ deployment. After each deployment is complete, the full suite of UI tests is
-run again (the same as for stage). As with untagged pushes, this is all handled by the pipeline, and is subject
-to change according to the settings in the `.gitlab-ci.yml file in the www-config repository`_.
+to Google Container Registry (privately because our infra requires it to be locked down) and also as a
+public image to `Docker Hub`_ if needed (usually this will have already happened as a result of a
+push to the ``main`` or ``stage`` branch), and deployed to each `production`_ deployment.
+
+After each deployment is complete, the full suite of UI tests is
+run again (the same as for stage). As with untagged pushes, this is all handled by the pipeline.
 
 **Push to prod cheat sheet**
 
 #. Check out the ``main`` branch
 #. Make sure the ``main`` branch is up to date with ``mozilla/bedrock main``
 #. Check that dev deployment is green:
-    #. View `deployment pipeline`_ and look at ``main`` branch
+    #. View the `Integration Tests Github Action`_ and look at the run labelled ``Run Integration tests for main``
+#. Check that stage deployment is also green (``Run Integration tests for stage``)
 #. Tag and push the deployment by running ``bin/tag-release.sh --push``
 
 .. note::
@@ -140,24 +138,20 @@ required OS / Browser configuration, so they should not need to be updated or sp
 Adding test runs
 ~~~~~~~~~~~~~~~~
 
-Test runs can be added by creating a new job in the `.gitlab-ci.yml file in the www-config repository`_
-with the desired variables. For example, if you wanted to run the smoke tests in IE10, you could create the
-following clauses:
+Test runs can be added by creating a new job in ``bedrock/.github/workflows/integration_tests.yml``
+with the desired variables and pushing that branch to Github.
+For example, if you wanted to run the smoke tests in IE10 (using Saucelabs) you could add the
+following clause to the matrix:
 
 .. code-block:: yaml
 
-  .ie10:
-    variables:
+    - LABEL: test-ie10-saucelabs
       BROWSER_NAME: internet explorer
       BROWSER_VERSION: "10.0"
+      DRIVER: SauceLabs
+      PYTEST_PROCESSES: "8"
       PLATFORM: Windows 8
       MARK_EXPRESSION: smoke
-
-  test-ie10-saucelabs:
-    extends:
-      - .test
-      - .ie10
-      - .saucelabs
 
 You can use `Sauce Labs platform configurator`_ to help with the parameter values.
 
@@ -177,11 +171,9 @@ may be commits on that branch which aren't in yours – so, if you have the
     $ git push -f mozilla $(git branch --show-current):run-integration-tests
 
 
-.. _Deployment Pipeline: https://gitlab.com/mozmeao/www-config/-/pipelines
-.. _pipeline configuration: https://gitlab.com/mozmeao/www-config/-/pipelines/207024459
-.. _CircleCI: https://circleci.com/
+.. _Unit Tests Github Action: https://github.com/mozilla/bedrock/actions/workflows/pull_request_tests.yml
+.. _Integration Tests Github Action: https://github.com/mozilla/bedrock/actions/workflows/integration_tests.yml
 .. _Sauce Labs: https://saucelabs.com/
-.. _.gitlab-ci.yml file in the www-config repository: https://github.com/mozmeao/www-config/tree/main/.gitlab-ci.yml
 .. _test dependencies: https://github.com/mozilla/bedrock/blob/main/requirements/dev.txt
 .. _Selenium Docker versions: https://hub.docker.com/r/selenium/hub/tags/
 .. _Sauce Labs platform configurator: https://wiki.saucelabs.com/display/DOCS/Platform+Configurator/


### PR DESCRIPTION
## One-line summary

This changeset updates documentation around the move from CircleCI and Gitlab to GH Actions, which is currently in progress.

## Significant changes and points to review

~It's not quite the ideal time to land this, but making a draft PR now so that it's ready to go when we cut over~ We're just about to unplug the old CI tests, and the new ones are OK, so it makes sense to update the docs now

## Issue / Bugzilla link

Resolves #12950 
