### PR TITLE
WNP117 Relay, copy updates [#13495]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-na-relay.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-na-relay.html
@@ -44,7 +44,7 @@
     </div>
     <h2 class="wnp-main-title">Avoiding spam just <br>got easier</h2>
     <div class="wnp-body-text">
-      <p>New feature alert: Now Firefox Relay subscribers can now access their email masks right in the Firefox Browser.</p>
+      <p>New feature alert: Firefox Relay subscribers can now access their email masks right in Firefox.</p>
       <p>Not using Relay? Let’s fix that.</p>
     </div>
     <p class="wnp-main-cta try-relay landing">


### PR DESCRIPTION
## One-line summary

Updates to body copy for the Relay WNP for Firefox 117.

## Testing

http://localhost:8000/en-US/firefox/117.0/whatsnew/?v=3
