### PR TITLE
Fix VPN what-is-a-vpn redirect to include a trailing slash

### DIFF
--- a/bedrock/products/redirects.py
+++ b/bedrock/products/redirects.py
@@ -7,7 +7,7 @@ from bedrock.redirects.util import redirect
 redirectpatterns = (
     # Issue 12937 -
     redirect(r"^products/vpn/more/what-is-an-ip-address/$", "/products/vpn/resource-center/what-is-an-ip-address/"),
-    redirect(r"^products/vpn/more/what-is-a-vpn$", "/products/vpn/resource-center/what-is-a-vpn/"),
+    redirect(r"^products/vpn/more/what-is-a-vpn/$", "/products/vpn/resource-center/what-is-a-vpn/"),
     redirect(r"^products/vpn/more/vpn-or-proxy/$", "/products/vpn/resource-center/the-difference-between-a-vpn-and-a-web-proxy/"),
     redirect(r"^products/vpn/more/when-to-use-a-vpn/$", "/products/vpn/resource-center/5-reasons-you-should-use-a-vpn/"),
     redirect(r"^products/vpn/more/why-mozilla-vpn/$", "products.vpn.landing"),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1219,7 +1219,7 @@ URLS = flatten(
         url_test("/privacy/facebook/", "/privacy/archive/facebook/2023-04/"),
         # Issue #12937 - updating VPN subnav
         url_test("/products/vpn/more/what-is-an-ip-address/", "/products/vpn/resource-center/what-is-an-ip-address/"),
-        url_test("/products/vpn/more/what-is-a-vpn", "/products/vpn/resource-center/what-is-a-vpn/"),
+        url_test("/products/vpn/more/what-is-a-vpn/", "/products/vpn/resource-center/what-is-a-vpn/"),
         url_test("/products/vpn/more/vpn-or-proxy/", "/products/vpn/resource-center/the-difference-between-a-vpn-and-a-web-proxy/"),
         url_test("/products/vpn/more/when-to-use-a-vpn/", "/products/vpn/resource-center/5-reasons-you-should-use-a-vpn/"),
         url_test("/products/vpn/more/why-mozilla-vpn/", "/products/vpn/"),


### PR DESCRIPTION
The way the regex was before this change, a request to the URL with a
trailing slash was a 404, but with this change both with and without
will redirect.
