### PR TITLE
Use window.ontouchstart to detect Safari on iPad.

### DIFF
--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -27,7 +27,7 @@
                 pf.indexOf('iPhone') !== -1 ||
                 pf.indexOf('iPad') !== -1 ||
                 pf.indexOf('iPod') !== -1 ||
-                (pf.indexOf('MacIntel') !== -1 && 'standalone' in navigator)
+                (pf.indexOf('MacIntel') !== -1 && 'ontouchstart' in window)
             ) {
                 // iPadOS
                 return 'ios';

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -118,7 +118,7 @@ describe('site.js', function () {
         });
 
         it('should identify iPadOS', function () {
-            window.navigator.standalone = sinon.stub();
+            window.ontouchstart = sinon.stub();
             expect(window.site.getPlatform('foo', 'MacIntel')).toBe('ios');
         });
 


### PR DESCRIPTION
## One-line summary

With yesterday's release of [Safari Tech Preview 173](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-173), Safari on macOS now supports Web Apps. This results in `navigator.standalone` existing, which in turn means that [Safari on macOS users will be prompted to install the iOS version of Firefox](https://github.com/mozilla/bedrock/assets/344777/8a7a85e7-018d-44bf-a4d5-e395cf10b904) on https://www.mozilla.org/en-US/firefox/new/

## Significant changes and points to review

This PR changes that to look for `window.ontouchstart` instead, as Safari on macOS does not support those. Thanks to @nt1m for that suggestion.

## Issue / Bugzilla link

n/a

## Screenshots

n/a

## Checklist

If relevant:

- [x] Tests added
- [ ] Feature flags added to www-config
- [ ] New secrets added to the secrets repository
- [ ] If new dependencies are added, I've checked their license is appropriate

## Testing

Demo server URL: (or None)

To test this work:

- [ ] Open `/en-US/firefox/new/` in Safari Tech Preview 173 on macOS and verify that the user is promoted to download the Mac versoin.
