### PR TITLE
Add documentation for GA4 product_download event

### DIFF
--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -290,17 +290,15 @@ Product Download
 
     Only Firefox and Pocket are currently supported. VPN support has not been added.
 
-We are using a the custom event `product_download` to track product downloads (Firefox and VPN). We are not using
-the default GA4 event file_download for a combination of reasons: it does not trigger for the Firefox file types,
-we would like to collect more information than is included with the default events, and we would like to treat
-product downloads as goals but not all file downloads are goals.
-
-Links to the app stores directly or through adjust are also treated as product downloads.
+We are using a the custom event `product_download` to track product downloads and app store referrals
+for Firefox, Pocket, and VPN. We are not using the default GA4 event file_download for a combination of reasons:
+it does not trigger for the Firefox file types, we would like to collect more information than is included with
+the default events, and we would like to treat product downloads as goals but not all file downloads are goals.
 
 .. Note::
 
     Most apps listed in *appstores.py* are supported but you may still want to check that the URL
-    you are tracking is identified as valid in `isValidDownloadURL` and will be recognized by `getEventFromUrl`.
+    you are tracking is identified as valid in ```isValidDownloadURL``` and will be recognized by ```getEventFromUrl``.
 
 Properties for use with `product_download` (not all products will have all options):
 

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -283,6 +283,52 @@ To use this method you will need to include ``datalayer-begincheckout-init.es6.j
     </a>
 
 
+Product Download
+~~~~~~~~~~~~~~~~
+
+.. Important::
+
+    Only Firefox and Pocket are currently supported. VPN support has not been added.
+
+We are using a the custom event `product_download` to track product downloads (Firefox and VPN). We are not using
+the default GA4 event file_download for a combination of reasons: it does not trigger for the Firefox file types,
+we would like to collect more information than is included with the default events, and we would like to treat
+product downloads as goals but not all file downloads are goals.
+
+Links to the app stores directly or through adjust are also treated as product downloads.
+
+.. Note::
+
+    Most apps listed in *appstores.py* are supported but you may still want to check that the URL
+    you are tracking is identified as valid in `isValidDownloadURL` and will be recognized by `getEventFromUrl`.
+
+Properties for use with `product_download` (not all products will have all options):
+
+- product (example: firefox)
+- platform (example: win64)
+- method (store, direct, or adjust)
+- link_url
+- release_channel (example: nightly)
+- download_language (example: en-CA)
+
+There are two ways to use TrackProductDownload:
+
+1) Call the function, passing it the same URL you are sending the user to:
+
+.. code-block:: javascript
+
+    TrackProductDownload.sendEventFromURL(downloadURL);
+
+2) Add a class to the link:
+
+.. code-block:: html
+
+    <a href="{{ link }}" class="ga-product-download">Link text</a>
+
+You do NOT need to include ``datalayer-productdownload-init.es6.js`` in the page bundle, it is already included
+in the site bundle.
+
+
 How can visitors opt out of GA?
 -------------------------------
 


### PR DESCRIPTION
## One-line summary

Add documentation for GA4 product_download event.

## Issue / Bugzilla link

#13238 

## Testing

`make livedocs`

http://127.0.0.1:8100/attribution/0001-analytics.html#product-download
