### PR TITLE
Drop use of cache_page helper

### DIFF
--- a/bedrock/legal_docs/views.py
+++ b/bedrock/legal_docs/views.py
@@ -4,13 +4,10 @@
 
 from django.conf import settings
 from django.http import Http404
-from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
 
 from bedrock.legal_docs.models import LegalDoc
 from lib import l10n_utils
-
-CACHE_TIMEOUT = settings.LEGAL_DOCS_CACHE_TIMEOUT
 
 
 def load_legal_doc(doc_name, locale):
@@ -46,16 +43,11 @@ class LegalDocView(l10n_utils.RequireSafeMixin, TemplateView):
     * legal_doc_name: The name of the folder in the legal_docs repo.
     * legal_doc_context_name: (default 'doc') template variable name for legal doc.
 
-    This view automatically adds the `cache_page` decorator. The default timeout
-    is 10 minutes, configurable by setting the `LEGAL_DOCS_CACHE_TIMEOUT` setting to change
-    the default for all views, or the `cache_timeout` property for an single instance.
-
     See `bedrock/privacy/views.py` for usage examples.
     """
 
     legal_doc_name = None
     legal_doc_context_name = "doc"
-    cache_timeout = CACHE_TIMEOUT
 
     def get_legal_doc(self):
         locale = l10n_utils.get_locale(self.request)
@@ -90,8 +82,3 @@ class LegalDocView(l10n_utils.RequireSafeMixin, TemplateView):
         context[self.legal_doc_context_name] = legal_doc["content"]
         context["active_locales"] = legal_doc["active_locales"]
         return context
-
-    @classmethod
-    def as_view(cls, **initkwargs):
-        cache_timeout = initkwargs.pop("cache_timeout", cls.cache_timeout)
-        return cache_page(cache_timeout)(super().as_view(**initkwargs))

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -10,7 +10,7 @@ from django.http import Http404
 from django.shortcuts import render as django_render
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page, never_cache
+from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import TemplateView
 
@@ -200,15 +200,10 @@ class WebvisionDocView(RequireSafeMixin, TemplateView):
     * doc_name: The name of the file in the webvision repo.
     * doc_context_name: (default 'doc') template variable name for doc.
 
-    This view automatically adds the `cache_page` decorator. The default timeout
-    is 10 minutes, configurable by setting the `WEBVISION_DOCS_CACHE_TIMEOUT` setting to change
-    the default for all views, or the `cache_timeout` property for an single instance.
-
     """
 
     doc_name = None
     doc_context_name = "doc"
-    cache_timeout = settings.WEBVISION_DOCS_CACHE_TIMEOUT
 
     def render_to_response(self, context, **response_kwargs):
         response_kwargs.setdefault("content_type", self.content_type)
@@ -223,11 +218,6 @@ class WebvisionDocView(RequireSafeMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         context[self.doc_context_name] = doc.content
         return context
-
-    @classmethod
-    def as_view(cls, **initkwargs):
-        cache_timeout = initkwargs.pop("cache_timeout", cls.cache_timeout)
-        return cache_page(cache_timeout)(super().as_view(**initkwargs))
 
 
 MIECO_EMAIL_SUBJECT = {"mieco": "MIECO Interest Form", "innovations": "Innovations Interest Form"}

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import re
 
-from django.views.decorators.cache import cache_page
-
 from bs4 import BeautifulSoup
 
 from bedrock.legal_docs.views import LegalDocView, load_legal_doc
@@ -84,7 +82,6 @@ subscription_services = PrivacyDocView.as_view(
 )
 
 
-@cache_page(60 * 60)  # cache for 1 hour
 def privacy(request):
     doc = load_legal_doc("mozilla_privacy_policy", l10n_utils.get_locale(request))
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1040,12 +1040,10 @@ LEGAL_DOCS_PATH = DATA_PATH / "legal_docs"
 LEGAL_DOCS_REPO = config("LEGAL_DOCS_REPO", default="https://github.com/mozilla/legal-docs.git")
 LEGAL_DOCS_BRANCH = config("LEGAL_DOCS_BRANCH", default="main" if DEV else "prod")
 LEGAL_DOCS_DMS_URL = config("LEGAL_DOCS_DMS_URL", default="")
-LEGAL_DOCS_CACHE_TIMEOUT = config("LEGAL_DOCS_CACHE_TIMEOUT", default="60" if DEV else "600", parser=int)
 
 WEBVISION_DOCS_PATH = DATA_PATH / "webvisions"
 WEBVISION_DOCS_REPO = config("WEBVISION_DOCS_REPO", default="https://github.com/mozilla/webvision.git")
 WEBVISION_DOCS_BRANCH = config("WEBVISION_DOCS_BRANCH", default="main")
-WEBVISION_DOCS_CACHE_TIMEOUT = config("WEBVISION_DOCS_CACHE_TIMEOUT", default="60" if DEV else "600", parser=int)
 
 MOFO_SECURITY_ADVISORIES_PATH = config("MOFO_SECURITY_ADVISORIES_PATH", default=data_path("mofo_security_advisories"))
 MOFO_SECURITY_ADVISORIES_REPO = config("MOFO_SECURITY_ADVISORIES_REPO", default="https://github.com/mozilla/foundation-security-advisories.git")


### PR DESCRIPTION
When used in combination with the production CDN, we ended up with incorrect country code being returned in these pages

For background see https://github.com/mozilla/bedrock/issues/13229

Resolves #13229
