### PR TITLE
Update Glean.js to v2.0.0 (Fixes #13493)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@mozilla-protocol/core": "^17.0.1",
-        "@mozilla/glean": "^1.4.0",
+        "@mozilla/glean": "^2.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2056,11 +2056,11 @@
       "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.4.0.tgz",
-      "integrity": "sha512-16YgRBPexUtgGD13dnAYYmHeeEzatQ2wSFuwopNvXuy4CeJw3xpJ+N4fVjnMJtQffpp89l2f4BvKva+eAmmBPg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.0.tgz",
+      "integrity": "sha512-4cVhtcWGkLb+KA+SGae0e68PGGNGFr/6nEi2M49J5EgFpEfNrzEAffJCi9PuKetjNeMdkFD6ZetSBvOJbrslEA==",
       "dependencies": {
-        "fflate": "^0.7.1",
+        "fflate": "^0.8.0",
         "jose": "^4.0.4",
         "tslib": "^2.3.1",
         "uuid": "^9.0.0"
@@ -5099,9 +5099,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -11936,11 +11936,11 @@
       "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
     },
     "@mozilla/glean": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-1.4.0.tgz",
-      "integrity": "sha512-16YgRBPexUtgGD13dnAYYmHeeEzatQ2wSFuwopNvXuy4CeJw3xpJ+N4fVjnMJtQffpp89l2f4BvKva+eAmmBPg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.0.tgz",
+      "integrity": "sha512-4cVhtcWGkLb+KA+SGae0e68PGGNGFr/6nEi2M49J5EgFpEfNrzEAffJCi9PuKetjNeMdkFD6ZetSBvOJbrslEA==",
       "requires": {
-        "fflate": "^0.7.1",
+        "fflate": "^0.8.0",
         "jose": "^4.0.4",
         "tslib": "^2.3.1",
         "uuid": "^9.0.0"
@@ -14272,9 +14272,9 @@
       }
     },
     "fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@mozilla-protocol/core": "^17.0.1",
-    "@mozilla/glean": "^1.4.0",
+    "@mozilla/glean": "^2.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -431,9 +431,9 @@ freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
     # via -r requirements/dev.in
-glean-parser==7.2.1 \
-    --hash=sha256:11496ac004fe421b914c7fbdc9a1d620e4821d56e1d9f65523d3858cdb907bbd \
-    --hash=sha256:651cfee34422ea1db90bbf1cb03732bd8c598773bf95daa289a62addeaf10295
+glean-parser==8.1.1 \
+    --hash=sha256:5fdd123d9711032a4e2acfa7983cbbfa6a53a29f7270dbe52be9e5ee1790a0f8 \
+    --hash=sha256:6d49e0c0aac34a1e9eda7fc63b12f1513efed1c827e0ac94078493114049021e
     # via -r requirements/prod.txt
 greenlet==0.4.17 \
     --hash=sha256:1023d7b43ca11264ab7052cb09f5635d4afdb43df55e0854498fc63070a0b206 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -27,7 +27,7 @@ envcat==0.1.1
 everett==3.2.0
 fluent.runtime==0.4.0
 fluent.syntax==0.19.0
-glean-parser==7.2.1  # Must match the required version in the Glean NPM package.
+glean-parser==8.1.1  # Must match the required version in the Glean NPM package.
 greenlet==0.4.17  # Pinned for stability but subdep of Meinheld
 gunicorn==19.7.1
 honcho==1.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -256,9 +256,9 @@ fluent-syntax==0.19.0 \
     # via
     #   -r requirements/prod.in
     #   fluent-runtime
-glean-parser==7.2.1 \
-    --hash=sha256:11496ac004fe421b914c7fbdc9a1d620e4821d56e1d9f65523d3858cdb907bbd \
-    --hash=sha256:651cfee34422ea1db90bbf1cb03732bd8c598773bf95daa289a62addeaf10295
+glean-parser==8.1.1 \
+    --hash=sha256:5fdd123d9711032a4e2acfa7983cbbfa6a53a29f7270dbe52be9e5ee1790a0f8 \
+    --hash=sha256:6d49e0c0aac34a1e9eda7fc63b12f1513efed1c827e0ac94078493114049021e
     # via -r requirements/prod.in
 greenlet==0.4.17 \
     --hash=sha256:1023d7b43ca11264ab7052cb09f5635d4afdb43df55e0854498fc63070a0b206 \


### PR DESCRIPTION
## One-line summary

- Bumps Glean.js to 2.0.0
- Bumps glean_parser to 8.1.1

## Issue / Bugzilla link

#13493

## Testing

- `make preflight`
- `npm start`