### PR TITLE
Add Relay FAQ Page

### DIFF
--- a/bedrock/products/templates/products/relay/base.html
+++ b/bedrock/products/templates/products/relay/base.html
@@ -6,6 +6,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% block page_desc %}{{ ftl('meta-description-2')}}{% endblock %}
+
 {% block page_title_suffix %} — {{ ftl('relay-shared-product-name') }}{% endblock %}
 
 {% block page_image %}{{ static('img/products/relay/social-share.png') }}{% endblock %}

--- a/bedrock/products/templates/products/relay/faq.html
+++ b/bedrock/products/templates/products/relay/faq.html
@@ -1,0 +1,214 @@
+{#
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/relay/base.html" %}
+
+{% block page_css %}
+  {{ css_bundle('relay-faq') }}
+{% endblock %}
+
+{% block sub_navigation %}
+  {% include 'products/relay/includes/subnav.html' %}
+{% endblock %}
+
+{% block content %}
+  <main class="c-relay-faq-wrapper mzp-t-dark">
+    <div class="mzp-l-content">
+      <h1>{{ ftl('faq-headline') }}</h1>
+      <div class="column-wrapper">
+        <div class="column">
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-what-is-question-2') }}</h3>
+            <p> {{ ftl('faq-question-what-is-answer-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-missing-emails-question-2') }}</h3>
+            <p> {{ ftl('faq-question-missing-emails-answer-a-2') }} </p>
+            <ul class="mzp-u-list-styled">
+              <li>{{ ftl('faq-question-missing-emails-answer-reason-spam') }}</li>
+              <li>{{ ftl('faq-question-missing-emails-answer-reason-blocked-2') }}</li>
+              <li>{{ ftl('faq-question-missing-emails-answer-reason-size') }}</li>
+              <li>{{ ftl('faq-question-missing-emails-answer-reason-not-accepted-2') }}</li>
+              <li>{{ ftl('faq-question-missing-emails-answer-reason-turned-off-2') }}</li>
+              <li>{{ ftl('faq-question-missing-emails-answer-reason-delay') }}</li>
+            </ul>
+            <p>{{ ftl('faq-question-missing-emails-answer-support-site-html', url='https://support.mozilla.org/products/relay', attrs='target="_blank" rel="noopener noreferrer"') }}</p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-use-cases-question-2') }}</h3>
+            <p> {{ ftl('faq-question-use-cases-answer-part1-2') }} </p>
+            <p> {{ ftl('faq-question-use-cases-answer-part2-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-2-question-2') }}</h3>
+            <p> {{ ftl('faq-question-2-answer-v4') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-1-question') }}</h3>
+            <p> {{ ftl('faq-question-1-answer-a-2') }} </p>
+            <p>{{ ftl('faq-question-1-answer-b-2-html', url='https://addons.mozilla.org/firefox/addon/private-relay/', attrs='target="_blank" rel="noopener noreferrer"') }}</p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-availability-question') }}</h3>
+            <p> {{ ftl('faq-question-availability-answer-v2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-4-question-2') }}</h3>
+            <p> {{ ftl('faq-question-4-answer-v4') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-subdomain-characters-question') }}</h3>
+            <p> {{ ftl('faq-question-subdomain-characters-answer-v2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-browser-support-question') }}</h3>
+            <p> {{ ftl('faq-question-browser-support-answer-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-longevity-question') }}</h3>
+            <p> {{ ftl('faq-question-longevity-answer-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-mozmail-question-2') }}</h3>
+            <p> {{ ftl('faq-question-mozmail-answer-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-attachments-question') }}</h3>
+            <p> {{ ftl('faq-question-attachments-answer-v2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-unsubscribe-domain-question-2') }}</h3>
+            <p> {{ ftl('faq-question-unsubscribe-domain-answer-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-8-question') }}</h3>
+            <p> {{ ftl('faq-question-8-answer-3-html', url=url('privacy.notices.subscription-services')) }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-email-storage-question') }}</h3>
+            <p> {{ ftl('faq-question-email-storage-answer') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-acceptable-use-question') }}</h3>
+            <p> {{ ftl('faq-question-acceptable-use-answer-a-html', url=url('legal.terms.acceptable-use')) }}</p>
+            <ul class="mzp-u-list-styled">
+              <li>{{ ftl('faq-question-acceptable-use-answer-measure-account') }}</li>
+              <li>{{ ftl('faq-question-acceptable-use-answer-measure-unlimited-payment-2') }}</li>
+              <li>{{ ftl('faq-question-acceptable-use-answer-measure-rate-limit-2') }}</li>
+            </ul>
+            <p>{{ ftl('faq-question-acceptable-use-answer-b-html', url=url('legal.terms.subscription-services')) }}</p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-promotional-email-blocking-question') }}</h3>
+            <p> {{ ftl('faq-question-promotional-email-blocking-answer') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-detect-promotional-question') }}</h3>
+            <p> {{ ftl('faq-question-detect-promotional-answer') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-disable-trackerremoval-question') }}</h3>
+            <p> {{ ftl('faq-question-disable-trackerremoval-answer') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
+            <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
+          </section>
+        </div>
+        <div class="column">
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
+            <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('faq-question-trackerremoval-breakage-question') }}</h3>
+            <p> {{ ftl('faq-question-trackerremoval-breakage-answer-2') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-what-is') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-what-is') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-where-is') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-where-is') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-how-many') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-how-many') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-change-phone-mask') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-change-phone-mask') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-can-reply') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-can-reply') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-forwarded-texts') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-forwarded-texts') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-pictures') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-pictures') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-historical') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-historical') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-can-i-send') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-can-i-send') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-limit') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-limit') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-call-length') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-call-length') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-can-i-call') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-can-i-call') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-can-i-see') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-can-i-see') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-can-i-block') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-can-i-block') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-spam') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-spam') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-disable-logging') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-disable-logging') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-can-i-share') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-can-i-share') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-how-i-save-card') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-how-i-save-card') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-install-app') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-install-app') }} </p>
+          </section>
+          <section class="mzp-c-details">
+            <h3> {{ ftl('phone-masking-faq-question-data') }}</h3>
+            <p> {{ ftl('phone-masking-faq-answer-data', url=url('privacy.notices.subscription-services')) }} </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  </main>
+{% endblock %}

--- a/bedrock/products/templates/products/relay/faq.html
+++ b/bedrock/products/templates/products/relay/faq.html
@@ -10,6 +10,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   {{ css_bundle('relay-faq') }}
 {% endblock %}
 
+{% block page_title %}{{ ftl('faq-headline') }}{% endblock %}
+
 {% block sub_navigation %}
   {% include 'products/relay/includes/subnav.html' %}
 {% endblock %}
@@ -18,196 +20,194 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <main class="c-relay-faq-wrapper mzp-t-dark">
     <div class="mzp-l-content">
       <h1>{{ ftl('faq-headline') }}</h1>
-      <div class="column-wrapper">
-        <div class="column">
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-what-is-question-2') }}</h3>
-            <p> {{ ftl('faq-question-what-is-answer-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-missing-emails-question-2') }}</h3>
-            <p> {{ ftl('faq-question-missing-emails-answer-a-2') }} </p>
-            <ul class="mzp-u-list-styled">
-              <li>{{ ftl('faq-question-missing-emails-answer-reason-spam') }}</li>
-              <li>{{ ftl('faq-question-missing-emails-answer-reason-blocked-2') }}</li>
-              <li>{{ ftl('faq-question-missing-emails-answer-reason-size') }}</li>
-              <li>{{ ftl('faq-question-missing-emails-answer-reason-not-accepted-2') }}</li>
-              <li>{{ ftl('faq-question-missing-emails-answer-reason-turned-off-2') }}</li>
-              <li>{{ ftl('faq-question-missing-emails-answer-reason-delay') }}</li>
-            </ul>
-            <p>{{ ftl('faq-question-missing-emails-answer-support-site-html', url='https://support.mozilla.org/products/relay', attrs='target="_blank" rel="noopener noreferrer"') }}</p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-use-cases-question-2') }}</h3>
-            <p> {{ ftl('faq-question-use-cases-answer-part1-2') }} </p>
-            <p> {{ ftl('faq-question-use-cases-answer-part2-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-2-question-2') }}</h3>
-            <p> {{ ftl('faq-question-2-answer-v4') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-1-question') }}</h3>
-            <p> {{ ftl('faq-question-1-answer-a-2') }} </p>
-            <p>{{ ftl('faq-question-1-answer-b-2-html', url='https://addons.mozilla.org/firefox/addon/private-relay/', attrs='target="_blank" rel="noopener noreferrer"') }}</p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-availability-question') }}</h3>
-            <p> {{ ftl('faq-question-availability-answer-v2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-4-question-2') }}</h3>
-            <p> {{ ftl('faq-question-4-answer-v4') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-subdomain-characters-question') }}</h3>
-            <p> {{ ftl('faq-question-subdomain-characters-answer-v2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-browser-support-question') }}</h3>
-            <p> {{ ftl('faq-question-browser-support-answer-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-longevity-question') }}</h3>
-            <p> {{ ftl('faq-question-longevity-answer-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-mozmail-question-2') }}</h3>
-            <p> {{ ftl('faq-question-mozmail-answer-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-attachments-question') }}</h3>
-            <p> {{ ftl('faq-question-attachments-answer-v2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-unsubscribe-domain-question-2') }}</h3>
-            <p> {{ ftl('faq-question-unsubscribe-domain-answer-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-8-question') }}</h3>
-            <p> {{ ftl('faq-question-8-answer-3-html', url=url('privacy.notices.subscription-services')) }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-email-storage-question') }}</h3>
-            <p> {{ ftl('faq-question-email-storage-answer') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-acceptable-use-question') }}</h3>
-            <p> {{ ftl('faq-question-acceptable-use-answer-a-html', url=url('legal.terms.acceptable-use')) }}</p>
-            <ul class="mzp-u-list-styled">
-              <li>{{ ftl('faq-question-acceptable-use-answer-measure-account') }}</li>
-              <li>{{ ftl('faq-question-acceptable-use-answer-measure-unlimited-payment-2') }}</li>
-              <li>{{ ftl('faq-question-acceptable-use-answer-measure-rate-limit-2') }}</li>
-            </ul>
-            <p>{{ ftl('faq-question-acceptable-use-answer-b-html', url=url('legal.terms.subscription-services')) }}</p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-promotional-email-blocking-question') }}</h3>
-            <p> {{ ftl('faq-question-promotional-email-blocking-answer') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-detect-promotional-question') }}</h3>
-            <p> {{ ftl('faq-question-detect-promotional-answer') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-disable-trackerremoval-question') }}</h3>
-            <p> {{ ftl('faq-question-disable-trackerremoval-answer') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
-            <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
-          </section>
-        </div>
-        <div class="column">
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
-            <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('faq-question-trackerremoval-breakage-question') }}</h3>
-            <p> {{ ftl('faq-question-trackerremoval-breakage-answer-2') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-what-is') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-what-is') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-where-is') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-where-is') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-how-many') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-how-many') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-change-phone-mask') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-change-phone-mask') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-can-reply') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-can-reply') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-forwarded-texts') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-forwarded-texts') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-pictures') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-pictures') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-historical') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-historical') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-can-i-send') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-can-i-send') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-limit') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-limit') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-call-length') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-call-length') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-can-i-call') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-can-i-call') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-can-i-see') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-can-i-see') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-can-i-block') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-can-i-block') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-spam') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-spam') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-disable-logging') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-disable-logging') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-can-i-share') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-can-i-share') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-how-i-save-card') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-how-i-save-card') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-install-app') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-install-app') }} </p>
-          </section>
-          <section class="mzp-c-details">
-            <h3> {{ ftl('phone-masking-faq-question-data') }}</h3>
-            <p> {{ ftl('phone-masking-faq-answer-data', url=url('privacy.notices.subscription-services')) }} </p>
-          </section>
-        </div>
+      <div class="column">
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-what-is-question-2') }}</h3>
+          <p> {{ ftl('faq-question-what-is-answer-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-missing-emails-question-2') }}</h3>
+          <p> {{ ftl('faq-question-missing-emails-answer-a-2') }} </p>
+          <ul class="mzp-u-list-styled">
+            <li>{{ ftl('faq-question-missing-emails-answer-reason-spam') }}</li>
+            <li>{{ ftl('faq-question-missing-emails-answer-reason-blocked-2') }}</li>
+            <li>{{ ftl('faq-question-missing-emails-answer-reason-size') }}</li>
+            <li>{{ ftl('faq-question-missing-emails-answer-reason-not-accepted-2') }}</li>
+            <li>{{ ftl('faq-question-missing-emails-answer-reason-turned-off-2') }}</li>
+            <li>{{ ftl('faq-question-missing-emails-answer-reason-delay') }}</li>
+          </ul>
+          <p>{{ ftl('faq-question-missing-emails-answer-support-site-html', url='https://support.mozilla.org/products/relay', attrs='target="_blank" rel="noopener noreferrer"') }}</p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-use-cases-question-2') }}</h3>
+          <p> {{ ftl('faq-question-use-cases-answer-part1-2') }} </p>
+          <p> {{ ftl('faq-question-use-cases-answer-part2-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-2-question-2') }}</h3>
+          <p> {{ ftl('faq-question-2-answer-v4') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-1-question') }}</h3>
+          <p> {{ ftl('faq-question-1-answer-a-2') }} </p>
+          <p>{{ ftl('faq-question-1-answer-b-2-html', url='https://addons.mozilla.org/firefox/addon/private-relay/', attrs='target="_blank" rel="noopener noreferrer"') }}</p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-availability-question') }}</h3>
+          <p> {{ ftl('faq-question-availability-answer-v2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-4-question-2') }}</h3>
+          <p> {{ ftl('faq-question-4-answer-v4') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-subdomain-characters-question') }}</h3>
+          <p> {{ ftl('faq-question-subdomain-characters-answer-v2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-browser-support-question') }}</h3>
+          <p> {{ ftl('faq-question-browser-support-answer-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-longevity-question') }}</h3>
+          <p> {{ ftl('faq-question-longevity-answer-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-mozmail-question-2') }}</h3>
+          <p> {{ ftl('faq-question-mozmail-answer-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-attachments-question') }}</h3>
+          <p> {{ ftl('faq-question-attachments-answer-v2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-unsubscribe-domain-question-2') }}</h3>
+          <p> {{ ftl('faq-question-unsubscribe-domain-answer-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-8-question') }}</h3>
+          <p> {{ ftl('faq-question-8-answer-3-html', url=url('privacy.notices.subscription-services')) }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-email-storage-question') }}</h3>
+          <p> {{ ftl('faq-question-email-storage-answer') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-acceptable-use-question') }}</h3>
+          <p> {{ ftl('faq-question-acceptable-use-answer-a-html', url=url('legal.terms.acceptable-use')) }}</p>
+          <ul class="mzp-u-list-styled">
+            <li>{{ ftl('faq-question-acceptable-use-answer-measure-account') }}</li>
+            <li>{{ ftl('faq-question-acceptable-use-answer-measure-unlimited-payment-2') }}</li>
+            <li>{{ ftl('faq-question-acceptable-use-answer-measure-rate-limit-2') }}</li>
+          </ul>
+          <p>{{ ftl('faq-question-acceptable-use-answer-b-html', url=url('legal.terms.subscription-services')) }}</p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-promotional-email-blocking-question') }}</h3>
+          <p> {{ ftl('faq-question-promotional-email-blocking-answer') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-detect-promotional-question') }}</h3>
+          <p> {{ ftl('faq-question-detect-promotional-answer') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-disable-trackerremoval-question') }}</h3>
+          <p> {{ ftl('faq-question-disable-trackerremoval-answer') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
+          <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
+        </section>
+      </div>
+      <div class="column">
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
+          <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('faq-question-trackerremoval-breakage-question') }}</h3>
+          <p> {{ ftl('faq-question-trackerremoval-breakage-answer-2') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-what-is') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-what-is') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-where-is') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-where-is') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-how-many') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-how-many') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-change-phone-mask') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-change-phone-mask') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-can-reply') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-can-reply') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-forwarded-texts') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-forwarded-texts') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-pictures') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-pictures') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-historical') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-historical') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-can-i-send') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-can-i-send') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-limit') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-limit') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-call-length') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-call-length') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-can-i-call') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-can-i-call') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-can-i-see') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-can-i-see') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-can-i-block') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-can-i-block') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-spam') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-spam') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-disable-logging') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-disable-logging') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-can-i-share') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-can-i-share') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-how-i-save-card') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-how-i-save-card') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-install-app') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-install-app') }} </p>
+        </section>
+        <section class="mzp-c-details">
+          <h3> {{ ftl('phone-masking-faq-question-data') }}</h3>
+          <p> {{ ftl('phone-masking-faq-answer-data', url=url('privacy.notices.subscription-services')) }} </p>
+        </section>
       </div>
     </div>
   </main>

--- a/bedrock/products/templates/products/relay/faq.html
+++ b/bedrock/products/templates/products/relay/faq.html
@@ -20,7 +20,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <main class="c-relay-faq-wrapper mzp-t-dark">
     <div class="mzp-l-content">
       <h1>{{ ftl('faq-headline') }}</h1>
-      <div class="column">
+      <div class="columns">
         <section class="mzp-c-details">
           <h3> {{ ftl('faq-question-what-is-question-2') }}</h3>
           <p> {{ ftl('faq-question-what-is-answer-2') }} </p>
@@ -118,8 +118,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
           <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>
         </section>
-      </div>
-      <div class="column">
         <section class="mzp-c-details">
           <h3> {{ ftl('faq-question-bulk-trackerremoval-question') }}</h3>
           <p> {{ ftl('faq-question-bulk-trackerremoval-answer') }} </p>

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -48,4 +48,5 @@ if settings.DEV:
     urlpatterns += (
         path("relay/", views.relay_landing_page, name="products.relay.landing"),
         path("relay/invite/", views.relay_invite_page, name="products.relay.invite"),
+        page("relay/faq/", "products/relay/faq.html", ftl_files=["products/relay/shared", "products/relay/faq"]),
     )

--- a/l10n/en/products/relay/faq.ftl
+++ b/l10n/en/products/relay/faq.ftl
@@ -90,6 +90,73 @@ faq-question-disable-trackerremoval-answer = Yes. If you’re having trouble wit
 faq-question-bulk-trackerremoval-question = Can I remove trackers only on some of my email masks?
 faq-question-bulk-trackerremoval-answer = You can only turn tracker removal on at an account level — it either removes trackers from all of your emails, or none of them.
 faq-question-trackerremoval-breakage-question = Why do my emails look broken?
+faq-question-trackerremoval-breakage-answer-2 = Sometimes removing trackers may cause your email to look broken because the trackers are often contained within images and links. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.
+
+
+## Frequently Asked Questions about Phone plans
+phone-masking-faq-question-what-is = What is a phone number mask?
+phone-masking-faq-answer-what-is = Similar to an email mask, a phone number mask is a phone number that can forward texts and calls to your true phone number without revealing what your true number is to the person calling or texting you.
+
+phone-masking-faq-question-where-is = Where is phone masking available?
+phone-masking-faq-answer-where-is = At this time, phone number masking is only available in the United States and Canada. This means you can only receive forwarded calls and texts from US or Canadian numbers. We’re working on finding a way to offer phone number masking outside these two countries.
+
+phone-masking-faq-question-how-many = How many phone masks do I get?
+phone-masking-faq-answer-how-many = You only get one phone number mask at this time. Once you choose your phone number mask, you cannot change it later.
+
+phone-masking-faq-question-change-phone-mask = Can I change my phone mask?
+phone-masking-faq-answer-change-phone-mask = No, you cannot change your phone number mask once you’ve chosen it. We are exploring this option.
+
+phone-masking-faq-question-can-reply = Can I reply to texts?
+phone-masking-faq-answer-can-reply = Yes, you can reply to the last text you received. Just reply as you would for any text message.
+
+phone-masking-faq-question-forwarded-texts = What kinds of texts will be forwarded?
+phone-masking-faq-answer-forwarded-texts = Only SMS text messages can be forwarded. MMS texts that include photos, videos, etc. will not be forwarded.
+
+phone-masking-faq-question-pictures = Can I send or receive pictures via text?
+phone-masking-faq-answer-pictures = No, only SMS text messages can be forwarded or sent as replies.
+
+phone-masking-faq-question-historical = Can I reply to historical text messages?
+phone-masking-faq-answer-historical = You can’t currently reply to texts you received previously, though this feature is on the way.
+
+phone-masking-faq-question-can-i-send = Can I send a text without replying to one?
+phone-masking-faq-answer-can-i-send = No, you can’t yet send texts that aren’t replies. You can only reply to forwarded texts.
+
+phone-masking-faq-question-limit = Is there a limit to how many text messages I get?
+phone-masking-faq-answer-limit = You can receive and reply up to 75 text messages per month total. Any additional texts sent to your phone number mask will not be forwarded to your true number. Any additional replies will not be delivered. The month turns over on your billing date, not the calendar date. Once your billing month has turned over, you will start receiving text messages again.
+
+phone-masking-faq-question-call-length = How long can I talk when I get a call?
+phone-masking-faq-answer-call-length = Each month you get 50 minutes of talking. Once these minutes are used up, you won’t be able to receive forwarded calls until the next month on your billing cycle.
+
+phone-masking-faq-question-can-i-call = Can I call someone with my phone mask?
+phone-masking-faq-answer-can-i-call = No, you can only pick up a forwarded call.
+
+phone-masking-faq-question-can-i-see = Can I see who texted or called me?
+phone-masking-faq-answer-can-i-see = Yes, you can see the number that texted or called you. You can also disable the storage of these records, but you will lose the ability to reply to or block individual callers & texters.
+
+phone-masking-faq-question-can-i-block = Can I block a call or text?
+phone-masking-faq-answer-can-i-block = You can block all forwarding from a single number.
+
+phone-masking-faq-question-spam = What if my phone mask starts getting spam?
+phone-masking-faq-answer-spam = If you start getting spam, you can block the numbers sending you spam.
+
+phone-masking-faq-question-disable-logging = Can I disable the logging of callers or text senders?
+phone-masking-faq-answer-disable-logging = Yes, you can disable logging of numbers from the { -brand-name-relay } dashboard. However, you will no longer be able to reply to texts or block specific numbers, because the log is how we are able to track who sent you a text message.
+
+phone-masking-faq-question-can-i-share = Can I share the number that forwards me text messages?
+phone-masking-faq-answer-can-i-share = If you share this number, nothing will happen — this number is not your phone number mask. It is just the contact number from which { -brand-name-relay } will forward your texts and calls.
+
+phone-masking-faq-question-how-i-save-card = How do I save the { -brand-name-relay } contact card?
+phone-masking-faq-answer-how-i-save-card = Once you upgrade to { -brand-name-relay } phone number masking, we will text you a contact card that contains the number from which you will receive forwarded calls and texts, similar to any contact card that stores the phone number of people who contact you. On most devices, you can select that contact card and save it like any other contact on your phone.
+
+phone-masking-faq-question-install-app = Do I need to install an app to use { -brand-name-relay } phone masking?
+phone-masking-faq-answer-install-app = No, { -brand-name-relay } phone masking works using your device’s standard text messaging and calling apps.
+phone-masking-faq-question-data = What kinds of data does { -brand-name-relay } phone masking store?
+#   $url (url) - link to Firefox Relay's Privacy Policy, i.e. https://www.mozilla.org/privacy/firefox-relay/
+#   $attrs (string) - specific attributes added to external links
+phone-masking-faq-answer-data = Please see the <a href="{ $url }" { $attrs }>{ -brand-name-firefox-relay } Privacy Policy</a>.
+
+
 # Deprecated
 faq-question-trackerremoval-breakage-answer = Sometimes removing trackers may cause your email to look broken, because the trackers are often contained within images. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.
-faq-question-trackerremoval-breakage-answer-2 = Sometimes removing trackers may cause your email to look broken because the trackers are often contained within images and links. When the tracker is removed, the email looks like it’s been formatted wrong because images are missing. This can’t be fixed for emails you’ve already received. If this is preventing you from reading your emails properly, turn off tracker removal.
+phone-masking-faq-answer-forwarded-texts-2 = Only text messages can be forwarded. MMS texts that include photos, videos, etc. will not be forwarded.
+phone-masking-faq-answer-pictures-2 = No, only text messages can be forwarded or sent as replies.

--- a/l10n/en/products/relay/faq.ftl
+++ b/l10n/en/products/relay/faq.ftl
@@ -4,7 +4,6 @@
 
 ### URL: https://www-dev.allizom.org/products/relay/
 
-
 ## FAQ Page
 
 faq-headline = Frequently Asked Questions

--- a/l10n/en/products/relay/shared.ftl
+++ b/l10n/en/products/relay/shared.ftl
@@ -8,3 +8,6 @@ relay-shared-product-name = { -brand-name-firefox-relay }
 
 # Subnav strings
 relay-shared-subnav-title = { -brand-name-firefox-relay }
+
+# Page description
+meta-description-2 = { -brand-name-firefox-relay } makes it easy to create email masks that forward your messages to your true inbox. Use them to protect your online accounts from hackers and unwanted messages.

--- a/media/css/products/relay/faq.scss
+++ b/media/css/products/relay/faq.scss
@@ -10,14 +10,9 @@ $image-path: '/media/protocol/img';
 .c-relay-faq-wrapper {
     background-color: #09204d;
 
-    .column-wrapper {
-        display: grid;
-        grid-template-columns: 1fr;
+    .column {
+        columns: 2 432px;
         column-gap: $layout-lg;
-
-        @media #{$mq-lg} {
-            grid-template-columns: 1fr 1fr;
-        }
     }
 
     .is-summary {

--- a/media/css/products/relay/faq.scss
+++ b/media/css/products/relay/faq.scss
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.c-relay-faq-wrapper {
+    background-color: #09204d;
+
+    .column-wrapper {
+        display: grid;
+        grid-template-columns: 1fr;
+        column-gap: $layout-lg;
+
+        @media #{$mq-lg} {
+            grid-template-columns: 1fr 1fr;
+        }
+    }
+
+    .is-summary {
+        @include font-size(24px);
+
+        button::before {
+            background: $url-image-expand-white top left no-repeat;
+            @include background-size(24px, 24px);
+            @include bidi(((right, 8px, left, auto),));
+            @include transition(transform 100ms ease-in-out);
+            content: '';
+            height: 24px;
+            margin-top: -12px;
+            width: 24px;
+        }
+    }
+}

--- a/media/css/products/relay/faq.scss
+++ b/media/css/products/relay/faq.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 .c-relay-faq-wrapper {
     background-color: #09204d;
 
-    .column {
+    .columns {
         columns: 2 432px;
         column-gap: $layout-lg;
     }

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1272,6 +1272,12 @@
         "css/products/relay/landing.scss"
       ],
       "name": "relay-landing"
+    },
+    {
+      "files": [
+        "css/products/relay/faq.scss"
+      ],
+      "name": "relay-faq"
     }
   ],
   "js": [


### PR DESCRIPTION
## One-line summary

Adds the FAQ page from relay site to bedrock

## Significant changes and points to review

Relay URL: https://relay.firefox.com/faq/

Talked with Elise about using the protocol details component - so the page is not a 1:1 match

## Issue / Bugzilla link
#12932 

## Testing

Demo server URL: (or None)

To test this work:

- [ ] http://localhost:8000/products/relay/faq
