### PR TITLE
Move Suba to steering committee section in leadership pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
@@ -402,5 +402,47 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           financial assistance in the form of scholarships and awards.</p>
       </div>
     </article>
+
+    <article id="suba-vasudevan" data-id="suba-vasudevan" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
+    <figure class="headshot">
+      {{ resp_img(
+        url='img/mozorg/about/leadership/suba-vasudevan.png',
+        srcset={
+          'img/mozorg/about/leadership/suba-vasudevan-high-res.png': '2x'
+        },
+        optional_attributes={
+          'width': '160',
+          'height': '160',
+          'class': 'photo',
+          'itemprop': 'image'
+        }
+      ) }}
+      <figcaption><h4 class="fn" itemprop="name">Suba Vasudevan</h4></figcaption>
+    </figure>
+
+    <div class="person-info">
+      <p class="title" itemprop="jobTitle">SVP of Strategy and Operations</p>
+
+      <ul class="utility">
+        <li><a class="link" href="{{ url('mozorg.about.leadership.index') }}#suba-vasudevan">Link to this bio</a></li>
+      </ul>
+    </div>
+
+    <div class="person-bio">
+      <p>As Mozilla’s Senior Vice President of Strategy and Operations, Suba Vasudevan is responsible for leading Mozilla’s
+      operational strategy to bring better, more relevant products to new audiences.</p>
+
+      <p>Suba spent well over two decades leading small and large teams in strategy, operations, analytics, customer support and
+      trust & safety. She has nurtured and expanded critical global organizations within Meta (formerly Facebook), driving
+      innovation and trust. Prior, she advised clients across industries at KPMG’s Advisory Services and began her career as a
+      journalist in India, exploring the intersection of technology and business.</p>
+
+      <p>She has a Master’s degree in Information Systems from Texas A&M, and a Bachelor’s in Computer Engineering from Mumbai
+      University. For several years, Suba served as a Board Member for Mainspring Schools, a local non-profit in Austin, Texas
+      for children from underprivileged families, leading their Strategic Planning Committee and demonstrating her commitment
+      to community and inclusion-focused initiatives.</p>
+
+    </div>
+  </article>
   </div>
 </section>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/senior.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/senior.html
@@ -520,49 +520,5 @@
 
     </div>
   </article>
-
-
-  <article id="suba-vasudevan" data-id="suba-vasudevan" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
-    <figure class="headshot">
-      {{ resp_img(
-        url='img/mozorg/about/leadership/suba-vasudevan.png',
-        srcset={
-          'img/mozorg/about/leadership/suba-vasudevan-high-res.png': '2x'
-        },
-        optional_attributes={
-          'width': '160',
-          'height': '160',
-          'class': 'photo',
-          'itemprop': 'image'
-        }
-      ) }}
-      <figcaption><h4 class="fn" itemprop="name">Suba Vasudevan</h4></figcaption>
-    </figure>
-
-    <div class="person-info">
-      <p class="title" itemprop="jobTitle">SVP of Strategy and Operations</p>
-
-      <ul class="utility">
-        <li><a class="link" href="{{ url('mozorg.about.leadership.index') }}#suba-vasudevan">Link to this bio</a></li>
-      </ul>
-    </div>
-
-    <div class="person-bio">
-      <p>As Mozilla’s Senior Vice President of Strategy and Operations, Suba Vasudevan is responsible for leading Mozilla’s
-      operational strategy to bring better, more relevant products to new audiences.</p>
-
-      <p>Suba spent well over two decades leading small and large teams in strategy, operations, analytics, customer support and
-      trust & safety. She has nurtured and expanded critical global organizations within Meta (formerly Facebook), driving
-      innovation and trust. Prior, she advised clients across industries at KPMG’s Advisory Services and began her career as a
-      journalist in India, exploring the intersection of technology and business.</p>
-
-      <p>She has a Master’s degree in Information Systems from Texas A&M, and a Bachelor’s in Computer Engineering from Mumbai
-      University. For several years, Suba served as a Board Member for Mainspring Schools, a local non-profit in Austin, Texas
-      for children from underprivileged families, leading their Strategic Planning Committee and demonstrating her commitment
-      to community and inclusion-focused initiatives.</p>
-
-    </div>
-  </article>
-
 </div>
 </section>


### PR DESCRIPTION
## One-line summary
Incorrectly placed Suba in Senior Leadership, so we moved her to the Steering Committee section.

## Testing
http://localhost:8000/en-US/about/leadership/