### PR TITLE
Flag macOS 10.11 as unsupported when downloading Firefox (Fixes #13013)

### DIFF
--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -34,7 +34,7 @@
             }
             if (
                 ua.indexOf('Mac OS X') !== -1 &&
-                !/Mac OS X 10.[0-8]\D/.test(ua)
+                !/Mac OS X 10.(1[0-1]|[1-9])\D/.test(ua)
             ) {
                 return 'osx';
             }

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -94,6 +94,18 @@ describe('site.js', function () {
                     'foo'
                 )
             ).toBe('other');
+            expect(
+                window.site.getPlatform(
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.10.3 (KHTML, like Gecko) Chrome/21.0.1180.89 Safari/537.1',
+                    'foo'
+                )
+            ).toBe('other');
+            expect(
+                window.site.getPlatform(
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36',
+                    'foo'
+                )
+            ).toBe('other');
         });
 
         it('should identify iOS', function () {
@@ -119,7 +131,13 @@ describe('site.js', function () {
             ).toBe('osx');
             expect(
                 window.site.getPlatform(
-                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.10.3 (KHTML, like Gecko) Chrome/21.0.1180.89 Safari/537.1',
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36',
+                    'foo'
+                )
+            ).toBe('osx');
+            expect(
+                window.site.getPlatform(
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
                     'foo'
                 )
             ).toBe('osx');


### PR DESCRIPTION
## One-line summary

Updates bedrock's UA detection to flag macOS 10.11 (El Capitan) and below as unsupported, as per https://www.mozilla.org/en-US/firefox/112.0.1/system-requirements/

## Significant changes and points to review

Does my feeble regex look OK?

## Issue / Bugzilla link

#13013

## Screenshots

This is the message people should see on El Capitan when clicking download and viewing the `/thanks/` page:

![image](https://user-images.githubusercontent.com/400117/233604097-1a8e5637-02cd-44df-ad55-790ab5f32320.png)

## Testing

This is on demo 3 for easier review: https://www-demo3.allizom.org/firefox/new/