### PR TITLE
Lint careers scss files

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -39,5 +39,5 @@
         "selector-not-notation": "simple",
         "media-feature-range-notation": "prefix"
     },
-    "ignoreFiles": ["media/css/libs/**/*", "media/css/careers/*"]
+    "ignoreFiles": ["media/css/libs/**/*"]
 }

--- a/media/css/careers/_utils.scss
+++ b/media/css/careers/_utils.scss
@@ -10,5 +10,5 @@ $purple-light: #d7d9f2;
 $teal-primary: #00b7aa;
 $teal-secondary: #84cfc8;
 $teal-tertiary: #d5edea;
-$blue-primary: #00ffff;
+$blue-primary: #0ff;
 $blue-secondary: #d4e9f8;


### PR DESCRIPTION
Looks like we were still ignoring careers CSS files in our stylelint config, from when we ported the pages over from the old careers site.