### PR TITLE
Remove high_res_img() helper (Fixes #13227)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -49,7 +49,13 @@
 {% set optional_img_attributes = {'alt': ftl('download-button-google-play'), 'width': '152', 'height': '45', 'l10n': True} %}
 {% do optional_img_attributes.update(extra_img_attributes) %}
 <a class="ga-product-download {{ class_name }}"{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="Android"{% endif %}{% if product == 'Firefox' %} data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}"{% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
-  {{ high_res_img('img/firefox/android/btn-google-play.png', optional_img_attributes) }}
+  {{ resp_img(
+    url='img/firefox/android/btn-google-play.png',
+    srcset={
+      'img/firefox/android/btn-google-play-high-res.png': '2x'
+    },
+    optional_attributes=optional_img_attributes
+  ) }}
 </a>
 {%- endmacro %}
 

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -80,14 +80,34 @@
 
     <div class="mzp-l-card-half">
       <div class="mzp-c-card">
-        {{ high_res_img('img/firefox/browsers/chromebook/mobile.png', {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '436', 'height': '464'}) }}
+        {{ resp_img(
+          url='img/firefox/browsers/chromebook/mobile.png',
+          srcset={
+            'img/firefox/browsers/chromebook/mobile-high-res.png': '2x'
+          },
+          optional_attributes={
+            'class': 'mzp-c-billboard-image',
+            'width': '436',
+            'height': '464'
+          }
+        ) }}
 
         <p>{{ ftl('browsers-chromebook-install-firefox-from') }}</p>
         {{ google_play_button(href=android_url, id='playStoreLink') }}
       </div>
 
       <div class="mzp-c-card">
-        {{ high_res_img('img/firefox/browsers/chromebook/addon.png', {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '436', 'height': '464'}) }}
+        {{ resp_img(
+          url='img/firefox/browsers/chromebook/addon.png',
+          srcset={
+            'img/firefox/browsers/chromebook/addon-high-res.png': '2x'
+          },
+          optional_attributes={
+            'class': 'mzp-c-billboard-image',
+            'width': '436',
+            'height': '464'
+          }
+        ) }}
 
         <p>{{ ftl('browsers-chromebook-install-firefox-as', url='href="https://support.mozilla.org/kb/run-firefox-chromeos?utm_source=www.mozilla.org-firefox-browsers-chromebook&amp;utm_medium=referral&amp;utm_campaign=seo" rel="external noopener" data-cta-text="Install Firefox for Chromebook" data-cta-type="link"'|safe) }}</p>
       </div>

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -39,7 +39,17 @@
     <section class="compare-details-section-summary">
       <p class="compare-details-section-intro">{{ ftl('compare-brave-just-like-the-firefox-browser') }}</p>
 
-      {{ high_res_img('img/firefox/compare/compare-browser-brave.png', {'alt': '', 'width': '544', 'height': '424', 'class': 'compare-details-image'}) }}
+      {{ resp_img(
+        url='img/firefox/compare/compare-browser-brave.png',
+        srcset={
+          'img/firefox/compare/compare-browser-brave-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '544',
+          'height': '424',
+          'class': 'compare-details-image'
+        }
+      ) }}
     </section>
 
     <section class="compare-section-privacy">

--- a/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
@@ -45,7 +45,17 @@
 
         <p>{{ ftl('compare-chrome-and-so-here-we-are-the-browser') }}</p>
 
-        {{ high_res_img('img/firefox/compare/compare-browser-chrome.png', {'alt': '', 'width': '541', 'height': '424', 'class': 'compare-details-image'}) }}
+        {{ resp_img(
+          url='img/firefox/compare/compare-browser-chrome.png',
+          srcset={
+            'img/firefox/compare/compare-browser-chrome-high-res.png': '2x'
+          },
+          optional_attributes={
+            'width': '541',
+            'height': '424',
+            'class': 'compare-details-image'
+          }
+        ) }}
     </section>
 
     <section class="compare-section-privacy">

--- a/bedrock/firefox/templates/firefox/browsers/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/edge.html
@@ -41,7 +41,17 @@
 
       <p>{{ ftl('compare-edge-here-well-compare-our-firefox') }}</p>
 
-      {{ high_res_img('img/firefox/compare/compare-browser-edge.png', {'alt': '', 'width': '545', 'height': '424', 'class': 'compare-details-image'}) }}
+      {{ resp_img(
+        url='img/firefox/compare/compare-browser-edge.png',
+        srcset={
+          'img/firefox/compare/compare-browser-edge-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '545',
+          'height': '424',
+          'class': 'compare-details-image'
+        }
+      ) }}
     </section>
 
     <section class="compare-section-privacy">

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -43,7 +43,17 @@
 
       <p>{{ ftl('compare-ie-here-well-compare-our-firefox') }}</p>
 
-      {{ high_res_img('img/firefox/compare/compare-browser-ie.png', {'alt': '', 'width': '543', 'height': '424', 'class': 'compare-details-image'}) }}
+      {{ resp_img(
+        url='img/firefox/compare/compare-browser-ie.png',
+        srcset={
+          'img/firefox/compare/compare-browser-ie-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '543',
+          'height': '424',
+          'class': 'compare-details-image'
+        }
+      ) }}
     </section>
 
     <section class="compare-section-privacy">

--- a/bedrock/firefox/templates/firefox/browsers/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/opera.html
@@ -41,7 +41,17 @@
     <section class="compare-details-section-summary">
       <p class="compare-details-section-intro">{{ ftl('compare-opera-the-firefox-browser-and-opera') }}</p>
 
-      {{ high_res_img('img/firefox/compare/compare-browser-opera.png', {'alt': '', 'width': '543', 'height': '424', 'class': 'compare-details-image'}) }}
+      {{ resp_img(
+        url='img/firefox/compare/compare-browser-opera.png',
+        srcset={
+          'img/firefox/compare/compare-browser-opera-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '543',
+          'height': '424',
+          'class': 'compare-details-image'
+        }
+      ) }}
     </section>
 
     <section class="compare-section-privacy">

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -41,7 +41,17 @@
     <section class="compare-details-section-summary">
       <p class="compare-details-section-intro">{{ ftl('compare-safari-if-you-use-a-mac-or-have-updated', fallback='compare-safari-if-you-use-a-mac-or-have') }}</p>
 
-      {{ high_res_img('img/firefox/compare/compare-browser-safari.png', {'alt': '', 'width': '544', 'height': '424', 'class': 'compare-details-image'}) }}
+      {{ resp_img(
+        url='img/firefox/compare/compare-browser-safari.png',
+        srcset={
+          'img/firefox/compare/compare-browser-safari-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '544',
+          'height': '424',
+          'class': 'compare-details-image'
+        }
+      ) }}
     </section>
 
     <section class="compare-section-privacy">

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -98,7 +98,17 @@
 
   <div class="mzp-l-content c-landing-grid">
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/browsers/desktop.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '233'}) }}
+      {{ resp_img(
+        url='img/firefox/browsers/desktop.jpg',
+        srcset={
+          'img/firefox/browsers/desktop-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '233'
+        }
+      ) }}
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Desktop">{{ ftl('firefox-browsers-desktop') }}</a></h2>
       <p>{{ ftl('firefox-browsers-seriously-private-browsing') }}</p>
 
@@ -117,7 +127,17 @@
     </div>
 
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/browsers/mobile.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '233'}) }}
+      {{ resp_img(
+        url='img/firefox/browsers/mobile.jpg',
+        srcset={
+          'img/firefox/browsers/mobile-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '233'
+        }
+      ) }}
       <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.mobile.index') }}" data-cta-type="link" data-cta-text="Mobile">{{ ftl('firefox-browsers-mobile') }}</a></h2>
       <p>{{ ftl('firefox-browsers-take-the-same-level-of-privacy') }}</p>
 
@@ -139,7 +159,17 @@
     </div>
 
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/browsers/enterprise.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '233'}) }}
+      {{ resp_img(
+        url='img/firefox/browsers/enterprise.jpg',
+        srcset={
+          'img/firefox/browsers/enterprise-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '233'
+        }
+      ) }}
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise">{{ ftl('firefox-browsers-enterprise') }}</a></h2>
       <p>{{ ftl('firefox-browsers-get-unmatched-data-protection') }}</p>
       <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}#download" data-cta-type="link" data-cta-text="Enterprise packages">{{ ftl('firefox-browsers-enterprise-packages') }}</a></p>

--- a/bedrock/firefox/templates/firefox/browsers/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/mobile/index.html
@@ -72,7 +72,17 @@
 
   <section class="mzp-l-content c-landing-grid">
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/browsers/mobile/index/firefox-android.png', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '263'}) }}
+      {{ resp_img(
+        url='img/firefox/browsers/mobile/index/firefox-android.png',
+        srcset={
+          'img/firefox/browsers/mobile/index/firefox-android-high-res.png': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '263'
+        }
+      ) }}
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.browsers.mobile.android') }}" data-cta-type="link" data-cta-text="Firefox for Android">{{ ftl('browsers-mobile-firefox-for-android') }}</a></h2>
       <p>{{ ftl('browsers-mobile-infinitely-customizable-private') }}</p>
 
@@ -84,7 +94,17 @@
     </div>
 
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/browsers/mobile/index/firefox-ios.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '218'}) }}
+      {{ resp_img(
+        url='img/firefox/browsers/mobile/index/firefox-ios.jpg',
+        srcset={
+          'img/firefox/browsers/mobile/index/firefox-ios-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '218'
+        }
+      ) }}
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.browsers.mobile.ios') }}" data-cta-type="link" data-cta-text="Firefox for iOS">{{ ftl('browsers-mobile-firefox-for-ios') }}</a></h2>
       <p>{{ ftl('browsers-mobile-get-enhanced-tracking-protection') }}</p>
 
@@ -96,7 +116,17 @@
     </div>
 
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/browsers/mobile/index/firefox-focus.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '218'}) }}
+      {{ resp_img(
+        url='img/firefox/browsers/mobile/index/firefox-focus.jpg',
+        srcset={
+          'img/firefox/browsers/mobile/index/firefox-focus-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '218'
+        }
+      ) }}
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-cta-type="link" data-cta-text="Firefox Focus">{{ ftl('browsers-mobile-firefox-focus') }}</a></h2>
       <p>{{ ftl('browsers-mobile-looking-for-a-streamlined') }}</p>
 

--- a/bedrock/firefox/templates/firefox/developer/includes/highlights.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/highlights.html
@@ -9,7 +9,16 @@
     {% if ftl_has_messages('firefox-developer-new-tools', 'firefox-developer-firefox-devtools-now-grays-out') %}
       <div class="c-gallery-item" id="devtools">
         <a href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools" rel="external" width="416" height="208">
-          {{ high_res_img('img/firefox/developer/hero-inactive-css.png', {'alt': ftl('firefox-developer-inactive-css'), 'class': 'highlight-image'}) }}
+          {{ resp_img(
+            url='img/firefox/developer/hero-inactive-css.png',
+            srcset={
+              'img/firefox/developer/hero-inactive-css-high-res.png': '2x'
+            },
+            optional_attributes={
+              'alt': ftl('firefox-developer-inactive-css'),
+              'class': 'highlight-image'
+            }
+          ) }}
         </a>
         <h2 class="c-title">{{ ftl('firefox-developer-new-tools') }}</h2>
         <h3 class="c-subtitle">{{ ftl('firefox-developer-inactive-css') }}</h3>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -67,7 +67,16 @@
       </p>
     </div>
     <div class="intro-image">
-      {{ high_res_img('img/firefox/developer/hero-screenshot.png', {'alt': '', 'width': '1200', 'height': '337'}) }}
+      {{ resp_img(
+        url='img/firefox/developer/hero-screenshot.png',
+        srcset={
+          'img/firefox/developer/hero-screenshot-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '1200',
+          'height': '337'
+        }
+      ) }}
     </div>
   </section>
 

--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -63,7 +63,15 @@
       {{ ftl('features-adblocker-on-firefox-you-can-use', privacy='https://restoreprivacy.com/firefox-privacy/', blocking='https://support.mozilla.org/kb/content-blocking') }}
     </p>
 
-    {{ high_res_img('img/firefox/features/adblocker/content-blocking-title.png', {'alt': '', 'class': 'block-image'}) }}
+    {{ resp_img(
+      url='img/firefox/features/adblocker/content-blocking-title.png',
+      srcset={
+        'img/firefox/features/adblocker/content-blocking-title-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'block-image'
+      }
+    ) }}
 
     <h2 class="section-title">{{ftl('features-adblocker-choose-your-level-of-protection') }}</h2>
     <p>
@@ -75,7 +83,15 @@
       {{ ftl('features-adblocker-if-ads-dont-bother-you', url=url('firefox.features.private-browsing')) }}
     </p>
 
-    {{ high_res_img('img/firefox/features/adblocker/content-blocking.png', {'alt': '', 'class': 'block-image'}) }}
+    {{ resp_img(
+      url='img/firefox/features/adblocker/content-blocking.png',
+      srcset={
+        'img/firefox/features/adblocker/content-blocking-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'block-image'
+      }
+    ) }}
 
     <h2 class="section-title">{{ftl('features-adblocker-get-tough-with-strict') }}</h2>
     <p>
@@ -87,14 +103,30 @@
       {{ ftl('features-adblocker-the-custom-setting-gives') }}
     </p>
 
-    {{ high_res_img('img/firefox/features/adblocker/content-blocking-custom.png', {'alt': '', 'class': 'block-image'}) }}
+    {{ resp_img(
+      url='img/firefox/features/adblocker/content-blocking-custom.png',
+      srcset={
+        'img/firefox/features/adblocker/content-blocking-custom-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'block-image'
+      }
+    ) }}
 
     <h2 class="section-title">{{ftl('features-adblocker-cover-your-trail-block') }}</h2>
     <p>
       {{ ftl('features-adblocker-click-on-the-trackers') }}
     </p>
 
-    {{ high_res_img('img/firefox/features/adblocker/custom-trackers.png', {'alt': '', 'class': 'block-image'}) }}
+    {{ resp_img(
+      url='img/firefox/features/adblocker/custom-trackers.png',
+      srcset={
+        'img/firefox/features/adblocker/custom-trackers-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'block-image'
+      }
+    ) }}
 
     <h2 class="section-title">{{ftl('features-adblocker-take-a-bite-out-of-cookies') }}</h2>
     <p>
@@ -103,14 +135,31 @@
     <p>
       {{ ftl('features-adblocker-in-firefox-you-can-block') }}
     </p>
-    {{ high_res_img('img/firefox/features/adblocker/third-party-cookies.png', {'alt': '', 'class': 'block-image'}) }}
+
+    {{ resp_img(
+      url='img/firefox/features/adblocker/third-party-cookies.png',
+      srcset={
+        'img/firefox/features/adblocker/third-party-cookies-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'block-image'
+      }
+    ) }}
 
     <h2 class="section-title">{{ftl('features-adblocker-send-a-do-not-track-signal') }}</h2>
     <p>
       {{ ftl('features-adblocker-if-you-dont-want-your', url='https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature') }}
     </p>
 
-    {{ high_res_img('img/firefox/features/adblocker/dnt_screenshot.png', {'alt': '', 'class': 'block-image'}) }}
+    {{ resp_img(
+      url='img/firefox/features/adblocker/dnt_screenshot.png',
+      srcset={
+        'img/firefox/features/adblocker/dnt_screenshot-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'block-image'
+      }
+    ) }}
 
     <h2 class="section-title">{{ftl('features-adblocker-speed-up-thanks-to-ad') }}</h2>
     <p>

--- a/bedrock/firefox/templates/firefox/flashback/index.html
+++ b/bedrock/firefox/templates/firefox/flashback/index.html
@@ -44,7 +44,17 @@
       <div class="mzp-l-content">
         <h3>Thanks for sticking with us.</h3>
         <!-- thank you Mathias Appel https://www.flickr.com/photos/mathiasappel/21694230388/ -->
-        {{ high_res_img('img/firefox/flashback/panda.jpg', {'alt': 'Happy looking red panda walking up a tree branch.', 'width': '1024', 'height': '679'}) }}
+        {{ resp_img(
+          url='img/firefox/flashback/panda.jpg',
+          srcset={
+            'img/firefox/flashback/panda-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'alt': 'Happy looking red panda walking up a tree branch.',
+            'width': '1024',
+            'height': '679'
+          }
+        ) }}
       </div>
     </div>
   </main>

--- a/bedrock/firefox/templates/firefox/more/misinformation.html
+++ b/bedrock/firefox/templates/firefox/more/misinformation.html
@@ -44,7 +44,18 @@
     <p>{{ ftl('misinformation-disinformation') }}</p>
     <p>{{ ftl('misinformation-ultimately-harmful') }}</p>
 
-    {{ high_res_img('img/firefox/more/misinformation/false-info.png', {'class': 'misinformation-article-block-img', 'alt': '', 'width': '688', 'height': '375', 'loading': 'lazy'}) }}
+    {{ resp_img(
+      url='img/firefox/more/misinformation/false-info.png',
+      srcset={
+        'img/firefox/more/misinformation/false-info-high-res.png': '2x'
+      },
+      optional_attributes={
+        'class': 'misinformation-article-block-img',
+        'width': '688',
+        'height': '375',
+        'loading': 'lazy'
+      }
+    ) }}
 
     <h2>{{ ftl('misinformation-false-info-heading') }}</h2>
 

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -272,7 +272,18 @@
           <button id="protection-report" type="button" class="mzp-c-cta-link">{{ ftl('firefox-desktop-download-see-your-report') }}</button>
         </div>
         <div class="c-block-media l-v-end l-h-end l-media-constrain-on-sm">
-          {{ high_res_img('img/firefox/new/desktop/block-mr1.jpg', {'width': '504', 'height': '343', 'alt': '', 'loading': 'lazy', 'class': 'c-block-media-img' }) }}
+          {{ resp_img(
+            url='img/firefox/new/desktop/block-mr1.jpg',
+            srcset={
+              'img/firefox/new/desktop/block-mr1-high-res.jpg': '2x'
+            },
+            optional_attributes={
+              'width': '504',
+              'height': '343',
+              'loading': 'lazy',
+              'class': 'c-block-media-img'
+            }
+          ) }}
         </div>
       </div>
     </div>
@@ -307,7 +318,18 @@
           </div>
         </div>
         <div class="c-block-media l-v-end l-h-end l-media-constrain-on-sm">
-          {{ high_res_img('img/firefox/new/desktop/devices.jpg', {'width': '483', 'height': '491', 'loading': 'lazy', 'class': 'c-block-media-img', 'alt': '' }) }}
+          {{ resp_img(
+            url='img/firefox/new/desktop/devices.jpg',
+            srcset={
+              'img/firefox/new/desktop/devices-high-res.jpg': '2x'
+            },
+            optional_attributes={
+              'width': '483',
+              'height': '491',
+              'loading': 'lazy',
+              'class': 'c-block-media-img'
+             }
+          ) }}
         </div>
       </div>
     </div>
@@ -423,7 +445,17 @@
       </svg>
       <!--<![endif]-->
       <div class="c-screenshot">
-        {{ high_res_img('img/firefox/new/desktop/screen-mr1.png', {'width': '1040', 'height': '412', 'loading': 'lazy', 'alt': ''}) }}
+        {{ resp_img(
+          url='img/firefox/new/desktop/screen-mr1.png',
+          srcset={
+            'img/firefox/new/desktop/screen-mr1-high-res.png': '2x'
+          },
+          optional_attributes={
+            'width': '1040',
+            'height': '412',
+            'loading': 'lazy'
+          }
+        ) }}
       </div>
     </div>
 
@@ -451,14 +483,34 @@
 
     <div class="mzp-l-card-half">
       <div class="mzp-c-card">
-        {{ high_res_img('img/firefox/new/desktop/person-mozilla.jpg', {'width': '436', 'height': '463', 'loading': 'lazy', 'alt': '' }) }}
+        {{ resp_img(
+          url='img/firefox/new/desktop/person-mozilla.jpg',
+          srcset={
+            'img/firefox/new/desktop/person-mozilla-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '436',
+            'height': '463',
+            'loading': 'lazy'
+          }
+        ) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-challenging-the-status') }}</h3>
         {% set created_attrs = 'href="%s" data-cta-type="link" data-cta-text="created by Mozilla"'|safe|format(url('mozorg.about.index')) %}
         <p>{{ ftl('firefox-desktop-download-firefox-was-created', attrs=created_attrs) }}</p>
       </div>
 
       <div class="mzp-c-card">
-        {{ high_res_img('img/firefox/new/desktop/person-privacy.jpg', {'width': '436', 'height': '463', 'loading': 'lazy', 'alt': '' }) }}
+        {{ resp_img(
+          url='img/firefox/new/desktop/person-privacy.jpg',
+          srcset={
+            'img/firefox/new/desktop/person-privacy-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '436',
+            'height': '463',
+            'loading': 'lazy'
+          }
+        ) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-your-privacy-comes') }}</h3>
         {% set internet_attrs = 'href="%s" data-cta-type="link" data-cta-text="Personal Data Promise"'|safe|format(url('firefox.privacy.index')) %}
         <p>{{ ftl('firefox-desktop-download-as-the-internet', attrs=internet_attrs) }}</p>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -75,7 +75,17 @@
     </div>
 
     <div class="c-landing-grid-item">
-      {{ high_res_img('img/firefox/products/browsers.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '350', 'height': '247'}) }}
+      {{ resp_img(
+        url='img/firefox/products/browsers.jpg',
+        srcset={
+          'img/firefox/products/browsers-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'class': 'c-landing-grid-img',
+          'width': '350',
+          'height': '247'
+        }
+      ) }}
       <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="Firefox browsers">{{ ftl('firefox-products-firefox-browsers') }}</a></h2>
       <p>{{ ftl('firefox-products-get-the-browsers-that-block') }}</p>
       <div id="menu-browsers-wrapper" class="mzp-c-menu-list mzp-t-cta mzp-t-download">

--- a/bedrock/foundation/templates/foundation/annualreport/2011.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2011.html
@@ -81,7 +81,18 @@
           <ul class="mzp-c-inline-list">
             <li id="topic-firefox"><img src="{{ static('img/foundation/annualreport/2011/logo-firefox.png') }}" alt="" width="162" height="162">Firefox</li>
             <li id="topic-firefoxos"><img src="{{ static('img/foundation/annualreport/2011/logo-firefoxos.png') }}" alt="" width="200" height="185">Firefox OS</li>
-            <li id="topic-webmaker">{{ high_res_img('img/foundation/annualreport/2011/logo-webmaker.png', {'alt': '', 'width': '170', 'height': '170'}) }}Webmaker</li>
+            <li id="topic-webmaker">
+              {{ resp_img(
+                url='img/foundation/annualreport/2011/logo-webmaker.png',
+                srcset={
+                  'img/foundation/annualreport/2011/logo-webmaker-high-res.png': '2x'
+                },
+                optional_attributes={
+                  'width': '170',
+                  'height': '170'
+                }
+              ) }}Webmaker
+            </li>
           </ul>
 
           <div class="overlay">

--- a/bedrock/foundation/templates/foundation/trademarks/list.html
+++ b/bedrock/foundation/templates/foundation/trademarks/list.html
@@ -118,7 +118,17 @@ established in any of its products, features, service names, or logos.</p>
     </tr>
     <tr>
       <td>
-        {{ high_res_img('img/trademarks/lightbeam-logo.png', { 'alt': 'Lightbeam logo', 'width': '100', 'height': '100' }) }}
+        {{ resp_img(
+          url='img/trademarks/lightbeam-logo.png',
+          srcset={
+            'img/trademarks/lightbeam-logo-high-res.png': '2x'
+          },
+          optional_attributes={
+            'alt': 'Lightbeam logo',
+            'width': '100',
+            'height': '100'
+          }
+        ) }}
       </td>
       <th>Lightbeam</th>
     </tr>
@@ -140,7 +150,17 @@ established in any of its products, features, service names, or logos.</p>
     </tr>
     <tr>
       <td>
-        {{ high_res_img('img/trademarks/logo-wordmark-webmaker.png', { 'alt': 'Webmaker logo', 'width': '100', 'height': '100' }) }}
+        {{ resp_img(
+          url='img/trademarks/logo-wordmark-webmaker.png',
+          srcset={
+            'img/trademarks/logo-wordmark-webmaker-high-res.png': '2x'
+          },
+          optional_attributes={
+            'alt': 'Webmaker logo',
+            'width': '100',
+            'height': '100'
+          }
+        ) }}
       </td>
       <th>Webmaker</th>
     </tr>

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -98,7 +98,12 @@
 <aside class="mzp-l-content">
   <div class="mzp-c-newsletter">
     <div class="mzp-c-newsletter-image">
-      {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+      {{ resp_img(
+        url='img/home/2018/newsletter-graphic.png',
+        srcset={
+          'img/home/2018/newsletter-graphic-high-res.png': '2x'
+        }
+      ) }}
     </div>
     <div class="newsletter-content">
       {% if LANG.startswith('en-') %}

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -167,7 +167,12 @@
 <div class="mzp-l-content">
   <aside class="mzp-c-newsletter">
     <div class="mzp-c-newsletter-image">
-      {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+      {{ resp_img(
+        url='img/home/2018/newsletter-graphic.png',
+        srcset={
+          'img/home/2018/newsletter-graphic-high-res.png': '2x'
+        }
+      ) }}
     </div>
 
     <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/about/leadership/boards.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/boards.html
@@ -16,7 +16,18 @@
 <div class="gallery">
   <article class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/mitchell-baker.jpg',
+        srcset={
+          'img/mozorg/about/leadership/mitchell-baker-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Mitchell Baker</h4></figcaption>
     </figure>
     <div class="person-info">
@@ -98,7 +109,18 @@
 
   <article id="karim-lakhani" data-id="karim-lakhani" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/karim-lakhani.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/karim-lakhani.jpg',
+        srcset={
+          'img/mozorg/about/leadership/karim-lakhani-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Karim Lakhani</h4></figcaption>
     </figure>
 
@@ -143,7 +165,18 @@
 
   <article id="bob-lisbonne" data-id="bob-lisbonne" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/bob-lisbonne.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/bob-lisbonne.jpg',
+        srcset={
+          'img/mozorg/about/leadership/bob-lisbonne-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Bob Lisbonne, Chair</h4></figcaption>
     </figure>
 
@@ -221,7 +254,18 @@
 
   <article id="kristin-skogen-lund" data-id="kristin-skogen-lund" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/kristin-skogen-lund.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/kristin-skogen-lund.jpg',
+        srcset={
+          'img/mozorg/about/leadership/kristin-skogen-lund-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Kristin Skogen Lund</h4></figcaption>
     </figure>
 
@@ -255,14 +299,36 @@
 <div class="gallery">
   <article class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/mitchell-baker.jpg',
+        srcset={
+          'img/mozorg/about/leadership/mitchell-baker-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Mitchell Baker, Chair</h4></figcaption>
     </figure>
   </article>
 
   <article id="brian-behlendorf" data-id="brian-behlendorf" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/brian-behlendorf.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/brian-behlendorf.jpg',
+        srcset={
+          'img/mozorg/about/leadership/brian-behlendorf-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Brian Behlendorf</h4></figcaption>
     </figure>
 
@@ -291,21 +357,54 @@
 
   <article id="amy-keating" data-id="amy-keating" class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/amy-keating.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/amy-keating.jpg',
+        srcset={
+          'img/mozorg/about/leadership/amy-keating-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Amy Keating</h4></figcaption>
     </figure>
   </article>
 
   <article class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/mark-surman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/mark-surman.jpg',
+        srcset={
+          'img/mozorg/about/leadership/mark-surman-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
     </figure>
   </article>
 
   <article id="helen-turvey" data-id="helen-turvey" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/helen-turvey.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/helen-turvey.jpg',
+        srcset={
+          'img/mozorg/about/leadership/helen-turvey-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Helen Turvey</h4></figcaption>
     </figure>
 
@@ -382,7 +481,18 @@
 
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/julie-hanna.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/julie-hanna.jpg',
+        srcset={
+          'img/mozorg/about/leadership/julie-hanna-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Julie Hanna</h4></figcaption>
     </figure>
   </li>
@@ -410,27 +520,71 @@
 
   <li id="navrina-singh" class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/navrina-singh.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/navrina-singh.jpg',
+        srcset={
+          'img/mozorg/about/leadership/navrina-singh-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Navrina Singh</h4></figcaption>
     </figure>
   </li>
 
   <li id="wambui-kinya" class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/wambui-kinya.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/wambui-kinya.jpg',
+        srcset={
+          'img/mozorg/about/leadership/wambui-kinya-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Wambui Kinya</h4></figcaption>
     </figure>
   </li>
 
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/ronaldo-lemos.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/ronaldo-lemos.jpg',
+        srcset={
+          'img/mozorg/about/leadership/ronaldo-lemos-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Ronaldo Lemos</h4></figcaption>
     </figure>
   </li>
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/mohamed-nanabhay.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image', 'title': 'Photo by Joi Ito'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/mohamed-nanabhay.jpg',
+        srcset={
+          'img/mozorg/about/leadership/mohamed-nanabhay-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Mohamed Nanabhay</h4></figcaption>
     </figure>
   </li>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/index.html
@@ -22,7 +22,18 @@
 <div class="gallery mgmt-corp">
   <article id="mitchell-baker" data-id="mitchell-baker" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/mitchell-baker.jpg',
+        srcset={
+          'img/mozorg/about/leadership/mitchell-baker-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Mitchell Baker</h4></figcaption>
     </figure>
 
@@ -106,7 +117,18 @@
 
   <article id="eric-muhlheim" data-id="eric-muhlheim" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/eric-muhlheim.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/eric-muhlheim.jpg',
+        srcset={
+          'img/mozorg/about/leadership/eric-muhlheim-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Eric Muhlheim</h4></figcaption>
     </figure>
 
@@ -152,7 +174,18 @@
 
   <article id="lindsey-obrien" data-id="lindsey-obrien" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/lindsey-obrien.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/lindsey-obrien.jpg',
+        srcset={
+          'img/mozorg/about/leadership/lindsey-obrien-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Lindsey O’Brien</h4></figcaption>
     </figure>
 
@@ -192,7 +225,18 @@
 
   <article id="steve-teixeira" data-id="steve-teixeira" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/steve-teixeira.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/steve-teixeira.jpg',
+        srcset={
+          'img/mozorg/about/leadership/steve-teixeira-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Steve Teixeira</h4></figcaption>
     </figure>
 
@@ -239,7 +283,18 @@
 
   <article id="carlos-torres" data-id="carlos-torres" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/carlos-torres.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/carlos-torres.jpg',
+        srcset={
+          'img/mozorg/about/leadership/carlos-torres-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Carlos Torres</h4></figcaption>
     </figure>
 
@@ -273,7 +328,18 @@
 
   <article id="imo-udom" data-id="imo-udom" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/imo-udom.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/imo-udom.jpg',
+        srcset={
+          'img/mozorg/about/leadership/imo-udom-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Imo Udom</h4></figcaption>
     </figure>
 

--- a/bedrock/mozorg/templates/mozorg/about/leadership/mofo.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/mofo.html
@@ -14,7 +14,18 @@
 <div class="gallery mgmt-foundation">
   <article id="mark-surman" data-id="mark-surman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/mark-surman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/mark-surman.jpg',
+        srcset={
+          'img/mozorg/about/leadership/mark-surman-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
     </figure>
 
@@ -74,7 +85,18 @@
 
   <article id="j-bob-alotta" data-id="j-bob-alotta" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/bob-alotta.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/bob-alotta.jpg',
+        srcset={
+          'img/mozorg/about/leadership/bob-alotta-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">J. Bob Alotta</h4></figcaption>
     </figure>
 
@@ -121,7 +143,18 @@
 
   <article id="ashley-boyd" data-id="ashley-boyd" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/ashley-boyd.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/ashley-boyd.jpg',
+        srcset={
+          'img/mozorg/about/leadership/ashley-boyd-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Ashley Boyd</h4></figcaption>
     </figure>
 
@@ -171,7 +204,18 @@
 
   <article id="angela-plohman" data-id="angela-plohman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/angela-plohman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/angela-plohman.jpg',
+        srcset={
+          'img/mozorg/about/leadership/angela-plohman-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Angela Plohman</h4></figcaption>
     </figure>
 

--- a/bedrock/mozorg/templates/mozorg/about/leadership/reps.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/reps.html
@@ -23,7 +23,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/bobreyes/">
-        {{ high_res_img('img/mozorg/about/leadership/robert-reyes.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/robert-reyes.jpg',
+          srcset={
+            'img/mozorg/about/leadership/robert-reyes-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Robert Reyes</h4></figcaption>
       </a>
     </figure>
@@ -32,7 +43,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/plwt/">
-        {{ high_res_img('img/mozorg/about/leadership/paul-wright.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/paul-wright.jpg',
+          srcset={
+            'img/mozorg/about/leadership/paul-wright-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Paul Wright</h4></figcaption>
       </a>
     </figure>
@@ -41,7 +63,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/siddhartharao17/">
-        {{ high_res_img('img/mozorg/about/leadership/siddhartha-rao.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/siddhartha-rao.jpg',
+          srcset={
+            'img/mozorg/about/leadership/siddhartha-rao-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Siddhartha Rao</h4></figcaption>
       </a>
     </figure>
@@ -50,7 +83,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/yulireyji/">
-        {{ high_res_img('img/mozorg/about/leadership/yuliana-reyna.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/yuliana-reyna.jpg',
+          srcset={
+            'img/mozorg/about/leadership/yuliana-reyna-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Yuliana Reyna Jiménez</h4></figcaption>
       </a>
     </figure>
@@ -59,7 +103,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/pransh15/">
-        {{ high_res_img('img/mozorg/about/leadership/pranshu-khanna.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/pranshu-khanna.jpg',
+          srcset={
+            'img/mozorg/about/leadership/pranshu-khanna-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Pranshu Khanna</h4></figcaption>
       </a>
     </figure>
@@ -68,7 +123,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/rtsayles/">
-        {{ high_res_img('img/mozorg/about/leadership/robby-sayles.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/robby-sayles.jpg',
+          srcset={
+            'img/mozorg/about/leadership/robby-sayles-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Robby Sayles</h4></figcaption>
       </a>
     </figure>
@@ -77,7 +143,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/nomadicmehul/">
-        {{ high_res_img('img/mozorg/about/leadership/mehul-patel.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/mehul-patel.jpg',
+          srcset={
+            'img/mozorg/about/leadership/mehul-patel-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Mehul Patel</h4></figcaption>
       </a>
     </figure>
@@ -86,7 +163,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/couci/">
-        {{ high_res_img('img/mozorg/about/leadership/konstantina-papadea.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/konstantina-papadea.jpg',
+          srcset={
+            'img/mozorg/about/leadership/konstantina-papadea-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Konstantina Papadea</h4></figcaption>
       </a>
     </figure>
@@ -95,7 +183,18 @@
   <li class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
       <a class="url" itemprop="url" rel="external" href="https://community.mozilla.org/people/francescam/">
-        {{ high_res_img('img/mozorg/about/leadership/francesca-minelli.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+        {{ resp_img(
+          url='img/mozorg/about/leadership/francesca-minelli.jpg',
+          srcset={
+            'img/mozorg/about/leadership/francesca-minelli-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '160',
+            'height': '160',
+            'class': 'photo',
+            'itemprop': 'image'
+          }
+        ) }}
         <figcaption><h4 class="fn" itemprop="name">Francesca Minelli</h4></figcaption>
       </a>
     </figure>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/senior.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/senior.html
@@ -15,7 +15,18 @@
 <div class="gallery mgmt-corp">
   <article id="brandon-borrman" data-id="brandon-borrman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/brandon-borrman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/brandon-borrman.jpg',
+        srcset={
+          'img/mozorg/about/leadership/brandon-borrman-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Brandon Borrman</h4></figcaption>
     </figure>
 
@@ -57,7 +68,18 @@
 
   <article id="katherine-bose" data-id="katherine-bose" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/katherine-bose.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/katherine-bose.jpg',
+        srcset={
+          'img/mozorg/about/leadership/katherine-bose-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Katherine Bose</h4></figcaption>
     </figure>
 
@@ -98,7 +120,18 @@
 
   <article id="ian-carmichael" data-id="ian-carmichael" class="vcard" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/ian-carmichael.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/ian-carmichael.jpg',
+        srcset={
+          'img/mozorg/about/leadership/ian-carmichael-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Ian Carmichael</h4></figcaption>
     </figure>
 
@@ -113,7 +146,18 @@
 
   <article id="vicky-chin" data-id="vicky-chin" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/vicky-chin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/vicky-chin.jpg',
+        srcset={
+          'img/mozorg/about/leadership/vicky-chin-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Vicky Chin</h4></figcaption>
     </figure>
 
@@ -149,7 +193,18 @@
 
   <article id="nicholas-grammater" data-id="nicholas-grammater" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/nicholas-grammater.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/nicholas-grammater.jpg',
+        srcset={
+          'img/mozorg/about/leadership/nicholas-grammater-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Nicholas Grammater</h4></figcaption>
     </figure>
 
@@ -184,7 +239,18 @@
 
   <article id="linda-griffin" data-id="linda-griffin" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/linda-griffin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/linda-griffin.jpg',
+        srcset={
+          'img/mozorg/about/leadership/linda-griffin-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Linda Griffin</h4></figcaption>
     </figure>
 
@@ -220,7 +286,18 @@
 
   <article id="robin-karakash" data-id="robin-karakash" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/robin-karakash.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/robin-karakash.jpg',
+        srcset={
+          'img/mozorg/about/leadership/robin-karakash-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Robin Karakash</h4></figcaption>
     </figure>
 
@@ -296,7 +373,18 @@
 
   <article id="dan-mckinley" data-id="dan-mckinley" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/dan-mckinley.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/dan-mckinley.jpg',
+        srcset={
+          'img/mozorg/about/leadership/dan-mckinley-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Dan McKinley</h4></figcaption>
     </figure>
 
@@ -326,7 +414,18 @@
 
   <article id="oscar-murillo" data-id="oscar-murillo" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/oscar-murillo.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/oscar-murillo.jpg',
+        srcset={
+          'img/mozorg/about/leadership/oscar-murillo-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Oscar Murillo</h4></figcaption>
     </figure>
 
@@ -377,7 +476,18 @@
 
   <article id="andrew-overholt" data-id="andrew-overholt" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      {{ high_res_img('img/mozorg/about/leadership/andrew-overholt.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+      {{ resp_img(
+        url='img/mozorg/about/leadership/andrew-overholt.jpg',
+        srcset={
+          'img/mozorg/about/leadership/andrew-overholt-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
       <figcaption><h4 class="fn" itemprop="name">Andrew Overholt</h4></figcaption>
     </figure>
 

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -139,7 +139,12 @@
     <div class="mzp-l-content">
       <aside class="mzp-c-newsletter">
         <div class="mzp-c-newsletter-image">
-          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+          {{ resp_img(
+            url='img/home/2018/newsletter-graphic.png',
+            srcset={
+              'img/home/2018/newsletter-graphic-high-res.png': '2x'
+            }
+          ) }}
         </div>
 
         <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -121,7 +121,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/stay-lean-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/stay-lean-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Stay Lean</h3>
@@ -133,7 +142,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.engage-users') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/engage-users-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/engage-users-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Engage Your Users</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -144,7 +144,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/stay-lean-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/stay-lean-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Stay Lean</h3>
@@ -156,7 +165,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/build-security-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/build-security-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Build Security</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
@@ -64,7 +64,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/stay-lean-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/stay-lean-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Stay Lean</h3>
@@ -76,7 +85,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/build-security-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/build-security-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Build Security</h3>
@@ -88,7 +106,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.engage-users') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/engage-users-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/engage-users-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Engage Your Users</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -124,7 +124,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/build-security-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/build-security-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Build Security</h3>
@@ -136,7 +145,16 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.engage-users') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ resp_img(
+            url='img/mozorg/about/lean-data/engage-users-hero.png',
+            srcset={
+              'img/mozorg/about/lean-data/engage-users-hero-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '424',
+              'height': '424'
+            }
+          ) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">Engage Your Users</h3>

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
@@ -31,7 +31,16 @@
         </p>
 
         <figure class="feature-img">
-          {{ high_res_img('img/contact/osm/spaces/beijing-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ resp_img(
+            url='img/contact/osm/spaces/beijing-small.png',
+            srcset={
+              'img/contact/osm/spaces/beijing-small-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '460',
+              'height': '250'
+            }
+          ) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
@@ -36,7 +36,16 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('img/contact/osm/spaces/berlin-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ resp_img(
+            url='img/contact/osm/spaces/berlin-small.png',
+            srcset={
+              'img/contact/osm/spaces/berlin-small-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '460',
+              'height': '250'
+            }
+          ) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
@@ -35,7 +35,16 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('img/contact/osm/spaces/paris-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ resp_img(
+            url='img/contact/osm/spaces/paris-small.png',
+            srcset={
+              'img/contact/osm/spaces/paris-small-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '460',
+              'height': '250'
+            }
+          ) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
@@ -35,7 +35,16 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('img/contact/osm/spaces/san-francisco-small.jpg', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ resp_img(
+            url='img/contact/osm/spaces/san-francisco-small.jpg',
+            srcset={
+              'img/contact/osm/spaces/san-francisco-small-high-res.jpg': '2x'
+            },
+            optional_attributes={
+              'width': '460',
+              'height': '250'
+            }
+          ) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
@@ -37,7 +37,16 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('img/contact/osm/spaces/toronto-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ resp_img(
+            url='img/contact/osm/spaces/toronto-small.png',
+            srcset={
+              'img/contact/osm/spaces/toronto-small-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '460',
+              'height': '250'
+            }
+          ) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -226,7 +226,12 @@
   <section class="mzp-l-content">
     <aside class="mzp-c-newsletter">
       <div class="mzp-c-newsletter-image">
-        {{ high_res_img('img/contribute/newsletter.png', {'alt': ''}) }}
+        {{ resp_img(
+          url='img/contribute/newsletter.png',
+          srcset={
+            'img/contribute/newsletter-high-res.png': '2x'
+          }
+        ) }}
       </div>
 
       <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home-contentful.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-contentful.html
@@ -93,7 +93,12 @@
   <div class="mzp-l-content">
     <aside class="mzp-c-newsletter">
       <div class="mzp-c-newsletter-image">
-        {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        {{ resp_img(
+          url='img/home/2018/newsletter-graphic.png',
+          srcset={
+            'img/home/2018/newsletter-graphic-high-res.png': '2x'
+          }
+        ) }}
       </div>
 
       <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -127,7 +127,12 @@
 
       <aside class="mzp-c-newsletter">
         <div class="mzp-c-newsletter-image">
-          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+          {{ resp_img(
+            url='img/home/2018/newsletter-graphic.png',
+            srcset={
+              'img/home/2018/newsletter-graphic-high-res.png': '2x'
+            }
+          ) }}
         </div>
 
         <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -121,7 +121,12 @@
 
       <aside class="mzp-c-newsletter">
         <div class="mzp-c-newsletter-image">
-          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+          {{ resp_img(
+            url='img/home/2018/newsletter-graphic.png',
+            srcset={
+              'img/home/2018/newsletter-graphic-high-res.png': '2x'
+            }
+          ) }}
         </div>
 
         <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -188,7 +188,12 @@
 
     <aside class="mzp-c-newsletter">
       <div class="mzp-c-newsletter-image">
-        {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        {{ resp_img(
+          url='img/home/2018/newsletter-graphic.png',
+          srcset={
+            'img/home/2018/newsletter-graphic-high-res.png': '2x'
+          }
+        ) }}
       </div>
 
       <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/moss/base.html
+++ b/bedrock/mozorg/templates/mozorg/moss/base.html
@@ -35,7 +35,12 @@
 <div class="mzp-l-content">
   <aside class="mzp-c-newsletter">
     <div class="mzp-c-newsletter-image">
-      {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+      {{ resp_img(
+        url='img/home/2018/newsletter-graphic.png',
+        srcset={
+          'img/home/2018/newsletter-graphic-high-res.png': '2x'
+        }
+      ) }}
     </div>
 
     <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/moss/includes/alittlebitmore.html
+++ b/bedrock/mozorg/templates/mozorg/moss/includes/alittlebitmore.html
@@ -10,7 +10,15 @@
 
     <ul class="moss-list moss-list-half">
       <li>
-        {{ high_res_img('img/mozorg/moss/selection-committee.jpg', {'width': '450'}) }}
+        {{ resp_img(
+          url='img/mozorg/moss/selection-committee.jpg',
+          srcset={
+            'img/mozorg/moss/selection-committee-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '450'
+          }
+        ) }}
 
         <h3 class="moss-section-subhead">Selection Committee</h3>
 
@@ -22,7 +30,15 @@
         </p>
       </li>
       <li>
-        {{ high_res_img('img/mozorg/moss/past-recipients.jpg', {'width': '450'}) }}
+        {{ resp_img(
+          url='img/mozorg/moss/past-recipients.jpg',
+          srcset={
+            'img/mozorg/moss/past-recipients-high-res.jpg': '2x'
+          },
+          optional_attributes={
+            'width': '450'
+          }
+        ) }}
 
         <h3 class="moss-section-subhead">Past Recipients</h3>
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -157,32 +157,6 @@ def field_with_attrs(bfield, **kwargs):
 
 @library.global_function
 @jinja2.pass_context
-def high_res_img(ctx, url, optional_attributes=None):
-    if optional_attributes and optional_attributes.pop("l10n", False) is True:
-        url = _strip_img_prefix(url)
-        url_high_res = convert_to_high_res(url)
-        url = l10n_img(ctx, url)
-        url_high_res = l10n_img(ctx, url_high_res)
-    else:
-        url_high_res = convert_to_high_res(url)
-        url = static(url)
-        url_high_res = static(url_high_res)
-
-    if optional_attributes:
-        class_name = optional_attributes.pop("class", "")
-        attrs = " " + " ".join(f'{attr}="{val}"' for attr, val in optional_attributes.items())
-    else:
-        class_name = ""
-        attrs = ""
-
-    # Use native srcset attribute for high res images
-    markup = f'<img class="{class_name}" src="{url}" srcset="{url_high_res} 1.5x"{attrs}>'
-
-    return Markup(markup)
-
-
-@library.global_function
-@jinja2.pass_context
 def resp_img(ctx={}, url=None, srcset=None, sizes=None, optional_attributes=None):
     alt = ""
     attrs = ""

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -348,55 +348,6 @@ class TestMozillaInstagramUrl(TestCase):
 
 
 @override_settings(STATIC_URL="/media/")
-class TestHighResImg(TestCase):
-    rf = RequestFactory()
-
-    def _render(self, url, optional_attributes=None):
-        req = self.rf.get("/")
-        req.locale = "en-US"
-        return render(f"{{{{ high_res_img('{url}', {optional_attributes}) }}}}", {"request": req})
-
-    def _render_l10n(self, url):
-        req = self.rf.get("/")
-        req.locale = "en-US"
-        return render(f"{{{{ l10n_img('{url}') }}}}", {"request": req})
-
-    def test_high_res_img_no_optional_attributes(self):
-        """Should return expected markup without optional attributes"""
-        expected = '<img class="" src="/media/img/test.png" ' 'srcset="/media/img/test-high-res.png 1.5x">'
-        markup = self._render("img/test.png")
-        self.assertEqual(markup, expected)
-
-    def test_high_res_img_with_optional_attributes(self):
-        """Should return expected markup with optional attributes"""
-        markup = self._render("img/test.png", {"data-test-attr": "test", "class": "logo"})
-        expected = '<img class="logo" src="/media/img/test.png" ' 'srcset="/media/img/test-high-res.png 1.5x" ' 'data-test-attr="test">'
-        self.assertEqual(markup, expected)
-
-    def test_high_res_img_with_l10n(self):
-        """Should return expected markup with l10n image path"""
-        l10n_url = self._render_l10n("test.png")
-        l10n_hr_url = misc.convert_to_high_res(l10n_url)
-        markup = self._render("test.png", {"l10n": True})
-        expected = '<img class="" src="' + l10n_url + '" ' 'srcset="' + l10n_hr_url + ' 1.5x">'
-        self.assertEqual(markup, expected)
-
-        l10n_url = self._render_l10n("img/test.png")
-        l10n_hr_url = misc.convert_to_high_res(l10n_url)
-        markup = self._render("test.png", {"l10n": True})
-        expected = '<img class="" src="' + l10n_url + '" ' 'srcset="' + l10n_hr_url + ' 1.5x">'
-        self.assertEqual(markup, expected)
-
-    def test_high_res_img_with_l10n_and_optional_attributes(self):
-        """Should return expected markup with l10n image path"""
-        l10n_url = self._render_l10n("test.png")
-        l10n_hr_url = misc.convert_to_high_res(l10n_url)
-        markup = self._render("test.png", {"l10n": True, "data-test-attr": "test"})
-        expected = '<img class="" src="' + l10n_url + '" ' 'srcset="' + l10n_hr_url + ' 1.5x" data-test-attr="test">'
-        self.assertEqual(markup, expected)
-
-
-@override_settings(STATIC_URL="/media/")
 class TestRespImg(TestCase):
     rf = RequestFactory()
 

--- a/bedrock/pocket/templates/pocket/jobs.html
+++ b/bedrock/pocket/templates/pocket/jobs.html
@@ -18,7 +18,16 @@
   <div class="mzp-l-content mzp-t-content-xl pocket-jobs-wrapper">
     <h1>Join the Pocket Team</h1>
     <figure>
-      {{ high_res_img('img/pocket/jobs/jobs-team.jpg', {'alt': '', 'width': '745', 'height': '408'}) }}
+      {{ resp_img(
+        url='img/pocket/jobs/jobs-team.jpg',
+        srcset={
+          'img/pocket/jobs/jobs-team-high-res.jpg': '2x'
+        },
+        optional_attributes={
+          'width': '745',
+          'height': '408'
+        }
+      ) }}
       <figcaption>Photo by Gaurang Katre</figcaption>
     </figure>
     <p>We invite you to become a vital part of our small team in San Francisco. We’re building a company that enables people to save and consume content that is worthy of both their time and attention. By doing so, we want to make it easier to spend time with more high-quality content, no matter how noisy it gets.</p>
@@ -31,10 +40,28 @@
       <a href="https://www.mozilla.org/en-US/careers/listings/?team=Core%20Product-Pocket" target="_blank" rel="external noopener">See our latest job openings</a>
       <figure class="figure-group" role="group">
         <figure>
-          {{ high_res_img('img/pocket/jobs/jobs-chat.jpg', {'alt': '', 'width': '360', 'height': '240'}) }}
+          {{ resp_img(
+            url='img/pocket/jobs/jobs-chat.jpg',
+            srcset={
+              'img/pocket/jobs/jobs-chat-high-res.jpg': '2x'
+            },
+            optional_attributes={
+              'width': '360',
+              'height': '240'
+            }
+          ) }}
         </figure>
         <figure>
-          {{ high_res_img('img/pocket/jobs/jobs-planning.jpg', {'alt': '', 'width': '360', 'height': '240'}) }}
+          {{ resp_img(
+            url='img/pocket/jobs/jobs-planning.jpg',
+            srcset={
+              'img/pocket/jobs/jobs-planning-high-res.jpg': '2x'
+            },
+            optional_attributes={
+              'width': '360',
+              'height': '240'
+            }
+          ) }}
         </figure>
         <figcaption>Photo by <a href="http://www.themogli.com/" target="_blank" rel="external noopener">Mogli</a></figcaption>
       </figure>

--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -74,7 +74,7 @@
 </section>
 {%- endmacro %}
 
-{% macro vpn_platform_hero(heading, subheading, desc, image_url) -%}
+{% macro vpn_platform_hero(heading, subheading, desc, image) -%}
 <section class="vpn-hero">
   <div class="mzp-l-content mzp-t-content-xl">
     <div class="vpn-hero-container">
@@ -87,7 +87,7 @@
         </div>
       </div>
       <div class="vpn-hero-image">
-        {{ high_res_img(image_url, {'alt': image_alt, 'width': '480', 'height': '480'}) }}
+        {{ image }}
       </div>
     </div>
   </div>
@@ -178,11 +178,11 @@
 </div>
 {%- endmacro %}
 
-{% macro vpn_content_media(heading, image_url, class_name=None, has_outline=False, loading='lazy') -%}
+{% macro vpn_content_media(heading, image, class_name=None, has_outline=False) -%}
   <section class="vpn-content-media {% if has_outline %}has-outline{% endif %} {% if class_name %}{{ class_name }}{% endif %}">
     <div class="vpn-content-media-image-container">
       <div class="vpn-content-media-image">
-        {{ high_res_img(image_url, {'alt': image_alt, 'width': '480', 'height': '480', 'loading': loading}) }}
+        {{ image }}
       </div>
     </div>
 

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -81,17 +81,35 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-landing-privacy-heading'),
-      image_url='img/products/vpn/landing/vpn-cntwell-01.png',
+      image=resp_img(
+        url='img/products/vpn/landing/vpn-cntwell-01.png',
+        srcset={
+          'img/products/vpn/landing/vpn-cntwell-01-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-landing-privacy-desc') }}</p>
     {% endcall %}
 
     {% call vpn_content_media(
       heading=ftl('vpn-landing-fast-secure-heading'),
-      image_url='img/products/vpn/landing/vpn-cntwell-02.png',
+      image=resp_img(
+        url='img/products/vpn/landing/vpn-cntwell-02.png',
+        srcset={
+          'img/products/vpn/landing/vpn-cntwell-02-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>
@@ -105,7 +123,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-landing-brand-trust-heading'),
-      image_url='img/products/vpn/landing/vpn-cntwell-03.png',
+      image=resp_img(
+        url='img/products/vpn/landing/vpn-cntwell-03.png',
+        srcset={
+          'img/products/vpn/landing/vpn-cntwell-03-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
       has_outline=True
     ) %}
@@ -115,7 +143,17 @@
     {% if vpn_available %}
       {% call vpn_content_media(
         heading=ftl('vpn-shared-features-server-countries', servers=connect_servers, countries=connect_countries),
-        image_url='img/products/vpn/landing/vpn-cntwell-05-v2.png',
+        image=resp_img(
+          url='img/products/vpn/landing/vpn-cntwell-05-v2.png',
+          srcset={
+            'img/products/vpn/landing/vpn-cntwell-05-v2-high-res.png': '2x'
+          },
+          optional_attributes={
+            'width': '480',
+            'height': '480',
+            'loading': 'lazy'
+          }
+        ),
         class_name='vpn-content-media-left-half vpn-connect-to-countries-and-servers'
       ) %}
         <p>{{ ftl('vpn-shared-features-full-list-servers', url='https://mullvad.net/servers/', attrs='target="_blank" rel="external noopener noreferrer"') }}</p>
@@ -131,7 +169,17 @@
     {% else %}
       {% call vpn_content_media(
         heading=ftl('vpn-shared-countries-coming-soon', countries=available_countries),
-        image_url='img/products/vpn/landing/vpn-cntwell-05-v2.png',
+        image=resp_img(
+          url='img/products/vpn/landing/vpn-cntwell-05-v2.png',
+          srcset={
+            'img/products/vpn/landing/vpn-cntwell-05-v2-high-res.png': '2x'
+          },
+          optional_attributes={
+            'width': '480',
+            'height': '480',
+            'loading': 'lazy'
+          }
+        ),
         class_name='vpn-content-media-left-half vpn-more-countries-coming-soon'
       ) %}
 
@@ -153,7 +201,17 @@
       <div id="bundle">
         {% call vpn_content_media(
           heading=ftl('vpn-shared-increase-your-privacy'),
-          image_url='img/products/vpn/landing/vpn-cntwell-06.png',
+          image=resp_img(
+            url='img/products/vpn/landing/vpn-cntwell-06.png',
+            srcset={
+              'img/products/vpn/landing/vpn-cntwell-06-high-res.png': '2x'
+            },
+            optional_attributes={
+              'width': '480',
+              'height': '480',
+              'loading': 'lazy'
+            }
+          ),
           class_name='vpn-content-media-right-half vpn-content-block-relay-bundle-promo'
         ) %}
           <p>

--- a/bedrock/products/templates/products/vpn/platforms/android.html
+++ b/bedrock/products/templates/products/vpn/platforms/android.html
@@ -44,7 +44,16 @@
       heading=ftl('vpn-shared-product-name'),
       subheading=ftl('vpn-android-hero-headline'),
       desc=ftl('vpn-android-page-description'),
-      image_url='img/products/vpn/platforms/vpn-hero-mobile.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-mobile.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-mobile-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
@@ -56,10 +65,18 @@
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-privacy-promise'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-android-maker-of-firefox') }}</p>
       <p>{{ ftl('vpn-android-ability') }}</p>
@@ -67,7 +84,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-what-youll-get'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <ul class="mzp-u-list-styled vpn-feature-list">
@@ -81,7 +108,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-android-wifi-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
     ) %}
       <p>{{ ftl('vpn-android-wifi-copy') }}</p>
@@ -89,7 +126,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-android-privacy-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <p>{{ ftl('vpn-android-privacy-copy') }}</p>
@@ -97,7 +144,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-android-servers-headline', servers=vpn_servers, countries=vpn_countries),
-      image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
     ) %}
       <p>{{ ftl('vpn-android-servers-copy', countries=vpn_countries) }}</p>
@@ -105,7 +162,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-android-devices-headline', devices=vpn_devices),
-      image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <p>{{ ftl('vpn-android-devices-copy', devices=vpn_devices) }}</p>
@@ -113,7 +180,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-android-speed-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
     ) %}
       <p>{{ ftl('vpn-android-speed-copy') }}</p>
@@ -121,7 +198,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-android-log-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <p>{{ ftl('vpn-android-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/platforms/desktop.html
+++ b/bedrock/products/templates/products/vpn/platforms/desktop.html
@@ -44,7 +44,16 @@
       heading=ftl('vpn-shared-product-name'),
       subheading=ftl('vpn-desktop-hero-headline'),
       desc=ftl('vpn-desktop-page-description'),
-      image_url='img/products/vpn/platforms/vpn-hero-desktop.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
@@ -56,10 +65,18 @@
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-privacy-promise'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-desktop-ability', devices=vpn_devices) }}</p>
       <p>{{ ftl('vpn-desktop-maker-of-firefox') }}</p>
@@ -67,7 +84,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-what-youll-get'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <ul class="mzp-u-list-styled vpn-feature-list">
@@ -81,7 +108,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-desktop-wifi-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
     ) %}
       <p>{{ ftl('vpn-desktop-wifi-copy') }}</p>
@@ -89,7 +126,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-desktop-privacy-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <p>{{ ftl('vpn-desktop-privacy-copy') }}</p>
@@ -97,7 +144,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-desktop-servers-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
     ) %}
       <p>{{ ftl('vpn-desktop-servers-copy-updated', fallback='vpn-desktop-servers-copy', servers=vpn_servers) }}</p>
@@ -105,7 +162,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-desktop-devices-headline', devices=vpn_devices),
-      image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <p>{{ ftl('vpn-desktop-devices-copy') }}</p>
@@ -113,7 +180,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-desktop-speed-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half',
     ) %}
       <p>{{ ftl('vpn-desktop-speed-copy') }}</p>
@@ -121,7 +198,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-desktop-log-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half',
     ) %}
       <p>{{ ftl('vpn-desktop-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/platforms/ios.html
+++ b/bedrock/products/templates/products/vpn/platforms/ios.html
@@ -44,7 +44,16 @@
       heading=ftl('vpn-shared-product-name'),
       subheading=ftl('vpn-ios-hero-headline'),
       desc=ftl('vpn-ios-page-description'),
-      image_url='img/products/vpn/platforms/vpn-hero-mobile.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-mobile.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-mobile-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
@@ -56,10 +65,18 @@
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-privacy-promise'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-ios-ability') }}</p>
       <p>{{ ftl('vpn-ios-maker-of-firefox') }}</p>
@@ -67,7 +84,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-what-youll-get'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <ul class="mzp-u-list-styled vpn-feature-list">
@@ -81,7 +108,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-ios-wifi-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-ios-wifi-copy') }}</p>
@@ -89,7 +126,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-ios-privacy-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-ios-privacy-copy') }}</p>
@@ -97,7 +144,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-ios-servers-headline', servers=vpn_servers),
-      image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-ios-servers-copy', countries=vpn_countries) }}</p>
@@ -105,7 +162,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-ios-devices-headline', devices=vpn_devices),
-      image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-ios-devices-copy', devices=vpn_devices) }}</p>
@@ -113,7 +180,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-ios-speed-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-ios-speed-copy') }}</p>
@@ -121,7 +198,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-ios-log-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-ios-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/platforms/linux.html
+++ b/bedrock/products/templates/products/vpn/platforms/linux.html
@@ -44,7 +44,16 @@
       heading=ftl('vpn-shared-product-name'),
       subheading=ftl('vpn-linux-hero-headline'),
       desc=ftl('vpn-linux-page-description'),
-      image_url='img/products/vpn/platforms/vpn-hero-desktop.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
@@ -56,10 +65,18 @@
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-privacy-promise'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-linux-ability') }}</p>
       <p>{{ ftl('vpn-linux-maker-of-firefox') }}</p>
@@ -67,7 +84,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-what-youll-get'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <ul class="mzp-u-list-styled vpn-feature-list">
@@ -81,7 +108,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-linux-wifi-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-linux-wifi-copy') }}</p>
@@ -89,7 +126,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-linux-privacy-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-linux-privacy-copy') }}</p>
@@ -97,7 +144,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-linux-servers-headline', servers=vpn_servers, countries=vpn_countries),
-      image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-linux-servers-copy', countries=vpn_countries) }}</p>
@@ -105,7 +162,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-linux-devices-headline', devices=vpn_devices),
-      image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-linux-devices-copy', devices=vpn_devices) }}</p>
@@ -113,7 +180,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-linux-speed-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-linux-speed-copy') }}</p>
@@ -121,7 +198,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-linux-log-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-linux-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/platforms/mac.html
+++ b/bedrock/products/templates/products/vpn/platforms/mac.html
@@ -44,7 +44,16 @@
       heading=ftl('vpn-shared-product-name'),
       subheading=ftl('vpn-mac-hero-headline'),
       desc=ftl('vpn-mac-page-description'),
-      image_url='img/products/vpn/platforms/vpn-hero-desktop.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
@@ -56,17 +65,35 @@
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-privacy-promise'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-mac-ability') }}</p>
     {% endcall %}
 
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-what-youll-get'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <ul class="mzp-u-list-styled vpn-feature-list">
@@ -80,7 +107,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mac-wifi-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-mac-wifi-copy') }}</p>
@@ -88,7 +125,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mac-privacy-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-mac-privacy-copy') }}</p>
@@ -96,7 +143,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mac-servers-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-mac-servers-copy', servers=vpn_servers, countries=vpn_countries) }}</p>
@@ -104,7 +161,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mac-devices-headline', devices=vpn_devices),
-      image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-mac-devices-copy', devices=vpn_devices) }}</p>
@@ -112,7 +179,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mac-speed-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-mac-speed-copy') }}</p>
@@ -120,7 +197,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mac-log-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-mac-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/platforms/mobile.html
+++ b/bedrock/products/templates/products/vpn/platforms/mobile.html
@@ -44,7 +44,16 @@
       heading=ftl('vpn-shared-product-name'),
       subheading=ftl('vpn-mobile-hero-headline'),
       desc=ftl('vpn-mobile-page-description'),
-      image_url='img/products/vpn/platforms/vpn-hero-mobile.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-mobile.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-mobile-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
     ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button') }}</a>
       <p class="guarantee-copy">
@@ -56,10 +65,18 @@
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-privacy-promise'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      ),
       class_name='vpn-content-media-right-half',
-      has_outline=True,
-      loading='eager'
+      has_outline=True
     ) %}
       <p>{{ ftl('vpn-mobile-maker-of-firefox') }}</p>
       <p>{{ ftl('vpn-mobile-ability', devices=vpn_devices) }}</p>
@@ -67,7 +84,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-shared-platform-what-youll-get'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <ul class="mzp-u-list-styled vpn-feature-list">
@@ -81,7 +108,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mobile-wifi-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-public-wifi-mobile-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-mobile-wifi-copy') }}</p>
@@ -89,7 +126,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mobile-privacy-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-mobile-privacy-copy') }}</p>
@@ -97,7 +144,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mobile-servers-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-mobile-servers-copy', servers=vpn_servers, countries=vpn_countries) }}</p>
@@ -105,7 +162,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mobile-devices-headline', devices=vpn_devices),
-      image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-mobile-devices-copy') }}</p>
@@ -113,7 +180,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mobile-speed-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-right-half'
     ) %}
       <p>{{ ftl('vpn-mobile-speed-copy') }}</p>
@@ -121,7 +198,17 @@
 
     {% call vpn_content_media(
       heading=ftl('vpn-mobile-log-headline'),
-      image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480',
+          'loading': 'lazy'
+        }
+      ),
       class_name='vpn-content-media-left-half'
     ) %}
       <p>{{ ftl('vpn-mobile-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/platforms/platform-base.html
+++ b/bedrock/products/templates/products/vpn/platforms/platform-base.html
@@ -31,7 +31,16 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       heading=ftl('vpn-shared-product-name'),
       subheading=subheading,
       desc=desc,
-      image_url='img/products/vpn/platforms/vpn-hero-desktop.png'
+      image=resp_img(
+        url='img/products/vpn/platforms/vpn-hero-desktop.png',
+        srcset={
+          'img/products/vpn/platforms/vpn-hero-desktop-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '480',
+          'height': '480'
+        }
+      )
       ) %}
       <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-subscribe-link')}}</a>
       <p class="guarantee-copy">

--- a/bedrock/products/templates/products/vpn/platforms/windows.html
+++ b/bedrock/products/templates/products/vpn/platforms/windows.html
@@ -45,7 +45,16 @@ alt_link_text='vpn-shared-platform-cta-button',
   heading=ftl('vpn-shared-product-name'),
   subheading=ftl('vpn-windows-hero-headline'),
   desc=ftl('vpn-windows-page-description'),
-  image_url='img/products/vpn/platforms/vpn-hero-desktop.png'
+  image=resp_img(
+    url='img/products/vpn/platforms/vpn-hero-desktop.png',
+    srcset={
+      'img/products/vpn/platforms/vpn-hero-desktop-high-res.png': '2x'
+    },
+    optional_attributes={
+      'width': '480',
+      'height': '480'
+    }
+  )
   ) %}
   <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-platform-cta-button')
     }}</a>
@@ -58,17 +67,35 @@ alt_link_text='vpn-shared-platform-cta-button',
   <div class="mzp-l-content mzp-t-content-xl">
     {% call vpn_content_media(
     heading=ftl('vpn-shared-platform-privacy-promise'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-privacy-promise.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-privacy-promise-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480'
+      }
+    ),
     class_name='vpn-content-media-right-half',
-    has_outline=True,
-    loading='eager'
+    has_outline=True
     ) %}
     <p>{{ ftl('vpn-windows-ability') }}</p>
     {% endcall %}
 
     {% call vpn_content_media(
     heading=ftl('vpn-shared-platform-what-youll-get'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-check-mark.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-check-mark-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-left-half'
     ) %}
     <ul class="mzp-u-list-styled vpn-feature-list">
@@ -82,7 +109,17 @@ alt_link_text='vpn-shared-platform-cta-button',
 
     {% call vpn_content_media(
     heading=ftl('vpn-windows-wifi-headline'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-public-wifi-desktop-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-right-half'
     ) %}
     <p>{{ ftl('vpn-windows-wifi-copy') }}</p>
@@ -90,7 +127,17 @@ alt_link_text='vpn-shared-platform-cta-button',
 
     {% call vpn_content_media(
     heading=ftl('vpn-windows-privacy-headline'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-one-click.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-one-click-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-left-half'
     ) %}
     <p>{{ ftl('vpn-windows-privacy-copy') }}</p>
@@ -98,7 +145,17 @@ alt_link_text='vpn-shared-platform-cta-button',
 
     {% call vpn_content_media(
     heading=ftl('vpn-windows-servers-headline'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-globe.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-globe-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-right-half'
     ) %}
     <p>{{ ftl('vpn-windows-servers-copy', servers=vpn_servers, countries=vpn_countries) }}</p>
@@ -106,7 +163,17 @@ alt_link_text='vpn-shared-platform-cta-button',
 
     {% call vpn_content_media(
     heading=ftl('vpn-windows-devices-headline'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-devices.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-devices-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-left-half'
     ) %}
     <p>{{ ftl('vpn-windows-devices-copy', devices=vpn_devices) }}</p>
@@ -114,7 +181,17 @@ alt_link_text='vpn-shared-platform-cta-button',
 
     {% call vpn_content_media(
     heading=ftl('vpn-windows-speed-headline'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-speed-guage.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-speed-guage-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-right-half'
     ) %}
     <p>{{ ftl('vpn-windows-speed-copy') }}</p>
@@ -122,7 +199,17 @@ alt_link_text='vpn-shared-platform-cta-button',
 
     {% call vpn_content_media(
     heading=ftl('vpn-windows-log-headline'),
-    image_url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+    image=resp_img(
+      url='img/products/vpn/platforms/vpn-cntwell-privacy.png',
+      srcset={
+        'img/products/vpn/platforms/vpn-cntwell-privacy-high-res.png': '2x'
+      },
+      optional_attributes={
+        'width': '480',
+        'height': '480',
+        'loading': 'lazy'
+      }
+    ),
     class_name='vpn-content-media-left-half'
     ) %}
     <p>{{ ftl('vpn-windows-log-copy') }}</p>

--- a/bedrock/products/templates/products/vpn/pricing-refresh.html
+++ b/bedrock/products/templates/products/vpn/pricing-refresh.html
@@ -5,7 +5,6 @@
 #}
 
 {% from "macros-protocol.html" import split with context %}
-{% from "products/vpn/includes/macros.html" import vpn_content_media with context %}
 
 {% extends "products/vpn/base.html" %}
 

--- a/bedrock/products/templates/products/vpn/pricing.html
+++ b/bedrock/products/templates/products/vpn/pricing.html
@@ -54,7 +54,17 @@
     {% else %}
       {% call vpn_content_media(
         heading=ftl('vpn-shared-countries-coming-soon', countries=available_countries),
-        image_url='img/products/vpn/landing/vpn-cntwell-05-v2.png',
+        image=resp_img(
+          url='img/products/vpn/landing/vpn-cntwell-05-v2.png',
+          srcset={
+            'img/products/vpn/landing/vpn-cntwell-05-v2-high-res.png': '2x'
+          },
+          optional_attributes={
+            'width': '480',
+            'height': '480',
+            'loading': 'lazy'
+          }
+        ),
         class_name='vpn-content-media-left-half vpn-more-countries-coming-soon'
       ) %}
 

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -617,34 +617,6 @@ Like ``resp_img()``, the ``picture()`` helper also supports L10n images and othe
         }
     )
 
-high_res_img() (deprecated)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-
-    The ``high_res_img()`` helper is now deprecated in favor of ``resp_img()``. If an image is large enough that it gets
-    scaled down at smaller viewport sizes, then you should probably be serving a responsive image. For cases where you
-    only really want to serve a high resolution alternative, then you can still do this using ``resp_img()`` (see the
-    example in the docs above).
-
-For images that include a high-resolution alternative for displays with a high pixel density, use the ``high_res_img()`` function:
-
-.. code-block:: python
-
-    high_res_img("img/firefox/new/firefox-logo.png", {"alt": "Firefox", "width": "200", "height": "100"})
-
-The ``high_res_img()`` function will automatically look for the image in the URL parameter suffixed with
-``'-high-res'``, e.g. ``img/firefox/new/firefox-logo-high-res.png`` and switch to it if the display has high pixel density.
-
-``high_res_img()`` supports localized images by setting the ``'l10n'`` parameter to ``True```:
-
-.. code-block:: python
-
-    high_res_img("img/firefox/new/firefox-logo.png", {"l10n": True, "alt": "Firefox", "width": "200", "height": "100"})
-
-When using localization, ``high_res_img()`` will look for images in the appropriate locale folder. In the above example,
-for the `de` locale, both standard and high-res versions of the image should be located at ``media/img/l10n/de/firefox/new/``.
-
 Which image helper should you use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## One-line summary

Removes all usage of `high_res_img()` and replaces it with `resp_img()`, so we finally have just a single image helper that can do everything :)

## Significant changes and points to review

Did i miss any stray occurrences of `high_res_img()`

**Note:** For the VPN platform pages, you may need to switch the template that gets shown in the view in order to see the older pages: https://github.com/mozilla/bedrock/blob/main/bedrock/products/views.py#L216-L217

## Issue / Bugzilla link

#13227

## Testing

- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/android/
- [ ] http://localhost:8000/en-US/firefox/browsers/chromebook/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/brave/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/chrome/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/edge/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/ie/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/opera/
- [ ] http://localhost:8000/en-US/firefox/browsers/compare/safari/
- [ ] http://localhost:8000/en-US/firefox/browsers/
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile/
- [ ] http://localhost:8000/en-US/firefox/developer/
- [ ] http://localhost:8000/en-US/firefox/features/adblocker/
- [ ] http://localhost:8000/en-US/firefox/flashback/
- [ ] http://localhost:8000/en-US/firefox/more/misinformation/
- [ ] http://localhost:8000/en-US/firefox/new/
- [ ] http://localhost:8000/en-US/firefox/products/
- [ ] http://localhost:8000/en-US/foundation/annualreport/2011/
- [ ] http://localhost:8000/en-US/foundation/trademarks/list/
- [ ] http://localhost:8000/en-US/about/legal/
- [ ] http://localhost:8000/en-US/about/
- [ ] http://localhost:8000/en-US/about/leadership/
- [ ] http://localhost:8000/en-US/about/leadership/senior-leadership/
- [ ] http://localhost:8000/en-US/about/leadership/mozilla-foundation/
- [ ] http://localhost:8000/en-US/about/leadership/reps-council/
- [ ] http://localhost:8000/en-US/about/leadership/boards-of-directors/
- [ ] http://localhost:8000/en-US/about/manifesto/
- [ ] http://localhost:8000/en-US/about/policy/lean-data/
- [ ] http://localhost:8000/en-US/about/policy/lean-data/stay-lean/
- [ ] http://localhost:8000/en-US/about/policy/lean-data/build-security/
- [ ] http://localhost:8000/en-US/about/policy/lean-data/engage-users/
- [ ] http://localhost:8000/en-US/contact/spaces/san-francisco/
- [ ] http://localhost:8000/en-US/contact/spaces/beijing/
- [ ] http://localhost:8000/en-US/contact/spaces/berlin/
- [ ] http://localhost:8000/en-US/contact/spaces/paris/
- [ ] http://localhost:8000/en-US/contact/spaces/toronto/
- [ ] http://localhost:8000/en-US/contribute/
- [ ] http://localhost:8000/en-US/
- [ ] http://localhost:8000/de/
- [ ] http://localhost:8000/fr/
- [ ] http://localhost:8000/es-ES/
- [ ] http://localhost:8000/en-US/moss/
- [ ] http://localhost:8000/de/products/vpn/
- [ ] http://localhost:8000/en-US/products/vpn/mobile/android/
- [ ] http://localhost:8000/en-US/products/vpn/mobile/ios/
- [ ] http://localhost:8000/en-US/products/vpn/mobile/
- [ ] http://localhost:8000/en-US/products/vpn/desktop/
- [ ] http://localhost:8000/en-US/products/vpn/desktop/windows/
- [ ] http://localhost:8000/en-US/products/vpn/desktop/mac/
- [ ] http://localhost:8000/en-US/products/vpn/desktop/linux/
- [ ] http://localhost:8000/en-US/products/vpn/pricing/
- [ ] http://localhost:8000/de/products/vpn/pricing/?geo=cn

In Pocket mode:

- [ ] http://localhost:8000/en/jobs/
