### PR TITLE
Update WNP 115 view logic to show English to target countries [#13215]

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -418,7 +418,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx114-en-gb.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx114-de.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx114-fr.html": ["firefox/whatsnew/whatsnew"],
-        "firefox/whatsnew/whatsnew-fx115-eu-vpn.html": ["firefox/whatsnew/whatsnew", "firefox/whatsnew/whatsnew-115-vpn"],
+        "firefox/whatsnew/whatsnew-fx115-eu-vpn.html": ["firefox/whatsnew/whatsnew-115-vpn", "firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx115-eu-ctd-de.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx115-eu-mobile-fr.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx115-eu-mobile-uk.html": ["firefox/whatsnew/whatsnew"],
@@ -521,7 +521,7 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/whatsnew/whatsnew-fx115-eu-vpn.html"
                 else:
                     template = "firefox/whatsnew/whatsnew-fx115-na-addons.html"
-            elif switch("vpn-wave-vi") and country in settings.VPN_COUNTRY_CODES_WAVE_VI and ftl_file_is_active("firefox/whatsnew/whatsnew-115-vpn"):
+            elif switch("vpn-wave-vi") and country in settings.VPN_COUNTRY_CODES_WAVE_VI:
                 template = "firefox/whatsnew/whatsnew-fx115-eu-vpn.html"
             elif locale == "de":
                 template = "firefox/whatsnew/whatsnew-fx115-eu-ctd-de.html"


### PR DESCRIPTION
## One-line summary

Removes the `ftl_file_is_active` condition allowing the template to be shown to all target countries, defaulting to English if it isn't localized. This disregards the user's preferred language and forces English instead of the localized fallback template. It's not an ideal user experience and isn't how we normally handle l10n on the what's new page, but stakeholders have chosen to take this calculated risk.

## Testing

http://localhost:8000/firefox/115.0/whatsnew/

To test this work:

Ideally this should be tested in prod mode because of the FTL activation rule (otherwise you'll see mixed content at the locale URL instead of being redirected to `/en-US/`). If you restart in prod mode also be sure you add `SWITCH_VPN_WAVE_VI=on` to your env file.

- [ ] http://localhost:8000/pl/firefox/115.0/whatsnew/?geo=PL should redirect to http://localhost:8000/en-US/firefox/115.0/whatsnew/?geo=PL and display the VPN promo page in English.
