### PR TITLE
Update NA WNP116 CTA [#13421]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx116-na.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}What’s new with Firefox{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
@@ -50,17 +50,9 @@
           bar, and boom. No more ads, buttons, background colors or videos on whatever
           webpage you’re viewing.</p>
 
-        <p class="cta-holder"><span></span></p>
-
-        <p class="wnp-main-cta fx-not-default">
-          <a class="mzp-c-button mzp-t-product" href="{{ url('firefox.set-as-default.thanks') }}" data-cta-type="button" data-cta-text="Always use Firefox">
-            Always use Firefox
-          </a>
-        </p>
-
-        <p class="wnp-main-cta fx-is-default">
-          <a class="mzp-c-button mzp-t-product" href="https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages" data-cta-text="Learn more" data-cta-type="button">
-            Learn more
+        <p class="wnp-main-cta try-reader-view">
+          <a class="mzp-c-button mzp-t-product" href="https://support.mozilla.org/kb/firefox-reader-view-clutter-free-web-pages?{{ utm_params }}" data-cta-text="Try Reader View" data-cta-type="button">
+            Try Reader View
           </a>
         </p>
       </div>

--- a/media/js/firefox/whatsnew/whatsnew-116-na.js
+++ b/media/js/firefox/whatsnew/whatsnew-116-na.js
@@ -4,66 +4,38 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-function defaultTrue() {
-    'use strict';
-
-    document.querySelector('.cta-holder').classList.add('hide');
-    document.querySelector('.fx-not-default').classList.add('hide');
-    document.querySelector('.fx-is-default').classList.add('show');
-
-    window.dataLayer.push({
-        event: 'non-interaction',
-        eAction: 'whatsnew-116-na',
-        eLabel: 'default-true'
-    });
-}
-
-function defaultFalse() {
-    'use strict';
-
-    document.querySelector('.cta-holder').classList.add('hide');
-    document.querySelector('.fx-is-default').classList.add('hide');
-    document.querySelector('.fx-not-default').classList.add('show');
-
-    window.dataLayer.push({
-        event: 'non-interaction',
-        eAction: 'whatsnew-116-na',
-        eLabel: 'default-false'
-    });
-}
-
 function init() {
     'use strict';
 
-    // If UITour is slow to respond, fallback to assuming Fx is not default.
-    const requestTimeout = window.setTimeout(defaultFalse, 2000);
+    Mozilla.UITour.ping(() => {
+        // main CTA toggles reader mode
+        const button = document.querySelector('.wnp-main-cta .mzp-c-button');
 
-    Mozilla.UITour.getConfiguration('appinfo', function (details) {
-        // Clear timeout as soon as we get a response.
-        window.clearTimeout(requestTimeout);
+        button.addEventListener(
+            'click',
+            (e) => {
+                e.preventDefault();
 
-        // If Firefox is already the default, show alternate call to action.
-        if (details.defaultBrowser) {
-            defaultTrue();
-            return;
-        }
+                Mozilla.UITour.toggleReaderMode();
+            },
+            false
+        );
 
-        defaultFalse();
+        // force show reader mode icon in Firefox UI bar
+        Mozilla.UITour.forceShowReaderIcon();
+
+        // show reader mode icon again on visibility change
+        // see https://github.com/mozilla/bedrock/issues/13484
+        document.addEventListener(
+            'visibilitychange',
+            () => {
+                if (!document.hidden) {
+                    Mozilla.UITour.forceShowReaderIcon();
+                }
+            },
+            false
+        );
     });
-
-    Mozilla.UITour.forceShowReaderIcon();
-
-    // show reader mode icon again on visibility change
-    // see https://github.com/mozilla/bedrock/issues/13484
-    document.addEventListener(
-        'visibilitychange',
-        () => {
-            if (!document.hidden) {
-                Mozilla.UITour.forceShowReaderIcon();
-            }
-        },
-        false
-    );
 }
 
 if (
@@ -72,9 +44,4 @@ if (
     window.Mozilla.Client.isFirefoxDesktop
 ) {
     init();
-} else {
-    // Fall back to learn more CTA if other checks fail
-    document.querySelector('.cta-holder').classList.add('hide');
-    document.querySelector('.fx-not-default').classList.add('hide');
-    document.querySelector('.fx-is-default').classList.add('show');
 }


### PR DESCRIPTION
## One-line summary

This removes the set-to-default alternative CTA and makes the main CTA trigger reader view. Also shortens the `<title>`.

## Testing

http://localhost:8000/en-US/firefox/116.0/whatsnew/