### PR TITLE
Rise 25 minor fixes

### DIFF
--- a/bedrock/mozorg/templates/mozorg/rise25/includes/rise25-social-share.html
+++ b/bedrock/mozorg/templates/mozorg/rise25/includes/rise25-social-share.html
@@ -23,8 +23,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       </button>
     </li>
     <li>
-      <a class="twitter" href="" target="_blank" role="external noopener noreferrer" data-cta-type="link" data-cta-text="share on twitter">
-        <svg title="Share on Twitter" width="16" height="14" viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <a class="twitter" href="" target="_blank" rel="external noopener noreferrer" data-cta-type="link" data-cta-text="share on twitter">
+        <svg width="16" height="14" viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
             d="M5.25191 13.2616C11.0665 13.2616 14.2468 8.44462 14.2468 4.26737C14.2468 4.13056 14.2468 3.99436 14.2375 3.85877C14.8562 3.41129 15.3903 2.85722 15.8147 2.22251C15.2378 2.47815 14.6257 2.6458 13.999 2.71986C14.6589 2.3248 15.1529 1.70345 15.3888 0.97143C14.7683 1.33964 14.0894 1.59913 13.3814 1.73872C12.4015 0.696806 10.8444 0.441794 9.58327 1.11668C8.32213 1.79156 7.6706 3.2285 7.99401 4.62174C5.45216 4.49433 3.08392 3.29383 1.47868 1.31902C0.63961 2.7634 1.06819 4.61118 2.45743 5.53879C1.95434 5.52388 1.46221 5.38818 1.02259 5.14313C1.02259 5.15607 1.02259 5.16963 1.02259 5.18319C1.023 6.68793 2.08377 7.98396 3.55883 8.28192C3.09341 8.40884 2.60509 8.42739 2.13138 8.33615C2.54553 9.62385 3.73237 10.506 5.08488 10.5314C3.96545 11.4111 2.58258 11.8887 1.1588 11.8872C0.907275 11.8868 0.655993 11.8715 0.40625 11.8416C1.85196 12.7693 3.53412 13.2614 5.25191 13.2591"
             fill="currentColor">
@@ -33,8 +33,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       </a>
     </li>
     <li>
-      <a class="facebook" href="" target="_blank" role="external noopener noreferrer" data-cta-type="link" data-cta-text="share on facebook">
-        <svg title="Share on Facebook" width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <a class="facebook" href="" target="_blank" rel="external noopener noreferrer" data-cta-type="link" data-cta-text="share on facebook">
+        <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
             d="M2.72851 15.7063V8.67785H0.363281V5.93867H2.72851V3.91863C2.72851 1.57434 4.16032 0.297852 6.25156 0.297852C7.25325 0.297852 8.11424 0.372451 8.36511 0.405773V2.85566L6.91473 2.85634C5.77737 2.85634 5.55718 3.39677 5.55718 4.18982V5.93867H8.26963L7.91642 8.67785H5.55718V15.7063H2.72851Z"
             fill="currentColor" />
@@ -44,7 +44,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     </li>
     <li>
       <a class="email" data-cta-type="link" data-cta-text="share with email">
-        <svg title="Share with email" width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
             d="M3.1942 2.86523H13.4665C14.1727 2.86523 14.7506 3.44305 14.7506 4.14927V11.8535C14.7506 12.5597 14.1727 13.1376 13.4665 13.1376H3.1942C2.48797 13.1376 1.91016 12.5597 1.91016 11.8535V4.14927C1.91016 3.44305 2.48797 2.86523 3.1942 2.86523Z"
             stroke="currentColor" stroke-width="1.28115" stroke-linecap="round" stroke-linejoin="round" />

--- a/bedrock/mozorg/templates/mozorg/rise25/rise25.html
+++ b/bedrock/mozorg/templates/mozorg/rise25/rise25.html
@@ -65,61 +65,61 @@ the internet for the better over the next quarter century and beyond. Submit you
 
 {% block content %}
   <section class="rise25-hero">
-      <button class="hero-static-container" value="Play video" data-cta-type="button" data-cta-text="Rise25 play video">
-        <div class="hero-text-container mzp-l-content">
-            <img src="/media/img/mozorg/rise25/RISE25.svg" width="171" height="35">
-            <h1>In search of<br/> the visionaries<br/> and builders of<br/> tomorrow</h1>
-            <div class="play-container">
-              <span class="play-button">
-                <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M23.3047 15.0008L10.8493 22.1919L10.8493 7.80973L23.3047 15.0008Z" fill="white" />
-                  <circle cx="15" cy="15" r="14.5908" stroke="white" stroke-width="0.818462" />
-                </svg>
-              </span>
-              <p>Play video</p>
-            </div>
-        </div>
-        <div class="rise25-hero-static-image">
-          {{ picture(
-            url='img/mozorg/rise25/r25_hero_432.jpg',
-            sources=[
-              {
-              'media': '(min-width: 1440px)',
-                'srcset': {
-                  'img/mozorg/rise25/r25_hero_os.jpg': '',
-                  'img/mozorg/rise25/r25_hero_os-2x.jpg': '2x',
-                }
-              },
-              {
-              'media': '(min-width: 982px)',
-                'srcset': {
-                  'img/mozorg/rise25/r25_hero_1440.jpg': '',
-                  'img/mozorg/rise25/r25_hero_1440-2x.jpg': '2x',
-                }
-              },
-              {
-              'media': '(min-width: 688px)',
-                'srcset': {
-                  'img/mozorg/rise25/r25_hero_982.jpg': '',
-                  'img/mozorg/rise25/r25_hero_982-2x.jpg': '2x',
-                }
-              },
-              {
-              'media': '(min-width: 432px)',
-                'srcset': {
-                  'img/mozorg/rise25/r25_hero_688.jpg': '',
-                  'img/mozorg/rise25/r25_hero_688-2x.jpg': '2x',
+    <a href="#" class="hero-static-container" value="Play video" data-cta-type="button" data-cta-text="Rise25 play video">
+      <div class="hero-text-container mzp-l-content">
+          <img src="/media/img/mozorg/rise25/RISE25.svg" width="171" height="35" alt="Rise 25">
+          <h1>In search of<br> the visionaries<br> and builders of<br> tomorrow</h1>
+          <div class="play-container">
+            <span class="play-button">
+              <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M23.3047 15.0008L10.8493 22.1919L10.8493 7.80973L23.3047 15.0008Z" fill="white" />
+                <circle cx="15" cy="15" r="14.5908" stroke="white" stroke-width="0.818462" />
+              </svg>
+            </span>
+            <p>Play video</p>
+          </div>
+      </div>
+      <div class="rise25-hero-static-image">
+        {{ picture(
+          url='img/mozorg/rise25/r25_hero_432.jpg',
+          sources=[
+            {
+            'media': '(min-width: 1440px)',
+              'srcset': {
+                'img/mozorg/rise25/r25_hero_os.jpg': '',
+                'img/mozorg/rise25/r25_hero_os-2x.jpg': '2x',
               }
-              },
-            ],
-            optional_attributes={
-              'srcset': '/media/img/mozorg/rise25/r25_hero_432-2x.jpg 2x',
-              'class': 'rise25-hero-static-image',
-              'alt': 'Help us find next wave of visionaries'
+            },
+            {
+            'media': '(min-width: 982px)',
+              'srcset': {
+                'img/mozorg/rise25/r25_hero_1440.jpg': '',
+                'img/mozorg/rise25/r25_hero_1440-2x.jpg': '2x',
+              }
+            },
+            {
+            'media': '(min-width: 688px)',
+              'srcset': {
+                'img/mozorg/rise25/r25_hero_982.jpg': '',
+                'img/mozorg/rise25/r25_hero_982-2x.jpg': '2x',
+              }
+            },
+            {
+            'media': '(min-width: 432px)',
+              'srcset': {
+                'img/mozorg/rise25/r25_hero_688.jpg': '',
+                'img/mozorg/rise25/r25_hero_688-2x.jpg': '2x',
             }
-          )}}
-        </div>
-    </button>
+            },
+          ],
+          optional_attributes={
+            'srcset': '/media/img/mozorg/rise25/r25_hero_432-2x.jpg 2x',
+            'class': 'rise25-hero-static-image',
+            'alt': 'Help us find next wave of visionaries'
+          }
+        )}}
+      </div>
+    </a>
     <div class="video-background">
       <video muted height="530">
         <source src="https://www.assets.mozilla.net/rise25/rise25-video.webm" type="video/webm">
@@ -157,7 +157,7 @@ the internet for the better over the next quarter century and beyond. Submit you
         <div class="nomination-card">
           <h3>{{ card.title }}</h3>
           <p>{{ card.desc }}</p>
-          <a class="mzp-c-button" target="_blank" role="external noopener noreferrer" href="{{ card.href }}">Nominate</a>
+          <a class="mzp-c-button" target="_blank" rel="external noopener noreferrer" href="{{ card.href }}">Nominate</a>
         </div>
       {% endfor %}
     </div>

--- a/media/css/mozorg/rise25.scss
+++ b/media/css/mozorg/rise25.scss
@@ -56,13 +56,13 @@ $image-path: '/media/protocol/img';
 
         h1 {
             @include font-base;
-            @include font-size(38px);
+            @include font-size(32px);
             font-weight: 900;
-            margin: 0;
+            margin: $spacing-md 0;
             color: $color-white;
 
-            @media #{$mq-xs} {
-                @include font-size(42px);
+            @media #{$mq-sm} {
+                @include font-size(38px);
             }
 
             @media #{$mq-md} {

--- a/media/js/mozorg/rise25.js
+++ b/media/js/mozorg/rise25.js
@@ -96,7 +96,9 @@
         element.addEventListener('click', handleCopyLink);
     }
 
-    staticImage.addEventListener('click', function () {
+    staticImage.addEventListener('click', function (e) {
+        e.preventDefault();
+
         var imageHeight = getComputedStyle(
             document.querySelector('.hero-static-container')
         ).height;


### PR DESCRIPTION
## One-line summary

Fixes a couple of small issues on the rise 25 page (mostly around the video section, but I noticed a couple of other small validation errors as well in the process):

- Tweaks main heading sizing/spacing on smaller viewports for slightly better readability.
- Updates video hero placeholder to use an `<a href="#">`, since `<div>` is not a valid child element of `<button>`.
- Renames `role="external noopener noreferrer"` to `rel="external noopener noreferrer"`.
- Removes invalid `title` attributes from inline `<svg>` elements.

Note: the hero video still needs a hover/focus state of some sorts, but I didn't try and tackle that here as it may require some further design input?

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/rise25/
