### PR TITLE
Remove Hubs from web-eligible-sites

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -148,13 +148,6 @@
     <li>monitor.firefox.com</li>
   </ul>
 
-  <h3>Hubs</h3>
-  <ul class="mzp-u-list-styled">
-    <li>hubs.mozilla.com</li>
-    <li>reticulum.io</li>
-    <li>*.reticulum.io</li>
-  </ul>
-
   <h3>Payment Subscription</h3>
   <ul class="mzp-u-list-styled">
     <li>subscriptions.firefox.com</li>


### PR DESCRIPTION
## One-line summary

(Temporarily) remove Hubs from web-eligible-sites as we've paused their involvement until end of August at the earliest

## Significant changes and points to review

This removes a stanza of HTML from the web-eligible-sites page

## Issue / Bugzilla link



## Screenshots

![Selection_405](https://github.com/mozilla/bedrock/assets/1134034/175a6789-d595-4056-97c3-8261d6c5996b)

## Checklist

If relevant:

- [ ] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: (or None)

To test this work:

- [ ] Observe that the "Hubs" section of the web-eligible-sites page is now absent
