### PR TITLE
Add VPN refresh pricing experiment [fix #13558]

### DIFF
--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -29,6 +29,12 @@
   {{ css_bundle('mozilla-vpn-landing-refresh') }}
 {% endblock %}
 
+{% block experiments %}
+  {% if switch('experiment-vpn-refresh-pricing-layout', ['en-US']) %}
+    {{ js_bundle('experiment_vpn_refresh_pricing_layout') }}
+  {% endif %}
+{% endblock %}
+
 {% block site_header %}
   {% with custom_nav_cta=vpn_nav_cta_refresh() %}
     {% include 'includes/protocol/navigation/navigation.html' %}
@@ -296,7 +302,11 @@
         <h3 class="c-section-title">One subscription for all your devices</h3>
       </header>
 
-      {% include 'products/vpn/includes/pricing-refresh-horizontal.html' %}
+      {% if entrypoint_variation == "2" %}
+        {% include 'products/vpn/includes/pricing-refresh-vertical.html' %}
+      {% else %}
+        {% include 'products/vpn/includes/pricing-refresh-horizontal.html' %}
+      {% endif %}
 
     {% else %}
       <header class="c-pricing-main-header">

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -58,6 +58,15 @@ def vpn_landing_page(request):
     attribution_available_in_country = country in settings.VPN_AFFILIATE_COUNTRIES
     vpn_affiliate_attribution_enabled = vpn_available_in_country and attribution_available_in_country and switch("vpn-affiliate-attribution")
     relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES and switch("vpn-relay-bundle")
+    entrypoint_experiment = request.GET.get("entrypoint_experiment", None)
+    entrypoint_variation = request.GET.get("entrypoint_variation", None)
+
+    # ensure experiment parameters matches pre-defined values
+    if entrypoint_variation not in ["1", "2"]:
+        entrypoint_variation = None
+
+    if entrypoint_experiment != "vpn-refresh-pricing":
+        entrypoint_variation = None
 
     if request.locale == "en-US":
         template_name = "products/vpn/landing-refresh.html"
@@ -72,6 +81,7 @@ def vpn_landing_page(request):
         "connect_devices": settings.VPN_CONNECT_DEVICES,
         "vpn_affiliate_attribution_enabled": vpn_affiliate_attribution_enabled,
         "relay_bundle_available_in_country": relay_bundle_available_in_country,
+        "entrypoint_variation": entrypoint_variation,
     }
 
     return l10n_utils.render(request, template_name, context, ftl_files=ftl_files)

--- a/media/js/products/vpn/experiment-refresh-pricing-layout.es6.js
+++ b/media/js/products/vpn/experiment-refresh-pricing-layout.es6.js
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrafficCop from '@mozmeao/trafficcop';
+import { isApprovedToRun } from '../../base/experiment-utils.es6.js';
+
+const href = window.location.href;
+
+const initTrafficCop = () => {
+    if (
+        href.indexOf(
+            'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation='
+        ) !== -1
+    ) {
+        if (href.indexOf('entrypoint_variation=1') !== -1) {
+            window.dataLayer.push({
+                'data-ex-variant': 'vpn-refresh-pricing-columns',
+                'data-ex-name': 'vpn-refresh-pricing'
+            });
+        } else if (href.indexOf('entrypoint_variation=2') !== -1) {
+            window.dataLayer.push({
+                'data-ex-variant': 'vpn-refresh-pricing-rows',
+                'data-ex-name': 'vpn-refresh-pricing'
+            });
+        }
+    } else if (TrafficCop) {
+        const odo = new TrafficCop({
+            id: 'vpn-refresh-pricing-experiment',
+            cookieExpires: 0,
+            variations: {
+                'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=1': 50, // Pricing in columns
+                'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=2': 50 // Pricing in rows
+            }
+        });
+        odo.init();
+    }
+};
+
+// Avoid entering automated tests into random experiments.
+if (isApprovedToRun()) {
+    initTrafficCop();
+}

--- a/media/js/products/vpn/experiment-refresh-pricing-layout.es6.js
+++ b/media/js/products/vpn/experiment-refresh-pricing-layout.es6.js
@@ -10,6 +10,20 @@ import { isApprovedToRun } from '../../base/experiment-utils.es6.js';
 const href = window.location.href;
 
 const initTrafficCop = () => {
+    if (TrafficCop) {
+        const odo = new TrafficCop({
+            id: 'vpn-refresh-pricing-experiment',
+            cookieExpires: 0,
+            variations: {
+                'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=1': 50, // Pricing in columns
+                'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=2': 50 // Pricing in rows
+            }
+        });
+        odo.init();
+    }
+};
+
+const init = function () {
     if (
         href.indexOf(
             'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation='
@@ -26,20 +40,10 @@ const initTrafficCop = () => {
                 'data-ex-name': 'vpn-refresh-pricing'
             });
         }
-    } else if (TrafficCop) {
-        const odo = new TrafficCop({
-            id: 'vpn-refresh-pricing-experiment',
-            cookieExpires: 0,
-            variations: {
-                'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=1': 50, // Pricing in columns
-                'entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=2': 50 // Pricing in rows
-            }
-        });
-        odo.init();
+    } else if (isApprovedToRun()) {
+        // Avoid entering automated tests into random experiments.
+        initTrafficCop();
     }
 };
 
-// Avoid entering automated tests into random experiments.
-if (isApprovedToRun()) {
-    initTrafficCop();
-}
+init();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1868,6 +1868,12 @@
     },
     {
       "files": [
+        "js/products/vpn/experiment-refresh-pricing-layout.es6.js"
+      ],
+      "name": "experiment_vpn_refresh_pricing_layout"
+    },
+    {
+      "files": [
         "js/careers/listings/listings.es6.js"
       ],
       "name": "careers-listings"


### PR DESCRIPTION
## One-line summary

Sets up a new traffic cop experiment testing two different pricing section layouts on the refreshed VPN landing page. 50% gets the column layout and 50% gets the row layout. This is limited to only en-US.

## Issue / Bugzilla link

#13558 

## Testing

Columns: http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=1#pricing
Rows: http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-refresh-pricing&entrypoint_variation=2#pricing

Ensure the `entrypoint_experiment` and `entrypoint_variation` params are added to the purchase buttons and passed through to FxA for attribution.