### PR TITLE
Add WNP 113 for EU (Fixes #12961)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx113-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx113-eu.html
@@ -1,0 +1,107 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-picto') }}
+  {{ css_bundle('firefox_whatsnew_113_eu') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+<div class="mzp-l-content mzp-t-content-md">
+  <section class="wnp-content-main">
+    <div class="wnp-main-wrapper">
+      <div class="wnp-main-image mzp-c-logo mzp-t-logo-xl mzp-t-product-vpn"></div>
+      <h2 class="wnp-main-title">{{ ftl('welcome-page10-main-heading') }}</h2>
+      <p class="wnp-main-tagline">{{ ftl('welcome-page10-main-description') }}</p>
+
+      <p class="wnp-main-tagline">
+        {% if LANG == 'fr' %}
+          Bénéficiez de 20% de réduction sur un abonnement de 12 mois à Mozilla VPN avec le code de réduction :
+          <strong>VPN20</strong>
+          <small>(à copier-coller en finalisant votre commande)</small>
+        {% elif LANG == 'de' %}
+          Erhalte 20 % Rabatt auf 12 Monate Mozilla VPN mit diesem Code:
+          <strong>VPN20</strong>
+          <small>(Einfach in die Zwischenablage kopieren und beim Checkout einfügen.)</small>
+        {% elif LANG == 'es-ES' %}
+          20 % de descuento en la suscripción de 12 meses a Mozilla VPN con este código descuento:
+          <strong>VPN20</strong>
+          <small>(copiar y pegar al realizar el pago)</small>
+        {% elif LANG == 'it' %}
+          Approfitta del 20% di sconto per 12 mesi su Mozilla VPN con questo codice promozionale:
+          <strong>VPN20</strong>
+          <small>(copia e incolla durante il pagamento)</small>
+        {% elif LANG == 'nl' %}
+          Ontvang 12 maanden lang 20% korting op Mozilla VPN met deze kortingscode:
+          <strong>VPN20</strong>
+          <small>(kopiëren en plakken bij het betalen)</small>
+        {% elif LANG == 'sv-SE' %}
+          Få 20 % rabatt på Mozillla VPN i 12 månader med den här rabattkoden:
+          <strong>VPN20</strong>
+          <small>(kopiera och klistra in vid betalningen)</small>
+        {% elif LANG == 'fi' %}
+          Saat 20 % alennusta 12 kk:n Mozilla VPN-tilauksesta tällä koodilla:
+          <strong>VPN20</strong>
+          <small>(kopioi ja liitä kassalla)</small>
+        {% else %}
+          Take 20% off 12 months of Mozilla VPN with this discount code:
+          <strong>VPN20</strong>
+          <small>(apply at checkout)</small>
+        {% endif %}
+      </p>
+
+      <div class="wnp-main-cta">
+        {{ vpn_product_referral_link(
+          referral_id='whatsnew-113-eu',
+          page_anchor='#pricing',
+          link_text=ftl('welcome-page10-get-mozilla-vpn'),
+          class_name='mzp-t-product mzp-t-xl',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN',
+              'data-cta-type' : 'button'
+          })
+        }}
+      </div>
+    </div>
+  </section>
+
+  <div class="wnp-content-extra">
+    <div class="mzp-l-columns mzp-t-columns-two">
+      <div class="mzp-c-picto">
+        <div class="mzp-c-picto-image">
+          {% include 'firefox/welcome/includes/page10/laptop.svg' %}
+        </div>
+        <h3 class="mzp-c-picto-title">{{ ftl('welcome-page10-very-fast') }}</h3>
+        <div class="mzp-c-picto-body">
+          <p>{{ ftl('welcome-page10-wireguard-powered') }}</p>
+        </div>
+      </div>
+
+      <div class="mzp-c-picto">
+        <div class="mzp-c-picto-image">
+          {% include 'firefox/welcome/includes/page10/mobile.svg' %}
+        </div>
+        <h3 class="mzp-c-picto-title">{{ ftl('welcome-page10-without-trace') }}</h3>
+        <div class="mzp-c-picto-body">
+          <p>{{ ftl('welcome-page10-never-log') }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_113_eu') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -1032,6 +1032,46 @@ class TestWhatsNew(TestCase):
 
     # end 112.0 whatsnew tests
 
+    # begin 113.0 whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_113_0_0_gb(self, render_mock):
+        """Should use whatsnew-fx113-eu template for en-GB locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-GB"
+        self.view(req, version="113.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx113-eu.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_113_0_0_us_gb(self, render_mock):
+        """Should use whatsnew-fx113-eu template for en-US locale in UK"""
+        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="GB")
+        req.locale = "en-US"
+        self.view(req, version="113.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx113-eu.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_113_0_0_de(self, render_mock):
+        """Should use whatsnew-fx113-eu template for de locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "de"
+        self.view(req, version="113.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx113-eu.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_113_0_0_fr(self, render_mock):
+        """Should use whatsnew-fx113-eu template for fr locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "fr"
+        self.view(req, version="113.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx113-eu.html"]
+
+    # end 113.0 whatsnew tests
+
 
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
 class TestFirstRun(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -495,6 +495,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx112-eu-privacy.fr.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx112-en.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx112-en-features.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx113-eu.html": ["firefox/welcome/page10", "firefox/whatsnew/whatsnew"],
     }
 
     # specific templates that should not be rendered in
@@ -513,6 +514,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx110-en-features-v2.html",
         "firefox/whatsnew/whatsnew-fx112-en.html",
         "firefox/whatsnew/whatsnew-fx112-en-features.html",
+        "firefox/whatsnew/whatsnew-fx113-eu.html",
     ]
 
     # place expected ?v= values in this list
@@ -585,6 +587,13 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/developer/whatsnew.html"
             elif show_57_dev_whatsnew(version):
                 template = "firefox/developer/whatsnew.html"
+            else:
+                template = "firefox/whatsnew/index.html"
+        elif version.startswith("113."):
+            if locale == "en-US" and country == "GB":
+                template = "firefox/whatsnew/whatsnew-fx113-eu.html"
+            elif locale in ["en-GB", "fr", "de", "it", "es-ES", "nl", "sv-SE", "fi"] and ftl_file_is_active("firefox/welcome/page10"):
+                template = "firefox/whatsnew/whatsnew-fx113-eu.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("112."):

--- a/media/css/firefox/whatsnew/whatsnew-113-eu.scss
+++ b/media/css/firefox/whatsnew/whatsnew-113-eu.scss
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import 'includes/base';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-vpn';
+
+.wnp-content-main {
+    text-align: center;
+    padding-top: $spacing-2xl;
+}
+
+.wnp-main-image {
+    margin: 0 auto $spacing-xl;
+}
+
+.wnp-main-title {
+    @include text-title-md;
+    color: get-theme('title-text-color');
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 750px;
+
+    strong {
+        color: $color-violet-50;
+    }
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+    color: $color-black;
+    margin-bottom: $spacing-2xl;
+    text-align: center;
+
+    strong {
+        @include text-body-xl;
+        display: block;
+        margin-top: $spacing-md;
+    }
+
+    small {
+        @include text-body-sm;
+        display: block;
+    }
+}
+
+.wnp-content-extra {
+    margin-top: $layout-xl;
+
+    .mzp-c-picto {
+        max-width: $content-sm;
+    }
+
+    .mzp-c-picto-image {
+        margin-left: auto;
+        margin-right: auto;
+        max-width: $content-xs;
+    }
+}

--- a/media/js/firefox/whatsnew/whatsnew-113-eu.js
+++ b/media/js/firefox/whatsnew/whatsnew-113-eu.js
@@ -1,0 +1,55 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function fxaSignedIn() {
+    'use strict';
+
+    window.dataLayer.push({
+        event: 'non-interaction',
+        eAction: 'whatsnew-113-eu',
+        eLabel: 'fxa-signed-in'
+    });
+}
+
+function fxaSignedOut() {
+    'use strict';
+
+    window.dataLayer.push({
+        event: 'non-interaction',
+        eAction: 'whatsnew-113-eu',
+        eLabel: 'fxa-signed-out'
+    });
+}
+
+function init() {
+    'use strict';
+
+    // If UITour is slow to respond, fallback to assuming Fx is not default.
+    const requestTimeout = window.setTimeout(fxaSignedOut, 2000);
+
+    Mozilla.UITour.getConfiguration(
+        'fxa',
+        (details) => {
+            // Clear timeout as soon as we get a response.
+            window.clearTimeout(requestTimeout);
+
+            if (details && details.setup) {
+                fxaSignedIn();
+            } else {
+                fxaSignedOut();
+            }
+        },
+        false
+    );
+}
+
+if (
+    typeof window.Mozilla.Client !== 'undefined' &&
+    typeof window.Mozilla.UITour !== 'undefined' &&
+    window.Mozilla.Client.isFirefoxDesktop
+) {
+    init();
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -541,6 +541,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-113-eu.scss"
+      ],
+      "name": "firefox_whatsnew_113_eu"
+    },
+    {
+      "files": [
         "css/firefox/privacy/common.scss"
       ],
       "name": "firefox-privacy-common"
@@ -1730,6 +1736,12 @@
         "js/firefox/whatsnew/whatsnew-112-eu-privacy.js"
       ],
       "name": "firefox_whatsnew_112_eu_privacy"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-113-eu.js"
+      ],
+      "name": "firefox_whatsnew_113_eu"
     },
     {
       "files": [

--- a/tests/functional/firefox/whatsnew/test_whatsnew_113.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_113.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.whatsnew.whatsnew_113 import FirefoxWhatsNew113Page
+
+
+@pytest.mark.skip_if_not_firefox(reason="Whatsnew pages are shown to Firefox only.")
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("locale", [("de"), ("fr"), ("en-GB")])
+def test_get_vpn_button_displayed(locale, base_url, selenium):
+    page = FirefoxWhatsNew113Page(selenium, base_url, locale=locale).open()
+    assert page.is_get_vpn_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_113.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_113.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class FirefoxWhatsNew113Page(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/113.0/whatsnew/"
+
+    _get_vpn_button_locator = (By.CSS_SELECTOR, ".wnp-main-cta .mzp-c-button")
+
+    @property
+    def is_get_vpn_button_displayed(self):
+        return self.is_element_displayed(*self._get_vpn_button_locator)


### PR DESCRIPTION
## One-line summary

- Repurposes https://www.mozilla.org/en-US/firefox/welcome/10/ strings for WNP 113.
- Adds a new hard-coded string to WNP for coupon code.

## Issue / Bugzilla link

#12961

## Testing

- GB: https://www-demo3.allizom.org/en-GB/firefox/113.0/whatsnew/
- FR: https://www-demo3.allizom.org/fr/firefox/113.0/whatsnew/
- DE: https://www-demo3.allizom.org/de/firefox/113.0/whatsnew/
- IT: https://www-demo3.allizom.org/it/firefox/113.0/whatsnew/
- ES: https://www-demo3.allizom.org/es-ES/firefox/113.0/whatsnew/
- NL: https://www-demo3.allizom.org/nl/firefox/113.0/whatsnew/
- SV: https://www-demo3.allizom.org/sv-SE/firefox/113.0/whatsnew/
- FI: https://www-demo3.allizom.org/fi/firefox/113.0/whatsnew/
