### PR TITLE
Remove Sidebar Menu JS from /all Fix #13236

### DIFF
--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -184,9 +184,6 @@
     <div id="all-downloads" class="c-all-downloads mzp-has-sidebar mzp-l-sidebar-left">
       <div class="mzp-l-sidebar">
         <nav class="mzp-c-sidemenu">
-          <section class="mzp-c-sidemenu-summary mzp-js-toggle" aria-controls="sidebar-menu">
-            <h3 class="mzp-c-sidemenu-label">{{ ftl('ui-menu') }}</h3>
-          </section>
           <section class="mzp-c-sidemenu-main" id="sidebar-menu">
             <h2 class="mzp-c-sidemenu-title">{{ ftl('firefox-all-which-browser-would') }}</h2>
             <ul>

--- a/media/css/firefox/all/all-unified.scss
+++ b/media/css/firefox/all/all-unified.scss
@@ -275,8 +275,8 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    .mzp-c-sidemenu {
-        background: $color-white;
+    .mzp-c-sidemenu-main {
+        display: block;
     }
 }
 

--- a/media/js/firefox/all/all-downloads-unified-init.es6.js
+++ b/media/js/firefox/all/all-downloads-unified-init.es6.js
@@ -6,7 +6,6 @@
 
 import TrackProductDownload from '../../base/datalayer-productdownload.es6';
 import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
-import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
 
 (function (Mozilla) {
     function onLoad() {
@@ -34,7 +33,6 @@ import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
         }
 
         Mozilla.FirefoxDownloader.init();
-        MzpSideMenu.init();
 
         // Browser help modal.
         browserHelpIcon.addEventListener(


### PR DESCRIPTION
## One-line summary

Remove Sidebar Menu JS from /all

## Issue / Bugzilla link

Fix #13236 

## Testing

http://localhost:8000/en-US/firefox/all/

- [ ] no JS errors