### PR TITLE
Update browser support documentation for Firefox (Fixes #13378)

### DIFF
--- a/docs/browser-support.rst
+++ b/docs/browser-support.rst
@@ -26,25 +26,102 @@ Some website experiences may require us to deviate from these principles -- imag
 marketing campaign page built under timeline pressure to deliver novel functionality to a
 particular locale for a short while* -- but those will be exceptions and rare.
 
-Browser Support Matrix (Updated 2022-07-06)
--------------------------------------------
+Browser Support Matrix
+----------------------
 
-We deliver enhanced CSS & JS to browsers in our browser support matrix (below).
-We deliver degraded support to all other user agents, except legacy IE browsers,
-which get basic support.
+*Last updated: Updated July 19, 2023*
 
-**The following browsers have enhanced support:**
+Firefox
+~~~~~~~
 
-  * All evergreen browsers (Firefox, Firefox ESR, Chrome, Safari, Edge, Opera, etc.)
+It is important for website visitors to be able to download Firefox on a very broad
+range of desktop operating systems. As such, we aim to deliver enhanced support to
+user agents in our browser support matrix below.
 
-**The following browsers have degraded support:**
+**Enhanced support:**
 
-  * Outdated evergreen browser versions.
-  * IE11 & IE10.
+  Windows 11 and above
+    - All evergreen browsers
 
-**The following browsers have basic support:**
+      - Firefox
+      - Firefox ESR
+      - Chrome
+      - Edge
+      - Brave
+      - Opera
 
-  * IE9 and below.
+  Windows 10
+    - All evergreen browsers
+
+  macOS 10.15 and above
+    - All evergreen browsers
+    - Safari
+
+  Linux
+    - All evergreen browsers
+
+**Degraded support:**
+
+Website visitors on slightly older browsers fall under degraded support, which means
+that the website should be fully readable and accessible, but they may not get enhanced
+CSS layout or JS features.
+
+  Windows 10
+    - Internet Explorer 11
+
+  Windows 8.1 and below
+    - Firefox 115
+    - Chrome 109
+    - Internet Explorer 10
+
+  macOS 10.14 and below
+    - Firefox 115
+    - Chrome 114
+    - Safari 12.1
+
+.. Note::
+
+    As of Firefox 116 (released August 1st 2023), support for Firefox has been ended
+    on Windows 8.1 and below, as well as on macOS 10.14 and below. Website visitors
+    on these outdated operating systems now fall under degraded support, and we
+    offer them to download Firefox ESR instead.
+
+**Basic support:**
+
+Website visitors on very old versions of Internet Explorer will get only a very basic
+universal CSS style sheet, and a basic no-JS experience.
+
+  Windows 7
+    - Internet Explorer 9
+    - Internet Explorer 8
+
+**Unsupported:**
+
+Even older versions of Internet Explorer are now unsupported.
+
+  Windows XP / Vista
+    - Internet Explorer 7
+    - Internet Explorer 6
+
+.. Note::
+
+    Firefox ended support for Windows XP and Vista in 2017 with Firefox 53. Since then,
+    we have continued to serve those users Firefox ESR 52 instead. However, since then
+    support for downloading has been discontinued. The SSL certificates on
+    download.mozilla.org no longer support TLS 1.0.
+
+Privacy & security products
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Browser support for our privacy and security products (such as VPN, Relay, Monitor etc)
+is thankfully a simpler story. Since all these product use a Firefox account for
+authentication, we can simply follow the `Firefox Ecosystem Platform`_ browser support
+documentation.
+
+The most notable thing here for bedrock is that Internet Explorer 11 does not need to be
+supported.
+
+.. _Firefox Ecosystem Platform: https://mozilla.github.io/ecosystem-platform/reference/browser-support
 
 Delivering basic support
 ------------------------

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -24,21 +24,21 @@ Note that a deployment of Bedrock will actually trigger two separate deployments
 one serving all of ``mozilla.org`` and another serving certain parts of ``getpocket.com``
 
 Dev
-```
+~~~
 - *Mozorg URL:* https://www-dev.allizom.org/
 - *Pocket Marketing pages URL:* https://dev.tekcopteg.com/
 - *Bedrock locales:* dev repo
 - *Bedrock Git branch:* main, deployed on git push
 
 Staging
-```````
+~~~~~~~
 - *Mozorg URL:* https://www.allizom.org/
 - *Pocket Marketing pages URL:* https://www.tekcopteg.com/
 - *Bedrock locales:* prod repo
 - *Bedrock Git branch:* stage, deployed on git push
 
 Production
-``````````
+~~~~~~~~~~
 - *Mozorg URL:* https://www.mozilla.org/
 - *Pocket Marketing pages URL:* https://getpocket.com/
 - *Bedrock locales:* prod repo
@@ -154,7 +154,7 @@ is deployed to each `production`_ deployment.
 
 
 What Is Currently Deployed?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 You can look at the git log of the ``main`` branch to find the last commit with a date-tag on it (e.g. 2022-05-05):
 this commit will be the last one that was deployed to production. You can also use the whatsdeployed.io service to get
@@ -165,7 +165,7 @@ a nice view of what is actually currently deployed to Dev, Stage, and Prod:
 
 
 Instance Configuration & Switches
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------
 
 We have a `separate repo <https://github.com/mozmeao/www-config>`_ for configuring our primary instances (dev, stage, and prod).
 The `docs for updating configurations <https://mozmeao.github.io/www-config/>`_ in that repo are on their own page,
@@ -176,7 +176,7 @@ version of the database in use, the git revision of the bedrock code, and how lo
 a change to one of these repos and are curious if the changes have made it to production, this is the URL you should check.
 
 Updating Selenium
-~~~~~~~~~~~~~~~~~
+-----------------
 
 There are several components for Selenium, which are independently versioned. The first is the Python client,
 and this can be updated via the `test dependencies`_. The other components are the Selenium versions used in
@@ -184,7 +184,7 @@ both SauceLabs and the local Selenium grid. These versions are selected automati
 required OS / Browser configuration, so they should not need to be updated or specified independently.
 
 Adding test runs
-~~~~~~~~~~~~~~~~
+----------------
 
 Test runs can be added by creating a new job in ``bedrock/.github/workflows/integration_tests.yml``
 with the desired variables and pushing that branch to Github.
@@ -204,7 +204,7 @@ following clause to the matrix:
 You can use `Sauce Labs platform configurator`_ to help with the parameter values.
 
 Pushing to the integration tests branch
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------
 
 If you have commit rights to our Github repo (mozilla/bedrock) you can simply push
 your branch to the branch named ``run-integration-tests``, and the app will be deployed


### PR DESCRIPTION
## One-line summary

- Updates bedrock's browser support documentation to take into account changes happening in https://github.com/mozilla/bedrock/issues/13317
- Also fixes a few heading warnings I noticed in the terminal in `pipeline.rst`.

## Issue / Bugzilla link

#13378

## Testing

- `make livedocs`