### PR TITLE
Bump Glean JS to v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^2.0.0",
+        "@mozilla/glean": "^2.0.1",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2056,9 +2056,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.0.tgz",
-      "integrity": "sha512-4cVhtcWGkLb+KA+SGae0e68PGGNGFr/6nEi2M49J5EgFpEfNrzEAffJCi9PuKetjNeMdkFD6ZetSBvOJbrslEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.1.tgz",
+      "integrity": "sha512-qPD5Je/ercCCUlFJnfs0T3+zNvU/IhP/SpLMaHiOwdF4RwuNC+eoCPzLIOjkDm1LnZwlAzd9qnyoqTPoAAmIpg==",
       "dependencies": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",
@@ -11936,9 +11936,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "@mozilla/glean": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.0.tgz",
-      "integrity": "sha512-4cVhtcWGkLb+KA+SGae0e68PGGNGFr/6nEi2M49J5EgFpEfNrzEAffJCi9PuKetjNeMdkFD6ZetSBvOJbrslEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.1.tgz",
+      "integrity": "sha512-qPD5Je/ercCCUlFJnfs0T3+zNvU/IhP/SpLMaHiOwdF4RwuNC+eoCPzLIOjkDm1LnZwlAzd9qnyoqTPoAAmIpg==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^2.0.0",
+    "@mozilla/glean": "^2.0.1",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",


### PR DESCRIPTION
## One-line summary

Fixes a minor issue introduced in 2.0.0 https://github.com/mozilla/glean.js/releases/tag/v2.0.1

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13431

## Testing

- `npm install`
- `npm start`