### PR TITLE
Update data preferences page to cover FxA/VPN attribution (Fixes #13165)

### DIFF
--- a/bedrock/privacy/templates/privacy/data-preferences.html
+++ b/bedrock/privacy/templates/privacy/data-preferences.html
@@ -26,20 +26,22 @@
     <h1 class="mzp-c-article-title">{{ ftl('data-preferences-page-title') }}</h1>
 
     <p>
-      {{ ftl('data-preferences-your-privacy',
+      {{ ftl('data-preferences-your-privacy-v2',
+      fallback='data-preferences-your-privacy',
         glean='https://docs.telemetry.mozilla.org/concepts/glean/glean.html',
         lean_data=url('mozorg.about.policy.lean-data.index'))
       }}
     </p>
     <p>
-      {{ ftl('data-preferences-mozilla-uses',
+      {{ ftl('data-preferences-mozilla-uses-v2',
+        fallback='data-preferences-mozilla-uses',
         dictionary='https://dictionary.telemetry.mozilla.org/',
         privacy_notice=url('privacy.notices.websites'))
       }}
     </p>
 
     <p>
-      {{ ftl('data-preferences-if-you-still-want-to') }}
+      {{ ftl('data-preferences-if-you-still-want-to-v2', fallback='data-preferences-if-you-still-want-to') }}
     </p>
 
     <p id="data-preference-status" class="data-preference-status">

--- a/l10n/en/privacy/data-preferences.ftl
+++ b/l10n/en/privacy/data-preferences.ftl
@@ -12,13 +12,28 @@ data-preferences-notification-opt-in = You are opted in to first-party data coll
 # Variables:
 #   $glean (url) - link to https://docs.telemetry.mozilla.org/concepts/glean/glean.html
 #   $lean_data (url) - link to https://www.mozilla.org/about/policy/lean-data/
+data-preferences-your-privacy-v2 = Your privacy is very important to { -brand-name-mozilla }. Our first-party telemetry and analytics systems follow our own high standards for <a href="{ $lean_data }">lean data practices</a>.
+
+# Outdated string
+# Variables:
+#   $glean (url) - link to https://docs.telemetry.mozilla.org/concepts/glean/glean.html
+#   $lean_data (url) - link to https://www.mozilla.org/about/policy/lean-data/
 data-preferences-your-privacy = Your privacy is very important to { -brand-name-mozilla }. Our first-party telemetry and analytics platform, called <a href="{ $glean }">{ -brand-name-glean }</a>, follows our own high standards for <a href="{ $lean_data }">lean data practices</a>.
 
 # Variables:
 #   $dictionary (url) - link to https://dictionary.telemetry.mozilla.org/
 #   $privacy_notice (url) - link to https://www.mozilla.org/privacy/websites/
+data-preferences-mozilla-uses-v2 = { -brand-name-mozilla } uses first party telemetry and analytics to collect website usage data on some mozilla.org websites in order to ensure that we’re delivering the best possible user experience for our visitors. { -brand-name-mozilla } does not share this information with any third parties. Every piece of data we collect also goes through a strict review process. For more information about the way we handle and share your data on { -brand-name-mozilla } websites, you can read our <a href="{ $privacy_notice }">Websites, Communications and Cookies Privacy Notice</a>.
+
+# Outdated string
+# Variables:
+#   $dictionary (url) - link to https://dictionary.telemetry.mozilla.org/
+#   $privacy_notice (url) - link to https://www.mozilla.org/privacy/websites/
 data-preferences-mozilla-uses = { -brand-name-mozilla } uses { -brand-name-glean } to collect website usage data on some mozilla.org websites in order to ensure that we’re delivering the best possible user experience for our visitors. { -brand-name-glean } does not share information with any third parties. Every piece of data we collect also goes through a strict review process. You can learn more about the specific types of data we collect in the <a href="{ $dictionary }">{ -brand-name-glean } Dictionary</a>. For more information about the way we handle and share your data on { -brand-name-mozilla } websites, you can read our <a href="{ $privacy_notice }">Websites, Communications and Cookies Privacy Notice</a>.
 
+data-preferences-if-you-still-want-to-v2 = If you still want to opt-out of first-party analytics you can do so below. Clicking the opt-out button will set a preference cookie that is used to prevent the website from sending data when you load our web pages. This preference cookie will last for 1 year.
+
+# Outdated string
 data-preferences-if-you-still-want-to = If you still want to opt-out of first-party analytics you can do so below. Clicking the opt-out button will set a preference cookie that is used to prevent { -brand-name-glean } from sending data when you load our web pages. This preference cookie will last for 1 year.
 
 data-preferences-current-preference = Current preference:


### PR DESCRIPTION
## One-line summary

Updates http://localhost:8000/en-US/privacy/websites/data-preferences/ to be more generic when it comes to 1st party analytics, and not exclusively about Glean.

## Issue / Bugzilla link

#13165

## Testing

http://localhost:8000/en-US/privacy/websites/data-preferences/
