### PR TITLE
Change name of productDownload event handler

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -140,7 +140,7 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
  * - sends it along for tracking
  * @param {Event}
  */
-TrackProductDownload.linkHandler = (event) => {
+TrackProductDownload.handleLink = (event) => {
     let el = event.target;
     // If the node isn't a link traverse up
     // but closest is not supported in IE

--- a/media/js/firefox/all/all-downloads-unified-init.es6.js
+++ b/media/js/firefox/all/all-downloads-unified-init.es6.js
@@ -75,7 +75,7 @@ import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
         downloadButton.addEventListener(
             'click',
             function (event) {
-                TrackProductDownload.linkHandler(event);
+                TrackProductDownload.handleLink(event);
             },
             false
         );
@@ -84,7 +84,7 @@ import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
             mobileDownloadButtons[i].addEventListener(
                 'click',
                 function (event) {
-                    TrackProductDownload.linkHandler(event);
+                    TrackProductDownload.handleLink(event);
                 },
                 false
             );

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -216,7 +216,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
 });
 
-describe('TrackProductDownload.linkHandler', function () {
+describe('TrackProductDownload.handleLink', function () {
     const download_button = `<a href="https://download.mozilla.org/?product=firefox-latest-ssl&amp;os=win64&amp;lang=en-CA" id="download-button-primary" class="mzp-c-button mzp-t-product c-download-button">Download Now</a>`;
 
     beforeEach(function () {
@@ -230,7 +230,7 @@ describe('TrackProductDownload.linkHandler', function () {
             'click',
             function (event) {
                 event.preventDefault();
-                TrackProductDownload.linkHandler(event);
+                TrackProductDownload.handleLink(event);
             },
             false
         );
@@ -242,7 +242,7 @@ describe('TrackProductDownload.linkHandler', function () {
     });
 
     it('should call the full chain of functions', function () {
-        spyOn(TrackProductDownload, 'linkHandler').and.callThrough();
+        spyOn(TrackProductDownload, 'handleLink').and.callThrough();
         spyOn(TrackProductDownload, 'sendEventFromURL').and.callThrough();
         spyOn(TrackProductDownload, 'isValidDownloadURL').and.callThrough();
         spyOn(TrackProductDownload, 'getEventObject').and.callThrough();
@@ -250,7 +250,7 @@ describe('TrackProductDownload.linkHandler', function () {
 
         document.getElementById('download-button-primary').click();
 
-        expect(TrackProductDownload.linkHandler).toHaveBeenCalled();
+        expect(TrackProductDownload.handleLink).toHaveBeenCalled();
         expect(TrackProductDownload.sendEventFromURL).toHaveBeenCalled();
         expect(TrackProductDownload.isValidDownloadURL).toHaveBeenCalled();
         expect(TrackProductDownload.getEventObject).toHaveBeenCalled();


### PR DESCRIPTION
## One-line summary

Change name of TrackProductDownload's event handler to be closer to the names of things in TrackBeginCheckout.

## Issue / Bugzilla link

#13238 

## Testing

`npm run karma`