### PR TITLE
Set `geo_template_names` default to a dict to avoid an `AttributeError`

### DIFF
--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -32,7 +32,7 @@ class GeoTemplateView(l10n_utils.L10nTemplateView):
     """
 
     # dict of country codes to template names
-    geo_template_names = None
+    geo_template_names = {}
 
     def get_template_names(self):
         country_code = get_country_from_request(self.request)


### PR DESCRIPTION
Alternatively we can remove `GeoTemplateView` completely, since nothing in the current codebase is using it, based on my searching. It seems like most people just use the underlying `get_country_from_request`. If it's not useful, we can drop the whole class.