### PR TITLE
Fix meta titles and add meta description for sustainability pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/sustainability/carbon-neutral.html
+++ b/bedrock/mozorg/templates/mozorg/sustainability/carbon-neutral.html
@@ -6,6 +6,8 @@
 
 {% extends "mozorg/sustainability/index.html" %}
 
+{% block page_title %}Mozilla is CarbonNeutralⓇ certified{% endblock %}
+
 {% block content %}
   <main>
   <section class="mzp-l-content">

--- a/bedrock/mozorg/templates/mozorg/sustainability/emissions-data.html
+++ b/bedrock/mozorg/templates/mozorg/sustainability/emissions-data.html
@@ -6,6 +6,8 @@
 
 {% extends "mozorg/sustainability/index.html" %}
 
+{% block page_title %}Mozilla Emissions Data{% endblock %}
+
 {% block content %}
   <main>
   <section class="mzp-l-content">

--- a/bedrock/mozorg/templates/mozorg/sustainability/index.html
+++ b/bedrock/mozorg/templates/mozorg/sustainability/index.html
@@ -8,7 +8,8 @@
 
 {% from "macros.html" import sub_nav with context %}
 
-{% block page_title %}Mozilla is CarbonNeutralⓇ certified{% endblock %}
+{% block page_title %}Sustainability at Mozilla{% endblock %}
+{% block page_desc %}Mozilla supports a sustainable future for all{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('sustainability') }}


### PR DESCRIPTION
## One-line summary
I updated the Sustainability report title to something more appropriate for each page, and added a meta description that suits the report pages 🍀

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/13458

## Testing

- [ ] http://localhost:8000/en-US/sustainability/
- [ ] http://localhost:8000/en-US/sustainability/carbon-neutral/
- [ ] http://localhost:8000/en-US/sustainability/emissions-data/
