### PR TITLE
Fix disappearing reader mode icon on WNP (Fixes #13484)

### DIFF
--- a/media/js/firefox/whatsnew/whatsnew-116-na.js
+++ b/media/js/firefox/whatsnew/whatsnew-116-na.js
@@ -52,6 +52,18 @@ function init() {
     });
 
     Mozilla.UITour.forceShowReaderIcon();
+
+    // show reader mode icon again on visibility change
+    // see https://github.com/mozilla/bedrock/issues/13484
+    document.addEventListener(
+        'visibilitychange',
+        () => {
+            if (!document.hidden) {
+                Mozilla.UITour.forceShowReaderIcon();
+            }
+        },
+        false
+    );
 }
 
 if (


### PR DESCRIPTION
## One-line summary

Adds a `visibilitychange` listener, to make sure we show the icon again after exit from reader mode

## Significant changes and points to review

Note: this bug isn't reproducible locally, but shows itself on demo https://www-demo1.allizom.org/en-US/firefox/116.0/whatsnew/

## Issue / Bugzilla link

#13484

## Testing

https://www-demo1.allizom.org/en-US/firefox/116.0/whatsnew/
