### PR TITLE
Update Pocket Mode docs

### DIFF
--- a/bedrock/pocket/urls.py
+++ b/bedrock/pocket/urls.py
@@ -9,6 +9,11 @@ from bedrock.legal_docs.views import LegalDocView
 from bedrock.mozorg.util import page
 from bedrock.pocket.views import newsletter_subscribe
 
+# IMPORTANT: URLs added here will work fine locally and on Demo servers, but
+# to make them visible on tekcopteg.com or getpocket.com you need to
+# also add to the configuration for the Pocket "dotcom gateway" router:
+# https://github.com/Pocket/dotcom-gateway/blob/main/lambda/src/config/behaviors/marketing.ts#L32
+
 urlpatterns = (
     page(
         "",
@@ -143,3 +148,5 @@ urlpatterns = (
         name="pocket.newsletter-subscribe",
     ),
 )
+
+# IMPORTANT: URLs added here need to be added to Pocket's dotcom gateway. See the comment above.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -233,29 +233,12 @@ To push to launch a demo on Heroku:
   $ git push -f mozilla my-demo-branch:demo/1
 
 
-Dev
-```
-- *URL:* http://www-dev.allizom.org/
-- *Bedrock locales:* dev repo
-- *Bedrock Git branch:* main, deployed on git push
-
-Staging
-```````
-- *URL:* http://www.allizom.org/
-- *Bedrock locales:* prod repo
-- *Bedrock Git branch:* prod, deployed on git push with date-tag
-
-Production
-``````````
-- *URL:* http://www.mozilla.org/
-- *Bedrock locales:* prod repo
-- *Bedrock Git branch:* prod, deployed on git push with date-tag
-
-You can check the currently deployed git commit by checking https://www.mozilla.org/revision.txt.
-
 Pushing to production
----------------------
+`````````````````````
+
 We're doing pushes as soon as new work is ready to go out.
+
+Code flows automatically to Dev, amd manually to Stage and to Production. See :ref:`pipeline` for details.
 
 After doing a push, those who are responsible for implementing changes need to update
 the bugs that have been pushed with a quick message stating that the code was deployed.

--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -41,7 +41,9 @@ own local flair to the ideas.
 
     Much of this documentation also applies to the use of Fluent with Pocket templates,
     with the main differences being that:
-    * the English Pocket Fluent directory is called ``l10n-pocket/``.
+
+    * the English Pocket Fluent directory is called ``l10n-pocket/``
+    * there are no activation-threshold checks for Pocket templates - we expect all strings to be translated in one go, because they are done via a vendor
 
 
 .. _Project Fluent: https://projectfluent.org/
@@ -766,7 +768,7 @@ operation can have its own distinct Fluent files and translation strategy.
 As of Summer 2022, there are two separate L10N integrations within Bedrock:
 
 * Mozilla.org ("Mozorg mode")
-* Pocket Marketing Pages ("Pocket mode" - intended for getpocket.com but not yet live)
+* Pocket Marketing Pages ("Pocket mode")
 
 These integrations are similar in their approach, but not identical in how they run.
 They use different translations strategies, which requires slightly different data flows.

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -17,6 +17,36 @@ by reading their respective pieces of documentation:
 * Redirect tests (see :ref:`testing-redirects`).
 * Functional tests (see :ref:`testing`).
 
+Deployed site URLs
+------------------
+
+Note that a deployment of Bedrock will actually trigger two separate deployments:
+one serving all of ``mozilla.org`` and another serving certain parts of ``getpocket.com``
+
+Dev
+```
+- *Mozorg URL:* https://www-dev.allizom.org/
+- *Pocket Marketing pages URL:* https://dev.tekcopteg.com/
+- *Bedrock locales:* dev repo
+- *Bedrock Git branch:* main, deployed on git push
+
+Staging
+```````
+- *Mozorg URL:* https://www.allizom.org/
+- *Pocket Marketing pages URL:* https://www.tekcopteg.com/
+- *Bedrock locales:* prod repo
+- *Bedrock Git branch:* stage, deployed on git push
+
+Production
+``````````
+- *Mozorg URL:* https://www.mozilla.org/
+- *Pocket Marketing pages URL:* https://getpocket.com/
+- *Bedrock locales:* prod repo
+- *Bedrock Git branch:* prod, deployed on git push with date-tag
+
+You can check the currently deployed git commit by checking /revision.txt on any of these URLs.
+
+
 Tests in the lifecycle of a change
 ----------------------------------
 


### PR DESCRIPTION
* Add comment to remind us all that github.com/Pocket/dotcom-gateway needs updating when we add routes
* Minor docs tidying
* Update documentation to make it easier to discover the URLs of the various Mozorg and Pocket sites (resolves #12690)