### PR TITLE
Add Old VPN Versions CTA to Downloads page

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -71,7 +71,7 @@
 
       {% if not block_download %}
 
-      <section class="vpn-download-options mzp-l-content">
+      <div class="vpn-download-options mzp-l-content">
 
         <!-- Primary list -->
       <div class="vpn-download-primary-platform">
@@ -216,8 +216,17 @@
           </a>
         </li>
       </ul>
-      </section>
-      {% endif %}
+    </div>
+
+    {% if ftl_has_messages('vpn-download-previous-versions') %}
+      <div class="vpn-download-previous-versions mzp-l-content ">
+        <p>
+          <a href="https://archive.mozilla.org/pub/vpn/releases/" data-cta-type="button" data-cta-text="VPN Download Previous Versions">{{ ftl('vpn-download-previous-versions') }}</a>
+        </p>
+      </div>
+    {% endif %}
+
+    {% endif %}
   </section>
 {% if ftl_has_messages('vpn-download-privacy-you-can') %}
   <section class="vpn-privacy">

--- a/l10n/en/products/vpn/download.ftl
+++ b/l10n/en/products/vpn/download.ftl
@@ -52,3 +52,5 @@ vpn-download-also-available = Also available for:
 #   $attrs (string) - specific attributes added to external links
 vpn-download-from-the-maker = From the maker of { -brand-name-firefox }, { -brand-name-mozilla-vpn } uses the advanced <a href="{ $url }" { $attrs }>{ -brand-name-wireguard }</a>® protocol to encrypt your online activity and hide your location.
 vpn-download-we-never-log = We never log, track, or share your network data.
+
+vpn-download-previous-versions = Download previous versions

--- a/media/css/products/vpn/download.scss
+++ b/media/css/products/vpn/download.scss
@@ -68,6 +68,7 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
     grid-template-columns: 1fr;
     grid-row-gap: $spacing-xs;
     grid-column-gap: $spacing-xl;
+    padding-bottom: $layout-md;
 
     @media #{$vpn-download-mq-2xl} {
         grid-template-columns: repeat(2, 1fr);
@@ -298,6 +299,22 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
         .secondary-platform.android {
             display: none;
         }
+    }
+}
+
+.vpn-download-previous-versions {
+    display: flex;
+    justify-content: center;
+    padding-bottom: $layout-lg;
+    padding-top: 0;
+
+    a {
+        color: $color-black;
+        font-weight: 700;
+    }
+
+    @media #{$mq-md} {
+        justify-content: flex-end;
     }
 }
 

--- a/media/css/products/vpn/download.scss
+++ b/media/css/products/vpn/download.scss
@@ -313,7 +313,7 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
         font-weight: 700;
     }
 
-    @media #{$mq-md} {
+    @media #{$vpn-download-mq-2xl} {
         justify-content: flex-end;
     }
 }


### PR DESCRIPTION
## One-line summary
I forgot to add the CTA for older VPN downloads on the new VPN download page in #12980 

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/11875

## Testing

To test this work:

- [ ] http://localhost:8000/en-US/products/vpn/download/
