### PR TITLE
Fix #13253: Ensure /firefox/set-as-default/thanks/ exists for Firefox

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -560,3 +560,11 @@ class TestFirefoxMobile(TestCase):
         view(req)
         template = render_mock.call_args[0][1]
         assert template == ["firefox/mobile/index.html"]
+
+
+# Issue 13253: Ensure that Firefox can continue to refer to this URL.
+class TestFirefoxSetAsDefaultThanks(TestCase):
+    def test_firefox_set_as_default_thanks(self):
+        resp = self.client.get("/firefox/set-as-default/thanks/", follow=True)
+        assert resp.status_code == 200, "Ensure this URL continues to work, see issue 13253"
+        assert resp.templates[0].name == "firefox/set-as-default/thanks.html"

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -195,6 +195,7 @@ urlpatterns = (
     page("firefox/privacy/products/", "firefox/privacy/products.html", ftl_files=["firefox/privacy-hub"]),
     page("firefox/privacy/safe-passwords/", "firefox/privacy/passwords.html", ftl_files=["firefox/privacy-hub", "firefox/privacy/passwords"]),
     # Issue 8432
+    # Issue 13253: Ensure that Firefox can continue to refer to this URL.
     page("firefox/set-as-default/thanks/", "firefox/set-as-default/thanks.html", ftl_files="firefox/set-as-default/thanks"),
     # Default browser campaign
     path(


### PR DESCRIPTION
Adds a comment and a test to ensure that if this URL goes away developers will get an error with a Github issue reference.