### PR TITLE
Update Glean ping helpers

### DIFF
--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -415,32 +415,46 @@ It will also first lint the schema files.
 Using Glean pings in individual page bundles
 --------------------------------------------
 
-All of our analytics code for Glean lives in a single bundle in the base template,
-which is intended to be shared across all web pages. There may be times where we
-want to send a ping from some JavaScript that exists only in a certain page
-specific bundle however. For instances like this, there is a global ``ping``
-helper available, which you can call from inside any custom event handler you write.
+Our analytics code for Glean lives in a single bundle in the base template,
+which is intended to be shared across all web pages. This bundle automatically
+initializes Glean and records page view pings. It also creates some helpers
+that can be used across different page bundles to record interaction pings
+such as link clicks and form submissions.
 
-For user initiated events, such as clicks:
+The ``Mozilla.Glean.pagePing()`` helper can be used to record pings that are
+specific to a page, such as successful form completions:
 
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.ping({
-            label: 'Newsletters: mozilla-and-you',
-            type: 'Newsletter Signup Success'
+        window.Mozilla.Glean.pagePing({
+            label: 'mozilla-and-you',
+            type: 'Newsletter sign-up success' // type is optional
         });
     }
 
-For non-interaction events that are not user initiated:
+It can also be used to record non-interaction pings that are not directly
+initiated by a visitor:
 
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.ping({
-            label: 'Auto Play',
-            type: 'Video'
+        window.Mozilla.Glean.pagePing({
+            label: 'Firefox default',
             nonInteraction: true
+        });
+    }
+
+The ``Mozilla.Glean.clickPing()`` helper can be used to record click pings
+that are specific to an element in a page, such as a link or button.
+
+.. code-block:: javascript
+
+    if (typeof window.Mozilla.Glean !== 'undefined') {
+        window.Mozilla.Glean.clickPing({
+            label: 'Firefox Download',
+            type: 'macOS, release, en-US', // type is optional
+            position: 'primary' // position is optional
         });
     }
 

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -163,7 +163,8 @@ element:
       type:
         description: |
           The type of element that was clicked.
-          Examples: 'Button', 'Link'.
+          Examples: 'macOS, release, en-US',
+          '12-month plan'.
         type: string
       position:
         description: |

--- a/media/js/glean/elements.es6.js
+++ b/media/js/glean/elements.es6.js
@@ -7,13 +7,15 @@
 import { interaction as interactionPing } from '../libs/glean/pings.js';
 import * as element from '../libs/glean/element.js';
 
-function interaction(obj) {
+function clickPing(obj) {
     if (typeof obj !== 'object' && typeof obj.label !== 'string') {
         return;
     }
 
     const data = {
-        label: obj.label
+        label: obj.label,
+        type: '',
+        position: ''
     };
 
     if (typeof obj.type === 'string') {
@@ -32,75 +34,4 @@ function interaction(obj) {
     }
 }
 
-function getElementAttributes(e) {
-    let el = e.target;
-
-    // If the node isn't a link or button, traverse upward
-    // in case this is a nested child element.
-    if (
-        (el.nodeName !== 'A' || el.nodeName !== 'BUTTON') &&
-        Element.prototype.closest
-    ) {
-        el = el.closest('a') || el.closest('button');
-    }
-
-    if (!el) {
-        return;
-    }
-
-    // Check all link and button elements for data attributes.
-    if (el.nodeName === 'A' || el.nodeName === 'BUTTON') {
-        const ctaText = el.getAttribute('data-cta-text');
-        const linkName = el.getAttribute('data-link-name');
-        const linkType = el.getAttribute('data-link-type');
-
-        // CTA link clicks
-        if (ctaText) {
-            const type = el.getAttribute('data-cta-type');
-            const position = el.getAttribute('data-cta-position');
-            interaction({
-                label: ctaText,
-                type: type,
-                position: position
-            });
-        }
-        // Firefox Download link clicks
-        else if (linkType && linkType === 'download') {
-            const os = el.getAttribute('data-download-os');
-            const name = el.getAttribute('data-display-name');
-            const position = el.getAttribute('data-download-location');
-
-            if (os) {
-                const label = `Firefox Download ${os}`;
-                interaction({
-                    label: label,
-                    type: name,
-                    position: position
-                });
-            }
-        }
-        // Older format links
-        else if (linkName) {
-            const position = el.getAttribute('data-link-position');
-            interaction({
-                label: linkName,
-                type: linkType,
-                position: position
-            });
-        }
-    }
-}
-
-function bindElementClicks() {
-    document
-        .querySelector('body')
-        .addEventListener('click', getElementAttributes, false);
-}
-
-function unbindElementClicks() {
-    document
-        .querySelector('body')
-        .removeEventListener('click', getElementAttributes, false);
-}
-
-export { bindElementClicks, unbindElementClicks };
+export { clickPing };

--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -6,7 +6,8 @@
 
 import Glean from '@mozilla/glean/web';
 
-import { initPageView, pageEventPing } from './page.es6';
+import { initPageView, pagePing } from './page.es6';
+import { clickPing } from './elements.es6';
 import Utils from './utils.es6';
 
 const shouldInitialize = Utils.hasValidURLScheme(window.location.href);
@@ -43,16 +44,29 @@ function initGlean() {
     });
 }
 
-function initPageEventHelper() {
+function initHelpers() {
     if (typeof window.Mozilla === 'undefined') {
         window.Mozilla = {};
     }
 
     // Create a global for external bundles to fire interaction pings.
     window.Mozilla.Glean = {
-        ping: (obj) => {
+        pagePing: (obj) => {
             if (shouldInitialize) {
-                pageEventPing(obj);
+                try {
+                    pagePing(obj);
+                } catch (e) {
+                    //do nothing
+                }
+            }
+        },
+        clickPing: (obj) => {
+            if (shouldInitialize) {
+                try {
+                    clickPing(obj);
+                } catch (e) {
+                    //do nothing
+                }
             }
         }
     };
@@ -63,4 +77,4 @@ if (shouldInitialize) {
     initPageView();
 }
 
-initPageEventHelper();
+initHelpers();

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -55,13 +55,14 @@ function initPageView() {
     pageViewPing.submit();
 }
 
-function pageEventPing(obj) {
+function pagePing(obj) {
     if (typeof obj !== 'object' && typeof obj.label !== 'string') {
         return;
     }
 
     const data = {
-        label: obj.label
+        label: obj.label,
+        type: ''
     };
 
     if (typeof obj.type === 'string') {
@@ -80,4 +81,4 @@ function pageEventPing(obj) {
     }
 }
 
-export { initPageView, pageEventPing };
+export { initPageView, pagePing };

--- a/tests/unit/spec/glean/elements.js
+++ b/tests/unit/spec/glean/elements.js
@@ -10,158 +10,33 @@
  */
 
 import { testResetGlean } from '@mozilla/glean/testing';
-import {
-    bindElementClicks,
-    unbindElementClicks
-} from '../../../../media/js/glean/elements.es6';
+import { clickPing } from '../../../../media/js/glean/elements.es6';
 import * as element from '../../../../media/js/libs/glean/element.js';
 import { interaction as interactionPing } from '../../../../media/js/libs/glean/pings.js';
 
 describe('elements.js', function () {
     beforeEach(async function () {
         await testResetGlean('moz-bedrock-test');
-        bindElementClicks();
     });
 
-    afterEach(function () {
-        unbindElementClicks();
-    });
-
-    describe('Element Click (data-cta)', function () {
-        beforeEach(async function () {
-            const link =
-                '<button type="button" class="mzp-c-button glean-test-element" data-cta-text="Subscribe" data-cta-type="button" data-cta-position="primary">Subscribe</button>';
-            document.body.insertAdjacentHTML('beforeend', link);
-        });
-
-        afterEach(function () {
-            document
-                .querySelectorAll('.glean-test-element')
-                .forEach(function (e) {
-                    e.parentNode.removeChild(e);
-                });
-        });
-
-        it('should send an interaction ping when element is clicked containing data-cta attributes', async function () {
+    describe('clickPing', function () {
+        it('should send an interaction ping when clickPing is called', async function () {
             const ping = interactionPing.testBeforeNextSubmit(
                 async function () {
                     const snapshot = await element.clicked.testGetValue();
                     expect(snapshot.length).toEqual(1);
                     const click = snapshot[0];
-                    expect(click.extra.label).toEqual('Subscribe');
-                    expect(click.extra.type).toEqual('button');
+                    expect(click.extra.label).toEqual('Firefox Download');
+                    expect(click.extra.type).toEqual('macOS, release, en-US');
                     expect(click.extra.position).toEqual('primary');
                 }
             );
 
-            document.querySelector('.glean-test-element').click();
-
-            // Wait for the validation to finish.
-            await expectAsync(ping).toBeResolved();
-        });
-    });
-
-    describe('Element Click (data-link)', function () {
-        beforeEach(async function () {
-            const link =
-                '<button type="button" class="mzp-c-button glean-test-element" data-link-name="Submit" data-link-type="button" data-link-position="primary">Submit</button>';
-            document.body.insertAdjacentHTML('beforeend', link);
-        });
-
-        afterEach(function () {
-            document
-                .querySelectorAll('.glean-test-element')
-                .forEach(function (e) {
-                    e.parentNode.removeChild(e);
-                });
-        });
-
-        it('should send an interaction ping when element is clicked containing data-link attributes', async function () {
-            const ping = interactionPing.testBeforeNextSubmit(
-                async function () {
-                    const snapshot = await element.clicked.testGetValue();
-                    expect(snapshot.length).toEqual(1);
-                    const click = snapshot[0];
-                    expect(click.extra.label).toEqual('Submit');
-                    expect(click.extra.type).toEqual('button');
-                    expect(click.extra.position).toEqual('primary');
-                }
-            );
-
-            document.querySelector('.glean-test-element').click();
-
-            // Wait for the validation to finish.
-            await expectAsync(ping).toBeResolved();
-        });
-    });
-
-    describe('Firefox Download Click', function () {
-        beforeEach(async function () {
-            const link =
-                '<button type="button" class="mzp-c-button glean-test-element" data-link-type="download" data-download-os="Desktop" data-display-name="macOS" data-download-version="osx" data-download-location="primary">Submit</button>';
-            document.body.insertAdjacentHTML('beforeend', link);
-        });
-
-        afterEach(function () {
-            document
-                .querySelectorAll('.glean-test-element')
-                .forEach(function (e) {
-                    e.parentNode.removeChild(e);
-                });
-        });
-
-        it('should send an interaction ping when element is clicked containing data-link attributes', async function () {
-            const ping = interactionPing.testBeforeNextSubmit(
-                async function () {
-                    const snapshot = await element.clicked.testGetValue();
-                    expect(snapshot.length).toEqual(1);
-                    const click = snapshot[0];
-                    expect(click.extra.label).toEqual(
-                        'Firefox Download Desktop'
-                    );
-                    expect(click.extra.type).toEqual('macOS');
-                    expect(click.extra.position).toEqual('primary');
-                }
-            );
-
-            document.querySelector('.glean-test-element').click();
-
-            // Wait for the validation to finish.
-            await expectAsync(ping).toBeResolved();
-        });
-    });
-
-    describe('Nested element click (data-cta)', function () {
-        beforeEach(async function () {
-            const link = `<button type="button" class="mzp-c-button glean-test-element" data-cta-text="Subscribe" data-cta-type="button" data-cta-position="primary">
-                    <span class="child-element">Subscribe</span>
-                </button>`;
-            document.body.insertAdjacentHTML('beforeend', link);
-        });
-
-        afterEach(function () {
-            document
-                .querySelectorAll('.glean-test-element')
-                .forEach(function (e) {
-                    e.parentNode.removeChild(e);
-                });
-        });
-
-        it('should send an interaction ping for a parent element when element a child element is clicked', async function () {
-            const ping = interactionPing.testBeforeNextSubmit(
-                async function () {
-                    const snapshot = await element.clicked.testGetValue();
-                    expect(snapshot.length).toEqual(1);
-                    const click = snapshot[0];
-                    expect(click.extra.label).toEqual('Subscribe');
-                    expect(click.extra.type).toEqual('button');
-                    expect(click.extra.position).toEqual('primary');
-                }
-            );
-
-            document
-                .querySelector('.glean-test-element > .child-element')
-                .click();
+            clickPing({
+                label: 'Firefox Download',
+                type: 'macOS, release, en-US',
+                position: 'primary'
+            });
 
             // Wait for the validation to finish.
             await expectAsync(ping).toBeResolved();

--- a/tests/unit/spec/glean/page.js
+++ b/tests/unit/spec/glean/page.js
@@ -11,10 +11,7 @@
 
 import * as page from '../../../../media/js/libs/glean/page.js';
 import Utils from '../../../../media/js/glean/utils.es6';
-import {
-    initPageView,
-    pageEventPing
-} from '../../../../media/js/glean/page.es6';
+import { initPageView, pagePing } from '../../../../media/js/glean/page.es6';
 import {
     pageView as pageViewPing,
     interaction as interactionPing,
@@ -193,13 +190,13 @@ describe('page.js', function () {
             const snapshot = await page.pageEvent.testGetValue();
             expect(snapshot.length).toEqual(1);
             const event = snapshot[0];
-            expect(event.extra.label).toEqual('Newsletter: mozilla-and-you');
-            expect(event.extra.type).toEqual('Newsletter Signup Success');
+            expect(event.extra.label).toEqual('mozilla-and-you');
+            expect(event.extra.type).toEqual('Newsletter sign-up success');
         });
 
-        pageEventPing({
-            label: 'Newsletter: mozilla-and-you',
-            type: 'Newsletter Signup Success'
+        pagePing({
+            label: 'mozilla-and-you',
+            type: 'Newsletter sign-up success'
         });
 
         // Wait for the validation to finish.
@@ -211,13 +208,12 @@ describe('page.js', function () {
             const snapshot = await page.pageEvent.testGetValue();
             expect(snapshot.length).toEqual(1);
             const event = snapshot[0];
-            expect(event.extra.label).toEqual('Auto Play');
-            expect(event.extra.type).toEqual('Video');
+            expect(event.extra.label).toEqual('Firefox default');
+            expect(event.extra.type).toEqual('');
         });
 
-        pageEventPing({
-            label: 'Auto Play',
-            type: 'Video',
+        pagePing({
+            label: 'Firefox default',
             nonInteraction: true
         });
 


### PR DESCRIPTION
## One-line summary

Updates Glean helpers so that we now have `Mozilla.Glean.pagePing()` and `Mozilla.Glean.clickPing()`.

## Significant changes and points to review

- Glean is only running when `Dev=True` for now, so making changes is pretty safe. 
- Removes old code that would try to automatically create pings based on data attributes (I want to concentrate on measuring a more targeted set of events for now, such as downloads and subscriptions)
- Both of the above helpers are not yet used, so this PR only defines them and adds tests.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13431

## Testing

- [ ] JS tests should be passing in CI