### PR TITLE
Update sys requirements for Mozilla VPN on Linux (Fixes #13442)

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -106,7 +106,7 @@
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-linux-long', fallback='vpn-download-for-linux') }}</h2>
             <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-for-linux-requirements', version='18.04') }}</p>
+            <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
             <a class="mzp-c-button" href="{{ linux_download_url }}" data-cta-type="button" data-cta-text="VPN Download (Linux)" class="platform-download-link">
             {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
             </a>
@@ -178,7 +178,7 @@
           </div>
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-linux') }}</h2>
-            <p>{{ ftl('vpn-download-for-linux-requirements', version='18.04') }}</p>
+            <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
           </div>
           <a href="{{ linux_download_url }}" data-cta-type="button" data-cta-text="VPN Download (Linux)" class="platform-download-link">
             <span class="visually-hidden">{{ ftl('vpn-download-for-linux-long') }}</span>

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -351,13 +351,7 @@
           {% endif %}
         </li>
         <li>
-          {% if ftl_has_messages('vpn-landing-faq-compatibility-question-desc-linux-v3') %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-linux-v3', url=url('products.vpn.platforms.linux')) }}
-          {% elif ftl_has_messages('vpn-landing-faq-compatibility-question-desc-linux-v2') %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-linux-v2', url=url('products.vpn.platforms.linux')) }}
-          {% else %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-linux') }}
-          {% endif %}
+          {{ ftl('vpn-landing-faq-compatibility-question-desc-linux-v4', fallback='vpn-landing-faq-compatibility-question-desc-linux-v3', url=url('products.vpn.platforms.linux')) }}
         </li>
       </ul>
     </details>

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -146,15 +146,11 @@ vpn-landing-faq-compatibility-question-desc-ios-v3 = <a href="{ $url }">{ -brand
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/linux/
-vpn-landing-faq-compatibility-question-desc-linux-v3 = <a href="{ $url }">{ -brand-name-linux }</a> ({ -brand-name-ubuntu } 18.04 and up)
+vpn-landing-faq-compatibility-question-desc-linux-v4 = <a href="{ $url }">{ -brand-name-linux }</a> ({ -brand-name-ubuntu } 20.04 and up)
 
 # Outdated string
-# Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/linux/
-vpn-landing-faq-compatibility-question-desc-linux-v2 = <a href="{ $url }">{ -brand-name-linux }</a> ({ -brand-name-ubuntu }-only)
-
-# Outdated string
-vpn-landing-faq-compatibility-question-desc-linux = { -brand-name-linux } ({ -brand-name-ubuntu }-only)
+vpn-landing-faq-compatibility-question-desc-linux-v3 = <a href="{ $url }">{ -brand-name-linux }</a> ({ -brand-name-ubuntu } 18.04 and up)
 
 vpn-landing-faq-refund-question-heading = What is { -brand-name-mozilla-vpn }’s refund policy?
 


### PR DESCRIPTION
## One-line summary

Updates Ubuntu 18.04 to 20.04

## Issue / Bugzilla link

#13442

## Testing

- http://localhost:8000/en-US/products/vpn/
- http://localhost:8000/en-US/products/vpn/download/
