### PR TITLE
Bump Node to v18 (Fixes #13525)

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: "Install JS dependencies"
         run: npm ci
       - name: "Run JS tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --require-hashes --no-cache-dir -r requirements/prod.txt
 ########
 # assets builder and dev server
 #
-FROM node:16-slim AS assets
+FROM node:18-slim AS assets
 
 ENV PATH=/app/node_modules/.bin:$PATH
 WORKDIR /app


### PR DESCRIPTION
## One-line summary

Bumps Node to v18 in both Docker images and in CI for pull requests

## Issue / Bugzilla link

 #13525

## Testing

Passing test run: https://github.com/mozilla/bedrock/actions/runs/5809529308