### PR TITLE
Fix test that fails if DEV=True in local env

### DIFF
--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -1101,6 +1101,7 @@ class TestPocketAdjustUrl(TestCase):
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+@override_settings(RELAY_PRODUCT_URL="https://relay.firefox.com/")
 @override_settings(DEV=False)
 class TestRelayFxAButton(TestCase):
     rf = RequestFactory()

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -1102,7 +1102,6 @@ class TestPocketAdjustUrl(TestCase):
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
 @override_settings(RELAY_PRODUCT_URL="https://relay.firefox.com/")
-@override_settings(DEV=False)
 class TestRelayFxAButton(TestCase):
     rf = RequestFactory()
 


### PR DESCRIPTION
This changeset covers an edge case where, if you have DEV=True in a local .env, the TestRelayFxAButton.test_relay_fxa_button test would fail.

This is because, despite DEV being patched to False, RELAY_PRODUCT_URL was set to something else before the patching. So, adding an additional override was needed to keep the test stably passing

