### PR TITLE
Filter newsletter token from path name in Glean page pings (Fixes #13583)

### DIFF
--- a/media/js/glean/utils.es6.js
+++ b/media/js/glean/utils.es6.js
@@ -6,8 +6,20 @@
 
 const Utils = {
     getPathFromUrl: (path) => {
-        const pathName = path ? path : document.location.pathname;
-        return pathName.replace(/^(\/\w{2}-\w{2}\/|\/\w{2,3}\/)/, '/');
+        let pathName = path ? path : document.location.pathname;
+        pathName = pathName.replace(/^(\/\w{2}-\w{2}\/|\/\w{2,3}\/)/, '/');
+
+        // Ensure we don't include tokens in newsletter page pings
+        // Issue https://github.com/mozilla/bedrock/issues/13583
+        if (pathName.indexOf('/newsletter/existing/') !== -1) {
+            pathName = '/newsletter/existing/';
+        }
+
+        if (pathName.indexOf('/newsletter/country/') !== -1) {
+            pathName = '/newsletter/country/';
+        }
+
+        return pathName;
     },
 
     getLocaleFromUrl: (path) => {

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -29,6 +29,20 @@ describe('utilsjs', function () {
         it('should return original path when there is no locale', function () {
             expect(Utils.getPathFromUrl('/locales/')).toEqual('/locales/');
         });
+
+        it('should exclude tokens from newsletter URLS', function () {
+            expect(
+                Utils.getPathFromUrl(
+                    '/en-US/newsletter/existing/a1a2a3a4-abc1-12ab-a123-12345a12345b/'
+                )
+            ).toEqual('/newsletter/existing/');
+
+            expect(
+                Utils.getPathFromUrl(
+                    '/en-US/newsletter/country/a1a2a3a4-abc1-12ab-a123-12345a12345b/'
+                )
+            ).toEqual('/newsletter/country/');
+        });
     });
 
     describe('getLocaleFromUrl', function () {


### PR DESCRIPTION
## One-line summary

Removes tokens from newsletter page pings

## Issue / Bugzilla link

#13583

## Testing

The tests hopefully speak for themselves, but if you would like to test locally you can first get your token here: https://www.mozilla.org/en-US/newsletter/recovery/

Next, set `GLEAN_LOG_PINGS=True` in your .`env`, and page pings should be viewable in the browser's web console.

Then open `http://localhost:8000/en-US/newsletter/existing/YOUR_TOKEN_HERE/`

- [x] In the page ping, you should see `"page.path": "/newsletter/existing/",`