### PR TITLE
Fix string ID for about page description [no bug]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -11,7 +11,7 @@
 {% block page_title %}{{ ftl('about-learn-about-mozilla') }}{% endblock %}
 
 {% block page_desc %}
-  {{ ftl('about-mozilla-makes-browsers-apps-long') }}
+  {{ ftl('about-mozilla-makes-browsers-apps-desc') }}
 {% endblock %}
 
 {% block body_id %}about{% endblock %}


### PR DESCRIPTION
## One-line summary
The template was referencing the wrong string ID. Ref: https://github.com/mozilla/bedrock/blob/main/l10n/en/mozorg/about.ftl#L11

## Testing

http://localhost:8000/about/ and you'll probably have to view source to see the meta description.