### PR TITLE
Update glean server endpoint (Fixes #13481)

### DIFF
--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -12,6 +12,7 @@ import Utils from './utils.es6';
 const shouldInitialize = Utils.hasValidURLScheme(window.location.href);
 
 function initGlean() {
+    const endpoint = 'https://www.mozilla.org';
     const channel =
         window.location.href.indexOf('https://www.mozilla.org/') === -1
             ? 'non-prod'
@@ -37,7 +38,8 @@ function initGlean() {
 
     Glean.initialize('bedrock', Utils.isTelemetryEnabled(), {
         channel: channel,
-        maxEvents: 1 // Set max events to 1 so pings are sent as soon as registered.
+        maxEvents: 1, // Set max events to 1 so pings are sent as soon as registered.
+        serverEndpoint: endpoint
     });
 }
 


### PR DESCRIPTION
## One-line summary

Adds `serverEndpoint` config to initializing Glean, that points to our own origin.

## Issue / Bugzilla link

#13481

## Testing

On page load you should see posts successfully sent to www.mozilla.org 

<img width="935" alt="image" src="https://github.com/mozilla/bedrock/assets/400117/e1029c0d-a435-4983-ae1a-9954ddbf9973">