### PR TITLE
Use relay_fxa_button helper for Get free Relay link

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -943,9 +943,9 @@ def relay_fxa_button(
     In Template
     -----------
 
-        {{ monitor_fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Relay') }}
+        {{ relay_fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Relay') }}
     """
-    product_url = "https://relay.firefox.com/accounts/fxa/login/?process=login"
+    product_url = settings.RELAY_PRODUCT_URL + "accounts/fxa/login/?process=login"
     return _fxa_product_button(
         product_url, entrypoint, button_text, class_name, is_button_class, include_metrics, optional_parameters, optional_attributes
     )

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -1150,6 +1150,7 @@ class TestPocketAdjustUrl(TestCase):
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+@override_settings(DEV=False)
 class TestRelayFxAButton(TestCase):
     rf = RequestFactory()
 

--- a/bedrock/products/templates/products/relay/includes/matrix.html
+++ b/bedrock/products/templates/products/relay/includes/matrix.html
@@ -85,7 +85,7 @@
         <td>
           <div class="c-matrix-footer">
             <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
-            <a href="https://relay.firefox.com/accounts/fxa/login/?process=login" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('plan-matrix-get-relay-cta') }}</a>
+            {{ relay_fxa_button(entrypoint='mozilla.org-relay-landing', button_text=ftl('plan-matrix-get-relay-cta'), class_name="mzp-c-button mzp-t-product mzp-t-lg") }}
           </div>
         </td>
         <td>
@@ -150,7 +150,7 @@
         </ul>
         <div class="c-matrix-footer">
             <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
-            <a href="https://relay.firefox.com/accounts/fxa/login/?process=login" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-lg">{{ ftl('plan-matrix-get-relay-cta') }}</a>
+            {{ relay_fxa_button(entrypoint='mozilla.org-relay-landing', button_text=ftl('plan-matrix-get-relay-cta'), class_name="mzp-c-button mzp-t-product mzp-t-lg") }}
         </div>
       </li>
       <li class="c-matrix-plan">

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1776,6 +1776,9 @@ RELAY_CLIENT_ID = "9ebfe2c2f9ea3c58"
 # URL for Mozilla Relay subscription links
 # ***This URL *MUST* end in a traling slash!***
 RELAY_SUBSCRIPTION_URL = config("RELAY_SUBSCRIPTION_URL", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
+RELAY_PRODUCT_URL = config(
+    "RELAY_PRODUCT_URL", default="https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/" if DEV else "https://relay.firefox.com/"
+)
 
 # Product ID for Relay subscriptions
 RELAY_EMAIL_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_KEq0LXqs7vysQT" if DEV else "prod_KGizMiBqUJdYoY")


### PR DESCRIPTION
## One-line summary

Use relay_fxa_button helper for Get free Relay link, so we link to staging on dev server.

## Significant changes and points to review

- Add setting for the link to the Relay product
- Update helper to use Relay setting
- Update test to check prod settings
