### PR TITLE
Add Security & Privacy newsletter subscription page [fix #12983]

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -95,6 +95,10 @@
     "description": "{{ ftl('newsletters-get-all-the-knowledge')|striptags }}",
     "title": "{{ ftl('newsletters-knowledge-is-power')|striptags }}"
   },
+  "security-privacy-news": {
+    "description": "{{ ftl('newsletters-stay-informed-of-the-latest')|striptags }}",
+    "title": "{{ ftl('newsletters-security-and-privacy-news')|striptags }}"
+  },
   "labs": {
     "title": "{{ ftl('newsletters-about-labs')|striptags }}"
   },

--- a/bedrock/newsletter/templates/newsletter/security-privacy-news.html
+++ b/bedrock/newsletter/templates/newsletter/security-privacy-news.html
@@ -1,0 +1,36 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends 'base-protocol.html' %}
+
+{% block page_title %}{{ ftl('newsletters-subscribe-to-the-newsletter') }}{% endblock page_title %}
+
+{% block page_desc %}{{ ftl('newsletters-get-security-and-privacy-news-and-tips')}}{% endblock %}
+
+{% block body_class %}{{ super() }} newsletter-security-privacy-news{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('newsletter-security-privacy-news') }}
+{% endblock %}
+
+{% block content %}
+<main class= "mzp-t-content-sm">
+  <section class="section-subscribe">
+    <header class="mzp-l-content mzp-t-content-lg header-container">
+      <h1 class="page-title">{{ self.page_title() }}</h1>
+      <h2 class="section-title">{{ self.page_desc() }}</h2>
+    </header>
+    <div class="mzp-l-content mzp-t-content-sm">
+      {{ email_newsletter_form(newsletters='security-privacy-news', include_title=False, spinner_color='#0c99d5') }}
+    </div>
+  </section>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('newsletter') }}
+{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/security-privacy-news.html
+++ b/bedrock/newsletter/templates/newsletter/security-privacy-news.html
@@ -20,7 +20,7 @@
 {% block content %}
 <main class= "mzp-t-content-sm">
   <section class="section-subscribe">
-    <header class="mzp-l-content mzp-t-content-lg header-container">
+    <header class="mzp-l-content mzp-t-content-lg">
       <h1 class="page-title">{{ self.page_title() }}</h1>
       <h2 class="section-title">{{ self.page_desc() }}</h2>
     </header>

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -37,5 +37,6 @@ urlpatterns = (
     page("newsletter/fxa-error/", "newsletter/fxa-error.html", ftl_files=["mozorg/newsletters"]),
     page("newsletter/knowledge-is-power/", "newsletter/knowledge-is-power.html", ftl_files=["mozorg/newsletters"]),
     page("newsletter/family/", "newsletter/family.html", ftl_files=["mozorg/newsletters"], active_locales=["en-US"]),
+    page("newsletter/security-and-privacy/", "newsletter/security-privacy-news.html", ftl_files=["mozorg/newsletters"]),
     path("newsletter/newsletter-strings.json", views.newsletter_strings_json, name="newsletter.strings"),
 )

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -435,4 +435,4 @@ newsletters-security-and-privacy-news = Security & Privacy News
 newsletters-stay-informed-of-the-latest = Stay informed of the latest trends in privacy & security products from { -brand-name-mozilla }, the makers of { -brand-name-firefox }.
 
 # Subtitle for https://www-dev.allizom.org/newsletter/security-and-privacy/
-newsletters-get-security-and-privacy-news-and-tips = Get security and privacy news and tips from { -brand-name-mozilla } to stay safe and informed on everything that makes the web a healthier place.
+newsletters-get-security-and-privacy-news-and-tips = Get security and privacy news and product updates from { -brand-name-mozilla } to stay safe and informed on everything that makes the web a healthier place.

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -427,3 +427,12 @@ knowledge-is-power-pocket = { -brand-name-pocket }
 
 # Out of date browser message for newsletter management page.
 newsletters-update-your-browser = Your web browser needs to be updated in order to use this page.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-security-and-privacy-news = Security & Privacy News
+
+# Description for the newsletter in Newsletter subscription page (Security & Privacy News)
+newsletters-stay-informed-of-the-latest = Stay informed of the latest trends in privacy & security products from { -brand-name-mozilla }, the makers of { -brand-name-firefox }.
+
+# Subtitle for https://www-dev.allizom.org/newsletter/security-and-privacy/
+newsletters-get-security-and-privacy-news-and-tips = Get security and privacy news and tips from { -brand-name-mozilla } to stay safe and informed on everything that makes the web a healthier place.

--- a/media/css/newsletter/newsletter-firefox.scss
+++ b/media/css/newsletter/newsletter-firefox.scss
@@ -53,6 +53,10 @@ $image-path: '/media/protocol/img';
     background: #fff;
     padding: $spacing-lg 0;
 
+    .mzp-l-content:first-child {
+        padding-bottom: 0;
+    }
+
     h1 {
         @include text-title-xl;
         text-align: center;

--- a/media/css/newsletter/newsletter-knowledge-is-power.scss
+++ b/media/css/newsletter/newsletter-knowledge-is-power.scss
@@ -14,6 +14,10 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-mozilla';
 
 .section-subscribe {
+    .mzp-l-content:first-child {
+        padding-bottom: 0;
+    }
+
     .mozilla-products-list {
         display: flex;
         align-items: center;

--- a/media/css/newsletter/newsletter-security-privacy-news.scss
+++ b/media/css/newsletter/newsletter-security-privacy-news.scss
@@ -8,6 +8,10 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .section-subscribe {
+    .mzp-l-content:first-child {
+        padding-bottom: 0;
+    }
+
     .page-title {
         @include font-mozilla;
         @include text-title-lg;

--- a/media/css/newsletter/newsletter-security-privacy-news.scss
+++ b/media/css/newsletter/newsletter-security-privacy-news.scss
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.section-subscribe {
+    .page-title {
+        @include font-mozilla;
+        @include text-title-lg;
+        text-align: center;
+        font-weight: 600;
+    }
+
+    .section-title {
+        @include font-base;
+        @include text-body-xl;
+        text-align: center;
+        font-weight: normal;
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -383,6 +383,12 @@
     },
     {
       "files": [
+        "css/newsletter/newsletter-security-privacy-news.scss"
+      ],
+      "name": "newsletter-security-privacy-news"
+    },
+    {
+      "files": [
         "css/newsletter/newsletter-family.scss"
       ],
       "name": "newsletter-family"

--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -14,6 +14,7 @@ from pages.newsletter.firefox import FirefoxNewsletterPage
 from pages.newsletter.index import NewsletterPage
 from pages.newsletter.knowledge_is_power import KnowledgeIsPowerNewsletterPage
 from pages.newsletter.mozilla import MozillaNewsletterPage
+from pages.newsletter.security_privacy_news import SecurityPrivacyNewsletterPage
 
 
 @pytest.mark.smoke
@@ -30,6 +31,7 @@ from pages.newsletter.mozilla import MozillaNewsletterPage
         FirefoxNewsletterPage,
         MozillaNewsletterPage,
         KnowledgeIsPowerNewsletterPage,
+        SecurityPrivacyNewsletterPage,
     ],
 )
 def test_newsletter_default_values(page_class, base_url, selenium):
@@ -56,6 +58,7 @@ def test_newsletter_default_values(page_class, base_url, selenium):
         FirefoxNewsletterPage,
         MozillaNewsletterPage,
         KnowledgeIsPowerNewsletterPage,
+        SecurityPrivacyNewsletterPage,
     ],
 )
 def test_newsletter_sign_up_success(page_class, base_url, selenium):
@@ -85,6 +88,7 @@ def test_newsletter_sign_up_success(page_class, base_url, selenium):
         FirefoxNewsletterPage,
         MozillaNewsletterPage,
         KnowledgeIsPowerNewsletterPage,
+        SecurityPrivacyNewsletterPage,
     ],
 )
 def test_newsletter_sign_up_failure(page_class, base_url, selenium):

--- a/tests/pages/newsletter/security_privacy_news.py
+++ b/tests/pages/newsletter/security_privacy_news.py
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from pages.base import BasePage
+
+
+class SecurityPrivacyNewsletterPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/newsletter/security-and-privacy/"

--- a/tests/unit/spec/newsletter/data.js
+++ b/tests/unit/spec/newsletter/data.js
@@ -880,6 +880,11 @@ const stringData = {
             'Get all the knowledge you need to stay safer and smarter online.',
         title: 'Knowledge is Power'
     },
+    'security-privacy-news': {
+        description:
+            'Stay informed of the latest trends in privacy & security products from Mozilla, the makers of Firefox.',
+        title: 'Security & Privacy News from Mozilla'
+    },
     labs: {
         title: 'About Labs'
     },


### PR DESCRIPTION
## One-line summary

Adds a standalone subscription page for the Security & Privacy News newsletter.

Primary stakeholders are Tina Rattliff and Mike Altman so check with them for any changes/approvals.

There is an email planned for some time during the week of 17-21 April that will refer to this page so it needs to be live before that email can be sent (and we need to let Tina know the URL).

## Issue / Bugzilla link

#12983 

## Testing

http://localhost:8000/newsletter/security-and-privacy/