### PR TITLE
Plug in mozmeao/github-asana-bridge so that we can make Asana Tasks from GH Issues

### DIFF
--- a/.github/workflows/github_asana_bridge.yaml
+++ b/.github/workflows/github_asana_bridge.yaml
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: "Github-Asana bridge"
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  handle_issue:
+    runs-on: ubuntu-latest
+    name: "Trigger after specific GH label was added"
+    if: github.event.label.name == 'Asana'
+    steps:
+      - id: run-bridger
+        uses: mozmeao/asana-github-bridge@v1
+        with:
+            only-react-to: repo-org
+            ASANA_PAT: ${{ secrets.ASANA_PAT }}
+            ASANA_PROJECT: ${{ secrets.ASANA_PROJECT }}
+            REPO_TOKEN: ${{ secrets.ASANA_GITHUB_BRIDGE_TOKEN }}


### PR DESCRIPTION
The relevant secrets have already been added to the repo secrets and the 'Asana' label has been made


