### PR TITLE
Persist FxA/VPN attribution over multiple page navigations (Fixes #13147)

### DIFF
--- a/tests/unit/spec/base/fxa-attribution.js
+++ b/tests/unit/spec/base/fxa-attribution.js
@@ -66,7 +66,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'desktop-snippet',
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here'
             };
 
@@ -88,7 +88,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'desktop-snippet',
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation'
@@ -130,7 +130,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'vpn-client',
                 utm_content: 'download-first-experiment',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation',
@@ -164,7 +164,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'desktop-snippet',
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 device_id: '45de19d8bc6845b1b7c121da2cb1cde2',
                 flow_id:
@@ -219,7 +219,7 @@ describe('fxa-attribution.js', function () {
             const data = {
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here'
             };
 
@@ -318,7 +318,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'vpn-client',
                 utm_content: 'download-first-experiment',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation',
@@ -340,7 +340,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'vpn-client',
                 utm_content: 'download-first-experiment',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation',
@@ -356,13 +356,22 @@ describe('fxa-attribution.js', function () {
             });
         });
 
-        it('should return referral data from storage if it exists', function () {
+        it('should return UTM referral data from storage if it exists', function () {
             const validObj = {
                 utm_source: 'vpn-client',
                 utm_content: 'download-first-experiment',
                 utm_medium: 'referral',
-                utm_term: 4242,
-                utm_campaign: 'F100_4242_otherstuff_in_here',
+                utm_term: '4242',
+                utm_campaign: 'F100_4242_otherstuff_in_here'
+            };
+
+            FxaAttribution.setReferralStorage(validObj);
+
+            expect(FxaAttribution.getAttributionData({})).toEqual(validObj);
+        });
+
+        it('should return experiment data from storage if it exists', function () {
+            const validObj = {
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation',
                 device_id: '45de19d8bc6845b1b7c121da2cb1cde2',
@@ -386,13 +395,20 @@ describe('fxa-attribution.js', function () {
             expect(FxaAttribution.getAttributionData({})).toEqual(validObj);
         });
 
-        it('should return both coupon and referral data from storage together', function () {
+        it('should return coupon, experiment and referral data from storage together', function () {
             const validObj1 = {
                 utm_source: 'vpn-client',
                 utm_content: 'download-first-experiment',
                 utm_medium: 'referral',
-                utm_term: 4242,
-                utm_campaign: 'F100_4242_otherstuff_in_here',
+                utm_term: '4242',
+                utm_campaign: 'F100_4242_otherstuff_in_here'
+            };
+
+            const validObj2 = {
+                coupon: 'test'
+            };
+
+            const validObj3 = {
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation',
                 device_id: '45de19d8bc6845b1b7c121da2cb1cde2',
@@ -401,15 +417,60 @@ describe('fxa-attribution.js', function () {
                 flow_begin_time: '1684417308435'
             };
 
+            FxaAttribution.setReferralStorage(validObj1);
+            FxaAttribution.setCouponStorage(validObj2);
+            FxaAttribution.setExperimentStorage(validObj3);
+
+            expect(FxaAttribution.getAttributionData({})).toEqual(
+                Object.assign(validObj1, validObj2, validObj3)
+            );
+        });
+
+        it('should add experiment data if there is already UTM referral data in storage', function () {
+            const validObj1 = {
+                utm_source: 'vpn-client',
+                utm_content: 'download-first-experiment',
+                utm_medium: 'referral',
+                utm_term: '4242',
+                utm_campaign: 'F100_4242_otherstuff_in_here'
+            };
+
             const validObj2 = {
+                entrypoint_experiment: 'test-id',
+                entrypoint_variation: 'test-variation',
+                device_id: '45de19d8bc6845b1b7c121da2cb1cde2',
+                flow_id:
+                    'd35341efcc26739b9f36d84410e4b49946071a7cdbee192d0e5707710052fe82',
+                flow_begin_time: '1684417308435'
+            };
+
+            spyOn(FxaAttribution, 'getReferralStorage').and.returnValue(
+                validObj1
+            );
+
+            expect(FxaAttribution.getAttributionData(validObj2)).toEqual(
+                Object.assign(validObj1, validObj2)
+            );
+        });
+
+        it('should always use the coupon value from the page URL, irrespective of what is in storage', function () {
+            const validObj1 = {
                 coupon: 'test'
             };
 
-            FxaAttribution.setReferralStorage(validObj1);
-            FxaAttribution.setCouponStorage(validObj2);
+            const validObj2 = {
+                utm_source: 'vpn-client',
+                utm_content: 'download-first-experiment',
+                utm_medium: 'referral',
+                utm_term: '4242',
+                utm_campaign: 'F100_4242_otherstuff_in_here',
+                coupon: 'test2'
+            };
 
-            expect(FxaAttribution.getAttributionData({})).toEqual(
-                Object.assign(validObj1, validObj2)
+            FxaAttribution.setCouponStorage(validObj1);
+
+            expect(FxaAttribution.getAttributionData(validObj2)).toEqual(
+                validObj2
             );
         });
     });
@@ -420,7 +481,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'desktop-snippet',
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here'
             };
 
@@ -509,7 +570,7 @@ describe('fxa-attribution.js', function () {
                 utm_source: 'desktop-snippet',
                 utm_content: 'rel-esr',
                 utm_medium: 'referral',
-                utm_term: 4242,
+                utm_term: '4242',
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 entrypoint_experiment: 'test-id',
                 entrypoint_variation: 'test-variation'


### PR DESCRIPTION
## One-line summary

Updates FxA/VPN attribution to store session attribution data to persist over multiple page navigations.

## Significant changes and points to review

Note for reviewer: attribution parameters will now persist for the duration of your tab remaining open (using [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)). So it's best to close / re-open the tab after each test below:

## Issue / Bugzilla link

#13147

## Testing

Single page view tests:

- [x] UTM parameters are passed through to subscription links: https://www-demo1.allizom.org/en-US/products/vpn/?utm_source=test&utm_campaign=test
- [x] Coupon parameters is passed through to subscription links: https://www-demo1.allizom.org/en-US/products/vpn/?coupon=test
- [x] UTM and coupons are passed through to subscription links: https://www-demo1.allizom.org/en-US/products/vpn/?utm_source=test&utm_campaign=test&coupon=test

Multiple page view tests:

1. Open https://www-demo1.allizom.org/en-US/?utm_source=test&utm_campaign=test
2. Scroll to the "Featured Mozilla Products" section and click "Get Mozilla VPN"

- [x] UTM parameters from step 1 are passed through to subscription links after page navigation

WNP test (clear cookies after this test):

1. Open https://www-demo1.allizom.org/en-GB/firefox/113.0/whatsnew/
2. Click "Get Mozilla VPN"

- [x] Verify `utm_campaign=whatsnew-113-eu` is passed through to subscription links.

Opt-out test (clear cookies after this test):

1. Open https://www-demo1.allizom.org/en-US/privacy/websites/data-preferences/
2. Click "Opt out of first-party data collection"
3. Close tab
4. Open https://www-demo1.allizom.org/en-US/products/vpn/?utm_source=test&utm_campaign=test
5. Verify the `utm_source=test&utm_campaign=test` params are **not** passed through to subscription links. Only the default set of UTM params should be present (`utm_source=www.mozilla.org-vpn-product-page` and `utm_campaign=vpn-product-page`).

Opt-out test with coupon (clear cookies after this test):

1. Open https://www-demo1.allizom.org/en-US/privacy/websites/data-preferences/
2. Click "Opt out of first-party data collection"
3. Close tab
4. Open https://www-demo1.allizom.org/en-US/products/vpn/?coupon=test
5. Verify coupon is still passed, even though opt-out was clicked.

