### PR TITLE
Disable PocketArticles feed sync

### DIFF
--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -26,7 +26,6 @@ from bedrock.contentful.models import ContentfulEntry
 from bedrock.mozorg.credits import CreditsFile
 from bedrock.mozorg.forms import MiecoEmailForm
 from bedrock.mozorg.models import WebvisionDoc
-from bedrock.pocketfeed.models import PocketArticle
 from lib import l10n_utils
 from lib.l10n_utils import L10nTemplateView, RequireSafeMixin
 
@@ -130,7 +129,6 @@ def home_view(request):
     locale = l10n_utils.get_locale(request)
 
     ctx = {
-        "pocket_articles": PocketArticle.objects.all()[:4],
         "ftl_files": ["mozorg/home", "mozorg/home-mr2-promo"],
         "add_active_locales": ["de", "fr"],
     }

--- a/bin/run-db-update.sh
+++ b/bin/run-db-update.sh
@@ -43,10 +43,10 @@ python manage.py update_webvision_docs --quiet || failure_detected=true
 python manage.py update_sitemaps_data --quiet || failure_detected=true
 python manage.py sync_greenhouse --quiet || failure_detected=true
 
-if [[ "$AUTH" == true ]]; then
-    # jobs that require some auth. don't run these during build.
-    python manage.py update_pocketfeed --quiet || failure_detected=true
-fi
+# if [[ "$AUTH" == true ]]; then
+#     # jobs that require some auth. don't run these during build.
+#     # The old Pocket Articles feed is an example of this
+# fi
 
 # If all is well, ping DMS to avoid an alert being raised.
 if [[ $failure_detected == false ]]; then


### PR DESCRIPTION
## One-line summary

This changeset removes syncing the PocketArticle model during the DB update (it's no longer getting data back), and also stops trying to load in PocketArticle records on the Mozorg homepage, because we no longer show them so it's redundant.

A ticket has been made to complete the cleanup: https://github.com/mozilla/bedrock/issues/12986

## Issue / Bugzilla link

Resolves #12985 

## Testing


To test this work:

- [x] CI passing should be enough
