### PR TITLE
Use existing subnav on refreshed VPN pages [fix #13453]

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/subnav-refresh.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav-refresh.html
@@ -14,14 +14,8 @@
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
-          <a href="{{ url('products.vpn.resource-center.article', 'what-is-a-vpn') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What’s a VPN?">
-            What’s a VPN?
-          </a>
-        </li>
-        <li class="c-sub-navigation-item">
-          {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
-          <a href="{{ pricing_url }}" data-link-type="nav" data-link-position="subnav" data-link-name="View VPN pricing">
-            Pricing
+          <a href="{{ url('products.vpn.resource-center.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Learn about VPNs">
+            {{ ftl('vpn-subnav-learn-about-vpns') }}
           </a>
         </li>
         <li class="c-sub-navigation-item">
@@ -30,8 +24,8 @@
           </a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="https://support.mozilla.org/products/firefox-private-network-vpn?{{ _params }}" data-link-type="nav" data-link-position="subnav" data-link-name="Get Help">
-            Get Help
+          <a href="{{ url('products.vpn.download') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Download Mozilla VPN">
+            {{ ftl('vpn-subnav-download-mozilla-vpn') }}
           </a>
         </li>
       </ul>

--- a/bedrock/products/templates/products/vpn/includes/subnav.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav.html
@@ -14,7 +14,6 @@
           </a>
         </h2>
         <ul class="c-sub-navigation-list is-details is-closed">
-
           <li class="c-sub-navigation-item">
             <a href="{{ url('products.vpn.resource-center.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Learn about VPNs">
               {{ ftl('vpn-subnav-learn-about-vpns') }}

--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -78,7 +78,7 @@
     {% if vpn_available %}
       <p class="c-main-cta">
         <a class="mzp-c-button mzp-t-product mzp-t-xl" href="#pricing" data-cta-type="button" data-cta-text="Save on Mozilla VPN" data-cta-position="primary">
-          {{ vpn_saving(country_code=country_code, lang=LANG, bundle_relay=True, ftl_string='vpn-shared-save-percent-on') }}
+          {{ vpn_saving(country_code=country_code, lang=LANG, bundle_relay=False, ftl_string='vpn-shared-save-percent-on') }}
         </a>
         <small>
           *with an annual subscription

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -130,6 +130,7 @@ def vpn_pricing_page(request):
 @require_safe
 def vpn_features_page(request):
     template_name = "products/vpn/features.html"
+    ftl_files = ["products/vpn/shared"]
     vpn_available_in_country = vpn_available(request)
 
     context = {
@@ -139,7 +140,7 @@ def vpn_features_page(request):
         "connect_devices": settings.VPN_CONNECT_DEVICES,
     }
 
-    return l10n_utils.render(request, template_name, context)
+    return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)
 
 
 @require_safe


### PR DESCRIPTION
## One-line summary

Updates the refreshed subnav to match the old subnav, with the addition of a Features link.
Also fixes the percentage shown in the main CTA button (it was showing the savings for the Relay bundle, but that bundle isn't currently active).

## Issue / Bugzilla link

#13453 

## Testing

http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-landing-refresh&entrypoint_variation=2

- [x] New landing page shows subnav "Learn about VPNs | Features | Download Mozilla VPN" (with features)
- [x] Old landing page still shows subnav "Learn about VPNs | Download Mozilla VPN" (without features)
- [ ] New landing page hero CTA says "Save 50% on Mozilla VPN" (not 40%)