### PR TITLE
VPN wave VI expansion post-launch cleanup (Fixes #13552)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -488,8 +488,7 @@ class TestWhatsNew(TestCase):
         assert template == ["firefox/whatsnew/whatsnew-fx115-na-windows.html"]
 
     @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="True")
-    def test_fx_115_0_0_en_bg_switch_on(self, render_mock):
+    def test_fx_115_0_0_en_bg(self, render_mock):
         """Should use whatsnew-fx115-eu-vpn template for en-US locale in Bulgaria if switch is on"""
         req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="BG")
         req.locale = "en-US"
@@ -498,27 +497,6 @@ class TestWhatsNew(TestCase):
         assert template == ["firefox/whatsnew/whatsnew-fx115-eu-vpn.html"]
 
     @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="False")
-    def test_fx_115_0_0_en_bg_switch_off(self, render_mock):
-        """Should use whatsnew-fx115-na-addons template for en-US locale in Bulgaria if switch is off"""
-        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="BG")
-        req.locale = "en-US"
-        self.view(req, version="115.0")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/whatsnew-fx115-na-addons.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="False")
-    def test_fx_115_0_0_bg_bg_switch_off(self, render_mock):
-        """Should use standard template for bg locale in Bulgaria if switch is off"""
-        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="BG")
-        req.locale = "bg"
-        self.view(req, version="115.0")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="True")
     def test_fx_115_0_0_bg_us(self, render_mock):
         """Should use standard template for bg locale in USA"""
         req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="US")
@@ -528,55 +506,10 @@ class TestWhatsNew(TestCase):
         assert template == ["firefox/whatsnew/index.html"]
 
     @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="True")
-    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
-    def test_fx_115_0_0_hu_hu_switch_on(self, render_mock):
-        """Should use whatsnew-fx115-eu-vpn template for hu locale in Hungary if switch is on"""
-        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="HU")
-        req.locale = "hu"
-        self.view(req, version="115.0")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/whatsnew-fx115-eu-vpn.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="False")
-    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
-    def test_fx_115_0_0_hu_hu_switch_off(self, render_mock):
-        """Should use standard template for hu locale in Hungary if switch is off"""
-        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="HU")
-        req.locale = "hu"
-        self.view(req, version="115.0")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="True")
-    def test_fx_115_0_0_en_hu_switch_on(self, render_mock):
+    def test_fx_115_0_0_en_hu(self, render_mock):
         """Should use whatsnew-fx115-eu-vpn template for en-US locale in Hungary if switch is on"""
         req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="HU")
         req.locale = "en-US"
-        self.view(req, version="115.0")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/whatsnew-fx115-eu-vpn.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="False")
-    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
-    def test_fx_115_0_0_en_hu_switch_off(self, render_mock):
-        """Should use whatsnew-fx115-na-addons template for en-US locale in Hungary if switch is off"""
-        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="HU")
-        req.locale = "en-US"
-        self.view(req, version="115.0")
-        template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/whatsnew-fx115-na-addons.html"]
-
-    @override_settings(DEV=True)
-    @patch.dict(os.environ, SWITCH_VPN_WAVE_VI="True")
-    @patch.object(fx_views, "ftl_file_is_active", lambda *x: True)
-    def test_fx_115_0_0_el_cy_switch_on(self, render_mock):
-        """Should use whatsnew-fx115-eu-vpn template for el locale in Cyprus if switch is on"""
-        req = self.rf.get("/firefox/whatsnew/", HTTP_CF_IPCOUNTRY="CY")
-        req.locale = "el"
         self.view(req, version="115.0")
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/whatsnew-fx115-eu-vpn.html"]

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -475,6 +475,26 @@ class WhatsnewView(L10nTemplateView):
 
         channel = detect_channel(version)
 
+        # Used by WNP 115
+        vpn_wave_vi_countries = [
+            "BG",  # Bulgaria
+            "CY",  # Cyprus
+            "CZ",  # Czech Republic
+            "DK",  # Denmark
+            "EE",  # Estonia
+            "HR",  # Croatia
+            "HU",  # Hungary
+            "LT",  # Lithuania
+            "LU",  # Luxembourg
+            "LV",  # Latvia
+            "MT",  # Malta
+            "PL",  # Poland
+            "PT",  # Portugal
+            "RO",  # Romania
+            "SI",  # Slovenia
+            "SK",  # Slovakia
+        ]
+
         if channel == "nightly":
             template = "firefox/nightly/whatsnew.html"
         elif channel == "developer":
@@ -519,11 +539,11 @@ class WhatsnewView(L10nTemplateView):
                     template = "firefox/whatsnew/whatsnew-fx115-eu-mobile-uk.html"
                 elif country == "GB":
                     template = "firefox/whatsnew/whatsnew-fx115-eu-mobile-uk.html"
-                elif switch("vpn-wave-vi") and country in settings.VPN_COUNTRY_CODES_WAVE_VI:
+                elif country in vpn_wave_vi_countries:
                     template = "firefox/whatsnew/whatsnew-fx115-eu-vpn.html"
                 else:
                     template = "firefox/whatsnew/whatsnew-fx115-na-addons.html"
-            elif switch("vpn-wave-vi") and country in settings.VPN_COUNTRY_CODES_WAVE_VI:
+            elif country in vpn_wave_vi_countries:
                 template = "firefox/whatsnew/whatsnew-fx115-eu-vpn.html"
             elif locale == "de":
                 template = "firefox/whatsnew/whatsnew-fx115-eu-ctd-de.html"

--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -108,11 +108,7 @@
     </a>
 
     <p class="availability-copy">
-    {% if switch('vpn-wave-vi') %}
       {{ ftl('vpn-shared-available-countries-v6', fallback='vpn-shared-available-countries-v5') }}
-    {% else %}
-      {{ ftl('vpn-shared-available-countries-v5') }}
-    {% endif %}
     </p>
   {% endif %}
 {%- endmacro %}

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -188,11 +188,7 @@
         </a>
 
         <p class="availability-copy">
-        {% if switch('vpn-wave-vi') %}
           {{ ftl('vpn-shared-available-countries-v6', fallback='vpn-shared-available-countries-v5') }}
-        {% else %}
-          {{ ftl('vpn-shared-available-countries-v5') }}
-        {% endif %}
         </p>
       {% endcall %}
     {% endif %}
@@ -242,11 +238,7 @@
               </a>
 
               <p class="availability-copy">
-              {% if switch('vpn-wave-vi') %}
                 {{ ftl('vpn-shared-available-countries-v6', fallback='vpn-shared-available-countries-v5') }}
-              {% else %}
-                {{ ftl('vpn-shared-available-countries-v5') }}
-              {% endif %}
               </p>
             </div>
             <div class="l-column-last">

--- a/bedrock/products/templates/products/vpn/pricing.html
+++ b/bedrock/products/templates/products/vpn/pricing.html
@@ -73,11 +73,7 @@
         </a>
 
         <p class="availability-copy">
-        {% if switch('vpn-wave-vi') %}
           {{ ftl('vpn-shared-available-countries-v6', fallback='vpn-shared-available-countries-v5') }}
-        {% else %}
-          {{ ftl('vpn-shared-available-countries-v5') }}
-        {% endif %}
         </p>
       {% endcall %}
     {% endif %}

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -34,9 +34,6 @@ def vpn_available(request):
     country = get_country_from_request(request)
     country_list = settings.VPN_COUNTRY_CODES
 
-    if switch("vpn-wave-vi"):
-        country_list = settings.VPN_COUNTRY_CODES + settings.VPN_COUNTRY_CODES_WAVE_VI
-
     return country in country_list
 
 
@@ -80,9 +77,6 @@ def vpn_landing_page(request):
     else:
         template_name = "products/vpn/landing.html"
 
-    if switch("vpn-wave-vi"):
-        available_countries = settings.VPN_AVAILABLE_COUNTRIES_WAVE_VI
-
     context = {
         "vpn_available": vpn_available_in_country,
         "available_countries": available_countries,
@@ -110,9 +104,6 @@ def vpn_pricing_page(request):
     # ensure variant matches pre-defined value
     if variant not in ["1", "2"]:
         variant = None
-
-    if switch("vpn-wave-vi"):
-        available_countries = settings.VPN_AVAILABLE_COUNTRIES_WAVE_VI
 
     context = {
         "vpn_available": vpn_available_in_country,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1656,9 +1656,6 @@ VPN_COUNTRY_CODES = [
     "NL",  # Netherlands
     "SE",  # Sweden
     "FI",  # Finland
-]
-
-VPN_COUNTRY_CODES_WAVE_VI = [
     "BG",  # Bulgaria
     "CY",  # Cyprus
     "CZ",  # Czech Republic
@@ -1676,10 +1673,9 @@ VPN_COUNTRY_CODES_WAVE_VI = [
     "SI",  # Slovenia
     "SK",  # Slovakia
 ]
-VPN_AVAILABLE_COUNTRIES_WAVE_VI = 33
 
 VPN_AFFILIATE_COUNTRIES = ["CA", "DE", "FR", "GB", "IE", "US"]
-VPN_AVAILABLE_COUNTRIES = 17
+VPN_AVAILABLE_COUNTRIES = 33
 VPN_CONNECT_SERVERS = 500
 VPN_CONNECT_COUNTRIES = 30
 VPN_CONNECT_DEVICES = 5


### PR DESCRIPTION
## One-line summary

Removed switches and conditionals for the now launched VPN expansion work

## Significant changes and points to review

Did I miss anything?

## Issue / Bugzilla link

#13552

## Testing

Wave VI countries should still see VPN pricing e.g. 

- [ ] http://localhost:8000/en-US/products/vpn/?geo=bg

Wave VI countries should still see the 115 WNP e.g.

- [ ] http://localhost:8000/en-US/firefox/115.0/whatsnew/?geo=bg

Full list of supported countries should be visible:

- [ ] http://localhost:8000/en-US/products/vpn/?geo=cn

Supported countries should say 33:

- [ ] http://localhost:8000/en-GB/products/vpn/pricing/?geo=cn