### PR TITLE
Adds a class to App and Play Store badges for GA4 tracking.

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -48,8 +48,15 @@
 {% macro google_play_button(class_name='', extra_data_attributes={}, extra_img_attributes={}, href=settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS, id='', product='Firefox', target='') -%}
 {% set optional_img_attributes = {'alt': ftl('download-button-google-play'), 'width': '152', 'height': '45', 'l10n': True} %}
 {% do optional_img_attributes.update(extra_img_attributes) %}
-<a{% if class_name %} class="{{ class_name }}"{% endif %}{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="Android"{% endif %}{% if product == 'Firefox' %} data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}"{% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
+<a class="ga-product-download {{ class_name }}"{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="Android"{% endif %}{% if product == 'Firefox' %} data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}"{% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
   {{ high_res_img('img/firefox/android/btn-google-play.png', optional_img_attributes) }}
+</a>
+{%- endmacro %}
+
+{% macro apple_app_store_button(class_name='', extra_data_attributes={}, extra_img_attributes={}, href=settings.APPLE_APPSTORE_FIREFOX_LINK, id='', product='Firefox', target='') -%}
+{% set optional_img_attributes = {'width': '152', 'height': '45'} %}
+<a class="ga-product-download {{ class_name }}"{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="iOS"{% endif %}{% if product == 'Firefox' %} {% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
+  <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}"{% for attr, val in optional_img_attributes.items() %} {{ attr }}="{{ val }}"{% endfor %}>
 </a>
 {%- endmacro %}
 

--- a/bedrock/base/templates/product-all-unified-macros.html
+++ b/bedrock/base/templates/product-all-unified-macros.html
@@ -113,9 +113,7 @@
     {% if id.startswith('ios') %}
       <ul class="c-download-list">
         <li>
-          <a id="appStoreLink-list-{{ id }}" href="{{ build.platforms.ios.download_url }}" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-          </a>
+          {{ apple_app_store_button(href=build.platforms.ios.download_url, id='appStoreLink-list-'+ id) }}
         </li>
         {% if id.endswith('release') %}
           <li><a href="{{ url('firefox.mobile.get-app') }}" class="c-get-app" data-cta-type="link" data-cta-text="Get It Now" data-cta-position="secondary">{{ ftl('firefox-all-product-send-link') }}</a></li>

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "product-all-unified-macros.html" import build_locale_list, bw, build_link, select_product_list, product_options with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -172,9 +172,7 @@
           <div id="download-ios-primary" data-product="ios_release" class="c-download-button">
             <ul class="c-download-list">
               <li>
-                <a id="appStoreLink-ios" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-                  <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-                </a>
+                {{ apple_app_store_button(href=ios_url, id='appStoreLink-ios') }}
               </li>
               <li><a href="{{ url('firefox.mobile.get-app') }}" class="c-get-app" data-cta-type="link" data-cta-text="Get It Now" data-cta-position="primary">{{ ftl('firefox-all-product-send-link') }}</a></li>
             </ul>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -5,7 +5,7 @@
 #}
 
 {% extends "firefox/base/base-protocol.html" %}
-{% from "macros.html" import google_play_button, fxa_email_form with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import split with context %}
 
 {# Issue 13019: Avoid duplicate content for English pages. #}
@@ -125,9 +125,7 @@
         {{ google_play_button(href=android_url, id='playStoreLink') }}
       </div>
       <div class="appstore-ios">
-        <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
+        {{ apple_app_store_button(href=ios_url, id='appStoreLink') }}
       </div>
       <div id="menu-mobile-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-browsers-download-for-mobile') }}</h3>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/compare.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "macros-protocol.html" import split with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -383,9 +383,7 @@
         {{ google_play_button(href=android_url, id='playStoreLink-primary') }}
       </li>
       <li class="ios">
-        <a id="appStoreLink-primary" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
+        {{ apple_app_store_button(href=ios_url, id='appStoreLink-primary') }}
       </li>
     </ul>
 

--- a/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/focus.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "macros-protocol.html" import split, call_out_compact with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -75,9 +75,11 @@
         {% endif %}
       </li>
       <li class="ios">
-        <a id="appStoreLink-primary" href="{% if variation == 'pb' %}{{ variation_ios_adjust_url}}{% else %}{{ ios_url }}{% endif %}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
+        {% if variation == 'pb' %}
+          {{ apple_app_store_button(href=variation_ios_adjust_url, id='appStoreLink-primary') }}
+        {% else %}
+          {{ apple_app_store_button(href=ios_url, id='appStoreLink-primary') }}
+        {% endif %}
       </li>
     </ul>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/get-ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/get-ios.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "macros.html" import apple_app_store_button with context %}
+
 {% extends "firefox/base/base-protocol.html" %}
 
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
@@ -32,10 +34,8 @@
     {{ ftl('get-ios-firefox-mobile-adapts') }}
   </p>
   <p class="c-cta">
-      <a href="https://nn8g.adj.st/?adjust_t=ucunb4r" data-link-type="download" data-download-os="iOS">
-        <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-      </a>
-    </p>
+    {{ apple_app_store_button(href='https://nn8g.adj.st/?adjust_t=ucunb4r') }}
+  </p>
 </div>
 
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/ios.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import apple_app_store_button with context %}
 {% from "macros-protocol.html" import split, call_out_compact with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -68,9 +68,7 @@
     </h1>
     <p class="c-tagline">{{ self.page_desc() }}</p>
     <p class="c-cta">
-      <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-        <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-      </a>
+      {{ apple_app_store_button(href=ios_url) }}
     </p>
   {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "macros-protocol.html" import split, call_out_compact with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -58,9 +58,7 @@
             {{ google_play_button(href=firefox_adjust_url('android', 'fb-container-page'), id='playStoreLink') }}
           </li>
           <li>
-            <a id="appStoreLink" href="{{ firefox_adjust_url('ios', 'fb-container-page') }}" data-link-type="download" data-download-os="iOS">
-              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-            </a>
+            {{ apple_app_store_button(href=firefox_adjust_url('ios', 'fb-container-page'), id='appStoreLink') }}
           </li>
         </ul>
       {% endif %}

--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -46,14 +46,13 @@
   </section>
 
   <aside class="mobile-download-buttons-wrapper">
+
     <ul class="mobile-download-buttons">
       <li class="android">
         {{ google_play_button(href=android_url, id='play-store-link') }}
       </li>
       <li class="ios">
-        <a id="app-store-link" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
+        {{ apple_app_store_button(href=ios_url, id='app-store-link') }}
       </li>
     </ul>
   </aside>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "macros-protocol.html" import split, call_out_compact with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -76,9 +76,7 @@
             {{ google_play_button(href=android_url, id='playStoreLink-primary') }}
           </li>
           <li class="ios">
-            <a id="appStoreLink-primary" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-            </a>
+            {{ apple_app_store_button(href=ios_url, id='appStoreLink-primary') }}
           </li>
         </ul>
       </div>
@@ -175,9 +173,7 @@
               {{ google_play_button(href=android_url, id='playStoreLink-secondary') }}
             </li>
             <li class="ios">
-              <a id="appStoreLink-secondary" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-              </a>
+              {{ apple_app_store_button(href=ios_url, id='appStoreLink-secondary') }}
             </li>
           </ul>
         </div>

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button, fxa_email_form with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button, fxa_email_form with context %}
 
 {% extends "firefox/new/desktop/base.html" %}
 
@@ -307,9 +307,7 @@
                 {{ google_play_button() }}
               </li>
               <li class="ios">
-                <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-                  <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45" loading="lazy">
-                </a>
+                {{ apple_app_store_button(href=ios_url) }}
               </li>
             </ul>
           </div>
@@ -542,9 +540,7 @@
             {{ google_play_button() }}
           </div>
           <div class="show-ios">
-            <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-            </a>
+            {{ apple_app_store_button(href=ios_url) }}
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -5,20 +5,16 @@
 #}
 
 {% extends "firefox/releases/notes.html" %}
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 
 {% if release.product == 'Firefox for iOS' %}
   {% set page_id = 'data-gtm-page-id="/firefox/ios/releasenotes/"' %}
   {% set product_name = release.product %}
   {% set download_button_primary %}
-    <a id="download-ios-primary" rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-    </a>
+    {{ apple_app_store_button(href=firefox_ios_url('mozorg-releasenotes_page-appstore-button'), id='download-ios-primary') }}
   {% endset %}
   {% set download_button_secondary %}
-    <a id="download-ios-secondary" rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-    </a>
+    {{ apple_app_store_button(href=firefox_ios_url('mozorg-releasenotes_page-appstore-button'), id='download-ios-secondary') }}
   {% endset %}
 {% elif release.product == 'Firefox for Android' %}
   {% set page_id = 'data-gtm-page-id="/firefox/android/releasenotes/"' %}

--- a/bedrock/firefox/templates/firefox/welcome/page4.html
+++ b/bedrock/firefox/templates/firefox/welcome/page4.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "macros-protocol.html" import call_out with context %}
 
 {% extends "firefox/welcome/base.html" %}
@@ -55,9 +55,7 @@
         {{ google_play_button(href=android_url, id='playStoreLink') }}
       </li>
       <li class="c-store-badge-apple">
-        <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
+        {{ apple_app_store_button(href=ios_url, id='appStoreLink') }}
       </li>
     </ul>
   </div>

--- a/bedrock/firefox/templates/firefox/welcome/page6.html
+++ b/bedrock/firefox/templates/firefox/welcome/page6.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 {% from "macros-protocol.html" import call_out with context %}
 
 {% extends "firefox/welcome/base.html" %}
@@ -66,9 +66,7 @@
         {{ google_play_button(href=android_url, id='playStoreLink') }}
       </li>
       <li>
-        <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-        </a>
+        {{ apple_app_store_button(href=ios_url, id='appStoreLink') }}
       </li>
     </ul>
   </aside>

--- a/bedrock/landing/templates/landing/firefox/fx100.html
+++ b/bedrock/landing/templates/landing/firefox/fx100.html
@@ -3,7 +3,7 @@
  License, v. 2.0. If a copy of the MPL was not distributed with this
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
-{% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button, apple_app_store_button with context %}
 
 {% extends 'landing/base-landing.html' %}
 
@@ -17,9 +17,7 @@
 {% block header %}Go your own way with Firefox mobile{% endblock %}
 {% block body_copy %}Firefox mobile adapts to you and makes it easier than ever to see all your open tabs, past searches, and favorite sites.{% endblock %}
 {% block ios_badge %}
-  <a class="ios store-badge" id="appStoreLink-primary" href="https://app.adjust.com/jcn6eyw?campaign=firefox100&adgroup=ios-store" data-link-type="download" data-download-os="iOS">
-    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-  </a>
+  {{ apple_app_store_button(href='https://app.adjust.com/jcn6eyw?campaign=firefox100&adgroup=ios-store', id='appStoreLink-primary', class_name='ios store-badge') }}
 {% endblock %}
 {% block android_badge %}
   {{ google_play_button(href='https://app.adjust.com/jcn6eyw?campaign=firefox100&adgroup=android-store', id='playStoreLink-primary', class_name='android store-badge') }}


### PR DESCRIPTION
## One-line summary

Add a class to App and Play Store badges for GA4 tracking.

## Significant changes and points to review

- adds the class 'ga-product-download' to the Play Store macro
- introduces an App Store macro which includes the class 'ga-product-download' 

## Issue / Bugzilla link

n/a

## Testing

http://localhost:8000/en-US/firefox/browsers/
http://localhost:8000/en-US/firefox/browsers/mobile/?xv=legacy
http://localhost:8000/en-US/firefox/browsers/mobile/
http://localhost:8000/en-US/firefox/ios/109.0/releasenotes/
http://localhost:8000/en-US/firefox/109.0/releasenotes/
http://localhost:8000/en-US/firefox/releases/
http://localhost:8000/en-US/firefox/welcome/4/
http://localhost:8000/en-US/firefox/welcome/6/
http://localhost:8000/en-US/landing/firefox/fx100
http://localhost:8000/en-US/firefox/
http://localhost:8000/en-US/firefox/facebookcontainer/
http://localhost:8000/en-US/firefox/browsers/mobile/ios/
http://localhost:8000/en-US/firefox/browsers/mobile/get-ios/
http://localhost:8000/en-US/firefox/browsers/mobile/focus/
http://localhost:8000/en-US/firefox/browsers/mobile/compare/

To test this work:

- [x] includes the `apple_app_store_button` macro in all templates
- [x] app store links match the link the macro is replacing
- [x] id matches the id of the link the macro is replacing
- [x] classes include the classes of the link the macro is replacing
