### PR TITLE
Updated string for VPN Download CTA

### DIFF
--- a/l10n/en/products/vpn/download.ftl
+++ b/l10n/en/products/vpn/download.ftl
@@ -53,4 +53,4 @@ vpn-download-also-available = Also available for:
 vpn-download-from-the-maker = From the maker of { -brand-name-firefox }, { -brand-name-mozilla-vpn } uses the advanced <a href="{ $url }" { $attrs }>{ -brand-name-wireguard }</a>® protocol to encrypt your online activity and hide your location.
 vpn-download-we-never-log = We never log, track, or share your network data.
 
-vpn-download-previous-versions = Download previous versions
+vpn-download-previous-versions = Download previous versions for { -brand-name-windows } and { -brand-name-mac-short }


### PR DESCRIPTION
## One-line summary
Updated the string from `Download previous versions` to `Download previous versions for Windows and Mac`. VPN Eng team requested the update. It's connected to https://github.com/mozilla/bedrock/issues/11875

## Testing

To test this work:

- [ ] http://localhost:8000/en-US/products/vpn/download/
