### PR TITLE
Use local newsletter data for email prefs page instead of basket (Fixes #13031)

### DIFF
--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -45,5 +45,6 @@ urlpatterns = (
     ),
     page("newsletter/family/", "newsletter/family.html", ftl_files=["mozorg/newsletters"], active_locales=["en-US"]),
     page("newsletter/security-and-privacy/", "newsletter/security-privacy-news.html", ftl_files=["mozorg/newsletters"]),
+    path("newsletter/newsletter-all.json", views.newsletter_all_json, name="newsletter.all"),
     path("newsletter/newsletter-strings.json", views.newsletter_strings_json, name="newsletter.strings"),
 )

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -2,13 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
 import re
 from html import escape
 
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponseRedirect, JsonResponse
 from django.views.decorators.cache import never_cache
 
 import basket
@@ -117,16 +116,12 @@ def confirm_thanks(request):
 
 def newsletter_all_json(request):
     """Returns a JSON string of all newsletters configured in Basket."""
-    data = {"newsletters": get_newsletters()}
-    return HttpResponse(json.dumps(data), content_type="application/json")
+    return JsonResponse({"newsletters": get_newsletters()})
 
 
 def newsletter_strings_json(request):
     """Returns a JSON string of newsletter IDs mapped to localized titles and descriptions."""
-    newsletters = json.dumps(get_newsletters())
-    return l10n_utils.render(
-        request, "newsletter/includes/newsletter-strings.json", {"newsletters": newsletters}, content_type="application/json", ftl_files=FTL_FILES
-    )
+    return l10n_utils.render(request, "newsletter/includes/newsletter-strings.json", content_type="application/json", ftl_files=FTL_FILES)
 
 
 @never_cache

--- a/media/js/newsletter/management.es6.js
+++ b/media/js/newsletter/management.es6.js
@@ -357,10 +357,13 @@ const NewsletterManagementForm = {
     renderTableRow: (newsletter, index) => {
         const checked = newsletter.subscribed ? ' checked=""' : '';
         const indent = newsletter.indent ? ' class="indented"' : '';
+        const title = FormUtils.stripHTML(newsletter.title);
+        const desc = FormUtils.stripHTML(newsletter.description);
+
         return `<tr${indent}>
             <th>
-                <h4>${newsletter.title}</h4>
-                <p>${newsletter.description}</p>
+                <h4>${title}</h4>
+                <p>${desc}</p>
             </th>
             <td>
                 <label for="id_form-${index}-subscribed_check">${newsletter.subscribeCopy}</label>


### PR DESCRIPTION
## One-line summary

Updates newsletter preferences page to pull the list of all available newsletters from bedrock, rather than directly from basket.

## Issue / Bugzilla link

#13031

## Testing

First get your token here: https://www.mozilla.org/en-US/newsletter/recovery/

Then open `http://localhost:8000/en-US/newsletter/existing/YOUR_TOKEN_HERE/`

I also pushed this to demo1 for testing: https://www-demo1.allizom.org/
