### PR TITLE
Give pricing matrix its own page

### DIFF
--- a/bedrock/products/templates/products/relay/includes/matrix.html
+++ b/bedrock/products/templates/products/relay/includes/matrix.html
@@ -86,9 +86,12 @@
           <div class="c-matrix-footer">
             <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
             {{ relay_fxa_button(
-                entrypoint='mozilla.org-relay-landing',
+                entrypoint=_utm_source,
                 button_text=ftl('plan-matrix-get-relay-cta'),
                 class_name="mzp-c-button mzp-t-product mzp-t-lg",
+                optional_parameters={
+                  'utm_campaign': _utm_campaign
+                },
                 optional_attributes={
                   'data-cta-type': 'cta: fxa-relay',
                   'data-cta-text': 'Sign Up - relay-free',
@@ -160,9 +163,12 @@
         <div class="c-matrix-footer">
             <em class="c-matrix-footer-free">{{ ftl('plan-matrix-price-free') }}</em>
             {{ relay_fxa_button(
-              entrypoint='mozilla.org-relay-landing',
+              entrypoint=_utm_source,
               button_text=ftl('plan-matrix-get-relay-cta'),
               class_name="mzp-c-button mzp-t-product mzp-t-lg",
+              optional_parameters={
+                'utm_campaign': _utm_campaign
+              },
               optional_attributes={
                 'data-cta-type': 'cta: fxa-relay',
                 'data-cta-text': 'Sign Up - relay-free',

--- a/bedrock/products/templates/products/relay/landing.html
+++ b/bedrock/products/templates/products/relay/landing.html
@@ -104,7 +104,8 @@
   <section id="pricing" class="mzp-l-content t-pricing">
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
-    <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body') }}</p>
+    {% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+    <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body', savings=savings) }}</p>
     {% include 'products/relay/includes/matrix.html' %}
   </section>
 

--- a/bedrock/products/templates/products/relay/premium.html
+++ b/bedrock/products/templates/products/relay/premium.html
@@ -57,7 +57,8 @@
   <div class="mzp-l-content">
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
-    <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body') }}</p>
+    {% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+    <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body', savings=savings) }}</p>
     {% include 'products/relay/includes/matrix.html' %}
   </div>
 </section>

--- a/bedrock/products/templates/products/relay/pricing.html
+++ b/bedrock/products/templates/products/relay/pricing.html
@@ -1,0 +1,44 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/relay/base.html" %}
+
+{% block page_title %}{{ ftl('plan-matrix-title') }}{% endblock %}
+
+{% block body_id %}{% endblock %}
+
+{% set _utm_source = 'www.mozilla.org-relay-pricing-page' %}
+{% set _utm_campaign = 'relay-pricing-page' %}
+{% set _params = '?utm_source=' ~ _utm_source ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign %}
+
+{% block page_css %}
+  {{ css_bundle('relay-landing') }}
+{% endblock %}
+
+{% block sub_navigation %}
+  {% include 'products/relay/includes/subnav.html' %}
+{% endblock %}
+
+
+{% block content %}
+
+<section class="t-odd c-pricing" id="pricing">
+  <div class="mzp-l-content">
+    <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
+    <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-relay mzp-l-wordmark-center">{{ ftl('relay-shared-firefox-relay') }}</div>
+    <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
+    {% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+    <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body', savings=savings) }}</p>
+    {% include 'products/relay/includes/matrix.html' %}
+  </div>
+</section>
+
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('fxa_product_button') }}
+  {{ js_bundle('data_begincheckout') }}
+{% endblock %}

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -45,4 +45,5 @@ if settings.DEV:
         path("relay/waitlist/bundle/", view=views.relay_bundle_waitlist__page, name="products.relay.waitlist.bundle"),
         page("relay/faq/", "products/relay/faq.html", ftl_files=["products/relay/shared", "products/relay/faq"]),
         path("relay/premium/", views.relay_premium_page, name="products.relay.premium"),
+        path("relay/pricing/", views.relay_pricing_page, name="products.relay.pricing"),
     )

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -429,6 +429,25 @@ def relay_premium_page(request):
 
 
 @require_safe
+def relay_pricing_page(request):
+    template_name = "products/relay/pricing.html"
+    ftl_files = ["products/relay/matrix", "products/relay/shared"]
+    relay_email_available_in_country = relay_available("relay-email", request)
+    relay_phone_available_in_country = relay_available("relay-phone", request)
+    vpn_available_in_country = vpn_available(request)
+    country = get_country_from_request(request)
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
+
+    context = {
+        "email_available": relay_email_available_in_country,
+        "phone_available": relay_phone_available_in_country,
+        "bundle_available": relay_bundle_available_in_country,
+    }
+
+    return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)
+
+
+@require_safe
 def relay_premium_waitlist__page(request):
     ftl_files = ["products/relay/waitlist", "products/relay/shared"]
     locale = l10n_utils.get_locale(request)


### PR DESCRIPTION
Create page which is only the pricing matrix, like the [VPN pricing page](https://www.mozilla.org/en-US/products/vpn/pricing/).

## Significant changes and points to review

- add page, url, and view
- fill in missing variable from some strings
- update entry point info

## Issue / Bugzilla link

#12876 

## Testing

http://localhost:8000/en-US/products/relay/pricing/
