### PR TITLE
Docs search fixup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx_copybutton",
+    "sphinxcontrib.jquery",
     "myst_parser",
 ]
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -172,7 +172,7 @@ using ``zsh``, the ``pyenv`` docs have other routes ::
     $ brew install pyenv-virtualenv
 
 2. Configure your shell to init ``pyenv-virtualenv`` on start - again, this is noted in the
-``pyenv-virtualenv``project's `own documentation <https://github.com/pyenv/pyenv-virtualenv>`_,
+``pyenv-virtualenv`` project's `own documentation <https://github.com/pyenv/pyenv-virtualenv>`_,
 in more detail. The following will slot in a command that will work as long as you have
 pyenv-virtualenv installed::
 


### PR DESCRIPTION
## One-line summary

This changeset fixes search in our ReadTheDocs site 

## Significant changes and points to review

The workaround comes from https://github.com/readthedocs/sphinx_rtd_theme/issues/1452 which also references a potential longer-term fix 


## Issue / Bugzilla link

No ticket

## Testing

To test this work:

- [ ] locally, in your bedrock working dir, install the docs dependency (`make install-local-docs-deps`)
- [ ] `cd docs`
- [ ] `make livehtml` - this will open a localhost-run page
- [ ] Use the search box - eg search for `demo`
