### PR TITLE
Update workflow to use a Slack notification to ping www-notify at start and end of integration tests

### DIFF
--- a/.github/actions/slack/action.yaml
+++ b/.github/actions/slack/action.yaml
@@ -1,0 +1,91 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+name: Slack notifications
+description: Slack notifications for Bedrock GHA events
+
+inputs:
+  env_name:
+    description: Name of env involved - one of dev, test, stage or prod
+    required: true
+  label:
+    description: Very brief summary of what this notification is for - e.g. 'Integration tests'
+    required: true
+  status:
+    description: Status of message type to be sent, supported values 'info', 'success', 'failure'
+    required: true
+  channel_id:
+    description: Slack channel id to send messages
+    required: true
+  slack_bot_token:
+    description: Slack bot token oauth secret
+    required: true
+  ref:
+    description: Deployment ref
+    required: false
+  message:
+    description: Message body to send
+    required: true
+    default: ""
+outputs:
+  ts:
+    description: Slack timestamp for updating messages
+    value: ${{ steps.slack-notification.outputs.ts }}
+
+runs:
+  using: composite
+
+  steps:
+    - id: set-build-status-color
+      shell: bash
+      run: >-
+        eval "case ${{ inputs.status }} in
+            info)
+                echo 'STATUS_COLOR=#00FFFF';;
+            success)
+                echo 'STATUS_COLOR=#00FF00';;
+            skipped)
+                echo 'STATUS_COLOR=#FF3333';;
+            failure)
+                echo 'STATUS_COLOR=#FF0000';;
+            *)
+                echo 'STATUS_COLOR=##8128a7';;
+        esac" >> $GITHUB_ENV
+
+    - id: slack-notification
+      uses: slackapi/slack-github-action@v1.23.0
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
+      with:
+        channel-id: ${{ inputs.channel_id }}
+        payload: |
+          {
+            "text": "${{ inputs.label }}",
+            "attachments": [
+              {
+                "color": "${{ env.STATUS_COLOR }}",
+                "fallback": "Bedrock ${{ inputs.env_name }} / ${{ inputs.ref }}: ${{ inputs.message }}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Bedrock ${{ inputs.env_name }} / ${{ inputs.ref }}:\n${{ inputs.message }}"
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Details",
+                        "emoji": true
+                      },
+                      "value": "click",
+                      "url": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}",
+                      "action_id": "button-action"
+                    }
+                  }
+                ]
+              }
+            ]
+          }

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,6 +2,9 @@
 
 name: Integration tests
 run-name: Integration tests for ${{ inputs.branch }}
+env:
+  SLACK_CHANNEL_ID: CBX0KH5GA # #www-notify in MoCo Slack
+  SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
 on:
   workflow_dispatch:
     inputs:
@@ -12,14 +15,30 @@ on:
         description: The git SHA just deployed to the service we want to test
         required: true
       mozorg_service_hostname:
-        description: The hostname of the Mozorg service to test - eg the dev hostname
+        description: The root URL of the Mozorg service to run tests against
         required: true
       pocket_service_hostname:
-        description: The hostname of the Mozorg service to test - eg the dev hostname
+        description: The root URL of the Pocket service to run tests against
         required: true
 jobs:
+  notify-of-test-run-start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify via Slack that tests are starting
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "Integration tests [${{ inputs.git_sha }}]"
+          status: info
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ inputs.branch }}
+          message: "Integration tests started"
+
   integration-tests:
     runs-on: ubuntu-latest
+    needs: notify-of-test-run-start
     strategy:
       matrix:
         include:
@@ -92,3 +111,20 @@ jobs:
           name: test-results
           path: results-${{github.run_id}}-${{matrix.label}}
           if-no-files-found: ignore  # this avoids a false "Warning" if there were no issues
+
+  notify-of-test-run-completion:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [notify-of-test-run-start, integration-tests]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify via Slack of test-run outcome
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "Integration tests [${{ inputs.git_sha }}]"
+          status: ${{ needs.integration-tests.result }}
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ inputs.branch }}
+          message: "Integration tests completed. Status: ${{ needs.integration-tests.result }}"


### PR DESCRIPTION
These bookend the integration tests running, and so the first one will be triggered immediately after the deployment is done, so devs can better see the state of the overall release pipelines

The GH action added is reusable, so other future actions can also send Slack pings the same way

## One-line summary

This changeset (explain what) in order to (why).

## Significant changes and points to review

## Issue / Bugzilla link

Resolves #12984 


## Screenshots


Example of failure

<img width="724" alt="Screenshot 2023-04-18 at 10 33 23" src="https://user-images.githubusercontent.com/101457/232741825-135aac8d-4d7f-4764-83ec-5633235f59c6.png">


Example of success

<img width="562" alt="Screenshot 2023-04-18 at 11 34 19" src="https://user-images.githubusercontent.com/101457/232751974-7fb83884-0ebb-4720-80ca-ec43b5760472.png">
<img width="558" alt="Screenshot 2023-04-18 at 11 34 25" src="https://user-images.githubusercontent.com/101457/232752005-5b3931f1-3825-457f-9464-b9b873770957.png">



## Checklist

- [X] New secrets added to the secrets repository

## Testing

To test this work:

- This is tricky to test without fiddling with manual triggers of GH actions, but you can see past runs at:
  - success: https://github.com/mozilla/bedrock/actions/runs/4731044856
  - (deliberate) failure: https://github.com/mozilla/bedrock/actions/runs/4730789510
