### PR TITLE
Adds GA4 custom event product_download to /all

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -1,0 +1,173 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const TrackProductDownload = {};
+const prodURL = /^https:\/\/download.mozilla.org/;
+const stageURL = /^https:\/\/bouncer-bouncer.stage.mozaws.net/;
+const appStoreURL = /^https:\/\/itunes.apple.com/;
+const playStoreURL = /^https:\/\/play.google.com/;
+
+/**
+ * Validate we got a link to download.mozilla.org with the correct parameters
+ * @param {URL}
+ * @returns {Boolean}
+ */
+TrackProductDownload.isValidDownloadURL = (downloadURL) => {
+    if (typeof downloadURL === 'string') {
+        if (prodURL.test(downloadURL) || stageURL.test(downloadURL)) {
+            return true;
+        } else if (
+            appStoreURL.test(downloadURL) ||
+            playStoreURL.test(downloadURL)
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+};
+
+/**
+ * Create the product_download event object
+ * @param {string} product
+ * @param {string} platform
+ * @param {string} release_channel - optional, we don't get it for ios downloads
+ * @param {string} download_language - optional, we don't get it for mobile downloads
+ * @returns {Object}
+ */
+TrackProductDownload.getEventObject = (
+    product,
+    platform,
+    release_channel = '',
+    download_language = ''
+) => {
+    const eventObject = {};
+    eventObject['event'] = 'product_download';
+    eventObject['product'] = product;
+    eventObject['platform'] = platform;
+    eventObject['release_channel'] = release_channel;
+    eventObject['download_language'] = download_language;
+    return eventObject;
+};
+
+/**
+ * Create the product_download event object
+ * @param {string} downloadURL
+ * @returns {Object}
+ */
+TrackProductDownload.getEventFromUrl = (downloadURL) => {
+    // bail out if we don't have our helper function
+    if (typeof window._SearchParams === 'undefined') {
+        return false;
+    }
+
+    // bail out if the url is not what we expect
+    if (!TrackProductDownload.isValidDownloadURL(downloadURL)) {
+        return false;
+    }
+
+    // separate query string from URL and transform it into an object
+    let params;
+    if (downloadURL.indexOf('?') > 0) {
+        params = window._SearchParams.queryStringToObject(
+            downloadURL.split('?')[1]
+        );
+    } else {
+        params = [];
+    }
+
+    let eventObject = {};
+    if (prodURL.test(downloadURL) || stageURL.test(downloadURL)) {
+        // extract the values we need from the parameters
+        const productParam = params.product;
+        const productSplit = productParam.split('-');
+        // product is first word of product param
+        const product = productSplit[0];
+        let platform = params.os;
+        platform = platform === 'osx' ? 'macos' : platform;
+        // release channel is second word of product param
+        // (except for release which says 'latest' but we want 'release')
+        const releaseChannel =
+            productSplit[1] === 'latest' ? 'release' : productSplit[1];
+
+        eventObject = TrackProductDownload.getEventObject(
+            product,
+            platform,
+            releaseChannel,
+            params.lang
+        );
+    } else if (playStoreURL.test(downloadURL)) {
+        const idParam = params.id;
+        let androidRelease = 'release';
+        // Android Play Store, need to check release, beta, nightly
+        switch (idParam) {
+            case 'org.mozilla.fenix':
+                androidRelease = 'nightly';
+                break;
+            case 'org.mozilla.firefox_beta':
+                androidRelease = 'beta';
+                break;
+        }
+        eventObject = TrackProductDownload.getEventObject(
+            'firefox',
+            'android',
+            androidRelease
+        );
+    } else if (appStoreURL.test(downloadURL)) {
+        // Apple App Store
+        eventObject = TrackProductDownload.getEventObject(
+            'firefox',
+            'ios',
+            'release'
+        );
+    }
+
+    return eventObject;
+};
+
+/**
+ * Callback for a click event attached to a link to download.mozilla.org
+ * - extracts the href of the link from an event
+ * - sends it along for tracking
+ * @param {Event}
+ */
+TrackProductDownload.linkHandler = (event) => {
+    let el = event.target;
+    // If the node isn't a link traverse up
+    // but closest is not supported in IE
+    // but this code should only run on the app store links because of the images
+    // so it's okay to not track IE users going to the App Stores IMHO
+    if (el.nodeName !== 'A' && Element.prototype.closest) {
+        el = el.closest('a');
+    } else if (!Element.prototype.closest) {
+        return false;
+    }
+    const downloadURL = el.href;
+    // send to be formatted then tracked
+    TrackProductDownload.sendEventFromURL(downloadURL);
+};
+
+/**
+ * @param {String} -  example: https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US
+ */
+TrackProductDownload.sendEventFromURL = (downloadURL) => {
+    // get event object
+    const eventObject = TrackProductDownload.getEventFromUrl(downloadURL);
+    // send for tracking
+    TrackProductDownload.sendEvent(eventObject);
+};
+
+/**
+ * Sends an event to the data layer
+ * @param {Object} - product details formatted into a product_download event
+ */
+TrackProductDownload.sendEvent = (eventObject) => {
+    window.dataLayer.push(eventObject);
+};
+
+export default TrackProductDownload;

--- a/media/js/firefox/all/all-downloads-unified-init.es6.js
+++ b/media/js/firefox/all/all-downloads-unified-init.es6.js
@@ -4,18 +4,23 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import TrackProductDownload from '../../base/datalayer-productdownload.es6';
+import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
+import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
+
 (function (Mozilla) {
-    'use strict';
-
-    var MzpModal = require('@mozilla-protocol/core/protocol/js/modal');
-    var MzpSideMenu = require('@mozilla-protocol/core/protocol/js/sidemenu');
-
     function onLoad() {
-        var browserHelpContent = document.getElementById('browser-help');
-        var browserHelpIcon = document.getElementById('icon-browser-help');
-        var installerHelpContent = document.getElementById('installer-help');
-        var installerHelpIcon = document.querySelectorAll(
+        const browserHelpContent = document.getElementById('browser-help');
+        const browserHelpIcon = document.getElementById('icon-browser-help');
+        const installerHelpContent = document.getElementById('installer-help');
+        const installerHelpIcon = document.querySelectorAll(
             '.icon-installer-help'
+        );
+        const downloadButton = document.getElementById(
+            'download-button-primary'
+        );
+        const mobileDownloadButtons = document.querySelectorAll(
+            '.ga-product-download'
         );
 
         function showHelpModal(modalContent, modalTitle, eventLabel) {
@@ -50,7 +55,7 @@
         );
 
         // Installer help modal.
-        for (var i = 0; i < installerHelpIcon.length; i++) {
+        for (let i = 0; i < installerHelpIcon.length; i++) {
             installerHelpIcon[i].addEventListener(
                 'click',
                 function (e) {
@@ -61,6 +66,25 @@
                         e.target.textContent,
                         'Get Installer Help'
                     );
+                },
+                false
+            );
+        }
+
+        // event tracking for GA4
+        downloadButton.addEventListener(
+            'click',
+            function (event) {
+                TrackProductDownload.linkHandler(event);
+            },
+            false
+        );
+
+        for (let i = 0; i < mobileDownloadButtons.length; i++) {
+            mobileDownloadButtons[i].addEventListener(
+                'click',
+                function (event) {
+                    TrackProductDownload.linkHandler(event);
                 },
                 false
             );

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1557,7 +1557,7 @@
     {
       "files": [
         "js/firefox/all/all-downloads-unified.js",
-        "js/firefox/all/all-downloads-unified-init.js"
+        "js/firefox/all/all-downloads-unified-init.es6.js"
       ],
       "name": "firefox_all_unified"
     },

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -42,6 +42,7 @@ module.exports = function (config) {
             'tests/unit/spec/base/core-datalayer-page-id.js',
             'tests/unit/spec/base/core-datalayer.js',
             'tests/unit/spec/base/datalayer-begincheckout.js',
+            'tests/unit/spec/base/datalayer-productdownload.js',
             'tests/unit/spec/base/experiment-utils.js',
             'tests/unit/spec/base/fxa-form.js',
             'tests/unit/spec/base/fxa-link.js',

--- a/tests/unit/spec/base/datalayer-begincheckout.js
+++ b/tests/unit/spec/base/datalayer-begincheckout.js
@@ -14,18 +14,20 @@ import TrackBeginCheckout from '../../../../media/js/base/datalayer-begincheckou
 describe('datalayer-begincheckout.es6.js', function () {
     const expectedObj = {
         event: 'begin_checkout',
-        currency: 'USD',
-        value: '11.88',
-        items: [
-            {
-                item_id: 'testid',
-                item_name: 'email',
-                item_category: 'relay',
-                item_variant: 'yearly',
-                price: '11.88',
-                discount: '12.00'
-            }
-        ]
+        ecommerce: {
+            currency: 'USD',
+            value: '11.88',
+            items: [
+                {
+                    item_id: 'testid',
+                    item_name: 'email',
+                    item_category: 'relay',
+                    item_variant: 'yearly',
+                    price: '11.88',
+                    discount: '12.00'
+                }
+            ]
+        }
     };
 
     describe('TrackBeginCheckout.getEventObject', function () {

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -1,0 +1,262 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import TrackProductDownload from '../../../../media/js/base/datalayer-productdownload.es6.js';
+
+describe('isValidDownloadURL', function () {
+    it('should recognize downloads.m.o as a valid URL', function () {
+        let testDownloadURL = TrackProductDownload.isValidDownloadURL(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testDownloadURL).toBe(true);
+    });
+    it('should recognize bouncer as a valid URL', function () {
+        let testBouncerURL = TrackProductDownload.isValidDownloadURL(
+            'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testBouncerURL).toBe(true);
+    });
+    it('should recognize the App Store as a valid URL', function () {
+        let testAppStoreURL = TrackProductDownload.isValidDownloadURL(
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+        );
+        expect(testAppStoreURL).toBe(true);
+    });
+    it('should recognize the Play Store as a valid URL', function () {
+        let testPlayStoreURL = TrackProductDownload.isValidDownloadURL(
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
+        );
+        expect(testPlayStoreURL).toBe(true);
+    });
+    it('should not accept Adjust as a valid URL', function () {
+        let testAdjustURL = TrackProductDownload.isValidDownloadURL(
+            'https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox&campaign=www.mozilla.org&adgroup=mobile-android-page'
+        );
+        expect(testAdjustURL).toBe(false);
+    });
+    it('should not accept a random link to mozilla.org as a valid URL', function () {
+        let testRandomURL = TrackProductDownload.isValidDownloadURL(
+            'https://www.mozilla.org/en-US/firefox/all/'
+        );
+        expect(testRandomURL).toBe(false);
+    });
+});
+
+describe('getEventObject', function () {
+    it('should insert parameters into the proper place in the event object', function () {
+        let testFullEventExpectedObject = {
+            event: 'product_download',
+            product: 'testProduct',
+            platform: 'testPlatform',
+            release_channel: 'testReleaseChannel',
+            download_language: 'testDownloadLanguage'
+        };
+        let testFullEventObject = TrackProductDownload.getEventObject(
+            'testProduct',
+            'testPlatform',
+            'testReleaseChannel',
+            'testDownloadLanguage'
+        );
+        expect(testFullEventObject).toEqual(testFullEventExpectedObject);
+    });
+    it('should create an event object even if there are no release_channel or download_language parameters', function () {
+        let testShortEventExpectedObject = {
+            event: 'product_download',
+            product: 'testProduct',
+            platform: 'testPlatform',
+            release_channel: '',
+            download_language: ''
+        };
+        let testShortEventObject = TrackProductDownload.getEventObject(
+            'testProduct',
+            'testPlatform'
+        );
+        expect(testShortEventObject).toEqual(testShortEventExpectedObject);
+    });
+});
+
+describe('getEventFromUrl', function () {
+    // product
+    it('should identify product for Firefox Desktop', function () {
+        let testProductDesktop = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
+        );
+        expect(testProductDesktop['product']).toBe('firefox');
+    });
+    it('should identify product for Firefox iOS', function () {
+        let testProductIOS = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+        );
+        expect(testProductIOS['product']).toBe('firefox');
+    });
+    it('should identify product for Firefox Android', function () {
+        let testProductAndroid = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
+        );
+        expect(testProductAndroid['product']).toBe('firefox');
+    });
+    // platform
+    it('should identify platform for Windows', function () {
+        let testPlatformWindows = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
+        );
+        expect(testPlatformWindows['platform']).toBe('win64');
+    });
+    it('should identify platform for MacOS', function () {
+        let testPlatformMacOS = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testPlatformMacOS['platform']).toBe('macos');
+    });
+    it('should identify platform for Linux', function () {
+        let testPlatformLinux = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US'
+        );
+        expect(testPlatformLinux['platform']).toBe('linux64');
+    });
+    it('should identify platform for iOS', function () {
+        let testPlatformIOS = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+        );
+        expect(testPlatformIOS['platform']).toBe('ios');
+    });
+    it('should identify platform for Android', function () {
+        let testPlatformAndroid = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
+        );
+        expect(testPlatformAndroid['platform']).toBe('android');
+    });
+    // release channel
+    it('should identify release_channel for Firefox Release', function () {
+        let testReleaseRelease = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
+        );
+        expect(testReleaseRelease['release_channel']).toBe('release');
+    });
+    it('should identify release_channel for Firefox Beta', function () {
+        let testBetaRelease = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testBetaRelease['release_channel']).toBe('beta');
+    });
+    it('should identify release_channel for Firefox Dev Edition', function () {
+        let testDevRelease = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testDevRelease['release_channel']).toBe('devedition');
+    });
+    it('should identify release_channel for Firefox Nightly', function () {
+        let testNightlyRelease = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testNightlyRelease['release_channel']).toBe('nightly');
+    });
+    it('should identify release_channel for Firefox ESR', function () {
+        let testNightlyRelease = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testNightlyRelease['release_channel']).toBe('esr');
+    });
+    it('should identify release_channel for Firefox iOS', function () {
+        let testIOSRelease = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+        );
+        expect(testIOSRelease['release_channel']).toBe('release');
+    });
+    it('should identify release_channel for Firefox Android Release', function () {
+        let testAndroidRelease = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
+        );
+        expect(testAndroidRelease['release_channel']).toBe('release');
+    });
+    it('should identify release_channel for Firefox Android Beta', function () {
+        let testAndroidBetaRelease = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta'
+        );
+        expect(testAndroidBetaRelease['release_channel']).toBe('beta');
+    });
+    it('should identify release_channel for Firefox Android Nightly', function () {
+        let testAndroidNightlyRelease = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.fenix'
+        );
+        expect(testAndroidNightlyRelease['release_channel']).toBe('nightly');
+    });
+    // language
+    it('should identify en-US for Firefox Desktop', function () {
+        let testLanguageDesktop = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
+        );
+        expect(testLanguageDesktop['download_language']).toBe('en-US');
+    });
+    it('should identify DE for Firefox Desktop', function () {
+        let testLanguageDesktop = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=de'
+        );
+        expect(testLanguageDesktop['download_language']).toBe('de');
+    });
+    it('should not identify language for Firefox iOS', function () {
+        let testLanguageIOS = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
+        );
+        expect(testLanguageIOS['download_language']).toBeFalsy();
+    });
+    it('should not identify language for Firefox Android', function () {
+        let testLanguageAndroid = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
+        );
+        expect(testLanguageAndroid['download_language']).toBeFalsy();
+    });
+});
+
+describe('linkHandler', function () {
+    const download_button = `<a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win64&amp;lang=en-CA" id="download-button-primary" class="mzp-c-button mzp-t-product c-download-button">Download Now</a>`;
+
+    beforeEach(function () {
+        document.body.insertAdjacentHTML('beforeend', download_button);
+        const downloadButton = document.getElementById(
+            'download-button-primary'
+        );
+        downloadButton.addEventListener(
+            'click',
+            function (event) {
+                event.preventDefault();
+                TrackProductDownload.linkHandler(event);
+            },
+            false
+        );
+    });
+
+    afterEach(function () {
+        document.getElementById('download-button-primary').remove();
+    });
+
+    it('should the full chain of functions', function () {
+        spyOn(TrackProductDownload, 'linkHandler').and.callThrough();
+        spyOn(TrackProductDownload, 'sendEventFromURL').and.callThrough();
+        spyOn(TrackProductDownload, 'isValidDownloadURL').and.callThrough();
+        spyOn(TrackProductDownload, 'getEventObject').and.callThrough();
+        spyOn(TrackProductDownload, 'sendEvent').and.callThrough();
+
+        document.getElementById('download-button-primary').click();
+
+        expect(TrackProductDownload.linkHandler).toHaveBeenCalled();
+        expect(TrackProductDownload.sendEventFromURL).toHaveBeenCalled();
+        expect(TrackProductDownload.isValidDownloadURL).toHaveBeenCalled();
+        expect(TrackProductDownload.getEventObject).toHaveBeenCalled();
+        expect(TrackProductDownload.sendEvent).toHaveBeenCalledWith({
+            event: 'product_download',
+            product: 'firefox',
+            platform: 'win64',
+            release_channel: 'release',
+            download_language: 'en-CA'
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Adds GA4 custom event product_download and adds event tracking to downloads on /all.

## Significant changes and points to review

Adds datalayer-product-download.es6.js and converts all-downloads-unified-ini to es6 to allow importing it.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13238

## Testing

https://www-demo4.allizom.org/en-US/firefox/all/ 

To test this work:

Bedrock code:
- [x] new tests provide adequate coverage
- [x] good checks exist so things don't break if the data is missing or malformed
- [x] `product_download` event is fired for Firefox download
- [x] `product_download` event is fired for Firefox Beta download
- [x] `product_download` event is fired for Firefox Developer download
- [x] `product_download` event is fired for Firefox Nightly download
- [x] `product_download` event is fired for Firefox ESR download
- [x] `product_download` event is fired for Firefox Android Play Store button
- [x] `product_download` event is fired for Firefox Android Beta Play Store button
- [x] `product_download` event is fired for Firefox Android Nightly Play Store button
- [x] `product_download` event is fired for Firefox iOS App Store button

GTM:
- Switch to the workspace in the www.mozilla.org workspace called "GA4 product_download"
- Click "preview" to open the tag assistant website.
- Add the domain https://www-demo4.allizom.org/en-US/firefox/all/ and click it 
- Disable add-ons and toggle off DNT, etc until tag assistant indicates it has a connection
- Navigate to the /all page and start clicking the download/store buttons
- Return to the tag assistant window and look through the 'product_download' events to verify they have the correct product, platform, release_channel, and download_language.
- [x] Firefox download
- [x] Firefox Beta download
- [x] Firefox Developer download
- [ ] Firefox Nightly download
- [ ] Firefox ESR download
- [ ] Firefox Android Play Store button **should not identify a download_language
- [ ] Firefox Android Beta Play Store button **should not identify a download_language
- [ ] Firefox Android Nightly Play Store button **should not identify a download_language
- [x] Firefox iOS App Store button *should not identify a release_channel **should not identify a download_language

GA4:
- Switch to the **www.mozilla.org - GA4 Testing** property
- Click the Admin menu item (bottom left)
- Click the DebugView link (last item in the second column before the colourful product links)
- Your tag assistant session should already have sent data here, you might have to pick a device out of the drop down until "Debug Device"
- [x] Verify the product_download events have been logged

Tests:
- [x] unit tests pass
- [x] integration tests pass