### PR TITLE
Update copy on careers/benefits

### DIFF
--- a/bedrock/careers/templates/careers/benefits.html
+++ b/bedrock/careers/templates/careers/benefits.html
@@ -137,9 +137,9 @@
             Mozilla is a private company, so our compensation isn’t tied to stock
             options or equity plans. Instead, we offer generous, performance-based
             bonus plans to all regular employees to underscore that we share in
-            our success as one team. As for retirement savings for U.S. and
-            Canadian employees, Mozilla contributes a percentage of your eligible
-            base salary each year to the 401(k) Plan/RRSP, with 100% vesting.
+            our success as one team. As for retirement savings for US and Canadian employees,
+            Mozilla contributes a % of your eligible base salary each year to the 401(k) Plan/RRSP
+            (regardless of whether you contribute or not), with 100% vesting.
           </p>
         {% endcall %}
 

--- a/bedrock/careers/templates/careers/benefits.html
+++ b/bedrock/careers/templates/careers/benefits.html
@@ -138,7 +138,7 @@
             options or equity plans. Instead, we offer generous, performance-based
             bonus plans to all regular employees to underscore that we share in
             our success as one team. As for retirement savings for US and Canadian employees,
-            Mozilla contributes a % of your eligible base salary each year to the 401(k) Plan/RRSP
+            Mozilla contributes a percentage of your eligible base salary each year to the 401(k) Plan/RRSP
             (regardless of whether you contribute or not), with 100% vesting.
           </p>
         {% endcall %}


### PR DESCRIPTION
## One-line summary

Requested change to the copy on the careers/benefits page. Request [here](https://mozilla.slack.com/archives/C4XSHENBY/p1684522566570639) and more info in [google doc](https://docs.google.com/document/d/1BFWvIfgB75RTWGJ76tEE40C2W8GMnrBVaf402UM1AVI/edit?usp=sharing)

## Issue / Bugzilla link
n/a

## Testing


To test this work:

- [ ] http://localhost:8000/careers/benefits
