### PR TITLE
remove absearch from scope, remove low severity issue from examples

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -140,11 +140,6 @@
 
   <p>Core websites pay out bounties, but at a reduced rate.</p>
 
-  <h3>ABSearch</h3>
-  <ul class="mzp-u-list-styled">
-    <li>search.services.mozilla.com</li>
-  </ul>
-
   <h3>Bedrock (www)</h3>
   <ul class="mzp-u-list-styled">
     <li>www.mozilla.org</li>

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -132,7 +132,6 @@
             <li>XSS (blocked by CSP)</li>
             <li>Clickjacking with demonstrated impact (Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty)</li>
             <li>External SSRF</li>
-            <li>EXIF Geolocation Data Not Stripped From Uploaded Images</li>
             <li>Open Redirects<sup>1</sup></li>
           </ul>
         </td>


### PR DESCRIPTION
## One-line summary

Remove absearch from scope since it is being deprecated. Also remove low severity issue from examples to prevent confusion about paying it.

