### PR TITLE
Pass Traffic Cop custom referrer to attribution scripts (Fixes #13593)

### DIFF
--- a/media/js/base/core-datalayer-page-id.js
+++ b/media/js/base/core-datalayer-page-id.js
@@ -15,6 +15,8 @@ if (typeof window.Mozilla === 'undefined') {
     var dataLayer = (window.dataLayer = window.dataLayer || []);
     var Analytics = {};
 
+    Analytics.customReferrer = '';
+
     /** Returns page ID used in Event Category for GA events tracked on page.
      * @param {String} path - URL path name fallback if page ID does not exist.
      * @return {String} GTM page ID.
@@ -68,9 +70,32 @@ if (typeof window.Mozilla === 'undefined') {
             // Traffic Cop sets the referrer to 'direct' if document.referer is empty
             // prior to the redirect, so this value will either be a URL or the string 'direct'.
             dataObj.customReferrer = referrer;
+
+            // make the custom referrer available to other scripts.
+            Analytics.customReferrer = referrer;
         }
 
         return dataObj;
+    };
+
+    /**
+     * Returns custom referrer set by Traffic Cop if exists,
+     * else returns standard referrer.
+     * See https://github.com/mozilla/bedrock/issues/13593
+     * @returns {String} referrer
+     */
+    Analytics.getReferrer = function (ref) {
+        var referrer = typeof ref === 'string' ? ref : document.referrer;
+        var customReferrer = Analytics.customReferrer;
+
+        if (customReferrer) {
+            // If customReferrer is returned from TC as "direct",
+            // return an empty string which is the default value
+            // for document.referrer. Otherwise return customReferrer.
+            return customReferrer === 'direct' ? '' : customReferrer;
+        }
+
+        return referrer;
     };
 
     // Push page ID into dataLayer so it's ready when GTM container loads.

--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -80,8 +80,18 @@ FxaAttribution.getFxALinkReferralData = () => {
     return null;
 };
 
-FxaAttribution.getSearchReferralData = (ref) => {
+FxaAttribution.getReferrer = (ref) => {
     const referrer = typeof ref === 'string' ? ref : document.referrer;
+
+    if (typeof window.Mozilla.Analytics !== 'undefined') {
+        return Mozilla.Analytics.getReferrer(referrer);
+    }
+
+    return referrer;
+};
+
+FxaAttribution.getSearchReferralData = (ref) => {
+    const referrer = FxaAttribution.getReferrer(ref);
     const google = /^https?:\/\/www\.google\.\w{2,3}(\.\w{2})?\/?/;
     const bing = /^https?:\/\/www\.bing\.com\/?/;
     const yahoo = /^https?:\/\/(\w*\.)?search\.yahoo\.com\/?/;

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -383,6 +383,16 @@ if (typeof window.Mozilla === 'undefined') {
         _checkGA();
     };
 
+    StubAttribution.getReferrer = function (ref) {
+        var referrer = typeof ref === 'string' ? ref : document.referrer;
+
+        if (typeof window.Mozilla.Analytics !== 'undefined') {
+            return Mozilla.Analytics.getReferrer(referrer);
+        }
+
+        return referrer;
+    };
+
     /**
      * Gets utm parameters and referrer information from the web page if they exist.
      * @param {String} ref - Optional referrer to facilitate testing.
@@ -395,7 +405,7 @@ if (typeof window.Mozilla === 'undefined') {
             params.get('experiment') || StubAttribution.experimentName;
         var variation =
             params.get('variation') || StubAttribution.experimentVariation;
-        var referrer = typeof ref !== 'undefined' ? ref : document.referrer;
+        var referrer = StubAttribution.getReferrer(ref);
         var ua = StubAttribution.getUserAgent();
         var clientID = StubAttribution.getGAClientID();
 

--- a/media/js/glean/utils.es6.js
+++ b/media/js/glean/utils.es6.js
@@ -40,7 +40,13 @@ const Utils = {
     },
 
     getReferrer: (ref) => {
-        return typeof ref === 'string' ? ref : document.referrer;
+        const referrer = typeof ref === 'string' ? ref : document.referrer;
+
+        if (typeof window.Mozilla.Analytics !== 'undefined') {
+            return Mozilla.Analytics.getReferrer(referrer);
+        }
+
+        return referrer;
     },
 
     getHttpStatus: () => {

--- a/tests/unit/spec/base/core-datalayer-page-id.js
+++ b/tests/unit/spec/base/core-datalayer-page-id.js
@@ -10,6 +10,10 @@
  */
 
 describe('core-datalayer-page-id.js', function () {
+    afterEach(function () {
+        Mozilla.Analytics.customReferrer = '';
+    });
+
     describe('getPageId', function () {
         const html = document.documentElement;
 
@@ -52,11 +56,13 @@ describe('core-datalayer-page-id.js', function () {
 
     describe('buildDataObject', function () {
         it('should contain customReferrer if found in cookie', function () {
+            const expected = 'http://www.google.com';
             spyOn(Mozilla.Analytics, 'getTrafficCopReferrer').and.returnValue(
-                'http://www.google.com'
+                expected
             );
             const obj = Mozilla.Analytics.buildDataObject();
             expect(obj.customReferrer).toBeDefined();
+            expect(Mozilla.Analytics.customReferrer).toEqual(expected);
         });
 
         it('should not contain customReferrer if not found in cookie', function () {
@@ -65,6 +71,26 @@ describe('core-datalayer-page-id.js', function () {
             );
             const obj = Mozilla.Analytics.buildDataObject();
             expect(obj.customReferrer).not.toBeDefined();
+            expect(Mozilla.Analytics.customReferrer).toEqual('');
+        });
+    });
+
+    describe('getReferrer', function () {
+        it('should return a custom referrer when set', function () {
+            const expected = 'http://www.google.com';
+            Mozilla.Analytics.customReferrer = expected;
+            expect(Mozilla.Analytics.getReferrer()).toEqual(expected);
+        });
+
+        it('should return an empty string if customReferrer is direct', function () {
+            Mozilla.Analytics.customReferrer = 'direct';
+            expect(Mozilla.Analytics.getReferrer()).toEqual('');
+        });
+
+        it('should return standard document referrer otherwise', function () {
+            const expected = 'http://www.bing.com';
+            Mozilla.Analytics.customReferrer = '';
+            expect(Mozilla.Analytics.getReferrer(expected)).toEqual(expected);
         });
     });
 });

--- a/tests/unit/spec/base/fxa-attribution.js
+++ b/tests/unit/spec/base/fxa-attribution.js
@@ -16,6 +16,10 @@ describe('fxa-attribution.js', function () {
         window.Mozilla.dntEnabled = sinon.stub();
     });
 
+    afterEach(function () {
+        Mozilla.Analytics.customReferrer = '';
+    });
+
     describe('getHostName', function () {
         it('should return a hostname as expected', function () {
             const url1 =
@@ -535,6 +539,20 @@ describe('fxa-attribution.js', function () {
                     expected
                 );
             });
+        });
+    });
+
+    describe('getReferrer', function () {
+        it('should return a custom referrer when set', function () {
+            const expected = 'http://www.google.com';
+            Mozilla.Analytics.customReferrer = expected;
+            expect(FxaAttribution.getReferrer()).toEqual(expected);
+        });
+
+        it('should return standard document referrer otherwise', function () {
+            const expected = 'http://www.bing.com';
+            Mozilla.Analytics.customReferrer = '';
+            expect(FxaAttribution.getReferrer(expected)).toEqual(expected);
         });
     });
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -24,6 +24,10 @@ describe('stub-attribution.js', function () {
         window.dataLayer.push = sinon.stub();
     });
 
+    afterEach(function () {
+        Mozilla.Analytics.customReferrer = '';
+    });
+
     describe('init', function () {
         let data = {};
 
@@ -533,6 +537,22 @@ describe('stub-attribution.js', function () {
 
             Mozilla.StubAttribution.waitForGoogleAnalytics(callback);
             expect(callback).toHaveBeenCalledWith(true);
+        });
+    });
+
+    describe('getReferrer', function () {
+        it('should return a custom referrer when set', function () {
+            const expected = 'http://www.google.com';
+            Mozilla.Analytics.customReferrer = expected;
+            expect(Mozilla.StubAttribution.getReferrer()).toEqual(expected);
+        });
+
+        it('should return standard document referrer otherwise', function () {
+            const expected = 'http://www.bing.com';
+            Mozilla.Analytics.customReferrer = '';
+            expect(Mozilla.StubAttribution.getReferrer(expected)).toEqual(
+                expected
+            );
         });
     });
 

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -12,6 +12,10 @@
 import Utils from '../../../../media/js/glean/utils.es6';
 
 describe('utilsjs', function () {
+    afterEach(function () {
+        Mozilla.Analytics.customReferrer = '';
+    });
+
     describe('getPathFromUrl', function () {
         it('should return the path from a page URL excluding locale', function () {
             expect(Utils.getPathFromUrl('/en-US/firefox/new/')).toEqual(
@@ -77,6 +81,20 @@ describe('utilsjs', function () {
                 v: 1,
                 xv: 'test-xv'
             });
+        });
+    });
+
+    describe('getReferrer', function () {
+        it('should return a custom referrer when set', function () {
+            const expected = 'http://www.google.com';
+            Mozilla.Analytics.customReferrer = expected;
+            expect(Utils.getReferrer()).toEqual(expected);
+        });
+
+        it('should return standard document referrer otherwise', function () {
+            const expected = 'http://www.bing.com';
+            Mozilla.Analytics.customReferrer = '';
+            expect(Utils.getReferrer(expected)).toEqual(expected);
         });
     });
 


### PR DESCRIPTION
## One-line summary

This PR fixes some existing holes in attribution data, where referrer was being lost when Traffic Cop performs a redirect.

## Significant changes and points to review

I added a global `Mozilla.Analytics.getReferrer()` helper that other scripts can use to get referrer more reliably. It touches three places:

- Glean
- Stub Attribution
- FxA Attribution

Hopefully the tests I added can give some confidence that the value is now being passed as expected, but I also added some manual testing instructions below.

## Issue / Bugzilla link

#13593

## Testing

Note: test all the items below using a browser with DNT disabled.

**Glean**

1. Set `GLEAN_LOG_PINGS=True` in your `.env`.
2. Open http://localhost:8000/en-US/firefox/new/
3. Click on the Mozilla logo in the main navigation to go to the home page. You should be entered into a traffic cop experiment with wither `?v=1` or `?v=2` in the URL.
4. Confirm in the page ping in the web console that referrer is `http://localhost:8000/en-US/firefox/new/` and not `http://localhost:8000/en-US/`

**Stub attribution**

1. Open http://localhost:8000/en-US/firefox/new/
2. Click on the Mozilla logo in the main navigation to go to the home page. You should be entered into a traffic cop experiment with wither `?v=1` or `?v=2` in the URL.
3. In the web console, run `Mozilla.StubAttribution.getAttributionData()`.
4. Confirm that `referrer` is `http://localhost:8000/en-US/firefox/new/` and not `http://localhost:8000/en-US/`.

**FxA Attribution**

I found [this add-on](https://addons.mozilla.org/en-US/firefox/addon/referer-modifier/) useful for manual testing. With it you can override the referrer to any value you choose:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/400117/218104709-c4e16521-aff1-4439-9f9f-d3c240aa060b.png">

1. With a modified referrer set to `https://www.google.com/`, open http://localhost:8000/en-US/products/vpn/. You should be redirected into a traffic cop experiment with `entrypoint_experiment=vpn-refresh-pricing` in the URL
2. Scroll down to the pricing section and inspect a subscription link in dev tools.
3. Verify the link contains `utm_source=google&utm_medium=organic`