### PR TITLE
Update WNP 115 to target Windows 8.1 and lower [#13277]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx115-na-windows.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx115-na-windows.html
@@ -22,7 +22,7 @@
 {% block wnp_content %}
   <section class="wnp-content-main">
     <div class="mzp-l-content mzp-t-content-md">
-      <h2 class="wnp-main-title">Using Windows 7<br> or older?</h2>
+      <h2 class="wnp-main-title">Using Windows 8<br> or older?</h2>
 
       <div class="wnp-main-image">
         {{ resp_img("img/firefox/whatsnew/whatsnew115-na/sync.png",

--- a/media/js/firefox/whatsnew/whatsnew-115-na-win7.js
+++ b/media/js/firefox/whatsnew/whatsnew-115-na-win7.js
@@ -33,7 +33,7 @@
     if (
         redirect &&
         window.site.platform === 'windows' &&
-        window.site.platformVersion <= 6.1
+        window.site.platformVersion <= 6.3 // Windows 8.1 and lower
     ) {
         window.location.href = redirect;
     } else {


### PR DESCRIPTION
## One-line summary

`6.1` -> `6.3`

## Testing

http://localhost:8000/en-US/firefox/115.0/whatsnew/

Firefox on Windows 8.1 or lower should redirect to `?xv=windows`. Windows 10 and higher should get the regular page promoting addons (or Fx mobile for en-GB, or VPN for wave vi countries).