### PR TITLE
Distinguish NA from EU in WNP117 WPN attribution [#13496]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-vpn.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx117-vpn.html
@@ -158,6 +158,16 @@
   {% set vpn_signoff = "<strong>Powered by Mozilla.</strong> Putting people before profits since 1998."|safe %}
 {%- endif -%}
 
+{% if LANG in ["en-US", "en-CA"] and country_code in ["US", "CA"] %}
+  {% if variant == "2" %}
+    {% set referral_id = "whatsnew-117-na-vpn-pricing" %}
+  {% else %}
+    {% set referral_id = "whatsnew-117-na-vpn" %}
+  {% endif %}
+{% else %}
+  {% set referral_id = "whatsnew-117-eu-vpn" %}
+{% endif %}
+
 {% block wnp_content %}
   <section class="wnp-content-main">
     <div class="mzp-l-content mzp-t-content-md">
@@ -175,7 +185,7 @@
         {% if variant == "2" %}
           {{ vpn_product_referral_link(
             page_anchor='#pricing',
-            referral_id='whatsnew-117-eu-vpn-pricing',
+            referral_id=referral_id,
             link_text=vpn_cta,
             class_name='mzp-t-product mzp-t-xl',
             optional_attributes= {
@@ -186,7 +196,7 @@
           ) }}
         {% else %}
           {{ vpn_product_referral_link(
-            referral_id='whatsnew-117-eu-vpn',
+            referral_id=referral_id,
             link_text=vpn_cta,
             class_name='mzp-t-product mzp-t-xl',
             optional_attributes= {


### PR DESCRIPTION
## One-line summary

Sets a different `referral_id` for traffic in North America, to help us track attribution on the refreshed VPN pages.

## Testing

http://localhost:8000/en-US/firefox/117.0/whatsnew/?geo=US : English in the US should get `whatsnew-117-na-vpn`
http://localhost:8000/en-US/firefox/117.0/whatsnew/?geo=US&v=2 : English in the US should get `whatsnew-117-na-vpn-pricing` for the pricing variation.
http://localhost:8000/en-US/firefox/117.0/whatsnew/?geo=LV : English in other target countries should get `whatsnew-117-eu-vpn`
http://localhost:8000/bg/firefox/117.0/whatsnew/?geo=BG : Other languages in other target countries should get `whatsnew-117-eu-vpn`
