### PR TITLE
Update Mastodon social footer link to mozilla.social

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -48,6 +48,8 @@
     <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicons/mozilla/favicon.ico') }}{% endblock %}">
     {% block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
     {% endblock shared_meta %}
+    {# keep the verification for the previous official mastodon profile #}
+    <link href="https://mastodon.social/@mozilla" rel="me">
 
     {{ l10n_css() }}
 

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -71,7 +71,7 @@
           <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-mozilla') }}</h5>
           <ul class="mzp-c-footer-links-social">
             <li><a class="twitter" href="{{ mozilla_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
-            <li><a class="mastodon" href="https://mastodon.social/@Mozilla" rel="me" data-link-type="footer" data-link-name="Mastodon (@mozilla)">{{ ftl('footer-mastodon') }}<span> (@mozilla)</span></a></li>
+            <li><a class="mastodon" href="https://mozilla.social/@Mozilla" rel="me" data-link-type="footer" data-link-name="Mastodon (@mozilla)">{{ ftl('footer-mastodon') }}<span> (@mozilla)</span></a></li>
             <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>
             <li><a class="linkedin" href="https://www.linkedin.com/company/mozilla-corporation/" data-link-type="footer" data-link-name="LinkedIn (@mozilla)">{{ ftl('footer-linkedin') }}<span> (@mozilla)</span></a></li>
             <li><a class="tiktok" href="https://www.tiktok.com/@mozilla" data-link-type="footer" data-link-name="TikTok (@mozilla)">{{ ftl('footer-tiktok') }}<span> (@mozilla)</span></a></li>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/index.html
@@ -197,7 +197,7 @@
 
       <ul class="elsewhere">
         <li><a class="url twitter" itemprop="url" rel="me external" href="https://twitter.com/stevetex">@stevetex</a></li>
-        <li><a class="url mastodon" itemprop="url" rel="me external" href="https://mastodon.social/@stevetex">@stevetex@mastodon.social</a></li>
+        <li><a class="url mastodon" itemprop="url" rel="me external" href="https://mozilla.social/@stevetex">@stevetex@mozilla.social</a></li>
       </ul>
 
       <ul class="utility">

--- a/bedrock/mozorg/templates/mozorg/about/leadership/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/index.html
@@ -113,6 +113,10 @@
     <div class="person-info">
       <p class="title" itemprop="jobTitle">Chief Financial Officer</p>
 
+      <ul class="elsewhere">
+        <li><a class="url mastodon" itemprop="url" rel="me external" href="https://mozilla.social/@muhlheim">@muhlheim@mozilla.social</a></li>
+      </ul>
+
       <ul class="utility">
         <li><a class="link" href="{{ url('mozorg.about.leadership.index') }}#eric-muhlheim">Link to this bio</a></li>
       </ul>
@@ -275,6 +279,10 @@
 
     <div class="person-info">
       <p class="title" itemprop="jobTitle">SVP of Innovation Ecosystems</p>
+
+      <ul class="elsewhere">
+        <li><a class="url mastodon" itemprop="url" rel="me external" href="https://mozilla.social/@imo">@imo@mozilla.social</a></li>
+      </ul>
 
       <ul class="utility">
         <li><a class="link" href="{{ url('mozorg.about.leadership.index') }}#imo-udom">Link to this bio</a></li>


### PR DESCRIPTION
Also add the old account to the header so that the old account will remain verified as it was our official account for a time.

Also update the link to the account for Steve Teixeira as he has also migrated his account.

The [docs for verified links](https://docs.joinmastodon.org/user/profile/#verification) suggest that both of these should work fine.
