### PR TITLE
Fix newsletter management page form submission when cookie has expired (Fixes #13324)

### DIFF
--- a/media/js/newsletter/form-utils.es6.js
+++ b/media/js/newsletter/form-utils.es6.js
@@ -21,10 +21,9 @@ const errorList = {
     REASON_ERROR: 'Reason not selected'
 };
 
-let _userToken;
-
 const FormUtils = {
     errorList,
+    userToken: '',
 
     /**
      * Really primitive validation (e.g a@a)
@@ -71,6 +70,11 @@ const FormUtils = {
             if (!token) {
                 reject();
             } else {
+                // always store token as a local variable in memory, so the
+                // form still works if left open long enough for cookie to
+                // expire: see issue 13324.
+                FormUtils.userToken = token;
+
                 resolve();
             }
         });
@@ -122,10 +126,10 @@ const FormUtils = {
         const cookiesEnabled =
             typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
 
-        if (cookiesEnabled) {
+        if (cookiesEnabled && Mozilla.Cookies.hasItem(BASKET_COOKIE_ID)) {
             token = Mozilla.Cookies.getItem(BASKET_COOKIE_ID);
         } else {
-            token = _userToken;
+            token = FormUtils.userToken;
         }
 
         if (FormUtils.isValidToken(token)) {
@@ -268,9 +272,12 @@ const FormUtils = {
                     false,
                     'lax'
                 );
-            } else {
-                _userToken = token;
             }
+
+            // always store token as a local variable in memory, so the
+            // form still works if left open long enough for cookie to
+            // expire: see issue 13324.
+            FormUtils.userToken = token;
         }
     },
 

--- a/tests/unit/spec/newsletter/form-utils.js
+++ b/tests/unit/spec/newsletter/form-utils.js
@@ -43,8 +43,19 @@ describe('getURLToken', function () {
 });
 
 describe('getUserToken', function () {
+    afterEach(function () {
+        FormUtils.userToken = '';
+    });
+
     it('should return a UUID token from cookie', function () {
+        spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(true);
         spyOn(Mozilla.Cookies, 'getItem').and.returnValue(TOKEN_MOCK);
+        expect(FormUtils.getUserToken()).toEqual(TOKEN_MOCK);
+    });
+
+    it('should return a token from local memory if cookie has expired', function () {
+        spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(false);
+        FormUtils.userToken = TOKEN_MOCK;
         expect(FormUtils.getUserToken()).toEqual(TOKEN_MOCK);
     });
 
@@ -151,6 +162,10 @@ describe('removeTokenFromURL', function () {
 });
 
 describe('setUserToken', function () {
+    afterEach(function () {
+        FormUtils.userToken = '';
+    });
+
     it('should set a cookie with a valid UUID token', function () {
         spyOn(Mozilla.Cookies, 'setItem');
         FormUtils.setUserToken(TOKEN_MOCK);
@@ -163,6 +178,7 @@ describe('setUserToken', function () {
             false,
             'lax'
         );
+        expect(FormUtils.userToken).toEqual(TOKEN_MOCK);
     });
 
     it('should not set a cookie if token is invalid', function () {

--- a/tests/unit/spec/newsletter/management.js
+++ b/tests/unit/spec/newsletter/management.js
@@ -126,6 +126,7 @@ describe('management.es6.js', function () {
     afterEach(function () {
         const form = document.getElementById('newsletter-management-test-form');
         form.parentNode.removeChild(form);
+        FormUtils.userToken = '';
     });
 
     describe('isFxALocale', function () {


### PR DESCRIPTION
## One-line summary

Stores token in local memory so that the form still works even if left open for a long period of time.

## Significant changes and points to review

Rather than wait for an hour for the cookie to expire, the easiest way to test this is to delete the `nl-token` cookie after the page has loaded, and then hit submit after that.

## Issue / Bugzilla link

#13324

## Testing

First get your token here: https://www.mozilla.org/en-US/newsletter/recovery/

Then open `http://localhost:8000/en-US/newsletter/existing/YOUR_TOKEN_HERE/`
