### PR TITLE
fix no-JS lang switcher (#5931)

### DIFF
--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -113,6 +113,11 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
     ftl_files = ftl_files or context.get("ftl_files")
     locale = get_locale(request)
 
+    # is this a request to change language from a non-javascript user? 
+    if request.GET.get('lang'):
+        locale = request.GET.get('lang')
+        request.META['QUERY_STRING'] = ''
+
     # is this a non-locale page?
     name_prefix = request.path_info.split("/", 2)[1]
     non_locale_url = name_prefix in settings.SUPPORTED_NONLOCALES or request.path_info in settings.SUPPORTED_LOCALE_IGNORE

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -113,9 +113,9 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
     ftl_files = ftl_files or context.get("ftl_files")
     locale = get_locale(request)
 
-    # is this a request to change language from a non-javascript user? 
-    if request.GET.get('lang'):
-        locale = request.GET.get('lang')
+    # is this a request to change language from a non-javascript user?
+    if request.GET.get("lang"):
+        locale = request.GET.get("lang")
 
     # is this a non-locale page?
     name_prefix = request.path_info.split("/", 2)[1]

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -116,7 +116,6 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
     # is this a request to change language from a non-javascript user? 
     if request.GET.get('lang'):
         locale = request.GET.get('lang')
-        request.META['QUERY_STRING'] = ''
 
     # is this a non-locale page?
     name_prefix = request.path_info.split("/", 2)[1]


### PR DESCRIPTION
## One-line summary

Fixes the no javascript language switcher that sits in the footer. 

## Significant changes and points to review
- added check in l10n_util render function for any a query parameter called lang. 

## Issue / Bugzilla link

#5931

## Testing

disable JS on your browser, try using the language switcher. 

Not sure what needs to be looked at to ensure this fully works

Tested on Firefox and Chrome. 

- [x] Tried switching languages on root path /
- [x] Tried switching languages on a non root path  
- [x] Tried switching from english to cn and the redirect worked. 
- [x] Tried going to non locale page (careers) and manually putting in parameters into the url -- something like localhost:8000/en-US/careers/?lang=da#. page did not break and parameters were removed on refresh. 