### PR TITLE
Fix typo in WNP 116 for DE

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-de.html
@@ -27,7 +27,7 @@
       </a>
     </div>
 
-    <h2 class="wnp-main-title">Nimm dieses Video mito</h2>
+    <h2 class="wnp-main-title">Nimm dieses Video mit</h2>
     <p class="wnp-main-tagline has-pip-icon">
       Befreie Videos von ihren Seiten mit dem überarbeiteten „Bild-im-Bild“-Feature. Probier es direkt mit dem Video über diesem Text. Drück auf play und anschließend auf <strong>das „Bild-im-Bild“-Symbol</strong>, um das Video zu lösen.
     </p>


### PR DESCRIPTION
## One-line summary

Hanns (our German copywriter) says we only need to update the headline, the other two items in the bug are intentional.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1846578

## Testing

http://localhost:8000/de/firefox/116.0/whatsnew/