### PR TITLE
Fix missing trailing slash on sustainability pages

### DIFF
--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -132,12 +132,12 @@ urlpatterns = (
     page("diversity/2021/beyond-our-products/", "mozorg/diversity/2021/beyond-products.html"),
     page("diversity/2021/who-we-are/", "mozorg/diversity/2021/who-we-are.html"),
     page("diversity/2022/", "mozorg/diversity/2022/index.html"),
-    page("diversity/2022/mozilla-foundation-data", "mozorg/diversity/2022/mofo-data.html"),
-    page("diversity/2022/mozilla-corporation-data", "mozorg/diversity/2022/moco-data.html"),
+    page("diversity/2022/mozilla-foundation-data/", "mozorg/diversity/2022/mofo-data.html"),
+    page("diversity/2022/mozilla-corporation-data/", "mozorg/diversity/2022/moco-data.html"),
     # Sustainability pages
     page("sustainability/", "mozorg/sustainability/index.html"),
-    page("sustainability/carbon-neutral", "mozorg/sustainability/carbon-neutral.html"),
-    page("sustainability/emissions-data", "mozorg/sustainability/emissions-data.html"),
+    page("sustainability/carbon-neutral/", "mozorg/sustainability/carbon-neutral.html"),
+    page("sustainability/emissions-data/", "mozorg/sustainability/emissions-data.html"),
     # Webvision
     redirect(r"^webvision/?$", "mozorg.about.webvision.summary", name="webvision", locale_prefix=False),
     path(


### PR DESCRIPTION
## One-line summary

The pages below currently 404 when there's a trailing slash at the end

## Issue / Bugzilla link

N/A

## Testing

- http://localhost:8000/en-US/sustainability/emissions-data/
- http://localhost:8000/en-US/sustainability/carbon-neutral/
- http://localhost:8000/en-US/diversity/2022/mozilla-foundation-data/
- http://localhost:8000/en-US/diversity/2022/mozilla-corporation-data/
