### PR TITLE
Unit tests for relay helpers

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -365,7 +365,7 @@ def relay_subscribe_link(
         {{ relay_subscribe_link(
             entrypoint=_utm_source,
             link_text=ftl('plan-matrix-sign-up'),
-            product=product,
+            product='relay-email',
             plan='monthly',
             class_name='mzp-c-button mzp-t-product mzp-t-lg c-matrix-footer-button c-matrix-footer-button-monthly',
             country_code=country_code,
@@ -406,7 +406,7 @@ def relay_subscribe_link(
 
 @library.global_function
 @jinja2.pass_context
-def relay_monthly_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=None, product=RELAY_PRODUCT):
+def relay_monthly_price(ctx, product=RELAY_PRODUCT, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=None):
     """
     Render a localized string displaying a Relay plan's monthly plan.
 
@@ -416,9 +416,10 @@ def relay_monthly_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=N
     In Template
     -----------
 
-        {{ relay_monthly_price(country_code=country_code,
+        {{ relay_monthly_price( product='relay-email',
+                             country_code=country_code,
                              lang=LANG,
-                             product='relay-email') }}
+                            ) }}
     """
 
     available_plans = _relay_get_plans(country_code, lang, product)
@@ -433,7 +434,7 @@ def relay_monthly_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=N
 
 @library.global_function
 @jinja2.pass_context
-def relay_total_price(ctx, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=None, product=RELAY_PRODUCT):
+def relay_total_price(ctx, product=RELAY_PRODUCT, plan=RELAY_12_MONTH_PLAN, country_code=None, lang=None):
     """
     Render a localized string displaying a Relay plan's total price.
 

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -1255,3 +1255,1097 @@ class TestVPNProductReferralLink(TestCase):
             'data-cta-text="Get Mozilla VPN" data-cta-type="button">Get Mozilla VPN</a>'
         )
         self.assertEqual(markup, expected)
+
+
+# RELAY ################################################################
+
+TEST_RELAY_SUBSCRIPTION_URL = "https://accounts.firefox.com/"
+
+TEST_RELAY_EMAIL_PRODUCT_ID = "prod_KGizMiBqUJdYoY"
+TEST_RELAY_PHONE_PRODUCT_ID = "prod_KGizMiBqUJdYoY"
+TEST_RELAY_VPN_BUNDLE_PRODUCT_ID = "prod_MIex7Q079igFZJ"
+
+
+# Relay email subscription plan IDs by currency/language
+TEST_RELAY_EMAIL_PLAN_ID_MATRIX = {
+    "chf": {  # Swiss franc
+        "de": {  # German
+            "monthly": {
+                "id": "price_1LYCqOJNcmPzuWtRuIXpQRxi",
+                "price": 2.00,
+                "currency": "CHF",
+            },
+            "yearly": {
+                "id": "price_1LYCqyJNcmPzuWtR3Um5qDPu",
+                "price": 1.00,
+                "currency": "CHF",
+            },
+        },
+        "fr": {  # French
+            "monthly": {
+                "id": "price_1LYCvpJNcmPzuWtRq9ci2gXi",
+                "price": 2.00,
+                "currency": "CHF",
+            },
+            "yearly": {
+                "id": "price_1LYCwMJNcmPzuWtRm6ebmq2N",
+                "price": 1.00,
+                "currency": "CHF",
+            },
+        },
+        "it": {  # Italian
+            "monthly": {
+                "id": "price_1LYCiBJNcmPzuWtRxtI8D5Uy",
+                "price": 2.00,
+                "currency": "CHF",
+            },
+            "yearly": {
+                "id": "price_1LYClxJNcmPzuWtRWjslDdkG",
+                "price": 1.00,
+                "currency": "CHF",
+            },
+        },
+    },
+    "euro": {  # Euro
+        "de": {  # German
+            "monthly": {
+                "id": "price_1LYC79JNcmPzuWtRU7Q238yL",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYC7xJNcmPzuWtRcdKXCVZp",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "es": {  # Spanish
+            "monthly": {
+                "id": "price_1LYCWmJNcmPzuWtRtopZog9E",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYCXNJNcmPzuWtRu586XOFf",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "fr": {  # French
+            "monthly": {
+                "id": "price_1LYBuLJNcmPzuWtRn58XQcky",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYBwcJNcmPzuWtRpgoWcb03",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "it": {  # Italian
+            "monthly": {
+                "id": "price_1LYCMrJNcmPzuWtRTP9vD8wY",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYCN2JNcmPzuWtRtWz7yMno",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "nl": {  # Dutch
+            "monthly": {
+                "id": "price_1LYCdLJNcmPzuWtR0J1EHoJ0",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYCdtJNcmPzuWtRVm4jLzq2",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "ga": {  # Irish
+            "monthly": {
+                "id": "price_1LhdrkJNcmPzuWtRvCc4hsI2",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LhdprJNcmPzuWtR7HqzkXTS",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "sv": {  # Sweedish
+            "monthly": {
+                "id": "price_1LYBblJNcmPzuWtRGRHIoYZ5",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYBeMJNcmPzuWtRT5A931WH",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+        "fi": {  # Finnish
+            "monthly": {
+                "id": "price_1LYBn9JNcmPzuWtRI3nvHgMi",
+                "price": 1.99,
+                "currency": "EUR",
+            },
+            "yearly": {
+                "id": "price_1LYBq1JNcmPzuWtRmyEa08Wv",
+                "price": 0.99,
+                "currency": "EUR",
+            },
+        },
+    },
+    "usd": {
+        "en": {
+            "monthly": {
+                "id": "price_1LXUcnJNcmPzuWtRpbNOajYS",
+                "price": 1.99,
+                "currency": "USD",
+            },
+            "yearly": {
+                "id": "price_1LXUdlJNcmPzuWtRKTYg7mpZ",
+                "price": 0.99,
+                "currency": "USD",
+            },
+        },
+        "gb": {
+            "monthly": {
+                "id": "price_1LYCHpJNcmPzuWtRhrhSYOKB",
+                "price": 1.99,
+                "currency": "USD",
+            },
+            "yearly": {
+                "id": "price_1LYCIlJNcmPzuWtRQtYLA92j",
+                "price": 0.99,
+                "currency": "USD",
+            },
+        },
+    },
+}
+
+# Relay email map countries to languages
+TEST_RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING = {
+    # Austria
+    "AT": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
+    },
+    # Belgium
+    "BE": {
+        "fr": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fr"],
+        "de": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    # Switzerland
+    "CH": {
+        "fr": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["fr"],
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["de"],
+        "it": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["it"],
+    },
+    # Germany
+    "DE": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
+    },
+    # Spain
+    "ES": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["es"],
+    },
+    # France
+    "FR": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fr"],
+    },
+    # Ireland
+    "IE": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["ga"],
+    },
+    # Italy
+    "IT": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["it"],
+    },
+    # Netherlands
+    "NL": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["nl"],
+    },
+    # Sweden
+    "SE": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["sv"],
+    },
+    # Finland
+    "FI": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fi"],
+    },
+    # USA
+    "US": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    # Great Britian
+    "GB": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Canada
+    "CA": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    # New Zealand
+    "NZ": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Malaysia
+    "MY": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+    # Singapore
+    "SG": {
+        "default": TEST_RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
+    },
+}
+
+# Countries where Relay Email Masking is available
+TEST_RELAY_EMAIL_COUNTRY_CODES = [
+    "CA",  # Canada
+    "GB",  # United Kingdom of Great Britain and Northern Island
+    "MY",  # Malaysia
+    "NZ",  # New Zealand
+    "SG",  # Singapore
+    "US",  # United States of America
+    # EU Countries
+    "AT",  # Austria
+    "BE",  # Belgium
+    "CH",  # Switzerland
+    "DE",  # Germany
+    "ES",  # Spain
+    "FI",  # Finland
+    "FR",  # France
+    "IE",  # Ireland
+    "IT",  # Italy
+    "NL",  # Netherlands
+    "SE",  # Sweden
+]
+
+# Relay phone subscription plan IDs by currency/language
+TEST_RELAY_PHONE_PLAN_ID_MATRIX = {
+    "usd": {
+        "en": {
+            "monthly": {
+                "id": "price_1Li0w8JNcmPzuWtR2rGU80P3",
+                "price": 4.99,
+                "currency": "USD",
+            },
+            "yearly": {
+                "id": "price_1Li15WJNcmPzuWtRIh0F4VwP",
+                "price": 3.99,
+                "currency": "USD",
+            },
+        },
+    },
+}
+
+# Relay phone subscription map countries to languages
+TEST_RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING = {
+    "US": {
+        "default": TEST_RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    "CA": {
+        "default": TEST_RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+}
+
+# Countries where Relay Phone Masking is available
+TEST_RELAY_PHONE_COUNTRY_CODES = [
+    "CA",  # Canada
+    "US",  # United States of America
+]
+
+# Relay VPN bundle plan IDs by currency/language
+TEST_RELAY_VPN_BUNDLE_PLAN_ID_MATRIX = {
+    "usd": {
+        "en": {
+            "yearly": {
+                "id": "price_1LwoSDJNcmPzuWtR6wPJZeoh",
+                "price": "6.99",
+                "currency": "USD",
+                "saving": 0.4,
+            },
+        },
+    }
+}
+
+# Relay VPN bundle map countries to languages
+TEST_RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING = {
+    "US": {
+        "default": TEST_RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+    "CA": {
+        "default": TEST_RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
+    },
+}
+
+# Countries where Relay & VPN bundle is available
+TEST_RELAY_VPN_BUNDLE_COUNTRY_CODES = [
+    "CA",  # Canada
+    "US",  # United States of America
+]
+
+
+@override_settings(
+    FXA_ENDPOINT=TEST_FXA_ENDPOINT,
+    RELAY_SUBSCRIPTION_URL=TEST_RELAY_SUBSCRIPTION_URL,
+    RELAY_EMAIL_PRODUCT_ID=TEST_RELAY_EMAIL_PRODUCT_ID,
+    RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING=TEST_RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING,
+)
+class TestRelayEmailSubscribeLink(TestCase):
+    rf = RequestFactory()
+
+    def _render(
+        self,
+        entrypoint="www.mozilla.org-relay-product-page",
+        link_text="Get Started",
+        product="relay-email",
+        plan="yearly",
+        class_name="mzp-c-button",
+        country_code=None,
+        lang=None,
+        optional_parameters=None,
+        optional_attributes=None,
+    ):
+        req = self.rf.get("/")
+        req.locale = "en-US"
+        return render(
+            f"""{{{{ relay_subscribe_link('{entrypoint}', '{link_text}', '{product}', '{plan}', '{class_name}', '{country_code}',
+                                        '{lang}', {optional_parameters}, {optional_attributes}) }}}}""",
+            {"request": req},
+        )
+
+    def test_relay_subscribe_link_email_yearly(self):
+        """Should return expected markup for yearly email subscription link"""
+        markup = self._render(
+            link_text="Get Relay email yearly",
+            product="relay-email",
+            plan="yearly",
+            country_code="DE",
+            lang="de",
+            optional_parameters={"utm_campaign": "relay-product-page"},
+            optional_attributes={"data-cta-text": "Get Relay email yearly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
+        )
+        expected = (
+            '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1LYC7xJNcmPzuWtRcdKXCVZp'
+            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
+            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay email yearly" data-cta-type="fxa-relay" '
+            'data-cta-position="primary">Get Relay email yearly</a>'
+        )
+        self.assertEqual(markup, expected)
+
+    def test_relay_subscribe_link_email_monthly(self):
+        """Should return expected markup for monthly email subscription link"""
+        markup = self._render(
+            link_text="Get Relay email monthly",
+            product="relay-email",
+            plan="monthly",
+            country_code="US",
+            lang="en-US",
+            optional_parameters={"utm_campaign": "relay-product-page"},
+            optional_attributes={"data-cta-text": "Get Relay email monthly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
+        )
+        expected = (
+            '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1LXUcnJNcmPzuWtRpbNOajYS'
+            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
+            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay email monthly" data-cta-type="fxa-relay" '
+            'data-cta-position="primary">Get Relay email monthly</a>'
+        )
+        self.assertEqual(markup, expected)
+
+    def test_relay_subscribe_link_email_yearly_us_en(self):
+        """Should return expected Stripe Product/Plan ID for yearly email subscription link (US / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="US",
+            lang="en-US",
+        )
+        self.assertIn("/prod_KGizMiBqUJdYoY?plan=price_1LXUdlJNcmPzuWtRKTYg7mpZ", markup)
+
+    def test_relay_subscribe_link_email_monthly_us_en(self):
+        """Should return expected Stripe Product/Plan ID for monthly email subscription link (US / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="US",
+            lang="en-US",
+        )
+        self.assertIn("/prod_KGizMiBqUJdYoY?plan=price_1LXUcnJNcmPzuWtRpbNOajYS", markup)
+
+    def test_relay_subscribe_link_email_yearly_ca_en(self):
+        """Should return expected Stripe Product/Plan ID for yearly email subscription link (CA / en-CA)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CA",
+            lang="en-CA",
+        )
+        self.assertIn("/prod_KGizMiBqUJdYoY?plan=price_1LXUdlJNcmPzuWtRKTYg7mpZ", markup)
+
+    # AT
+
+    def test_relay_subscribe_link_email_monthly_at_de(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (AT / de)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="AT",
+            lang="de",
+        )
+        self.assertIn("plan=price_1LYC79JNcmPzuWtRU7Q238yL", markup)
+
+    def test_relay_subscribe_link_email_yearly_at_de(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (AT / de)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="AT",
+            lang="de",
+        )
+        self.assertIn("plan=price_1LYC7xJNcmPzuWtRcdKXCVZp", markup)
+
+    # BE
+
+    def test_relay_subscribe_link_email_monthly_be_fr(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (BE / fr)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="BE",
+            lang="fr",
+        )
+        self.assertIn("plan=price_1LYBuLJNcmPzuWtRn58XQcky", markup)
+
+    def test_relay_subscribe_link_email_yearly_be_fr(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (BE / fr)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="BE",
+            lang="fr",
+        )
+        self.assertIn("plan=price_1LYBwcJNcmPzuWtRpgoWcb03", markup)
+
+    def test_relay_subscribe_link_email_monthly_be_de(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (BE / de)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="BE",
+            lang="de",
+        )
+        self.assertIn("plan=price_1LYC79JNcmPzuWtRU7Q238yL", markup)
+
+    def test_relay_subscribe_link_email_yearly_be_de(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (BE / de)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="BE",
+            lang="de",
+        )
+        self.assertIn("plan=price_1LYC7xJNcmPzuWtRcdKXCVZp", markup)
+
+    def test_relay_subscribe_link_email_monthly_be_en(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (BE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="BE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCdLJNcmPzuWtR0J1EHoJ0", markup)
+
+    def test_relay_subscribe_link_email_yearly_be_en(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (BE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="BE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCdtJNcmPzuWtRVm4jLzq2", markup)
+
+    # CH
+
+    def test_relay_subscribe_link_email_monthly_ch_fr(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (CH / fr)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CH",
+            lang="fr",
+        )
+        self.assertIn("plan=price_1LYCvpJNcmPzuWtRq9ci2gXi", markup)
+
+    def test_relay_subscribe_link_email_yearly_ch_fr(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (CH / fr)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CH",
+            lang="fr",
+        )
+        self.assertIn("plan=price_1LYCwMJNcmPzuWtRm6ebmq2N", markup)
+
+    def test_relay_subscribe_link_email_monthly_ch_it(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (CH / it)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CH",
+            lang="it",
+        )
+        self.assertIn("plan=price_1LYCiBJNcmPzuWtRxtI8D5Uy", markup)
+
+    def test_relay_subscribe_link_email_yearly_ch_it(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (CH / it)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CH",
+            lang="it",
+        )
+        self.assertIn("plan=price_1LYClxJNcmPzuWtRWjslDdkG", markup)
+
+    def test_relay_subscribe_link_email_monthly_ch_de(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (CH / de)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CH",
+            lang="de",
+        )
+        self.assertIn("plan=price_1LYCqOJNcmPzuWtRuIXpQRxi", markup)
+
+    def test_relay_subscribe_link_email_yearly_ch_de(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (CH / de)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CH",
+            lang="de",
+        )
+        self.assertIn("plan=price_1LYCqyJNcmPzuWtR3Um5qDPu", markup)
+
+    def test_relay_subscribe_link_email_monthly_ch_en(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (CH / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CH",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCqOJNcmPzuWtRuIXpQRxi", markup)
+
+    def test_relay_subscribe_link_email_yearly_ch_en(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (CH / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CH",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCqyJNcmPzuWtR3Um5qDPu", markup)
+
+    # DE
+
+    def test_relay_subscribe_link_email_monthly_de(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (DE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="DE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYC79JNcmPzuWtRU7Q238yL", markup)
+
+    def test_relay_subscribe_link_email_yearly_de(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (DE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="DE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYC7xJNcmPzuWtRcdKXCVZp", markup)
+
+    # ES
+
+    def test_relay_subscribe_link_email_monthly_es(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (ES / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="ES",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCWmJNcmPzuWtRtopZog9E", markup)
+
+    def test_relay_subscribe_link_email_yearly_es(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (ES / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="ES",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCXNJNcmPzuWtRu586XOFf", markup)
+
+    # FR
+
+    def test_relay_subscribe_link_email_monthly_fr(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (FR / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="FR",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYBuLJNcmPzuWtRn58XQcky", markup)
+
+    def test_relay_subscribe_link_email_yearly_fr(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (FR / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="FR",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYBwcJNcmPzuWtRpgoWcb03", markup)
+
+    # IE
+
+    def test_relay_subscribe_link_email_monthly_ie(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (IE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="IE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LhdrkJNcmPzuWtRvCc4hsI2", markup)
+
+    def test_relay_subscribe_link_email_yearly_ie(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (IE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="IE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LhdprJNcmPzuWtR7HqzkXTS", markup)
+
+    # IT
+
+    def test_relay_subscribe_link_email_monthly_it(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (IT / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="IT",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCMrJNcmPzuWtRTP9vD8wY", markup)
+
+    def test_relay_subscribe_link_email_yearly_it(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (IT / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="IT",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCN2JNcmPzuWtRtWz7yMno", markup)
+
+    # NL
+
+    def test_relay_subscribe_link_email_monthly_nl(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (NL / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="NL",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCdLJNcmPzuWtR0J1EHoJ0", markup)
+
+    def test_relay_subscribe_link_email_yearly_nl(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (NL / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="NL",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCdtJNcmPzuWtRVm4jLzq2", markup)
+
+    # SE
+
+    def test_relay_subscribe_link_email_monthly_se(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (SE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="SE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYBblJNcmPzuWtRGRHIoYZ5", markup)
+
+    def test_relay_subscribe_link_email_yearly_se(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (SE / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="SE",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYBeMJNcmPzuWtRT5A931WH", markup)
+
+    # FI
+
+    def test_relay_subscribe_link_email_monthly_fi(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (FI / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="FI",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYBn9JNcmPzuWtRI3nvHgMi", markup)
+
+    def test_relay_subscribe_link_email_yearly_fi(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (FI / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="FI",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYBq1JNcmPzuWtRmyEa08Wv", markup)
+
+    # US
+
+    def test_relay_subscribe_link_email_monthly_us(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (US / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="US",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LXUcnJNcmPzuWtRpbNOajYS", markup)
+
+    def test_relay_subscribe_link_email_yearly_us(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (US / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="US",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LXUdlJNcmPzuWtRKTYg7mpZ", markup)
+
+    # GB
+
+    def test_relay_subscribe_link_email_monthly_gb(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (GB / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="GB",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCHpJNcmPzuWtRhrhSYOKB", markup)
+
+    def test_relay_subscribe_link_email_yearly_gb(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (GB / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="GB",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCIlJNcmPzuWtRQtYLA92j", markup)
+
+    # CA
+
+    def test_relay_subscribe_link_email_monthly_ca(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (CA / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CA",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LXUcnJNcmPzuWtRpbNOajYS", markup)
+
+    def test_relay_subscribe_link_email_yearly_ca(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (CA / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CA",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LXUdlJNcmPzuWtRKTYg7mpZ", markup)
+
+    # NZ
+
+    def test_relay_subscribe_link_email_monthly_nz(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (NZ / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="NZ",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCHpJNcmPzuWtRhrhSYOKB", markup)
+
+    def test_relay_subscribe_link_email_yearly_nz(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (NZ / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="NZ",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCIlJNcmPzuWtRQtYLA92j", markup)
+
+    # MY
+
+    def test_relay_subscribe_link_email_monthly_my(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (MY / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="MY",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCHpJNcmPzuWtRhrhSYOKB", markup)
+
+    def test_relay_subscribe_link_email_yearly_my(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (MY / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="MY",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCIlJNcmPzuWtRQtYLA92j", markup)
+
+    # SG
+
+    def test_relay_subscribe_link_email_monthly_sg(self):
+        """Should return expected Stripe Plan ID for monthly email subscription link (SG / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="SG",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCHpJNcmPzuWtRhrhSYOKB", markup)
+
+    def test_relay_subscribe_link_email_yearly_sg(self):
+        """Should return expected Stripe Plan ID for yearly email subscription link (SG / en-US)"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="SG",
+            lang="en-US",
+        )
+        self.assertIn("plan=price_1LYCIlJNcmPzuWtRQtYLA92j", markup)
+
+
+@override_settings(
+    RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING=TEST_RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING,
+)
+class TestRelayEmailMonthlyPrice(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, product, plan, country_code, lang):
+        req = self.rf.get("/")
+        req.locale = "en-US"
+        return render(f"{{{{ relay_monthly_price('{product}', '{plan}', '{country_code}', '{lang}') }}}}", {"request": req})
+
+    def test_relay_monthly_price_usd(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="monthly", country_code="US", lang="en-US")
+        expected = "$1.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_usd_ca(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="monthly", country_code="CA", lang="en-CA")
+        expected = "US$1.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_euro(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="monthly", country_code="DE", lang="de")
+        expected = "1,99\xa0€"  # \xa0 is a non breaking space
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_chf(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="monthly", country_code="CH", lang="fr")
+        expected = "2,00\xa0CHF"  # \xa0 is a non breaking space
+        self.assertEqual(markup, expected)
+
+    # yearly
+
+    def test_relay_yearly_price_usd(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="yearly", country_code="US", lang="en-US")
+        expected = "$0.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_yearly_price_usd_ca(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="yearly", country_code="CA", lang="en-CA")
+        expected = "US$0.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_yearly_price_euro(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="yearly", country_code="DE", lang="de")
+        expected = "0,99\xa0€"  # \xa0 is a non breaking space
+        self.assertEqual(markup, expected)
+
+    def test_relay_yearly_price_chf(self):
+        """Should return expected markup"""
+        markup = self._render(product="relay-email", plan="yearly", country_code="CH", lang="fr")
+        expected = "1,00\xa0CHF"  # \xa0 is a non breaking space
+        self.assertEqual(markup, expected)
+
+
+@override_settings(
+    FXA_ENDPOINT=TEST_FXA_ENDPOINT,
+    RELAY_SUBSCRIPTION_URL=TEST_RELAY_SUBSCRIPTION_URL,
+    RELAY_PHONE_PRODUCT_ID=TEST_RELAY_PHONE_PRODUCT_ID,
+    RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING=TEST_RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING,
+)
+class TestRelayPhoneSubscribeLink(TestCase):
+    rf = RequestFactory()
+
+    def _render(
+        self,
+        entrypoint="www.mozilla.org-relay-product-page",
+        link_text="Get Started",
+        product="relay-email",
+        plan="yearly",
+        class_name="mzp-c-button",
+        country_code=None,
+        lang=None,
+        optional_parameters=None,
+        optional_attributes=None,
+    ):
+        req = self.rf.get("/")
+        req.locale = "en-US"
+        return render(
+            f"""{{{{ relay_subscribe_link('{entrypoint}', '{link_text}', '{product}', '{plan}', '{class_name}', '{country_code}',
+                                        '{lang}', {optional_parameters}, {optional_attributes}) }}}}""",
+            {"request": req},
+        )
+
+    def test_relay_subscribe_link_phone_monthly(self):
+        """Should return expected markup for monthly phone subscription link"""
+        markup = self._render(
+            link_text="Get Relay phone monthly",
+            product="relay-phone",
+            plan="monthly",
+            country_code="US",
+            lang="en-US",
+            optional_parameters={"utm_campaign": "relay-product-page"},
+            optional_attributes={"data-cta-text": "Get Relay phone monthly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
+        )
+        expected = (
+            '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1Li0w8JNcmPzuWtR2rGU80P3'
+            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
+            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay phone monthly" data-cta-type="fxa-relay" '
+            'data-cta-position="primary">Get Relay phone monthly</a>'
+        )
+        self.assertEqual(markup, expected)
+
+    def test_relay_subscribe_link_phone_yearly(self):
+        """Should return expected markup for yearly phone subscription link"""
+        markup = self._render(
+            link_text="Get Relay phone yearly",
+            product="relay-phone",
+            plan="yearly",
+            country_code="US",
+            lang="en-US",
+            optional_parameters={"utm_campaign": "relay-product-page"},
+            optional_attributes={"data-cta-text": "Get Relay phone yearly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
+        )
+        expected = (
+            '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1Li15WJNcmPzuWtRIh0F4VwP'
+            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
+            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay phone yearly" data-cta-type="fxa-relay" '
+            'data-cta-position="primary">Get Relay phone yearly</a>'
+        )
+        self.assertEqual(markup, expected)
+
+
+@override_settings(
+    FXA_ENDPOINT=TEST_FXA_ENDPOINT,
+    RELAY_SUBSCRIPTION_URL=TEST_RELAY_SUBSCRIPTION_URL,
+    RELAY_VPN_BUNDLE_PRODUCT_ID=TEST_RELAY_VPN_BUNDLE_PRODUCT_ID,
+    RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING=TEST_RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING,
+)
+class TestRelayBundleSubscribeLink(TestCase):
+    rf = RequestFactory()
+
+    def _render(
+        self,
+        entrypoint="www.mozilla.org-relay-product-page",
+        link_text="Get Started",
+        product="relay-email",
+        plan="yearly",
+        class_name="mzp-c-button",
+        country_code=None,
+        lang=None,
+        optional_parameters=None,
+        optional_attributes=None,
+    ):
+        req = self.rf.get("/")
+        req.locale = "en-US"
+        return render(
+            f"""{{{{ relay_subscribe_link('{entrypoint}', '{link_text}', '{product}', '{plan}', '{class_name}', '{country_code}',
+                                        '{lang}', {optional_parameters}, {optional_attributes}) }}}}""",
+            {"request": req},
+        )
+
+    def test_relay_subscribe_link_bundle_yearly(self):
+        """Should return expected markup for yearly bundle subscription link"""
+        markup = self._render(
+            link_text="Get Relay bundle yearly",
+            product="relay-bundle",
+            plan="yearly",
+            country_code="US",
+            lang="en-US",
+            optional_parameters={"utm_campaign": "relay-product-page"},
+            optional_attributes={"data-cta-text": "Get Relay bundle yearly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
+        )
+        expected = (
+            '<a href="https://accounts.firefox.com/subscriptions/products/prod_MIex7Q079igFZJ?plan=price_1LwoSDJNcmPzuWtR6wPJZeoh'
+            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
+            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay bundle yearly" data-cta-type="fxa-relay" '
+            'data-cta-position="primary">Get Relay bundle yearly</a>'
+        )
+        self.assertEqual(markup, expected)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1770,6 +1770,9 @@ RELAY_MAIL_DOMAIN = "mozmail.com"
 # Relay, number of email addresses include in the free plan
 RELAY_MAX_NUM_FREE_ALIASES = 5
 
+# Bundle guarantee period
+RELAY_VPN_BUNDLE_GUARANTEE = 30
+
 # VPN client ID for referral parameter tracking (issue 10811)
 RELAY_CLIENT_ID = "9ebfe2c2f9ea3c58"
 
@@ -1783,8 +1786,9 @@ RELAY_PRODUCT_URL = config(
 # Product ID for Relay subscriptions
 RELAY_EMAIL_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_KEq0LXqs7vysQT" if DEV else "prod_KGizMiBqUJdYoY")
 RELAY_PHONE_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_LviM2I0paxH1DZ" if DEV else "prod_KGizMiBqUJdYoY")
+RELAY_VPN_BUNDLE_PRODUCT_ID = config("VPN_RELAY_BUNDLE_PRODUCT_ID", default="prod_MQ9Zf1cyI81XS2" if DEV else "prod_MIex7Q079igFZJ")
 
-# Relay subscription plan IDs by currency/language.
+# Relay email subscription plan IDs by currency/language
 RELAY_EMAIL_PLAN_ID_MATRIX = {
     "chf": {  # Swiss franc
         "de": {  # German
@@ -1949,6 +1953,8 @@ RELAY_EMAIL_PLAN_ID_MATRIX = {
         },
     },
 }
+
+# Relay email map countries to languages
 RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING = {
     # Austria
     "AT": {
@@ -2024,7 +2030,7 @@ RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING = {
     },
 }
 
-# Countries where Relay Email Masking is available.
+# Countries where Relay Email Masking is available
 RELAY_EMAIL_COUNTRY_CODES = [
     "CA",  # Canada
     "GB",  # United Kingdom of Great Britain and Northern Island
@@ -2046,6 +2052,7 @@ RELAY_EMAIL_COUNTRY_CODES = [
     "SE",  # Sweden
 ]
 
+# Relay phone subscription plan IDs by currency/language
 RELAY_PHONE_PLAN_ID_MATRIX = {
     "usd": {
         "en": {
@@ -2063,6 +2070,7 @@ RELAY_PHONE_PLAN_ID_MATRIX = {
     },
 }
 
+# Relay phone subscription map countries to languages
 RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING = {
     "US": {
         "default": RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
@@ -2072,22 +2080,13 @@ RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING = {
     },
 }
 
-# Countries where Relay Phone Masking is available.
+# Countries where Relay Phone Masking is available
 RELAY_PHONE_COUNTRY_CODES = [
     "CA",  # Canada
     "US",  # United States of America
 ]
 
-
-# RELAY / VPN BUNDLE ============================================================================
-
-# Bundle guarantee period
-RELAY_VPN_BUNDLE_GUARANTEE = 30
-
-# Product ID for VPN & Relay bundle subscriptions.
-RELAY_VPN_BUNDLE_PRODUCT_ID = config("VPN_RELAY_BUNDLE_PRODUCT_ID", default="prod_MQ9Zf1cyI81XS2" if DEV else "prod_MIex7Q079igFZJ")
-
-# VPN & Relay bundle plan IDs by currency/language.
+# Relay VPN bundle plan IDs by currency/language
 RELAY_VPN_BUNDLE_PLAN_ID_MATRIX = {
     "usd": {
         "en": {
@@ -2096,19 +2095,12 @@ RELAY_VPN_BUNDLE_PLAN_ID_MATRIX = {
                 "price": "6.99",
                 "currency": "USD",
                 "saving": 0.4,
-                "analytics": {
-                    "brand": "vpn",
-                    "name": "vpn-relay",
-                    "currency": "USD",
-                    "discount": "83.88",
-                    "price": "83.88",
-                    "variant": "yearly",
-                },
             },
         }
     },
 }
 
+# Relay VPN bundle map countries to languages
 RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING = {
     "US": {
         "default": RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
@@ -2118,8 +2110,7 @@ RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING = {
     },
 }
 
-# Countries where VPN & Relay bundle is available.
-# Phone masking is only supported in these countries.
+# Countries where Relay & VPN bundle is available
 RELAY_VPN_BUNDLE_COUNTRY_CODES = [
     "CA",  # Canada
     "US",  # United States of America


### PR DESCRIPTION
## One-line summary

Add unit tests for helpers for Relay pages

## Significant changes and points to review

- added tests
- tweaked comments to improve docs
- removed comments separating relay email and phone plans from bundle

## Issue / Bugzilla link

#12876 

## Testing

In the venv: `py.test lib bedrock/products/tests/test_helper_misc.py`