### PR TITLE
added static image helper

### DIFF
--- a/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
+++ b/bedrock/pocket/templates/pocket/firefox/new-tab-learn-more.html
@@ -47,7 +47,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <section class="mzp-c-split mzp-l-split-center-on-sm-md mzp-t-content-xl mzp-l-split-reversed mzp-t-split-nospace new-tab-section">
       <div class="mzp-c-split-container">
         <div class="mzp-c-split-media mzp-l-split-h-center mzp-l-split-media-overflow hidden-gem-media">
-          <img class="mzp-c-split-media-asset" src="/media/img/pocket/new-tab/hidden-gem.svg" alt="" loading="eager">
+          <img class="mzp-c-split-media-asset" src="{{ static('img/pocket/new-tab/hidden-gem.svg') }}" alt="" loading="eager">
         </div>
         <div class="mzp-c-split-body hidden-gem-body">
           <h2 class="new-tab-section-header">{{ ftl('pocket-new-tab-finding-the') }}</h2>


### PR DESCRIPTION
## One-line summary
The Pocket New Tab page had a broken image URL in prod because the image tag in the code wasn't using an appropriate image helper that we typically use in Bedrock. So I just wrapped it in a `static()` image helper.

This is what the section currently looks like in prod:
<kbd>![Screenshot 2023-06-06 at 5 32 32 PM](https://github.com/mozilla/bedrock/assets/42309026/698a5c91-c83d-418b-9663-621c7cdb03a7)</kbd>

But it should look like this:
<kbd>![Screenshot 2023-06-06 at 5 33 09 PM](https://github.com/mozilla/bedrock/assets/42309026/0acea8ca-1d32-4fde-b68a-6923856f6b9f)</kbd>



The image URL in prod is shown as: 
```
src="/media/img/pocket/new-tab/hidden-gem.svg"
```

But it should look like the following:
```
src="https://www.mozilla.org/media/img/pocket/new-tab/fortress.41ba0083d924.svg"
```

The `static()` image helper should help to update that


To test this work:

- [ ] run the Pocket sever by running `npm run in-pocket-mode`
- [ ] http://localhost:8000/en/firefox/new_tab_learn_more/ 
