### PR TITLE
Load Stripe JS on VPN lead pages (Fixes #13527)

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -153,6 +153,8 @@
 
     {% block js %}{% endblock %}
 
+    {% block third_party_js %}{% endblock %}
+
     {% if self.structured_data()|trim|length %}
       <script type="application/ld+json">
     {% endif %}

--- a/bedrock/products/templates/products/vpn/base.html
+++ b/bedrock/products/templates/products/vpn/base.html
@@ -16,3 +16,7 @@
 {% block sub_navigation %}
   {% include 'products/vpn/includes/subnav.html' %}
 {% endblock %}
+
+{% block third_party_js %}
+  <script async src="https://js.stripe.com/v3/"></script>
+{% endblock %}

--- a/bedrock/products/templates/products/vpn/resource-center/base-article.html
+++ b/bedrock/products/templates/products/vpn/resource-center/base-article.html
@@ -91,5 +91,5 @@
 {% endblock content %}
 
 {% block js %}
-    {{ js_bundle("vpn-resource-center-article")}}
+  {{ js_bundle("vpn-resource-center-article") }}
 {% endblock js %}

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -199,6 +199,7 @@ else:
         "data.track.convertexperiments.com",
         "1003350.track.convertexperiments.com",
         "1003343.track.convertexperiments.com",
+        "js.stripe.com",
     ]
     _csp_style_src = [
         # TODO fix things so that we don't need this
@@ -214,6 +215,7 @@ else:
         "accounts.firefox.com",
         "accounts.firefox.com.cn",
         "www.youtube.com",
+        "js.stripe.com",
     ]
     _csp_connect_src = [
         "www.googletagmanager.com",


### PR DESCRIPTION
## One-line summary

Adds 3rd party Stripe JS script to all VPN morog pages

## Significant changes and points to review

This has already passed legal review. They are OK with loading the script given that it helps perform a critical business function (fraud prevention).

## Issue / Bugzilla link

#13527

## Testing

http://localhost:8000/en-US/products/vpn/

Stripe scripts should load successfully:

<img width="702" alt="image" src="https://github.com/mozilla/bedrock/assets/400117/bb4bc128-ca33-416c-b137-d359260c8500">

Stripe POST requests should fire successfully:

<img width="906" alt="image" src="https://github.com/mozilla/bedrock/assets/400117/b3343136-aa43-465f-8f00-cf71826e4009">
