### PR TITLE
Fix dataLayer test failure #13259

### DIFF
--- a/media/js/base/datalayer-begincheckout.es6.js
+++ b/media/js/base/datalayer-begincheckout.es6.js
@@ -5,6 +5,9 @@
  */
 
 const TrackBeginCheckout = {};
+if (typeof window.dataLayer === 'undefined') {
+    window.dataLayer = [];
+}
 
 /**
  */

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -10,6 +10,10 @@ const stageURL = /^https:\/\/bouncer-bouncer.stage.mozaws.net/;
 const appStoreURL = /^https:\/\/itunes.apple.com/;
 const playStoreURL = /^https:\/\/play.google.com/;
 
+if (typeof window.dataLayer === 'undefined') {
+    window.dataLayer = [];
+}
+
 /**
  * Validate we got a link to download.mozilla.org with the correct parameters
  * @param {URL}

--- a/tests/unit/spec/base/datalayer-begincheckout.js
+++ b/tests/unit/spec/base/datalayer-begincheckout.js
@@ -75,7 +75,7 @@ describe('datalayer-begincheckout.es6.js', function () {
         });
 
         afterEach(function () {
-            delete window.dataLayer;
+            window.dataLayer = [];
         });
 
         it('will append the begin_checkout event to the dataLayer', function () {

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -238,7 +238,7 @@ describe('linkHandler', function () {
         document.getElementById('download-button-primary').remove();
     });
 
-    it('should the full chain of functions', function () {
+    it('should call the full chain of functions', function () {
         spyOn(TrackProductDownload, 'linkHandler').and.callThrough();
         spyOn(TrackProductDownload, 'sendEventFromURL').and.callThrough();
         spyOn(TrackProductDownload, 'isValidDownloadURL').and.callThrough();


### PR DESCRIPTION
## Fix intermittent test failure writing to the dataLayer

- add checks that the dataLayer exists to two new tests (this does not actually fix the test failure because the check is executed when the file loads and not when the function calls are activated, but it seems prudent)
- change the test to set the dataLayer array to be empty instead of deleting it, which was what was causing the problem
- fix the test message, which was missing a word

## Issue / Bugzilla link

#13259

## Testing

`npm run karma`