### PR TITLE
Fix view for EU WNP 113

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -595,7 +595,7 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/whatsnew/whatsnew-fx113-eu.html"
                 else:
                     template = "firefox/whatsnew/whatsnew-fx113-en.html"
-            elif locale in ["en-GB", "fr", "de", "it", "es-ES", "nl", "sv-SE", "fi"] and ftl_file_is_active("firefox/welcome/page10"):
+            elif locale in ["en-GB", "fr", "de", "it", "es-ES", "nl", "sv-SE", "fi"]:
                 template = "firefox/whatsnew/whatsnew-fx113-eu.html"
             else:
                 template = "firefox/whatsnew/index.html"


### PR DESCRIPTION
## One-line summary
I inadvertently added back the Fluent file check for the page, which breaks for en-GB. We don't actually need that check after all (all locales are already active). See https://github.com/mozilla/bedrock/pull/13063/files#diff-4fec82465cd60d028a383c064b7ea42028d1ae3ce15a98ee0dbdf4330578d385L595

## Testing

With `DEV=False` http://localhost:8000/en-GB/firefox/113.0/whatsnew/ should display the VPN page, not the default.