### PR TITLE
Remove duplicate page descriptions from Relay pages

### DIFF
--- a/bedrock/products/templates/products/relay/base.html
+++ b/bedrock/products/templates/products/relay/base.html
@@ -6,7 +6,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% block page_desc %}{{ ftl('meta-description-2')}}{% endblock %}
+{% block page_desc %}{% endblock %}
 
 {% block page_title_suffix %} — {{ ftl('relay-shared-firefox-relay') }}{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Remove duplicate page descriptions from Relay pages

## Significant changes and points to review

Talked to Adria about it and she said no description is better than a duplicate one.

## Issue / Bugzilla link

#12876 
