### PR TITLE
l10n tweaks to Relay ftls

### DIFF
--- a/bedrock/products/templates/products/relay/landing.html
+++ b/bedrock/products/templates/products/relay/landing.html
@@ -83,7 +83,7 @@
       <div>
         <a class="c-review-amo" href="https://addons.mozilla.org/en-US/firefox/addon/private-relay/">
           <span class="c-review-amo-browser">{{ ftl('landing-reviews-logo-title') }}</span>
-          <span class="c-review-amo-title">{{ ftl('relay-landing-brand-addons') }}</span>
+          <span class="c-review-amo-title">{{ ftl('landing-reviews-add-ons') }}</span>
         </a>
       </div>
       <div>

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -42,7 +42,6 @@
 -brand-name-firefox-nightly = Firefox Nightly
 -brand-name-firefox-reality = Firefox Reality
 -brand-name-firefox-daylight = Firefox Daylight
--brand-name-firefox-addons = Firefox Add-ons
 
 ## Firefox browsers (short names)
 
@@ -55,7 +54,6 @@
 -brand-name-nightly = Nightly
 -brand-name-reality = Reality
 -brand-name-daylight = Daylight
--brand-name-addons = Add-ons
 
 ## Firefox browsers (legacy)
 

--- a/l10n/en/products/relay/landing.ftl
+++ b/l10n/en/products/relay/landing.ftl
@@ -32,10 +32,9 @@ how-it-works-section-manage-body = Sign in to your { -brand-name-relay } dashboa
 
 ## REVIEWS SECTION
 
-landing-reviews-add-ons = Add-ons
-landing-reviews-logo-title = { -brand-name-firefox-browser }
 landing-reviews-title = Reviews
 landing-reviews-logo-title = { -brand-name-firefox-browser }
+landing-reviews-add-ons = Add-ons
 # Do not localize addons.mozilla.org
 landing-reviews-details-source = Source: addons.mozilla.org
 # This string is displayed in a smaller font under a big number representing the average review score (e.g. "4.2").

--- a/l10n/en/products/relay/landing.ftl
+++ b/l10n/en/products/relay/landing.ftl
@@ -32,7 +32,8 @@ how-it-works-section-manage-body = Sign in to your { -brand-name-relay } dashboa
 
 ## REVIEWS SECTION
 
-relay-landing-brand-addons = { -brand-name-addons }
+landing-reviews-add-ons = Add-ons
+landing-reviews-logo-title = { -brand-name-firefox-browser }
 landing-reviews-title = Reviews
 landing-reviews-logo-title = { -brand-name-firefox-browser }
 # Do not localize addons.mozilla.org

--- a/media/css/products/relay/components/reviews.scss
+++ b/media/css/products/relay/components/reviews.scss
@@ -57,10 +57,14 @@ $brand-theme: 'firefox';
 }
 
 .c-review-amo-title {
-    @include text-display-sm;
     font-weight: bold;
+    line-height: 1;
     padding-bottom: $spacing-lg;
     text-transform: uppercase;
+
+    html[lang^='en'] & {
+        @include text-display-sm;
+    }
 }
 
 .c-review-rating {


### PR DESCRIPTION
## One-line summary

l10n tweaks to Relay ftls

## Significant changes and points to review

- Don't treat Addons as a brand name
  - Migrate Relay strings instead
- CSS tweak to try to handle longer translations of "Add-ons"

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/pull/12964#pullrequestreview-1546515308

## Testing

localhost:8000/en-US/products/relay/

Use dev tools to change the contents of `.c-review-amo-title` to something longer... like the French "Modules complémentaires" for example