### PR TITLE
Update title fonts in Firefox pages (fixes #13577)

### DIFF
--- a/media/css/firefox/browsers/best-browser.scss
+++ b/media/css/firefox/browsers/best-browser.scss
@@ -28,7 +28,6 @@ $image-path: '/media/protocol/img';
         }
 
         h1 {
-            @include font-base;
             @include text-title-lg;
             color: get-theme('title-text-color-inverse');
             margin: 0 auto $spacing-2xl;
@@ -60,7 +59,6 @@ $image-path: '/media/protocol/img';
         margin-bottom: $layout-lg;
 
         h2 {
-            @include font-base;
             @include text-title-md;
         }
     }

--- a/media/css/firefox/features/safebrowser.scss
+++ b/media/css/firefox/features/safebrowser.scss
@@ -26,7 +26,6 @@ $image-path: '/media/protocol/img';
         }
 
         h1 {
-            @include font-base;
             @include text-title-lg;
             color: get-theme('title-text-color-inverse');
             margin: 0 auto $spacing-2xl;
@@ -58,7 +57,6 @@ $image-path: '/media/protocol/img';
         margin-bottom: $layout-lg;
 
         h2 {
-            @include font-base;
             @include text-title-md;
         }
     }

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -202,7 +202,6 @@ $image-path: '/media/protocol/img';
     }
 
     h3 {
-        @include font-base;
         @include text-title-xs;
         margin-bottom: $layout-sm;
     }
@@ -392,7 +391,6 @@ $image-path: '/media/protocol/img';
     padding: $layout-sm 0;
 
     h2 {
-        @include font-base;
         @include text-body-md;
     }
 


### PR DESCRIPTION
## One-line summary
There were some Firefox pages that were using the Inter font instead of Metropolis because they were hard-coded in.



## Significant changes and points to review

- Update heading fonts from Inter to Metropolis 
- See if updating some of the header fonts in the release notes page was fine to do?

## Issue / Bugzilla link
#13577 

## Testing
- http://localhost:8000/en-US/firefox/features/safebrowser/
- http://localhost:8000/en-US/firefox/116.0/releasenotes/
- http://localhost:8000/en-US/firefox/browsers/best-browser/

