### PR TITLE
Move Fluent-PR-opening CI tasks from GL to GHA

### DIFF
--- a/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
@@ -1,0 +1,21 @@
+# Workflow to open a PR on mozilla-l10n/www-l10n with
+# new strings that exist in Bedrock and need localising
+
+name: Open Fluent PR for Mozorg
+
+on:
+  push:
+    paths:
+      - "l10n/**/*"
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  open_l10n_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run PR-opening script
+        shell: bash
+        run: SITE_MODE=Mozorg bin/open-ftl-pr.sh

--- a/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
@@ -1,0 +1,21 @@
+# Workflow to open a PR on mozilla-l10n/pocket-www-l10n with
+# new strings that exist in Bedrock and need localising
+
+name: Open Fluent PR for Pocket
+
+on:
+  push:
+    paths:
+      - "l10n-pocket/**/*"
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  open_l10n_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run PR opening script
+        shell: bash
+        run: SITE_MODE=Pocket bin/open-ftl-pr.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,33 +32,35 @@ build-test:
     - bin/build-release-image.sh --push
   retry: 2
 
-update-l10n:
-  stage: update-config
-  tags:
-    - mozmeao
-    - aws
-  only:
-    changes:
-      - "l10n/**/*"
-    refs:
-      - main
-  script:
-    - SITE_MODE=Mozorg bin/open-ftl-pr.sh
-  retry: 2
+# Replaced by GHA - see .github/workflows
+# update-l10n:
+#   stage: update-config
+#   tags:
+#     - mozmeao
+#     - aws
+#   only:
+#     changes:
+#       - "l10n/**/*"
+#     refs:
+#       - main
+#   script:
+#     - SITE_MODE=Mozorg bin/open-ftl-pr.sh
+#   retry: 2
 
-update-pocket-l10n:
-  stage: update-config
-  tags:
-    - mozmeao
-    - aws
-  only:
-    changes:
-      - "l10n-pocket/**/*"
-    refs:
-      - main
-  script:
-    - SITE_MODE=Pocket bin/open-ftl-pr.sh
-  retry: 2
+# Replaced by GHA - see .github/workflows
+# update-pocket-l10n:
+#   stage: update-config
+#   tags:
+#     - mozmeao
+#     - aws
+#   only:
+#     changes:
+#       - "l10n-pocket/**/*"
+#     refs:
+#       - main
+#   script:
+#     - SITE_MODE=Pocket bin/open-ftl-pr.sh
+#   retry: 2
 
 .update-config:
   stage: update-config


### PR DESCRIPTION
Moves the call to the ftl-PR shell scripts out of the Gitlab config and into GH Actions

Resolves #13051