### PR TITLE
Localization-related links update

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -49,6 +49,7 @@
           <ul class="mzp-c-footer-list">
             <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-name="Product Help">{{ ftl('footer-product-help', fallback='footer-support') }}</a></li>
             <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-name="File a Bug">{{ ftl('footer-file-a-bug') }}</a></li>
+            <li><a href="https://pontoon.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-name="Localise Mozilla">{{ ftl('footer-localize-mozilla') }}</a></li>
           </ul>
         </section>
 

--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -51,7 +51,7 @@
     <h2 class="mzp-c-section-heading">{{ ftl('contribute-how-heading') }}</h2>
     <div class="mzp-l-card-quarter contribute-card-container">
       <section class="mzp-c-card contribute-card">
-        <a class="mzp-c-card-block-link contribute-card-wrapper" href="https://community.mozilla.org/activities/localize-mozilla/{{ utm_params }}">
+        <a class="mzp-c-card-block-link contribute-card-wrapper" href="https://pontoon.mozilla.org/{{ utm_params }}">
           <div class="mzp-c-card-media-wrapper">
             {{ picture(
               url='img/contribute/contribute-card-translate-lg.png',

--- a/l10n/en/footer.ftl
+++ b/l10n/en/footer.ftl
@@ -75,6 +75,7 @@ footer-contact = Contact
 footer-product-help = Product Help
 footer-support = Support
 footer-file-a-bug = File a Bug
+footer-localize-mozilla = Localize { -brand-name-mozilla }
 footer-community-participation-guidelines = Community Participation Guidelines
 footer-websites-privacy-notice = Website Privacy Notice
 footer-websites-cookies = Cookies


### PR DESCRIPTION
## One-line summary

This changeset:
* changes the link for "Translate Content" on /contribute/ to point to Pontoon directly
* adds a "Localize Mozilla" link in the Support column of the footer, also pointing to Pontoon

## Significant changes and points to review

Both sets of links append the same UTM params that other links on the page do

A new Fluent string has been added, so the new footer link will not be localied immediately for non-en locales. Is this a problem, given the widespread (if small) impact of the additional link?

This changeset should land before the end of H2 as it's tied to Q2 goals for the L10N team

## Issue / Bugzilla link

Resolves #13045 

## Screenshots

<img width="650" alt="Screenshot 2023-06-01 at 10 43 10" src="https://github.com/mozilla/bedrock/assets/101457/73993693-62a6-40b5-bf08-6187a7ac8c99">

<img width="1705" alt="Screenshot 2023-06-01 at 10 42 56" src="https://github.com/mozilla/bedrock/assets/101457/8d1cd707-152a-44d5-9778-7522c67f54fc">


## Testing

To test this work:
* View http://www-demo5.allizom.org/contribute/ where you can see the footer change and the "Translate Content" card change in action
