### PR TITLE
Distinguish 404 in Glean page metrics (Fixes #13581)

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -8,6 +8,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="404"{% endblock %}
 
+{% block html_attrs %}data-http-status="404"{% endblock %}
+
 {% block page_title %}{{ ftl('not-found-page-not-found-page-page-not-found') }}{% endblock %}
 
 {% block page_css %}

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -102,6 +102,24 @@ page:
     notification_emails:
       - marketing-websites-team@mozilla.com
     expires: never
+  http_status:
+      type: string
+      description: |
+        The HTTP status code of the page.
+      lifetime: application
+      send_in_pings:
+        - page-view
+        - interaction
+        - non-interaction
+      data_sensitivity:
+        - technical
+      bugs:
+        - https://github.com/mozilla/bedrock/issues/13581
+      data_reviews:
+        - https://bugzilla.mozilla.org/show_bug.cgi?id=1848981
+      notification_emails:
+        - marketing-websites-team@mozilla.com
+      expires: never
   page_event:
     type: event
     lifetime: ping

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -30,6 +30,7 @@ function initPageView() {
     page.path.set(Utils.getPathFromUrl());
     page.locale.set(Utils.getLocaleFromUrl());
     page.referrer.set(Utils.getReferrer());
+    page.httpStatus.set(Utils.getHttpStatus());
 
     const params = Utils.getQueryParamsFromURL();
     const finalParams = {};

--- a/media/js/glean/utils.es6.js
+++ b/media/js/glean/utils.es6.js
@@ -31,6 +31,13 @@ const Utils = {
         return typeof ref === 'string' ? ref : document.referrer;
     },
 
+    getHttpStatus: () => {
+        const pageId = document
+            .getElementsByTagName('html')[0]
+            .getAttribute('data-http-status');
+        return pageId && pageId === '404' ? '404' : '200';
+    },
+
     hasValidURLScheme: (url) => {
         return /^https?:\/\//.test(url);
     },

--- a/tests/unit/spec/glean/page.js
+++ b/tests/unit/spec/glean/page.js
@@ -40,6 +40,9 @@ describe('page.js', function () {
 
             const referrer = await page.referrer.testGetValue();
             expect(referrer).toEqual('https://google.com/');
+
+            const httpStatus = await page.httpStatus.testGetValue();
+            expect(httpStatus).toEqual('200');
         });
 
         initPageView();

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -66,6 +66,25 @@ describe('utilsjs', function () {
         });
     });
 
+    describe('getHttpStatus', function () {
+        afterEach(function () {
+            document
+                .getElementsByTagName('html')[0]
+                .removeAttribute('data-http-status');
+        });
+
+        it('should return 200 by default', function () {
+            expect(Utils.getHttpStatus()).toEqual('200');
+        });
+
+        it('should return 404 if matching data-http-status attribute is present in the page', function () {
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-http-status', '404');
+            expect(Utils.getHttpStatus()).toEqual('404');
+        });
+    });
+
     describe('hasValidURLScheme', function () {
         it('should return true for non secure URLs', function () {
             expect(Utils.hasValidURLScheme('http://localhost:8000')).toBeTrue();


### PR DESCRIPTION
## One-line summary

Adds `httpStatus` metric to Glean page pings to help distinguish 404 pages.

## Significant changes and points to review

Adding this new metric has been approved in data review here: https://bugzilla.mozilla.org/show_bug.cgi?id=1848981

## Issue / Bugzilla link

#13581

## Testing

The easiest way to test this change is to set `GLEAN_LOG_PINGS=True` in your `.env`, and page pings should be viewable in the browser's web console.

- [x] Loading http://localhost:8000/en-US/ should see `"page.http_status": "200"` in the ping.
- [x] Loading http://localhost:8000/en-US/404/ should see `"page.http_status": "404"` in the ping.