### PR TITLE
Bug 1841816 :  Update nightly/whatsnew template to also link to Mastodon

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -46,7 +46,7 @@
 
       <p>{{ ftl('nightly-whatsnew-this-is-a-good') }}</p>
 
-      <p>{{ ftl('nightly-whatsnew-if-you-want-to', blog='https://blog.nightly.mozilla.org/', twitter='https://twitter.com/FirefoxNightly') }}</p>
+      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v2', blog='https://blog.nightly.mozilla.org/', twitter='https://twitter.com/FirefoxNightly', mastodon='https://mozilla.social/@FirefoxNightly', fallback='nightly-whatsnew-if-you-want-to' ) }}</p>
 
       <p>
         {% if ftl_has_messages('nightly-whatsnew-want-to-know-which-v2') %}

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -21,7 +21,11 @@ nightly-whatsnew-this-is-a-good = This is a good time to thank you for helping u
 
 # Variables:
 #   $blog (url) - link to https://blog.nightly.mozilla.org/
+#   $mastodon (url) - link to https://mozilla.social/@FirefoxNightly
 #   $twitter (url) - link to https://twitter.com/FirefoxNightly
+nightly-whatsnew-if-you-want-to-v2 = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a href="{ $blog }">blog</a> and following us on <a href="{ $mastodon }">{ -brand-name-mastodon }</a> or <a href="{ $twitter }">{ -brand-name-twitter }</a> are good starting points!
+
+# Obsolete
 nightly-whatsnew-if-you-want-to = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a href="{ $blog }">blog</a> and following us on <a href="{ $twitter }">{ -brand-name-twitter }</a> are good starting points!
 
 # Variables:


### PR DESCRIPTION
## One-line summary

This changeset adds a link to our new FirefoxNightly Mastodon account on the Nightly whatsnew.html page.

## Significant changes and points to review

* Added an updated string to mention and link to our FirefoxNightly Mastodon account
* Previously translated string without the mastodon link is used as a fallback

## Issue / Bugzilla link
Bug 1841816 - Add link to mastodon feed before twitter feed in nightly release notes - https://bugzil.la/1841816