### PR TITLE
Resintate: Port CDN tests to Github Actions

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -1,0 +1,94 @@
+# Workflow that runs download-link tests on live infra
+
+name: CDN tests
+run-name: CDN tests for ${{ github.sha }}
+env:
+  SLACK_CHANNEL_ID: CBX0KH5GA # #www-notify in MoCo Slack
+  SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
+on:
+  schedule:
+    - cron: "0 11 * * *" # 11am daily
+  workflow_dispatch:
+    inputs:
+      mozorg_service_hostname:
+        description: The root URL of the Mozorg service to run tests against. eg 'https://www.mozilla.org/'
+        required: true
+
+concurrency:
+  group: cdn-tests
+  cancel-in-progress: false
+
+jobs:
+  notify-of-test-run-start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify via Slack that tests are starting
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "CDN tests [${{ github.sha }}]"
+          status: info
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ github.sha }}
+          message: "CDN tests started"
+
+  cdn-tests:
+    runs-on: ubuntu-latest
+    needs: notify-of-test-run-start
+    strategy:
+      matrix:
+        include:
+          - LABEL: "General CDN Tests"
+            MARK_EXPRESSION: "cdn and not cdnprod"
+          - LABEL: "Prod-only CDN Tests"
+            MARK_EXPRESSION: cdnprod
+    env:
+      BASE_URL: ${{ github.event.inputs.mozorg_service_hostname || 'https://www.mozilla.org/' }} # Mozorg base URL
+      BROWSER_NAME: firefox
+      CI_JOB_ID: ${{ github.run_id }}
+      DRIVER: ""
+      LABEL: ${{ matrix.LABEL }}
+      MARK_EXPRESSION: ${{ matrix.MARK_EXPRESSION }}
+      PYTEST_PROCESSES: auto
+
+    # Note we use if: always() below to keep things going, rather than
+    # continue-on-error, because that approach falsely marks the overall
+    # test suite as green/passed even if it has some failures.
+
+    steps:
+      - name: Fetch codebase
+        uses: actions/checkout@v3
+
+      - name: Run CDN tests
+        run: ./bin/integration_tests/functional_tests.sh
+        env:
+          TEST_IMAGE: mozmeao/bedrock_test:${{ github.sha }}
+
+      - name: Cleanup CDN tests
+        run: ./bin/integration_tests/cleanup_after_functional_tests.sh
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: results-${{github.run_id}}
+          if-no-files-found: ignore  # this avoids a false "Warning" if there were no issues
+
+  notify-of-test-run-completion:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [notify-of-test-run-start, cdn-tests]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Notify via Slack of test-run outcome
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "CDN tests [${{ github.sha }}]"
+          status: ${{ needs.cdn-tests.result }}
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ github.sha }}
+          message: "CDN tests completed. Status: ${{ needs.cdn-tests.result }}"


### PR DESCRIPTION
Reinstates https://github.com/mozilla/bedrock/pull/13105 which was lost in a tragic rebasing moment before coffee 🙈 