### PR TITLE
Update VPN iOS app store URL (Fixes #13384)

### DIFF
--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -209,7 +209,7 @@ class TestVPNDownloadPage(TestCase):
         self.assertEqual(ctx["mac_download_url"], "https://vpn.mozilla.org/r/vpn/download/mac")
         self.assertEqual(ctx["linux_download_url"], "https://vpn.mozilla.org/r/vpn/download/linux")
         self.assertEqual(ctx["android_download_url"], "https://play.google.com/store/apps/details?id=org.mozilla.firefox.vpn")
-        self.assertEqual(ctx["ios_download_url"], "https://apps.apple.com/us/app/firefox-private-network-vpn/id1489407738")
+        self.assertEqual(ctx["ios_download_url"], "https://apps.apple.com/us/app/mozilla-vpn/id1489407738")
 
 
 class TestVPNResourceCenterHelpers(TestCase):

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -96,7 +96,7 @@ def vpn_download_page(request):
     mac_download_url = f"{settings.VPN_ENDPOINT}r/vpn/download/mac"
     linux_download_url = f"{settings.VPN_ENDPOINT}r/vpn/download/linux"
     android_download_url = "https://play.google.com/store/apps/details?id=org.mozilla.firefox.vpn"
-    ios_download_url = "https://apps.apple.com/us/app/firefox-private-network-vpn/id1489407738"
+    ios_download_url = "https://apps.apple.com/us/app/mozilla-vpn/id1489407738"
     block_download = country in settings.VPN_BLOCK_DOWNLOAD_COUNTRY_CODES
 
     context = {


### PR DESCRIPTION
## One-line summary

Request from VPN team to update the iOS app store URL (removes mention of FPN)

## Issue / Bugzilla link

#13384

## Testing

http://localhost:8000/en-US/products/vpn/download/
