### PR TITLE
Relay waitlist

### DIFF
--- a/bedrock/products/forms.py
+++ b/bedrock/products/forms.py
@@ -8,3 +8,13 @@ from bedrock.newsletter.forms import NewsletterFooterForm
 class VPNWaitlistForm(NewsletterFooterForm):
     def __init__(self, locale, data=None, *args, **kwargs):
         super().__init__("guardian-vpn-waitlist", locale, data, *args, **kwargs)
+
+
+class RelayBundleWaitlistForm(NewsletterFooterForm):
+    def __init__(self, locale, data=None, *args, **kwargs):
+        super().__init__("relay-vpn-bundle-waitlist", locale, data, *args, **kwargs)
+
+
+class RelayPhoneWaitlistForm(NewsletterFooterForm):
+    def __init__(self, locale, data=None, *args, **kwargs):
+        super().__init__("relay-phone-masking-waitlist", locale, data, *args, **kwargs)

--- a/bedrock/products/templates/products/relay/includes/waitlist-base.html
+++ b/bedrock/products/templates/products/relay/includes/waitlist-base.html
@@ -14,7 +14,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% include 'products/relay/includes/subnav.html' %}
 {% endblock %}
 
-{% set product = "{{ ftl('waitlist-bundle-name') }}" %}
+{% set product = ftl('waitlist-bundle-name') %}
 
 
 {% block content %}
@@ -23,7 +23,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <h1>{% block waitlist_heading %}{% endblock %}</h1>
     <p>{% block waitlist_lede %}{% endblock %}</p>
   </div>
-  <form id="newsletter-form" class="mzp-l-content mzp-t-content-md  mzp-t-content-nospace mzp-c-newsletter-form"
+  <form id="newsletter-form" class="mzp-l-content mzp-t-content-md  mzp-t-content-nospace mzp-c-newsletter-form c-waitlist-form"
     action="{{ action }}" method="post">
     <div hidden>
       {{ newsletter_form.newsletters|safe }}
@@ -32,8 +32,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <input type="hidden" name="format" id="format-html" value="H">
 
     <fieldset class="mzp-c-newsletter-content">
-      <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">
+      <div class="mzp-c-form-errors hide-from-legacy-ie" id="newsletter-errors">
         <ul class="mzp-u-list-styled">
+          <li class="error-email-invalid hidden">{{ ftl('waitlist-subscribe-please-enter-a-valid') }}</li>
+          <li class="error-select-country hidden">{{ ftl('waitlist-subscribe-please-select-country') }}</li>
+          <li class="error-select-language hidden">{{ ftl('waitlist-subscribe-please-select-language') }}</li>
           <li class="error-try-again-later hidden">{{ ftl('waitlist-subscribe-error-unknown') }}</li>
         </ul>
       </div>
@@ -73,9 +76,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       </div>
     </fieldset>
   </form>
-  <div id="newsletter-thanks" class="vpn-invite-success hidden">
-    <h3>{{ ftl('vpn-landing-invite-thanks-heading') }}</h3>
-    <p>{{ ftl('vpn-landing-invite-thanks-desc') }}</p>
+  <div id="newsletter-thanks" class="c-waitlist-success hidden">
+    <h3>{{ ftl('waitlist-subscribe-success-title') }}</h3>
+    <p>{{ ftl('waitlist-subscribe-success-desc', product=product) }}</p>
   </div>
 </main>
 {% endblock %}
+
+{% block js %}{{ js_bundle("relay-waitlist")}}{% endblock %}

--- a/bedrock/products/templates/products/relay/includes/waitlist-base.html
+++ b/bedrock/products/templates/products/relay/includes/waitlist-base.html
@@ -1,0 +1,81 @@
+{#
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/relay/base.html" %}
+
+{% block page_css %}
+{{ css_bundle('relay-waitlist') }}
+{% endblock %}
+
+{% block sub_navigation %}
+{% include 'products/relay/includes/subnav.html' %}
+{% endblock %}
+
+{% set product = "{{ ftl('waitlist-bundle-name') }}" %}
+
+
+{% block content %}
+<main class="mzp-l-content c-waitlist-container">
+  <div class="c-waitlist-heading">
+    <h1>{% block waitlist_heading %}{% endblock %}</h1>
+    <p>{% block waitlist_lede %}{% endblock %}</p>
+  </div>
+  <form id="newsletter-form" class="mzp-l-content mzp-t-content-md  mzp-t-content-nospace mzp-c-newsletter-form"
+    action="{{ action }}" method="post">
+    <div hidden>
+      {{ newsletter_form.newsletters|safe }}
+    </div>
+    <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
+    <input type="hidden" name="format" id="format-html" value="H">
+
+    <fieldset class="mzp-c-newsletter-content">
+      <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">
+        <ul class="mzp-u-list-styled">
+          <li class="error-try-again-later hidden">{{ ftl('waitlist-subscribe-error-unknown') }}</li>
+        </ul>
+      </div>
+
+      <div>
+        <label for="id_email">
+          {{ ftl('waitlist-control-email-label') }}
+          <em class="mzp-c-fieldnote">{{ ftl('waitlist-control-required') }}</em>
+        </label>
+        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true"
+          placeholder="{{ ftl('waitlist-control-email-placeholder') }}">
+      </div>
+
+      <div id="newsletter-details">
+        <label for="id_country">
+          {{ ftl('waitlist-control-country-label-2') }}
+          <em class="mzp-c-fieldnote">{{ ftl('waitlist-control-required') }}</em>
+        </label>
+        {{ newsletter_form.country|safe }}
+
+        <label for="id_lang">
+          {{ ftl('waitlist-control-locale-label') }}
+          <em class="mzp-c-fieldnote">{{ ftl('waitlist-control-required') }}</em>
+        </label>
+        {{ newsletter_form.lang|safe }}
+      </div>
+
+      <p class="mzp-c-form-submit">
+        <button class="mzp-c-button mzp-t-product mzp-t-xl" id="newsletter-submit" type="submit">{{
+          ftl('waitlist-submit-label-2')}}</button>
+      </p>
+
+      <div class="c-waitlist-privacy">
+        <p>{{ ftl('waitlist-privacy-policy-agree-2', url=url('privacy.notices.subscription-services')) }}</p>
+
+        <p>{% block waitlist_privacy %}{% endblock %}</p>
+      </div>
+    </fieldset>
+  </form>
+  <div id="newsletter-thanks" class="vpn-invite-success hidden">
+    <h3>{{ ftl('vpn-landing-invite-thanks-heading') }}</h3>
+    <p>{{ ftl('vpn-landing-invite-thanks-desc') }}</p>
+  </div>
+</main>
+{% endblock %}

--- a/bedrock/products/templates/products/relay/waitlist/phone.html
+++ b/bedrock/products/templates/products/relay/waitlist/phone.html
@@ -3,3 +3,11 @@
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
+
+{% extends "products/relay/includes/waitlist-base.html" %}
+
+{% set product = ftl('waitlist-phone-name') %}
+
+{% block waitlist_heading %}{{ ftl('waitlist-heading-phone') }}{% endblock %}
+{% block waitlist_lede %}{{ ftl('waitlist-lead-phone') }}{% endblock %}
+{% block waitlist_privacy %}{{ ftl('waitlist-privacy-policy-use-phone') }}{% endblock %}

--- a/bedrock/products/templates/products/relay/waitlist/phone.html
+++ b/bedrock/products/templates/products/relay/waitlist/phone.html
@@ -1,0 +1,5 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}

--- a/bedrock/products/templates/products/relay/waitlist/vpn-relay.html
+++ b/bedrock/products/templates/products/relay/waitlist/vpn-relay.html
@@ -1,5 +1,0 @@
-{#
- This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#}

--- a/bedrock/products/templates/products/relay/waitlist/vpn-relay.html
+++ b/bedrock/products/templates/products/relay/waitlist/vpn-relay.html
@@ -1,0 +1,5 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}

--- a/bedrock/products/templates/products/relay/waitlist/vpn.html
+++ b/bedrock/products/templates/products/relay/waitlist/vpn.html
@@ -1,0 +1,13 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/relay/includes/waitlist-base.html" %}
+
+{% set product = "{{ ftl('waitlist-bundle-name') }}" %}
+
+{% block waitlist_heading %}{{ ftl('waitlist-heading-bundle') }}{% endblock %}
+{% block waitlist_lede %}{{ ftl('waitlist-lead-bundle') }}{% endblock %}
+{% block waitlist_privacy %}{{ ftl('waitlist-privacy-policy-use-bundle') }}{% endblock %}

--- a/bedrock/products/templates/products/relay/waitlist/vpn.html
+++ b/bedrock/products/templates/products/relay/waitlist/vpn.html
@@ -6,7 +6,7 @@
 
 {% extends "products/relay/includes/waitlist-base.html" %}
 
-{% set product = "{{ ftl('waitlist-bundle-name') }}" %}
+{% set product = ftl('waitlist-bundle-name') %}
 
 {% block waitlist_heading %}{{ ftl('waitlist-heading-bundle') }}{% endblock %}
 {% block waitlist_lede %}{{ ftl('waitlist-lead-bundle') }}{% endblock %}

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -48,4 +48,6 @@ if settings.DEV:
     urlpatterns += (
         path("relay/", views.relay_landing_page, name="products.relay.landing"),
         path("relay/invite/", views.relay_invite_page, name="products.relay.invite"),
+        page("relay/phone/waitlist/", "products/relay/waitlist/phone.html"),
+        page("relay/vpn-relay/waitlist/", "products/relay/waitlist/vpn-relay.html"),
     )

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -49,5 +49,5 @@ if settings.DEV:
         path("relay/", views.relay_landing_page, name="products.relay.landing"),
         path("relay/invite/", views.relay_invite_page, name="products.relay.invite"),
         path("relay/waitlist/vpn/", view=views.relay_vpn_waitlist__page, name="products.relay.waitlist.vpn"),
-        path("relay/waitlist/phone/", view=views.relay_vpn_waitlist__page, name="products.relay.waitlist.phone"),
+        path("relay/waitlist/phone/", view=views.relay_phone_waitlist__page, name="products.relay.waitlist.phone"),
     )

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -48,6 +48,6 @@ if settings.DEV:
     urlpatterns += (
         path("relay/", views.relay_landing_page, name="products.relay.landing"),
         path("relay/invite/", views.relay_invite_page, name="products.relay.invite"),
-        page("relay/phone/waitlist/", "products/relay/waitlist/phone.html"),
-        page("relay/vpn-relay/waitlist/", "products/relay/waitlist/vpn-relay.html"),
+        path("relay/waitlist/vpn/", view=views.relay_vpn_waitlist__page, name="products.relay.waitlist.vpn"),
+        path("relay/waitlist/phone/", view=views.relay_vpn_waitlist__page, name="products.relay.waitlist.phone"),
     )

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -253,9 +253,8 @@ def relay_vpn_waitlist__page(request):
     ftl_files = ["products/relay/waitlist", "products/relay/shared"]
     locale = l10n_utils.get_locale(request)
     newsletter_form = RelayBundleWaitlistForm(locale)
-    action = "relay-vpn-bundle-waitlist"
 
-    ctx = {"action": action, "newsletter_form": newsletter_form}
+    ctx = {"action": settings.BASKET_SUBSCRIBE_URL, "newsletter_form": newsletter_form}
 
     return l10n_utils.render(request, "products/relay/waitlist/vpn.html", ctx, ftl_files=ftl_files)
 
@@ -265,8 +264,7 @@ def relay_phone_waitlist__page(request):
     ftl_files = ["products/relay/waitlist", "products/relay/shared"]
     locale = l10n_utils.get_locale(request)
     newsletter_form = RelayPhoneWaitlistForm(locale)
-    action = "relay-phone-masking-waitlist"
 
-    ctx = {"action": action, "newsletter_form": newsletter_form}
+    ctx = {"action": settings.BASKET_SUBSCRIBE_URL, "newsletter_form": newsletter_form}
 
     return l10n_utils.render(request, "products/relay/waitlist/phone.html", ctx, ftl_files=ftl_files)

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -20,7 +20,11 @@ from bedrock.contentful.constants import (
 )
 from bedrock.contentful.models import ContentfulEntry
 from bedrock.contentful.utils import locales_with_available_content
-from bedrock.products.forms import VPNWaitlistForm
+from bedrock.products.forms import (
+    RelayBundleWaitlistForm,
+    RelayPhoneWaitlistForm,
+    VPNWaitlistForm,
+)
 from lib import l10n_utils
 
 
@@ -242,3 +246,27 @@ def relay_invite_page(request):
     ctx = {"action": "action", "newsletter_form": "newsletter_form"}
 
     return l10n_utils.render(request, "products/relay/invite.html", ctx, ftl_files=ftl_files)
+
+
+@require_safe
+def relay_vpn_waitlist__page(request):
+    ftl_files = ["products/relay/waitlist", "products/relay/shared"]
+    locale = l10n_utils.get_locale(request)
+    newsletter_form = RelayBundleWaitlistForm(locale)
+    action = "relay-vpn-bundle-waitlist"
+
+    ctx = {"action": action, "newsletter_form": newsletter_form}
+
+    return l10n_utils.render(request, "products/relay/waitlist/vpn.html", ctx, ftl_files=ftl_files)
+
+
+@require_safe
+def relay_phone_waitlist__page(request):
+    ftl_files = ["products/relay/waitlist", "products/relay/shared"]
+    locale = l10n_utils.get_locale(request)
+    newsletter_form = RelayPhoneWaitlistForm(locale)
+    action = "relay-phone-masking-waitlist"
+
+    ctx = {"action": action, "newsletter_form": newsletter_form}
+
+    return l10n_utils.render(request, "products/relay/waitlist/phone.html", ctx, ftl_files=ftl_files)

--- a/l10n/en/products/relay/waitlist.ftl
+++ b/l10n/en/products/relay/waitlist.ftl
@@ -26,10 +26,14 @@ waitlist-privacy-policy-agree-2 = By clicking “{ waitlist-submit-label-2 }”,
 waitlist-privacy-policy-use = Your information will only be used to notify you about { -brand-name-firefox-relay-premium } availability.
 waitlist-privacy-policy-use-phone = Your information will only be used to notify you when phone masking is available in your area.
 waitlist-privacy-policy-use-bundle = Your information will only be used to notify you about { -brand-name-relay } + { -brand-name-vpn } bundle availability.
+waitlist-subscribe-success-title = Thanks! You're on the list
 # Variables:
 #   $product (string) one of the following three options:
 #      - { -brand-name-firefox-firefox-relay-premium }
-#      - { -brand-name-relay } + { -brand-name-vpn } bundle
-#      - { -brand-name-relay } phone masking
-waitlist-subscribe-success = You’re on the list! Once { $product } becomes available for your region, we’ll email you.
+#      - { waitlist-bundle-name }
+#      - { waitlist-phone-name }
+waitlist-subscribe-success-desc = Once { $product } becomes available for your region, we’ll email you.
+waitlist-subscribe-please-enter-a-valid = Please enter a valid email address
+waitlist-subscribe-please-select-country = Please select a country or region
+waitlist-subscribe-please-select-language = Please select a language
 waitlist-subscribe-error-unknown = There was an error adding you to the waitlist. Please try again.

--- a/l10n/en/products/relay/waitlist.ftl
+++ b/l10n/en/products/relay/waitlist.ftl
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/products/relay/waitlist/[vpn|phone].html
+
+waitlist-bundle-name = { -brand-name-relay } + { -brand-name-vpn } bundle
+waitlist-phone-name = { -brand-name-relay } phone masking
+## old variables
+waitlist-heading-2 = Join the { -brand-name-relay-premium } waitlist
+waitlist-heading-phone = Join the { -brand-name-relay } phone masking waitlist
+waitlist-heading-bundle = Join the waitlist for the { -brand-name-relay } + { -brand-name-vpn } bundle
+waitlist-lead-2 = We’ll let you know when { -brand-name-relay-premium } is available in your area.
+waitlist-lead-phone = We’ll let you know when phone masking is available in your area.
+waitlist-lead-bundle = We’ll let you know when you can get { -brand-name-relay-premium } and { -brand-name-mozilla-vpn } at a discount in your area.
+waitlist-control-required = Required
+waitlist-control-email-label = What is your email address?
+# Please only translate `yourname`; example.com is an actual example domain that is safe to use.
+waitlist-control-email-placeholder = yourname@example.com
+waitlist-control-country-label-2 = What country or region do you live in?
+waitlist-control-locale-label = Select your preferred language.
+waitlist-submit-label-2 = Join the waitlist
+# Variables:
+#   $url (url) - https://www.mozilla.org/en-US/privacy/subscription-services/
+waitlist-privacy-policy-agree-2 = By clicking “{ waitlist-submit-label-2 }”, you agree to our <a href="{ $url }">Privacy Policy</a>.
+waitlist-privacy-policy-use = Your information will only be used to notify you about { -brand-name-firefox-relay-premium } availability.
+waitlist-privacy-policy-use-phone = Your information will only be used to notify you when phone masking is available in your area.
+waitlist-privacy-policy-use-bundle = Your information will only be used to notify you about { -brand-name-relay } + { -brand-name-vpn } bundle availability.
+# Variables:
+#   $product (string) one of the following three options:
+#      - { -brand-name-firefox-firefox-relay-premium }
+#      - { -brand-name-relay } + { -brand-name-vpn } bundle
+#      - { -brand-name-relay } phone masking
+waitlist-subscribe-success = You’re on the list! Once { $product } becomes available for your region, we’ll email you.
+waitlist-subscribe-error-unknown = There was an error adding you to the waitlist. Please try again.

--- a/media/css/products/relay/waitlist.scss
+++ b/media/css/products/relay/waitlist.scss
@@ -8,12 +8,7 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '@mozilla-protocol/core/protocol/css/components/newsletter-form';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '@mozilla-protocol/core/protocol/css/includes/lib';
-
-.c-waitlist-container {
-    padding-top: $spacing-lg;
-}
 
 .c-waitlist-heading {
     text-align: center;
@@ -23,14 +18,14 @@ $image-path: '/media/protocol/img';
     }
 }
 
+.c-waitlist-success {
+    text-align: center;
+}
+
 .mzp-c-form {
     i {
         display: block;
     }
-
-    // input, select {
-    //     width: 100%;
-    // }
 }
 
 .mzp-c-newsletter-form .mzp-c-button {

--- a/media/css/products/relay/waitlist.scss
+++ b/media/css/products/relay/waitlist.scss
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@import '@mozilla-protocol/core/protocol/css/components/newsletter-form';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '@mozilla-protocol/core/protocol/css/includes/lib';
+
+.c-waitlist-container {
+    padding-top: $spacing-lg;
+}
+
+.c-waitlist-heading {
+    text-align: center;
+
+    h1 {
+        @include font-size(38px);
+    }
+}
+
+.mzp-c-form {
+    i {
+        display: block;
+    }
+
+    // input, select {
+    //     width: 100%;
+    // }
+}
+
+.mzp-c-newsletter-form .mzp-c-button {
+    width: inherit;
+    display: block;
+    margin: 0 auto;
+}
+
+.c-waitlist-privacy {
+    @include font-size(14px);
+    text-align: center;
+}

--- a/media/js/products/relay/waitlist.es6.js
+++ b/media/js/products/relay/waitlist.es6.js
@@ -1,0 +1,144 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import FormUtils from '../../newsletter/form-utils.es6';
+
+let form;
+
+const WaitlistForm = {
+    serialize: () => {
+        const email = encodeURIComponent(
+            form.querySelector('input[type="email"]').value
+        );
+        // newsletter ID
+        const newsletter = form.querySelector(
+            'input[name="newsletters"]'
+        ).value;
+        // country
+        const country = form.querySelector('select[name="country"]').value;
+        // Language
+        const lang = form.querySelector('select[name="lang"]').value;
+        // Source URL (hidden field)
+        const sourceUrl = encodeURIComponent(
+            form.querySelector('input[name="source_url"]').value
+        );
+
+        return `email=${email}&newsletters=${newsletter}&fpn_country=${country}&lang=${lang}&format=H&source_url=${sourceUrl}`;
+    },
+
+    subscribe: (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const email = form.querySelector('input[type=email]').value;
+        const url = form.getAttribute('action');
+
+        // Disable form fields until POST has completed.
+        FormUtils.disableFormFields(form);
+
+        // Clear any prior messages that might have been displayed.
+        FormUtils.clearFormErrors(form);
+
+        // Perform client side form field validation.
+        if (!WaitlistForm.validateFields()) {
+            return;
+        }
+
+        const params = WaitlistForm.serialize();
+
+        FormUtils.postToBasket(
+            email,
+            params,
+            url,
+            WaitlistForm.handleFormSuccess,
+            WaitlistForm.handleFormError
+        );
+    },
+
+    handleFormSuccess: () => {
+        const thanks = document.getElementById('newsletter-thanks');
+        const title = document.querySelector('.c-waitlist-heading');
+        const newsletter = form.querySelector(
+            'input[name="newsletters"]'
+        ).value;
+
+        // show thanks message
+        title.classList.add('hidden');
+        form.classList.add('hidden');
+        thanks.classList.remove('hidden');
+        window.scrollTo(0, 0);
+
+        if (window.dataLayer) {
+            window.dataLayer.push({
+                event: 'newsletter-signup-success',
+                newsletter: newsletter
+            });
+        }
+    },
+
+    handleFormError: (msg) => {
+        let error;
+
+        FormUtils.enableFormFields(form);
+
+        form.querySelector('.mzp-c-form-errors').style.display = 'block';
+
+        switch (msg) {
+            case FormUtils.errorList.EMAIL_INVALID_ERROR:
+                error = form.querySelector('.error-email-invalid');
+                break;
+            case FormUtils.errorList.COUNTRY_ERROR:
+                error = form.querySelector('.error-select-country');
+                break;
+            case FormUtils.errorList.LANGUAGE_ERROR:
+                error = form.querySelector('.error-select-language');
+                break;
+            default:
+                error = form.querySelector('.error-try-again-later');
+        }
+
+        if (error) {
+            error.classList.remove('hidden');
+        }
+    },
+
+    validateFields: () => {
+        const email = form.querySelector('input[type="email"]').value;
+        const countrySelect = form.querySelector('select[name="country"]');
+        const lang = form.querySelector('#id_lang').value;
+
+        // Really basic client side email validity check.
+        if (!FormUtils.checkEmailValidity(email)) {
+            form.handleFormError(FormUtils.errorList.EMAIL_INVALID_ERROR);
+            return false;
+        }
+
+        // Check for country selection value.
+        if (countrySelect && !countrySelect.value) {
+            WaitlistForm.handleFormError(FormUtils.errorList.COUNTRY_ERROR);
+            return false;
+        }
+
+        // Check for language selection value.
+        if (!lang) {
+            WaitlistForm.handleFormError(FormUtils.errorList.LANGUAGE_ERROR);
+            return false;
+        }
+
+        return true;
+    },
+
+    init: () => {
+        form = document.querySelector('.c-waitlist-form');
+
+        if (!form) {
+            return;
+        }
+
+        form.addEventListener('submit', WaitlistForm.subscribe, false);
+    }
+};
+
+WaitlistForm.init();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1272,6 +1272,12 @@
         "css/products/relay/landing.scss"
       ],
       "name": "relay-landing"
+    },
+    {
+      "files": [
+        "css/products/relay/waitlist.scss"
+      ],
+      "name": "relay-waitlist"
     }
   ],
   "js": [

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -2032,6 +2032,12 @@
         "js/mozorg/santa-locator.js"
       ],
       "name": "santa_locator"
+    },
+    {
+      "files": [
+        "js/products/relay/waitlist.es6.js"
+      ],
+      "name": "relay-waitlist"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds relay waitlist pages to bedrock for the VPN + Relay Bundle and Phone Masking
- Phone masking wait list page https://relay.firefox.com/phone/waitlist/
- VPN / Relay bundle wait list page https://relay.firefox.com/vpn-relay/waitlist/

Something to note - the original relay pages use notification bars, but I decided to use the standard newsletter Thank you messaging instead of notification bars

## Issue / Bugzilla link
#12933

## Testing

To test this work:
- http://localhost:8000/products/relay/waitlist/vpn/
- http://localhost:8000/products/relay/waitlist/phone/


