### PR TITLE
Reduce padding on VPN download pages

### DIFF
--- a/media/css/products/vpn/download.scss
+++ b/media/css/products/vpn/download.scss
@@ -32,7 +32,7 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
         }
 
         @media #{$mq-md} {
-            padding: $spacing-lg 0;
+            padding: $spacing-lg 0 0;
             @include text-body-xl;
         }
 
@@ -69,6 +69,7 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
     grid-template-columns: 1fr;
     grid-row-gap: $spacing-xs;
     grid-column-gap: $spacing-xl;
+    padding-top: 0;
     padding-bottom: $layout-md;
 
     @media #{$vpn-download-mq-2xl} {

--- a/media/css/products/vpn/platform-download.scss
+++ b/media/css/products/vpn/platform-download.scss
@@ -33,8 +33,16 @@ $image-path: '/media/protocol/img';
     }
 }
 
+.vpn-download-instructions {
+    padding-top: $spacing-xl;
+}
+
 .mzp-c-picto {
     text-align: center;
+
+    .mzp-c-picto-image {
+        height: 220px;
+    }
 }
 
 .vpn-download-faq {


### PR DESCRIPTION
## One-line summary
VPN team wanted to reduce padding on the download pages so content can appear over-the-fold for whoever opens the page, so they can see the download buttons + instructions on load instead of scrolling

## Issue / Bugzilla link
Based off https://github.com/mozilla/bedrock/issues/11875


## Testing

To test this work:

- [x] http://localhost:8000/en-US/products/vpn/download
- [x] http://localhost:8000/en-US/products/vpn/download/mac/thanks/
- [x] http://localhost:8000/en-US/products/vpn/download/windows/thanks/

