### PR TITLE
Fix layout overflow on enterprise page [fix #13130]

### DIFF
--- a/media/css/firefox/enterprise/landing.scss
+++ b/media/css/firefox/enterprise/landing.scss
@@ -218,12 +218,12 @@ $image-path: '/media/protocol/img';
 
 .enterprise-download-title {
     @include bidi((
-        (padding-left, $layout-lg, 0),
-        (padding-right, 0, $layout-lg),
+        (padding-left, $layout-md, 0),
+        (padding-right, 0, $layout-md),
     ));
-    @include text-title-sm;
+    @include text-title-xs;
     margin-bottom: $spacing-lg;
-    min-height: 48px;
+    min-height: 40px;
     position: relative;
 
     &::before {
@@ -232,25 +232,25 @@ $image-path: '/media/protocol/img';
         background-repeat: no-repeat;
         content: '';
         display: block;
-        height: 48px;
+        height: 40px;
         position: absolute;
         top: -8px;
-        width: 48px;
+        width: 40px;
     }
 
     .platform-win64 &::before {
         background-image: url('/media/img/firefox/enterprise/icon-win64.svg');
-        background-size: 39px 40px;
+        background-size: 35px 36px;
     }
 
     .platform-mac &::before {
         background-image: url('/media/img/firefox/enterprise/icon-mac.svg');
-        background-size: 32px 40px;
+        background-size: 29px 36px;
     }
 
     .platform-win32 &::before {
         background-image: url('/media/img/firefox/enterprise/icon-win32.svg');
-        background-size: 39px 40px;
+        background-size: 35px 36px;
     }
 }
 


### PR DESCRIPTION
## One-line summary

The columns were getting pushed wide because the size of the titles meant the word "Windows" plus the padding for the logo forced the column to be wider. We could also try moving the logos to make more room for the text but just reducing the text size (and shrinking the logos a bit as well) seems to work too. At the next smaller breakpoint it shifts to a stacked layout so it's just this in-between size where it's a problem.

## Issue / Bugzilla link

#13130 

## Screenshots

![image](https://github.com/mozilla/bedrock/assets/205591/efd580a9-9974-4b6a-931a-c22f7f0c289c)

## Testing

http://localhost:8000/firefox/enterprise/