### PR TITLE
Add WNP 117 for EU (Reader mode) (Fixes #13480)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-de-reader-view.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-de-reader-view.html
@@ -1,0 +1,99 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}Was ist neu in Firefox?{% endblock %}
+
+{#- This will appear as <meta property="og:description"> which can be used for social share -#}
+{% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_117_eu_reader_view') }}
+{% endblock %}
+
+{% block experiments %}
+  {% if switch('experiment-firefox-whatsnew-117-eu-reader-view') %}
+    {{ js_bundle('firefox_whatsnew_117_eu_reader_view_experiment') }}
+  {% endif %}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_header %}
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      <h2 class="c-page-header-logo-fx">{{ ftl('whatsnew-firefox') }}</h2>
+      {# aside is used to hide notification content from reader mode #}
+      <aside class="c-page-header-notification">
+        <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+          <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
+        </div>
+        <div class="mzp-c-notification-bar out-of-date">
+          {% if ftl_has_messages('whatsnew-out-of-date-notification-v3') %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v3', url='https://support.mozilla.org/kb/update-firefox-latest-release?' + utm_params) }}</p>
+          {% else %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v2') }}</p>
+          {% endif %}
+        </div>
+      </aside>
+    </div>
+  </header>
+{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="wnp-grid mzp-l-content mzp-t-content-lg">
+      <div class="wnp-grid-body">
+        <h2 class="wnp-main-title">Reduzier Websites aufs Wesentliche</h2>
+
+        <p class="wnp-main-tagline has-reader-icon">
+          {% if variant == '2' %}
+            Klicke auf <strong>das Leseansicht-Symbol</strong> in der Firefox-Adressleiste und zack:
+            keine Werbung, Buttons, Hintergrundfarben oder Videos auf den Webseiten, die du dir
+            anschaust.
+          {% else %}
+            Hast du schon mal von einer Webseite gehört, die durch Werbung besser wurde? Wir auch
+            nicht. Klicke auf <strong>das Leseansicht-Symbol</strong> in der Firefox-Adressleiste
+            und lass alles verschwinden, was nicht Teil des Contents ist.
+          {% endif %}
+        </p>
+
+        <p class="wnp-main-cta try-reader-view">
+          <a class="mzp-c-button mzp-t-product" href="https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages?{{ utm_params }}" data-cta-text="Try Reader View" data-cta-type="button">
+            Teste die Leseansicht
+          </a>
+        </p>
+      </div>
+
+      <p class="wnp-sign-off">
+        <strong>Powered by Mozilla.</strong> Für dich und das Web. Schon seit 1998.
+      </p>
+
+      <div class="wnp-grid-head">
+        <div class="eyesore eyesore-one" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col1">
+        <div class="eyesore eyesore-two" role="presentation"></div>
+        <div class="eyesore eyesore-three" role="presentation"></div>
+        <div class="eyesore eyesore-four" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col2">
+        <div class="eyesore eyesore-five" role="presentation"></div>
+        <div class="eyesore eyesore-six" role="presentation"></div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_117_eu_reader_view') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-fr-reader-view.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-fr-reader-view.html
@@ -1,0 +1,100 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}Les nouveautés de Firefox{% endblock %}
+
+{#- This will appear as <meta property="og:description"> which can be used for social share -#}
+{% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_117_eu_reader_view') }}
+{% endblock %}
+
+{% block experiments %}
+  {% if switch('experiment-firefox-whatsnew-117-eu-reader-view') %}
+    {{ js_bundle('firefox_whatsnew_117_eu_reader_view_experiment') }}
+  {% endif %}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_header %}
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      <h2 class="c-page-header-logo-fx">{{ ftl('whatsnew-firefox') }}</h2>
+      {# aside is used to hide notification content from reader mode #}
+      <aside class="c-page-header-notification">
+        <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+          <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
+        </div>
+        <div class="mzp-c-notification-bar out-of-date">
+          {% if ftl_has_messages('whatsnew-out-of-date-notification-v3') %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v3', url='https://support.mozilla.org/kb/update-firefox-latest-release?' + utm_params) }}</p>
+          {% else %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v2') }}</p>
+          {% endif %}
+        </div>
+      </aside>
+    </div>
+  </header>
+{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="wnp-grid mzp-l-content mzp-t-content-lg">
+      <div class="wnp-grid-body">
+        <h2 class="wnp-main-title">Le web, simplifié</h2>
+
+        <p class="wnp-main-tagline has-reader-icon">
+          {% if variant == '2' %}
+            Cliquez sur l’icône <strong>symbole mode lecture</strong> dans la barre d’adresse
+            de Firefox, et voilà ! Plus de pubs, boutons, couleurs de fond ou vidéos sur la
+            page web que vous visitez.
+          {% else %}
+            Avez-vous déjà vu une page web rendue meilleure par la pub ? Nous non plus.
+            Cliquez sur l’icône <strong>symbole du mode lecture</strong> dans la barre
+            d’adresse de Firefox et nettoyez vos pages de ce que vous n’êtes pas venu
+            lire.
+          {% endif %}
+        </p>
+
+        <p class="wnp-main-cta try-reader-view">
+          <a class="mzp-c-button mzp-t-product" href="https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages?{{ utm_params }}" data-cta-text="Try Reader View" data-cta-type="button">
+            Essayer le mode lecture
+          </a>
+        </p>
+      </div>
+
+      <p class="wnp-sign-off">
+        <strong>Conçu par Mozilla.</strong> Pensé pour vous depuis 1998
+      </p>
+
+      <div class="wnp-grid-head">
+        <div class="eyesore eyesore-one" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col1">
+        <div class="eyesore eyesore-two" role="presentation"></div>
+        <div class="eyesore eyesore-three" role="presentation"></div>
+        <div class="eyesore eyesore-four" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col2">
+        <div class="eyesore eyesore-five" role="presentation"></div>
+        <div class="eyesore eyesore-six" role="presentation"></div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_117_eu_reader_view') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-uk-reader-view.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-uk-reader-view.html
@@ -1,0 +1,99 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/whatsnew/base.html" %}
+
+{% block page_title %}What’s new with Firefox{% endblock %}
+
+{#- This will appear as <meta property="og:description"> which can be used for social share -#}
+{% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
+
+{% block body_id %}firefox-whatsnew{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_117_eu_reader_view') }}
+{% endblock %}
+
+{% block experiments %}
+  {% if switch('experiment-firefox-whatsnew-117-eu-reader-view') %}
+    {{ js_bundle('firefox_whatsnew_117_eu_reader_view_experiment') }}
+  {% endif %}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block wnp_header %}
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      <h2 class="c-page-header-logo-fx">{{ ftl('whatsnew-firefox') }}</h2>
+      {# aside is used to hide notification content from reader mode #}
+      <aside class="c-page-header-notification">
+        <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+          <p>{{ ftl('whatsnew-up-to-date-notification-v2', fallback='whatsnew-up-to-date-notification') }}</p>
+        </div>
+        <div class="mzp-c-notification-bar out-of-date">
+          {% if ftl_has_messages('whatsnew-out-of-date-notification-v3') %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v3', url='https://support.mozilla.org/kb/update-firefox-latest-release?' + utm_params) }}</p>
+          {% else %}
+            <p>{{ ftl('whatsnew-out-of-date-notification-v2') }}</p>
+          {% endif %}
+        </div>
+      </aside>
+    </div>
+  </header>
+{% endblock %}
+
+{% block wnp_content %}
+  <section class="wnp-content-main">
+    <div class="wnp-grid mzp-l-content mzp-t-content-lg">
+      <div class="wnp-grid-body">
+        <h2 class="wnp-main-title">Webpages, simplified</h2>
+
+        <p class="wnp-main-tagline has-reader-icon">
+          {% if variant == '2' %}
+            Click the little <strong>Reader View</strong> icon in Firefox’s address bar,
+            and boom. No more ads, buttons, background colours or videos on webpages
+            you’re viewing.
+          {% else %}
+            Ever heard of a webpage made better by its ads? Us neither. Click on the
+            <strong>Reader View</strong> icon in Firefox’s URL bar, and get rid of
+            everything that’s distracting you from what you actually came to read.
+          {% endif %}
+        </p>
+
+        <p class="wnp-main-cta try-reader-view">
+          <a class="mzp-c-button mzp-t-product" href="https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages?{{ utm_params }}" data-cta-text="Try Reader View" data-cta-type="button">
+            Try Reader View
+          </a>
+        </p>
+      </div>
+
+      <p class="wnp-sign-off">
+        <strong>Powered by Mozilla.</strong> Putting people before profits since 1998.
+      </p>
+
+      <div class="wnp-grid-head">
+        <div class="eyesore eyesore-one" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col1">
+        <div class="eyesore eyesore-two" role="presentation"></div>
+        <div class="eyesore eyesore-three" role="presentation"></div>
+        <div class="eyesore eyesore-four" role="presentation"><span></span></div>
+      </div>
+
+      <div class="wnp-grid-col2">
+        <div class="eyesore eyesore-five" role="presentation"></div>
+        <div class="eyesore eyesore-six" role="presentation"></div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_update') }}
+  {{ js_bundle('firefox_whatsnew_117_eu_reader_view') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -668,6 +668,46 @@ class TestWhatsNew(TestCase):
 
     # end 116.0 whatsnew tests
 
+    # begin 117.0 whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_117_0_0_en_gb(self, render_mock):
+        """Should use whatsnew-fx117-uk-reader-view template for en-GB locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-GB"
+        self.view(req, version="117.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx117-uk-reader-view.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_117_0_0_en_us_gb(self, render_mock):
+        """Should use whatsnew-fx117-uk-reader-view template for en-US locale if country is GB"""
+        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="GB")
+        req.locale = "en-US"
+        self.view(req, version="117.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx117-uk-reader-view.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_117_0_0_de(self, render_mock):
+        """Should use whatsnew-fx117-de-reader-view template for de locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "de"
+        self.view(req, version="117.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx117-de-reader-view.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_117_0_0_fr(self, render_mock):
+        """Should use whatsnew-fx117-fr-reader-view template for fr locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "fr"
+        self.view(req, version="117.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx117-fr-reader-view.html"]
+
+    # end 117.0 whatsnew tests
+
 
 @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
 class TestFirstRun(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -409,6 +409,9 @@ class WhatsnewView(L10nTemplateView):
         "firefox/whatsnew/whatsnew-fx116-uk.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx116-de.html": ["firefox/whatsnew/whatsnew"],
         "firefox/whatsnew/whatsnew-fx116-fr.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx117-de-reader-view.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx117-fr-reader-view.html": ["firefox/whatsnew/whatsnew"],
+        "firefox/whatsnew/whatsnew-fx117-uk-reader-view.html": ["firefox/whatsnew/whatsnew"],
     }
 
     # specific templates that should not be rendered in
@@ -418,18 +421,13 @@ class WhatsnewView(L10nTemplateView):
     ]
 
     # place expected ?v= values in this list
-    variations = ["1", "2", "3", "4", "5", "6"]
+    variations = ["1", "2"]
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         version = self.kwargs.get("version") or ""
         pre_release_channels = ["nightly", "developer", "beta"]
         channel = detect_channel(version)
-
-        # activate en-GB locale for 113.0 WNP
-        locale = l10n_utils.get_locale(self.request)
-        if locale == "en-GB" and version.startswith("113.") and channel not in pre_release_channels:
-            ctx["active_locales"] = locale
 
         # add version to context for use in templates
         match = re.match(r"\d{1,3}", version)
@@ -487,6 +485,18 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/developer/whatsnew.html"
             elif show_57_dev_whatsnew(version):
                 template = "firefox/developer/whatsnew.html"
+            else:
+                template = "firefox/whatsnew/index.html"
+        elif version.startswith("117."):
+            if locale.startswith("en-"):
+                if locale == "en-GB" or country == "GB":
+                    template = "firefox/whatsnew/whatsnew-fx117-uk-reader-view.html"
+                else:
+                    template = "firefox/whatsnew/index.html"
+            elif locale == "de":
+                template = "firefox/whatsnew/whatsnew-fx117-de-reader-view.html"
+            elif locale == "fr":
+                template = "firefox/whatsnew/whatsnew-fx117-fr-reader-view.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("116."):

--- a/media/css/firefox/whatsnew/whatsnew-117-eu-reader-view.scss
+++ b/media/css/firefox/whatsnew/whatsnew-117-eu-reader-view.scss
@@ -1,0 +1,326 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import 'includes/base';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+
+:root {
+    --main-bg-color: #{$color-violet-05};
+    --eyesore-bg-color: rgba(255, 255, 255, 0.8);
+    --eyesore-text-color: #{$color-violet-05};
+}
+
+.wnp-content-main {
+    color: $color-black;
+    margin-top: $spacing-md;
+    overflow: hidden;
+    text-align: center;
+}
+
+// Hide the eyesores on mobile
+.wnp-grid-head,
+.wnp-grid-col1,
+.wnp-grid-col2 {
+    display: none;
+}
+
+.wnp-grid-body {
+    max-width: $content-sm;
+    margin: 0 auto;
+}
+
+.wnp-main-title {
+    @include text-title-xl;
+    padding-top: $layout-lg;
+    position: relative;
+
+    &::before {
+        background: transparent url("/media/img/firefox/whatsnew/whatsnew117-eu/reader-icon.svg") center top / contain no-repeat;
+        content: "";
+        display: block;
+        height: 40px;
+        left: 50%;
+        margin-left: -20px;
+        position: absolute;
+        top: 0;
+        width: 40px;
+    }
+}
+
+.wnp-main-tagline {
+    @include text-body-lg;
+    color: $color-black;
+}
+
+.has-reader-icon strong {
+    @include image-replaced;
+    @include background-size(2ex, 2ex);
+    background-image: url("/media/img/firefox/whatsnew/whatsnew117-eu/reader-icon.svg");
+    background-repeat: no-repeat;
+    display: inline-block;
+    height: 2ex;
+    margin-bottom: -0.25ex;
+    width: 2ex;
+}
+
+// ---------------------------------------------------------------------------*/
+// All the bells and whistles
+
+@media #{$mq-md} and (prefers-reduced-motion: no-preference) {
+    .wnp-grid {
+        display: grid;
+        grid-gap: $spacing-md;
+        grid-template-columns: 1fr 3fr 1fr;
+        grid-template-rows: 90px 1fr 90px;
+    }
+
+    .wnp-sign-off {
+        grid-column: 1 / span 3;
+        grid-row: 3;
+    }
+
+    .wnp-grid-body {
+        grid-column: 2;
+        grid-row: 2;
+        max-width: none;
+        padding: $spacing-2xl $spacing-lg;
+    }
+
+    .wnp-grid-head {
+        display: block;
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .wnp-grid-col1 {
+        display: grid;
+        grid-column: 1;
+        grid-gap: $spacing-md;
+        grid-row: 1 / span 2;
+        grid-template-rows: 1fr 2fr 1.5fr;
+    }
+
+    .wnp-grid-col2 {
+        display: grid;
+        grid-column: 3;
+        grid-gap: $spacing-md;
+        grid-row: 1 / span 2;
+        grid-template-rows: 2fr 1fr;
+    }
+
+    .wnp-content-main {
+        animation: mainbg 500ms 3250ms ease-in forwards;
+        background-color: var(--main-bg-color);
+    }
+
+    .wnp-main-title {
+        margin-top: -$layout-lg;
+
+        &::before {
+            animation: fade-in 300ms 3200ms ease-in forwards, pop 400ms 3200ms ease-in forwards;
+            transform: scale(0.9);
+            opacity: 0;
+        }
+    }
+
+    .eyesore {
+        background-color: var(--eyesore-bg-color);
+        box-sizing: border-box;
+        color: var(--eyesore-text-color);
+        padding: $spacing-md $spacing-lg;
+        position: relative;
+        text-align: start;
+    }
+
+    .eyesore-one {
+        animation: eyesore-one 1000ms 2500ms ease-in forwards, fade-out 500ms 3500ms ease-out forwards;
+        min-height: 90px;
+
+        span {
+            left: $spacing-lg;
+            max-width: 60%;
+            position: absolute;
+            top: $spacing-md;
+
+            &::before {
+                @include box-decoration-break(clone);
+                background: var(--eyesore-text-color);
+                color: transparent;
+                content: "The 91 best clickbait listicles of the week so far. Number 36 will shock you!";
+                display: inline;
+                font-size: 12px;
+            }
+        }
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            content: "";
+            height: 2em;
+            position: absolute;
+            right: $spacing-lg;
+            width: 20%;
+        }
+    }
+
+    .eyesore-two,
+    .eyesore-three,
+    .eyesore-five {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+
+        &::before {
+            @include text-title-xs;
+            content: "Ad";
+            font-weight: bold;
+        }
+    }
+
+    .eyesore-two {
+        animation: eyesore-two 1000ms 2200ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+    }
+
+    .eyesore-three {
+        animation: eyesore-three 1000ms 2750ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+    }
+
+    .eyesore-four {
+        animation: eyesore-four 1000ms 2400ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+
+        span {
+            left: $spacing-lg;
+            max-width: 60%;
+            position: absolute;
+            top: $spacing-md;
+
+            &::before {
+                @include box-decoration-break(clone);
+                background: var(--eyesore-text-color);
+                color: transparent;
+                content: "Lose weight fast by emptying your wallet!";
+                display: inline;
+                font-size: 12px;
+            }
+        }
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            bottom: $spacing-md;
+            content: "";
+            display: block;
+            height: 1.5em;
+            position: absolute;
+            right: $spacing-lg;
+            width: 50%;
+        }
+    }
+
+    .eyesore-five {
+        animation: eyesore-five 1000ms 2880ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            bottom: $spacing-md;
+            content: "";
+            display: block;
+            height: 1.5em;
+            left: $spacing-lg;
+            position: absolute;
+            right: $spacing-lg;
+        }
+    }
+
+    .eyesore-six {
+        animation: eyesore-six 1000ms 2220ms ease-in forwards, fade-out 500ms 3500ms ease-in forwards;
+
+        &::before {
+            background: var(--eyesore-text-color);
+            content: "";
+            display: block;
+            height: 50%;
+            width: 100%;
+        }
+
+        &::after {
+            background: var(--eyesore-text-color);
+            border-radius: $border-radius-sm;
+            bottom: $spacing-md;
+            content: "";
+            display: block;
+            height: 1.5em;
+            left: $spacing-lg;
+            position: absolute;
+            right: $spacing-lg;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------*/
+// Animations
+
+@keyframes fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes pop {
+    0% { transform: scale(0.9); }
+    25% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+@keyframes eyesore-one {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    50% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(25deg); }
+}
+
+@keyframes eyesore-two {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    50% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(-16deg); }
+}
+
+@keyframes eyesore-three {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    52% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(-20deg); }
+}
+
+@keyframes eyesore-four {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    48% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(16deg); }
+}
+
+@keyframes eyesore-five {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    50% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(22deg); }
+}
+
+@keyframes eyesore-six {
+    15% { transform: translateY(2px); }
+    30% { transform: translateY(-5px) scale(1.02); }
+    54% { transform: translateY(-5px) scale(1.02); }
+    100% { transform: translateY(150vh) scale(1.02) rotate(-18deg); }
+}
+
+@keyframes mainbg {
+    to { background-color: transparent; }
+}

--- a/media/img/firefox/whatsnew/whatsnew117-eu/reader-icon.svg
+++ b/media/img/firefox/whatsnew/whatsnew117-eu/reader-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" x="0" y="0" version="1.1" viewBox="0 0 16 16" width="16" height="16">
+  <style>
+    .st0{fill:none;stroke:#000;stroke-width:1.7131;stroke-linecap:round}
+  </style>
+  <path d="M5.5 4.5h4.8" class="st0"/>
+  <path d="M5.5 7.7h4.8" class="st0"/>
+  <path d="M5.5 10.9h2.2" class="st0"/>
+  <path fill="none" stroke="#000" stroke-width="1.7131" d="M3.4.9h9.1c.8 0 1.4.6 1.4 1.4v11.3c0 .8-.6 1.4-1.4 1.4H3.4c-.8 0-1.4-.6-1.4-1.4V2.3C2 1.5 2.6.9 3.4.9z"/>
+</svg>

--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -277,6 +277,10 @@ if (typeof window.Mozilla === 'undefined') {
         });
     };
 
+    Mozilla.UITour.toggleReaderMode = function () {
+        _sendEvent('toggleReaderMode');
+    };
+
     Mozilla.UITour.forceShowReaderIcon = function () {
         _sendEvent('forceShowReaderIcon');
     };

--- a/media/js/firefox/whatsnew/whatsnew-117-eu-reader-view.js
+++ b/media/js/firefox/whatsnew/whatsnew-117-eu-reader-view.js
@@ -1,0 +1,47 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function init() {
+    'use strict';
+
+    Mozilla.UITour.ping(() => {
+        // main CTA toggles reader mode
+        const button = document.querySelector('.wnp-main-cta .mzp-c-button');
+
+        button.addEventListener(
+            'click',
+            (e) => {
+                e.preventDefault();
+
+                Mozilla.UITour.toggleReaderMode();
+            },
+            false
+        );
+
+        // force show reader mode icon in Firefox UI bar
+        Mozilla.UITour.forceShowReaderIcon();
+
+        // show reader mode icon again on visibility change
+        // see https://github.com/mozilla/bedrock/issues/13484
+        document.addEventListener(
+            'visibilitychange',
+            () => {
+                if (!document.hidden) {
+                    Mozilla.UITour.forceShowReaderIcon();
+                }
+            },
+            false
+        );
+    });
+}
+
+if (
+    typeof window.Mozilla.Client !== 'undefined' &&
+    typeof window.Mozilla.UITour !== 'undefined' &&
+    window.Mozilla.Client.isFirefoxDesktop
+) {
+    init();
+}

--- a/media/js/firefox/whatsnew/whatsnew-117-experiment-eu-reader-view.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-117-experiment-eu-reader-view.es6.js
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrafficCop from '@mozmeao/trafficcop';
+import { isApprovedToRun } from '../../base/experiment-utils.es6.js';
+
+const href = window.location.href;
+
+const initTrafficCop = () => {
+    if (href.indexOf('v=') !== -1) {
+        if (href.indexOf('v=1') !== -1) {
+            window.dataLayer.push({
+                'data-ex-variant': 'wnp117-eu-reader-view-v1',
+                'data-ex-name': 'wnp117-eu-reader-view'
+            });
+        } else if (href.indexOf('v=2') !== -1) {
+            window.dataLayer.push({
+                'data-ex-variant': 'wnp117-eu-reader-view-v2',
+                'data-ex-name': 'wnp117-eu-reader-view'
+            });
+        }
+    } else if (TrafficCop) {
+        const columbo = new TrafficCop({
+            id: 'exp-wnp-117-eu-reader-view',
+            cookieExpires: 0,
+            variations: {
+                'v=1': 50,
+                'v=2': 50
+            }
+        });
+        columbo.init();
+    }
+};
+
+// Avoid entering automated tests into random experiments.
+if (isApprovedToRun()) {
+    initTrafficCop();
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -457,6 +457,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-117-eu-reader-view.scss"
+      ],
+      "name": "firefox_whatsnew_117_eu_reader_view"
+    },
+    {
+      "files": [
         "css/firefox/privacy/common.scss"
       ],
       "name": "firefox-privacy-common"
@@ -1618,6 +1624,18 @@
         "js/firefox/whatsnew/whatsnew-116-na.js"
       ],
       "name": "firefox_whatsnew_116_na"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-117-eu-reader-view.js"
+      ],
+      "name": "firefox_whatsnew_117_eu_reader_view"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-117-experiment-eu-reader-view.es6.js"
+      ],
+      "name": "firefox_whatsnew_117_eu_reader_view_experiment"
     },
     {
       "files": [

--- a/tests/functional/firefox/whatsnew/test_whatsnew_117.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_117.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.whatsnew.whatsnew_117 import FirefoxWhatsNew117Page
+
+
+@pytest.mark.skip_if_not_firefox(reason="Whatsnew pages are shown to Firefox only.")
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("locale", [("de"), ("fr"), ("en-GB")])
+def test_try_reader_view_button_displayed(locale, base_url, selenium):
+    page = FirefoxWhatsNew117Page(selenium, base_url, locale=locale).open()
+    assert page.is_try_reader_view_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_117.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_117.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class FirefoxWhatsNew117Page(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/117.0/whatsnew/"
+
+    _try_reader_view_button_locator = (By.CSS_SELECTOR, ".wnp-main-cta.try-reader-view .mzp-c-button")
+
+    @property
+    def is_try_reader_view_button_displayed(self):
+        return self.is_element_displayed(*self._try_reader_view_button_locator)


### PR DESCRIPTION
## One-line summary

Adds WNP for Firefox 117 for `/de/`, `/fr/`, and `/en-GB/` promoting reader view.

## Significant changes and points to review

Unlike the NA version that this design is using, clicking the main CTA button now triggers Reader View directly (via [UITour](https://bedrock.readthedocs.io/en/latest/uitour.html)), rather than linking off to SUMO. If JS is disabled, the CTA should still go to SUMO like a normal link.

There's also a 50/50 split A/B test for each locale, where each variation displays slightly different tagline copy.

## Issue / Bugzilla link

#13480

## Testing

Clicking "Try Reader View" should activate reader view. Reader view icon should also be displayed in the Firefox address bar on page load.

- [x] http://localhost:8000/en-GB/firefox/117.0/whatsnew/?v=1
- [x] http://localhost:8000/en-GB/firefox/117.0/whatsnew/?v=2
- [x] http://localhost:8000/de/firefox/117.0/whatsnew/?v=1
- [x] http://localhost:8000/defirefox/117.0/whatsnew/?v=2
- [x] http://localhost:8000/fr/firefox/117.0/whatsnew/?v=1
- [x] http://localhost:8000/fr/firefox/117.0/whatsnew/?v=2

URLs should trigger traffic cop redirects (test with DNT disabled):

- http://localhost:8000/en-GB/firefox/117.0/whatsnew/
- http://localhost:8000/de/firefox/117.0/whatsnew/
- http://localhost:8000/fr/firefox/117.0/whatsnew/

UK template should be displayed for `/en-US/` locale when viewed in GB:

 - http://localhost:8000/en-US/firefox/117.0/whatsnew/?geo=gb