### PR TITLE
fix bug #10571 remove firefox app store banner on mobile devices usin…

### DIFF
--- a/media/js/base/banners/firefox-app-store-banner-init.js
+++ b/media/js/base/banners/firefox-app-store-banner-init.js
@@ -19,6 +19,7 @@ if (typeof window.Mozilla === 'undefined') {
     if (
         window.Mozilla.run &&
         window.site &&
+        !window.Mozilla.Client.isFirefox &&
         (window.site.platform === 'android' || window.site.platform === 'ios')
     ) {
         window.Mozilla.run(onLoad);


### PR DESCRIPTION
…g firefox

## One-line summary

Removed firefox app store banner on iOS and Android devices using firefox. 

## Significant changes and points to review

Needs testing. For some reason iOS UA spoofing wasn't triggering the banner - even on the original code. Was able to succesfully test with Android UA's  
- Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36
- Mozilla/5.0 (Linux; Android 10; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36
- Mozilla/5.0 (Android 4.4; Mobile; rv:70.0) Gecko/70.0 Firefox/70.0 

untested:  
- Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4
- Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1 

as the banner wasn't triggering no matter what. 

## Issue / Bugzilla link

#10571

## Testing

To test this work:

Unsure why spoofing UA spoofing for iOS wasn't working. 
