### PR TITLE
Bump APScheduler to 3.10.3 - bugfix

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,9 +10,9 @@ appdirs==1.4.4 \
     # via
     #   -r requirements/prod.txt
     #   glean-parser
-apscheduler==3.10.2 \
-    --hash=sha256:1b6b4cb3fcb1cfd858d12d77c206f838b1c0cd0489a2643c1303e198ed7c0167 \
-    --hash=sha256:64b65f9ad6803846ca6d9ce0efcb4d7a049df7cb7cf2eb46eddf74dfa7665f8d
+apscheduler==3.10.3 \
+    --hash=sha256:1611d207b095ff52d97884e90736c192bdd94dbd44ce27eb92c3f1da24a400d3 \
+    --hash=sha256:3f17fd3915f14f4bfa597f552130a14a9d1cc74a002fa1d95dd671cb48dba70e
     # via -r requirements/prod.txt
 asgiref==3.5.0 \
     --hash=sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -1,4 +1,4 @@
-APScheduler==3.10.2
+APScheduler==3.10.3
 babis==0.2.4
 basket-client==1.1.0
 beautifulsoup4==4.12.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
     # via glean-parser
-apscheduler==3.10.2 \
-    --hash=sha256:1b6b4cb3fcb1cfd858d12d77c206f838b1c0cd0489a2643c1303e198ed7c0167 \
-    --hash=sha256:64b65f9ad6803846ca6d9ce0efcb4d7a049df7cb7cf2eb46eddf74dfa7665f8d
+apscheduler==3.10.3 \
+    --hash=sha256:1611d207b095ff52d97884e90736c192bdd94dbd44ce27eb92c3f1da24a400d3 \
+    --hash=sha256:3f17fd3915f14f4bfa597f552130a14a9d1cc74a002fa1d95dd671cb48dba70e
     # via -r requirements/prod.in
 asgiref==3.5.0 \
     --hash=sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0 \


### PR DESCRIPTION
After bumping APScheduler to 3.10.2, dependabot spotted a newer release, with a bugfix in it:

>    Fixed TypeError related to entry point iteration on Python 3.9

Because we're still on Python 3.9, I thought it made sense to get this included ASAP, just in case

@pmac @robhudson **Please merge after approval, as I'm not around rest of today**

