### PR TITLE
Add message to email preference center on timing of unsubscribes (Fixes #13050)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -129,6 +129,8 @@
                 <tr>
                   <th>
                     {{ form.remove_all.label_tag(ftl('newsletters-remove-me-from-all-the')) }}
+
+                    <p>{{ ftl('newsletters-opt-out-delay') }}</p>
                   </th>
                   <td>
                     {{ form['remove_all'] }}

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -436,3 +436,5 @@ newsletters-stay-informed-of-the-latest = Stay informed of the latest trends in 
 
 # Subtitle for https://www-dev.allizom.org/newsletter/security-and-privacy/
 newsletters-get-security-and-privacy-news-and-tips = Get security and privacy news and product updates from { -brand-name-mozilla } to stay safe and informed on everything that makes the web a healthier place.
+
+newsletters-opt-out-delay =  It may take 1-2 business days to process your opt-out request during which time you may still receive another email.


### PR DESCRIPTION
## One-line summary

Adds message underneath the unsubscribe all checkbox.

## Issue / Bugzilla link

#13050

## Testing

First get your token here: https://www.mozilla.org/en-US/newsletter/recovery/

Then open `http://localhost:8000/en-US/newsletter/existing/YOUR_TOKEN_HERE/`