### PR TITLE
Add Monitor waitlist subscription page [fix #13522]

### DIFF
--- a/bedrock/newsletter/templates/newsletter/monitor-waitlist.html
+++ b/bedrock/newsletter/templates/newsletter/monitor-waitlist.html
@@ -1,0 +1,40 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends 'base-protocol.html' %}
+
+{% block page_title %}Coming soon: Automatic data removal from Monitor{% endblock page_title %}
+
+{% block page_desc %}Sign up to get access to Monitor’s latest upgrade as soon as we launch.{% endblock %}
+
+{% block body_class %}{{ super() }} monitor-waitlist{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('newsletter-monitor-waitlist') }}
+{% endblock %}
+
+{% block content %}
+<main class= "mzp-t-content-sm">
+  <section class="section-subscribe">
+    <header class="mzp-l-content mzp-t-content-lg">
+      <h1 class="page-title">Coming soon:<br> Automatic data removal from Monitor</h1>
+      <h2 class="section-title">{{ self.page_desc() }}</h2>
+    </header>
+    <div class="mzp-l-content mzp-t-content-sm">
+    {% if country_code == "US" %}
+      {{ email_newsletter_form(newsletters='monitor-waitlist', include_title=False, include_country=False, include_language=False, submit_text='Sign up now', spinner_color='#0c99d5') }}
+    {% else %}
+      <p class="c-not-available">Sorry, this service is not currently available in your country.</p>
+    {% endif %}
+    </div>
+  </section>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('newsletter') }}
+{% endblock %}

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -45,6 +45,7 @@ urlpatterns = (
     ),
     page("newsletter/family/", "newsletter/family.html", ftl_files=["mozorg/newsletters"], active_locales=["en-US"]),
     page("newsletter/security-and-privacy/", "newsletter/security-privacy-news.html", ftl_files=["mozorg/newsletters"]),
+    page("newsletter/monitor-waitlist/", "newsletter/monitor-waitlist.html", ftl_files=["mozorg/newsletters"]),
     path("newsletter/newsletter-all.json", views.newsletter_all_json, name="newsletter.all"),
     path("newsletter/newsletter-strings.json", views.newsletter_strings_json, name="newsletter.strings"),
 )

--- a/media/css/newsletter/newsletter-monitor-waitlist.scss
+++ b/media/css/newsletter/newsletter-monitor-waitlist.scss
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.section-subscribe {
+    .mzp-l-content:first-child {
+        padding-bottom: 0;
+    }
+
+    .page-title {
+        @include text-title-md;
+        text-align: center;
+        font-weight: 600;
+    }
+
+    .section-title {
+        @include font-base;
+        @include text-body-xl;
+        text-align: center;
+        font-weight: normal;
+    }
+
+    .c-not-available {
+        @include text-body-xl;
+        text-align: center;
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -383,6 +383,12 @@
     },
     {
       "files": [
+        "css/newsletter/newsletter-monitor-waitlist.scss"
+      ],
+      "name": "newsletter-monitor-waitlist"
+    },
+    {
+      "files": [
         "css/newsletter/newsletter-family.scss"
       ],
       "name": "newsletter-family"

--- a/tests/functional/newsletter/test_monitor_waitlist.py
+++ b/tests/functional/newsletter/test_monitor_waitlist.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.newsletter.monitor_waitlist import MonitorWaitlistNewsletterPage
+
+
+@pytest.mark.nondestructive
+def test_monitor_waitlist_success(base_url, selenium):
+    page = MonitorWaitlistNewsletterPage(selenium, base_url, params="?geo=us").open()
+    assert not page.newsletter.sign_up_successful
+    page.newsletter.expand_form()
+    page.newsletter.type_email("success@example.com")
+    page.newsletter.select_text_format()
+    page.newsletter.accept_privacy_policy()
+    page.newsletter.click_sign_me_up()
+    assert page.newsletter.sign_up_successful
+
+
+@pytest.mark.nondestructive
+def test_monitor_waitlist_failure(base_url, selenium):
+    page = MonitorWaitlistNewsletterPage(selenium, base_url, params="?geo=us").open()
+    assert not page.newsletter.is_form_error_displayed
+    page.newsletter.expand_form()
+    page.newsletter.type_email("failure@example.com")
+    page.newsletter.select_text_format()
+    page.newsletter.accept_privacy_policy()
+    page.newsletter.click_sign_me_up(expected_result="error")
+    assert page.newsletter.is_form_error_displayed
+
+
+@pytest.mark.nondestructive
+def test_monitor_waitlist_unavailable_country(base_url, selenium):
+    page = MonitorWaitlistNewsletterPage(selenium, base_url, params="?geo=de").open()
+    assert page.is_unavailable_country_message_displayed

--- a/tests/pages/newsletter/monitor_waitlist.py
+++ b/tests/pages/newsletter/monitor_waitlist.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class MonitorWaitlistNewsletterPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/newsletter/monitor-waitlist/{params}"
+
+    _unavailable_country_message_locator = (By.CLASS_NAME, "c-not-available")
+
+    @property
+    def is_unavailable_country_message_displayed(self):
+        return self.is_element_displayed(*self._unavailable_country_message_locator)

--- a/tests/unit/spec/newsletter/data.js
+++ b/tests/unit/spec/newsletter/data.js
@@ -104,6 +104,21 @@ const newsletterData = {
         is_mofo: false,
         order: 6
     },
+    'monitor-waitlist': {
+        title: 'Monitor Waitlist',
+        description:
+            'Sign up to get access to Monitor’s latest upgrade as soon as we launch.',
+        show: false,
+        active: true,
+        private: false,
+        indent: false,
+        vendor_id: 'Sub_monitor_waitlist',
+        languages: ['en'],
+        requires_double_optin: true,
+        firefox_confirm: true,
+        is_mofo: false,
+        order: 6
+    },
     'firefox-sweepstakes': {
         title: 'Firefox Sweepstakes',
         description:
@@ -884,6 +899,11 @@ const stringData = {
         description:
             'Stay informed of the latest trends in privacy & security products from Mozilla, the makers of Firefox.',
         title: 'Security & Privacy News from Mozilla'
+    },
+    'monitor-waitlist': {
+        description:
+            'Sign up to get access to Monitor’s latest upgrade as soon as we launch.',
+        title: 'Monitor Waitlist'
     },
     labs: {
         title: 'About Labs'


### PR DESCRIPTION
## One-line summary

Adds a newsletter subscription page for the Monitor pre-launch waitlist. It's English-only and also US-only. Non-US countries should see an apologetic message in place of the form.

This needs to go live on **Monday, 14 August 2023** 

## Issue / Bugzilla link

#13522 

## Testing

US: http://localhost:8000/en-US/newsletter/monitor-waitlist/?geo=US
Non-US: http://localhost:8000/en-US/newsletter/monitor-waitlist/?geo=DE