### PR TITLE
Bump Glean to v1.4.0

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -145,7 +145,11 @@
     {% endblock %}
 
     <!--[if !IE]><!-->
-    {% block glean %}{% endblock %}
+    {% block glean %}
+      {% if switch('glean-analytics') %}
+        {{ js_bundle('glean') }}
+      {% endif %}
+    {% endblock %}
 
     {% block js %}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -279,12 +279,6 @@
   {% include '/includes/sticky-promo.html' %}
 {% endblock %}
 
-{% block glean %}
-  {% if switch('glean-analytics') %}
-    {{ js_bundle('glean') }}
-  {% endif %}
-{% endblock %}
-
 {% block js %}
   {{ js_bundle('fxa_product_button') }}
   {{ js_bundle('firefox-master') }}

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -41,9 +41,3 @@
 {% block old_ie_styles %}{% endblock %}
 {% block site_css %}{% endblock %}
 {% block page_css %}{% endblock %}
-
-{% block glean %}
-  {% if switch('glean-analytics') %}
-    {{ js_bundle('glean') }}
-  {% endif %}
-{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -35,9 +35,3 @@
 {% endblock %}
 
 {% block body_class %}mzp-t-firefox{% endblock %}
-
-{% block glean %}
-  {% if switch('glean-analytics') %}
-    {{ js_bundle('glean') }}
-  {% endif %}
-{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/base.html
+++ b/bedrock/mozorg/templates/mozorg/home/base.html
@@ -22,9 +22,3 @@
 {% block structured_data %}
   {% include 'includes/structured-data/organizations/mozilla-corporation-organisation.json' %}
 {% endblock %}
-
-{% block glean %}
-  {% if switch('glean-analytics') %}
-    {{ js_bundle('glean') }}
-  {% endif %}
-{% endblock %}

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -351,12 +351,6 @@
 
 {% endblock %}
 
-{% block glean %}
-  {% if switch('glean-analytics') %}
-    {{ js_bundle('glean') }}
-  {% endif %}
-{% endblock %}
-
 {% block js %}
   {% if vpn_affiliate_attribution_enabled %}
     {{ js_bundle('mozilla-vpn-affiliate') }}

--- a/bedrock/products/templates/products/vpn/pricing.html
+++ b/bedrock/products/templates/products/vpn/pricing.html
@@ -81,12 +81,6 @@
 
 {% endblock %}
 
-{% block glean %}
-  {% if switch('glean-analytics') %}
-    {{ js_bundle('glean') }}
-  {% endif %}
-{% endblock %}
-
 {% block js %}
   {% if vpn_affiliate_attribution_enabled %}
     {{ js_bundle('mozilla-vpn-affiliate') }}

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -312,10 +312,18 @@ Debugging pings
 
 For all non-production environments, bedrock will automatically set a debug
 view tag for all pings. This means that when running on localhost, on a demo,
-or on a staging environment, ping data will not be sent to the production data
-pipeline. Instead, it will be sent to the `Glean debug dashboard`_ which can
-be used to test that pings are working correctly. All bedrock debug pings will
-register in the debug dashboard with the tag name ``bedrock``.
+or on a staging environment, ping data will be viewable in the
+`Glean debug dashboard`_ which can be used to test that pings are working
+correctly. All bedrock debug pings will register in the debug dashboard with
+the tag name ``bedrock``.
+
+Filtering out non-production pings
+----------------------------------
+
+Bedrock will also set an ``app_channel`` tag with a value of either ``prod`` or
+``non-prod``, depending on the environment. This is present in all pings in the
+``client_info`` section, and is useful for filtering out non-production data
+in telemetry dashboards.
 
 Logging pings in the console
 ----------------------------
@@ -366,7 +374,7 @@ Using Glean pings in individual page bundles
 All of our analytics code for Glean lives in a single bundle in the base template,
 which is intended to be shared across all web pages. There may be times where we
 want to send a ping from some JavaScript that exists only in a certain page
-specific bundle however. For instances like this, there is a global ``pageEventPing``
+specific bundle however. For instances like this, there is a global ``ping``
 helper available, which you can call from inside any custom event handler you write.
 
 For user initiated events, such as clicks:
@@ -374,7 +382,7 @@ For user initiated events, such as clicks:
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.pageEventPing({
+        window.Mozilla.Glean.ping({
             label: 'Newsletters: mozilla-and-you',
             type: 'Newsletter Signup Success'
         });
@@ -385,7 +393,7 @@ For non-interaction events that are not user initiated:
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.pageEventPing({
+        window.Mozilla.Glean.ping({
             label: 'Auto Play',
             type: 'Video'
             nonInteraction: true

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -79,7 +79,7 @@ page:
       - utm_medium
       - utm_content
       - entrypoint_experiment
-      - entrypoing_variation
+      - entrypoint_variation
       - experiment
       - variation
       - v

--- a/media/js/base/banners/mozilla-banner.js
+++ b/media/js/base/banners/mozilla-banner.js
@@ -48,14 +48,6 @@ if (typeof window.Mozilla === 'undefined') {
             'data-banner-name': Banner.id,
             'data-banner-dismissal': '1'
         });
-
-        // Track event in Glean.
-        if (typeof window.Mozilla.Glean !== 'undefined') {
-            window.Mozilla.Glean.pageEventPing({
-                label: Banner.id,
-                type: 'Banner Dismissal'
-            });
-        }
     };
 
     Banner.show = function (renderAtTopOfPage) {

--- a/media/js/base/protocol/init-lang-switcher.es6.js
+++ b/media/js/base/protocol/init-lang-switcher.es6.js
@@ -15,12 +15,4 @@ MzpLangSwitcher.init(function (previousLanguage, newLanguage) {
         languageSelected: newLanguage,
         previousLanguage: previousLanguage
     });
-
-    // Track event in Glean.
-    if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.pageEventPing({
-            label: 'Language Selected: ' + newLanguage,
-            type: 'Change Language'
-        });
-    }
 });

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -12,18 +12,18 @@ import {
     nonInteraction as nonInteractionPing
 } from '../libs/glean/pings.js';
 
-const validParams = [
-    'utm_source',
-    'utm_campaign',
-    'utm_medium',
-    'utm_content',
-    'entrypoint_experiment',
-    'entrypoint_variation',
-    'experiment',
-    'variation',
-    'v', // short param for 'variation'
-    'xv' // short param for 'experience version'.
-];
+const defaultParams = {
+    utm_source: '',
+    utm_campaign: '',
+    utm_medium: '',
+    utm_content: '',
+    entrypoint_experiment: '',
+    entrypoint_variation: '',
+    experiment: '',
+    variation: '',
+    v: '', // short param for 'variation'
+    xv: '' // short param for 'experience version'.
+};
 
 function initPageView() {
     page.viewed.set();
@@ -32,21 +32,23 @@ function initPageView() {
     page.referrer.set(Utils.getReferrer());
 
     const params = Utils.getQueryParamsFromURL();
+    const finalParams = {};
 
-    if (params) {
-        // validate only known & trusted query params
-        // for inclusion in Glean metrics.
-        for (const param in validParams) {
+    // validate only known & trusted query params
+    // for inclusion in Glean metrics.
+    for (const param in defaultParams) {
+        if (Object.prototype.hasOwnProperty.call(defaultParams, param)) {
             const allowedChars = /^[\w/.%-]+$/;
-            const p = validParams[param];
-            let v = params.get(p);
+            let v = params.get(param);
 
             if (v) {
                 v = decodeURIComponent(v);
-                if (allowedChars.test(v)) {
-                    page.queryParams[p].set(v);
-                }
+                finalParams[param] = allowedChars.test(v) ? v : '';
+            } else {
+                finalParams[param] = '';
             }
+
+            page.queryParams[param].set(finalParams[param]);
         }
     }
 

--- a/media/js/glean/utils.es6.js
+++ b/media/js/glean/utils.es6.js
@@ -5,19 +5,19 @@
  */
 
 const Utils = {
-    getPathFromUrl: function (path) {
+    getPathFromUrl: (path) => {
         const pathName = path ? path : document.location.pathname;
         return pathName.replace(/^(\/\w{2}-\w{2}\/|\/\w{2,3}\/)/, '/');
     },
 
-    getLocaleFromUrl: function (path) {
+    getLocaleFromUrl: (path) => {
         const pathName = path ? path : document.location.pathname;
         const locale = pathName.match(/^\/(\w{2}-\w{2}|\w{2,3})\//);
         // If there's no locale in the path then assume language is `en-US`;
         return locale && locale.length > 0 ? locale[1] : 'en-US';
     },
 
-    getQueryParamsFromURL: function (qs) {
+    getQueryParamsFromURL: (qs) => {
         const query = typeof qs === 'string' ? qs : window.location.search;
 
         if (typeof window._SearchParams !== 'undefined') {
@@ -27,11 +27,15 @@ const Utils = {
         return false;
     },
 
-    getReferrer: function (ref) {
+    getReferrer: (ref) => {
         return typeof ref === 'string' ? ref : document.referrer;
     },
 
-    isTelemetryEnabled: function () {
+    hasValidURLScheme: (url) => {
+        return /^https?:\/\//.test(url);
+    },
+
+    isTelemetryEnabled: () => {
         if (
             typeof Mozilla.Cookies !== 'undefined' &&
             Mozilla.Cookies.enabled()

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@mozilla-protocol/core": "^17.0.1",
-        "@mozilla/glean": "^1.3.0",
+        "@mozilla/glean": "^1.4.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2014,9 +2014,9 @@
       "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.3.0.tgz",
-      "integrity": "sha512-2bEhpV8Tf4U/KEAJvaesVhe8SXk089jeDCHicEiBbznsRiIElHZVku7t7QHJI16oTqJEf/wHqjTDSQI9Wl3p3A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.4.0.tgz",
+      "integrity": "sha512-16YgRBPexUtgGD13dnAYYmHeeEzatQ2wSFuwopNvXuy4CeJw3xpJ+N4fVjnMJtQffpp89l2f4BvKva+eAmmBPg==",
       "dependencies": {
         "fflate": "^0.7.1",
         "jose": "^4.0.4",
@@ -11922,9 +11922,9 @@
       "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
     },
     "@mozilla/glean": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.3.0.tgz",
-      "integrity": "sha512-2bEhpV8Tf4U/KEAJvaesVhe8SXk089jeDCHicEiBbznsRiIElHZVku7t7QHJI16oTqJEf/wHqjTDSQI9Wl3p3A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.4.0.tgz",
+      "integrity": "sha512-16YgRBPexUtgGD13dnAYYmHeeEzatQ2wSFuwopNvXuy4CeJw3xpJ+N4fVjnMJtQffpp89l2f4BvKva+eAmmBPg==",
       "requires": {
         "fflate": "^0.7.1",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@mozilla-protocol/core": "^17.0.1",
-    "@mozilla/glean": "^1.3.0",
+    "@mozilla/glean": "^1.4.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -430,9 +430,9 @@ freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
     # via -r requirements/dev.in
-glean-parser==6.2.1 \
-    --hash=sha256:672689a97fe458d38f230b5f8d2e2f8e5c582ce98dd31e38363a6b437639d56c \
-    --hash=sha256:daa4b7b127a432118733f0ddc77c95bdd7a8b78ac9a4f3254f68b45a25ccb32e
+glean-parser==7.2.1 \
+    --hash=sha256:11496ac004fe421b914c7fbdc9a1d620e4821d56e1d9f65523d3858cdb907bbd \
+    --hash=sha256:651cfee34422ea1db90bbf1cb03732bd8c598773bf95daa289a62addeaf10295
     # via -r requirements/prod.txt
 greenlet==0.4.17 \
     --hash=sha256:1023d7b43ca11264ab7052cb09f5635d4afdb43df55e0854498fc63070a0b206 \
@@ -779,10 +779,7 @@ parsimonious==0.8.1 \
 pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
     --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
-    # via
-    #   -r requirements/prod.txt
-    #   black
-    #   yamllint
+    # via black
 pillow==10.0.0 \
     --hash=sha256:00e65f5e822decd501e374b0650146063fbb30a7264b4d2744bdd7b913e0cab5 \
     --hash=sha256:040586f7d37b34547153fa383f7f9aed68b738992380ac911447bb78f2abe530 \
@@ -1073,7 +1070,6 @@ pyyaml==6.0 \
     #   -r requirements/prod.txt
     #   glean-parser
     #   responses
-    #   yamllint
 qrcode==7.4.2 \
     --hash=sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a \
     --hash=sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845
@@ -1346,11 +1342,6 @@ wsproto==1.1.0 \
     --hash=sha256:2218cb57952d90b9fca325c0dcfb08c3bda93e8fd8070b0a17f048e2e47a521b \
     --hash=sha256:a2e56bfd5c7cd83c1369d83b5feccd6d37798b74872866e62616e0ecf111bda8
     # via trio-websocket
-yamllint==1.26.3 \
-    --hash=sha256:3934dcde484374596d6b52d8db412929a169f6d9e52e20f9ade5bf3523d9b96e
-    # via
-    #   -r requirements/prod.txt
-    #   glean-parser
 zipp==3.7.0 \
     --hash=sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d \
     --hash=sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -27,7 +27,7 @@ envcat==0.1.1
 everett==3.2.0
 fluent.runtime==0.4.0
 fluent.syntax==0.19.0
-glean-parser==6.2.1  # Must match the required version in the Glean NPM package.
+glean-parser==7.2.1  # Must match the required version in the Glean NPM package.
 greenlet==0.4.17  # Pinned for stability but subdep of Meinheld
 gunicorn==19.7.1
 honcho==1.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -252,9 +252,9 @@ fluent-syntax==0.19.0 \
     # via
     #   -r requirements/prod.in
     #   fluent-runtime
-glean-parser==6.2.1 \
-    --hash=sha256:672689a97fe458d38f230b5f8d2e2f8e5c582ce98dd31e38363a6b437639d56c \
-    --hash=sha256:daa4b7b127a432118733f0ddc77c95bdd7a8b78ac9a4f3254f68b45a25ccb32e
+glean-parser==7.2.1 \
+    --hash=sha256:11496ac004fe421b914c7fbdc9a1d620e4821d56e1d9f65523d3858cdb907bbd \
+    --hash=sha256:651cfee34422ea1db90bbf1cb03732bd8c598773bf95daa289a62addeaf10295
     # via -r requirements/prod.in
 greenlet==0.4.17 \
     --hash=sha256:1023d7b43ca11264ab7052cb09f5635d4afdb43df55e0854498fc63070a0b206 \
@@ -560,10 +560,6 @@ packaging==23.0 \
     --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2 \
     --hash=sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
     # via django-allow-cidr
-pathspec==0.9.0 \
-    --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
-    --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
-    # via yamllint
 pillow==10.0.0 \
     --hash=sha256:00e65f5e822decd501e374b0650146063fbb30a7264b4d2744bdd7b913e0cab5 \
     --hash=sha256:040586f7d37b34547153fa383f7f9aed68b738992380ac911447bb78f2abe530 \
@@ -736,7 +732,6 @@ pyyaml==6.0 \
     # via
     #   -r requirements/prod.in
     #   glean-parser
-    #   yamllint
 qrcode==7.4.2 \
     --hash=sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a \
     --hash=sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845
@@ -900,9 +895,6 @@ wrapt==1.14.0 \
     --hash=sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33 \
     --hash=sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653
     # via deprecated
-yamllint==1.26.3 \
-    --hash=sha256:3934dcde484374596d6b52d8db412929a169f6d9e52e20f9ade5bf3523d9b96e
-    # via glean-parser
 zipp==3.7.0 \
     --hash=sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d \
     --hash=sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -163,7 +163,7 @@ module.exports = function (config) {
 
         // Supress console logs triggered in code.
         client: {
-            captureConsole: false
+            captureConsole: true
         },
 
         // Continuous Integration mode

--- a/tests/unit/spec/glean/page.js
+++ b/tests/unit/spec/glean/page.js
@@ -161,15 +161,15 @@ describe('page.js', function () {
 
         const ping = pageViewPing.testBeforeNextSubmit(async function () {
             const source = await page.queryParams['utm_source'].testGetValue();
-            expect(source).toBeUndefined();
+            expect(source).toEqual('');
 
             const campaign = await page.queryParams[
                 'utm_campaign'
             ].testGetValue();
-            expect(campaign).toBeUndefined();
+            expect(campaign).toEqual('');
 
             const medium = await page.queryParams['utm_medium'].testGetValue();
-            expect(medium).toBeUndefined();
+            expect(medium).toEqual('');
 
             const content = await page.queryParams[
                 'utm_content'
@@ -179,7 +179,7 @@ describe('page.js', function () {
             const experiment = await page.queryParams[
                 'experiment'
             ].testGetValue();
-            expect(experiment).toBeUndefined();
+            expect(experiment).toEqual('');
         });
 
         initPageView();

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -66,6 +66,22 @@ describe('utilsjs', function () {
         });
     });
 
+    describe('hasValidURLScheme', function () {
+        it('should return true for non secure URLs', function () {
+            expect(Utils.hasValidURLScheme('http://localhost:8000')).toBeTrue();
+        });
+
+        it('should return true for secure URLs', function () {
+            expect(
+                Utils.hasValidURLScheme('https://www.mozilla.org')
+            ).toBeTrue();
+        });
+
+        it('should return false for file URLs', function () {
+            expect(Utils.hasValidURLScheme('file://C:/Users/')).toBeFalse();
+        });
+    });
+
     describe('isTelemetryEnabled', function () {
         it('should return true if opt out cookie does not exist', function () {
             spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(false);


### PR DESCRIPTION
## One-line summary

Bumps Glean to v.14.0 and makes some smaller updates / improvements to how we collect metrics.

## Significant changes and points to review

Note: Glean is currently only enabled when `dev=True` so it's pretty safe to make changes.

- Adds Glean bundle to `base-protocol.html`.
- Removes click measurement (leaving only page views for now, until the next release is out).
- Sets `channel` to either `prod` or `non-prod` for easier query filtering.
- Adds a default value of `""` (an empty string) for known parameters, to make querying easier.
- Adds a `hasValidURLScheme()` helper to filter out a small amount of bad data.

https://github.com/mozmeao/www-config/blob/main/waffle_configs/bedrock-prod.env#L44

## Issue / Bugzilla link

N/A

## Testing

- `make preflight`
- `npm start`

You should see the glean page event ping in the console