### PR TITLE
Reinstate download tests, now via GHA

### DIFF
--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -1,0 +1,85 @@
+# Workflow that runs download-link tests on live infra
+
+name: Download tests
+run-name: Download tests for ${{ github.sha }}
+env:
+  SLACK_CHANNEL_ID: CBX0KH5GA # #www-notify in MoCo Slack
+  SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
+on:
+  schedule:
+    - cron: "0 14 * * *" # 2pm daily
+  workflow_dispatch:
+    inputs:
+      mozorg_service_hostname:
+        description: The root URL of the Mozorg service to run tests against. eg 'https://www.mozilla.org'
+        required: true
+
+jobs:
+  notify-of-test-run-start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify via Slack that tests are starting
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "Download tests [${{ github.sha }}]"
+          status: info
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ github.sha }}
+          message: "Download tests started"
+
+  download-tests:
+    runs-on: ubuntu-latest
+    needs: notify-of-test-run-start
+    env:
+      BASE_URL: ${{ github.event.inputs.mozorg_service_hostname || 'https://www.mozilla.org' }} # Mozorg base URL
+      BROWSER_NAME: firefox
+      CI_JOB_ID: ${{ github.run_id }}
+      DRIVER: ""
+      LABEL: test-downloads
+      MARK_EXPRESSION: download
+      PYTEST_PROCESSES: auto
+      SAUCELABS_API_KEY: ""
+      SAUCELABS_USERNAME: ""
+
+    # Note we use if: always() below to keep things going, rather than
+    # continue-on-error, because that approach falsely marks the overall
+    # test suite as green/passed even if it has some failures.
+
+    steps:
+      - name: Fetch codebase
+        uses: actions/checkout@v3
+
+      - name: Run functional download tests
+        run: ./bin/integration_tests/functional_tests.sh
+        env:
+          TEST_IMAGE: mozmeao/bedrock_test:${{ github.sha }}
+
+      - name: Cleanup after functional download tests
+        run: ./bin/integration_tests/cleanup_after_functional_tests.sh
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: results-${{github.run_id}}
+          if-no-files-found: ignore  # this avoids a false "Warning" if there were no issues
+
+  notify-of-test-run-completion:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [notify-of-test-run-start, download-tests]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify via Slack of test-run outcome
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "Download tests [${{ github.sha }}]"
+          status: ${{ needs.download-tests.result }}
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ github.sha }}
+          message: "Download tests completed. Status: ${{ needs.download-tests.result }}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -61,11 +61,6 @@ jobs:
             DRIVER: Remote
             MARK_EXPRESSION: "not headless and not download and not skip_if_not_firefox and not cdn"
             PYTEST_PROCESSES: auto
-          - LABEL: download-tests
-            BROWSER_NAME: firefox
-            DRIVER: Remote
-            MARK_EXPRESSION: download
-            PYTEST_PROCESSES: auto
 
     env:
       BASE_URL: ${{ github.event.inputs.mozorg_service_hostname }}
@@ -94,7 +89,7 @@ jobs:
           echo "BOUNCER_URL=https://bouncer-bouncer.stage.mozaws.net/" >> $GITHUB_ENV
 
       - name: Run functional integration tests
-        if: ${{ matrix.LABEL != 'download-tests' || github.events.inputs.branch == 'stage' || github.events.inputs.branch == 'prod' }}
+        if: always()
         run: ./bin/integration_tests/functional_tests.sh
         env:
           TEST_IMAGE: mozmeao/bedrock_test:${{ github.event.inputs.git_sha }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -94,7 +94,7 @@ jobs:
           echo "BOUNCER_URL=https://bouncer-bouncer.stage.mozaws.net/" >> $GITHUB_ENV
 
       - name: Run functional integration tests
-        if: always()
+        if: ${{ matrix.LABEL != 'download-tests' || github.events.inputs.branch == 'stage' || github.events.inputs.branch == 'prod' }}
         run: ./bin/integration_tests/functional_tests.sh
         env:
           TEST_IMAGE: mozmeao/bedrock_test:${{ github.event.inputs.git_sha }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,12 +47,12 @@ jobs:
             DRIVER: SauceLabs
             MARK_EXPRESSION: "smoke or sanity"
             PLATFORM: Windows 10
-            PYTEST_PROCESSES: "8"
+            PYTEST_PROCESSES: 8
           - LABEL: test-firefox-remote
             BROWSER_NAME: firefox
             MARK_EXPRESSION: "not headless and not download and not skip_if_firefox and not cdn"
             DRIVER: Remote
-            PYTEST_PROCESSES: "auto"
+            PYTEST_PROCESSES: auto
           - LABEL: test-headless
             DRIVER: ""
             MARK_EXPRESSION: headless
@@ -60,26 +60,25 @@ jobs:
             BROWSER_NAME: chrome
             DRIVER: Remote
             MARK_EXPRESSION: "not headless and not download and not skip_if_not_firefox and not cdn"
-            PYTEST_PROCESSES: "auto"
-          # TEMPORARILY DISABLE DOWNLOAD TESTS - may need selectively running
-          # - LABEL: test-download-remote
-          #   BROWSER_NAME: "firefox"
-          #   DRIVER: Remote
-          #   MARK_EXPRESSION: download
-          #   PYTEST_PROCESSES: "auto"
+            PYTEST_PROCESSES: auto
+          - LABEL: download-tests
+            BROWSER_NAME: firefox
+            DRIVER: Remote
+            MARK_EXPRESSION: download
+            PYTEST_PROCESSES: auto
 
     env:
       BASE_URL: ${{ github.event.inputs.mozorg_service_hostname }}
       BASE_POCKET_URL: ${{ github.event.inputs.pocket_service_hostname }}
-      BROWSER_NAME: ${{matrix.BROWSER_NAME}}
-      CI_JOB_ID: ${{github.run_id}}
-      DRIVER: ${{matrix.DRIVER}}
-      LABEL: ${{matrix.LABEL}}
-      MARK_EXPRESSION: ${{matrix.MARK_EXPRESSION}}
-      PLATFORM: ${{matrix.PLATFORM}}
-      PYTEST_PROCESSES: ${{matrix.PYTEST_PROCESSES}}
-      SAUCELABS_API_KEY: ${{secrets.SAUCELABS_API_KEY}}
-      SAUCELABS_USERNAME: ${{secrets.SAUCELABS_USERNAME}}
+      BROWSER_NAME: ${{ matrix.BROWSER_NAME }}
+      CI_JOB_ID: ${{ github.run_id }}
+      DRIVER: ${{ matrix.DRIVER }}
+      LABEL: ${{ matrix.LABEL }}
+      MARK_EXPRESSION: ${{ matrix.MARK_EXPRESSION }}
+      PLATFORM: ${{ matrix.PLATFORM }}
+      PYTEST_PROCESSES: ${{ matrix.PYTEST_PROCESSES }}
+      SAUCELABS_API_KEY: ${{ secrets.SAUCELABS_API_KEY }}
+      SAUCELABS_USERNAME: ${{ secrets.SAUCELABS_USERNAME }}
 
     # Note we use if: always() below to keep things going, rather than
     # continue-on-error, because that approach falsely marks the overall


### PR DESCRIPTION
These tests were effectively disabled via restrictive configuration in GitLab. We're reinstating them here as a scheduled job rather than part of main integration tests, because we don't need them to run at every step, and they put a reasonably high load on the origin servers.

The tests now run against the CDN, which will still put load on prod for the less common options and also because the tests use HEAD not GET, so we should keep an eye on loading. However, autoscaling should keep things happy

Resolves #12946

As with https://github.com/mozilla/bedrock/pull/13105 this may need some tuning after merge