### PR TITLE
Adjust view logic for EU WNP 113 [#12961]

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -590,9 +590,11 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("113."):
-            if locale == "en-US" and country == "GB":
+            if locale.startswith("en-") and country == "GB":
                 template = "firefox/whatsnew/whatsnew-fx113-eu.html"
-            elif locale in ["en-GB", "fr", "de", "it", "es-ES", "nl", "sv-SE", "fi"] and ftl_file_is_active("firefox/welcome/page10"):
+            elif locale == "en-GB":
+                template = "firefox/whatsnew/whatsnew-fx113-eu.html"
+            elif locale in ["fr", "de", "it", "es-ES", "nl", "sv-SE", "fi"] and ftl_file_is_active("firefox/welcome/page10"):
                 template = "firefox/whatsnew/whatsnew-fx113-eu.html"
             else:
                 template = "firefox/whatsnew/index.html"


### PR DESCRIPTION
## One-line summary

A [test failure on stage](https://github.com/mozilla/bedrock/actions/runs/4854777103/jobs/8653653619) had us stumped for a while until @pmac spotted the view condition had `en-GB` in the list of locales and also required an active Fluent file, but it turns out that file isn't active for en-GB so it was falling back to the default template for that locale. The functional tests worked locally and on dev because all locales are active in dev mode, but failed on stage and would have failed on prod as well.

This tweaks the conditions a bit so the EU template shows for any English locale when viewed from GB, adds an explicit rule for the en-GB locale, and removes en-GB from the extended locale list.