### PR TITLE
add notes about migrating to hackerone

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -79,7 +79,7 @@
     <dd>
       <p>Only a limited subset of our websites are eligible for monetary payouts. Please see our
       <a href="{{ url('security.bug-bounty.web-eligible-sites') }}">list of eligible sites</a>
-      for additional information. Note that some low severity issues are not eligible for monetary awards based on their impact. We will recognize the reporter by thanking them on our HackerOne pages.</p>
+      for additional information. Note that some low severity issues are not eligible for monetary awards based on their impact. We will recognize the reporter by thanking them on each program's Thanks page, <a href="https://hackerone.com/mozilla_critical_services/thanks">Critical services program Thanks page</a> and <a href="https://hackerone.com/mozilla_core_services/thanks">Core services program Thanks page</a>.</p>
     </dd>
 
     <dt id="dos-bugs">Why don’t you provide a reward for denial-of-service bugs?</dt>
@@ -96,7 +96,7 @@
     <dt id="what-next">Once I have found a vulnerability, what next?</dt>
     <dd>
       <p>The sooner we can reproduce the bug, the sooner we can fix it
-        and send you your bounty. Please submit all bugs to our HackerOne programs <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a>.
+        and send you your bounty. Please submit all bugs to our HackerOne programs, <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a>.
         <strong>Do not send vulnerabilities via email and please avoid using video.</strong></p>
 
       <p>There are three main things you can provide which will help us

--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -77,11 +77,9 @@
   <dl class="mzp-u-list-styled">
     <dt id="eligible-bugs">Which domains and web applications will be considered to be part of the bug bounty?</dt>
     <dd>
-      <p>Although all of our non-community websites are considered in scope for acknowledgment on our
-      <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">hall of fame</a>, only
-      a limited subset are eligible for monetary payouts. Please see our
+      <p>Only a limited subset of our websites are eligible for monetary payouts. Please see our
       <a href="{{ url('security.bug-bounty.web-eligible-sites') }}">list of eligible sites</a>
-      for additional information.</p>
+      for additional information. Note that some low severity issues are not eligible for monetary awards based on their impact. We will recognize the reporter by thanking them on our HackerOne pages.</p>
     </dd>
 
     <dt id="dos-bugs">Why don’t you provide a reward for denial-of-service bugs?</dt>

--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -98,8 +98,7 @@
     <dt id="what-next">Once I have found a vulnerability, what next?</dt>
     <dd>
       <p>The sooner we can reproduce the bug, the sooner we can fix it
-        and send you your bounty. Please submit all bugs using the
-        <a href="https://bugzilla.mozilla.org/form.web.bounty">Bugzilla web bounty form</a>.
+        and send you your bounty. Please submit all bugs to our HackerOne programs <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a>.
         <strong>Do not send vulnerabilities via email and please avoid using video.</strong></p>
 
       <p>There are three main things you can provide which will help us

--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -22,6 +22,6 @@
   <p>On behalf of the Mozilla and the millions of people who visit our sites, use Firefox and our other products we would like to thank them for their hard work in helping to make us more secure.</p>
   <p>As of this date, we have paid out over <b>$4,000,000</b> across all of our bounties. Congratulations to everybody who has participated!</p>
   <p>If your name is on the list incorrectly or you feel you should be on the list please feel free to mail us at <a href="mailto:security@mozilla.org">security@mozilla.org</a>.</p>
-  <p><strong>Our program has been migrated to HackerOne.</strong> Therefore, we will discontinue adding researchers on this page. Starting from May 2023, researchers will be recognized on our HackerOne pages: <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
+  <p><strong>Our Web bug bounty program has been migrated to HackerOne.</strong> Therefore, we will discontinue adding researchers on this page. Starting from May 2023, researchers will be recognized on our HackerOne pages, <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
   {% include "security/partials/hall-of-famers-list.html" %}
 {% endblock %}

--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -21,6 +21,7 @@
 
   <p>On behalf of the Mozilla and the millions of people who visit our sites, use Firefox and our other products we would like to thank them for their hard work in helping to make us more secure.</p>
   <p>As of this date, we have paid out over <b>$4,000,000</b> across all of our bounties. Congratulations to everybody who has participated!</p>
-  {% include "security/partials/hall-of-famers-list.html" %}
   <p>If your name is on the list incorrectly or you feel you should be on the list please feel free to mail us at <a href="mailto:security@mozilla.org">security@mozilla.org</a>.</p>
+  <p><strong>Our program has been migrated to HackerOne.</strong> Therefore, we will discontinue adding researchers on this page. Starting from May 2023, researchers will be recognized on our HackerOne pages: <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
+  {% include "security/partials/hall-of-famers-list.html" %}
 {% endblock %}

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -46,19 +46,19 @@
         <th scope="row">High <br>(sec-high)</th>
         <td>$3000-$6000</td>
         <td>$1000-$3000</td>
-        <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a> - $500</td>
+        <td>0-$500</td>
       </tr>
       <tr>
         <th scope="row">Moderate <br>(sec-moderate)</th>
         <td>$1000-$3000</td>
         <td>$500-$1000</td>
-        <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
+        <td>-</td>
       </tr>
       <tr>
         <th scope="row">Low <br>(sec-low)</th>
-        <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a> - $1000</td>
-        <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a> - $500</td>
-        <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
+        <td>0-$1000</td>
+        <td>0-$500</td>
+        <td>-</td>
       </tr>
     </tbody>
   </table>
@@ -66,8 +66,6 @@
   <ol class="mzp-u-list-styled">
     <li>Excludes community websites</li>
   </ol>
-
-  <p>Any bounty that receives a payout also obtains inclusion on our <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">Hall of Fame</a>.</p>
 
   <h2>Definition and Examples</h2>
 

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -18,6 +18,8 @@
 
   <p>The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who find unique and original bugs in our web infrastructure.</p>
 
+  <p><strong>We have migrated our web bug bounty program to HackerOne.</strong> Please visit our policy pages to learn more and to submit reports. <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
+
   <p><strong>Guidelines:</strong> Submissions must conform to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a></p>
 
   <p>Please submit all bug reports via our <a href="{{ url('security.bug-bounty.faq-webapp') }}#bug-reporting">secure bug reporting process</a>.</p>


### PR DESCRIPTION
## One-line summary

Add notes about migrating web bug bounty to hackerone

## Screenshots

Main page
<img width="1022" alt="Screenshot 2023-05-05 at 11 32 36" src="https://user-images.githubusercontent.com/95376064/236424194-bdcb1f08-6fd2-41b4-97e1-5540f5fb4529.png">

<img width="952" alt="Screenshot 2023-05-05 at 11 18 24" src="https://user-images.githubusercontent.com/95376064/236424276-d8ac092f-f926-4044-818d-70b19cf5f418.png">

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/95376064/236424376-c6bb7516-8277-4303-b6f8-ae97fa1d2912.png">

Bounty table
<img width="821" alt="image" src="https://user-images.githubusercontent.com/95376064/236440591-cb5aa2ff-8692-46d6-b3d9-7148bce300fd.png">



