### PR TITLE
Pass coupon URL parameter to FxA subscription links (Fixes #13043)

### DIFF
--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -253,7 +253,7 @@ button in the main navigation that links to the ``/products/vpn/`` landing page.
 
 In scenarios such as this we want to understand how many people click the link in the
 navigation and go on to signup / subscribe to :abbr:`VPN (Virtual Private Network)`. To achieve this, we have some
-additional logic in ``fxa-utm-referral.js`` that will check for a specific cookie
+additional logic in ``fxa-attribution.js`` that will check for a specific cookie
 that gets set when someone clicks a specific referral link.
 
 To create a Mozilla :abbr:`VPN (Virtual Private Network)` referral link, you can use the ``vpn_product_referral_link`` helper:
@@ -289,7 +289,7 @@ The helper supports the following parameters:
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 
 When someone clicks the link a cookie gets set with a 1 hour expiry. The
-``fxa-utm-referral.js`` script will then check for the existence of this
+``fxa-attribution.js`` script will then check for the existence of this
 cookie on page load and update the product landing page subscription links
 with utm parameters that attribute where the click came from.
 
@@ -352,7 +352,7 @@ Tracking External Referrers
 If the URL of a bedrock page contains existing :abbr:`UTM (Urchin Tracking Module)` parameters on page load, bedrock will
 attempt to automatically use those values to replace the inline UTM parameters in Firefox Account and Mozilla
 :abbr:`VPN (Virtual Private Network)` links. This is handled using a client side script in the
-site common bundle which can be found in ``/media/js/base/fxa-utm-referral.js``.
+site common bundle which can be found in ``/media/js/base/fxa-attribution.js``.
 
 The behavior is as follows:
 

--- a/media/js/base/fxa-bundle-init.es6.js
+++ b/media/js/base/fxa-bundle-init.es6.js
@@ -4,13 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import FxALink from './fxa-link.es6.js';
-import FxAUtm from './fxa-utm.es6.js';
+import FxaLink from './fxa-link.es6.js';
+import FxaAttribution from './fxa-attribution.es6.js';
 
 const urlParams = new window._SearchParams();
 
 // Track external URL parameter referrals for Firefox Account links.
-FxAUtm.init(urlParams.params);
+FxaAttribution.init(urlParams.params);
 
 // Configure Firefox Account links for Sync on desktop.
-FxALink.init();
+FxaLink.init();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1673,7 +1673,7 @@
     {
       "files": [
         "js/base/fxa-link.es6.js",
-        "js/base/fxa-utm.es6.js",
+        "js/base/fxa-attribution.es6.js",
         "js/base/fxa-bundle-init.es6.js"
       ],
       "name": "fxa"

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = function (config) {
             'tests/unit/spec/base/experiment-utils.js',
             'tests/unit/spec/base/fxa-form.js',
             'tests/unit/spec/base/fxa-link.js',
-            'tests/unit/spec/base/fxa-utm.js',
+            'tests/unit/spec/base/fxa-attribution.js',
             'tests/unit/spec/base/mozilla-banner.js',
             'tests/unit/spec/base/mozilla-client.js',
             'tests/unit/spec/base/fxa-product-button.js',

--- a/tests/unit/spec/base/fxa-attribution.js
+++ b/tests/unit/spec/base/fxa-attribution.js
@@ -9,9 +9,9 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-import FxaUtm from '../../../../media/js/base/fxa-utm.es6.js';
+import FxaAttribution from '../../../../media/js/base/fxa-attribution.es6.js';
 
-describe('fxa-utm.js', function () {
+describe('fxa-attribution.js', function () {
     beforeEach(function () {
         window.Mozilla.dntEnabled = sinon.stub();
     });
@@ -25,50 +25,20 @@ describe('fxa-utm.js', function () {
             const url3 =
                 'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=source-one&utm_campaign=campaign-one';
 
-            expect(FxaUtm.getHostName(url1)).toEqual(
+            expect(FxaAttribution.getHostName(url1)).toEqual(
                 'https://monitor.firefox.com/'
             );
-            expect(FxaUtm.getHostName(url2)).toEqual(
+            expect(FxaAttribution.getHostName(url2)).toEqual(
                 'https://accounts.firefox.com/'
             );
-            expect(FxaUtm.getHostName(url3)).toEqual('https://getpocket.com/');
+            expect(FxaAttribution.getHostName(url3)).toEqual(
+                'https://getpocket.com/'
+            );
         });
 
         it('should return null if no match is found', function () {
             const url = 'thedude';
-            expect(FxaUtm.getHostName(url)).toBeNull();
-        });
-    });
-
-    describe('hasUtmParams', function () {
-        it('should return true when utm params are present', function () {
-            const data = {
-                utm_source: 'vpn-client',
-                utm_content: 'download-first-experiment',
-                utm_medium: 'referral',
-                entrypoint_experiment: 'test-id',
-                entrypoint_variation: 'test-variation'
-            };
-
-            expect(FxaUtm.hasUtmParams(data)).toBeTruthy();
-        });
-
-        it('should return false when utm params are not present', function () {
-            const data = {
-                entrypoint_experiment: 'test-id',
-                entrypoint_variation: 'test-variation'
-            };
-
-            expect(FxaUtm.hasUtmParams(data)).toBeFalsy();
-        });
-
-        it('should return false when data is not a valid object', function () {
-            const data1 = undefined;
-            expect(FxaUtm.hasUtmParams(data1)).toBeFalsy();
-            const data2 = null;
-            expect(FxaUtm.hasUtmParams(data2)).toBeFalsy();
-            const data3 = {};
-            expect(FxaUtm.hasUtmParams(data3)).toBeFalsy();
+            expect(FxaAttribution.getHostName(url)).toBeNull();
         });
     });
 
@@ -90,7 +60,9 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'F100_4242_otherstuff_in_here'
             };
 
-            expect(FxaUtm.getAttributionData(validObj)).toEqual(validData);
+            expect(FxaAttribution.getAttributionData(validObj)).toEqual(
+                validData
+            );
         });
 
         it('should return a additional entrypoint params if present', function () {
@@ -114,7 +86,9 @@ describe('fxa-utm.js', function () {
                 entrypoint_variation: 'test-variation'
             };
 
-            expect(FxaUtm.getAttributionData(validObj)).toEqual(validData);
+            expect(FxaAttribution.getAttributionData(validObj)).toEqual(
+                validData
+            );
         });
 
         it('should return entrypoint params if not utms are present', function () {
@@ -128,7 +102,9 @@ describe('fxa-utm.js', function () {
                 entrypoint_variation: 'test-variation'
             };
 
-            expect(FxaUtm.getAttributionData(validObj)).toEqual(validData);
+            expect(FxaAttribution.getAttributionData(validObj)).toEqual(
+                validData
+            );
         });
 
         it('should return FxA flow params if present together with experiment entrypoint params', function () {
@@ -158,7 +134,9 @@ describe('fxa-utm.js', function () {
                 flow_begin_time: '1234567899'
             };
 
-            expect(FxaUtm.getAttributionData(validObj)).toEqual(validData);
+            expect(FxaAttribution.getAttributionData(validObj)).toEqual(
+                validData
+            );
         });
 
         it('should not return FxA flow params if experiment entrypoint params are also not present', function () {
@@ -181,18 +159,12 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'F100_4242_otherstuff_in_here'
             };
 
-            expect(FxaUtm.getAttributionData(validObj)).toEqual(validData);
+            expect(FxaAttribution.getAttributionData(validObj)).toEqual(
+                validData
+            );
         });
 
-        it('should return null if source attribute is non-specific', function () {
-            const validObj = {
-                source: 'the-dude'
-            };
-
-            expect(FxaUtm.getAttributionData(validObj)).toBeNull();
-        });
-
-        it('should return an object without any danagerous params', function () {
+        it('should return an object without any dangerous params', function () {
             const dangerousSource = {
                 utm_source: 'www.mozilla.org',
                 utm_campaign: 'rel-esr',
@@ -204,12 +176,12 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'rel-esr'
             };
 
-            expect(FxaUtm.getAttributionData(dangerousSource)).toEqual(
+            expect(FxaAttribution.getAttributionData(dangerousSource)).toEqual(
                 safeSource
             );
         });
 
-        it('should not return an object if all params are unsafe', function () {
+        it('should return an empty object if all params are unsafe', function () {
             const dangerousData = {
                 utm_source: '%5C',
                 utm_content: '%3C',
@@ -218,10 +190,11 @@ describe('fxa-utm.js', function () {
                 utm_campaign: '%22'
             };
 
-            expect(FxaUtm.getAttributionData(dangerousData)).toBeNull();
+            const result = FxaAttribution.getAttributionData(dangerousData);
+            expect(Object.keys(result).length).toEqual(0);
         });
 
-        it('should not return an object if utm_source is missing', function () {
+        it('should return an empty object if utm_source is missing', function () {
             const data = {
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
@@ -229,10 +202,11 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'F100_4242_otherstuff_in_here'
             };
 
-            expect(FxaUtm.getAttributionData(data)).toBeNull();
+            const result = FxaAttribution.getAttributionData(data);
+            expect(Object.keys(result).length).toEqual(0);
         });
 
-        it('should not return an object if utm_campaign is missing', function () {
+        it('should return an empty object if utm_campaign is missing', function () {
             const data = {
                 utm_source: 'desktop-snippet',
                 utm_content: 'rel-esr',
@@ -240,7 +214,8 @@ describe('fxa-utm.js', function () {
                 utm_term: 4242
             };
 
-            expect(FxaUtm.getAttributionData(data)).toBeNull();
+            const result = FxaAttribution.getAttributionData(data);
+            expect(Object.keys(result).length).toEqual(0);
         });
 
         it('should not strip allowed special characters', function () {
@@ -258,7 +233,7 @@ describe('fxa-utm.js', function () {
                 utm_term: '/'
             };
 
-            expect(FxaUtm.getAttributionData(specialData)).toEqual(
+            expect(FxaAttribution.getAttributionData(specialData)).toEqual(
                 specialSource
             );
         });
@@ -274,7 +249,7 @@ describe('fxa-utm.js', function () {
                 utm_campaign: '/'
             };
 
-            expect(FxaUtm.getAttributionData(encodedData)).toEqual(
+            expect(FxaAttribution.getAttributionData(encodedData)).toEqual(
                 encodedSource
             );
         });
@@ -291,13 +266,13 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'fxa'
             };
 
-            expect(FxaUtm.getAttributionData(encodedData)).toEqual(
+            expect(FxaAttribution.getAttributionData(encodedData)).toEqual(
                 encodedSource
             );
         });
     });
 
-    describe('appendToDownloadURL', function () {
+    describe('appendToProductURL', function () {
         it("should append a new query string if there isn't one", function () {
             const data = {
                 utm_source: 'desktop-snippet',
@@ -309,7 +284,7 @@ describe('fxa-utm.js', function () {
 
             const url = 'https://accounts.firefox.com/';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?utm_source=desktop-snippet&utm_content=rel-esr&utm_medium=referral&utm_term=4242&utm_campaign=F100_4242_otherstuff_in_here'
             );
         });
@@ -321,7 +296,7 @@ describe('fxa-utm.js', function () {
 
             const url = 'https://accounts.firefox.com/?spice=pumpkin';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?spice=pumpkin&utm_source=test-source'
             );
         });
@@ -338,7 +313,7 @@ describe('fxa-utm.js', function () {
             const url =
                 'https://accounts.firefox.com/?utm_medium=medium-one&utm_term=term-one&utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?utm_source=source-two&utm_content=content-two&utm_medium=medium-two&utm_term=term-two&utm_campaign=campaign-two'
             );
         });
@@ -355,7 +330,7 @@ describe('fxa-utm.js', function () {
             const url =
                 'https://accounts.firefox.com/?utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?utm_source=source-two&utm_content=content-two&utm_medium=medium-two&utm_term=term-two&utm_campaign=campaign-two'
             );
         });
@@ -369,7 +344,7 @@ describe('fxa-utm.js', function () {
             const url =
                 'https://accounts.firefox.com/?utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?utm_source=source-two&utm_campaign=campaign-two'
             );
         });
@@ -382,7 +357,7 @@ describe('fxa-utm.js', function () {
             const url =
                 'https://accounts.firefox.com:8000/grande/nofat.html?spice=pumpkin';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com:8000/grande/nofat.html?spice=pumpkin&utm_source=test-source'
             );
         });
@@ -400,7 +375,7 @@ describe('fxa-utm.js', function () {
 
             const url = 'https://accounts.firefox.com/';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?utm_source=desktop-snippet&utm_content=rel-esr&utm_medium=referral&utm_term=4242&utm_campaign=F100_4242_otherstuff_in_here&entrypoint_experiment=test-id&entrypoint_variation=test-variation'
             );
         });
@@ -414,8 +389,21 @@ describe('fxa-utm.js', function () {
             const url =
                 'https://accounts.firefox.com/?utm_medium=medium-one&utm_term=term-one&utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
 
-            expect(FxaUtm.appendToDownloadURL(url, data)).toEqual(
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
                 'https://accounts.firefox.com/?utm_medium=medium-one&utm_term=term-one&utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one&entrypoint_experiment=test-id&entrypoint_variation=test-variation'
+            );
+        });
+
+        it('should append coupon parameter when present', function () {
+            const data = {
+                coupon: 'test'
+            };
+
+            const url =
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing';
+
+            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing&coupon=test'
             );
         });
     });
@@ -437,7 +425,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -455,7 +443,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -473,7 +461,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -490,7 +478,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -509,7 +497,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -526,7 +514,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -543,30 +531,7 @@ describe('fxa-utm.js', function () {
             ];
 
             supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(null, domain)).toEqual(
-                    expected
-                );
-            });
-        });
-
-        it('should return search referral data along with other valid referral data', function () {
-            const params = {
-                entrypoint_experiment: 'test-experiment',
-                entrypoint_variation: 'test-variation'
-            };
-            const expected = {
-                utm_medium: 'organic',
-                utm_source: 'naver',
-                entrypoint_experiment: 'test-experiment',
-                entrypoint_variation: 'test-variation'
-            };
-            const supportedDomains = [
-                'https://search.naver.com',
-                'https://search.naver.com/search.naver?query=firefox'
-            ];
-
-            supportedDomains.forEach((domain) => {
-                expect(FxaUtm.getSearchReferralData(params, domain)).toEqual(
+                expect(FxaAttribution.getSearchReferralData(domain)).toEqual(
                     expected
                 );
             });
@@ -578,9 +543,11 @@ describe('fxa-utm.js', function () {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
             spyOn(Mozilla.Cookies, 'setItem');
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(false);
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                false
+            );
 
-            FxaUtm.setFxALinkReferralCookie('navigation');
+            FxaAttribution.setFxALinkReferralCookie('navigation');
 
             expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(
                 'fxa-product-referral-id',
@@ -597,9 +564,11 @@ describe('fxa-utm.js', function () {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
             spyOn(Mozilla.Cookies, 'setItem');
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(true);
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                true
+            );
 
-            FxaUtm.setFxALinkReferralCookie('navigation');
+            FxaAttribution.setFxALinkReferralCookie('navigation');
 
             expect(Mozilla.Cookies.setItem).not.toHaveBeenCalled();
         });
@@ -610,15 +579,13 @@ describe('fxa-utm.js', function () {
             // assume cookie are enabled.
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
 
-            // assume DNT is disabled
-            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
-
             // link to change
             const links = `<div id="test-links">
                     <a id="test-expected" class="js-fxa-cta-link" href="https://accounts.firefox.com/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Firefox Account</a>
                     <a id="test-not-accounts" class="js-fxa-cta-link" href="https://www.mozilla.org/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Firefox Account</a>
                     <a id="test-second-expected" class="js-fxa-cta-link" href="https://monitor.firefox.com/oauth/init?form_type=button&amp;entrypoint=mozilla.org-firefox-accounts&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Sign In to Firefox Monitor</a>
                     <a id="test-third-expected" class="js-fxa-cta-link" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral">Activate Pocket</a>
+                    <a id="test-subscription" class="js-vpn-cta-link" href="https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&amp;entrypoint=www.mozilla.org-vpn-product-page&amp;form_type=button&amp;service=e6eb0d1e856335fc&amp;utm_source=www.mozilla.org-vpn-product-page&amp;utm_medium=referral&amp;utm_campaign=vpn-product-page&amp;data_cta_position=pricing">Get Mozilla VPN</a>
                 </div>`;
 
             document.body.insertAdjacentHTML('beforeend', links);
@@ -629,7 +596,7 @@ describe('fxa-utm.js', function () {
             content.parentNode.removeChild(content);
         });
 
-        it('should update the href of links with class js-fxa-cta-link', function () {
+        it('should update UTM parameters on links with class js-fxa-cta-link and js-vpn-cta-link', function () {
             const data = {
                 utm_source: 'source-two',
                 utm_content: 'content-two',
@@ -638,7 +605,7 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'campaign-two'
             };
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');
@@ -650,6 +617,8 @@ describe('fxa-utm.js', function () {
                 'test-third-expected'
             );
             const thirdExpectedHref = thirdExpected.getAttribute('href');
+            const fourthExpected = document.getElementById('test-subscription');
+            const fourthExpectedHref = fourthExpected.getAttribute('href');
 
             expect(expectedHref).toEqual(
                 'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two'
@@ -660,12 +629,15 @@ describe('fxa-utm.js', function () {
             expect(thirdExpectedHref).toEqual(
                 'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two'
             );
+            expect(fourthExpectedHref).toEqual(
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&data_cta_position=pricing&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two'
+            );
         });
 
         it('should not make changes if there are no UTM params', function () {
             const data = {};
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');
@@ -684,7 +656,7 @@ describe('fxa-utm.js', function () {
                 utm_campaign: 'campaign-two'
             };
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const unexpected = document.getElementById('test-not-accounts');
             const unexpectedHref = unexpected.getAttribute('href');
@@ -694,12 +666,165 @@ describe('fxa-utm.js', function () {
             );
         });
 
+        it('should pass experimental parameters to FxA links', function () {
+            const data = {
+                entrypoint_experiment: 'test-experiment',
+                entrypoint_variation: 'test-variation',
+                device_id: '10646c078bb9484585971c1451fc2ab2',
+                flow_begin_time: '1683735311599',
+                flow_id:
+                    '2f8d4301abb8b864ff76ee9058e5cdc1e727fe286ad6ea47a698fd430c4d3222'
+            };
+
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                false
+            );
+            spyOn(FxaAttribution, 'getSearchReferralData').and.returnValue(
+                null
+            );
+
+            FxaAttribution.init(data);
+
+            const expected = document.getElementById('test-expected');
+            const expectedHref = expected.getAttribute('href');
+            const secondExpected = document.getElementById(
+                'test-second-expected'
+            );
+            const secondExpectedHref = secondExpected.getAttribute('href');
+            const thirdExpected = document.getElementById(
+                'test-third-expected'
+            );
+            const thirdExpectedHref = thirdExpected.getAttribute('href');
+            const fourthExpected = document.getElementById('test-subscription');
+            const fourthExpectedHref = fourthExpected.getAttribute('href');
+
+            const unexpected = document.getElementById('test-not-accounts');
+            const unexpectedHref = unexpected.getAttribute('href');
+
+            expect(expectedHref).toEqual(
+                'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page&device_id=10646c078bb9484585971c1451fc2ab2&flow_id=2f8d4301abb8b864ff76ee9058e5cdc1e727fe286ad6ea47a698fd430c4d3222&flow_begin_time=1683735311599&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(secondExpectedHref).toEqual(
+                'https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page&device_id=10646c078bb9484585971c1451fc2ab2&flow_id=2f8d4301abb8b864ff76ee9058e5cdc1e727fe286ad6ea47a698fd430c4d3222&flow_begin_time=1683735311599&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(thirdExpectedHref).toEqual(
+                'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral&device_id=10646c078bb9484585971c1451fc2ab2&flow_id=2f8d4301abb8b864ff76ee9058e5cdc1e727fe286ad6ea47a698fd430c4d3222&flow_begin_time=1683735311599&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(fourthExpectedHref).toEqual(
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing&device_id=10646c078bb9484585971c1451fc2ab2&flow_id=2f8d4301abb8b864ff76ee9058e5cdc1e727fe286ad6ea47a698fd430c4d3222&flow_begin_time=1683735311599&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(unexpectedHref).toEqual(
+                'https://www.mozilla.org/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
+            );
+        });
+
+        it('should pass coupon parameter only to FxA subscription links', function () {
+            const data = {
+                coupon: 'test'
+            };
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                false
+            );
+            spyOn(FxaAttribution, 'getSearchReferralData').and.returnValue(
+                null
+            );
+
+            FxaAttribution.init(data);
+
+            const expected = document.getElementById('test-expected');
+            const expectedHref = expected.getAttribute('href');
+            const secondExpected = document.getElementById(
+                'test-second-expected'
+            );
+            const secondExpectedHref = secondExpected.getAttribute('href');
+            const thirdExpected = document.getElementById(
+                'test-third-expected'
+            );
+            const thirdExpectedHref = thirdExpected.getAttribute('href');
+            const fourthExpected = document.getElementById('test-subscription');
+            const fourthExpectedHref = fourthExpected.getAttribute('href');
+
+            const unexpected = document.getElementById('test-not-accounts');
+            const unexpectedHref = unexpected.getAttribute('href');
+
+            expect(expectedHref).toEqual(
+                'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
+            );
+            expect(secondExpectedHref).toEqual(
+                'https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
+            );
+            expect(thirdExpectedHref).toEqual(
+                'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral'
+            );
+            expect(fourthExpectedHref).toEqual(
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing&coupon=test'
+            );
+            expect(unexpectedHref).toEqual(
+                'https://www.mozilla.org/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
+            );
+        });
+
+        it('should handle padding all accepted query parameters together', function () {
+            const data = {
+                utm_source: 'source-two',
+                utm_content: 'content-two',
+                utm_medium: 'medium-two',
+                utm_term: 'term-two',
+                utm_campaign: 'campaign-two',
+                entrypoint_experiment: 'test-experiment',
+                entrypoint_variation: 'test-variation',
+                coupon: 'test'
+            };
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                false
+            );
+            spyOn(FxaAttribution, 'getSearchReferralData').and.returnValue(
+                null
+            );
+
+            FxaAttribution.init(data);
+
+            const expected = document.getElementById('test-expected');
+            const expectedHref = expected.getAttribute('href');
+            const secondExpected = document.getElementById(
+                'test-second-expected'
+            );
+            const secondExpectedHref = secondExpected.getAttribute('href');
+            const thirdExpected = document.getElementById(
+                'test-third-expected'
+            );
+            const thirdExpectedHref = thirdExpected.getAttribute('href');
+            const fourthExpected = document.getElementById('test-subscription');
+            const fourthExpectedHref = fourthExpected.getAttribute('href');
+
+            const unexpected = document.getElementById('test-not-accounts');
+            const unexpectedHref = unexpected.getAttribute('href');
+
+            expect(expectedHref).toEqual(
+                'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(secondExpectedHref).toEqual(
+                'https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(thirdExpectedHref).toEqual(
+                'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
+            );
+            expect(fourthExpectedHref).toEqual(
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&data_cta_position=pricing&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation&coupon=test'
+            );
+            expect(unexpectedHref).toEqual(
+                'https://www.mozilla.org/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
+            );
+        });
+
         it('should get referral cookie data if there are no UTM params', function () {
             const data = {};
             spyOn(Mozilla.Cookies, 'getItem').and.returnValue('navigation');
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(true);
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                true
+            );
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');
@@ -712,9 +837,11 @@ describe('fxa-utm.js', function () {
         it('should set expected values for in-product /whatsnew page referrals', function () {
             const data = {};
             spyOn(Mozilla.Cookies, 'getItem').and.returnValue('whatsnew92');
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(true);
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                true
+            );
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');
@@ -727,9 +854,11 @@ describe('fxa-utm.js', function () {
         it('should set expected values for in-product /welcome page referrals', function () {
             const data = {};
             spyOn(Mozilla.Cookies, 'getItem').and.returnValue('welcome12');
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(true);
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                true
+            );
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');
@@ -745,27 +874,31 @@ describe('fxa-utm.js', function () {
                 entrypoint_variation: 'test-variation'
             };
             spyOn(Mozilla.Cookies, 'getItem').and.returnValue('navigation');
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(true);
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                true
+            );
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');
 
             expect(expectedHref).toEqual(
-                'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=www.mozilla.org&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation&utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=navigation'
+                'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=www.mozilla.org&utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=navigation&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
             );
         });
 
         it('should pass through search referral data if there are no UTM params present in the page', function () {
             const data = {};
-            spyOn(FxaUtm, 'hasFxALinkReferralCookie').and.returnValue(false);
-            spyOn(FxaUtm, 'getSearchReferralData').and.returnValue({
+            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
+                false
+            );
+            spyOn(FxaAttribution, 'getSearchReferralData').and.returnValue({
                 utm_medium: 'organic',
                 utm_source: 'google'
             });
 
-            FxaUtm.init(data);
+            FxaAttribution.init(data);
 
             const expected = document.getElementById('test-expected');
             const expectedHref = expected.getAttribute('href');


### PR DESCRIPTION
## One-line summary

Adds support for automated coupon passing to the VPN landing page.

## Significant changes and points to review

This started out simpler, but I took the opportunity to do a bit of a refactor that should hopefully simplify making more changes like this in the future. I also renamed `fxa-utm.js` to `fxa-attribution.js`, since the file has (for a while now) handled more than just UTM passing.

Also updated our test coverage 

## Issue / Bugzilla link

#13043

## Testing

Open each of the following URLs below, scroll down to the pricing section and inspect the "Get 12-month plan" link `href`. Then verify that the `coupon` parameter and any additional parameters are passed through to the subscription link.

- [x] https://www-demo1.allizom.org/en-US/products/vpn/?coupon=FIREFOX105 (coupon only)
- [x] https://www-demo1.allizom.org/en-US/products/vpn/?utm_source=test&utm_campaign=test&coupon=FIREFOX105 (coupon and utm)
- [x] https://www-demo1.allizom.org/en-US/products/vpn/?utm_source=test&utm_campaign=test (utm only)
- [x] https://www-demo1.allizom.org/en-US/products/vpn/?entrypoint_experiment=test&entrypoint_variation=test&coupon=test (coupon and experiment params)
- [x] https://www-demo1.allizom.org/en-US/products/vpn/?entrypoint_experiment=test&entrypoint_variation=test (experiment params only)
- [x] https://www-demo1.allizom.org/en-US/products/vpn/?entrypoint_experiment=test&entrypoint_variation=test&coupon=test&utm_source=test&utm_campaign=test (everything together)

Additional test:

Open https://www-demo1.allizom.org/en-US/firefox/113.0/whatsnew/?geo=gb and click "Get Mozilla VPN".

- [x] Verify that the "Get 12-month plan" link contains `utm_source=www.mozilla.org-whatsnew&utm_medium=referral&utm_campaign=whatsnew-113-eu`. (note: you may need to clear cookies after this test to reset).