### PR TITLE
Help Google to distinguish between EN pages localized to different regions (Fixes #13019)

### DIFF
--- a/bedrock/base/templates/404-locale.html
+++ b/bedrock/base/templates/404-locale.html
@@ -14,6 +14,10 @@
   {%- endif -%}
 {%- endblock -%}
 
+{%- block page_title_suffix -%}
+  {% if is_root %} — Mozilla Global{% else %} — Mozilla{% endif %}
+{%- endblock -%}
+
 {%- block page_desc -%}
   {%- if is_root -%}
     Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.
@@ -23,9 +27,12 @@
 {%- endblock -%}
 
 {% block canonical_urls %}
-{% if is_root %}
-  <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL + '/' }}">
-{% endif %}
+  {% if is_root %}
+    <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL + '/' }}">
+    {% for locale in available_locales if locale in languages %}
+      <link rel="alternate" hreflang="{{ locale }}" href="{{ settings.CANONICAL_URL + '/' + locale + '/'}}" title="{{ languages[locale]['native'] }}">
+    {% endfor %}
+  {% endif %}
 {% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -8,8 +8,16 @@
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import split with context %}
 
-{% block page_title %}{{ ftl('firefox-browsers-page-title', fallback='firefox-browsers-get-the-browsers-that-put') }}{% endblock %}
-{% block page_title_suffix %} — Mozilla{% endblock %}
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_full -%}
+  {%- if LANG == 'en-US' -%}
+    Get Firefox browser — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Download Firefox Browser — Mozilla (UK)
+  {%- else -%}
+    {{ ftl('firefox-browsers-page-title', fallback='firefox-browsers-get-the-browsers-that-put') }} - Mozilla
+  {%- endif -%}
+{%- endblock -%}
 
 {% block page_desc %}{{ ftl('firefox-browsers-page-desc', fallback='firefox-browsers-get-the-privacy-you-deserve') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/mobile/android.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/android.html
@@ -43,7 +43,17 @@
   {% set s2d_include = 'firefox/browsers/mobile/includes/s2d-android.html' %}
 {% endif %}
 
-{% block page_title %}{{ ftl('mobile-android-firefox-browser-android') }}{% endblock %}
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_full -%}
+  {%- if LANG == 'en-US' -%}
+    Get Firefox for Android — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Download Firefox for Android — Mozilla (UK)
+  {%- else -%}
+    {{ ftl('mobile-android-firefox-browser-android') }} - Mozilla
+  {%- endif -%}
+{%- endblock -%}
+
 {% block page_desc %}{{ ftl('mobile-android-firefox-browser-for') }}{% endblock %}
 
 {% block body_class %}{{ super() }} mobile-android{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -23,7 +23,17 @@
   {% endif %}
 {% endblock %}
 
-{% block page_title %}{{ ftl('mobile-ios-firefox-browser-ios') }}{% endblock %}
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_full -%}
+  {%- if LANG == 'en-US' -%}
+    Get Firefox for iOS (iPhone and iPad) — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Download Firefox for iOS (iPhone and iPad) — Mozilla (UK)
+  {%- else -%}
+    {{ ftl('mobile-ios-firefox-browser-ios') }} - Mozilla
+  {%- endif -%}
+{%- endblock -%}
+
 {% block page_desc %}{{ ftl('mobile-ios-see-your-open-tabs', fallback='mobile-ios-firefox-browser-for') }}{% endblock %}
 
 {% block body_class %}{{ super() }} mobile-ios{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -6,19 +6,15 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% block page_title_prefix %}{{ ftl('firefox-desktop-download-meta-title-prefix') }} — {% endblock %}
-
-{%- block page_title -%}{{ ftl('firefox-desktop-download-meta-title-v2', fallback='firefox-desktop-download-meta-title') }}{%- endblock -%}
-
-{# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
+{# Bug 1438302,  Issue 13019: Avoid duplicate content for English pages. #}
 {%- block page_title_full -%}
-  {% if LANG == 'en-CA' %}
-    Download Firefox for Desktop — from Mozilla (CA)
-  {% elif LANG == 'en-GB' %}
-    Download Firefox for Desktop — from Mozilla (UK)
-  {% else %}
+  {%- if LANG == 'en-US' -%}
+    Get Firefox for desktop — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Download Firefox for Desktop — Mozilla (UK)
+  {%- else -%}
     {{ ftl('firefox-desktop-download-meta-title-v2', fallback='firefox-desktop-download-meta-title') }}
-  {% endif %}
+  {%- endif -%}
 {%- endblock -%}
 
 {% block page_desc %}{{ ftl('firefox-desktop-download-meta-desc-v2', fallback='firefox-desktop-download-meta-desc') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -8,7 +8,17 @@
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import split with context %}
 
-{% block page_title %}{{ ftl('firefox-products-firefox-is-more-than-a-browser') }}{% endblock %}
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_full -%}
+  {%- if LANG == 'en-US' -%}
+    Mozilla’s products — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Mozilla’s products — Mozilla (UK)
+  {%- else -%}
+    {{ ftl('firefox-products-firefox-is-more-than-a-browser') }} - Mozilla
+  {%- endif -%}
+{%- endblock -%}
+
 {% block page_desc %}{{ ftl('firefox-products-its-a-whole-family-of-products') }}{% endblock %}
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}

--- a/bedrock/mozorg/templates/mozorg/home/base.html
+++ b/bedrock/mozorg/templates/mozorg/home/base.html
@@ -8,17 +8,6 @@
 
 {% block gtm_page_id %}data-gtm-page-id="Homepage"{% endblock %}
 
-{# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
-{%- block page_title_suffix -%}
-  {% if LANG == 'en-CA' %}
-    — Mozilla (CA)
-  {% elif LANG == 'en-GB' %}
-    — Mozilla (UK)
-  {% else %}
-    — Mozilla
-  {% endif %}
-{%- endblock -%}
-
 {% block extra_meta %}
 <!-- validates bing webmaster tools -->
 <meta name="msvalidate.01" content="B7B177115A634927D608514DA17B2574">

--- a/bedrock/mozorg/templates/mozorg/home/home-contentful.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-contentful.html
@@ -10,7 +10,18 @@
 
 {% extends "mozorg/home/base.html" %}
 
-{% block page_title %}Internet for people, not profit{% endblock %}
+{# Bug 1438302, Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_full -%}
+  {%- if LANG == 'en-US' -%}
+    Internet for people, not profit — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Internet for people, not profit — Mozilla (UK)
+  {%- else -%}
+    Internet for people, not profit - Mozilla
+  {%- endif -%}
+{%- endblock -%}
+{% block page_title_suffix %}{% endblock %}
+
 {% block page_desc %}Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.{% endblock %}
 
 {% set show_fundraising_banner = switch('fundraising-banner-giving2022') and ftl_has_messages('banner-fundraising-title', 'banner-fundraising-body') %}

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -8,7 +8,17 @@
 
 {% extends "products/vpn/base.html" %}
 
-{% block page_title_full %}{{ ftl('vpn-landing-page-title') }}{% endblock %}
+{# Issue 13019: Avoid duplicate content for English pages. #}
+{%- block page_title_full -%}
+  {%- if LANG == 'en-US' -%}
+    Get Mozilla VPN  — Mozilla (US)
+  {%- elif LANG == 'en-GB' -%}
+    Get Mozilla VPN — Mozilla (UK)
+  {%- else -%}
+    {{ ftl('vpn-landing-page-title') }}
+  {%- endif -%}
+{%- endblock -%}
+
 {% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}{{ ftl('vpn-landing-page-desc', countries=available_countries) }}{% endblock %}


### PR DESCRIPTION
## One-line summary

- Updates root page to include hreflangs for localized home pages.
- Updates <title> tags of key pages to use unique values for English translations.

You can find the [list of titles here](https://docs.google.com/spreadsheets/d/1RIuM1b23UfqtKEtNu1-f-pb_yihr8z0swoWW4v0BzMg/edit?usp=sharing) for reference.

## Issue / Bugzilla link

#13019

## Testing

Root page contains `hreflang` tags for all localized home pages (you may need to empty your accept-language preference to test):

- [x] https://www-demo5.allizom.org/ 

Updated page titles:

- [x] https://www-demo5.allizom.org/en-US/
- [x] https://www-demo5.allizom.org/en-GB/
- [x] https://www-demo5.allizom.org/en-US/firefox/browsers/
- [x] https://www-demo5.allizom.org/en-GB/firefox/browsers/
- [x] https://www-demo5.allizom.org/en-US/firefox/new/
- [x] https://www-demo5.allizom.org/en-GB/firefox/new/
- [x] https://www-demo5.allizom.org/en-US/firefox/browsers/mobile/ios/
- [x] https://www-demo5.allizom.org/en-GB/firefox/browsers/mobile/ios/
- [x] https://www-demo5.allizom.org/en-US/firefox/browsers/mobile/android/
- [x] https://www-demo5.allizom.org/en-GB/firefox/browsers/mobile/android/
- [x] https://www-demo5.allizom.org/en-US/firefox/products/
- [x] https://www-demo5.allizom.org/en-GB/firefox/products/
- [x] https://www-demo5.allizom.org/en-US/products/vpn/
- [x] https://www-demo5.allizom.org/en-GB/products/vpn/
