### PR TITLE
Remove CircleCI badge, because we don't use it any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ awesome, and open source as always. Perhaps even a little more.
 
 [mozilla]: https://www.mozilla.org/
 
-[![Circle CI](https://circleci.com/gh/mozilla/bedrock.svg?style=svg)](https://circleci.com/gh/mozilla/bedrock)
 [![What's deployed on dev,stage,prod?](https://img.shields.io/badge/whatsdeployed-dev,stage,prod-green.svg)](https://whatsdeployed.io/s/RuO/mozilla/bedrock)
 
 Docs


### PR DESCRIPTION
Token change to run through the full infra pipelines