### PR TITLE
[July 5th] Add new strings to newsletter-strings.json (Fixes #13250)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -48,8 +48,8 @@
     "title": "{{ ftl('newsletters-drumbeat-newsgroup')|striptags }}"
   },
   "firefox-accounts-journey": {
-    "description": "{{ ftl('newsletters-get-the-most-firefox-account')|striptags }}",
-    "title": "{{ ftl('newsletters-firefox-accounts-tips')|striptags }}"
+    "description": "{{ ftl('newsletters-welcome-emails', fallback='newsletters-get-the-most-firefox-account')|striptags }}",
+    "title": "{{ ftl('newsletter-welcome-emails-that-get-you', fallback='newsletters-firefox-accounts-tips')|striptags }}"
   },
   "firefox-desktop": {
     "description": "{{ ftl('newsletters-dont-miss-the-latest')|striptags }}",
@@ -119,6 +119,10 @@
   "mobile": {
     "description": "{{ ftl('newsletters-keep-up-with-releases')|striptags }}",
     "title": "{{ ftl('newsletters-firefox-for-android')|striptags }}"
+  },
+  "mozilla-accounts": {
+    "description": "{{ ftl('newsletters-get-tips-from-mozilla')|striptags }}",
+    "title": "{{ ftl('newsletters-firefox-accounts')|striptags }}"
   },
   "mozilla-and-you": {
     "description": "{{ ftl('newsletters-get-how-tos')|striptags }}",


### PR DESCRIPTION
## One-line summary

Adds strings that we're exposed for L10n in https://github.com/mozilla/bedrock/pull/13291 to `newsletter-strings.json`

## Significant changes and points to review

This should **not be merged** until July 5th

## Issue / Bugzilla link

#13250

## Testing

JSON should show:

```
"mozilla-accounts": {
  "description": "Get tips from Mozilla on how to get the most out of your account.",
  "title": "Firefox Accounts"
},
```

```
"firefox-accounts-journey": {
  "description": "Welcome emails",
  "title": "Welcome emails that get you started using our products and services."
},
```

http://localhost:8000/en-US/newsletter/newsletter-strings.json