### PR TITLE
Fix failure to open L10N-org PRs, due to missing auth

### DIFF
--- a/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
@@ -11,8 +11,6 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  FLUENT_REPO_AUTH: ${{ secrets.FLUENT_REPO_AUTH }}
 
 jobs:
   open_l10n_pr:
@@ -21,4 +19,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run PR-opening script
         shell: bash
-        run: SITE_MODE=Mozorg bin/open-ftl-pr.sh
+        run: SITE_MODE=Mozorg FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh

--- a/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
@@ -11,9 +11,6 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  FLUENT_REPO_AUTH: ${{ secrets.FLUENT_REPO_AUTH }}
-
 jobs:
   open_l10n_pr:
     runs-on: ubuntu-latest
@@ -21,4 +18,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run PR opening script
         shell: bash
-        run: SITE_MODE=Pocket bin/open-ftl-pr.sh
+        run: SITE_MODE=Pocket FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh


### PR DESCRIPTION
Looks like the env var for the auth vars, while present, needed explicitly passing into the shell script which runs the Docker container. Without that, the automatic attempts to open a PR on mozilla-l10n/www-l10n failed

Workflow not working: https://github.com/mozilla/bedrock/actions/runs/4891935488

Workflow now working: https://github.com/mozilla/bedrock/actions/runs/4892916392/jobs/8735242756, resulting in this PR https://github.com/mozilla-l10n/www-l10n/pull/327/files

Am also updating the equivalent Pocket command