### PR TITLE
Add Relay pricing and display logic #13204

### DIFF
--- a/bedrock/products/forms.py
+++ b/bedrock/products/forms.py
@@ -12,7 +12,7 @@ class VPNWaitlistForm(NewsletterFooterForm):
 
 class RelayBundleWaitlistForm(NewsletterFooterForm):
     def __init__(self, locale, data=None, *args, **kwargs):
-        super().__init__("relay-waitlist", locale, data, *args, **kwargs)
+        super().__init__("relay-vpn-bundle-waitlist", locale, data, *args, **kwargs)
 
 
 class RelayPhoneWaitlistForm(NewsletterFooterForm):
@@ -22,4 +22,4 @@ class RelayPhoneWaitlistForm(NewsletterFooterForm):
 
 class RelayPremiumWaitlistForm(NewsletterFooterForm):
     def __init__(self, locale, data=None, *args, **kwargs):
-        super().__init__("relay-phone-masking-waitlist", locale, data, *args, **kwargs)
+        super().__init__("relay-waitlist", locale, data, *args, **kwargs)

--- a/bedrock/products/forms.py
+++ b/bedrock/products/forms.py
@@ -12,9 +12,14 @@ class VPNWaitlistForm(NewsletterFooterForm):
 
 class RelayBundleWaitlistForm(NewsletterFooterForm):
     def __init__(self, locale, data=None, *args, **kwargs):
-        super().__init__("relay-vpn-bundle-waitlist", locale, data, *args, **kwargs)
+        super().__init__("relay-waitlist", locale, data, *args, **kwargs)
 
 
 class RelayPhoneWaitlistForm(NewsletterFooterForm):
+    def __init__(self, locale, data=None, *args, **kwargs):
+        super().__init__("relay-phone-masking-waitlist", locale, data, *args, **kwargs)
+
+
+class RelayPremiumWaitlistForm(NewsletterFooterForm):
     def __init__(self, locale, data=None, *args, **kwargs):
         super().__init__("relay-phone-masking-waitlist", locale, data, *args, **kwargs)

--- a/bedrock/products/templates/products/relay/faq.html
+++ b/bedrock/products/templates/products/relay/faq.html
@@ -54,7 +54,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         </section>
         <section class="mzp-c-details">
           <h3> {{ ftl('faq-question-availability-question') }}</h3>
-          <p> {{ ftl('faq-question-availability-answer-v2') }} </p>
+          <p> {{ ftl('faq-question-availability-answer-v3') }} </p>
         </section>
         <section class="mzp-c-details">
           <h3> {{ ftl('faq-question-4-question-2') }}</h3>

--- a/bedrock/products/templates/products/relay/includes/bundle.html
+++ b/bedrock/products/templates/products/relay/includes/bundle.html
@@ -4,11 +4,15 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+
+{% set monthly_price = relay_monthly_price(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
+
+{% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+
 <div class="mzp-l-content">
   <div class="mzp-c-emphasis-box mzp-t-dark t-bundle">
-
-    <h2 class="mzp-u-title-sm">{{ ftl('bundle-banner-header-2', monthly_price="TKTK") }}</h2>
-    <p>{{ ftl('bundle-banner-body-3', savings="TKTK") }}</p>
+    <h2 class="mzp-u-title-sm">{{ ftl('bundle-banner-header-2', monthly_price=monthly_price) }}</h2>
+    <p>{{ ftl('bundle-banner-body-3', savings=savings) }}</p>
     <h3 class="c-bundle-list-heading">{{ ftl('bundle-banner-plan-header-2') }}</h3>
     <ul class="c-bundle-list">
       <li>{% include 'products/relay/includes/email.svg' %} {{ ftl('bundle-banner-plan-modules-email-masking') }}</li>
@@ -19,8 +23,24 @@
       <li class="c-bundle-stat">{{ ftl('bundle-feature-three') }}</li>
     </ul>
     <div>
-      <button>{{ ftl('bundle-banner-cta') }}</button>
-      <small>{{ ftl('bundle-banner-money-back-guarantee-2', days_guarantee="TKTK") }}</small>
+      {{ vpn_subscribe_link(
+        entrypoint=_utm_source,
+        link_text=ftl('bundle-banner-cta'),
+        plan='12-month',
+        class_name='mzp-c-button mzp-t-primary mzp-t-dark mzp-t-lg',
+        country_code=country_code,
+        lang=LANG,
+        bundle_relay=True,
+        optional_parameters={
+          'utm_campaign': _utm_campaign
+        },
+        optional_attributes={
+          'data-cta-type': 'fxa-vpn',
+          'data-cta-text': 'Get VPN plus Relay 12-month',
+          'data-cta-position': 'pricing'
+        })
+      }}
+      <small>{{ ftl('bundle-banner-money-back-guarantee-2', days_guarantee=settings.RELAY_VPN_BUNDLE_GUARANTEE) }}</small>
     </div>
   </div>
 </div>

--- a/bedrock/products/templates/products/relay/includes/bundle.html
+++ b/bedrock/products/templates/products/relay/includes/bundle.html
@@ -36,8 +36,8 @@
         },
         optional_attributes={
           'data-cta-type': 'fxa-vpn',
-          'data-cta-text': 'Get VPN plus Relay 12-month',
-          'data-cta-position': 'pricing'
+          'data-cta-text': 'Get Mozilla VPN + Relay',
+          'data-cta-position': 'bundle'
         })
       }}
       <small>{{ ftl('bundle-banner-money-back-guarantee-2', days_guarantee=settings.RELAY_VPN_BUNDLE_GUARANTEE) }}</small>

--- a/bedrock/products/templates/products/relay/includes/macros.html
+++ b/bedrock/products/templates/products/relay/includes/macros.html
@@ -1,0 +1,69 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+
+{% macro waitlist(product) -%}
+  {% if product == 'relay-bundle' %}
+    {% set link = url('products.relay.waitlist.bundle') %}
+  {% elif product == 'relay-phone' %}
+    {% set link = url('products.relay.waitlist.phone') %}
+  {% else %}
+    {% set link = url('products.relay.waitlist.premium') %}
+  {% endif %}
+  <a href="{{ link }}" class="mzp-c-button mzp-t-product mzp-t-secondary c-matrix-footer-waitlist">{{ ftl('plan-matrix-join-waitlist')}}</a>
+{%- endmacro %}
+
+{% macro toggle(position, product) -%}
+  {% set group = 'plan-{position}-{product}'.format(position=position, product=product) %}
+
+      <span class="c-toggle-track"></span>
+      <input type="radio" name="{{ group }}" value="monthly" id="{{ group }}-monthly" class="c-toggle-input c-toggle-input-monthly">
+      <label for="{{ group }}-monthly" class="c-toggle-label c-toggle-label-monthly">
+        <span>{{ ftl('plan-matrix-price-period-monthly') }}</span>
+      </label>
+      <input type="radio" name="{{ group }}" value="yearly" id="{{ group }}-yearly" class="c-toggle-input c-toggle-input-yearly" checked>
+      <label for="{{ group }}-yearly" class="c-toggle-label c-toggle-label-yearly">
+        <span>{{ ftl('plan-matrix-price-period-yearly') }}</span>
+      </label>
+
+      <em class="c-toggle-price c-toggle-price-monthly">{{ relay_monthly_price(plan='monthly', country_code=country_code, lang=LANG, product=product) }}</em>
+      <small class="c-matrix-footer-period c-matrix-footer-period-monthly">{{ ftl('plan-matrix-price-period-monthly-footnote-1') }}</small>
+      {{ relay_subscribe_link(
+        entrypoint=_utm_source,
+        link_text=ftl('plan-matrix-sign-up'),
+        product=product,
+        plan='monthly',
+        class_name='mzp-c-button mzp-t-product mzp-t-lg c-matrix-footer-button c-matrix-footer-button-monthly',
+        country_code=country_code,
+        lang=LANG,
+        optional_parameters={
+          'utm_campaign': _utm_campaign
+        },
+        optional_attributes={
+          'data-cta-type': 'fxa-relay',
+          'data-cta-position': 'matrix'
+        })
+      }}
+
+      <em class="c-toggle-price c-toggle-price-yearly">{{ relay_monthly_price(plan='yearly', country_code=country_code, lang=LANG, product=product) }}</em>
+      <small class="c-matrix-footer-period c-matrix-footer-period-yearly">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
+      {{ relay_subscribe_link(
+        entrypoint=_utm_source,
+        link_text=ftl('plan-matrix-sign-up'),
+        product=product,
+        plan='yearly',
+        class_name='mzp-c-button mzp-t-product mzp-t-lg c-matrix-footer-button c-matrix-footer-button-yearly',
+        country_code=country_code,
+        lang=LANG,
+        optional_parameters={
+          'utm_campaign': _utm_campaign
+        },
+        optional_attributes={
+          'data-cta-type': 'fxa-relay',
+          'data-cta-position': 'matrix'
+        })
+      }}
+{%- endmacro %}

--- a/bedrock/products/templates/products/relay/includes/matrix.html
+++ b/bedrock/products/templates/products/relay/includes/matrix.html
@@ -4,6 +4,10 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "products/relay/includes/macros.html" import waitlist, toggle with context %}
+
+{% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+
 <section>
   <table class="c-matrix-desktop">
     <thead>
@@ -66,7 +70,7 @@
         <td><img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></td>
       </tr>
       <tr>
-        <th scope="row">{{ ftl('plan-matrix-feature-mobile-vpn') }}</th>
+        <th scope="row">{{ ftl('plan-matrix-feature-mobile-mozvpn') }}</th>
         <td><img src="{{ static('img/products/relay/icon-not.svg') }}" alt="{{ ftl('plan-matrix-feature-not-included') }}"></td>
         <td><img src="{{ static('img/products/relay/icon-not.svg') }}" alt="{{ ftl('plan-matrix-feature-not-included') }}"></td>
         <td><img src="{{ static('img/products/relay/icon-not.svg') }}" alt="{{ ftl('plan-matrix-feature-not-included') }}"></td>
@@ -79,26 +83,55 @@
           <div class="u-hidden">{{ ftl('plan-matrix-heading-price') }}</div>
         </th>
         <td>
-            {{ ftl('plan-matrix-price-free') }}
-            <button>{{ ftl('plan-matrix-get-relay-cta') }}</button>
+            <div class="c-matrix-footer">
+              <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
+              <a href="https://relay.firefox.com/accounts/fxa/login/?process=login" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('plan-matrix-get-relay-cta') }}</a>
+            </div>
         </td>
         <td>
-          <div class="c-toggle">
-            <input type="radio" name="plan-email" value="monthly" id="plan-email-monthly"><label for="plan-email-monthly">{{ ftl('plan-matrix-price-period-monthly') }}<em>TKTK/mo</em></label>
-            <input type="radio" name="plan-email" value="yearly" id="plan-email-yearly" checked><label for="plan-email-yearly">{{ ftl('plan-matrix-price-period-yearly') }}<em>TKTK/mo</em></label>
+          <div class="c-matrix-footer">
+            {% if email_available %}
+              {{ toggle("table", "relay-email") }}
+            {% else %}
+              {{ waitlist("relay-email") }}
+            {% endif %}
           </div>
-          <div><button>{{ ftl('plan-matrix-sign-up') }}</button><small>Billed TKTK</small></div>
         </td>
         <td>
-          <div class="c-toggle">
-            <input type="radio" name="plan-email-phone" value="monthly" id="plan-email-phone-monthly"><label for="plan-email-phone-monthly">{{ ftl('plan-matrix-price-period-monthly') }}<em>TKTK/mo</em></label>
-            <input type="radio" name="plan-email-phone" value="yearly" id="plan-email-phone-yearly" checked><label for="plan-email-phone-yearly">{{ ftl('plan-matrix-price-period-yearly') }}<em>TKTK/mo</em></label>
+          <div class="c-matrix-footer">
+            {% if phone_available %}
+              {{ toggle("table","relay-phone") }}
+            {% else %}
+            {{ waitlist("relay-phone") }}
+            {% endif %}
           </div>
-          <div><button>{{ ftl('plan-matrix-sign-up') }}</button><small>Billed TKTK</small></div>
         </td>
         <td>
-          <p> {{ ftl('plan-matrix-price-vpn-discount-promo', savings='TKTK') }} </p>
-          <div><button>{{ ftl('plan-matrix-sign-up') }}</button><small>Billed TKTK</small></div>
+          <div class="c-matrix-footer">
+            {% if bundle_available %}
+              <p class="c-matrix-footer-savings">{{ ftl('plan-matrix-price-vpn-discount-promo', savings=savings) }} </p>
+              <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
+                {{ vpn_subscribe_link(
+                  entrypoint=_utm_source,
+                  link_text=ftl('plan-matrix-sign-up'),
+                  plan='12-month',
+                  class_name='mzp-c-button mzp-t-primary mzp-t-product mzp-t-lg',
+                  country_code=country_code,
+                  lang=LANG,
+                  bundle_relay=True,
+                  optional_parameters={
+                    'utm_campaign': _utm_campaign
+                  },
+                  optional_attributes={
+                    'data-cta-type': 'fxa-vpn',
+                    'data-cta-text': 'Get VPN plus Relay 12-month',
+                    'data-cta-position': 'pricing'
+                  })
+                }}
+            {% else %}
+              {{ waitlist("relay-bundle") }}
+          {% endif %}
+        </div>
         </td>
       </tr>
     </tfoot>
@@ -116,7 +149,8 @@
           <li>{{ ftl('plan-matrix-feature-mobile-email-tracker-removal') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
         </ul>
         <div class="c-matrix-footer">
-          <div> Free <button>{{ ftl('plan-matrix-sign-up') }}</button></div>
+            <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
+            <a href="https://relay.firefox.com/accounts/fxa/login/?process=login" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('plan-matrix-get-relay-cta') }}</a>
         </div>
       </li>
       <li class="c-matrix-plan">
@@ -130,12 +164,11 @@
           <li>{{ ftl('plan-matrix-feature-mobile-email-reply') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
         </ul>
         <div class="c-matrix-footer">
-          <div class="c-toggle">
-            <input type="radio" name="plan-mobile-email" value="monthly" id="plan-mobile-email-monthly"><label for="plan-mobile-email-monthly">{{ ftl('plan-matrix-price-period-monthly') }}<em>TKTK/mo</em></label>
-            <input type="radio" name="plan-mobile-email" value="yearly" id="plan-mobile-email-yearly" checked><label for="plan-mobile-email-yearly">{{ ftl('plan-matrix-price-period-yearly') }}<em>TKTK/mo</em></label>
-          </div>
-          <div><button>{{ ftl('plan-matrix-sign-up') }}</button><small>Billed TKTK</small></div>
-        </div>
+          {% if email_available %}
+            {{ toggle("mobile","relay-email") }}
+          {% else %}
+            {{ waitlist("relay-email") }}
+          {% endif %}
       </li>
       <li class="c-matrix-plan">
         <h3 class="mzp-u-title-xs">{{ ftl('plan-matrix-heading-plan-phones') }}</h3>
@@ -148,13 +181,12 @@
           <li>{{ ftl('plan-matrix-feature-mobile-email-reply') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
           <li>{{ ftl('plan-matrix-feature-mobile-phone-mask') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
         </ul>
-        <div class="c-matrix-footer">
-          <div class="c-toggle">
-            <input type="radio" name="plan-mobile-email-phone" value="monthly" id="plan-mobile-email-phone-monthly"><label for="plan-mobile-email-phone-monthly">{{ ftl('plan-matrix-price-period-monthly') }}<em>TKTK/mo</em></label>
-            <input type="radio" name="plan-mobile-email-phone" value="yearly" id="plan-mobile-email-phone-yearly" checked><label for="plan-mobile-email-phone-yearly">{{ ftl('plan-matrix-price-period-yearly') }}<em>TKTK/mo</em></label>
-          </div>
-          <div><button>{{ ftl('plan-matrix-sign-up') }}</button><small>Billed TKTK</small></div>
-        </div>
+      <div class="c-matrix-footer">
+        {% if phone_available %}
+          {{ toggle("mobile","relay-phone") }}
+        {% else %}
+          {{ waitlist("relay-phone") }}
+        {% endif %}
       </li>
       <li class="c-matrix-plan t-matrix-mobile-bundle">
         <h3 class="mzp-u-title-xs">{{ ftl('plan-matrix-heading-plan-bundle-2') }}</h3>
@@ -166,13 +198,32 @@
           <li>{{ ftl('plan-matrix-feature-mobile-email-subdomain') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
           <li>{{ ftl('plan-matrix-feature-mobile-email-reply') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
           <li>{{ ftl('plan-matrix-feature-mobile-phone-mask') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
-          <li>{{ ftl('plan-matrix-feature-mobile-vpn') }}</li>
+          <li>{{ ftl('plan-matrix-feature-mobile-mozvpn') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li></li>
         </ul>
       <div class="c-matrix-footer">
-        <div>
-          <p>{{ ftl('plan-matrix-price-vpn-discount-promo', savings='TKTK') }}</p>
-        </div>
-        <div>$TKTK/mo. <button>{{ ftl('plan-matrix-sign-up') }}</button><small>Billed TKTK</small></div>
+        {% if bundle_available %}
+            <p class="c-matrix-footer-savings">{{ ftl('plan-matrix-price-vpn-discount-promo', savings=savings) }} </p>
+            <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
+            {{ vpn_subscribe_link(
+              entrypoint=_utm_source,
+              link_text=ftl('plan-matrix-sign-up'),
+              plan='12-month',
+              class_name='mzp-c-button mzp-t-primary mzp-t-product mzp-t-lg',
+              country_code=country_code,
+              lang=LANG,
+              bundle_relay=True,
+              optional_parameters={
+                'utm_campaign': _utm_campaign
+              },
+              optional_attributes={
+                'data-cta-type': 'fxa-vpn',
+                'data-cta-text': 'Get VPN plus Relay 12-month',
+                'data-cta-position': 'pricing'
+              })
+            }}
+        {% else %}
+          {{ waitlist("relay-bundle") }}
+        {% endif %}
       </div>
       </li>
     </ul>

--- a/bedrock/products/templates/products/relay/includes/matrix.html
+++ b/bedrock/products/templates/products/relay/includes/matrix.html
@@ -83,10 +83,10 @@
           <div class="u-hidden">{{ ftl('plan-matrix-heading-price') }}</div>
         </th>
         <td>
-            <div class="c-matrix-footer">
-              <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
-              <a href="https://relay.firefox.com/accounts/fxa/login/?process=login" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('plan-matrix-get-relay-cta') }}</a>
-            </div>
+          <div class="c-matrix-footer">
+            <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
+            <a href="https://relay.firefox.com/accounts/fxa/login/?process=login" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('plan-matrix-get-relay-cta') }}</a>
+          </div>
         </td>
         <td>
           <div class="c-matrix-footer">
@@ -102,14 +102,14 @@
             {% if phone_available %}
               {{ toggle("table","relay-phone") }}
             {% else %}
-            {{ waitlist("relay-phone") }}
+              {{ waitlist("relay-phone") }}
             {% endif %}
           </div>
         </td>
         <td>
           <div class="c-matrix-footer">
             {% if bundle_available %}
-              <p class="c-matrix-footer-savings">{{ ftl('plan-matrix-price-vpn-discount-promo', savings=savings) }} </p>
+              <p class="c-matrix-footer-savings">{{ ftl('plan-matrix-price-vpn-discount-promo', savings=savings) }}</p>
               <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
                 {{ vpn_subscribe_link(
                   entrypoint=_utm_source,
@@ -124,14 +124,14 @@
                   },
                   optional_attributes={
                     'data-cta-type': 'fxa-vpn',
-                    'data-cta-text': 'Get VPN plus Relay 12-month',
+                    'data-cta-text': 'Sign Up',
                     'data-cta-position': 'pricing'
                   })
                 }}
             {% else %}
               {{ waitlist("relay-bundle") }}
-          {% endif %}
-        </div>
+            {% endif %}
+          </div>
         </td>
       </tr>
     </tfoot>
@@ -169,6 +169,7 @@
           {% else %}
             {{ waitlist("relay-email") }}
           {% endif %}
+        </div>
       </li>
       <li class="c-matrix-plan">
         <h3 class="mzp-u-title-xs">{{ ftl('plan-matrix-heading-plan-phones') }}</h3>
@@ -181,12 +182,13 @@
           <li>{{ ftl('plan-matrix-feature-mobile-email-reply') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
           <li>{{ ftl('plan-matrix-feature-mobile-phone-mask') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
         </ul>
-      <div class="c-matrix-footer">
-        {% if phone_available %}
-          {{ toggle("mobile","relay-phone") }}
-        {% else %}
-          {{ waitlist("relay-phone") }}
-        {% endif %}
+        <div class="c-matrix-footer">
+          {% if phone_available %}
+            {{ toggle("mobile","relay-phone") }}
+          {% else %}
+            {{ waitlist("relay-phone") }}
+          {% endif %}
+        </div>
       </li>
       <li class="c-matrix-plan t-matrix-mobile-bundle">
         <h3 class="mzp-u-title-xs">{{ ftl('plan-matrix-heading-plan-bundle-2') }}</h3>
@@ -198,29 +200,29 @@
           <li>{{ ftl('plan-matrix-feature-mobile-email-subdomain') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
           <li>{{ ftl('plan-matrix-feature-mobile-email-reply') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
           <li>{{ ftl('plan-matrix-feature-mobile-phone-mask') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
-          <li>{{ ftl('plan-matrix-feature-mobile-mozvpn') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li></li>
+          <li>{{ ftl('plan-matrix-feature-mobile-mozvpn') }} <img src="{{ static('img/products/relay/icon-check.svg') }}" alt="{{ ftl('plan-matrix-feature-included') }}" width="16"></li>
         </ul>
       <div class="c-matrix-footer">
         {% if bundle_available %}
-            <p class="c-matrix-footer-savings">{{ ftl('plan-matrix-price-vpn-discount-promo', savings=savings) }} </p>
-            <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
-            {{ vpn_subscribe_link(
-              entrypoint=_utm_source,
-              link_text=ftl('plan-matrix-sign-up'),
-              plan='12-month',
-              class_name='mzp-c-button mzp-t-primary mzp-t-product mzp-t-lg',
-              country_code=country_code,
-              lang=LANG,
-              bundle_relay=True,
-              optional_parameters={
-                'utm_campaign': _utm_campaign
-              },
-              optional_attributes={
-                'data-cta-type': 'fxa-vpn',
-                'data-cta-text': 'Get VPN plus Relay 12-month',
-                'data-cta-position': 'pricing'
-              })
-            }}
+          <p class="c-matrix-footer-savings">{{ ftl('plan-matrix-price-vpn-discount-promo', savings=savings) }}</p>
+          <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
+          {{ vpn_subscribe_link(
+            entrypoint=_utm_source,
+            link_text=ftl('plan-matrix-sign-up'),
+            plan='12-month',
+            class_name='mzp-c-button mzp-t-primary mzp-t-product mzp-t-lg',
+            country_code=country_code,
+            lang=LANG,
+            bundle_relay=True,
+            optional_parameters={
+              'utm_campaign': _utm_campaign
+            },
+            optional_attributes={
+              'data-cta-type': 'fxa-vpn',
+              'data-cta-text': 'Sign Up',
+              'data-cta-position': 'pricing'
+            })
+          }}
         {% else %}
           {{ waitlist("relay-bundle") }}
         {% endif %}

--- a/bedrock/products/templates/products/relay/includes/waitlist-base.html
+++ b/bedrock/products/templates/products/relay/includes/waitlist-base.html
@@ -14,7 +14,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% include 'products/relay/includes/subnav.html' %}
 {% endblock %}
 
-{% set product = ftl('waitlist-bundle-name') %}
+{% set product = product|default(ftl('waitlist-premium-name')) %}
 
 
 {% block content %}

--- a/bedrock/products/templates/products/relay/invite.html
+++ b/bedrock/products/templates/products/relay/invite.html
@@ -1,7 +1,0 @@
-{#
- This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- file, You can obtain one at https://mozilla.org/MPL/2.0/.
-#}
-
-{% extends "products/relay/base.html" %}

--- a/bedrock/products/templates/products/relay/landing.html
+++ b/bedrock/products/templates/products/relay/landing.html
@@ -40,14 +40,16 @@
     <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-relay">{{ ftl('relay-shared-firefox-relay') }}</div>
     <h1 class="c-hero-title">{{ ftl('hero-section-title') }}</h1>
     <p class="c-hero-body">{{ ftl('hero-section-body') }}</p>
-    <p><button>{{ ftl('hero-section-cta') }}</button></p>
+    <p><a href="#pricing" class="mzp-c-button mzp-t-product" data-cta-type="button" data-cta-text="Get Started">{{ ftl('hero-section-cta') }}</a></p>
     <div class="c-hero-brands">
       <div>{{ ftl('hero-section-social-proof') }}</div>
       <img class="c-brands" src="{{ static('img/products/relay/landing/brands.svg') }}" alt="Forbes, ZD Net, Life Hacker, PC MAG" width="480" height="54">
     </div>
   {% endcall %}
 
-  {% include 'products/relay/includes/bundle.html' %}
+  {% if bundle_available %}
+    {% include 'products/relay/includes/bundle.html' %}
+  {% endif %}
 
 </div>
 
@@ -99,7 +101,7 @@
     </div>
   </section>
 
-  <section class="mzp-l-content t-pricing">
+  <section id="pricing" class="mzp-l-content t-pricing">
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
     <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body') }}</p>
@@ -110,14 +112,14 @@
 
   <section class="mzp-l-content u-center">
     <h2 class="mzp-c-section-heading">{{ ftl('highlighted-features-section-bottom-title') }}</h2>
-    <p><button>{{ ftl('highlighted-features-section-bottom-cta') }}</button></p>
+    <p><a href="#pricing" class="mzp-c-button mzp-t-product mzp-t-primary">{{ ftl('highlighted-features-section-bottom-cta') }}</a></p>
   </section>
 
 </div>
 
 <section class="mzp-l-content c-landing-faq">
   <h2>{{ ftl('landing-faq-headline') }}</h2>
-  <p><a href="TKTK" class="mzp-c-cta-link">{{ ftl('landing-faq-cta') }}</a></p>
+  <p><a href="{{ url('products.relay.faq') }}" class="mzp-c-cta-link">{{ ftl('landing-faq-cta') }}</a></p>
   <div>
     <details>
       <summary><h3 class="mzp-u-title-2xs">{{ ftl('faq-question-availability-question') }}</h3></summary>

--- a/bedrock/products/templates/products/relay/landing.html
+++ b/bedrock/products/templates/products/relay/landing.html
@@ -146,3 +146,5 @@
 </section>
 
 {% endblock %}
+
+{{ js_bundle('fxa_product_button') }}

--- a/bedrock/products/templates/products/relay/premium.html
+++ b/bedrock/products/templates/products/relay/premium.html
@@ -38,12 +38,15 @@
   ) %}
     <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-premium">{{ ftl('relay-shared-firefox-relay') }}</div>
     <h1 class="c-hero-title">{{ ftl('premium-promo-hero-headline') }}</h1>
-    <p class="c-hero-body">{{ ftl('premium-promo-hero-body-2-html', monthly_price='TKTK', fallback='premium-promo-hero-body-3') }}</p>
-    <p><button>{{ ftl('hero-section-cta') }}</button></p>
+    {% set monthly_price = relay_monthly_price(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
+    <p class="c-hero-body">{{ ftl('premium-promo-hero-body-2-html', monthly_price=monthly_price, fallback='premium-promo-hero-body-3') }}</p>
+    <p><a href="#pricing" class="mzp-c-button mzp-t-product" data-cta-type="button" data-cta-text="Get Started">{{ ftl('hero-section-cta') }}</a></p>
     <p class="c-hero-availability">{{ ftl('premium-promo-availability-warning-3') }}</p>
   {% endcall %}
 
-  {% include 'products/relay/includes/bundle.html' %}
+  {% if bundle_available %}
+    {% include 'products/relay/includes/bundle.html' %}
+  {% endif %}
 </div>
 
 <section class="c-features-premium">

--- a/bedrock/products/templates/products/relay/premium.html
+++ b/bedrock/products/templates/products/relay/premium.html
@@ -12,8 +12,8 @@
 
 {% block body_id %}{% endblock %}
 
-{% set _utm_source = 'www.mozilla.org-relay-product-page' %}
-{% set _utm_campaign = 'relay-product-page' %}
+{% set _utm_source = 'www.mozilla.org-relay-premium-page' %}
+{% set _utm_campaign = 'relay-premium-page' %}
 {% set _params = '?utm_source=' ~ _utm_source ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign %}
 
 {% block page_css %}
@@ -53,7 +53,7 @@
   {% include 'products/relay/includes/features.html' %}
 </div>
 
-<section class="t-odd c-pricing">
+<section class="t-odd c-pricing" id="pricing">
   <div class="mzp-l-content">
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
@@ -64,3 +64,6 @@
 
 
 {% endblock %}
+
+
+{{ js_bundle('fxa_product_button') }}

--- a/bedrock/products/templates/products/relay/waitlist/bundle.html
+++ b/bedrock/products/templates/products/relay/waitlist/bundle.html
@@ -8,6 +8,8 @@
 
 {% set product = ftl('waitlist-bundle-name') %}
 
+{% block page_title %}{{ ftl('waitlist-heading-bundle') }}{% endblock %}
+
 {% block waitlist_heading %}{{ ftl('waitlist-heading-bundle') }}{% endblock %}
 {% block waitlist_lede %}{{ ftl('waitlist-lead-bundle') }}{% endblock %}
 {% block waitlist_privacy %}{{ ftl('waitlist-privacy-policy-use-bundle') }}{% endblock %}

--- a/bedrock/products/templates/products/relay/waitlist/phone.html
+++ b/bedrock/products/templates/products/relay/waitlist/phone.html
@@ -8,6 +8,8 @@
 
 {% set product = ftl('waitlist-phone-name') %}
 
+{% block page_title %}{{ ftl('waitlist-heading-phone') }}{% endblock %}
+
 {% block waitlist_heading %}{{ ftl('waitlist-heading-phone') }}{% endblock %}
 {% block waitlist_lede %}{{ ftl('waitlist-lead-phone') }}{% endblock %}
 {% block waitlist_privacy %}{{ ftl('waitlist-privacy-policy-use-phone') }}{% endblock %}

--- a/bedrock/products/templates/products/relay/waitlist/premium.html
+++ b/bedrock/products/templates/products/relay/waitlist/premium.html
@@ -1,0 +1,15 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/relay/includes/waitlist-base.html" %}
+
+{% block page_title %}{{ ftl('waitlist-heading-2') }}{% endblock %}
+
+{% set product = ftl('waitlist-premium-name') %}
+
+{% block waitlist_heading %}{{ ftl('waitlist-heading-2') }}{% endblock %}
+{% block waitlist_lede %}{{ ftl('waitlist-lead-2') }}{% endblock %}
+{% block waitlist_privacy %}{{ ftl('waitlist-privacy-policy-use') }}{% endblock %}

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -5,6 +5,7 @@
 from django.conf import settings
 
 import jinja2
+from babel.numbers import format_currency, format_percent
 from django_jinja import library
 from markupsafe import Markup
 
@@ -12,6 +13,9 @@ from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils.fluent import ftl
 
 FTL_FILES = ["products/vpn/shared"]
+
+# VPN ==================================================================
+
 
 VPN_12_MONTH_PLAN = "12-month"
 
@@ -256,6 +260,12 @@ def vpn_product_referral_link(ctx, referral_id="", page_anchor="", link_text=Non
     return Markup(markup)
 
 
+# RELAY ================================================================
+
+RELAY_12_MONTH_PLAN = "yearly"
+RELAY_PRODUCT = "relay-email"
+
+
 @library.global_function
 def relay_free_addresses():
     return settings.RELAY_MAX_NUM_FREE_ALIASES
@@ -263,9 +273,210 @@ def relay_free_addresses():
 
 @library.global_function
 def relay_bundle_servers():
-    return settings.RELAY_BUNDLE_VPN_SERVERS
+    return settings.VPN_CONNECT_SERVERS
 
 
 @library.global_function
 def relay_bundle_countries():
-    return settings.RELAY_BUNDLE_VPN_COUNTRIES
+    return settings.VPN_CONNECT_COUNTRIES
+
+
+# Relay has 4 plans
+# free
+# email
+# phone
+# bundle
+
+# free is available everywhere
+# email is available according to RELAY_EMAIL_COUNTRY_CODES
+# phone is available according to RELAY_PHONE_COUNTRY_CODES
+# bundle is available according to RELAY_VPN_BUNDLE_COUNTRY_CODES
+
+
+def _relay_get_plans(country_code, lang, product):
+    """
+    Get subscription plan IDs using country_code and page language.
+    Defaults to "US" if no matching country code is found.
+    Each country also has a default language if no match is found.
+    """
+
+    if product == "relay-bundle":
+        country_plans = settings.RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING.get(country_code, settings.RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING["US"])
+    elif product == "relay-phone":
+        country_plans = settings.RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING.get(country_code, settings.RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING["US"])
+    else:  # product == 'relay-email'
+        country_plans = settings.RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING.get(country_code, settings.RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING["US"])
+
+    return country_plans.get(lang, country_plans.get("default"))
+
+
+def _relay_product_link(product_url, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
+    separator = "&" if "?" in product_url else "?"
+    client_id = settings.VPN_CLIENT_ID
+    href = f"{product_url}{separator}entrypoint={entrypoint}&form_type=button&service={client_id}&utm_source={entrypoint}&utm_medium=referral"
+
+    if optional_parameters:
+        params = "&".join(f"{param}={val}" for param, val in optional_parameters.items())
+        href += f"&{params}"
+
+    css_class = "js-vpn-cta-link js-fxa-product-button"
+    attrs = ""
+
+    if optional_attributes:
+        attrs += " ".join(f'{attr}="{val}"' for attr, val in optional_attributes.items())
+
+        # If there's a `data-cta-position` attribute for GA, also pass that as a query param
+        position = optional_attributes.get("data-cta-position", None)
+
+        if position:
+            href += f"&data_cta_position={position}"
+
+    if class_name:
+        css_class += f" {class_name}"
+
+    markup = f'<a href="{href}" data-action="{settings.FXA_ENDPOINT}" class="{css_class}" {attrs}>' f"{link_text}" f"</a>"
+
+    return Markup(markup)
+
+
+@library.global_function
+@jinja2.pass_context
+def relay_subscribe_link(
+    ctx,
+    entrypoint,
+    link_text,
+    product="relay-email",
+    plan=RELAY_12_MONTH_PLAN,
+    class_name=None,
+    country_code=None,
+    lang=None,
+    optional_parameters=None,
+    optional_attributes=None,
+):
+    """
+    Render a Relay subscribe link with required params for FxA authentication.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ relay_subscribe_link(
+            entrypoint=_utm_source,
+            link_text=ftl('plan-matrix-sign-up'),
+            product=product,
+            plan='monthly',
+            class_name='mzp-c-button mzp-t-product mzp-t-lg c-matrix-footer-button c-matrix-footer-button-monthly',
+            country_code=country_code,
+            lang=LANG,
+            optional_parameters={
+                'utm_campaign': _utm_campaign
+            },
+            optional_attributes={
+                'data-cta-type': 'fxa-relay',
+                'data-cta-position': 'matrix'
+            })
+        }}
+    """
+
+    if product == "relay-email":
+        product_id = settings.RELAY_EMAIL_PRODUCT_ID
+    elif product == "relay-phone":
+        product_id = settings.RELAY_PHONE_PRODUCT_ID
+    elif product == "relay-bundle":
+        product_id = settings.RELAY_VPN_BUNDLE_PRODUCT_ID
+
+    available_plans = _relay_get_plans(country_code, lang, product)
+    selected_plan = available_plans.get(plan, RELAY_12_MONTH_PLAN)
+    plan_id = selected_plan.get("id")
+
+    product_url = f"{settings.RELAY_SUBSCRIPTION_URL}subscriptions/products/{product_id}?plan={plan_id}"
+
+    if "analytics" in selected_plan:
+        if class_name is None:
+            class_name = ""
+        class_name += " ga-begin-checkout"
+        if optional_attributes is None:
+            optional_attributes = {}
+        optional_attributes["data-ga-item"] = _vpn_get_ga_data(selected_plan)
+
+    return _relay_product_link(product_url, entrypoint, link_text, class_name, optional_parameters, optional_attributes)
+
+
+@library.global_function
+@jinja2.pass_context
+def relay_monthly_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=None, product=RELAY_PRODUCT):
+    """
+    Render a localized string displaying a Relay plan's monthly plan.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ relay_monthly_price(country_code=country_code,
+                             lang=LANG,
+                             product='relay-email') }}
+    """
+
+    available_plans = _relay_get_plans(country_code, lang, product)
+    selected_plan = available_plans.get(plan, RELAY_12_MONTH_PLAN)
+    amount = float(selected_plan.get("price"))
+    currency = selected_plan.get("currency")
+    currency_locale = lang.replace("-", "_")
+    price = format_currency(amount, currency, locale=currency_locale)
+    markup = f"{price}"
+    return Markup(markup)
+
+
+@library.global_function
+@jinja2.pass_context
+def relay_total_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=None, product=RELAY_PRODUCT):
+    """
+    Render a localized string displaying a Relay plan's total price.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ relay_total_price(country_code=country_code, lang=LANG, product='relay-email') }}
+    """
+
+    period = 12 if plan == RELAY_12_MONTH_PLAN else 1
+    available_plans = _relay_get_plans(country_code, lang, product)
+    selected_plan = available_plans.get(plan, RELAY_12_MONTH_PLAN)
+    amount = float(selected_plan.get("price"))
+    total = amount * period
+    currency = selected_plan.get("currency")
+    currency_locale = lang.replace("-", "_")
+    price = format_currency(total, currency, locale=currency_locale)
+    markup = f"{price}"
+    return Markup(markup)
+
+
+@library.global_function
+@jinja2.pass_context
+def relay_bundle_savings(ctx, country_code=None, lang=None, product="relay-bundle"):
+    """
+    Render a localized string displaying VPN total plan price.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ relay_bundle_savings(country_code=country_code, lang=LANG) }}
+    """
+
+    available_plans = _relay_get_plans(country_code, lang, product)
+    selected_plan = available_plans.get(RELAY_12_MONTH_PLAN)
+    saving = float(selected_plan.get("saving"))
+    saving_locale = lang.replace("-", "_")
+    saving = format_percent(saving, locale=saving_locale)
+    markup = f"{saving}"
+    return Markup(markup)

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -312,14 +312,14 @@ def _relay_get_plans(country_code, lang, product):
 
 def _relay_product_link(product_url, entrypoint, link_text, class_name=None, optional_parameters=None, optional_attributes=None):
     separator = "&" if "?" in product_url else "?"
-    client_id = settings.VPN_CLIENT_ID
+    client_id = settings.RELAY_CLIENT_ID
     href = f"{product_url}{separator}entrypoint={entrypoint}&form_type=button&service={client_id}&utm_source={entrypoint}&utm_medium=referral"
 
     if optional_parameters:
         params = "&".join(f"{param}={val}" for param, val in optional_parameters.items())
         href += f"&{params}"
 
-    css_class = "js-vpn-cta-link js-fxa-product-button"
+    css_class = "js-fxa-product-cta-link js-fxa-product-button"
     attrs = ""
 
     if optional_attributes:
@@ -462,7 +462,7 @@ def relay_total_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=Non
 @jinja2.pass_context
 def relay_bundle_savings(ctx, country_code=None, lang=None, product="relay-bundle"):
     """
-    Render a localized string displaying VPN total plan price.
+    Render a localized string displaying the VPN/Relay bundle savings as a percent
 
     Examples
     ========

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -40,8 +40,9 @@ urlpatterns = (
 if settings.DEV:
     urlpatterns += (
         path("relay/", views.relay_landing_page, name="products.relay.landing"),
-        path("relay/waitlist/vpn/", view=views.relay_vpn_waitlist__page, name="products.relay.waitlist.vpn"),
+        path("relay/waitlist/", view=views.relay_premium_waitlist__page, name="products.relay.waitlist.premium"),
         path("relay/waitlist/phone/", view=views.relay_phone_waitlist__page, name="products.relay.waitlist.phone"),
+        path("relay/waitlist/bundle/", view=views.relay_bundle_waitlist__page, name="products.relay.waitlist.bundle"),
         page("relay/faq/", "products/relay/faq.html", ftl_files=["products/relay/shared", "products/relay/faq"]),
         path("relay/premium/", views.relay_premium_page, name="products.relay.premium"),
     )

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -23,6 +23,7 @@ from bedrock.contentful.utils import locales_with_available_content
 from bedrock.products.forms import (
     RelayBundleWaitlistForm,
     RelayPhoneWaitlistForm,
+    RelayPremiumWaitlistForm,
     VPNWaitlistForm,
 )
 from lib import l10n_utils
@@ -35,6 +36,18 @@ def vpn_available(request):
 
     if switch("vpn-wave-vi"):
         country_list = settings.VPN_COUNTRY_CODES + settings.VPN_COUNTRY_CODES_WAVE_VI
+
+    return country in country_list
+
+
+def relay_available(product, request):
+    country = get_country_from_request(request)
+    if product == "relay-bundle":
+        country_list = settings.VPN_COUNTRY_CODES
+    elif product == "relay-phone":
+        country_list = settings.RELAY_PHONE_COUNTRY_CODES
+    else:
+        country_list = settings.RELAY_EMAIL_COUNTRY_CODES
 
     return country in country_list
 
@@ -374,36 +387,60 @@ def resource_center_article_view(request, slug):
 def relay_landing_page(request):
     template_name = "products/relay/landing.html"
     ftl_files = ["products/relay/shared", "products/relay/landing", "products/relay/bundle", "products/relay/matrix", "products/relay/faq"]
+    relay_email_available_in_country = relay_available("relay-email", request)
+    relay_phone_available_in_country = relay_available("relay-phone", request)
+    vpn_available_in_country = vpn_available(request)
+    country = get_country_from_request(request)
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
 
-    return l10n_utils.render(request, template_name, ftl_files=ftl_files)
+    context = {
+        "email_available": relay_email_available_in_country,
+        "phone_available": relay_phone_available_in_country,
+        "bundle_available": relay_bundle_available_in_country,
+    }
+
+    return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)
 
 
 @require_safe
 def relay_premium_page(request):
     template_name = "products/relay/premium.html"
     ftl_files = ["products/relay/shared", "products/relay/landing", "products/relay/premium", "products/relay/bundle", "products/relay/matrix"]
+    relay_email_available_in_country = relay_available("relay-email", request)
+    relay_phone_available_in_country = relay_available("relay-phone", request)
+    vpn_available_in_country = vpn_available(request)
+    country = get_country_from_request(request)
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
 
-    return l10n_utils.render(request, template_name, ftl_files=ftl_files)
+    context = {
+        "email_available": relay_email_available_in_country,
+        "phone_available": relay_phone_available_in_country,
+        "bundle_available": relay_bundle_available_in_country,
+    }
+
+    return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)
 
 
 @require_safe
-def relay_invite_page(request):
-    ftl_files = ["products/relay/landing", "products/relay/shared"]
+def relay_premium_waitlist__page(request):
+    ftl_files = ["products/relay/waitlist", "products/relay/shared"]
+    locale = l10n_utils.get_locale(request)
+    newsletter_form = RelayPremiumWaitlistForm(locale)
 
-    ctx = {"action": "action", "newsletter_form": "newsletter_form"}
+    ctx = {"action": settings.BASKET_SUBSCRIBE_URL, "newsletter_form": newsletter_form}
 
-    return l10n_utils.render(request, "products/relay/invite.html", ctx, ftl_files=ftl_files)
+    return l10n_utils.render(request, "products/relay/waitlist/premium.html", ctx, ftl_files=ftl_files)
 
 
 @require_safe
-def relay_vpn_waitlist__page(request):
+def relay_bundle_waitlist__page(request):
     ftl_files = ["products/relay/waitlist", "products/relay/shared"]
     locale = l10n_utils.get_locale(request)
     newsletter_form = RelayBundleWaitlistForm(locale)
 
     ctx = {"action": settings.BASKET_SUBSCRIBE_URL, "newsletter_form": newsletter_form}
 
-    return l10n_utils.render(request, "products/relay/waitlist/vpn.html", ctx, ftl_files=ftl_files)
+    return l10n_utils.render(request, "products/relay/waitlist/bundle.html", ctx, ftl_files=ftl_files)
 
 
 @require_safe

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -386,7 +386,14 @@ def resource_center_article_view(request, slug):
 @require_safe
 def relay_landing_page(request):
     template_name = "products/relay/landing.html"
-    ftl_files = ["products/relay/shared", "products/relay/landing", "products/relay/bundle", "products/relay/matrix", "products/relay/faq"]
+    ftl_files = [
+        "products/relay/landing",
+        "products/relay/features",
+        "products/relay/matrix",
+        "products/relay/faq",
+        "products/relay/bundle",
+        "products/relay/shared",
+    ]
     relay_email_available_in_country = relay_available("relay-email", request)
     relay_phone_available_in_country = relay_available("relay-phone", request)
     vpn_available_in_country = vpn_available(request)
@@ -405,7 +412,7 @@ def relay_landing_page(request):
 @require_safe
 def relay_premium_page(request):
     template_name = "products/relay/premium.html"
-    ftl_files = ["products/relay/shared", "products/relay/landing", "products/relay/premium", "products/relay/bundle", "products/relay/matrix"]
+    ftl_files = ["products/relay/premium", "products/relay/features", "products/relay/matrix", "products/relay/bundle", "products/relay/shared"]
     relay_email_available_in_country = relay_available("relay-email", request)
     relay_phone_available_in_country = relay_available("relay-phone", request)
     vpn_available_in_country = vpn_available(request)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1770,6 +1770,9 @@ RELAY_MAIL_DOMAIN = "mozmail.com"
 # Relay, number of email addresses include in the free plan
 RELAY_MAX_NUM_FREE_ALIASES = 5
 
+# VPN client ID for referral parameter tracking (issue 10811)
+RELAY_CLIENT_ID = "9ebfe2c2f9ea3c58"
+
 # URL for Mozilla Relay subscription links
 # ***This URL *MUST* end in a traling slash!***
 RELAY_SUBSCRIPTION_URL = config("RELAY_SUBSCRIPTION_URL", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
@@ -2021,24 +2024,11 @@ RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING = {
 # Countries where Relay Email Masking is available.
 RELAY_EMAIL_COUNTRY_CODES = [
     "CA",  # Canada
+    "GB",  # United Kingdom of Great Britain and Northern Island
     "MY",  # Malaysia
     "NZ",  # New Zealand
     "SG",  # Singapore
-    # United Kingdom + "Territories"
-    "GB",  # United Kingdom of Great Britain and Northern Island
-    "GG",  # Guernsey (a British Crown dependency)
-    "IM",  # Isle of Man (a British Crown dependency)
-    "IO",  # British Indian Ocean Territory
-    "JE",  # Jersey (a British Crown dependency)
-    "UK",  # United Kingdom
-    "VG",  # Virgin Islands (British)
-    # USA + "Territories"
-    "AS",  # American Samoa
-    "MP",  # Northern Mariana Islands
-    "PR",  # Puerto Rico
-    "UM",  # United States Minor Outlying Islands
     "US",  # United States of America
-    "VI",  # Virgin Islands (U.S.)
     # EU Countries
     "AT",  # Austria
     "BE",  # Belgium

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1719,6 +1719,8 @@ VPN_BLOCK_DOWNLOAD_COUNTRY_CODES = [
     "SY",  # Syria
 ]
 
+# VPN / RELAY BUNDLE ============================================================================
+
 # Product ID for VPN & Relay bundle subscriptions.
 VPN_RELAY_BUNDLE_PRODUCT_ID = config("VPN_RELAY_BUNDLE_PRODUCT_ID", default="prod_MQ9Zf1cyI81XS2" if DEV else "prod_MIex7Q079igFZJ")
 
@@ -1730,7 +1732,7 @@ VPN_RELAY_BUNDLE_PLAN_ID_MATRIX = {
                 "id": "price_1Lwp7uKb9q6OnNsLQYzpzUs5" if DEV else "price_1LwoSDJNcmPzuWtR6wPJZeoh",
                 "price": "US$6.99",
                 "total": "US$83.88",
-                "saving": 50,
+                "saving": 40,
                 "analytics": {
                     "brand": "vpn",
                     "plan": "vpn + relay",
@@ -1760,12 +1762,372 @@ VPN_RELAY_BUNDLE_COUNTRY_CODES = [
     "US",  # United States of America
 ]
 
-# RELAY ==============================================================
+# RELAY =========================================================================================
 
 # Relay email mask domain
 RELAY_MAIL_DOMAIN = "mozmail.com"
 
-# Relay stats
+# Relay, number of email addresses include in the free plan
 RELAY_MAX_NUM_FREE_ALIASES = 5
-RELAY_BUNDLE_VPN_SERVERS = 400
-RELAY_BUNDLE_VPN_COUNTRIES = 30
+
+# URL for Mozilla Relay subscription links
+# ***This URL *MUST* end in a traling slash!***
+RELAY_SUBSCRIPTION_URL = config("RELAY_SUBSCRIPTION_URL", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
+
+# Product ID for Relay subscriptions
+RELAY_EMAIL_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_KEq0LXqs7vysQT" if DEV else "prod_KGizMiBqUJdYoY")
+RELAY_PHONE_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_LviM2I0paxH1DZ" if DEV else "prod_KGizMiBqUJdYoY")
+
+# Relay subscription plan IDs by currency/language.
+RELAY_EMAIL_PLAN_ID_MATRIX = {
+    "chf": {  # Swiss franc
+        "de": {  # German
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCqOJNcmPzuWtRuIXpQRxi",
+                "price": 2.00,
+                "currency": "CHF",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYCqyJNcmPzuWtR3Um5qDPu",
+                "price": 1.00,
+                "currency": "CHF",
+            },
+        },
+        "fr": {  # French
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCvpJNcmPzuWtRq9ci2gXi",
+                "price": 2.00,
+                "currency": "CHF",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYCwMJNcmPzuWtRm6ebmq2N",
+                "price": 1.00,
+                "currency": "CHF",
+            },
+        },
+        "it": {  # Italian
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCiBJNcmPzuWtRxtI8D5Uy",
+                "price": 2.00,
+                "currency": "CHF",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYClxJNcmPzuWtRWjslDdkG",
+                "price": 1.00,
+                "currency": "CHF",
+            },
+        },
+    },
+    "euro": {  # Euro
+        "de": {  # German
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYC79JNcmPzuWtRU7Q238yL",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYC7xJNcmPzuWtRcdKXCVZp",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "es": {  # Spanish
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCWmJNcmPzuWtRtopZog9E",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYCXNJNcmPzuWtRu586XOFf",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "fr": {  # French
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYBuLJNcmPzuWtRn58XQcky",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYBwcJNcmPzuWtRpgoWcb03",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "it": {  # Italian
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCMrJNcmPzuWtRTP9vD8wY",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYCN2JNcmPzuWtRtWz7yMno",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "nl": {  # Dutch
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCdLJNcmPzuWtR0J1EHoJ0",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYCdtJNcmPzuWtRVm4jLzq2",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "ga": {  # Irish
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LhdrkJNcmPzuWtRvCc4hsI2",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LhdprJNcmPzuWtR7HqzkXTS",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "sv": {  # Sweedish
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYBblJNcmPzuWtRGRHIoYZ5",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYBeMJNcmPzuWtRT5A931WH",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "fi": {  # Finnish
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYBn9JNcmPzuWtRI3nvHgMi",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYBq1JNcmPzuWtRmyEa08Wv",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+    },
+    "usd": {
+        "en": {
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LXUcnJNcmPzuWtRpbNOajYS",
+                "price": 1.99,
+                "currency": "USD",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LXUdlJNcmPzuWtRKTYg7mpZ",
+                "price": 0.99,
+                "currency": "USD",
+            },
+        },
+        "gb": {
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1LYCHpJNcmPzuWtRhrhSYOKB",
+                "price": 1.99,
+                "currency": "USD",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1LYCIlJNcmPzuWtRQtYLA92j",
+                "price": 0.99,
+                "currency": "USD",
+            },
+        },
+    },
+}
+RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING = {
+    # Austria
+    "AT": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
+    },
+    # Belgium
+    "BE": {
+        "fr": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fr"],
+        "de": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    # Switzerland
+    "CH": {
+        "fr": RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["fr"],
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["de"],
+        "it": RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["it"],
+    },
+    # Germany
+    "DE": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
+    },
+    # Spain
+    "ES": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["es"],
+    },
+    # France
+    "FR": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fr"],
+    },
+    # Ireland
+    "IE": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["ga"],
+    },
+    # Italy
+    "IT": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["it"],
+    },
+    # Netherlands
+    "NL": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    # Sweden
+    "SE": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["sv"],
+    },
+    # Finland
+    "FI": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fi"],
+    },
+    # USA
+    "US": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    # Great Britian
+    "GB": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Canada
+    "CA": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    # New Zealand
+    "NZ": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Malaysia
+    "MY": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Singapore
+    "SG": {
+        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+}
+
+# Countries where Relay Email Masking is available.
+RELAY_EMAIL_COUNTRY_CODES = [
+    "CA",  # Canada
+    "MY",  # Malaysia
+    "NZ",  # New Zealand
+    "SG",  # Singapore
+    # United Kingdom + "Territories"
+    "GB",  # United Kingdom of Great Britain and Northern Island
+    "GG",  # Guernsey (a British Crown dependency)
+    "IM",  # Isle of Man (a British Crown dependency)
+    "IO",  # British Indian Ocean Territory
+    "JE",  # Jersey (a British Crown dependency)
+    "UK",  # United Kingdom
+    "VG",  # Virgin Islands (British)
+    # USA + "Territories"
+    "AS",  # American Samoa
+    "MP",  # Northern Mariana Islands
+    "PR",  # Puerto Rico
+    "UM",  # United States Minor Outlying Islands
+    "US",  # United States of America
+    "VI",  # Virgin Islands (U.S.)
+    # EU Countries
+    "AT",  # Austria
+    "BE",  # Belgium
+    "CH",  # Switzerland
+    "DE",  # Germany
+    "ES",  # Spain
+    "FI",  # Finland
+    "FR",  # France
+    "IE",  # Ireland
+    "IT",  # Italy
+    "NL",  # Netherlands
+    "SE",  # Sweden
+]
+
+RELAY_PHONE_PLAN_ID_MATRIX = {
+    "usd": {
+        "en": {
+            "monthly": {
+                "id": "TKTK" if DEV else "price_1Li0w8JNcmPzuWtR2rGU80P3",
+                "price": 4.99,
+                "currency": "USD",
+            },
+            "yearly": {
+                "id": "TKTK" if DEV else "price_1Li15WJNcmPzuWtRIh0F4VwP",
+                "price": 3.99,
+                "currency": "USD",
+            },
+        },
+    },
+}
+
+RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING = {
+    "US": {
+        "default": RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    "CA": {
+        "default": RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+}
+
+# Countries where Relay Phone Masking is available.
+RELAY_PHONE_COUNTRY_CODES = [
+    "CA",  # Canada
+    "US",  # United States of America
+]
+
+
+# RELAY / VPN BUNDLE ============================================================================
+
+# Bundle guarantee period
+RELAY_VPN_BUNDLE_GUARANTEE = 30
+
+# Product ID for VPN & Relay bundle subscriptions.
+RELAY_VPN_BUNDLE_PRODUCT_ID = config("VPN_RELAY_BUNDLE_PRODUCT_ID", default="prod_MQ9Zf1cyI81XS2" if DEV else "prod_MIex7Q079igFZJ")
+
+# VPN & Relay bundle plan IDs by currency/language.
+RELAY_VPN_BUNDLE_PLAN_ID_MATRIX = {
+    "usd": {
+        "en": {
+            "yearly": {
+                "id": "price_1Lwp7uKb9q6OnNsLQYzpzUs5" if DEV else "price_1LwoSDJNcmPzuWtR6wPJZeoh",
+                "price": "6.99",
+                "currency": "USD",
+                "saving": 0.4,
+                "analytics": {
+                    "brand": "vpn",
+                    "name": "vpn-relay",
+                    "currency": "USD",
+                    "discount": "83.88",
+                    "price": "83.88",
+                    "variant": "yearly",
+                },
+            },
+        }
+    },
+}
+
+RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING = {
+    "US": {
+        "default": RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    "CA": {
+        "default": RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+}
+
+# Countries where VPN & Relay bundle is available.
+# Phone masking is only supported in these countries.
+RELAY_VPN_BUNDLE_COUNTRY_CODES = [
+    "CA",  # Canada
+    "US",  # United States of America
+]

--- a/l10n/en/products/relay/bundle.ftl
+++ b/l10n/en/products/relay/bundle.ftl
@@ -15,7 +15,6 @@ bundle-banner-plan-modules-email-masking = Email masking
 bundle-banner-plan-modules-phone-masking = Phone masking
 bundle-banner-plan-modules-mozilla-vpn = { -brand-name-mozilla-vpn }
 bundle-banner-cta = Get { -brand-name-mozilla-vpn } + { -brand-name-relay }
-bundle-banner-alt = { -brand-name-mozilla-vpn } and { -brand-name-relay }
 # Variables:
 #   $days_guarantee (string) - the number of days for money-back guarantee. Examples: 30, 90
 bundle-banner-money-back-guarantee-2 = { $days_guarantee }-day money back guarantee for first time subscribers

--- a/l10n/en/products/relay/faq.ftl
+++ b/l10n/en/products/relay/faq.ftl
@@ -7,11 +7,6 @@
 ## FAQ Page
 
 faq-headline = Frequently Asked Questions
-# String used to display the attachment limit, e.g. 10 MB
-# Variables:
-#  $size (number): maximum size for attachments
-#  $unit (string): unit of measurement (e.g. MB for Megabyte)
-email-size-limit = { $size } { $unit }
 faq-question-what-is-question-2 = What is a { -brand-name-relay } email mask?
 faq-question-what-is-answer-2 = Email masks are masked, or private, email addresses that forward messages to your true email address. These masks allow you to share an address with third parties which will mask your true email address and forward messages to it.
 faq-question-missing-emails-question-2 = I’m not getting messages from my email masks
@@ -22,9 +17,6 @@ faq-question-missing-emails-answer-reason-size = The email forwarded has an atta
 faq-question-missing-emails-answer-reason-not-accepted-2 = The site doesn’t accept email masks
 faq-question-missing-emails-answer-reason-turned-off-2 = The mask might have forwarding turned off
 faq-question-missing-emails-answer-reason-delay = { -brand-name-relay } might be taking longer than usual to forward your messages
-#   $url (url) - link to the support site
-#   $attrs (string) - specific attributes added to external links
-faq-question-missing-emails-answer-b-html = If you’re a { -brand-name-relay-premium } user struggling with any of these issues, please <a href="{ $url }" { $attrs }>contact our support team</a>.
 #   $url (url) - link to the support site
 #   $attrs (string) - specific attributes added to external links
 faq-question-missing-emails-answer-support-site-html = If you’re struggling with any of these issues, please <a href="{ $url }" { $attrs }>visit our support site</a>.
@@ -44,8 +36,6 @@ faq-question-1-answer-a-2 = While { -brand-name-relay } does not filter for spam
 #   $attrs (string) - specific attributes added to external links
 faq-question-1-answer-b-2-html = If you see a broader problem of unwanted email from all of your masks, please <a href="{ $url }" { $attrs }>report this to us</a> so we can consider adjusting the SES spam thresholds for this service. If you report these as spam, your email provider will see { -brand-name-relay } as the source of spam, not the original sender.
 faq-question-availability-question = Where is { -brand-name-relay } available?
-faq-question-availability-answer = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } is available in the United States, Germany, United Kingdom, Canada, Singapore, Malaysia, New Zealand, France, Belgium, Austria, Spain, Italy, Switzerland, Netherlands, and Ireland.
-faq-question-availability-answer-v2 = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } is available in the United States, Germany, United Kingdom, Canada, Singapore, Malaysia, New Zealand, Finland, France, Belgium, Austria, Spain, Italy, Sweden, Switzerland, the Netherlands, and Ireland.
 faq-question-availability-answer-v3 = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } is available in Austria, Belgium, Canada, Cyprus, Estonia, Finland, France, Germany, Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malaysia, Malta, Netherlands, New Zealand, Portugal, Singapore, Slovakia, Slovenia, Spain, Sweden, Switzerland, United Kingdom, and the United States.
 faq-question-landing-page-availability = Free { -brand-name-relay } is available in most countries. { -brand-name-relay-premium } email masking is available in the United States, Germany, United Kingdom, Canada, Singapore, Malaysia, New Zealand, France, Belgium, Austria, Spain, Italy, Switzerland, Netherlands, and Ireland. { -brand-name-relay-premium } phone masking is only available in the US and Canada.
 faq-question-4-question-2 = Can I reply to messages using my { -brand-name-relay } email mask?
@@ -66,7 +56,6 @@ faq-question-8-question = What data does { -brand-name-firefox-relay } collect?
 # Variables:
 #   $url (url) - https://www.mozilla.org/privacy/firefox-relay/
 #   $attrs (string) - specific attributes added to external links
-faq-question-8-answer-2-html = You can learn more about the data { -brand-name-firefox-relay } collects by taking a look at our <a href="{ $url }" { $attrs }>Privacy Notice</a>. You’re also able to optionally share data about the labels and site you use for your email masks so we can provide you that service and improve it for you.
 faq-question-8-answer-3-html = { -brand-name-firefox-relay } collects the websites where you’ve used your email masks, and labels your masks with those websites so you can easily identify them. You can opt out of this on your Settings page, under Privacy. But please note, turning that setting off means you won’t be able to see where you’ve used each mask, and your account names will no longer sync between devices. You can learn more about the data { -brand-name-firefox-relay } collects in our <a href="{ $url }" { $attrs }>Privacy Notice</a>.
 faq-question-email-storage-question = Does { -brand-name-relay } store my emails?
 faq-question-email-storage-answer = Under the rare circumstance in which the service is down, we may temporarily store your emails until we are able to send them. We will never store your emails for longer than three days.

--- a/l10n/en/products/relay/features.ftl
+++ b/l10n/en/products/relay/features.ftl
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/products/relay/
+
+## HIGHLIGHTED FEATURES SECTION
+
+highlighted-features-section-title = Secure, simple features to help protect your identity
+highlighted-features-section-bottom-title = Protect your identity (and your inbox) with { -brand-name-firefox-relay }
+highlighted-features-section-bottom-cta = Get started
+
+highlighted-features-section-unlimited-masks-headline = Create unlimited email masks
+# Variables:
+#   $mask_limit (number) - the number of masks included with a particular plan
+highlighted-features-section-unlimited-masks-body = Everyone gets { $mask_limit } email masks for free.
+    But with { -brand-name-relay-premium }, you can generate as many masks as you need to help protect your email inbox
+    from spammers, hackers, and online trackers.
+
+highlighted-features-section-masks-on-the-go-headline = Instantly create masks on the go
+# Variables:
+#   $mozmail (string): domain used by Relay masks (mozmail.com)
+highlighted-features-section-masks-on-the-go-body = { -brand-name-relay-premium } gives you a unique { -brand-name-relay } email domain so you can instantly
+    create new masks anywhere you are. Simply add any word or phrase before the @ symbol. At a restaurant? Use restaurant@yourdomain.{ $mozmail }.
+    Shopping? Try shop@yourdomain.{ $mozmail }.
+
+highlighted-features-section-replying-headline = Reply to emails & texts anonymously
+highlighted-features-section-replying-body = { -brand-name-relay-premium } lets you respond to emails from your
+    masked email account, so senders will never know your real email address. With phone masking, you can reply
+    to texts from your masked phone number to protect your real number.
+
+highlighted-features-section-block-promotions-headline = Block promotional emails
+highlighted-features-section-block-promotions-body = With { -brand-name-relay-premium }, you can block promotional emails from reaching your
+    inbox while still receiving emails like receipts or shipping information.
+
+highlighted-features-section-remove-trackers-headline = Remove email trackers
+highlighted-features-section-remove-trackers-body = { -brand-name-relay } can remove common email trackers from any emails forwarded to you, helping
+    you stay invisible to trackers and advertisers.

--- a/l10n/en/products/relay/landing.ftl
+++ b/l10n/en/products/relay/landing.ftl
@@ -13,7 +13,6 @@ hero-section-title = Protect your identity with secure phone and email masking
 hero-section-body = Our secure, easy-to-use email and phone masks help keep your identity
     private so you can sign up for new accounts anonymously, stop spam texts and junk calls, and
     get only the emails you want in your inbox.
-hero-section-cta = Get started
 # Context: This lists the various websites and magazines who have mentioned Firefox Relay.
 # Example: "As seen in: FORBES magainze and LifeHacker"
 hero-section-social-proof = As seen in:
@@ -51,39 +50,6 @@ landing-review-user-four-review-list-1 = Gives peace of mind when surfing the in
 landing-review-user-four-review-list-2 = Protects ones identity from trackers through generation of aliases where one does not want to share the real email address for various reasons.
 landing-review-user-four-review-list-3 = Email inbox data is safe in the hands of { -brand-name-firefox-relay }.
 landing-review-user-four-review-list-4 = { -brand-name-firefox-relay } works wonders, try it!!!
-
-## HIGHLIGHTED FEATURES SECTION
-
-highlighted-features-section-title = Secure, simple features to help protect your identity
-highlighted-features-section-bottom-title = Protect your identity (and your inbox) with { -brand-name-firefox-relay }
-highlighted-features-section-bottom-cta = Get started
-
-highlighted-features-section-unlimited-masks-headline = Create unlimited email masks
-# Variables:
-#   $mask_limit (number) - the number of masks included with a particular plan
-highlighted-features-section-unlimited-masks-body = Everyone gets { $mask_limit } email masks for free.
-    But with { -brand-name-relay-premium }, you can generate as many masks as you need to help protect your email inbox
-    from spammers, hackers, and online trackers.
-
-highlighted-features-section-masks-on-the-go-headline = Instantly create masks on the go
-# Variables:
-#   $mozmail (string): domain used by Relay masks (mozmail.com)
-highlighted-features-section-masks-on-the-go-body = { -brand-name-relay-premium } gives you a unique { -brand-name-relay } email domain so you can instantly
-    create new masks anywhere you are. Simply add any word or phrase before the @ symbol. At a restaurant? Use restaurant@yourdomain.{ $mozmail }.
-    Shopping? Try shop@yourdomain.{ $mozmail }.
-
-highlighted-features-section-replying-headline = Reply to emails & texts anonymously
-highlighted-features-section-replying-body = { -brand-name-relay-premium } lets you respond to emails from your
-    masked email account, so senders will never know your real email address. With phone masking, you can reply
-    to texts from your masked phone number to protect your real number.
-
-highlighted-features-section-block-promotions-headline = Block promotional emails
-highlighted-features-section-block-promotions-body = With { -brand-name-relay-premium }, you can block promotional emails from reaching your
-    inbox while still receiving emails like receipts or shipping information.
-
-highlighted-features-section-remove-trackers-headline = Remove email trackers
-highlighted-features-section-remove-trackers-body = { -brand-name-relay } can remove common email trackers from any emails forwarded to you, helping
-    you stay invisible to trackers and advertisers.
 
 ## FAQ SECTION
 

--- a/l10n/en/products/relay/matrix.ftl
+++ b/l10n/en/products/relay/matrix.ftl
@@ -31,8 +31,7 @@ plan-matrix-feature-promo-email-blocking = Block promotional emails
 plan-matrix-feature-email-subdomain = { -brand-name-relay } email domain to create masks on-the-go
 plan-matrix-feature-email-reply = Reply to emails anonymously
 plan-matrix-feature-phone-mask = Phone mask to protect your real phone number
-plan-matrix-feature-vpn = { -brand-name-mozilla-vpn }
-plan-matrix-feature-list-email-masks-unlimited = Unlimited email masks
+plan-matrix-feature-mozvpn = { -brand-name-mozilla-vpn }
 
 ## Feature Breakdowns Mobile (Shorter than desktop strings)
 
@@ -43,7 +42,7 @@ plan-matrix-feature-mobile-promo-email-blocking = Block promotional emails
 plan-matrix-feature-mobile-email-subdomain = Unique { -brand-name-relay } email domain
 plan-matrix-feature-mobile-email-reply = Reply to emails anonymously
 plan-matrix-feature-mobile-phone-mask = Protect your real phone number
-plan-matrix-feature-mobile-vpn = Access to { -brand-name-mozilla-vpn }
+plan-matrix-feature-mobile-mozvpn = { -brand-name-mozilla-vpn }
 
 ## Plan Details
 
@@ -60,7 +59,7 @@ plan-matrix-price-free = Free
 plan-matrix-price-monthly-calculated = { $monthly_price }/mo.
 plan-matrix-price-period-yearly = Yearly
 plan-matrix-price-period-monthly = Monthly
-plan-matrix-price-period-yearly-footnote-1 = Billed annually
+plan-matrix-price-period-yearly-footnote-1 = Billed yearly
 plan-matrix-price-period-monthly-footnote-1 = Billed monthly
 plan-matrix-price-vpn-discount-promo = <span>Save { $savings }</span> on regular { -brand-name-vpn } price
 

--- a/l10n/en/products/relay/premium.ftl
+++ b/l10n/en/products/relay/premium.ftl
@@ -5,11 +5,9 @@
 ### URL: https://www-dev.allizom.org/products/relay/premium/
 
 premium-promo-hero-headline = Make protecting your inbox easier with { -brand-name-firefox-relay-premium }
+premium-promo-hero-body-3 = With { -brand-name-firefox-relay-premium }, you get unlimited custom email masks that forward only the emails you want to your true email address.
 # Variables:
 #   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
 premium-promo-hero-body-2-html = With { -brand-name-firefox-relay-premium }, you get unlimited custom email masks that forward only the emails you want to your true email address. <b>For a limited time, you can upgrade to { -brand-name-relay-premium } for only { $monthly_price } a month.</b>
-# Variables:
-#   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
-premium-promo-hero-body-3 = With { -brand-name-firefox-relay-premium }, you get unlimited custom email masks that forward only the emails you want to your true email address.
 
 premium-promo-availability-warning-3 = { -brand-name-relay-premium } is available in Austria, Belgium, Canada, Cyprus, Estonia, Finland, France, Germany, Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malaysia, Malta, Netherlands, New Zealand, Portugal, Singapore, Slovakia, Slovenia, Spain, Sweden, Switzerland, United Kingdom, and the United States.

--- a/l10n/en/products/relay/premium.ftl
+++ b/l10n/en/products/relay/premium.ftl
@@ -11,6 +11,5 @@ premium-promo-hero-body-2-html = With { -brand-name-firefox-relay-premium }, you
 # Variables:
 #   $monthly_price (string) - the monthly cost (including currency symbol) for Relay Premium. Examples: $0.99, 0,99 €
 premium-promo-hero-body-3 = With { -brand-name-firefox-relay-premium }, you get unlimited custom email masks that forward only the emails you want to your true email address.
-premium-promo-hero-cta = Upgrade now
 
 premium-promo-availability-warning-3 = { -brand-name-relay-premium } is available in Austria, Belgium, Canada, Cyprus, Estonia, Finland, France, Germany, Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malaysia, Malta, Netherlands, New Zealand, Portugal, Singapore, Slovakia, Slovenia, Spain, Sweden, Switzerland, United Kingdom, and the United States.

--- a/l10n/en/products/relay/shared.ftl
+++ b/l10n/en/products/relay/shared.ftl
@@ -13,3 +13,5 @@ relay-shared-subnav-faq = { -brand-name-relay } FAQs
 
 # Page description
 meta-description-2 = { -brand-name-firefox-relay } makes it easy to create email masks that forward your messages to your true inbox. Use them to protect your online accounts from hackers and unwanted messages.
+
+hero-section-cta = Get started

--- a/l10n/en/products/relay/waitlist.ftl
+++ b/l10n/en/products/relay/waitlist.ftl
@@ -4,9 +4,9 @@
 
 ### URL: https://www-dev.allizom.org/products/relay/waitlist/[vpn|phone].html
 
+waitlist-premium-name = { -brand-name-relay-premium }
 waitlist-bundle-name = { -brand-name-relay } + { -brand-name-vpn } bundle
 waitlist-phone-name = { -brand-name-relay } phone masking
-## old variables
 waitlist-heading-2 = Join the { -brand-name-relay-premium } waitlist
 waitlist-heading-phone = Join the { -brand-name-relay } phone masking waitlist
 waitlist-heading-bundle = Join the waitlist for the { -brand-name-relay } + { -brand-name-vpn } bundle
@@ -29,7 +29,7 @@ waitlist-privacy-policy-use-bundle = Your information will only be used to notif
 waitlist-subscribe-success-title = Thanks! You're on the list
 # Variables:
 #   $product (string) one of the following three options:
-#      - { -brand-name-firefox-firefox-relay-premium }
+#      - { -brand-name-relay-premium }
 #      - { waitlist-bundle-name }
 #      - { waitlist-phone-name }
 waitlist-subscribe-success-desc = Once { $product } becomes available for your region, we’ll email you.

--- a/media/css/products/relay/matrix.scss
+++ b/media/css/products/relay/matrix.scss
@@ -80,7 +80,6 @@ $brand-theme: 'firefox';
 // * -------------------------------------------------------------------------- */
 
 .c-matrix-mobile {
-
     @media #{$mq-xl} {
         display: none;
     }
@@ -138,6 +137,7 @@ $brand-theme: 'firefox';
         height: 16px;
         width: 16px;
         margin-left: $spacing-md;
+        border-top: 3px solid transparent; // 3px look best ¯\_(ツ)_/¯
     }
 
     span {
@@ -153,14 +153,6 @@ $brand-theme: 'firefox';
     }
 }
 
-.c-matrix-footer {
-    text-align: center;
-
-    small {
-        display: block;
-    }
-}
-
 @media #{$mq-md} {
     .c-matrix-mobile {
         > ul {
@@ -169,61 +161,172 @@ $brand-theme: 'firefox';
     }
 }
 
-.c-toggle {
-    background-color: $color-marketing-gray-20;
-    border-radius: $border-radius-lg + 2px;
-    display: flex;
-    margin-bottom: 4em; // making space for one line of text, units scale with text site
-    padding: $spacing-xs;
+// * -------------------------------------------------------------------------- */
+
+.c-matrix-footer {
+    display: grid;
+    gap: $spacing-xs;
+    grid-template-areas:
+        "toggle"
+        "price"
+        "button"
+        "period";
+    grid-template-rows: 2rem 3rem min-content 1.4rem;
     position: relative;
+    width: 100%;
+    text-align: center;
+}
 
-    > input {
-        opacity: 0;
-        position: absolute;
-        top: 0;
-        left: 0;
+.c-matrix-footer-free {
+    @include text-body-lg;
+    align-self: end;
+    color: $color-blue-50;
+    font-weight: bold;
+    grid-area: price;
+}
 
-        &:nth-child(2n+1) {
-            left: 50%;
-        }
+.c-matrix-footer-savings {
+    align-self: end;
+    grid-row-start: 1;
+    grid-row-end: 3;
+
+    span {
+        font-weight: bold;
+        display: block;
     }
+}
 
-    > label {
-        @include text-body-sm;
-        border: 2px solid transparent;
-        color: $color-marketing-gray-80;
-        cursor: pointer;
-        font-weight: 500;
-        padding: $spacing-xs $spacing-sm;
-        text-align: center;
-        width: 50%;
+small.c-matrix-footer-period {
+    grid-area: period;
+    display: grid;
+    align-items: center;
+}
 
-        em {
-            @include text-body-lg;
-            display: none;
-            font-weight: bold;
-            left: 0;
-            padding: $spacing-md $spacing-sm;
-            position: absolute;
-            right: 0;
-            text-align: center;
-            top: 100%;
-            cursor: default;
-            pointer-events: none;
-        }
+.c-matrix-footer .mzp-c-button {
+    grid-area: button;
+}
+
+.c-matrix-footer .c-matrix-footer-waitlist {
+    align-self: end;
+    grid-row-start: 1;
+    grid-row-end: 3;
+}
+
+
+// * -------------------------------------------------------------------------- */
+
+.c-toggle-track,
+.c-toggle-input,
+.c-toggle-label {
+    left: 0;
+    position: absolute;
+    top: 0;
+}
+
+
+.c-toggle-track {
+    background-color: $color-marketing-gray-20;
+    border-radius: $border-radius-lg;
+    border: 4px solid $color-marketing-gray-20;
+    box-sizing: border-box;
+    padding: 2px 0;
+    width: 100%;
+
+    // adding text styled the same way as the labels we're trying to contain
+    // this replicates the height
+    &::after {
+        content: '.';
+        color: $color-marketing-gray-30;
     }
+}
 
-    > input:focus + label {
-        border: 2px solid $color-blue-50;
-    }
+.c-toggle-input {
+    height: 2rem;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    width: 45%;
+    z-index: 4;
+}
 
-    > input:checked + label {
-        background-color: $color-white;
+.c-toggle-input-yearly {
+    left: auto;
+    position: absolute;
+    right: 0;
+}
+
+
+.c-toggle-label {
+    width: 100%;
+    padding: 0;
+
+    span {
         border-radius: $border-radius-lg;
-        color: $color-blue-50;
+        border: 2px solid transparent;
+        color: $color-marketing-gray-70;
+        font-weight: normal;
+        left: 3px;
+        padding: 2px 0;
+        position: absolute;
+        top: 3px;
+        white-space: nowrap;
+        width: 50%;
+        z-index: 3;
+    }
 
-        em {
-            display: block;
-        }
+    &.c-toggle-label-yearly span {
+        left: auto;
+        position: absolute;
+        right: 3px;
+        top: 3px;
+    }
+}
+
+.c-toggle-price {
+    @include text-body-lg;
+    align-self: end;
+    color: $color-blue-50;
+    font-weight: bold;
+    grid-area: price;
+    text-align: center;
+    visibility: hidden;
+}
+
+.c-toggle-input ~ {
+    small.c-matrix-footer-period,
+    .c-matrix-footer-button {
+        visibility: hidden;
+    }
+}
+
+.c-toggle-input:hover + .c-toggle-label span {
+    color: $color-blue-50;
+}
+
+.c-toggle-input:focus + .c-toggle-label span {
+    border: 2px solid $color-blue-50;
+}
+
+.c-toggle-input:checked + .c-toggle-label span {
+    background-color: $color-white;
+    color: $color-blue-50;
+}
+
+.c-toggle-input-yearly:checked ~ {
+    .c-toggle-price-yearly,
+    small.c-matrix-footer-period-yearly,
+    .c-matrix-footer-button-yearly {
+        visibility: visible;
+        z-index: 2;
+    }
+}
+
+.c-toggle-input-monthly:checked ~ {
+    .c-toggle-price-monthly,
+    small.c-matrix-footer-period-monthly,
+    .c-matrix-footer-button-monthly {
+        visibility: visible;
+        z-index: 2;
     }
 }


### PR DESCRIPTION
## One-line summary

Add Relay pricing and display logic.

## Significant changes and points to review

- Add HTML and CSS for pricing toggle and display
- Add pricing and availability lookup tables for Relay Premium, phone, and VPN bundle
- Only display purple bundle promo in CA and US
- Display pricing according to geolocation and language in bundle promo, and pricing matrix for desktop and mobile
- Add waitlist page for Premium
- Add macros to display pricing and waitlist buttons
- Remove unreferenced Fluent string IDs

## Issue / Bugzilla link

#13204

## Testing

http://localhost:8000/en-US/products/relay/
http://localhost:8000/en-US/products/relay/premium
http://localhost:8000/en-US/products/relay/waitlist

Add the query string `?geo={COUNTRY_CODE}` (e.g. AF, CA, DE) to the URL to help test geolocation setup.

**To test this work:**

This PR builds on several previous PRs that have had their code reviewed and are merged into the branch `relay-base` but have not yet merged into `main`. This code review is just for the code that has changed as part of this PR - but comments on all other code in the Relay migration are welcome.

Most of the Relay code in misc.py and base.py were copy and pasted from the VPN configuration. Please keep an eye out for places where I did not replace something I should have, including in comments.

- [ ] The bedrock pages on www-dev should link to the Relay & FxA staging servers.
- [x] The bedrock pages on prod should link to the Relay & FxA prod servers.
- [ ] Subscription links should use different stripe IDs for www-dev / prod.
- [x] Relay Premium is only available in [countries listed at the top of this page](https://relay.firefox.com/premium/).
- [x] Phone masking is only available in US and Canada.
- [x] In unsupported countries, a wait list button is shown instead of a subscription button.
- [x] Multiple currencies and price plans are also supported, in the same type of setup we have for VPN.
- [x] Pricing toggles update price, period, and button URL.
- [x] Pricing displays well in RTL
- [x] Pricing toggles are accessible with keyboard and voice over 

**Follow up PRs will add:**
- tests
- attribution & analytics
- documentation
- Stripe IDs for the staging environment, we only have prod ones at the moment
