### PR TITLE
Trigger TrackProductDownload for all mobile and desktop downloads

### DIFF
--- a/bedrock/base/templates/includes/banners/mobile/firefox-app-store.html
+++ b/bedrock/base/templates/includes/banners/mobile/firefox-app-store.html
@@ -21,8 +21,8 @@
             <p class="show-android">{{ ftl('banner-firefox-app-store-free-google-play') }}</p>
             <p class="show-ios">{{ ftl('banner-firefox-app-store-free-app-store') }}</p>
           </div>
-          <a class="c-banner-button show-android" href="{{ android_url }}" data-link-type="download" data-download-os="Android" data-download-location="Banner">{{ ftl('ui-view') }}</a>
-          <a class="c-banner-link show-ios" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS" data-download-location="Banner">{{ ftl('ui-view') }}</a>
+          <a class="c-banner-button show-android ga-product-download" href="{{ android_url }}" data-link-type="download" data-download-os="Android" data-download-location="Banner">{{ ftl('ui-view') }}</a>
+          <a class="c-banner-link show-ios ga-product-download" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS" data-download-location="Banner">{{ ftl('ui-view') }}</a>
       </div>
     </div>
   </div>

--- a/bedrock/base/templates/includes/banners/mobile/focus-app-store.html
+++ b/bedrock/base/templates/includes/banners/mobile/focus-app-store.html
@@ -21,8 +21,8 @@
             <p class="show-android">{{ ftl('banner-firefox-app-store-free-google-play') }}</p>
             <p class="show-ios">{{ ftl('banner-firefox-app-store-free-app-store') }}</p>
           </div>
-          <a class="c-banner-button show-android" href="{{ android_url }}" data-link-type="download" data-download-os="Android" data-download-location="Banner">{{ ftl('ui-view') }}</a>
-          <a class="c-banner-link show-ios" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS" data-download-location="Banner">{{ ftl('ui-view') }}</a>
+          <a class="c-banner-button show-android ga-product-download" href="{{ android_url }}" data-link-type="download" data-download-os="Android" data-download-location="Banner">{{ ftl('ui-view') }}</a>
+          <a class="c-banner-link show-ios ga-product-download" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS" data-download-location="Banner">{{ ftl('ui-view') }}</a>
       </div>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -43,7 +43,7 @@
     <h4 class="mzp-c-menu-list-title">{{ ftl('browsers-chromebook-dropdown-copy') }}</h4>
     <ul class="mzp-c-menu-list-list download-platform-list">
       <li class="mzp-c-menu-list-item">
-        <a href="{{ firefox_adjust_url('android', 'firefox-browsers-faq') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">
+        <a href="{{ firefox_adjust_url('android', 'firefox-browsers-faq') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">
           {{ ftl('browsers-chromebook-browsers-chromebook-get-firefox-for') }}
           <p><small>{{ ftl('browsers-chromebook-x86-based-chromebook') }}</small></p>
         </a>

--- a/bedrock/firefox/templates/firefox/browsers/compare/includes/download-menu-list.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/includes/download-menu-list.html
@@ -20,7 +20,7 @@
     {# Download link should be locale neutral see issue 7982 #}
     <li class="mzp-c-menu-list-item"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ get_desktop }}</a></li>
   <!--<![endif]-->
-    <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> {{ get_android }}</a></li>
-    <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ get_ios }}</a></li>
+    <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> {{ get_android }}</a></li>
+    <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ get_ios }}</a></li>
   </ul>
 </div>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -150,8 +150,8 @@
       <div id="menu-mobile-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-browsers-download-for-mobile') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-mobile">
-          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-browsers-android') }}</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-browsers-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-browsers-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-browsers-ios') }}</a></li>
           <li class="mzp-c-menu-list-item t-getapp"><a href="{{ url('firefox.mobile.get-app') }}" data-cta-type="link" data-cta-text="Get App Mobile">{{ ftl('firefox-browsers-send-me-a-link') }}</a></li>
         </ul>
       </div>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -87,10 +87,10 @@
       <p>{{ ftl('browsers-mobile-infinitely-customizable-private') }}</p>
 
       <p id="android-download">
-        <a class="mzp-c-cta-link" href="{{ firefox_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Download" data-download-version="android" data-download-os="Android">{{ ftl('browsers-mobile-download') }}</a>
+        <a class="mzp-c-cta-link ga-product-download" href="{{ firefox_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Download" data-download-version="android" data-download-os="Android">{{ ftl('browsers-mobile-download') }}</a>
       </p>
 
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.mobile.android') }}" data-cta-type="link" data-cta-text="Android Learn More">{{ ftl('ui-learn-more') }}</a></p>
+      <p><a class="mzp-c-cta-link ga-product-download" href="{{ url('firefox.browsers.mobile.android') }}" data-cta-type="link" data-cta-text="Android Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
 
     <div class="c-landing-grid-item">
@@ -109,10 +109,10 @@
       <p>{{ ftl('browsers-mobile-get-enhanced-tracking-protection') }}</p>
 
       <p id="ios-download">
-        <a class="mzp-c-cta-link" href="{{ firefox_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Download" data-download-version="ios" data-download-os="iOS">{{ ftl('browsers-mobile-download') }}</a>
+        <a class="mzp-c-cta-link ga-product-download" href="{{ firefox_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Download" data-download-version="ios" data-download-os="iOS">{{ ftl('browsers-mobile-download') }}</a>
       </p>
 
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-cta-type="link" data-cta-text="iOS Learn More">{{ ftl('ui-learn-more') }}</a></p>
+      <p><a class="mzp-c-cta-link ga-product-download" href="{{ url('firefox.browsers.mobile.ios') }}" data-cta-type="link" data-cta-text="iOS Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
 
     <div class="c-landing-grid-item">
@@ -133,8 +133,8 @@
       <div id="menu-focus-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h3 class="mzp-c-menu-list-title">{{ ftl('browsers-mobile-download') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-mobile">
-          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('browsers-mobile-android') }}</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('browsers-mobile-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('browsers-mobile-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('browsers-mobile-ios') }}</a></li>
         </ul>
       </div>
 

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -139,22 +139,22 @@
             <h4 class="mzp-c-menu-list-title">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox">
                   {{ ftl('firefox-enterprise-firefox-browser-msi-installer') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox Extended Support Release">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release-msi') }}
                 </a>
               </li>
@@ -182,12 +182,12 @@
             <h4 class="mzp-c-menu-list-title">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
@@ -214,22 +214,22 @@
             <h4 class="mzp-c-menu-list-title">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox">
                   {{ ftl('firefox-enterprise-firefox-browser-msi-installer') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox Extended Support Release">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release-msi') }}
                 </a>
               </li>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -135,11 +135,11 @@
         <h5 class="mzp-c-menu-list-title">{{ ftl('firefox-home-download-the-browser') }}</h5>
         <ul class="mzp-c-menu-list-list" id="menu-browsers">
           {# Direct users on unsupported OSes to the /new/ page, where they can read EOL messaging (see issue 13317) #}
-          <li class="mzp-c-menu-list-item menu-desktop-unsupported"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ ftl('firefox-home-desktop') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-desktop-unsupported"><a href="{{ url('firefox.new') }}" class="ga-product-download"  data-cta-type="link" data-cta-text="Firefox Desktop">{{ ftl('firefox-home-desktop') }}</a></li>
           {# Download link should be locale neutral see issue 7982 #}
-          <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-name="Trackers">{{ ftl('firefox-home-desktop') }}</a></li>
-          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android" data-link-name="Trackers"> {{ ftl('firefox-home-android') }}</a></li>
-          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS" data-link-name="Trackers">{{ ftl('firefox-home-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" class="ga-product-download" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-name="Trackers">{{ ftl('firefox-home-desktop') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" class="ga-product-download"  rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android" data-link-name="Trackers"> {{ ftl('firefox-home-android') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" class="ga-product-download"  rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS" data-link-name="Trackers">{{ ftl('firefox-home-ios') }}</a></li>
         </ul>
       </div>
       <p id="test-fbc" class="js-fx-only"><a class="mzp-c-cta-link" href="https://addons.mozilla.org/firefox/addon/facebook-container/{{ referrals }}">{{ ftl('firefox-home-get-the-facebook-container') }}</a></p>

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -20,7 +20,7 @@
     <ul>
       {% for plat in builds -%}
         <li><a href="{{ plat.download_link_direct or plat.download_link }}"
-               class="download-link mzp-c-button mzp-t-product"
+               class="download-link mzp-c-button mzp-t-product ga-product-download"
                data-link-type="download"
                data-download-version="{{ plat.os }}"
                {% if plat.os == 'android' %}data-download-os="Android"
@@ -57,7 +57,7 @@
   <ul class="download-list">
     {% for plat in builds %}
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
-        <a class="download-link button {{ button_class }} mzp-c-button mzp-t-product"
+        <a class="download-link button {{ button_class }} mzp-c-button mzp-t-product ga-product-download"
            id="{{ id }}-{{ plat.os }}"
            href="{{ plat.download_link }}"{% if plat.download_link_direct %}
            data-direct-link="{{ plat.download_link_direct }}"{% endif %}

--- a/bedrock/firefox/templates/firefox/includes/download-unsupported.html
+++ b/bedrock/firefox/templates/firefox/includes/download-unsupported.html
@@ -19,12 +19,12 @@
   <p>{{ ftl('download-button-please-download-esr') }}</p>
   <div class="download-platform-list">
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win64" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
+      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
         {{ ftl('download-firefox-esr-64') }}
       </a>
     </p>
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
+      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
         {{ ftl('download-firefox-esr-32') }}
       </a>
     </p>
@@ -42,7 +42,7 @@
   <p>{{ ftl('download-button-please-download-esr') }}</p>
 
   <div class="download-platform-list">
-    <a class="mzp-c-button mzp-t-product download-link" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
+    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
       {{ ftl('download-firefox-esr') }}
     </a>
   </div>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -99,8 +99,8 @@
             {# Download link should be locale neutral see issue 7982 #}
             <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ ftl('firefox-products-desktop') }}</a></li>
           <!--<![endif]-->
-          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-products-android') }}</a></li>
-          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-products-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-products-android') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-products-ios') }}</a></li>
         </ul>
       </div>
       <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="See all browsers">{{ ftl('firefox-products-see-all-browsers') }}</a></p>
@@ -150,8 +150,8 @@
       <div id="menu-focus-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h3 class="mzp-c-menu-list-title">{{ ftl('download-button-download') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-mobile">
-          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('android', 'firefox_products') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-products-android') }}</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('ios', 'firefox_products') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-products-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('android', 'firefox_products') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-products-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ focus_adjust_url('ios', 'firefox_products') }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-products-ios') }}</a></li>
         </ul>
       </div>
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -696,7 +696,7 @@ def lang_short(ctx):
     return locale.split("-")[0]
 
 
-def _get_adjust_link(adjust_url, app_store_url, google_play_url, redirect, locale, adgroup, creative=None):
+def _get_adjust_link(adjust_url, app_store_url, google_play_url, redirect, locale, product, adgroup, creative=None):
     link = adjust_url
     params = "campaign=www.mozilla.org&adgroup=" + adgroup
     redirect_url = None
@@ -715,10 +715,12 @@ def _get_adjust_link(adjust_url, app_store_url, google_play_url, redirect, local
     if creative:
         params += "&creative=" + creative
 
+    params += "&mz_pr=" + product
+
     if redirect_url:
-        link += "?redirect=" + quote(redirect_url, safe="") + "&" + params
+        link += "?redirect=" + quote(redirect_url, safe="") + "&" + params + "&mz_pl=" + redirect
     else:
-        link += "?" + params
+        link += "?" + params + "&mz_pl=mobile"
 
     return link
 
@@ -742,7 +744,7 @@ def firefox_adjust_url(ctx, redirect, adgroup, creative=None):
     play_store_url = settings.GOOGLE_PLAY_FIREFOX_LINK
     locale = getattr(ctx["request"], "locale", "en-US")
 
-    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, adgroup, creative)
+    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, "firefox", adgroup, creative)
 
 
 @library.global_function
@@ -764,13 +766,15 @@ def focus_adjust_url(ctx, redirect, adgroup, creative=None):
     app_store_url = settings.APPLE_APPSTORE_FOCUS_LINK
     play_store_url = settings.GOOGLE_PLAY_FOCUS_LINK
     locale = getattr(ctx["request"], "locale", "en-US")
+    product = "focus"
 
     if locale in klar_locales:
         adjust_url = settings.ADJUST_KLAR_URL
         app_store_url = settings.APPLE_APPSTORE_KLAR_LINK
         play_store_url = settings.GOOGLE_PLAY_KLAR_LINK
+        product = "klar"
 
-    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, adgroup, creative)
+    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, product, adgroup, creative)
 
 
 @library.global_function
@@ -792,7 +796,7 @@ def pocket_adjust_url(ctx, redirect, adgroup, creative=None):
     play_store_url = settings.GOOGLE_PLAY_POCKET_LINK
     locale = getattr(ctx["request"], "locale", "en-US")
 
-    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, adgroup, creative)
+    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, "pocket", adgroup, creative)
 
 
 @library.global_function
@@ -814,7 +818,7 @@ def lockwise_adjust_url(ctx, redirect, adgroup, creative=None):
     play_store_url = settings.GOOGLE_PLAY_LOCKWISE_LINK
     locale = getattr(ctx["request"], "locale", "en-US")
 
-    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, adgroup, creative)
+    return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, "lockwise", adgroup, creative)
 
 
 def _fxa_product_url(product_url, entrypoint, optional_parameters=None):

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -905,7 +905,7 @@ class TestFirefoxAdjustUrl(TestCase):
         assert (
             self._render("en-US", "ios", "test-page") == "https://app.adjust.com/2uo1qc?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=firefox&amp;mz_pl=ios"
         )
 
     def test_firefox_ios_adjust_url_invalid_country(self):
@@ -913,7 +913,7 @@ class TestFirefoxAdjustUrl(TestCase):
         assert (
             self._render("zz", "ios", "test-page") == "https://app.adjust.com/2uo1qc?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=firefox&amp;mz_pl=ios"
         )
 
     def test_firefox_ios_adjust_url_creative(self):
@@ -921,7 +921,7 @@ class TestFirefoxAdjustUrl(TestCase):
         assert (
             self._render("de", "ios", "test-page", "experiment-name") == "https://app.adjust.com/2uo1qc?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name&amp;mz_pr=firefox&amp;mz_pl=ios"
         )
 
     def test_firefox_android_adjust_url(self):
@@ -929,12 +929,15 @@ class TestFirefoxAdjustUrl(TestCase):
         assert (
             self._render("en-US", "android", "test-page") == "https://app.adjust.com/2uo1qc?redirect="
             "https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=firefox&amp;mz_pl=android"
         )
 
     def test_firefox_no_redirect_adjust_url(self):
         """Firefox for mobile with no redirect"""
-        assert self._render("en-US", None, "test-page") == "https://app.adjust.com/2uo1qc?campaign=www.mozilla.org&amp;adgroup=test-page"
+        assert (
+            self._render("en-US", None, "test-page") == "https://app.adjust.com/2uo1qc?"
+            "campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=firefox&amp;mz_pl=mobile"
+        )
 
 
 class TestFocusAdjustUrl(TestCase):
@@ -954,7 +957,7 @@ class TestFocusAdjustUrl(TestCase):
         assert (
             self._render("en-US", "ios", "test-page") == "https://app.adjust.com/b8s7qo?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=focus&amp;mz_pl=ios"
         )
 
     def test_focus_ios_adjust_url_invalid_country(self):
@@ -962,7 +965,7 @@ class TestFocusAdjustUrl(TestCase):
         assert (
             self._render("zz", "ios", "test-page") == "https://app.adjust.com/b8s7qo?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=focus&amp;mz_pl=ios"
         )
 
     def test_focus_ios_adjust_url_creative(self):
@@ -970,7 +973,7 @@ class TestFocusAdjustUrl(TestCase):
         assert (
             self._render("fr", "ios", "test-page", "experiment-name") == "https://app.adjust.com/b8s7qo?"
             "redirect=https%3A%2F%2Fitunes.apple.com%2Ffr%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name&amp;mz_pr=focus&amp;mz_pl=ios"
         )
 
     def test_focus_android_adjust_url(self):
@@ -978,19 +981,22 @@ class TestFocusAdjustUrl(TestCase):
         assert (
             self._render("en-US", "android", "test-page") == "https://app.adjust.com/b8s7qo?redirect="
             "https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.focus"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=focus&amp;mz_pl=android"
         )
 
     def test_focus_no_redirect_adjust_url(self):
         """Firefox Focus for mobile with no redirect"""
-        assert self._render("en-US", None, "test-page") == "https://app.adjust.com/b8s7qo?campaign=www.mozilla.org&amp;adgroup=test-page"
+        assert (
+            self._render("en-US", None, "test-page") == "https://app.adjust.com/b8s7qo?"
+            "campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=focus&amp;mz_pl=mobile"
+        )
 
     def test_klar_ios_adjust_url(self):
         """Firefox Klar with an App Store URL redirect"""
         assert (
             self._render("de", "ios", "test-page") == "https://app.adjust.com/jfcx5x?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Fklar-by-firefox%2Fid1073435754"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=klar&amp;mz_pl=ios"
         )
 
     def test_klar_android_adjust_url(self):
@@ -998,7 +1004,7 @@ class TestFocusAdjustUrl(TestCase):
         assert (
             self._render("de", "android", "test-page") == "https://app.adjust.com/jfcx5x?redirect="
             "https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.klar"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=klar&amp;mz_pl=android"
         )
 
 
@@ -1019,7 +1025,7 @@ class TestLockwiseAdjustUrl(TestCase):
         assert (
             self._render("en-US", "ios", "test-page") == "https://app.adjust.com/6tteyjo?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Fid1314000270%3Fmt%3D8"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=lockwise&amp;mz_pl=ios"
         )
 
     def test_lockwise_ios_adjust_url_invalid_country(self):
@@ -1027,7 +1033,7 @@ class TestLockwiseAdjustUrl(TestCase):
         assert (
             self._render("zz", "ios", "test-page") == "https://app.adjust.com/6tteyjo?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fapp%2Fid1314000270%3Fmt%3D8"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=lockwise&amp;mz_pl=ios"
         )
 
     def test_lockwise_ios_adjust_url_creative(self):
@@ -1035,7 +1041,7 @@ class TestLockwiseAdjustUrl(TestCase):
         assert (
             self._render("de", "ios", "test-page", "experiment-name") == "https://app.adjust.com/6tteyjo"
             "?redirect=https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Fid1314000270%3Fmt%3D8"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name&amp;mz_pr=lockwise&amp;mz_pl=ios"
         )
 
     def test_lockwise_android_adjust_url(self):
@@ -1043,12 +1049,15 @@ class TestLockwiseAdjustUrl(TestCase):
         assert (
             self._render("en-US", "android", "test-page") == "https://app.adjust.com/6tteyjo?redirect="
             "https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dmozilla.lockbox"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=lockwise&amp;mz_pl=android"
         )
 
     def test_lockwise_no_redirect_adjust_url(self):
         """Firefox Lockwise for mobile with no redirect"""
-        assert self._render("en-US", None, "test-page") == "https://app.adjust.com/6tteyjo?campaign=www.mozilla.org&amp;adgroup=test-page"
+        assert (
+            self._render("en-US", None, "test-page") == "https://app.adjust.com/6tteyjo?"
+            "campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=lockwise&amp;mz_pl=mobile"
+        )
 
 
 class TestPocketAdjustUrl(TestCase):
@@ -1068,7 +1077,7 @@ class TestPocketAdjustUrl(TestCase):
         assert (
             self._render("en-US", "ios", "test-page") == "https://app.adjust.com/m54twk?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=pocket&amp;mz_pl=ios"
         )
 
     def test_pocket_ios_adjust_url_invalid_country(self):
@@ -1076,7 +1085,7 @@ class TestPocketAdjustUrl(TestCase):
         assert (
             self._render("zz", "ios", "test-page") == "https://app.adjust.com/m54twk?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=pocket&amp;mz_pl=ios"
         )
 
     def test_pocket_ios_adjust_url_creative(self):
@@ -1084,7 +1093,7 @@ class TestPocketAdjustUrl(TestCase):
         assert (
             self._render("de", "ios", "test-page", "experiment-name") == "https://app.adjust.com/m54twk?redirect="
             "https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name&amp;mz_pr=pocket&amp;mz_pl=ios"
         )
 
     def test_pocket_android_adjust_url(self):
@@ -1092,12 +1101,15 @@ class TestPocketAdjustUrl(TestCase):
         assert (
             self._render("en-US", "android", "test-page") == "https://app.adjust.com/m54twk?redirect="
             "https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dcom.ideashower.readitlater.pro"
-            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page"
+            "&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=pocket&amp;mz_pl=android"
         )
 
     def test_pocket_no_redirect_adjust_url(self):
         """Pocket for mobile with no redirect"""
-        assert self._render("en-US", None, "test-page") == "https://app.adjust.com/m54twk?campaign=www.mozilla.org&amp;adgroup=test-page"
+        assert (
+            self._render("en-US", None, "test-page") == "https://app.adjust.com/m54twk?"
+            "campaign=www.mozilla.org&amp;adgroup=test-page&amp;mz_pr=pocket&amp;mz_pl=mobile"
+        )
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -304,7 +304,7 @@ Properties for use with `product_download` (not all products will have all optio
 
 - product (example: firefox)
 - platform (example: win64)
-- method (store, direct, or adjust)
+- method (store, site, or adjust)
 - link_url
 - release_channel (example: nightly)
 - download_language (example: en-CA)

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -305,7 +305,6 @@ Properties for use with `product_download` (not all products will have all optio
 - product (example: firefox)
 - platform (example: win64)
 - method (store, site, or adjust)
-- link_url
 - release_channel (example: nightly)
 - download_language (example: en-CA)
 

--- a/media/js/base/datalayer-productdownload-init.es6.js
+++ b/media/js/base/datalayer-productdownload-init.es6.js
@@ -6,6 +6,13 @@
 
 import TrackProductDownload from './datalayer-productdownload.es6';
 
+// Create namespace
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+window.Mozilla.TrackProductDownload = TrackProductDownload;
+
 // init tracking on links
 // other methods of triggering downloads (example: /thanks) are handled separately
 const productLinks = document.querySelectorAll('.ga-product-download');

--- a/media/js/base/datalayer-productdownload-init.es6.js
+++ b/media/js/base/datalayer-productdownload-init.es6.js
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrackProductDownload from './datalayer-productdownload.es6';
+
+// init tracking on links
+// other methods of triggering downloads (example: /thanks) are handled separately
+const productLinks = document.querySelectorAll('.ga-product-download');
+for (let i = 0; i < productLinks.length; ++i) {
+    productLinks[i].addEventListener(
+        'click',
+        function (event) {
+            TrackProductDownload.handleLink(event);
+        },
+        false
+    );
+}

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -112,17 +112,17 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
         platform =
             productParam.indexOf('msi') !== -1 ? platform + '-msi' : platform;
         // release channel is second word of product param
-        let releaseChannel = productSplit[1];
+        let release = productSplit[1];
         // (except for latest, msi, or sub installer - we update those to say release)
-        if (['latest', 'stub', 'msi'].includes(releaseChannel)) {
-            releaseChannel = 'release';
+        if (release === 'latest' || release === 'stub' || release === 'msi') {
+            release = 'release';
         }
 
         eventObject = TrackProductDownload.getEventObject(
             product,
             platform,
             'site',
-            releaseChannel,
+            release,
             params.lang
         );
     } else if (playStoreURL.test(downloadURL) || marketURL.test(downloadURL)) {

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -44,7 +44,7 @@ TrackProductDownload.isValidDownloadURL = (downloadURL) => {
  * Create the product_download event object
  * @param {string} product
  * @param {string} platform
- * @param {string} method - direct, store, or adjust
+ * @param {string} method - site, store, or adjust
  * @param {string} linkUrl
  * @param {string} release_channel - optional, we don't get it for ios downloads
  * @param {string} download_language - optional, we don't get it for mobile downloads
@@ -118,7 +118,7 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
         eventObject = TrackProductDownload.getEventObject(
             product,
             platform,
-            'direct',
+            'site',
             downloadURL,
             releaseChannel,
             params.lang

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -158,13 +158,13 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
         );
     } else if (appStoreURL.test(downloadURL) || iTunesURL.test(downloadURL)) {
         let iosProduct = 'unrecognized';
-        if (downloadURL.includes('/id989804926')) {
+        if (downloadURL.indexOf('/id989804926') !== -1) {
             iosProduct = 'firefox';
-        } else if (downloadURL.includes('/id1055677337')) {
+        } else if (downloadURL.indexOf('/id1055677337') !== -1) {
             iosProduct = 'focus';
-        } else if (downloadURL.includes('/id1073435754')) {
+        } else if (downloadURL.indexOf('/id1073435754') !== -1) {
             iosProduct = 'klar';
-        } else if (downloadURL.includes('/id309601447')) {
+        } else if (downloadURL.indexOf('/id309601447') !== -1) {
             iosProduct = 'pocket';
         }
         // Apple App Store
@@ -177,21 +177,21 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
     } else if (adjustURL.test(downloadURL)) {
         // product
         let adjustProduct = 'unrecognized';
-        if (downloadURL.includes('/2uo1qc')) {
+        if (downloadURL.indexOf('/2uo1qc') !== -1) {
             adjustProduct = 'firefox';
-        } else if (downloadURL.includes('/b8s7qo')) {
+        } else if (downloadURL.indexOf('/b8s7qo') !== -1) {
             adjustProduct = 'focus';
-        } else if (downloadURL.includes('/jfcx5x')) {
+        } else if (downloadURL.indexOf('/jfcx5x') !== -1) {
             adjustProduct = 'klar';
-        } else if (downloadURL.includes('/m54twk')) {
+        } else if (downloadURL.indexOf('/m54twk') !== -1) {
             adjustProduct = 'pocket';
         }
 
         // platform
         let adjustPlatform = 'mobile';
-        if (downloadURL.includes('play.google.com')) {
+        if (downloadURL.indexOf('play.google.com') !== -1) {
             adjustPlatform = 'android';
-        } else if (downloadURL.includes('itunes.apple.com')) {
+        } else if (downloadURL.indexOf('itunes.apple.com') !== -1) {
             adjustPlatform = 'ios';
         }
 

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -179,29 +179,9 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             'release'
         );
     } else if (adjustURL.test(downloadURL)) {
-        // product
-        let adjustProduct = 'unrecognized';
-        if (downloadURL.indexOf('/2uo1qc') !== -1) {
-            adjustProduct = 'firefox';
-        } else if (downloadURL.indexOf('/b8s7qo') !== -1) {
-            adjustProduct = 'focus';
-        } else if (downloadURL.indexOf('/jfcx5x') !== -1) {
-            adjustProduct = 'klar';
-        } else if (downloadURL.indexOf('/m54twk') !== -1) {
-            adjustProduct = 'pocket';
-        }
-
-        // platform
-        let adjustPlatform = 'mobile';
-        if (downloadURL.indexOf('play.google.com') !== -1) {
-            adjustPlatform = 'android';
-        } else if (downloadURL.indexOf('itunes.apple.com') !== -1) {
-            adjustPlatform = 'ios';
-        }
-
         eventObject = TrackProductDownload.getEventObject(
-            adjustProduct,
-            adjustPlatform,
+            params.mz_pr,
+            params.mz_pl,
             'adjust',
             'release'
         );

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -10,6 +10,7 @@ const stageURL = /^https:\/\/bouncer-bouncer.stage.mozaws.net/;
 const iTunesURL = /^https:\/\/itunes.apple.com/;
 const appStoreURL = /^https:\/\/apps.apple.com/;
 const playStoreURL = /^https:\/\/play.google.com/;
+const marketURL = /^market:\/\/play.google.com/;
 const adjustURL = /^https:\/\/app.adjust.com/;
 
 if (typeof window.dataLayer === 'undefined') {
@@ -29,6 +30,7 @@ TrackProductDownload.isValidDownloadURL = (downloadURL) => {
             iTunesURL.test(downloadURL) ||
             appStoreURL.test(downloadURL) ||
             playStoreURL.test(downloadURL) ||
+            marketURL.test(downloadURL) ||
             adjustURL.test(downloadURL)
         ) {
             return true;
@@ -119,7 +121,7 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             releaseChannel,
             params.lang
         );
-    } else if (playStoreURL.test(downloadURL)) {
+    } else if (playStoreURL.test(downloadURL) || marketURL.test(downloadURL)) {
         const idParam = params.id;
         let androidProduct = 'unrecognized';
         let androidRelease = '';

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -106,13 +106,17 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
         // product is first word of product param
         const product = productSplit[0];
         let platform = params.os;
+        // change platform to macos if it's osx
         platform = platform === 'osx' ? 'macos' : platform;
+        // append 'msi' to platform if msi is in the product parameter
+        platform =
+            productParam.indexOf('msi') !== -1 ? platform + '-msi' : platform;
         // release channel is second word of product param
-        // (except for latest or sub installer - we update those to say release)
-        const releaseChannel =
-            productSplit[1] === ('latest' || 'stub')
-                ? 'release'
-                : productSplit[1];
+        let releaseChannel = productSplit[1];
+        // (except for latest, msi, or sub installer - we update those to say release)
+        if (['latest', 'stub', 'msi'].includes(releaseChannel)) {
+            releaseChannel = 'release';
+        }
 
         eventObject = TrackProductDownload.getEventObject(
             product,

--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -45,7 +45,6 @@ TrackProductDownload.isValidDownloadURL = (downloadURL) => {
  * @param {string} product
  * @param {string} platform
  * @param {string} method - site, store, or adjust
- * @param {string} linkUrl
  * @param {string} release_channel - optional, we don't get it for ios downloads
  * @param {string} download_language - optional, we don't get it for mobile downloads
  * @returns {Object}
@@ -54,7 +53,6 @@ TrackProductDownload.getEventObject = (
     product,
     platform,
     method,
-    linkUrl,
     release_channel = false,
     download_language = false
 ) => {
@@ -63,7 +61,6 @@ TrackProductDownload.getEventObject = (
     eventObject['product'] = product;
     eventObject['platform'] = platform;
     eventObject['method'] = method;
-    eventObject['link_url'] = linkUrl;
     if (release_channel) {
         eventObject['release_channel'] = release_channel;
     }
@@ -119,7 +116,6 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             product,
             platform,
             'site',
-            downloadURL,
             releaseChannel,
             params.lang
         );
@@ -156,7 +152,6 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             androidProduct,
             'android',
             'store',
-            downloadURL,
             androidRelease
         );
     } else if (appStoreURL.test(downloadURL) || iTunesURL.test(downloadURL)) {
@@ -175,7 +170,6 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             iosProduct,
             'ios',
             'store',
-            downloadURL,
             'release'
         );
     } else if (adjustURL.test(downloadURL)) {
@@ -203,7 +197,6 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
             adjustProduct,
             adjustPlatform,
             'adjust',
-            downloadURL,
             'release'
         );
     }

--- a/media/js/firefox/all/all-downloads-unified-init.es6.js
+++ b/media/js/firefox/all/all-downloads-unified-init.es6.js
@@ -19,9 +19,6 @@ import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
         const downloadButton = document.getElementById(
             'download-button-primary'
         );
-        const mobileDownloadButtons = document.querySelectorAll(
-            '.ga-product-download'
-        );
 
         function showHelpModal(modalContent, modalTitle, eventLabel) {
             MzpModal.createModal(this, modalContent, {
@@ -79,16 +76,6 @@ import MzpSideMenu from '@mozilla-protocol/core/protocol/js/sidemenu';
             },
             false
         );
-
-        for (let i = 0; i < mobileDownloadButtons.length; i++) {
-            mobileDownloadButtons[i].addEventListener(
-                'click',
-                function (event) {
-                    TrackProductDownload.handleLink(event);
-                },
-                false
-            );
-        }
     }
 
     Mozilla.run(onLoad);

--- a/media/js/firefox/new/common/thanks-direct.js
+++ b/media/js/firefox/new/common/thanks-direct.js
@@ -31,11 +31,29 @@
                 // Make sure the 'Try downloading again' link is well formatted! (issue 9615)
                 if (directDownloadLink && directDownloadLink.href) {
                     directDownloadLink.href = downloadURL;
+                    directDownloadLink.addEventListener(
+                        'click',
+                        function (event) {
+                            try {
+                                Mozilla.TrackProductDownload.handleLink(event);
+                            } catch (error) {
+                                return;
+                            }
+                        },
+                        false
+                    );
                 }
 
                 // Start the platform-detected download a second after DOM ready event.
                 Mozilla.Utils.onDocumentReady(function () {
                     setTimeout(function () {
+                        try {
+                            Mozilla.TrackProductDownload.sendEventFromURL(
+                                downloadURL
+                            );
+                        } catch (error) {
+                            return;
+                        }
                         window.location.href = downloadURL;
                     }, 1000);
                 });

--- a/media/js/firefox/new/common/thanks-init.js
+++ b/media/js/firefox/new/common/thanks-init.js
@@ -25,11 +25,29 @@
             // Make sure the 'Try downloading again' link is well formatted! (issue 9615)
             if (directDownloadLink && directDownloadLink.href) {
                 directDownloadLink.href = downloadURL;
+                directDownloadLink.addEventListener(
+                    'click',
+                    function (event) {
+                        try {
+                            Mozilla.TrackProductDownload.handleLink(event);
+                        } catch (error) {
+                            return;
+                        }
+                    },
+                    false
+                );
             }
 
             // Start the platform-detected download a second after DOM ready event.
             Mozilla.Utils.onDocumentReady(function () {
                 setTimeout(function () {
+                    try {
+                        Mozilla.TrackProductDownload.sendEventFromURL(
+                            downloadURL
+                        );
+                    } catch (error) {
+                        return;
+                    }
                     window.location.href = downloadURL;
                 }, 1000);
             });

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1706,7 +1706,8 @@
     {
       "files": [
         "js/base/core-datalayer.js",
-        "js/base/core-datalayer-init.js"
+        "js/base/core-datalayer-init.js",
+        "js/base/datalayer-productdownload-init.es6.js"
       ],
       "name": "data"
     },

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -113,7 +113,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify product for Firefox with Adjust', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/2uo1qc'
+            'https://app.adjust.com/2uo1qc?mz_pr=firefox&mz_pl=mobile'
         );
         expect(testEvent['product']).toBe('firefox');
     });
@@ -131,7 +131,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify product for Pocket with Adjust', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/m54twk'
+            'https://app.adjust.com/m54twk?mz_pr=pocket&mz_pl=mobile'
         );
         expect(testEvent['product']).toBe('pocket');
     });
@@ -149,7 +149,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify product for Focus with Adjust', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/b8s7qo'
+            'https://app.adjust.com/b8s7qo?mz_pr=focus&mz_pl=android'
         );
         expect(testEvent['product']).toBe('focus');
     });
@@ -167,15 +167,9 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify product for Klar with Adjust', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/jfcx5x'
+            'https://app.adjust.com/jfcx5x?mz_pr=klar&mz_pl=mobile'
         );
         expect(testEvent['product']).toBe('klar');
-    });
-    it('should identify product as unrecognized if Adjust link is not found', function () {
-        let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/aabbcc'
-        );
-        expect(testEvent['product']).toBe('unrecognized');
     });
     it('should identify product as unrecognized if App Store link is not found', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
@@ -234,13 +228,13 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should identify platform for Adjust link direct to Play Store', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/b8s7qo?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.focus&campaign=www.mozilla.org&adgroup=mobile-focus-page'
+            'https://app.adjust.com/b8s7qo?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.focus&campaign=www.mozilla.org&adgroup=mobile-focus-page&mz_pr=focus&mz_pl=android'
         );
         expect(testEvent['platform']).toBe('android');
     });
     it('should identify platform for Adjust link direct to App Store', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/b8s7qo?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337&campaign=www.mozilla.org&adgroup=mobile-focus-page'
+            'https://app.adjust.com/b8s7qo?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337&campaign=www.mozilla.org&adgroup=mobile-focus-page&mz_pr=focus&mz_pl=ios'
         );
         expect(testEvent['platform']).toBe('ios');
     });
@@ -338,7 +332,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     });
     it('should not identify language for an Adjust link', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
-            'https://app.adjust.com/2uo1qc'
+            'https://app.adjust.com/2uo1qc?mz_pr=focus&mz_pl=android'
         );
         expect(testEvent['download_language']).toBeFalsy();
     });

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -57,7 +57,6 @@ describe('TrackProductDownload.getEventObject', function () {
             product: 'testProduct',
             platform: 'testPlatform',
             method: 'testMethod',
-            link_url: 'linkURL',
             release_channel: 'testReleaseChannel',
             download_language: 'testDownloadLanguage'
         };
@@ -65,7 +64,6 @@ describe('TrackProductDownload.getEventObject', function () {
             'testProduct',
             'testPlatform',
             'testMethod',
-            'linkURL',
             'testReleaseChannel',
             'testDownloadLanguage'
         );
@@ -76,14 +74,12 @@ describe('TrackProductDownload.getEventObject', function () {
             event: 'product_download',
             product: 'testProduct',
             platform: 'testPlatform',
-            method: 'testMethod',
-            link_url: 'linkURL'
+            method: 'testMethod'
         };
         let testShortEventObject = TrackProductDownload.getEventObject(
             'testProduct',
             'testPlatform',
-            'testMethod',
-            'linkURL'
+            'testMethod'
         );
         expect(testShortEventObject).toEqual(testShortEventExpectedObject);
     });
@@ -361,8 +357,6 @@ describe('TrackProductDownload.handleLink', function () {
             product: 'firefox',
             platform: 'win64',
             method: 'site',
-            link_url:
-                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-CA',
             release_channel: 'release',
             download_language: 'en-CA'
         });

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -360,7 +360,7 @@ describe('TrackProductDownload.handleLink', function () {
             event: 'product_download',
             product: 'firefox',
             platform: 'win64',
-            method: 'direct',
+            method: 'site',
             link_url:
                 'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-CA',
             release_channel: 'release',

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -208,6 +208,18 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         );
         expect(testEvent['platform']).toBe('linux64');
     });
+    it('should identify platform for msi', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang=en-US'
+        );
+        expect(testEvent['platform']).toBe('win64-msi');
+    });
+    it('should identify platform for esr msi', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang=en-US'
+        );
+        expect(testEvent['platform']).toBe('win64-msi');
+    });
     it('should identify platform for Firefox in the App Store', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
             'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
@@ -260,6 +272,18 @@ describe('TrackProductDownload.getEventFromUrl', function () {
     it('should identify release_channel for Firefox ESR', function () {
         let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testEvent['release_channel']).toBe('esr');
+    });
+    it('should identify release_channel for Firefox MSI', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang=en-US'
+        );
+        expect(testEvent['release_channel']).toBe('release');
+    });
+    it('should identify release_channel for Firefox ESR', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang=en-US'
         );
         expect(testEvent['release_channel']).toBe('esr');
     });

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -36,11 +36,11 @@ describe('TrackProductDownload.isValidDownloadURL', function () {
         );
         expect(testPlayStoreURL).toBe(true);
     });
-    it('should not accept Adjust as a valid URL', function () {
+    it('should recognize Adjust as a valid URL', function () {
         let testAdjustURL = TrackProductDownload.isValidDownloadURL(
             'https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox&campaign=www.mozilla.org&adgroup=mobile-android-page'
         );
-        expect(testAdjustURL).toBe(false);
+        expect(testAdjustURL).toBe(true);
     });
     it('should not accept a random link to mozilla.org as a valid URL', function () {
         let testRandomURL = TrackProductDownload.isValidDownloadURL(
@@ -56,12 +56,16 @@ describe('TrackProductDownload.getEventObject', function () {
             event: 'product_download',
             product: 'testProduct',
             platform: 'testPlatform',
+            method: 'testMethod',
+            link_url: 'linkURL',
             release_channel: 'testReleaseChannel',
             download_language: 'testDownloadLanguage'
         };
         let testFullEventObject = TrackProductDownload.getEventObject(
             'testProduct',
             'testPlatform',
+            'testMethod',
+            'linkURL',
             'testReleaseChannel',
             'testDownloadLanguage'
         );
@@ -72,12 +76,14 @@ describe('TrackProductDownload.getEventObject', function () {
             event: 'product_download',
             product: 'testProduct',
             platform: 'testPlatform',
-            release_channel: '',
-            download_language: ''
+            method: 'testMethod',
+            link_url: 'linkURL'
         };
         let testShortEventObject = TrackProductDownload.getEventObject(
             'testProduct',
-            'testPlatform'
+            'testPlatform',
+            'testMethod',
+            'linkURL'
         );
         expect(testShortEventObject).toEqual(testShortEventExpectedObject);
     });
@@ -86,133 +92,229 @@ describe('TrackProductDownload.getEventObject', function () {
 describe('TrackProductDownload.getEventFromUrl', function () {
     // product
     it('should identify product for Firefox Desktop', function () {
-        let testProductDesktop = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
         );
-        expect(testProductDesktop['product']).toBe('firefox');
+        expect(testEvent['product']).toBe('firefox');
     });
-    it('should identify product for Firefox iOS', function () {
-        let testProductIOS = TrackProductDownload.getEventFromUrl(
+    it('should identify product for Firefox in the App Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
         );
-        expect(testProductIOS['product']).toBe('firefox');
+        expect(testEvent['product']).toBe('firefox');
     });
-    it('should identify product for Firefox Android', function () {
-        let testProductAndroid = TrackProductDownload.getEventFromUrl(
+    it('should identify product for Firefox in the Play Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
         );
-        expect(testProductAndroid['product']).toBe('firefox');
+        expect(testEvent['product']).toBe('firefox');
+    });
+    it('should identify product for Firefox with Adjust', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/2uo1qc'
+        );
+        expect(testEvent['product']).toBe('firefox');
+    });
+    it('should identify product for Pocket in the App Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/{country}/app/pocket-save-read-grow/id309601447'
+        );
+        expect(testEvent['product']).toBe('pocket');
+    });
+    it('should identify product for Pocket in the Play Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro'
+        );
+        expect(testEvent['product']).toBe('pocket');
+    });
+    it('should identify product for Pocket with Adjust', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/m54twk'
+        );
+        expect(testEvent['product']).toBe('pocket');
+    });
+    it('should identify product for Focus in the App Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/{country}/app/firefox-focus-privacy-browser/id1055677337'
+        );
+        expect(testEvent['product']).toBe('focus');
+    });
+    it('should identify product for Focus in the Play Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.focus'
+        );
+        expect(testEvent['product']).toBe('focus');
+    });
+    it('should identify product for Focus with Adjust', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/b8s7qo'
+        );
+        expect(testEvent['product']).toBe('focus');
+    });
+    it('should identify product for Klar in the App Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/{country}/app/klar-by-firefox/id1073435754'
+        );
+        expect(testEvent['product']).toBe('klar');
+    });
+    it('should identify product for Klar in the Play Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=org.mozilla.klar'
+        );
+        expect(testEvent['product']).toBe('klar');
+    });
+    it('should identify product for Klar with Adjust', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/jfcx5x'
+        );
+        expect(testEvent['product']).toBe('klar');
+    });
+    it('should identify product as unrecognized if Adjust link is not found', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/aabbcc'
+        );
+        expect(testEvent['product']).toBe('unrecognized');
+    });
+    it('should identify product as unrecognized if App Store link is not found', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://itunes.apple.com/us/app/49th-parallel-coffee-roasters/id1567407403'
+        );
+        expect(testEvent['product']).toBe('unrecognized');
+    });
+    it('should identify product as unrecognized if Play Store link is not found', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://play.google.com/store/apps/details?id=co.tapcart.app.id_rBugj0qbKV'
+        );
+        expect(testEvent['product']).toBe('unrecognized');
     });
     // platform
-    it('should identify platform for Windows', function () {
-        let testPlatformWindows = TrackProductDownload.getEventFromUrl(
+    it('should identify platform for Firefox for Windows', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
         );
-        expect(testPlatformWindows['platform']).toBe('win64');
+        expect(testEvent['platform']).toBe('win64');
     });
-    it('should identify platform for MacOS', function () {
-        let testPlatformMacOS = TrackProductDownload.getEventFromUrl(
+    it('should identify platform for Firefox for MacOS', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US'
         );
-        expect(testPlatformMacOS['platform']).toBe('macos');
+        expect(testEvent['platform']).toBe('macos');
     });
-    it('should identify platform for Linux', function () {
-        let testPlatformLinux = TrackProductDownload.getEventFromUrl(
+    it('should identify platform for Firefox for Linux', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US'
         );
-        expect(testPlatformLinux['platform']).toBe('linux64');
+        expect(testEvent['platform']).toBe('linux64');
     });
-    it('should identify platform for iOS', function () {
-        let testPlatformIOS = TrackProductDownload.getEventFromUrl(
+    it('should identify platform for Firefox in the App Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
         );
-        expect(testPlatformIOS['platform']).toBe('ios');
+        expect(testEvent['platform']).toBe('ios');
     });
-    it('should identify platform for Android', function () {
-        let testPlatformAndroid = TrackProductDownload.getEventFromUrl(
+    it('should identify platform for Firefox in the Play Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
         );
-        expect(testPlatformAndroid['platform']).toBe('android');
+        expect(testEvent['platform']).toBe('android');
+    });
+    it('should identify platform for Adjust link direct to Play Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/b8s7qo?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.focus&campaign=www.mozilla.org&adgroup=mobile-focus-page'
+        );
+        expect(testEvent['platform']).toBe('android');
+    });
+    it('should identify platform for Adjust link direct to App Store', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/b8s7qo?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337&campaign=www.mozilla.org&adgroup=mobile-focus-page'
+        );
+        expect(testEvent['platform']).toBe('ios');
     });
     // release channel
     it('should identify release_channel for Firefox Release', function () {
-        let testReleaseRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
         );
-        expect(testReleaseRelease['release_channel']).toBe('release');
+        expect(testEvent['release_channel']).toBe('release');
     });
     it('should identify release_channel for Firefox Beta', function () {
-        let testBetaRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US'
         );
-        expect(testBetaRelease['release_channel']).toBe('beta');
+        expect(testEvent['release_channel']).toBe('beta');
     });
     it('should identify release_channel for Firefox Dev Edition', function () {
-        let testDevRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=en-US'
         );
-        expect(testDevRelease['release_channel']).toBe('devedition');
+        expect(testEvent['release_channel']).toBe('devedition');
     });
     it('should identify release_channel for Firefox Nightly', function () {
-        let testNightlyRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=osx&lang=en-US'
         );
-        expect(testNightlyRelease['release_channel']).toBe('nightly');
+        expect(testEvent['release_channel']).toBe('nightly');
     });
     it('should identify release_channel for Firefox ESR', function () {
-        let testNightlyRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=en-US'
         );
-        expect(testNightlyRelease['release_channel']).toBe('esr');
+        expect(testEvent['release_channel']).toBe('esr');
     });
     it('should identify release_channel for Firefox iOS', function () {
-        let testIOSRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
         );
-        expect(testIOSRelease['release_channel']).toBe('release');
+        expect(testEvent['release_channel']).toBe('release');
     });
     it('should identify release_channel for Firefox Android Release', function () {
-        let testAndroidRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
         );
-        expect(testAndroidRelease['release_channel']).toBe('release');
+        expect(testEvent['release_channel']).toBe('release');
     });
     it('should identify release_channel for Firefox Android Beta', function () {
-        let testAndroidBetaRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta'
         );
-        expect(testAndroidBetaRelease['release_channel']).toBe('beta');
+        expect(testEvent['release_channel']).toBe('beta');
     });
     it('should identify release_channel for Firefox Android Nightly', function () {
-        let testAndroidNightlyRelease = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.fenix'
         );
-        expect(testAndroidNightlyRelease['release_channel']).toBe('nightly');
+        expect(testEvent['release_channel']).toBe('nightly');
     });
     // language
     it('should identify en-US for Firefox Desktop', function () {
-        let testLanguageDesktop = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-US&_gl=1&234*_ga*ABC'
         );
-        expect(testLanguageDesktop['download_language']).toBe('en-US');
+        expect(testEvent['download_language']).toBe('en-US');
     });
     it('should identify DE for Firefox Desktop', function () {
-        let testLanguageDesktop = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=de'
         );
-        expect(testLanguageDesktop['download_language']).toBe('de');
+        expect(testEvent['download_language']).toBe('de');
     });
     it('should not identify language for Firefox iOS', function () {
-        let testLanguageIOS = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://itunes.apple.com/app/firefox-private-safe-browser/id989804926'
         );
-        expect(testLanguageIOS['download_language']).toBeFalsy();
+        expect(testEvent['download_language']).toBeFalsy();
     });
     it('should not identify language for Firefox Android', function () {
-        let testLanguageAndroid = TrackProductDownload.getEventFromUrl(
+        let testEvent = TrackProductDownload.getEventFromUrl(
             'https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
         );
-        expect(testLanguageAndroid['download_language']).toBeFalsy();
+        expect(testEvent['download_language']).toBeFalsy();
+    });
+    it('should not identify language for an Adjust link', function () {
+        let testEvent = TrackProductDownload.getEventFromUrl(
+            'https://app.adjust.com/2uo1qc'
+        );
+        expect(testEvent['download_language']).toBeFalsy();
     });
 });
 
@@ -258,6 +360,9 @@ describe('TrackProductDownload.handleLink', function () {
             event: 'product_download',
             product: 'firefox',
             platform: 'win64',
+            method: 'direct',
+            link_url:
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang=en-CA',
             release_channel: 'release',
             download_language: 'en-CA'
         });

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -36,6 +36,12 @@ describe('TrackProductDownload.isValidDownloadURL', function () {
         );
         expect(testPlayStoreURL).toBe(true);
     });
+    it('should recognize the Android Market as a valid URL', function () {
+        let testPlayStoreURL = TrackProductDownload.isValidDownloadURL(
+            'market://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dmozilla%26utm_medium%3DReferral%26utm_campaign%3Dmozilla-org'
+        );
+        expect(testPlayStoreURL).toBe(true);
+    });
     it('should recognize Adjust as a valid URL', function () {
         let testAdjustURL = TrackProductDownload.isValidDownloadURL(
             'https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox&campaign=www.mozilla.org&adgroup=mobile-android-page'


### PR DESCRIPTION
## One-line summary

Add Adjust support to TrackProductDownload and trigger on all remaining desktop downloads (previously this had just been triggered on /all).

## Significant changes and points to review

- add `method` and `link_url` parameters to product_download event
  - update tests
- stop assuming product is firefox and log it if the product is unrecognized
  - update tests
- add support for App Store links in addition to iTunes links
- add logic to support Adjust links
  - and identify which product and app store adjust links are for
- add TrackProductDownload to all pages on the site and init it
  - listen to links with class `ga-product-download` on all pages
  - remove what is now duplicate listener from /all
- add class `ga-product-download` to adjust links and download buttons

## Issue / Bugzilla link

#13238 

## Testing

[Successful integration tests](https://github.com/mozilla/bedrock/actions/runs/5884698384)

- [ ] Referrals to the app or play stores should trigger before leaving the site
- [ ] Buttons/links/dropdowns that refer to /thanks should **_only_** trigger on /thanks
- [ ] Buttons/links/dropdowns that link directly to bouncer should trigger an event when clicked

This branch is up on demo4 for testing with https://tagassistant.google.com/

https://www-demo4.allizom.org/en-US/firefox/new/ (and click download)
https://www-demo4.allizom.org/en-US/firefox/download/thanks/?s=direct
https://www-demo4.allizom.org/en-US/firefox/
https://www-demo4.allizom.org/en-US/firefox/browsers/
https://www-demo4.allizom.org/en-US/firefox/browsers/
https://www-demo4.allizom.org/en-US/firefox/browsers/mobile/
https://www-demo4.allizom.org/en-US/firefox/browsers/mobile/ios
https://www-demo4.allizom.org/en-US/firefox/browsers/mobile/android
https://www-demo4.allizom.org/en-US/firefox/browsers/mobile/focus
https://www-demo4.allizom.org/en-US/firefox/developer/
https://www-demo4.allizom.org/en-US/firefox/channel/desktop/