### PR TITLE
Add Convert experiment block to /firefox/flashback

### DIFF
--- a/bedrock/firefox/templates/firefox/flashback/index.html
+++ b/bedrock/firefox/templates/firefox/flashback/index.html
@@ -49,3 +49,9 @@
     </div>
   </main>
 {% endblock %}
+
+{% block experiments %}
+    {% if switch('experiment-convert-firefox-flashback', ['en-US']) %}
+        {{ js_bundle('convert') }}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## One-line summary

Adds the convert experiment block to /firefox/flashback/

## Issue / Bugzilla link

This is part of my Marketing Manifesto goal. It is just to test the system since it hasn't been used recently and will not be enabled on the production server.

## Testing

http://localhost:8000/en-US/firefox/flashback

To test this work:

- [x] does Convert fail to load if you have DNT enabled?
- [x] does Convert load with all your ad-blockers and privacy stuff disabled?
- [x] switch name should match https://github.com/mozmeao/www-config/pull/519