### PR TITLE
Fix small copy errors in VPN Linux and Mobile pages

### DIFF
--- a/bedrock/products/templates/products/vpn/platforms/v2/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/v2/linux.html
@@ -45,11 +45,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <h3>{{ ftl('vpn-linux-why-choose') }}</h3>
 <ul class="mzp-u-list-styled">
   <li>
-    {% if ftl_has_messages('vpn-linux-fast-and-v2') %}
-      {{ ftl('vpn-linux-fast-and-v2') }}
-    {% else %}
-      {{ ftl('vpn-linux-fast-and') }}
-    {% endif %}
+    {{ ftl('vpn-linux-fast-and-v2', fallback='vpn-linux-fast-and') }}
   </li>
   <li>{{ ftl('vpn-linux-no-logs') }}</li>
   <li>{{ ftl('vpn-linux-additional-security') }}</li>
@@ -62,11 +58,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <p>{{ ftl('vpn-linux-by-using') }}</p>
 <h3>{{ ftl('vpn-linux-how-to-install') }}</h3>
 <p>
-  {% if ftl_has_messages('vpn-linux-if-you-use-v2') %}
-    {{ ftl('vpn-linux-if-you-use-v2', attrs='href="https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn" rel="external noopener noreferrer" target="_blank"') }}
-  {% else %}
-    {{ ftl('vpn-linux-if-you-use', attrs='href="https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn" rel="external noopener noreferrer" target="_blank"') }}
-  {% endif %}
+  {{ ftl('vpn-linux-if-you-use-v2', fallback='vpn-linux-if-you-use', attrs='href="https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn" rel="external noopener noreferrer" target="_blank"') }}
 </p>
 <ol class="mzp-u-list-styled">
   <li>{{ ftl('vpn-linux-ubuntu-command', attrs='href="https://support.mozilla.org/en-US/kb/how-install-mozilla-vpn-linux-computer" rel="external noopener noreferrer" target="_blank"') }}</li>

--- a/bedrock/products/templates/products/vpn/platforms/v2/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/v2/linux.html
@@ -44,7 +44,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <p>{{ ftl('vpn-linux-mozilla-vpn-is-a') }}</p>
 <h3>{{ ftl('vpn-linux-why-choose') }}</h3>
 <ul class="mzp-u-list-styled">
-  <li>{{ ftl('vpn-linux-fast-and') }}</li>
+  <li>
+    {% if ftl_has_messages('vpn-linux-fast-and-v2') %}
+      {{ ftl('vpn-linux-fast-and-v2') }}
+    {% else %}
+      {{ ftl('vpn-linux-fast-and') }}
+    {% endif %}
+  </li>
   <li>{{ ftl('vpn-linux-no-logs') }}</li>
   <li>{{ ftl('vpn-linux-additional-security') }}</li>
   <li>{{ ftl('vpn-linux-device-level') }}</li>
@@ -55,7 +61,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 </ul>
 <p>{{ ftl('vpn-linux-by-using') }}</p>
 <h3>{{ ftl('vpn-linux-how-to-install') }}</h3>
-<p>{{ ftl('vpn-linux-if-you-use', attrs='href="https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn" rel="external noopener noreferrer" target="_blank"') }}</p>
+<p>
+  {% if ftl_has_messages('vpn-linux-if-you-use-v2') %}
+    {{ ftl('vpn-linux-if-you-use-v2', attrs='href="https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn" rel="external noopener noreferrer" target="_blank"') }}
+  {% else %}
+    {{ ftl('vpn-linux-if-you-use', attrs='href="https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn" rel="external noopener noreferrer" target="_blank"') }}
+  {% endif %}
+</p>
 <ol class="mzp-u-list-styled">
   <li>{{ ftl('vpn-linux-ubuntu-command', attrs='href="https://support.mozilla.org/en-US/kb/how-install-mozilla-vpn-linux-computer" rel="external noopener noreferrer" target="_blank"') }}</li>
   <li>{{ ftl('vpn-linux-ubuntu-graphical', attrs='href="https://help.ubuntu.com/community/Repositories/Ubuntu#Adding_Personal_Package_Archives_.28PPAs.29" rel="external noopener noreferrer" target="_blank"') }}</li>

--- a/bedrock/products/templates/products/vpn/platforms/v2/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/v2/linux.html
@@ -44,9 +44,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <p>{{ ftl('vpn-linux-mozilla-vpn-is-a') }}</p>
 <h3>{{ ftl('vpn-linux-why-choose') }}</h3>
 <ul class="mzp-u-list-styled">
-  <li>
-    {{ ftl('vpn-linux-fast-and-v2', fallback='vpn-linux-fast-and') }}
-  </li>
+  <li>{{ ftl('vpn-linux-fast-and-v2', fallback='vpn-linux-fast-and') }}</li>
   <li>{{ ftl('vpn-linux-no-logs') }}</li>
   <li>{{ ftl('vpn-linux-additional-security') }}</li>
   <li>{{ ftl('vpn-linux-device-level') }}</li>

--- a/bedrock/products/templates/products/vpn/platforms/v2/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/v2/mobile.html
@@ -46,25 +46,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <ul class="mzp-u-list-styled">
   <li>{{ ftl('vpn-mobile-the-mozilla-vpn') }}</li>
   <li>
-    {% if ftl_has_messages('vpn-mobile-your-internet-v2') %}
-      {{ ftl('vpn-mobile-your-internet-v2') }}
-    {% else %}
-      {{ ftl('vpn-mobile-your-internet') }}
-    {% endif %}
+  {{ ftl('vpn-mobile-your-internet-v2', fallback='vpn-mobile-your-internet') }}
   </li>
   <li>
-    {% if ftl_has_messages('vpn-mobile-your-isp-v2') %}
-      {{ ftl('vpn-mobile-your-isp-v2') }}
-    {% else %}
-      {{ ftl('vpn-mobile-your-isp') }}
-    {% endif %}
+  {{ ftl('vpn-mobile-your-isp-v2', fallback='vpn-mobile-your-isp') }}
   </li>
   <li>
-    {% if ftl_has_messages('vpn-mobile-hackers-can-steal-v2') %}
-      {{ ftl('vpn-mobile-hackers-can-steal-v2') }}
-    {% else %}
-      {{ ftl('vpn-mobile-hackers-can-steal') }}
-    {% endif %}
+  {{ ftl('vpn-mobile-hackers-can-steal-v2', fallback='vpn-mobile-hackers-can-steal') }}
   </li>
 </ul>
 <p>{{ ftl('vpn-mobile-a-vpn-works') }}

--- a/bedrock/products/templates/products/vpn/platforms/v2/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/v2/mobile.html
@@ -45,9 +45,27 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <h3>{{ ftl('vpn-mobile-why-do-i') }}</h3>
 <ul class="mzp-u-list-styled">
   <li>{{ ftl('vpn-mobile-the-mozilla-vpn') }}</li>
-  <li>{{ ftl('vpn-mobile-your-internet') }}</li>
-  <li>{{ ftl('vpn-mobile-your-isp') }}</li>
-  <li>{{ ftl('vpn-mobile-hackers-can-steal') }}</li>
+  <li>
+    {% if ftl_has_messages('vpn-mobile-your-internet-v2') %}
+      {{ ftl('vpn-mobile-your-internet-v2') }}
+    {% else %}
+      {{ ftl('vpn-mobile-your-internet') }}
+    {% endif %}
+  </li>
+  <li>
+    {% if ftl_has_messages('vpn-mobile-your-isp-v2') %}
+      {{ ftl('vpn-mobile-your-isp-v2') }}
+    {% else %}
+      {{ ftl('vpn-mobile-your-isp') }}
+    {% endif %}
+  </li>
+  <li>
+    {% if ftl_has_messages('vpn-mobile-hackers-can-steal-v2') %}
+      {{ ftl('vpn-mobile-hackers-can-steal-v2') }}
+    {% else %}
+      {{ ftl('vpn-mobile-hackers-can-steal') }}
+    {% endif %}
+  </li>
 </ul>
 <p>{{ ftl('vpn-mobile-a-vpn-works') }}
 </p>

--- a/bedrock/products/templates/products/vpn/platforms/v2/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/v2/mobile.html
@@ -45,15 +45,9 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <h3>{{ ftl('vpn-mobile-why-do-i') }}</h3>
 <ul class="mzp-u-list-styled">
   <li>{{ ftl('vpn-mobile-the-mozilla-vpn') }}</li>
-  <li>
-  {{ ftl('vpn-mobile-your-internet-v2', fallback='vpn-mobile-your-internet') }}
-  </li>
-  <li>
-  {{ ftl('vpn-mobile-your-isp-v2', fallback='vpn-mobile-your-isp') }}
-  </li>
-  <li>
-  {{ ftl('vpn-mobile-hackers-can-steal-v2', fallback='vpn-mobile-hackers-can-steal') }}
-  </li>
+  <li>{{ ftl('vpn-mobile-your-internet-v2', fallback='vpn-mobile-your-internet') }}</li>
+  <li>{{ ftl('vpn-mobile-your-isp-v2', fallback='vpn-mobile-your-isp') }}</li>
+  <li>{{ ftl('vpn-mobile-hackers-can-steal-v2', fallback='vpn-mobile-hackers-can-steal') }}</li>
 </ul>
 <p>{{ ftl('vpn-mobile-a-vpn-works') }}
 </p>

--- a/l10n/en/products/vpn/platforms/linux_v2.ftl
+++ b/l10n/en/products/vpn/platforms/linux_v2.ftl
@@ -10,6 +10,8 @@ vpn-linux-mozilla-vpn-on-linux = { -brand-name-mozilla-vpn } on Linux for a more
 vpn-linux-linux-is-free = Linux is free, open-source, and customizable, but it’s not immune to online security and privacy issues. Just like users of other operating systems, Linux users face censorship, surveillance, and hacking.
 vpn-linux-mozilla-vpn-is-a = { -brand-name-mozilla-vpn } is a virtual private network service that uses open-source state-of-the-art encryption and does not log, track or share any of your network activity. It allows you to connect to over 500 servers in 30+ countries.
 vpn-linux-why-choose = Why choose { -brand-name-mozilla-vpn } for Linux?
+vpn-linux-fast-and-v2 = <strong>Fast and reliable:</strong> { -brand-name-mozilla-vpn } uses the { -brand-name-wireguard }® protocol, which offers better performance and stability than other VPN protocols.
+# Obsolete string
 vpn-linux-fast-and = <strong>Fast and reliable:</strong> { -brand-name-mozilla-vpn } uses the { -brand-name-wireguard }® protocol, which offers better performance and stability than other VPN protocols
 vpn-linux-no-logs = <strong>No logs:</strong> { -brand-name-mozilla-vpn } does not keep any logs of your network activity; we don’t record which websites you visit or inspect your traffic.
 vpn-linux-additional-security = <strong>Additional security features:</strong> We use DNS blocking to block ads, trackers, and malware. While a browser can prevent only websites from giving you malware and tracking you.
@@ -21,6 +23,12 @@ vpn-linux-gui-client = <strong>GUI client:</strong>{ -brand-name-mozilla-vpn } h
 vpn-linux-by-using = By using { -brand-name-mozilla-vpn }, you can take back control of your online activities and protect your privacy and data. Download { -brand-name-mozilla-vpn } today and enjoy a 30-day money-back guarantee with no logs, no hassle, and no risk.
 vpn-linux-how-to-install = How to install { -brand-name-mozilla-vpn } on Linux
 
+# Variables:
+#   $url (string) - https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn
+# 'mozillavpn' should not be translated as it is the proper name of the package
+vpn-linux-if-you-use-v2 = If you use one of the supported Ubuntu releases, there are two ways to install mozillavpn official packages hosted on <a { $attrs }>Launchpad:</a>
+
+# Obsolete string
 # Variables:
 #   $url (string) - https://launchpad.net/~mozillacorp/+archive/ubuntu/mozillavpn
 # 'mozillavpn' should not be translated as it is the proper name of the package

--- a/l10n/en/products/vpn/platforms/mobile_v2.ftl
+++ b/l10n/en/products/vpn/platforms/mobile_v2.ftl
@@ -10,7 +10,13 @@ vpn-mobile-vpn-for-mobile = VPN for Mobile from { -brand-name-mozilla }
 vpn-mobile-in-todays = In today’s mobile-focused world, we rely on our mobile phones and devices for communication, entertainment and work. However, without a VPN, your personal information may be vulnerable to several security and privacy risks.
 vpn-mobile-why-do-i = Why do I need a VPN for Mobile?
 vpn-mobile-the-mozilla-vpn = The { -brand-name-mozilla-vpn } mobile app is small, so it doesn’t use up too much of your memory, and it won’t slow down your phone or burn through your battery.
+vpn-mobile-your-internet-v2 = Your internet service provider (ISP) may throttle your bandwidth if they know you are watching movies, listening to music, or streaming.
+# Obsolete string
 vpn-mobile-your-internet = Your internet service provider (ISP) may throttle your bandwidth if they know you are watching movies, listening to music, or streaming
+vpn-mobile-your-isp-v2 = Your ISP may block websites or services that they don’t like or which compete with their own.
+# Obsolete string
 vpn-mobile-your-isp = Your ISP may block websites or services that they don’t like or which compete with their own
+vpn-mobile-hackers-can-steal-v2 = Hackers can steal your personal data when you are using public Wi-Fi, such as in cafes or airports.
+# Obsolete string
 vpn-mobile-hackers-can-steal = Hackers can steal your personal data when you are using public Wi-Fi, such as in cafes or airports
 vpn-mobile-a-vpn-works = A VPN works across your device, not just your browser, therefore across your mobile apps too. And unlike free VPNs or proxy sites, which may pay for their servers by spying on you and selling your information, { -brand-name-mozilla } does not keep records of where you go and what you do.


### PR DESCRIPTION
Noticed a few issues while reviewing the Italian translation.

https://www-dev.allizom.org/en-US/products/vpn/desktop/linux/
* The first list item is missing a period.
* [Launchpad](https://help.launchpad.net/Legal) should be spelled uppercase

https://www-dev.allizom.org/en-US/products/vpn/mobile/
* All list items but the first are missing a period.
