### PR TITLE
Add affiliate flow back to landing refresh page

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -121,7 +121,8 @@
   <div class="c-aside {{ position }} mzp-l-content mzp-t-content-xl">
     {% if vpn_available %}
       <p>
-        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.landing') }}#pricing" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="{{ position }}">
+        {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
+        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="{{ position }}">
           Get Mozilla VPN
         </a>
       </p>
@@ -153,7 +154,8 @@
 {% macro vpn_nav_cta_refresh() -%}
   <div class="vpn-nav-cta">
     {% if vpn_available %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.pricing') }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="navigation">
+      {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
+      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="navigation">
         Get Mozilla VPN
       </a>
     {% else %}

--- a/bedrock/products/templates/products/vpn/includes/subnav-refresh.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav-refresh.html
@@ -19,7 +19,8 @@
           </a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="{{ url('products.vpn.landing') }}#pricing" data-link-type="nav" data-link-position="subnav" data-link-name="View VPN pricing">
+          {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
+          <a href="{{ pricing_url }}" data-link-type="nav" data-link-position="subnav" data-link-name="View VPN pricing">
             Pricing
           </a>
         </li>

--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -14,6 +14,8 @@
 
 {% block page_desc %}Use Mozilla VPN for full-device protection for all apps. With servers in { $countries }+ countries, you can connect to anywhere, from anywhere.{% endblock %}
 
+{% block html_attrs %}{{ super() }} data-vpn-affiliate-endpoint="{{ settings.VPN_AFFILIATE_ENDPOINT }}"{% endblock %}
+
 {% block experiments %}
   {% if switch('experiment-vpn-landing-refresh', ['en-US']) %}
     {{ js_bundle('mozilla-vpn-landing-refresh-exp') }}
@@ -45,6 +47,9 @@
 
 {% block content %}
 <main>
+  {% if vpn_affiliate_attribution_enabled %}
+    {% include 'products/vpn/includes/cookie-notification.html' %}
+  {% endif %}
   {% call split(
     block_class='c-hero mzp-l-split-center-on-sm-md mzp-t-content-xl',
     image=resp_img(

--- a/media/css/products/vpn/landing-refresh.scss
+++ b/media/css/products/vpn/landing-refresh.scss
@@ -10,6 +10,17 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 // * -------------------------------------------------------------------------- */
+// Smooth Scroll
+
+html {
+    scroll-behavior: smooth;
+
+    @media (prefers-reduced-motion: reduce) {
+        scroll-behavior: auto;
+    }
+}
+
+// * -------------------------------------------------------------------------- */
 // Hero section
 
 .c-main-cta {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -998,6 +998,7 @@
     },
     {
       "files": [
+        "css/products/vpn/components/affiliate.scss",
         "css/products/vpn/common-refresh.scss"
       ],
       "name": "mozilla-vpn-common-refresh"
@@ -1025,7 +1026,6 @@
     },
     {
       "files": [
-        "css/products/vpn/components/affiliate.scss",
         "css/products/vpn/pricing-refresh.scss"
       ],
       "name": "mozilla-vpn-pricing-refresh"


### PR DESCRIPTION
## One-line summary

- Adds VPN affiliate logic back to refreshed landing page. 
- Also updates pricing links to use relative pricing anchors.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13159

## Testing

 - [x] http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-refresh&entrypoint_variation=2&cjevent=123456789 should display affiliate cookie banner
