### PR TITLE
Update Convert CDN URL

### DIFF
--- a/bedrock/privacy/templates/privacy/convert-opt-out.html
+++ b/bedrock/privacy/templates/privacy/convert-opt-out.html
@@ -11,7 +11,7 @@
 {% block page_desc %}Your privacy is very important to Mozilla. This page will enable you to opt-out of Convert experiments on www.mozilla.org{% endblock %}
 
 {% block experiments %}
-  <script src="https://cdn-3.convertexperiments.com/js/{{ settings.CONVERT_PROJECT_ID }}.js" async></script>
+  <script src="https://cdn-4.convertexperiments.com/js/{{ settings.CONVERT_PROJECT_ID }}.js" async></script>
 {% endblock %}
 
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -184,7 +184,7 @@ else:
         "adservice.google.de",
         "adservice.google.dk",
         "creativecommons.org",
-        "cdn-3.convertexperiments.com",
+        "cdn-4.convertexperiments.com",
         "logs.convertexperiments.com",
         "images.ctfassets.net",
     ]
@@ -199,7 +199,7 @@ else:
         "tagmanager.google.com",
         "www.youtube.com",
         "s.ytimg.com",
-        "cdn-3.convertexperiments.com",
+        "cdn-4.convertexperiments.com",
         "app.convert.com",
         "data.track.convertexperiments.com",
         "1003350.track.convertexperiments.com",

--- a/media/js/base/convert-snippet.js
+++ b/media/js/base/convert-snippet.js
@@ -20,7 +20,7 @@
         var newScriptTag = document.createElement('script');
         var target = document.getElementsByTagName('script')[0];
         newScriptTag.src =
-            'https://cdn-3.convertexperiments.com/js/' +
+            'https://cdn-4.convertexperiments.com/js/' +
             CONVERT_PROJECT_ID +
             '.js';
         target.parentNode.insertBefore(newScriptTag, target);


### PR DESCRIPTION
## One-line summary

Update Convert CDN URL.

## Issue / Bugzilla link

n/a

Convert [introduced a new CDN](https://support.convert.com/hc/en-us/articles/11205619183373-What-s-new-Nov-2022) that is faster than the one we are referencing.

## Testing

1. Pick a page on the site and add the convert bundle in an experiments block. [Docs here](https://bedrock.readthedocs.io/en/latest/abtest.html#convert-experiments).
2. Disable all your ad-blockers and DNT.
3. Open the network panel and reload the page.
4. Watch for the convert URL, make sure it's a 200.