### PR TITLE
Remove brand names from vpn download string (Issue #13551)

### DIFF
--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -146,7 +146,7 @@ vpn-landing-faq-compatibility-question-desc-ios-v3 = <a href="{ $url }">{ -brand
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/linux/
-vpn-landing-faq-compatibility-question-desc-linux-v4 = <a href="{ $url }">{ -brand-name-linux }</a> ({ -brand-name-ubuntu } 20.04 and up)
+vpn-landing-faq-compatibility-question-desc-linux-v4 = <a href="{ $url }">Linux</a> (Ubuntu 20.04 and up)
 
 # Outdated string
 #   $url (url) - link to https://www.mozilla.org/products/vpn/desktop/linux/


### PR DESCRIPTION
Fixes: https://github.com/mozilla-l10n/www-l10n/pull/345#discussion_r1296434589