### PR TITLE
Update advertising page heading and class names (Fixes #13294)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/advertising.html
+++ b/bedrock/mozorg/templates/mozorg/advertising.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 
-<header class="mzp-c-call-out mzp-t-dark ads-header">
+<header class="mzp-c-call-out mzp-t-dark c-header">
     <div class="mzp-l-content">
       <h1>Find hard-to-reach audiences with Mozilla Ads</h1>
       <p>Reach unique audiences while protecting your brand’s safety and your customer’s privacy</p>
@@ -26,10 +26,10 @@
     </div>
 </header>
 
-<section class="ads-info mzp-l-content mzp-l-columns mzp-t-columns-two">
+<section class="c-info mzp-l-content mzp-l-columns mzp-t-columns-two">
   {% call picto(
     base_el='div',
-    title='Hard-to-reach customers',
+    title='Valuable audiences',
     image=resp_img(
           url='img/mozorg/advertising/mountain.svg',
           optional_attributes={
@@ -93,7 +93,7 @@
   {% endcall %}
 </section>
 
-<section class="mzp-c-call-out ads-purple-callout">
+<section class="mzp-c-call-out c-purple-callout">
   <div class="mzp-l-content">
     <h2>Learn more about advertising on Mozilla</h2>
     <a href="https://mozilla.formstack.com/forms/advertising" class="mzp-c-button mzp-t-dark">Contact us</a>

--- a/media/css/mozorg/advertising.scss
+++ b/media/css/mozorg/advertising.scss
@@ -10,13 +10,13 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
 @import '~@mozilla-protocol/core/protocol/css/components/video';
 
-.ads-header {
+.c-header {
     p {
         @include text-body-lg;
     }
 }
 
-.ads-purple-callout {
+.c-purple-callout {
     background-color: $color-purple-90;
 
     h2 {


### PR DESCRIPTION
## One-line summary

- Updates requested headline
- Changes CSS classes to prevent ad-blockers removing the header (tested with UBlock Origin)

## Issue / Bugzilla link

#13294

## Testing

http://localhost:8000/en-US/advertising/
