### PR TITLE
Send dataLayer event for GA4 for newsletter subscriptions

### DIFF
--- a/media/js/newsletter/newsletter.es6.js
+++ b/media/js/newsletter/newsletter.es6.js
@@ -55,10 +55,18 @@ const NewsletterForm = {
         document.getElementById('newsletter-thanks').classList.remove('hidden');
 
         if (window.dataLayer) {
+            // UA
             window.dataLayer.push({
                 event: 'newsletter-signup-success',
                 newsletter: newsletters
             });
+            // GA4
+            for (let i = 0; i < newsletters.length; ++i) {
+                window.dataLayer.push({
+                    event: 'newsletter_subscribe',
+                    newsletter_id: newsletters[i]
+                });
+            }
         }
     },
 


### PR DESCRIPTION
## One-line summary

Send a second dataLayer event when someone subscribes to a newsletter, to be processed by GA4.

## Significant changes and points to review

Small code change but necessary because GA4 is going to be counting the number of subscriptions not the number of form submissions.

## Issue / Bugzilla link

#13238 
Fix #13348

## Testing

- find a few newsletters and look at the dataLayer in the console after you fill them out (use success@example.com to fill them out if you don't want a subscription 😉 )