### PR TITLE
Update VPN stage endpoint [fix #13312]

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1176,7 +1176,7 @@ CONVERT_PROJECT_ID = "10039-1003350" if DEV else "10039-1003343"
 
 # URL for Mozilla VPN sign-in links
 # ***This URL *MUST* end in a traling slash!***
-VPN_ENDPOINT = config("VPN_ENDPOINT", default="https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/" if DEV else "https://vpn.mozilla.org/")
+VPN_ENDPOINT = config("VPN_ENDPOINT", default="https://stage.guardian.nonprod.cloudops.mozgcp.net/" if DEV else "https://vpn.mozilla.org/")
 
 # URL for Mozilla VPN subscription links
 # ***This URL *MUST* end in a traling slash!***

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -283,7 +283,7 @@ For Mozilla :abbr:`VPN (Virtual Private Network)` links you can also set:
 
 .. code-block:: text
 
-    VPN_ENDPOINT=https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/
+    VPN_ENDPOINT=https://stage.guardian.nonprod.cloudops.mozgcp.net/
     VPN_SUBSCRIPTION_URL=https://accounts.stage.mozaws.net/
 
 .. Note::

--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -12,7 +12,7 @@ const _allowedDomains = [
     'https://monitor.firefox.com/',
     'https://getpocket.com/',
     'https://vpn.mozilla.org/',
-    'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/',
+    'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
     'https://guardian-dev.herokuapp.com/'
 ];
 

--- a/media/js/base/fxa-product-button.es6.js
+++ b/media/js/base/fxa-product-button.es6.js
@@ -14,7 +14,7 @@ const allowedList = [
     'https://guardian-dev.herokuapp.com/',
     'https://monitor.firefox.com/',
     'https://relay.firefox.com/',
-    'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/',
+    'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
     'https://vpn.mozilla.org/'
 ];
 


### PR DESCRIPTION
## One-line summary

The stage URL has changed from `stage-vpn.guardian.nonprod.cloudops.mozgcp.net` to `stage.guardian.nonprod.cloudops.mozgcp.net` (minus the `-vpn` bit) and the previous URL will soon stop working.

## Issue / Bugzilla link

#13312 

## Testing

http://localhost:8000/products/vpn/download/

- [ ] Ensure download links point to `stage.guardian.nonprod.cloudops.mozgcp.net` and that the client download works from that URL.
