### PR TITLE
Revert "Update protocol to v18.0.0"

### DIFF
--- a/bedrock/products/templates/products/relay/includes/waitlist-base.html
+++ b/bedrock/products/templates/products/relay/includes/waitlist-base.html
@@ -11,7 +11,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% endblock %}
 
 {% block sub_navigation %}
-  {% include 'products/relay/includes/subnav.html' %}
+{% include 'products/relay/includes/subnav.html' %}
 {% endblock %}
 
 {% set product_name = product_name|default(ftl('waitlist-premium-name')) %}

--- a/media/css/firefox/all/all-unified.scss
+++ b/media/css/firefox/all/all-unified.scss
@@ -8,7 +8,7 @@ $font-path: '/media/protocol/fonts';
 $image-path: '/media/protocol/img';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/forms';
+@import '~@mozilla-protocol/core/protocol/css/includes/forms/lib';
 @import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
 @import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';

--- a/media/css/firefox/browsers/best-browser.scss
+++ b/media/css/firefox/browsers/best-browser.scss
@@ -13,14 +13,10 @@ $image-path: '/media/protocol/img';
 .seo-hero {
     background: $color-purple-90 url('/media/img/firefox/browsers/best-browser/hero-pattern.png') 55% 60% no-repeat;
     @include background-size(2500px);
-    color: $body-text-color-inverse;
+    color: get-theme('body-text-color-inverse');
     text-align: center;
     min-height: 520px;
     margin-bottom: $spacing-xl;
-
-    @supports (--css: variables) {
-        color: var(--body-text-color-inverse);
-    }
 
     .hero-content {
         padding-top: $layout-xl;
@@ -34,13 +30,9 @@ $image-path: '/media/protocol/img';
         h1 {
             @include font-base;
             @include text-title-lg;
-            color: $title-text-color-inverse;
+            color: get-theme('title-text-color-inverse');
             margin: 0 auto $spacing-2xl;
             max-width: 580px;
-
-            @supports (--css: variables) {
-                color: var(--title-text-color-inverse);
-            }
         }
 
         p {

--- a/media/css/firefox/browsers/windows-64-bit.scss
+++ b/media/css/firefox/browsers/windows-64-bit.scss
@@ -11,14 +11,10 @@ $image-path: '/media/protocol/img';
 
 .c-hero {
     background: $color-purple-90;
-    color: $body-text-color-inverse;
+    color: get-theme('body-text-color-inverse');
     text-align: center;
     min-height: 500px;
     margin-bottom: $spacing-xl;
-
-    @supports (--css: variables) {
-        color: var(--body-text-color-inverse);
-    }
 
     .hero-content {
         padding-top: $layout-xl;
@@ -30,12 +26,8 @@ $image-path: '/media/protocol/img';
 
         h1 {
             @include text-title-lg;
-            color: $title-text-color-inverse;
+            color: get-theme('title-text-color-inverse');
             margin: 0 auto $spacing-2xl;
-
-            @supports (--css: variables) {
-                color: var(--title-text-color-inverse);
-            }
 
             @media #{$mq-lg} {
                 width: 400px;

--- a/media/css/firefox/challenge-the-default/index.scss
+++ b/media/css/firefox/challenge-the-default/index.scss
@@ -11,7 +11,7 @@ $font-path: '/media/protocol/fonts';
 @import "./compare-table";
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/forms';
+@import '~@mozilla-protocol/core/protocol/css/includes/forms/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/modal';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';

--- a/media/css/firefox/family/components/_dad-jokes-banner.scss
+++ b/media/css/firefox/family/components/_dad-jokes-banner.scss
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @use '../utils' as f3;
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 
 .no-js .c-dad-jokes-banner {

--- a/media/css/firefox/features/safebrowser.scss
+++ b/media/css/firefox/features/safebrowser.scss
@@ -11,14 +11,10 @@ $image-path: '/media/protocol/img';
 
 .c-hero {
     background: $color-purple-90;
-    color: $body-text-color-inverse;
+    color: get-theme('body-text-color-inverse');
     text-align: center;
     min-height: 520px;
     margin-bottom: $spacing-xl;
-
-    @supports (--css: variables) {
-        color: var(--body-text-color-inverse);
-    }
 
     .hero-content {
         padding-top: $layout-xl;
@@ -32,13 +28,9 @@ $image-path: '/media/protocol/img';
         h1 {
             @include font-base;
             @include text-title-lg;
-            color: $title-text-color-inverse;
+            color: get-theme('title-text-color-inverse');
             margin: 0 auto $spacing-2xl;
             max-width: 580px;
-
-            @supports (--css: variables) {
-                color: var(--title-text-color-inverse);
-            }
         }
 
         p {

--- a/media/css/firefox/firstrun/nightly.scss
+++ b/media/css/firefox/firstrun/nightly.scss
@@ -31,15 +31,11 @@ main {
 
 .contribute-title {
     @include text-title-xs;
-    color: $title-text-color-inverse;
+    color: get-theme('title-text-color-inverse');
     font-weight: normal;
     margin: $spacing-lg auto;
     max-width: 580px;
     text-align: center;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color-inverse);
-    }
 }
 
 .contribute-list {

--- a/media/css/firefox/welcome10.scss
+++ b/media/css/firefox/welcome10.scss
@@ -31,26 +31,18 @@ $image-path: '/media/protocol/img';
 
 .c-pre-title {
     @include text-title-2xs;
-    color: $title-text-color;
+    color: get-theme('title-text-color');
     font-weight: bold;
     margin: 0 auto $spacing-xl;
     max-width: 750px;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
 }
 
 .c-main-title {
     @include text-title-md;
-    color: $title-text-color;
+    color: get-theme('title-text-color');
     max-width: 750px;
     margin-left: auto;
     margin-right: auto;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
 
     strong {
         color: $color-violet-50;

--- a/media/css/firefox/welcome11.scss
+++ b/media/css/firefox/welcome11.scss
@@ -31,13 +31,9 @@ $image-path: '/media/protocol/img';
 
 .c-main-title {
     @include text-title-md;
-    color: $title-text-color;
+    color: get-theme('title-text-color');
     margin-left: auto;
     margin-right: auto;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
 
     strong {
         color: $color-violet-50;
@@ -93,20 +89,12 @@ $image-path: '/media/protocol/img';
 
     #outer-wrapper {
         background: $color-dark-gray-60;
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-                color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .c-main-title,
     .mzp-c-picto-title {
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .c-main-image {

--- a/media/css/firefox/welcome12.scss
+++ b/media/css/firefox/welcome12.scss
@@ -31,13 +31,9 @@ $image-path: '/media/protocol/img';
 
 .c-main-title {
     @include text-title-md;
-    color: $title-text-color;
+    color: get-theme('title-text-color');
     margin-left: auto;
     margin-right: auto;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
 
     strong {
         color: $color-violet-50;
@@ -104,20 +100,12 @@ $image-path: '/media/protocol/img';
 
     #outer-wrapper {
         background: $color-dark-gray-60;
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .c-main-title,
     .mzp-c-picto-title {
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .c-main-image {

--- a/media/css/firefox/welcome13.scss
+++ b/media/css/firefox/welcome13.scss
@@ -31,13 +31,9 @@ $image-path: '/media/protocol/img';
 
 .c-main-title {
     @include text-title-md;
-    color: $title-text-color;
+    color: get-theme('title-text-color');
     margin-left: auto;
     margin-right: auto;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
 
     strong {
         color: $color-violet-50;
@@ -104,20 +100,12 @@ $image-path: '/media/protocol/img';
 
     #outer-wrapper {
         background: $color-dark-gray-60;
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .c-main-title,
     .mzp-c-picto-title {
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .c-main-image {

--- a/media/css/firefox/whatsnew/whatsnew-115-eu-ctd.scss
+++ b/media/css/firefox/whatsnew/whatsnew-115-eu-ctd.scss
@@ -2,8 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
 @import 'includes/base';
 @import 'includes/dark-mode';

--- a/media/css/firefox/whatsnew/whatsnew-115-eu-mobile.scss
+++ b/media/css/firefox/whatsnew/whatsnew-115-eu-mobile.scss
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import 'includes/base';

--- a/media/css/firefox/whatsnew/whatsnew-115-eu-vpn.scss
+++ b/media/css/firefox/whatsnew/whatsnew-115-eu-vpn.scss
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import 'includes/base';

--- a/media/css/firefox/whatsnew/whatsnew-account.scss
+++ b/media/css/firefox/whatsnew/whatsnew-account.scss
@@ -31,11 +31,7 @@ $image-path: '/media/protocol/img';
 
 .wnp-main-title {
     @include text-title-md;
-    color: $title-text-color;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
+    color: get-theme('title-text-color');
 }
 
 .wnp-main-tagline {
@@ -72,20 +68,12 @@ $image-path: '/media/protocol/img';
         color: $color-white;
 
         h2.thank-you {
-            color: $title-text-color-inverse;
-
-            @supports (--css: variables) {
-                color: var(--title-text-color-inverse);
-            }
+            color: get-theme('title-text-color-inverse');
         }
     }
 
     .wnp-main-title {
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
 
         strong {
             color: $color-violet-20;

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -38,14 +38,10 @@ body {
 
 .mzp-c-emphasis-box {
     @include border-box;
-    color: $body-text-color;
+    color: get-theme('body-text-color');
     margin: 0 auto $layout-sm;
     max-width: $content-md - ($layout-md * 2);
     padding: $spacing-xl;
-
-    @supports (--css: variables) {
-        color: var(--body-text-color);
-    }
 
     a:link,
     a:visited {
@@ -63,11 +59,7 @@ body {
 
     .c-emphasis-box-title {
         @include text-title-sm;
-        color: $title-text-color;
+        color: get-theme('title-text-color');
         text-align: center;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color);
-        }
     }
 }

--- a/media/css/firefox/whatsnew/whatsnew.scss
+++ b/media/css/firefox/whatsnew/whatsnew.scss
@@ -31,11 +31,7 @@ $image-path: '/media/protocol/img';
 
 .wnp-main-title {
     @include text-title-md;
-    color: $title-text-color;
-
-    @supports (--css: variables) {
-        color: var(--title-text-color);
-    }
+    color: get-theme('title-text-color');
 }
 
 .wnp-main-tagline {
@@ -55,22 +51,14 @@ $image-path: '/media/protocol/img';
 @media (prefers-color-scheme: dark) {
     .wnp-main-title,
     .c-picto-block .c-picto-block-title {
-        color: $title-text-color-inverse;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
+        color: get-theme('title-text-color-inverse');
     }
 
     .send-to-device {
         color: $color-white;
 
         h2.thank-you {
-            color: $title-text-color-inverse;
-
-            @supports (--css: variables) {
-                color: var(--title-text-color-inverse);
-            }
+            color: get-theme('title-text-color-inverse');
         }
     }
 }

--- a/media/css/foundation/annual-report-2019-2020.scss
+++ b/media/css/foundation/annual-report-2019-2020.scss
@@ -366,11 +366,7 @@ $image-path: '/media/protocol/img';
         &:hover,
         &:focus,
         &:active {
-            color: $link-color-hover;
-
-            @supports (--css: variables) {
-                color: var(--link-color-hover);
-            }
+            color: get-theme('link-color-hover');
         }
     }
 

--- a/media/css/foundation/annual-report-2021.scss
+++ b/media/css/foundation/annual-report-2021.scss
@@ -179,11 +179,7 @@ main {
         &:hover,
         &:focus,
         &:active {
-            color: $link-color-hover;
-
-            @supports (--css: variables) {
-                color: var(--link-color-hover);
-            }
+            color: get-theme('link-color-hover');
         }
     }
 

--- a/media/css/legal/legal.scss
+++ b/media/css/legal/legal.scss
@@ -2,7 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -69,26 +69,17 @@ dd {
 
 .c-page-header {
     @include text-title-xs;
-    background: $background-color-inverse;
-    color: $body-text-color-inverse;
+    background: get-theme('background-color-inverse');
+    color: get-theme('body-text-color-inverse');
 
     h1 {
-        color: $title-text-color-inverse;
+        color: get-theme('title-text-color-inverse');
     }
 
     span {
         @include text-title-xs;
         display: block;
         margin-top: $spacing-md;
-    }
-
-    @supports (--css: variables) {
-        background: var(--background-color-inverse);
-        color: var(--body-text-color-inverse);
-
-        h1 {
-            color: var(--title-text-color-inverse);
-        }
     }
 }
 

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -236,11 +236,7 @@ $image-path: '/media/protocol/img';
 .contribute-banner-gethelp {
     background: $color-ink-80 url('/media/img/contribute/contribute-gethelp-banner-bg.jpg') center top no-repeat;
     background-size: cover;
-    color: $body-text-color-inverse;
-
-    @supports (--css: variables) {
-        color: var(--body-text-color-inverse);
-    }
+    color: get-theme('body-text-color-inverse');
 
     @media #{$mq-lg} {
         margin-bottom: $layout-lg;
@@ -249,12 +245,8 @@ $image-path: '/media/protocol/img';
     .contribute-banner-gethelp-title {
         @include font-firefox;
         @include font-size(24px);
-        color: $title-text-color-inverse;
+        color: get-theme('title-text-color-inverse');
         position: relative;
-
-        @supports (--css: variables) {
-            color: var(--title-text-color-inverse);
-        }
 
         @media #{$mq-lg} {
             @include font-size(40px);

--- a/media/css/mozorg/diversity/diversity.scss
+++ b/media/css/mozorg/diversity/diversity.scss
@@ -225,11 +225,7 @@ $image-path: '/media/protocol/img';
         &:hover,
         &:focus,
         &:active {
-            color: $link-color-hover;
-
-            @supports (--css: variables) {
-                color: var(--link-color-hover);
-            }
+            color: get-theme('link-color-hover');
         }
     }
 

--- a/media/css/mozorg/home/home-mr2-promo.scss
+++ b/media/css/mozorg/home/home-mr2-promo.scss
@@ -34,13 +34,7 @@ $image-path: '/media/protocol/img';
 
     @media #{$mq-md} {
         .mzp-c-split-body {
-            @include bidi(((padding-left, $h-grid-sm, padding-right, $h-grid-sm),));
-
-            @supports (--css: variables) {
-                // css variables and  sass mixins don't work well together so we need to assign it to a sass variable before passing
-                $grid-sm: #{var(--h-grid-sm)};
-                @include bidi(((padding-left, $grid-sm, padding-right, $grid-sm), ));
-            }
+            @include bidi(((padding-left, get-theme('h-grid-sm'), padding-right, get-theme('h-grid-sm')),));
         }
 
         .c-fxpromo-title {
@@ -66,12 +60,7 @@ $image-path: '/media/protocol/img';
         }
 
         .mzp-c-split-body {
-            @include bidi(((padding-left, $h-grid-md, padding-right, $h-grid-md),));
-
-            @supports (--css: variables) {
-                $grid-md: #{var(--h-grid-md)};
-                @include bidi(((padding-left, $grid-md, padding-right, $grid-md), ));
-            }
+            @include bidi(((padding-left, get-theme('h-grid-md'), padding-right, get-theme('h-grid-md')),));
         }
 
         [lang^='en'] & .c-fxpromo-title {

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -18,11 +18,7 @@ $image-path: '/media/protocol/img';
 // * -------------------------------------------------------------------------- */
 // Billboard
 .mzp-c-billboard {
-    margin-top: $v-grid-xl;
-
-    @supports (--css: variables) {
-        margin-top: var(--v-grid-xl);
-    }
+    margin-top: get-theme('v-grid-xl');
 
     @media #{$mq-md} {
         margin-top: 0;

--- a/media/css/newsletter/newsletter-recovery.scss
+++ b/media/css/newsletter/newsletter-recovery.scss
@@ -2,11 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 /* stylelint-disable declaration-no-important */
 

--- a/media/css/pocket/components/updates-signup.scss
+++ b/media/css/pocket/components/updates-signup.scss
@@ -10,7 +10,7 @@
 @import '../includes/footer';
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/forms';
+@import '~@mozilla-protocol/core/protocol/css/includes/forms/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/base/elements/forms';
 @import '~@mozilla-protocol/core/protocol/css/components/button';

--- a/media/css/products/relay/waitlist.scss
+++ b/media/css/products/relay/waitlist.scss
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 @import '~@mozilla-protocol/core/protocol/css/components/forms/field';
 @import '@mozilla-protocol/core/protocol/css/components/newsletter-form';

--- a/media/css/products/vpn/components/pricing-basic.scss
+++ b/media/css/products/vpn/components/pricing-basic.scss
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';

--- a/media/css/protocol/basic-article.scss
+++ b/media/css/protocol/basic-article.scss
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/components/article';
 @import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
 @import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';

--- a/media/css/protocol/protocol-firefox.scss
+++ b/media/css/protocol/protocol-firefox.scss
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$brand-theme: 'firefox';
+$type-scale: 'standard';
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
 
 // These are general styles for elements/components that occur on every page.
 // Individual pages may include additional component styles as needed.
-
-@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($brand-theme: 'firefox', $type-scale: 'standard', $font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
-@use '~@mozilla-protocol/core/protocol/css/includes/themes';
-@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
 
 // Fonts
 @import '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
@@ -49,11 +49,7 @@
 }
 
 .mzp-c-newsletter-details legend {
-    font-family: $body-font-family;
-
-    @supports (--css:variables) {
-        font-family: var(--body-font-family);
-    }
+    font-family: get-theme('body-font-family');
 }
 
 #newsletter-submit + .mzp-c-fieldnote {
@@ -65,8 +61,8 @@
 .errorlist,
 .error-msg {
     @include light-links;
-    background-color: form.$form-red;
-    border-radius: form.$field-border-radius;
+    background-color: $form-red;
+    border-radius: $field-border-radius;
     color: $color-white;
     padding: $spacing-sm;
     margin-bottom: $spacing-xl;

--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -2,14 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
-
+$brand-theme: 'mozilla';
+$type-scale: 'standard';
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
 
 // These are general styles for elements/components that occur on every page.
 // Individual pages may include additional component styles as needed.
-@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($brand-theme: 'mozilla', $type-scale: 'standard', $font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
-@use '~@mozilla-protocol/core/protocol/css/includes/themes';
-@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
 
 // Fonts
 @import '~@mozilla-protocol/core/protocol/css/includes/fonts/inter';
@@ -29,7 +28,6 @@
 @import '~@mozilla-protocol/core/protocol/css/components/button';
 @import '~@mozilla-protocol/core/protocol/css/components/footer';
 @import '~@mozilla-protocol/core/protocol/css/components/language-switcher';
-
 @import 'components/download-button';
 
 // Custom global components for nav and footer
@@ -52,11 +50,7 @@
 }
 
 .mzp-c-newsletter-details legend {
-    font-family: $body-font-family;
-
-    @supports (--css: variables) {
-        font-family: var(--body-font-family);
-    }
+    font-family: get-theme('body-font-family');
 }
 
 #newsletter-submit + .mzp-c-fieldnote {
@@ -67,8 +61,8 @@
 // style classes automatically added by python to match Protocol form error styles
 .errorlist {
     @include white-links;
-    background-color: form.$form-red;
-    border-radius: form.$field-border-radius;
+    background-color: $form-red;
+    border-radius: $field-border-radius;
     color: $color-white;
     padding: $spacing-sm;
     margin-bottom: $spacing-xl;
@@ -76,8 +70,8 @@
 
 .error-msg {
     @include light-links;
-    background-color: form.$form-red;
-    border-radius: form.$field-border-radius;
+    background-color: $form-red;
+    border-radius: $field-border-radius;
     color: $color-white;
     padding: $spacing-sm;
     margin-bottom: $spacing-xl;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
-        "@mozilla-protocol/core": "^18.0.0",
+        "@mozilla-protocol/core": "^17.0.1",
         "@mozilla/glean": "^1.4.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
@@ -2051,9 +2051,9 @@
       "dev": true
     },
     "node_modules/@mozilla-protocol/core": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-18.0.0.tgz",
-      "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-17.0.1.tgz",
+      "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
     },
     "node_modules/@mozilla/glean": {
       "version": "1.4.0",
@@ -11931,9 +11931,9 @@
       "dev": true
     },
     "@mozilla-protocol/core": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-18.0.0.tgz",
-      "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-17.0.1.tgz",
+      "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
     },
     "@mozilla/glean": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
-    "@mozilla-protocol/core": "^18.0.0",
+    "@mozilla-protocol/core": "^17.0.1",
     "@mozilla/glean": "^1.4.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",


### PR DESCRIPTION
Reverts mozilla/bedrock#13146 because we have a regression related to at least one image disappearing from protocol, breaking the collection of static assets 

See https://mozilla.slack.com/archives/G7ACJHJCB/p1691403445675989 for discussion