### PR TITLE
Update Brave browser comparison page for screenshot feature (Fixes #13471)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -164,7 +164,7 @@
             <tr>
               <th scope="row">{{ ftl('compare-shared-in-browser-screenshot-tool') }}</th>
               <td><img alt="{{ ftl('compare-shared-yes') }}" src="{{ static('img/firefox/compare/icon-check.svg') }}" height="24" width="24"></td>
-              <td><img alt="{{ ftl('compare-shared-no') }}" src="{{ static('img/firefox/compare/icon-dash.svg') }}" height="24" width="24"></td>
+              <td><img alt="{{ ftl('compare-shared-yes') }}" src="{{ static('img/firefox/compare/icon-check.svg') }}" height="24" width="24"></td>
             </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## One-line summary

Brave now supports an in-browser screenshot feature.

## Issue / Bugzilla link

#13471

## Testing

http://localhost:8000/en-US/firefox/browsers/compare/brave/