### PR TITLE
WNP for Firefox 116, NA [fix #13421]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base.html
@@ -16,7 +16,9 @@
 
 {% block content %}
 <main class="content-wrapper mzp-t-firefox">
-  {% include 'firefox/whatsnew/includes/header.html' %}
+  {% block wnp_header %}
+    {% include 'firefox/whatsnew/includes/header.html' %}
+  {% endblock %}
 
   {% block wnp_content %}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
@@ -23,7 +23,7 @@
   <section class="wnp-content-main">
     <div class="wnp-grid mzp-l-content mzp-t-content-lg">
       <div class="wnp-grid-body">
-        <h2 class="wnp-main-title">Webpages,<br> simplified.</h2>
+        <h2 class="wnp-main-title">Webpages, simplified.</h2>
 
         <p class="wnp-main-tagline has-reader-icon">Click the little <strong>Reader View</strong> icon in Firefox’s address
           bar, and boom. No more ads, buttons, background colors or videos on whatever

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
@@ -1,0 +1,72 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+
+{#- This will appear as <meta property="og:description"> which can be used for social share -#}
+{% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_116_na') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="wnp-grid mzp-l-content mzp-t-content-lg">
+      <div class="wnp-grid-body">
+        <h2 class="wnp-main-title">Webpages,<br> simplified.</h2>
+
+        <p class="wnp-main-tagline has-reader-icon">Click the little <strong>Reader View</strong> icon in Firefox’s address
+          bar, and boom. No more ads, buttons, background colors or videos on whatever
+          webpage you’re viewing.</p>
+
+        <p class="cta-holder"><span></span></p>
+
+        <p class="wnp-main-cta fx-not-default">
+          <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.set-as-default.thanks') }}" data-cta-type="button" data-cta-text="Always use Firefox">
+            Always use Firefox
+          </a>
+        </p>
+
+        <p class="wnp-main-cta fx-is-default">
+          <a class="mzp-c-button mzp-t-product" href="https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages" data-cta-text="Learn more" data-cta-type="button">
+            Learn more
+          </a>
+        </p>
+      </div>
+
+      <p class="wnp-sign-off">
+        <strong>Powered by Mozilla.</strong> Putting people before profits since 1998.
+      </p>
+
+      <div class="wnp-grid-head">
+        <div class="eyesore eyesore-one" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col1">
+        <div class="eyesore eyesore-two" role="presentation"></div>
+        <div class="eyesore eyesore-three" role="presentation"></div>
+        <div class="eyesore eyesore-four" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col2">
+        <div class="eyesore eyesore-five" role="presentation"></div>
+        <div class="eyesore eyesore-six" role="presentation"></div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_116_na') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
@@ -19,6 +19,27 @@
 
 {% block site_header %}{% endblock %}
 
+{% block wnp_header %}
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      <h2 class="c-page-header-logo-fx">{{ ftl('whatsnew-firefox') }}</h2>
+      {# aside is used to hide notification content from reader mode #}
+      <aside class="c-page-header-notification">
+        <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+          <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
+        </div>
+        <div class="mzp-c-notification-bar out-of-date">
+          {% if ftl_has_messages('whatsnew-out-of-date-notification-v3') %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v3', url='https://support.mozilla.org/kb/update-firefox-latest-release?' + utm_params) }}</p>
+          {% else %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v2') }}</p>
+          {% endif %}
+        </div>
+      </aside>
+    </div>
+  </header>
+{% endblock %}
+
 {% block wnp_content %}
   <section class="wnp-content-main">
     <div class="wnp-grid mzp-l-content mzp-t-content-lg">

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -916,6 +916,15 @@ class TestWhatsNew(TestCase):
     # begin 116.0 whatsnew tests
 
     @override_settings(DEV=True)
+    def test_fx_116_0_0_en_us(self, render_mock):
+        """Should use whatsnew-fx116-na template for en-US locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-US"
+        self.view(req, version="116.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx116-na.html"]
+
+    @override_settings(DEV=True)
     def test_fx_116_0_0_en_gb(self, render_mock):
         """Should use whatsnew-fx116-uk template for en-GB locale"""
         req = self.rf.get("/firefox/whatsnew/")

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -424,6 +424,7 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx115-eu-mobile-uk.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx115-na-windows.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx115-na-addons.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx116-na.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx116-uk.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx116-de.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx116-fr.html": ["firefox/whatsnew/whatsnew"],
@@ -517,7 +518,7 @@ class WhatsnewView(L10nTemplateView):
                 if locale == "en-GB" or country == "GB":
                     template = "firefox/whatsnew/whatsnew-fx116-uk.html"
                 else:
-                    template = "firefox/whatsnew/index.html"
+                    template = "firefox/whatsnew/whatsnew-fx116-na.html"
             elif locale == "de":
                 template = "firefox/whatsnew/whatsnew-fx116-de.html"
             elif locale == "fr":

--- a/media/css/firefox/whatsnew/whatsnew-116-na.scss
+++ b/media/css/firefox/whatsnew/whatsnew-116-na.scss
@@ -1,0 +1,372 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import 'includes/base';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+
+:root {
+    --main-bg-color: #{$color-violet-05};
+    --eyesore-bg-color: rgba(255, 255, 255, 0.8);
+    --eyesore-text-color: #{$color-violet-05};
+}
+
+.wnp-content-main {
+    color: $color-black;
+    margin-top: $spacing-md;
+    overflow: hidden;
+    text-align: center;
+}
+
+// Show a placeholder until we can detect default browser
+.cta-holder {
+    text-align: center;
+
+    span {
+        display: block;
+        height: 2.5rem;
+        margin: 0 auto;
+    }
+
+    &.hide {
+        display: none;
+    }
+}
+
+.fx-is-default,
+.fx-not-default {
+    &.show {
+        display: block;
+    }
+
+    &.hide {
+        display: none;
+    }
+}
+
+// Assuming JS is available, show no content until we can detect default browser
+.js {
+    .fx-is-default,
+    .fx-not-default {
+        display: none;
+
+        &.show {
+            animation: fade-in 150ms ease forwards;
+            display: block;
+        }
+    }
+}
+
+// Fall back to the is-default content if JS fails
+.no-js {
+    .cta-holder,
+    .fx-not-default {
+        display: none;
+    }
+
+    .fx-is-default {
+        display: block;
+    }
+}
+
+// Hide the eyesores on mobile
+.wnp-grid-head,
+.wnp-grid-col1,
+.wnp-grid-col2 {
+    display: none;
+}
+
+.wnp-main-title {
+    @include text-title-xl;
+    padding-top: $layout-lg;
+    position: relative;
+
+    &::before {
+        background: transparent url("/media/img/firefox/whatsnew/whatsnew116-na/reader-icon.svg") center top / contain no-repeat;
+        content: "";
+        display: block;
+        height: 40px;
+        left: 50%;
+        margin-left: -20px;
+        position: absolute;
+        top: 0;
+        width: 40px;
+    }
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+    color: $color-black;
+}
+
+.has-reader-icon strong {
+    @include image-replaced;
+    @include background-size(2ex, 2ex);
+    background-image: url("/media/img/firefox/whatsnew/whatsnew116-na/reader-icon.svg");
+    background-repeat: no-repeat;
+    display: inline-block;
+    height: 2ex;
+    margin-bottom: -0.25ex;
+    width: 2ex;
+}
+
+// ---------------------------------------------------------------------------*/
+// All the bells and whistles
+
+@media #{$mq-md} and (prefers-reduced-motion: no-preference) {
+    .wnp-grid {
+        display: grid;
+        grid-gap: $spacing-md;
+        grid-template-columns: 1fr 3fr 1fr;
+        grid-template-rows: 90px 1fr 90px;
+    }
+
+    .wnp-sign-off {
+        grid-column: 1 / span 3;
+        grid-row: 3;
+    }
+
+    .wnp-grid-body {
+        grid-column: 2;
+        grid-row: 2;
+        margin: 0 auto;
+        padding: $spacing-2xl $spacing-lg;
+    }
+
+    .wnp-grid-head {
+        display: block;
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .wnp-grid-col1 {
+        display: grid;
+        grid-column: 1;
+        grid-gap: $spacing-md;
+        grid-row: 1 / span 2;
+        grid-template-rows: 1fr 2fr 1.5fr;
+    }
+
+    .wnp-grid-col2 {
+        display: grid;
+        grid-column: 3;
+        grid-gap: $spacing-md;
+        grid-row: 1 / span 2;
+        grid-template-rows: 2fr 1fr;
+    }
+
+    .wnp-content-main {
+        animation: mainbg 500ms 3250ms ease-in forwards;
+        background-color: var(--main-bg-color);
+    }
+
+    .wnp-main-title {
+        margin-top: -$layout-lg;
+
+        &::before {
+            animation: fade-in 300ms 3200ms ease-in forwards, pop 400ms 3200ms ease-in forwards;
+            transform: scale(0.9);
+            opacity: 0;
+        }
+    }
+
+    .eyesore {
+        background-color: var(--eyesore-bg-color);
+        box-sizing: border-box;
+        color: var(--eyesore-text-color);
+        padding: $spacing-md $spacing-lg;
+        position: relative;
+        text-align: start;
+    }
+
+    .eyesore-one {
+        animation: eyesore-one 1000ms 2500ms ease-in forwards, fade-out 500ms 3500ms ease-out forwards;
+        min-height: 90px;
+
+        span {
+            left: $spacing-lg;
+            max-width: 60%;
+            position: absolute;
+            top: $spacing-md;
+
+            &::before {
+                @include box-decoration-break(clone);
+                background: var(--eyesore-text-color);
+                color: transparent;
+                content: "The 91 best clickbait listicles of the week so far. Number 36 will shock you!";
+                display: inline;
+                font-size: 12px;
+            }
+        }
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            content: "";
+            height: 2em;
+            position: absolute;
+            right: $spacing-lg;
+            width: 20%;
+        }
+    }
+
+    .eyesore-two,
+    .eyesore-three,
+    .eyesore-five {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+
+        &::before {
+            @include text-title-xs;
+            content: "Ad";
+            font-weight: bold;
+        }
+    }
+
+    .eyesore-two {
+        animation: eyesore-two 1000ms 2200ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+    }
+
+    .eyesore-three {
+        animation: eyesore-three 1000ms 2750ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+    }
+
+    .eyesore-four {
+        animation: eyesore-four 1000ms 2400ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+
+        span {
+            left: $spacing-lg;
+            max-width: 60%;
+            position: absolute;
+            top: $spacing-md;
+
+            &::before {
+                @include box-decoration-break(clone);
+                background: var(--eyesore-text-color);
+                color: transparent;
+                content: "Lose weight fast by emptying your wallet!";
+                display: inline;
+                font-size: 12px;
+            }
+        }
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            bottom: $spacing-md;
+            content: "";
+            display: block;
+            height: 1.5em;
+            position: absolute;
+            right: $spacing-lg;
+            width: 50%;
+        }
+    }
+
+    .eyesore-five {
+        animation: eyesore-five 1000ms 2880ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            bottom: $spacing-md;
+            content: "";
+            display: block;
+            height: 1.5em;
+            left: $spacing-lg;
+            position: absolute;
+            right: $spacing-lg;
+        }
+    }
+
+    .eyesore-six {
+        animation: eyesore-six 1000ms 2220ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+
+        &::before {
+            background: var(--eyesore-text-color);
+            content: "";
+            display: block;
+            height: 50%;
+            width: 100%;
+        }
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            bottom: $spacing-md;
+            content: "";
+            display: block;
+            height: 1.5em;
+            left: $spacing-lg;
+            position: absolute;
+            right: $spacing-lg;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------*/
+// Animations
+
+@keyframes fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes pop {
+    0% { transform: scale(0.9); }
+    25% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+@keyframes eyesore-one {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    50% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(25deg); }
+}
+
+@keyframes eyesore-two {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    50% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(-16deg); }
+}
+
+@keyframes eyesore-three {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    52% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(-20deg); }
+}
+
+@keyframes eyesore-four {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    48% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(16deg); }
+}
+
+@keyframes eyesore-five {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    50% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(22deg); }
+}
+
+@keyframes eyesore-six {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    54% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(-18deg); }
+}
+
+@keyframes mainbg {
+    to { background-color: transparent; }
+}

--- a/media/css/firefox/whatsnew/whatsnew-116-na.scss
+++ b/media/css/firefox/whatsnew/whatsnew-116-na.scss
@@ -77,6 +77,11 @@
     display: none;
 }
 
+.wnp-grid-body {
+    max-width: $content-sm;
+    margin: 0 auto;
+}
+
 .wnp-main-title {
     @include text-title-xl;
     padding-top: $layout-lg;
@@ -130,7 +135,7 @@
     .wnp-grid-body {
         grid-column: 2;
         grid-row: 2;
-        margin: 0 auto;
+        max-width: none;
         padding: $spacing-2xl $spacing-lg;
     }
 

--- a/media/img/firefox/whatsnew/whatsnew116-na/reader-icon.svg
+++ b/media/img/firefox/whatsnew/whatsnew116-na/reader-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" x="0" y="0" version="1.1" viewBox="0 0 16 16" width="16" height="16">
+  <style>
+    .st0{fill:none;stroke:#000;stroke-width:1.7131;stroke-linecap:round}
+  </style>
+  <path d="M5.5 4.5h4.8" class="st0"/>
+  <path d="M5.5 7.7h4.8" class="st0"/>
+  <path d="M5.5 10.9h2.2" class="st0"/>
+  <path fill="none" stroke="#000" stroke-width="1.7131" d="M3.4.9h9.1c.8 0 1.4.6 1.4 1.4v11.3c0 .8-.6 1.4-1.4 1.4H3.4c-.8 0-1.4-.6-1.4-1.4V2.3C2 1.5 2.6.9 3.4.9z"/>
+</svg>

--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -277,6 +277,10 @@ if (typeof window.Mozilla === 'undefined') {
         });
     };
 
+    Mozilla.UITour.forceShowReaderIcon = function () {
+        _sendEvent('forceShowReaderIcon');
+    };
+
     Mozilla.UITour.ping = function (callback) {
         var data = {};
         if (callback) {

--- a/media/js/firefox/whatsnew/whatsnew-116-na.js
+++ b/media/js/firefox/whatsnew/whatsnew-116-na.js
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function defaultTrue() {
+    'use strict';
+
+    document.querySelector('.cta-holder').classList.add('hide');
+    document.querySelector('.fx-not-default').classList.add('hide');
+    document.querySelector('.fx-is-default').classList.add('show');
+
+    window.dataLayer.push({
+        event: 'non-interaction',
+        eAction: 'whatsnew-116-na',
+        eLabel: 'default-true'
+    });
+}
+
+function defaultFalse() {
+    'use strict';
+
+    document.querySelector('.cta-holder').classList.add('hide');
+    document.querySelector('.fx-is-default').classList.add('hide');
+    document.querySelector('.fx-not-default').classList.add('show');
+
+    window.dataLayer.push({
+        event: 'non-interaction',
+        eAction: 'whatsnew-116-na',
+        eLabel: 'default-false'
+    });
+}
+
+function init() {
+    'use strict';
+
+    // If UITour is slow to respond, fallback to assuming Fx is not default.
+    const requestTimeout = window.setTimeout(defaultFalse, 2000);
+
+    Mozilla.UITour.getConfiguration('appinfo', function (details) {
+        // Clear timeout as soon as we get a response.
+        window.clearTimeout(requestTimeout);
+
+        // If Firefox is already the default, show alternate call to action.
+        if (details.defaultBrowser) {
+            defaultTrue();
+            return;
+        }
+
+        defaultFalse();
+    });
+}
+
+if (
+    typeof window.Mozilla.Client !== 'undefined' &&
+    typeof window.Mozilla.UITour !== 'undefined' &&
+    window.Mozilla.Client.isFirefoxDesktop
+) {
+    init();
+} else {
+    // Fall back to learn more CTA if other checks fail
+    document.querySelector('.cta-holder').classList.add('hide');
+    document.querySelector('.fx-not-default').classList.add('hide');
+    document.querySelector('.fx-is-default').classList.add('show');
+}

--- a/media/js/firefox/whatsnew/whatsnew-116-na.js
+++ b/media/js/firefox/whatsnew/whatsnew-116-na.js
@@ -50,6 +50,8 @@ function init() {
 
         defaultFalse();
     });
+
+    Mozilla.UITour.forceShowReaderIcon();
 }
 
 if (

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -517,6 +517,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-116-na.scss"
+      ],
+      "name": "firefox_whatsnew_116_na"
+    },
+    {
+      "files": [
         "css/firefox/privacy/common.scss"
       ],
       "name": "firefox-privacy-common"
@@ -1752,6 +1758,12 @@
         "js/firefox/whatsnew/whatsnew-116-eu.js"
       ],
       "name": "firefox_whatsnew_116_eu"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-116-na.js"
+      ],
+      "name": "firefox_whatsnew_116_na"
     },
     {
       "files": [

--- a/tests/functional/firefox/whatsnew/test_whatsnew_116.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_116.py
@@ -9,7 +9,7 @@ from pages.firefox.whatsnew.whatsnew_116 import FirefoxWhatsNew116Page
 
 @pytest.mark.skip_if_not_firefox(reason="Whatsnew pages are shown to Firefox only.")
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("locale", [("de"), ("fr"), ("en-GB")])
+@pytest.mark.parametrize("locale", [("de"), ("fr"), ("en-GB"), ("en-US")])
 def test_firefox_default_button_displayed(locale, base_url, selenium):
     page = FirefoxWhatsNew116Page(selenium, base_url, locale=locale).open()
     assert page.is_firefox_default_button_displayed


### PR DESCRIPTION
## One-line summary

Adds WNP for Firefox 116 for en-US and en-CA, promoting reader view.

## Issue / Bugzilla link

#13421 

## Testing

http://localhost:8000/en-US/firefox/116.0/whatsnew/

- [x] If Firefox is not the default browser, show "Always use Firefox" CTA linking to set-as-default page.
- [x] If Firefox is the default browser, show "Learn more" CTA linking to SUMO.
- [x] If prefers-reduced-motion: reduce, show a simplified page with no animation.