### PR TITLE
Fix missmatch FTL string IDs for newsletter welcome emails

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -48,8 +48,8 @@
     "title": "{{ ftl('newsletters-drumbeat-newsgroup')|striptags }}"
   },
   "firefox-accounts-journey": {
-    "description": "{{ ftl('newsletters-welcome-emails-that-get-you', fallback='newsletters-get-the-most-firefox-account')|striptags }}",
-    "title": "{{ ftl('newsletter-welcome-emails', fallback='newsletters-firefox-accounts-tips')|striptags }}"
+    "description": "{{ ftl('newsletter-welcome-emails-that-get-you', fallback='newsletters-get-the-most-firefox-account')|striptags }}",
+    "title": "{{ ftl('newsletters-welcome-emails', fallback='newsletters-firefox-accounts-tips')|striptags }}"
   },
   "firefox-desktop": {
     "description": "{{ ftl('newsletters-dont-miss-the-latest')|striptags }}",


### PR DESCRIPTION
FTL strings are here https://github.com/mozilla/bedrock/blob/fd32cdce0a1f15996b33432cfcc7bff7b62484e6/l10n/en/mozorg/newsletters.ftl#L419