### PR TITLE
ESR download link aliases should use esr-next (Issue #13317)

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -66,12 +66,12 @@
       <p>{{ ftl('download-button-please-download-esr') }}</p>
       <ul class="download-platform-list">
         <li>
-          <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
+          <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
             {{ ftl('download-firefox-esr-64') }}
           </a>
         </li>
         <li>
-          <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
+          <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
             {{ ftl('download-firefox-esr-32') }}
           </a>
         </li>
@@ -84,7 +84,7 @@
 
       <ul class="download-platform-list">
         <li>
-          <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
+          <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
             {{ ftl('download-firefox-esr') }}
           </a>
         </li>


### PR DESCRIPTION
Same as https://github.com/mozilla/bedrock/pull/13349 but I didn't realize it needed to be `esr-next` :/