### PR TITLE
Add H1 2023 transparency report [fix #13633]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,7 @@
 <nav class="prev-reports-nav">
   <h3>Previous Reports</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2022') }}">July-December 2022</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2022') }}">January-June 2022</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2021') }}">July-December 2021</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2021') }}">January-June 2021</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -15,7 +15,7 @@
     </li>
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2022') }}">July-December 2022 Report</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2023') }}">January-June 2023 Report</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2023.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2023.html
@@ -1,0 +1,427 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}Transparency Report - January-June 2023{% endblock %}
+
+{% block report_title %}
+<h1>Transparency Report <span>Reporting Period: January 1, 2023 to June 30, 2023</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for User Data</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received the following.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Legal Processes</th>
+          <th scope="col">Received</th>
+          <th scope="col">User Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">Search Warrants</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">Subpoenas</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">Court Orders</a>
+          </th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">Wiretap Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">Pen Register Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">Emergency Requests</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">National Security Requests</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>0-249</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p id="footnote-1">
+        <sup>1</sup> We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for Content Removal</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received no government request for content removal from our services.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Requesting Country</th>
+          <th scope="col">Requests Received</th>
+          <th scope="col">Items Removed</th>
+          <th scope="col">Items Geographically Restricted</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">None</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Copyright</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received eight Copyright Takedown Notices (note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>8</td>
+          <td>0</td>
+          <td>8</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Trademark</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 23 Trademark Takedown Notices and 3 Counter Notices (note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>23</td>
+          <td>3</td>
+          <td>104</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="other-content" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Other Takedown Requests By Companies or Individuals</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 0 private takedown notices invoking laws other than copyright or trademark.</p>
+  </div>
+</section>
+
+<section id="personal-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Personal Data Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 12,238 requests.</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Received</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Mozilla</th>
+          <td>9,604</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>2,634</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="targeted-advertising" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Targeted Advertising Disclosures</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, and during the time we started targeted advertising, we have placed the following targeted advertisements.</p>
+
+    <h3>Mozilla</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/2023-na-mozilla-rise25-promotion-meta-campaign.pdf">
+          2023 NA Mozilla Rise 25 Promotion
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/mradi-2023-campaign.pdf">
+          Mradi 2023 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/pocket-eu-campaign-q1-2023.pdf">
+          Pocket EU Campaign
+        </a>
+      </li>
+    </ul>
+
+    <h3>Firefox</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/firefox-h1-2023-eu-challenge-the-default-meta-and-reddit.pdf">
+          H1 2023 EU Challenge the Default
+        </a>
+      </li>
+    </ul>
+
+    <h3>Mozilla Foundation Ads</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/alternative-data-governance-playbook-campaign.pdf">
+          Alternative Data Governance Playbook Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/mozfest-2023-campaign.pdf">
+          Mozfest 2023 Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/mozilla-common-voice-kiswahili-festival-campaign.pdf">
+          Mozilla Common Voice Kiswahili Festival Campaign
+        </a>
+      </li>
+      <li>
+        <a href="https://assets.mozilla.net/pdf/transparency-report/h1-2023/responsible-computing-challenge-campaign.pdf">
+          Responsible Computing Challenge Campaign
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section id="monthly-active-users" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">EU Monthly Active Users</h2>
+
+  <div data-accordion-role="tabpanel">
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Average MAU in the European Union</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Addons.mozilla.org</th>
+          <td>3,031,122</td>
+        </tr>
+        <tr>
+          <th scope="row">Hubs</th>
+          <td>&lt;50,000</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>337,992</td>
+        </tr>
+        <tr>
+          <th scope="row">MDN</th>
+          <td>3,052,833</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Supplement</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      During the course of this reporting period, Mozilla continued its efforts to
+      protect the security and privacy of our users through public policy. In the
+      European Union, we ramped up our work on the eIDAS legislation, which
+      <a href="https://blog.mozilla.org/netpolicy/2021/11/04/mozilla-publishes-position-paper-on-the-eu-digital-identity-framework/">threatens</a>
+      web security by placing a ceiling on the standards for web certificates.
+      This included amplifying our public <a href="https://securityriskahead.eu/">campaign</a>
+      to drive awareness of the risks posed by the issue, organizing an
+      <a href="https://securityriskahead.eu/wp-content/uploads/2023/02/MEPs-adapt-eIDAS-article-45.2-due-to-cybersecurity-concerns.pdf">event</a>
+      with a Member of European Parliament and our CSO, briefing the US National Institute of Standards and Technology
+      (NIST) delegation, conducting meetings with members of the European Council,
+      Parliament and Commission, and publishing a
+      <a href="https://securityriskahead.eu/wp-content/uploads/2023/05/A-law-of-unintended-consequences-EUs-digital-identity-law.pdf">report</a>
+      on the negative impact of the law on Europe’s cybersecurity. After some positive developments in the
+      Parliament vote, we are currently engaging with EU policymakers during the
+      interinstitutional negotiations to ensure a net positive outcome for web security.
+      We also organized a <a href="https://www.cpdpconferences.org/panels/thursday-25-may-2023-grid">panel</a>
+      at the Computers, Privacy and Data Protection (CPDP)
+      conference on privacy preserving advertising. We also published our
+      <a href="https://blog.mozilla.org/netpolicy/2023/07/13/european-parliaments-version-of-the-cra-threatens-cybersecurity-and-open-source-development/">position paper</a>
+      on the Cyber Resilience Act (CRA) and are engaged in conversations to protect
+      the interests of the open source community.
+    </p>
+
+    <p>
+      In the United Kingdom, we continued our work on privacy preserving advertising
+      and mitigating online tracking via conversations with the Competition and Markets
+      Authority (CMA). We intend to expand our policy engagements in the United Kingdom
+      in the coming months.
+    </p>
+
+    <p>
+      In the United States, we testified at a congressional
+      <a href="https://democrats-energycommerce.house.gov/committee-activity/hearings/hearing-on-who-is-selling-your-data-a-critical-examination-of-the-role">hearing</a>
+      in DC on data brokers, spoke at an event organized by National Academies of Sciences,
+      Engineering, and Medicine on children privacy, held meetings with the FTC and
+      Congressional Staffers on privacy and advertising, and
+      <a href="https://blog.mozilla.org/netpolicy/2023/03/27/mozilla-submits-comments-to-ntia-on-privacy-equity-and-civil-rights/">submitted comments to the US National Telecommunications Information Administration (NTIA)’s</a>
+      <a href="https://www.federalregister.gov/documents/2023/01/20/2023-01088/privacy-equity-and-civil-rights-request-for-comment">request</a>
+      on the intersection of privacy, equity, and civil rights in commercial data
+      collection practices.
+    </p>
+
+    <p>
+      Globally, we <a href="https://www.globalencryption.org/2023/04/mozilla-and-internet-freedom-foundation-join-global-encryption-coalition-steering-committee/">joined</a>
+      the Steering Committee of the Global Encryption Coalition
+      to defend encryption in the jurisdictions where it is most at-risk, including
+      India. We also worked with local think tanks on the drawbacks present in the
+      latest version of India’s data protection law. We also spoke on a
+      <a href="https://foundation.mozilla.org/de/blog/mozilla-rightscon-2023/">panel</a>
+      at RightsCon 2023 on how privacy and security might look in the federated social
+      media systems with a global perspective. In Kenya, we briefed the Parliament’s
+      Committee on Communication, Information and Innovation on privacy and the
+      importance of implementing Kenya’s data protection law.
+    </p>
+
+    <h3>Voluntary Threat Indicators & Data Disclosures</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Type of Disclosure</th>
+          <th scope="col">Number of Disclosures</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">Cybersecurity Threat Indicator</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            Other <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-specific-user' }}">Specific User</a> Data Disclosure
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -81,6 +81,7 @@ urlpatterns = (
     page("about/policy/transparency/jul-dec-2021/", "mozorg/about/policy/transparency/jul-dec-2021.html"),
     page("about/policy/transparency/jan-jun-2022/", "mozorg/about/policy/transparency/jan-jun-2022.html"),
     page("about/policy/transparency/jul-dec-2022/", "mozorg/about/policy/transparency/jul-dec-2022.html"),
+    page("about/policy/transparency/jan-jun-2023/", "mozorg/about/policy/transparency/jan-jun-2023.html"),
     page("contact/", "mozorg/contact/contact-landing.html"),
     page("contact/spaces/", "mozorg/contact/spaces/spaces-landing.html"),
     page("contact/spaces/beijing/", "mozorg/contact/spaces/beijing.html"),


### PR DESCRIPTION
## One-line summary
Adds the transparency report for the period from January to June, 2023.

## Issue / Bugzilla link
#13633 

## Testing
http://localhost:8000/en-US/about/policy/transparency/
http://localhost:8000/en-US/about/policy/transparency/jan-jun-2023/