### PR TITLE
Update welcome/15 referral_id if no variation is set (Issue #13303)

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page15/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/page15/base.html
@@ -105,8 +105,9 @@
         <p class="c-main-tagline">
           {{ var_1_main_tagline }}
         </p>
+        {% set referral_id = 'welcome-page15-v1' if variation == '1' else 'welcome-page15' %}
         {{ vpn_product_referral_link(
-          referral_id='welcome-page15-v1',
+          referral_id=referral_id,
           link_to_pricing_page=True,
           link_text=cta_text,
           class_name='mzp-t-product mzp-t-xl',


### PR DESCRIPTION
## One-line summary

Small update to make sure that we can equally compare the same number of people in both variations.

## Issue / Bugzilla link

#13303

## Testing

You may need to clear cookies between testing each variation

- [ ] http://localhost:8000/en-US/firefox/welcome/15/ (clicking "Try Mozilla VPN" should set a cookie called `fxa-product-referral-id` with a value of `welcome-page15`).
- [ ] http://localhost:8000/en-US/firefox/welcome/15/?v=1 (clicking "Try Mozilla VPN" should set a cookie with the value `welcome-page15-v1`).
- [ ] http://localhost:8000/en-US/firefox/welcome/15/?v=2 (clicking "Try Mozilla VPN" should set a cookie with the value `welcome-page15-v2`).
