### PR TITLE
Add permanent redirect for /en/ to /en-US/

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -560,4 +560,6 @@ redirectpatterns = (
     redirect(r"^/exp/firefox/new/?$", "firefox.new"),
     redirect(r"^/exp/firefox/accounts/?$", "firefox.accounts"),
     redirect(r"^/exp/opt-out/?$", "privacy.convert-opt-out"),
+    # Issue 13211
+    redirect(r"^/en/$", "/en-US/", permanent=True),
 )

--- a/tests/redirects/map_301.py
+++ b/tests/redirects/map_301.py
@@ -570,6 +570,7 @@ URLS = flatten(
         url_test("/donate_form.pdf", "https://donate.mozilla.org/"),
         url_test("/donate.html", "https://donate.mozilla.org/"),
         url_test("/download-mozilla.html", "http://developer.mozilla.org/en/Download_Mozilla_Source_Code"),
+        url_test("/en/", "/en-US/"),  # Issue 13211
         url_test("/feedback.html", "/contact/"),
         url_test("/firebird", "http://www.firefox.com"),
         url_test("/foundation/privacy-policy.html", "/privacy/websites/"),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -13,8 +13,7 @@ URLS = flatten(
     (
         # bug 832348 **/index.html -> **/
         url_test("/any/random/url/with/index.html", "/any/random/url/with/"),
-        # bug 774675
-        url_test("/en/", "/en-US/", status_code=requests.codes.found),
+        # bug 774675 + also see Issue 13211 for why /en/ isn't included here any more
         url_test("/es/", "/es-ES/", status_code=requests.codes.found),
         url_test("/pt/", "/pt-BR/", status_code=requests.codes.found),
         # bug 795970 - lowercase to uppercase, e.g. en-us to en-US


### PR DESCRIPTION
...so that Google indexes the right page. A 302 Found isn't enough - see https://github.com/mozilla/bedrock/issues/13211 for context

Resolves #13211

