### PR TITLE
Make L10N PR automation more robust + better documented

### DIFF
--- a/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
@@ -10,7 +10,8 @@ on:
     branches:
       - main
   workflow_dispatch:
-
+  schedule:
+    - cron: "0 0/3 * * *" # Every 3 hours
 
 jobs:
   open_l10n_pr:

--- a/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 0/3 * * *" # Every 3 hours
 
 jobs:
   open_l10n_pr:

--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -560,13 +560,24 @@ String extraction
 -----------------
 
 The string extraction process for both new .ftl content and updates to existing .ftl
-content is handled through automation. On each commit to main a command is run that
-looks for changes to the ``l10n/`` directory. If a change is detected, it will copy
+content is handled through automation. On each commit to ``main`` a command is run that
+looks for changes to the ``l10n/`` and ``l10n-pocket/`` directories. If a change is
+detected, it will copy
 those files into a new branch in `mozilla-l10n/www-l10n`_ and then a bot will open a
 pull request containing those changes. Once the pull request has been reviewed and
 merged by the L10n team, everything is done.
 
+To view the state of the latest automated attempt to open an L10N PR, see:
+
+* `Mozorg L10N PR action`_
+* `Pocket L10N PR action`_
+
+(We also just try to open L10N PRs every 3 hours, to catch any failed jobs that
+are triggered by a commit to ``main``)
+
 .. _mozilla-l10n/www-l10n: https://github.com/mozilla-l10n/www-l10n
+.. _Mozorg L10N PR action: https://github.com/mozilla/bedrock/actions/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+.. _Pocket L10N PR action: https://github.com/mozilla/bedrock/actions/workflows/send_pocket_fluent_strings_to_l10n_org.yml
 
 CSS
 ---


### PR DESCRIPTION
Since moving to GHA for opening L10N PRs, we've lost the (two) automatic retries that Gitlab supported, which came in handy when the L10N PR update failed. 

We're seeing more of those failures than expected, which I think is a race condition between the Docker image building vs the L10N automation happening - before it all happened in one place in GL, now it's spread across two places in GHA.

To deal with this, this changeset adds a schedule so that the tasks are run every three hours, just in case. The PR-opening script is idempotent, so can be run multiple times without creating duplicate FTL strings, etc 

I've also improved documentation a bit, including linking to the relevant automation in GH