### PR TITLE
Update root store policy to 2.9 [fix bug #1851326]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
@@ -28,8 +28,8 @@
    #    with links to each top-level heading.
   #}
   <h1 class="mzp-c-article-title" id="mozilla-root-store-policy">Mozilla Root Store Policy</h1>
-  <p><em>Version 2.8.1</em></p>
-  <p><em><a href="https://wiki.mozilla.org/CA/Root_Store_Policy_Archive">Effective February 15, 2023</a></em></p>
+  <p><em>Version 2.9</em></p>
+  <p><em><a href="https://wiki.mozilla.org/CA/Root_Store_Policy_Archive">Effective September 1, 2023</a></em></p>
 
   <ol class="mzp-u-list-styled">
     <li><a href="#1-introduction">Introduction</a></li>
@@ -54,44 +54,43 @@
   <p>This policy covers how the default set of certificates and associated trust
   bits is maintained for software products distributed by Mozilla. Other entities
   distributing software based on ours are free to adopt their own policies. In
-  particular, under the terms of the relevant Mozilla license(s) distributors of
+  particular, under the terms of the relevant Mozilla license(s), distributors of
   such software are permitted to add or delete CA certificates and modify the
   values of the trust bits in the versions that they distribute. However,
   as with other software modifications, by making such changes a distributor may
   well affect its ability to use Mozilla trademarks in connection with its
-  versions of the software. See the <a href="https://www.mozilla.org/foundation/trademarks/policy/">Mozilla trademark policy</a> for more
+  versions of the software. See the <a href="{{ url('foundation.trademarks.policy') }}">Mozilla trademark policy</a> for more
   information.</p>
   <h3 id="11-scope">1.1 Scope</h3>
   <p>This policy applies, as appropriate, to certificates matching any of the
   following (and to the CA operators* that control or issue them):</p>
   <ol class="mzp-u-list-styled">
-    <li>
-      <p>CA certificates included in, or under consideration for inclusion in, the
-        Mozilla root store;</p>
-    </li>
-    <li>
-    <p>intermediate certificates that have at least one valid, unrevoked chain up
-        to such a CA certificate and that are technically capable of issuing
-        working server or email certificates. Intermediate certificates that are not considered to be technically capable will contain either:</p>
-      <ul>
-        <li>an Extended Key Usage (EKU) extension that does not contain any of
-          these KeyPurposeIds: anyExtendedKeyUsage, id-kp-serverAuth,
-          id-kp-emailProtection; or</li>
-        <li>name constraints that do not allow Subject Alternative Names (SANs) of
-          any of the following types: dNSName, iPAddress, SRVName, or rfc822Name; <em>and</em></li>
-      </ul>
-    </li>
-    <li>
-    <p>end entity certificates that have at least one valid, unrevoked chain up
-        to such a CA certificate through intermediate certificates that are all in
-        scope, such end entity certificates having either:</p>
-      <ul>
-        <li>an Extended Key Usage (EKU) extension that contains one or more of these
-          KeyPurposeIds: anyExtendedKeyUsage, id-kp-serverAuth,
-          id-kp-emailProtection; or</li>
-        <li>no EKU extension.</li>
-      </ul>
-    </li>
+  <li>
+  <p>CA certificates included in, or under consideration for inclusion in, the
+      Mozilla root store;</p>
+  </li>
+  <li>
+  <p>intermediate certificates that have at least one valid, unrevoked chain up
+      to such a CA certificate and that are technically capable of issuing
+      working server or email certificates. Intermediate certificates that are not considered to be technically capable will contain either:</p>
+  <ul>
+  <li>an Extended Key Usage (EKU) extension that does not contain any of
+    these KeyPurposeIds: anyExtendedKeyUsage, id-kp-serverAuth,
+    id-kp-emailProtection; or</li>
+  <li>name constraints that do not allow Subject Alternative Names (SANs) of
+    any of the following types: dNSName, iPAddress, SRVName, or rfc822Name; <em>and</em></li>
+  </ul>
+  </li>
+  <li>
+  <p>end entity certificates that have at least one valid, unrevoked chain up
+      to such a CA certificate through intermediate certificates that are all in
+      scope and</p>
+  <ul>
+  <li>an EKU extension that contains the anyExtendedKeyUsage KeyPurposeId, or no EKU extension;</li>
+  <li>an EKU extension that contains the id-kp-serverAuth KeyPurposeId; or</li>
+  <li>an EKU extension that contains the id-kp-emailProtection KeyPurposeId and an rfc822Name or an otherName of type id-on-SmtpUTF8Mailbox in the subjectAltName.</li>
+  </ul>
+  </li>
   </ol>
   <p>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
   "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
@@ -114,68 +113,61 @@
   <h3 id="21-ca-operations">2.1 CA Operations</h3>
   <p>CA operators whose certificates are included in Mozilla's root store MUST:</p>
   <ol class="mzp-u-list-styled">
-    <li>provide some service relevant to users of our software
-        products;</li>
-    <li>follow industry best practice for securing their networks, for example
-        by conforming to the <a href="https://cabforum.org/network-security-requirements/">CA/Browser Forum's Network and Certificate System Security Requirements</a> or a
-        successor document;</li>
-    <li>enforce multi-factor authentication for all accounts capable of causing
-        certificate issuance or performing Registration Authority or Delegated
-        Third Party functions, or implement technical controls operated by the CA
-        to restrict certificate issuance through the account to a limited set of
-        pre-approved domains or email addresses;</li>
-    <li>prior to issuing certificates, verify certificate
-        requests in a manner that we deem acceptable for the stated
-        purpose(s) of the certificates;</li>
-    <li>verify that all of the information that is included in server certificates remains current and correct at intervals of 825 days or less;
-      <p>5.1. for server certificates issued on or after October 1, 2021, each dNSName or IPAddress in a SAN or commonName MUST have been validated in accordance with section 3.2.2 of the CA/Browser Forum's Baseline Requirements within the preceding 398 days;</p>
-    </li>
-    <li>otherwise operate in accordance with published criteria that we
-        deem acceptable; <em>and</em></li>
-    <li>ensure that all certificates within the scope of this policy,
-        as described in Section 1.1, adhere to this policy.</li>
+  <li>provide some service relevant to users of our software
+      products;</li>
+  <li>follow industry best practice for securing their networks, for example
+      by conforming to the <a href="https://cabforum.org/network-security-requirements/">CA/Browser Forum's Network and Certificate System Security Requirements</a> or a
+      successor document;</li>
+  <li>enforce multi-factor authentication for all accounts capable of causing
+      certificate issuance or performing Registration Authority or Delegated
+      Third Party functions, or implement technical controls operated by the CA
+      to restrict certificate issuance through the account to a limited set of
+      pre-approved domains or email addresses;</li>
+  <li>prior to issuing certificates, verify certificate
+      requests in a manner that we deem acceptable for the stated
+      purpose(s) of the certificates;</li>
+  <li>verify each dNSName or IPAddress in a SAN or commonName in server certificates in accordance with sections 3.2.2.4 and 3.2.2.5 of the CA/Browser Forum's Baseline Requirements at intervals of 398 days or less, and verify that all other information that is included in server certificates remains current and correct at intervals of 825 days or less;</li>
+  <li>otherwise operate in accordance with published criteria that we
+      deem acceptable; <em>and</em></li>
+  <li>ensure that all certificates within the scope of this policy,
+      as described in Section 1.1, adhere to this policy.</li>
   </ol>
-  <p>CA operators MUST follow and be aware of discussions in
-  <a href="https://groups.google.com/a/mozilla.org/g/dev-security-policy">Mozilla dev-security-policy</a> forum and the <a href="https://groups.google.com/a/ccadb.org/g/public">CCADB Public List</a>, where root store policies and program updates are announced and public discussions of root inclusion requests occur.  They are encouraged, but not required, to contribute to those discussions.</p>
+  <p>CA operators MUST follow and be aware of discussions in both the
+  <a href="https://groups.google.com/a/mozilla.org/g/dev-security-policy">Mozilla dev-security-policy</a> forum and the <a href="https://groups.google.com/a/ccadb.org/g/public">CCADB Public List</a>, where root store policies and program updates are announced and public discussions of root inclusion requests occur. They are encouraged, but not required, to contribute to those
+  discussions.</p>
   <h3 id="22-validation-practices">2.2 Validation Practices</h3>
   <p>We consider verification of certificate signing requests to be acceptable if it
   meets or exceeds the following requirements:</p>
   <ol class="mzp-u-list-styled">
-    <li>all information that is supplied by the certificate subscriber
-        MUST be verified by using an independent source of information
-        or an alternative communication channel before it is included in
-        the certificate;</li>
-    <li>for a certificate capable of being used for digitally signing or encrypting
-        email messages, the CA operator MUST take reasonable measures to verify that
-        the entity submitting the request controls the email account
-        associated with the email address referenced in the certificate
-        <em>or</em> has been authorized by the email account holder to act on
-        the account holder’s behalf. The CA operator SHALL NOT delegate validation
-        of the domain portion of an email address. The CA MAY rely
-        on validation the CA has performed for
-        an Authorization Domain Name (as specified in the Baseline Requirements)
-        as being valid for subdomains of that Authorization Domain Name.
-        The CA operator's CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the procedure(s)
-        that the CA employs to perform this verification;</li>
-    <li>for a certificate capable of being used for TLS-enabled servers, the CA
-        MUST ensure that the applicant has registered all domain(s) referenced
-        in the certificate or has been authorized by the domain registrant to
-        act on their behalf. This MUST be done using one or more of the
-        methods documented in section 3.2.2.4 of the CA/Browser Forum Baseline Requirements. The CA operator's
-        CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the procedure(s) that the CA employs, and
-        each documented procedure MUST state which subsection of 3.2.2.4 it is
-        complying with. CAs are not permitted to use 3.2.2.5 (4) ("any other method")
-        to fulfill the requirements of method 3.2.2.4.8 (IP Address);</li>
-    <li>for a certificate capable of being used for TLS-enabled servers, the CA
-        MUST ensure that the applicant has control over all IP Address(es) referenced
-        in the certificate. This MUST be done using one or more of the
-        methods documented in section 3.2.2.5 of the CA/Browser Forum Baseline Requirements. The CA operator's
-        CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the procedure(s) that the CA employs, and
-        each documented procedure SHOULD state which subsection of 3.2.2.5 it is
-        complying with; <em>and</em></li>
-    <li>for certificates marked as Extended Validation, CA operators MUST comply with the
-        latest version of the <a href="https://cabforum.org/extended-validation/">Guidelines for the Issuance and Management of
-        Extended Validation Certificates</a>.</li>
+  <li>all information that is supplied by the certificate subscriber
+      MUST be verified by using an independent source of information
+      or an alternative communication channel before it is included in
+      the certificate;</li>
+  <li>for a certificate capable of being used for digitally signing or encrypting
+      email messages, the CA operator MUST take reasonable measures to verify that
+      the entity submitting the request controls the email account
+      associated with the email address referenced in the certificate
+      <em>or</em> has been authorized by the email account holder to act on
+      the account holder’s behalf. This MUST be done using one or more of the methods documented in section 3.2.2 of the <a href="https://cabforum.org/smime-br/">CA/Browser Forum's S/MIME Baseline Requirements</a>. The CA operator's CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the procedure(s)
+      that the CA employs to perform this verification;</li>
+  <li>for a certificate capable of being used for TLS-enabled servers, the CA
+      MUST ensure that the applicant has registered all domain(s) referenced
+      in the certificate or has been authorized by the domain registrant to
+      act on their behalf. This MUST be done using one or more of the
+      methods documented in section 3.2.2.4 of the <a href="https://cabforum.org/baseline-requirements-documents/">TLS Baseline Requirements</a>. The CA operator's
+      CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the procedure(s) that the CA employs, and
+      each documented procedure MUST state which subsection of 3.2.2.4 it is
+      complying with;</li>
+  <li>for a certificate capable of being used for TLS-enabled servers, the CA
+      MUST ensure that the applicant has control over all IP Address(es) referenced
+      in the certificate. This MUST be done using one or more of the
+      methods documented in section 3.2.2.5 of the <a href="https://cabforum.org/baseline-requirements-documents/">TLS Baseline Requirements</a>. The CA operator's
+      CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the procedure(s) that the CA employs, and
+      each documented procedure SHOULD state which subsection of 3.2.2.5 it is
+      complying with; <em>and</em></li>
+  <li>for certificates marked as Extended Validation, CA operators MUST comply with the
+      latest version of the <a href="https://cabforum.org/extended-validation/">Guidelines for the Issuance and Management of
+      Extended Validation Certificates</a>.</li>
   </ol>
   <p>Validation methods are occasionally found to contain security flaws. When this happens,
   Mozilla expects CA operators to evaluate their practices and respond appropriately to mitigate the risk.
@@ -183,33 +175,41 @@
   immediately discontinuing use of a method.</p>
   <h3 id="23-baseline-requirements-conformance">2.3 Baseline Requirements Conformance</h3>
   <p>CA operations relating to issuance of certificates capable of being used for
-  TLS-enabled servers MUST also conform to the latest version of the <a href="https://cabforum.org/baseline-requirements-documents/">CA/Browser
+  TLS-enabled servers MUST conform to the latest version of the <a href="https://cabforum.org/baseline-requirements-documents/">CA/Browser
   Forum Baseline Requirements for the Issuance and Management of Publicly-Trusted
-  Certificates</a> ("Baseline Requirements"). In the event of inconsistency
-  between this policy's requirements and the Baseline Requirements,
+  Certificates</a> ("TLS Baseline Requirements"). Certificates issued on or after September 1, 2023, that are capable of being used to digitally sign or encrypt email messages, and CA operations relating to the issuance of such certificates, MUST conform to the latest version of the <a href="https://cabforum.org/smime-br/">CA/Browser Forum Baseline Requirements for the Issuance and Management of Publicly-Trusted S/MIME Certificates</a> ("S/MIME Baseline Requirements"). In the event of inconsistency
+  between this policy's requirements and either the S/MIME or TLS Baseline Requirements,
   this policy's requirements take precedence. The following is a list of known
-  places where this policy takes precedence over the Baseline Requirements. If
+  places where this policy takes precedence over the S/MIME and TLS Baseline Requirements. If
   you find an inconsistency that is not listed here, notify Mozilla so the item
   can be considered for addition or clarification.</p>
   <ul class="mzp-u-list-styled">
-    <li>Insofar as the Baseline Requirements attempt to define their own scope, the
-        scope of this policy (section 1.1) overrides that. CA
-        operations relating to issuance of <strong>all</strong> TLS server certificates in the scope of
-        this policy SHALL conform to the Baseline Requirements.</li>
-    <li>Mozilla MAY accept audits by auditors who do not meet the
-        qualifications given in section 8.2 of the Baseline Requirements, or refuse
-        audits from auditors who do.</li>
-    <li>Mozilla MAY restrict permitted algorithms to a subset of those allowed by the
-        Baseline Requirements.</li>
+  <li>
+  <p>Insofar as the S/MIME or TLS Baseline Requirements attempt to define their own scope, the
+      scope of this policy (section 1.1) overrides that. CA
+      operations relating to issuance of <strong>all</strong> S/MIME or TLS server certificates in the scope of
+      this policy SHALL conform to the S/MIME or TLS Baseline Requirements, as applicable.</p>
+  </li>
+  <li>
+  <p>Mozilla MAY accept audits by auditors who do not meet the
+      qualifications given in section 8.2 of the S/MIME or TLS Baseline Requirements, or refuse
+      audits from auditors who do.</p>
+  </li>
+  <li>
+  <p>Mozilla MAY restrict permitted algorithms to a subset of those allowed by the S/MIME or TLS
+      Baseline Requirements.</p>
+  </li>
   </ul>
   <h3 id="24-incidents">2.4 Incidents</h3>
   <p>When a CA operator fails to comply with any requirement of this policy - whether it be
   a misissuance, a procedural or operational issue, or any other variety of
-  non-compliance - the event is classified as an incident and MUST be reported to Mozilla as soon as the CA operator is made aware. At a minimum, CA operators MUST promptly report all incidents to Mozilla in the form of an <a href="https://wiki.mozilla.org/CA/Responding_To_An_Incident">Incident Report</a>. Any matter documented in an audit as a qualification, a modified opinion, or a major non-conformity is also considered an incident and MUST have a corresponding Incident Report. CA operators
-  MUST regularly update the Incident Report until the corresponding bug
-  is marked as resolved in the mozilla.org <a href="https://bugzilla.mozilla.org">Bugzilla</a> system by a Mozilla representative.
+  non-compliance - the event is classified as an incident and MUST be reported to Mozilla as soon as the CA operator is made aware. At a minimum, CA operators MUST promptly report all <a href="https://wiki.mozilla.org/CA/Responding_To_An_Incident">incidents</a> to Mozilla in the form of an Incident Report that follows <a href="https://www.ccadb.org/cas/incident-report">guidance provided on the CCADB website</a>. </p>
+  <p>Any matter documented in an audit as a qualification, a modified opinion, or a major non-conformity is also considered an incident and MUST have a corresponding <a href="https://www.ccadb.org/cas/incident-report#audit-incident-reports">Audit Incident Report</a>. CA operators MUST regularly update the Incident Report until the corresponding bug
+  is marked as resolved in <a href="https://bugzilla.mozilla.org">Bugzilla</a> by a root store representative.
   CA operators SHOULD cease issuance until the problem has been prevented from reoccurring.  </p>
   <p>Mozilla expects the timely remediation of the problems that caused or gave rise to the incident. In response to incidents, Mozilla MAY require the CA operator to submit a plan of action with milestones or to submit one or more additional audits to provide sufficient assurance that the incident has been remediated. Such audits MAY be expected sooner than the CA operator’s next scheduled audit, and thus MAY be expected to be for a period less than a year.</p>
+  <h4 id="241-vulnerability-and-security-incident-reporting">2.4.1 Vulnerability and Security Incident Reporting</h4>
+  <p>Additionally, and not in lieu of the requirement to publicly report incidents as outlined above, a CA Operator MUST disclose a serious vulnerability or security incident in <a href="https://bugzilla.mozilla.org">Bugzilla</a> as a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&amp;component=CA%20Security%20Vulnerability&amp;groups=ca-program-security&amp;product=CA%20Program">secure bug</a> in accordance with guidance found on the <a href="https://wiki.mozilla.org/CA/Vulnerability_Disclosure">Vulnerability Disclosure wiki page</a>.</p>
   <h2 id="3-documentation">3. Documentation</h2>
   <h3 id="31-audits">3.1 Audits</h3>
   <p>Before being included and at least annually thereafter, CA operators MUST obtain certain
@@ -219,69 +219,82 @@
   <h4 id="311-audit-criteria">3.1.1 Audit Criteria</h4>
   <p>We consider the criteria for CA operations published in the
   following documents to be acceptable:</p>
+  <p><strong>WebTrust Program for Certification Authorities</strong> (<a href="https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/principles-and-criteria">WebTrust</a>)</p>
   <ul class="mzp-u-list-styled">
-    <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100awebtrust-for-ca-221-110120-finalaoda.pdf">Principles and Criteria for Certification Authorities - Version
-        2.2.1</a>" or later in <a href="https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/principles-and-criteria">WebTrust Program for Certification
-        Authorities</a>;</li>
-    <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100bwtbr-25-110120-finalaoda.pdf">Principles and Criteria for Certification Authorities – SSL
-        Baseline with Network Security - Version 2.5</a>" or later in
-        <a href="https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/principles-and-criteria">WebTrust Program for Certification Authorities</a>;</li>
-    <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100cwtev-173-110120-finalaoda.pdf">Principles and Criteria for Certification Authorities -
-        Extended Validation SSL 1.7.3</a>" or later in
-        <a href="https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/principles-and-criteria">WebTrust Program for Certification Authorities</a>;</li>
-    <li>“Trust Service Providers practice” in ETSI EN 319 411-1 v1.3.1 or
-        later version <a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.01_60/en_31941101v010301p.pdf">Policy and security requirements for Trust Service Providers
-        issuing certificates; Part 1: General requirements</a>,
-        specifying a policy or policies appropriate to the trust bit(s) being
-        applied for; <em>and</em></li>
-    <li>“Trust Service Providers practice” in ETSI EN 319 411-2 v2.4.1 or
-        later version <a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941102/02.04.01_60/en_31941102v020401p.pdf">Policy and security requirements for Trust Service Providers
-        issuing certificates; Part 2: Requirements for trust service providers
-        issuing EU qualified certificates</a>, specifying a
-        policy or policies appropriate to the trust bit(s) being applied for.</li>
+  <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216webtrustca-222final-(15).pdf">Principles and Criteria for Certification Authorities - Version
+      2.2.2</a>", or later;</li>
+  <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216wtbr-26-rev-august-2022final.pdf">Principles and Criteria for Certification Authorities – SSL
+      Baseline with Network Security - Version 2.6</a>", or later;</li>
+  <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216wtev-178final.pdf">Principles and Criteria for Certification Authorities -
+      Extended Validation SSL 1.7.8</a>", or later;</li>
+  <li>WebTrust "<a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/01618_ms_smime-certificates_final_aoda-compliant.pdf">Principles and Criteria for Certification Authorities - S/MIME Certificates</a>;</li>
+  </ul>
+  <p><strong>European Telecommunications Standards Institute</strong> (ETSI)</p>
+  <ul class="mzp-u-list-styled">
+  <li>"Trust Service Providers practice" in ETSI EN 319 411-1 v1.3.1 or
+      later version <a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.01_60/en_31941101v010301p.pdf">Policy and security requirements for Trust Service Providers
+      issuing certificates; Part 1: General requirements</a>,
+      specifying a policy or policies appropriate to the trust bit(s) being
+      applied for;</li>
+  <li>"Trust Service Providers practice" in ETSI EN 319 411-2 v2.4.1 or
+      later version <a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941102/02.04.01_60/en_31941102v020401p.pdf">Policy and security requirements for Trust Service Providers
+      issuing certificates; Part 2: Requirements for trust service providers
+      issuing EU qualified certificates</a>, specifying a
+      policy or policies appropriate to the trust bit(s) being applied for; <em>and</em></li>
+  <li>ETSI "<a href="https://www.etsi.org/deliver/etsi_ts/119400_119499/11941106/01.01.01_60/ts_11941106v010101p.pdf">Requirements for Trust Service Providers issuing publicly trusted S/MIME certificates</a>", ETSI TS 119 411-6 v1.1.1 or later version.</li>
   </ul>
   <h4 id="312-required-audits">3.1.2 Required Audits</h4>
   <h5 id="3121-webtrust">3.1.2.1 WebTrust</h5>
   <p>If being audited to the WebTrust criteria, the following audit requirements
   apply (see section 3.1.1 for specific version numbers):</p>
   <ul class="mzp-u-list-styled">
-    <li>For the websites trust bit, a CA and all intermediate CAs technically capable
-        of issuing server certificates MUST have all of the following audits:
-      <ul>
-        <li><a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100awebtrust-for-ca-221-110120-finalaoda.pdf">WebTrust for CAs</a>;</li>
-        <li><a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100bwtbr-25-110120-finalaoda.pdf">WebTrust for CAs - SSL Baseline with Network Security</a>; <em>and</em></li>
-        <li><a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100cwtev-173-110120-finalaoda.pdf">WebTrust for CAs - EV SSL</a> if <a href="https://wiki.mozilla.org/CA/EV_Processing_for_CAs#EV_TLS_Capable">capable of issuing EV certificates</a>.</li>
-      </ul>
-    </li>
-    <li>For the email trust bit, a CA and all intermediate CAs technically capable
-        of issuing email certificates MUST have all of the following audits:
-      <ul>
-        <li><a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/wt100awebtrust-for-ca-221-110120-finalaoda.pdf">WebTrust for CAs</a>.</li>
-      </ul>
-    </li>
+  <li>
+  <p>For the websites trust bit, a CA and all intermediate CAs technically capable
+      of issuing server certificates MUST have all of the following audits:</p>
+  <ul>
+  <li><a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216webtrustca-222final-(15).pdf">WebTrust for CAs</a>;</li>
+  <li><a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216wtbr-26-rev-august-2022final.pdf">WebTrust for CAs - SSL Baseline with Network Security</a>; <em>and</em></li>
+  <li><a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216wtev-178final.pdf">WebTrust for CAs - EV SSL</a> if <a href="https://wiki.mozilla.org/CA/EV_Processing_for_CAs#EV_TLS_Capable">capable of issuing EV certificates</a>.</li>
+  </ul>
+  </li>
+  <li>
+  <p>For the email trust bit, a CA and all intermediate CAs technically capable
+      of issuing email certificates MUST have all of the following audits:</p>
+  <ul>
+  <li><a href="https://www.cpacanada.ca/-/media/site/operational/ep-education-pld/docs/mds21216webtrustca-222final-(15).pdf">WebTrust for CAs</a>;
+  and,  </li>
+  <li>for audit periods ending after October 30, 2023, a period-of-time audit performed in accordance with <a href="https://www.cpacanada.ca/-/media/site/operational/ms-member-services/docs/webtrust/01618_ms_smime-certificates_final_aoda-compliant.pdf">WebTrust for CAs - S/MIME</a>.</li>
+  </ul>
+  </li>
   </ul>
   <h5 id="3122-etsi">3.1.2.2 ETSI</h5>
   <p>If being audited to the ETSI criteria, the following audit requirements apply
   (see section 3.1.1 for version numbers):</p>
   <ul class="mzp-u-list-styled">
-    <li>For the websites trust bit, a CA and all intermediate CAs technically
-        capable of issuing server certificates MUST have one of the
-        following audits, with at least one of the noted policies or sets of
-        policies:
-      <ul>
-        <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.01_60/en_31941101v010301p.pdf">ETSI EN 319 411-1</a> (LCP and (DVCP or OVCP)) and/or (NCP and EVCP); <em>or</em></li>
-        <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941102/02.04.01_60/en_31941102v020401p.pdf">ETSI EN 319 411-2</a> (QCP-w).</li>
-      </ul>
-      <p>An audit showing conformance with the EVCP policy is REQUIRED if a CA is <a href="https://wiki.mozilla.org/CA/EV_Processing_for_CAs#EV_TLS_Capable">capable of issuing EV certificates</a>.</p>
-    </li>
-    <li>For the email trust bit, a CA and all intermediate CAs technically
-        capable of issuing email certificates MUST have one of the
-        following audits, with at least one of the noted policies:
-      <ul>
-        <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.01_60/en_31941101v010301p.pdf">ETSI EN 319 411-1</a> (LCP, NCP, or NCP+); <em>or</em></li>
-        <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941102/02.04.01_60/en_31941102v020401p.pdf">ETSI EN 319 411-2</a> (QCP-l, QCP-l-qscd, QCP-n, or QCP-n-qscd)</li>
-      </ul>
-    </li>
+  <li>
+  <p>For the websites trust bit, a CA and all intermediate CAs technically
+      capable of issuing server certificates MUST have one of the
+      following audits, with at least one of the noted policies or sets of
+      policies:</p>
+  <ul>
+  <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.01_60/en_31941101v010301p.pdf">ETSI EN 319 411-1</a> (LCP and (DVCP or OVCP)) and/or (NCP
+    and EVCP); <em>or</em></li>
+  <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941102/02.04.01_60/en_31941102v020401p.pdf">ETSI EN 319 411-2</a> (QCP-w).</li>
+  </ul>
+  <p>An audit showing conformance with the EVCP policy is REQUIRED if a CA is <a href="https://wiki.mozilla.org/CA/EV_Processing_for_CAs#EV_TLS_Capable">capable of issuing EV certificates</a>.</p>
+  </li>
+  <li>
+  <p>For the email trust bit, a CA and all intermediate CAs technically
+      capable of issuing email certificates MUST have the
+      following audits, with at least one of the noted policies:</p>
+  <ul>
+  <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.01_60/en_31941101v010301p.pdf">ETSI EN 319 411-1</a> (LCP, NCP, or NCP+); <em>or</em></li>
+  <li><a href="https://www.etsi.org/deliver/etsi_en/319400_319499/31941102/02.04.01_60/en_31941102v020401p.pdf">ETSI EN 319 411-2</a> (QCP-l, QCP-l-qscd, QCP-n, or
+    QCP-n-qscd);
+    and,  </li>
+  <li>for audit periods ending after October 30, 2023, a period-of-time audit performed in accordance with <a href="https://www.etsi.org/deliver/etsi_ts/119400_119499/11941106/01.01.01_60/ts_11941106v010101p.pdf">ETSI TS 119 411-6</a>.</li>
+  </ul>
+  </li>
   </ul>
   <h4 id="313-audit-parameters">3.1.3 Audit Parameters</h4>
   <p>Full-surveillance period-of-time audits MUST be conducted and updated audit
@@ -295,36 +308,11 @@
   Mozilla root store MUST be provided to Mozilla via the CCADB within three
   months of the point-in-time date or the end date of the period.</p>
   <h4 id="314-public-audit-information">3.1.4 Public Audit Information</h4>
-  <p>The publicly-available documentation relating to each audit MUST contain at
-  least the following clearly-labelled information:</p>
-  <ol class="mzp-u-list-styled">
-    <li>name of the company being audited;</li>
-    <li>name and address of the organization performing the audit;</li>
-    <li>name of the lead auditor and <a href="https://wiki.mozilla.org/CA/Audit_Statements#Auditor_Qualifications">qualifications of the team</a> performing the audit, as required by section 3.2; </li>
-    <li>Distinguished Name and SHA256 fingerprint of each root and intermediate
-        certificate that was in scope;</li>
-    <li>audit criteria (with version number) that were used to audit each of
-        the certificates;</li>
-    <li>a list of the CA policy documents (with version numbers) referenced during
-        the audit;</li>
-    <li>whether the audit is for a period of time or a point in time;</li>
-    <li>the start date and end date of the period, for those that cover a period
-        of time;</li>
-    <li>the point-in-time date, for those that are for a point in time;</li>
-    <li>the date the report was issued (which will necessarily be after the end
-        date or point-in-time date); </li>
-    <li>all incidents (as defined in section 2.4) disclosed by the CA, discovered by the auditor, or reported by a third party, that, at any time during the audit period, occurred or were open in Bugzilla;</li>
-    <li>the <a href="https://wiki.mozilla.org/CA/Audit_Statements#Audited_Locations">CA locations that were or were not audited</a>; <em>and</em></li>
-    <li>for ETSI, a statement to indicate if the audit was a full audit, and which
-        parts of the criteria were applied, e.g. DVCP, OVCP, NCP, NCP+, LCP, EVCP,
-        EVCP+, QCP-w, Part1 (General Requirements), and/or Part 2 (Requirements for
-        trust service providers).</li>
-  </ol>
-  <p>An authoritative English language version of the publicly-available audit information MUST be supplied by the Auditor.</p>
+  <p>The publicly-available documentation relating to each audit MUST contain the information required by section 5.1 of the <a href="https://www.ccadb.org/policy">CCADB Policy</a> (v.1.2.3) and the <a href="https://wiki.mozilla.org/CA/Audit_Statements#Audited_Locations">CA locations that were or were not audited</a>. Audit reports MUST also contain or be accompanied by the name of the lead auditor and <a href="https://wiki.mozilla.org/CA/Audit_Statements#Auditor_Qualifications">qualifications of the team</a> performing the audit, as required by section 3.2.</p>
   <p>If Mozilla determines that an audit provided does not meet the requirements of this policy, then Mozilla MAY require that the CA operator obtain a new audit, at the CA operator's expense, for the period of time in question. Additionally, depending on the nature of concerns with the audit, Mozilla MAY require that the CA operator obtain such an audit from a new auditor.</p>
   <h3 id="32-auditors">3.2 Auditors</h3>
   <p>In normal circumstances, Mozilla requires that audits MUST be performed
-  by a Qualified Auditor, as defined in the Baseline Requirements, section 8.2.</p>
+  by a Qualified Auditor, as defined in section 8.2 of the S/MIME or TLS Baseline Requirements.</p>
   <p>A Qualified Auditor MUST have relevant IT Security experience, or have audited a number of CAs, and be independent. ETSI Audit Attestation Letters MUST follow the Audit Attestation Letter template on the <a href="https://www.acab-c.com/downloads">ACAB'c website</a>, and ETSI auditors MUST be members of the <a href="https://www.acab-c.com/members/">Accredited Conformity Assessment Bodies' Council</a> and follow the ACAB'c Charter and Code of Conduct. WebTrust audit statements MUST follow the practitioner guidance, principles, and illustrative assurance reports on the <a href="https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/principles-and-criteria">CPA Canada website</a>, and WebTrust auditors MUST be listed as <a href="https://www.cpacanada.ca/en/business-and-accounting-resources/audit-and-assurance/overview-of-webtrust-services/licensed-webtrust-practitioners-international">enrolled WebTrust practitioners</a> on the CPA Canada website. Mozilla MAY, at its sole discretion, decide to temporarily waive membership or enrollment requirements.</p>
   <p>Each Audit Report MUST be accompanied by documentation provided to Mozilla of the <a href="https://wiki.mozilla.org/CA/Audit_Statements#Auditor_Qualifications">audit team qualifications</a> sufficient for Mozilla to determine the competence, experience, and independence of the auditor. </p>
   <p>If a CA operator wishes to use auditors who do not fit the definition of Qualified Auditor, then it MUST
@@ -336,60 +324,71 @@
   Certification Practice Statement) to ascertain that our requirements are met.
   Therefore:</p>
   <ol class="mzp-u-list-styled">
-    <li>the publicly disclosed documentation MUST provide sufficient
-        information for Mozilla to determine whether and how the CA operator
-        complies with this policy, including a description of the steps
-        taken by the CA to verify certificate requests;</li>
-    <li>the publicly disclosed documentation MUST be available from the CA operator’s official website;</li>
-    <li>the documentation MUST be made available to Mozilla under one
-        of the following Creative Commons licenses (or later versions):
-      <ul>
-        <li>Attribution (<a href="https://creativecommons.org/licenses/by/4.0/">CC-BY</a>) 4.0;</li>
-        <li>Attribution-ShareAlike (<a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>) 4.0;</li>
-        <li>Attribution-NoDerivs (<a href="https://creativecommons.org/licenses/by-nd/4.0/">CC-BY-ND</a>) 4.0; <em>or</em></li>
-        <li>Public Domain Dedication (<a href="https://creativecommons.org/publicdomain/zero/1.0/">CC-0</a>) 1.0; </li>
-      </ul>
-        or a set of equally permissive licensing terms accepted by Mozilla in
-        writing. If no such license is indicated, the fact of application is
-        considered as permission from the CA operator to allow Mozilla and the public to
-        deal with these documents, and any later versions for root certificates
-        that are included in Mozilla's root store, under CC-BY-ND 4.0;</li>
-    <li>all CPs, CPSes, and combined CP/CPSes MUST be reviewed and updated as necessary at least once every
-        365 days, as required by the Baseline Requirements. CA operators MUST indicate that this has
-        happened by incrementing the version number and adding a dated changelog entry,
-        even if no other changes are made to the document;</li>
-    <li>all CPs, CPSes, and combined CP/CPSes MUST be structured according to RFC 3647 and MUST:
-      <ul>
-        <li>include at least every section and subsection defined in RFC 3647; </li>
-        <li>only use the words "No Stipulation" to mean that the particular document
-        imposes no requirements related to that section; and</li>
-        <li>contain no sections that are blank and have no subsections; </li>
-      </ul>
-    </li>
-    <li>CA operators MUST provide a way to clearly determine which CP, CPS, or combined CP/CPS
-        applies to each of its root and intermediate certificates; <em>and</em></li>
-    <li>CA operators SHALL maintain links to all historic versions of each CP and CPS (or CP/CPS) from the creation of included CA certificates, regardless of changes in ownership or control of such CA certificates, until the entire CA certificate hierarchies (i.e. end entity certificates, intermediate CA certificates, and cross-certificates) operated in accordance with such documents are no longer trusted by the Mozilla root store. For CA certificates that were included in Mozilla's root store before December 31, 2022, the CA Operator shall maintain links in their online repositories to all reasonably available historic versions of CPs and CPSes (or CP/CPSes) from creation of the included CA certificates.</li>
+  <li>
+  <p>the publicly disclosed documentation MUST provide sufficient
+      information for Mozilla to determine whether and how the CA operator
+      complies with this policy, including a description of the steps
+      taken by the CA to verify certificate requests;</p>
+  </li>
+  <li>
+  <p>the publicly disclosed documentation MUST be available from the CA operator’s official website;</p>
+  </li>
+  <li>
+  <p>the documentation MUST be made available to Mozilla under one
+      of the following Creative Commons licenses (or later versions):</p>
+  <ul>
+  <li>Attribution (<a href="https://creativecommons.org/licenses/by/4.0/">CC-BY</a>) 4.0;</li>
+  <li>Attribution-ShareAlike (<a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>) 4.0;</li>
+  <li>Attribution-NoDerivs (<a href="https://creativecommons.org/licenses/by-nd/4.0/">CC-BY-ND</a>) 4.0; <em>or</em></li>
+  <li>Public Domain Dedication (<a href="https://creativecommons.org/publicdomain/zero/1.0/">CC-0</a>) 1.0; </li>
+  </ul>
+  <p>or a set of equally permissive licensing terms accepted by Mozilla in
+  writing. If no such license is indicated, the fact of application is
+  considered as permission from the CA operator to allow Mozilla and the public to
+  deal with these documents, and any later versions for root certificates
+  that are included in Mozilla's root store, under CC-BY-ND 4.0;</p>
+  </li>
+  <li>
+  <p>all CPs, CPSes, and combined CP/CPSes MUST be reviewed and updated as necessary at least once every 365 days, as required by the S/MIME or TLS Baseline Requirements. CA operators MUST indicate that this has
+  happened by incrementing the version number and adding a dated changelog entry,
+  even if no other changes are made to the document;</p>
+  </li>
+  <li>
+  <p>all CPs, CPSes, and combined CP/CPSes MUST be structured according to RFC 3647 and MUST:</p>
+  <ul>
+  <li>include at least every section and subsection defined in RFC 3647; </li>
+  <li>only use the words "No Stipulation" to mean that the particular document
+  imposes no requirements related to that section; and</li>
+  <li>contain no sections that are blank and have no subsections; </li>
+  </ul>
+  </li>
+  <li>
+  <p>CA operators MUST provide a way to clearly determine which CP, CPS, or combined CP/CPS
+  applies to each of its root and intermediate certificates; <em>and</em></p>
+  </li>
+  <li>
+  <p>CA operators SHALL maintain links to all historic versions of each CP and CPS (or CP/CPS) from the creation of included CA certificates, regardless of changes in ownership or control of such CA certificates, until the entire CA certificate hierarchies (i.e. end entity certificates, intermediate CA certificates, and cross-certificates) operated in accordance with such documents are no longer trusted by the Mozilla root store. For CA certificates that were included in Mozilla's root store before December 31, 2022, the CA Operator shall maintain links in their online repositories to all reasonably available historic versions of CPs and CPSes (or CP/CPSes) from creation of the included CA certificates.</p>
+  </li>
   </ol>
+  <h3 id="34-compliance-self-assessments">3.4 Compliance Self-Assessments</h3>
+  <p>CA operators with CA certificates capable of issuing working TLS server certificates MUST perform a <a href="https://www.ccadb.org/cas/self-assessment">Compliance Self-Assessment</a> annually. The annual self-assessment MUST be completed and submitted to the CCADB within 92 calendar days from the CA operator's earliest appearing root record “BR Audit Period End Date” that is after December 31, 2023. CA operators SHOULD submit the self-assessment at the same time as uploading audit reports in a <a href="https://www.ccadb.org/cas/updates">CCADB Case</a>. CA operators SHOULD use the latest available version of the <a href="https://www.ccadb.org/cas/self-assessment">Compliance Self-Assessment</a> template, and MUST NOT use a version of the self-assessment template that has been superseded by more than 90 calendar days before submission.</p>
   <h2 id="4-common-ca-database">4. Common CA Database</h2>
   <p>Mozilla manages its root store using the Common CA Database (CCADB). CA operators with
   certificates in Mozilla’s root store MUST use the CCADB, and are bound by the
-  latest published version of the <a href="https://www.ccadb.org/policy">Common CCADB Policy</a>, which is
+  latest published version of the <a href="https://www.ccadb.org/policy">CCADB Policy</a>, which is
   incorporated here by reference.</p>
-  <p>When required by the CCADB Policy, Mozilla’s root store may be contacted
-  <a href="mailto:certificates@mozilla.org">by email</a>.</p>
   <p>Mozilla has requirements for the use of the CCADB above and beyond those in the
   CCADB Policy, as indicated below in this section 4.</p>
   <h3 id="41-additional-requirements">4.1 Additional Requirements</h3>
   <ul class="mzp-u-list-styled">
-    <li>CA operators with intermediate CA certificates that are capable of issuing TLS certificates chaining up to root certificates in Mozilla's root store SHALL populate the CCADB fields under "Pertaining to Certificates Issued by This CA" with either the CRL Distribution Point for the "Full CRL Issued By This CA" or a "JSON Array of Partitioned CRLs" within 7 days of such intermediate CA issuing its first certificate;</li>
-    <li>Each CRL referenced by the JSON Array of Partitioned CRLs MUST contain a critical Issuing Distribution Point extension as described in section 6.1.2; <em>and</em></li>
-    <li>if the revocation of an intermediate certificate chaining up to a root in
-    Mozilla’s root store is due to a security concern, as well as performing the
-    actions defined in the CCADB Policy, a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS&amp;component=CA%20Certificate%20Compliance&amp;groups=crypto-core-security">security bug MUST be filed in
-    Bugzilla</a>.</li>
+  <li>CA operators with intermediate CA certificates that are capable of issuing TLS certificates chaining up to root certificates in Mozilla's root store SHALL populate the "Pertaining to Certificates Issued by This CA" section of the CCADB records corresponding to those intermediate CA certificates with either the CRL Distribution Point for the "Full CRL Issued By This CA" or a "JSON Array of Partitioned CRLs" within 7 days of such intermediate CA issuing its first certificate;</li>
+  <li>Each CRL referenced by the JSON Array of Partitioned CRLs MUST contain a critical Issuing Distribution Point extension as described in section 6.1.2; <em>and</em></li>
+  <li>if the revocation of an intermediate certificate chaining up to a root in
+  Mozilla’s root store is due to a security concern, as well as performing the
+  actions defined in the CCADB Policy, a <a href="https://wiki.mozilla.org/CA/Vulnerability_Disclosure">Vulnerability Disclosure</a> MUST be filed as <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&amp;component=CA%20Security%20Vulnerability&amp;groups=ca-program-security&amp;product=CA%20Program">a secure bug in Bugzilla</a>.</li>
   </ul>
   <h3 id="42-surveys">4.2 Surveys</h3>
-  <p>Mozilla MAY conduct a survey of CA operators from time to time using the CCADB. CA operators are
+  <p>Mozilla MAY conduct a survey of CA operators from time to time. CA operators are
   REQUIRED to respond to the surveys with accurate information, within the
   timescale defined in the survey.</p>
   <h2 id="5-certificates">5. Certificates</h2>
@@ -398,25 +397,26 @@
   chains up to them, MUST use only algorithms and key sizes from the following
   set:</p>
   <ul class="mzp-u-list-styled">
-    <li>RSA keys whose modulus size in bits is divisible by 8, and is at
-        least 2048 bits; <em>or</em></li>
-    <li>ECDSA keys using one of the following curves:
-      <ul>
-        <li>P-256; <em>or</em></li>
-        <li>P-384.</li>
-      </ul>
-    </li>
+  <li>RSA keys whose modulus size in bits is divisible by 8, and is at
+      least 2048 bits; <em>or</em></li>
+  <li>ECDSA keys using one of the following curves:<ul>
+  <li>P-256; <em>or</em></li>
+  <li>P-384.</li>
   </ul>
+  </li>
+  </ul>
+  <p>The following curves are not prohibited, but are not currently supported: P-521, Curve25519, and Curve448.</p>
+  <p>EdDSA keys MAY be included in certificates that chain to a root certificate in our root store if the certificate contains ‘id-kp-emailProtection` in the EKU extension. Otherwise, EdDSA keys MUST NOT be included.</p>
   <p>The following sections detail encoding and signature algorithm requirements for
   each of these keys. The encoding requirements on signature algorithms apply to
   any contexts where the algorithm is encoded as an AlgorithmIdentifier,
   including:</p>
   <ul class="mzp-u-list-styled">
-    <li>The signatureAlgorithm field of a Certificate;</li>
-    <li>The signature field of a TBSCertificate;</li>
-    <li>The signatureAlgorithm field of a CertificateList;</li>
-    <li>The signature field of a TBSCertList; <em>and</em></li>
-    <li>The signatureAlgorithm field of a BasicOCSPResponse.</li>
+  <li>The signatureAlgorithm field of a Certificate;</li>
+  <li>The signature field of a TBSCertificate;</li>
+  <li>The signatureAlgorithm field of a CertificateList;</li>
+  <li>The signature field of a TBSCertList; <em>and</em></li>
+  <li>The signatureAlgorithm field of a BasicOCSPResponse.</li>
   </ul>
   <h4 id="511-rsa">5.1.1 RSA</h4>
   <p>When RSA keys are encoded in a SubjectPublicKeyInfo structure, the algorithm
@@ -432,50 +432,48 @@
   signature, only the following algorithms MAY be used, and with the following
   encoding requirements:</p>
   <ul class="mzp-u-list-styled">
-    <li>
-      <p>RSASSA-PKCS1-v1_5 with SHA-1.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
-      <code>300d06092a864886f70d0101050500</code>.</p>
-    </li>
-  </ul>
-  <p><strong>See section 5.1.3 for further restrictions on the use of SHA-1.</strong></p>
-  <ul class="mzp-u-list-styled">
-    <li>
-      <p>RSASSA-PKCS1-v1_5 with SHA-256.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
-      <code>300d06092a864886f70d01010b0500</code>.</p>
-    </li>
-    <li>
-      <p>RSASSA-PKCS1-v1_5 with SHA-384.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
-      <code>300d06092a864886f70d01010c0500</code>.</p>
-    </li>
-    <li>
-      <p>RSASSA-PKCS1-v1_5 with SHA-512.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
-      <code>300d06092a864886f70d01010d0500</code>.</p>
-    </li>
-    <li>
-      <p>RSASSA-PSS with SHA-256, MGF-1 with SHA-256, and a salt length of 32 bytes.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:</p>
-      <p><code>304106092a864886f70d01010a3034a00f300d0609608648016503040201
-        0500a11c301a06092a864886f70d010108300d0609608648016503040201
-        0500a203020120</code></p>
-    </li>
-    <li>
-      <p>RSASSA-PSS with SHA-384, MGF-1 with SHA-384, and a salt length of 48 bytes.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:</p>
-      <p><code>304106092a864886f70d01010a3034a00f300d0609608648016503040202
-        0500a11c301a06092a864886f70d010108300d0609608648016503040202
-        0500a203020130</code></p>
-    </li>
-    <li>
-      <p>RSASSA-PSS with SHA-512, MGF-1 with SHA-512, and a salt length of 64 bytes.</p>
-      <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:</p>
-      <p><code>304106092a864886f70d01010a3034a00f300d0609608648016503040203
-        0500a11c301a06092a864886f70d010108300d0609608648016503040203
-        0500a203020140</code></p>
-    </li>
+  <li>
+  <p>RSASSA-PKCS1-v1_5 with SHA-1.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
+  <code>300d06092a864886f70d0101050500</code>.</p>
+  <p><em>See section 5.1.3 for further restrictions on the use of SHA-1.</em></p>
+  </li>
+  <li>
+  <p>RSASSA-PKCS1-v1_5 with SHA-256.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
+  <code>300d06092a864886f70d01010b0500</code>.</p>
+  </li>
+  <li>
+  <p>RSASSA-PKCS1-v1_5 with SHA-384.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
+  <code>300d06092a864886f70d01010c0500</code>.</p>
+  </li>
+  <li>
+  <p>RSASSA-PKCS1-v1_5 with SHA-512.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
+  <code>300d06092a864886f70d01010d0500</code>.</p>
+  </li>
+  <li>
+  <p>RSASSA-PSS with SHA-256, MGF-1 with SHA-256, and a salt length of 32 bytes.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:</p>
+  <p><code>304106092a864886f70d01010a3034a00f300d0609608648016503040201
+  0500a11c301a06092a864886f70d010108300d0609608648016503040201
+  0500a203020120</code></p>
+  </li>
+  <li>
+  <p>RSASSA-PSS with SHA-384, MGF-1 with SHA-384, and a salt length of 48 bytes.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:</p>
+  <p><code>304106092a864886f70d01010a3034a00f300d0609608648016503040202
+  0500a11c301a06092a864886f70d010108300d0609608648016503040202
+  0500a203020130</code></p>
+  </li>
+  <li>
+  <p>RSASSA-PSS with SHA-512, MGF-1 with SHA-512, and a salt length of 64 bytes.</p>
+  <p>The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:</p>
+  <p><code>304106092a864886f70d01010a3034a00f300d0609608648016503040203
+  0500a11c301a06092a864886f70d010108300d0609608648016503040203
+  0500a203020140</code></p>
+  </li>
   </ul>
   <p>The above RSASSA-PKCS1-v1_5 encodings consist of the corresponding OID,
   e.g. sha256WithRSAEncryption (1.2.840.113549.1.1.11), with an explicit NULL
@@ -493,10 +491,14 @@
   <p>When ECDSA keys are encoded in a SubjectPublicKeyInfo structure, the algorithm
   field MUST be one of the following, as specified by <a href="https://datatracker.ietf.org/doc/html/rfc5480#section-2.1.1">RFC 5480, Section 2.1.1</a>:</p>
   <ul class="mzp-u-list-styled">
-    <li>the encoded AlgorithmIdentifier for a P-256 key MUST match the following
-      hex-encoded bytes: <code>301306072a8648ce3d020106082a8648ce3d030107</code>; <em>or</em></li>
-    <li>the encoded AlgorithmIdentifier for a P-384 key MUST match the following
-      hex-encoded bytes: <code>301006072a8648ce3d020106052b81040022</code>.</li>
+  <li>
+  <p>the encoded AlgorithmIdentifier for a P-256 key MUST match the following
+    hex-encoded bytes: <code>301306072a8648ce3d020106082a8648ce3d030107</code>; <em>or</em></p>
+  </li>
+  <li>
+  <p>the encoded AlgorithmIdentifier for a P-384 key MUST match the following
+    hex-encoded bytes: <code>301006072a8648ce3d020106052b81040022</code>.</p>
+  </li>
   </ul>
   <p>The above encodings consist of an ecPublicKey OID (1.2.840.10045.2.1) with a
   named curve parameter of the corresponding curve OID. Certificates MUST NOT use
@@ -505,16 +507,16 @@
   signature, only the following algorithms MAY be used, and with the following
   encoding requirements:</p>
   <ul class="mzp-u-list-styled">
-    <li>
-      <p>If the signing key is P-256, the signature MUST use ECDSA with SHA-256. The
-        encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
-        <code>300a06082a8648ce3d040302</code>.</p>
-    </li>
-    <li>
-      <p>If the signing key is P-384, the signature MUST use ECDSA with SHA-384. The
-        encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
-        <code>300a06082a8648ce3d040303</code>.</p>
-    </li>
+  <li>
+  <p>If the signing key is P-256, the signature MUST use ECDSA with SHA-256. The
+    encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
+    <code>300a06082a8648ce3d040302</code>.</p>
+  </li>
+  <li>
+  <p>If the signing key is P-384, the signature MUST use ECDSA with SHA-384. The
+    encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
+    <code>300a06082a8648ce3d040303</code>.</p>
+  </li>
   </ul>
   <p>The above encodings consist of the corresponding OID with the parameters field
   omitted, as specified by <a href="https://datatracker.ietf.org/doc/html/rfc5758#section-3.2">RFC 5758, Section 3.2</a>.
@@ -524,47 +526,42 @@
   <p>Effective July 1, 2022, CAs SHALL NOT sign SHA-1 hashes over end entity certificates with an EKU extension containing the id-kp-emailProtection key purpose.</p>
   <p>Effective July 1, 2023, CAs SHALL NOT sign SHA-1 hashes over:</p>
   <ul class="mzp-u-list-styled">
-    <li>certificates with an EKU extension containing the id-kp-ocspSigning key purpose;</li>
-    <li>intermediate certificates that chain up to roots in Mozilla's program;</li>
-    <li>OCSP responses; <em>or</em></li>
-    <li>CRLs.</li>
+  <li>certificates with an EKU extension containing the id-kp-ocspSigning key purpose;</li>
+  <li>intermediate certificates that chain up to roots in Mozilla's program;</li>
+  <li>OCSP responses; <em>or</em></li>
+  <li>CRLs.</li>
   </ul>
-  <p>CAs MAY sign SHA-1 hashes over end entity certificates which chain
+  <p>CAs MAY sign SHA-1 hashes over end entity certificates that chain
   up to roots in Mozilla's program only if all the following are true:</p>
   <ol class="mzp-u-list-styled">
-    <li>the end entity certificate:
-      <ul>
-        <li>is not within the scope of the Baseline Requirements;</li>
-        <li>contains an EKU extension which does not contain either of the
-          id-kp-serverAuth or anyExtendedKeyUsage key purposes; <em>and</em></li>
-        <li>has at least 64 bits of entropy from a CSPRNG in the serial number; <em>and</em></li>
-      </ul>
-    </li>
-    <li>the issuing certificate:
-      <ul>
-        <li>contains an EKU extension which does not contain either of the
-          id-kp-serverAuth or anyExtendedKeyUsage key purposes; <em>and</em></li>
-        <li>has a pathlen:0 constraint.</li>
-      </ul>
-    </li>
+  <li>
+  <p>the end entity certificate:</p>
+  <ul>
+  <li>is not within the scope of the S/MIME or TLS Baseline Requirements;</li>
+  <li>contains an EKU extension that does not contain the
+   id-kp-serverAuth, id-kp-emailProtection, or anyExtendedKeyUsage key purposes; <em>and</em></li>
+  <li>has at least 64 bits of entropy from a CSPRNG in the serial number; <em>and</em></li>
+  </ul>
+  </li>
+  <li>
+  <p>the issuing certificate:</p>
+  <ul>
+  <li>contains an EKU extension that does not contain the
+   id-kp-serverAuth, id-kp-emailProtection, or anyExtendedKeyUsage key purposes; <em>and</em></li>
+  <li>has a pathlen:0 constraint.</li>
+  </ul>
+  </li>
   </ol>
-  <p>Point 2 does not apply if the certificate is an OCSP signing certificate
-  manually issued directly from a root.</p>
   <p>CAs MAY sign SHA-1 hashes over intermediate certificates that
   chain up to roots in Mozilla's root store only if the certificate to be signed
   is a duplicate of an existing SHA-1 intermediate certificate with the
   only changes being all of:</p>
-  <ul class="mzp-u-list-styled">
-    <li>a new key (of the same size);</li>
-    <li>a new serial number (of the same length); <em>and/or</em></li>
-    <li>the addition of an EKU and/or a pathlen constraint to meet the
-        requirements outlined above. </li>
+  <ul>
+  <li>a new key (of the same size);</li>
+  <li>a new serial number (of the same length); <em>and/or</em></li>
+  <li>the addition of an EKU and/or a pathlen constraint to meet the
+      requirements outlined above. </li>
   </ul>
-  <p>CAs MAY sign SHA-1 hashes over OCSP responses only if the signing
-  certificate contains an EKU extension which contains only the
-  id-kp-ocspSigning EKU.</p>
-  <p>CAs MAY sign SHA-1 hashes over CRLs for roots and intermediates
-  only if they have issued SHA-1 certificates. </p>
   <p>CAs MUST NOT sign SHA-1 hashes over other data, including CT pre-certificates.</p>
   <h3 id="52-forbidden-and-required-practices">5.2 Forbidden and Required Practices</h3>
   <p>CA operations MUST at all times be in accordance with the applicable CP
@@ -572,36 +569,35 @@
   <p>CA operators MUST maintain a certificate hierarchy such that an included
   root certificate does not directly issue end entity certificates to
   customers (i.e. a root certificate signs intermediate
-  issuing certificates), as described in section 6.1.7 of the
-  <a href="https://cabforum.org/baseline-requirements-documents/">Baseline Requirements</a>.</p>
+  issuing certificates), as described in section 6.1.7 of the <a href="https://cabforum.org/baseline-requirements-documents/">TLS
+  Baseline Requirements</a> and the <a href="https://cabforum.org/smime-br/">S/MIME Baseline Requirements</a>.</p>
   <p>CA operators MUST maintain current best practices to prevent
   algorithm attacks against certificates. As such, all new certificates
   MUST have a serial number greater than zero, containing at least 64 bits of
   output from a CSPRNG.</p>
   <p>CA operators MUST NOT issue certificates, CRLs, or OCSP responses, that have:</p>
   <ul class="mzp-u-list-styled">
-    <li>ASN.1 DER encoding errors;</li>
-    <li>invalid public keys (e.g., RSA certificates with public exponent
-        equal to 1); <em>or</em></li>
-    <li>missing or incorrect extensions (e.g., TLS certificates with no subjectAltName extension, delegated OCSP responders without the id-pkix-ocsp-nocheck extension, partial/scoped CRLs that lack a distributionPoint in a critical issuingDistributionPoint extension).</li>
+  <li>ASN.1 DER encoding errors;</li>
+  <li>invalid public keys (e.g., RSA certificates with public exponent
+      equal to 1); <em>or</em></li>
+  <li>missing or incorrect extensions (e.g., TLS certificates with no subjectAltName extension, delegated OCSP responders without the id-pkix-ocsp-nocheck extension, partial/scoped CRLs that lack a distributionPoint in a critical issuingDistributionPoint extension).</li>
   </ul>
   <p>CA operators MUST NOT issue certificates that have:</p>
   <ul class="mzp-u-list-styled">
-    <li>duplicate issuer names and serial numbers (except that a Certificate
-        Transparency pre-certificate is allowed to match the corresponding
-        certificate); <em>or</em></li>
-    <li>cRLDistributionPoints or OCSP authorityInfoAccess extensions for
-        which no operational CRL or OCSP service exists.</li>
+  <li>duplicate issuer names and serial numbers (except that a Certificate
+      Transparency pre-certificate is allowed to match the corresponding
+      certificate); <em>or</em></li>
+  <li>cRLDistributionPoints or OCSP authorityInfoAccess extensions for
+      which no operational CRL or OCSP service exists.</li>
   </ul>
   <p>CA operators MUST NOT generate the key pairs for end entity certificates that have an
   EKU extension containing the KeyPurposeIds id-kp-serverAuth or anyExtendedKeyUsage, unless the certificate is being issued to the CA itself.</p>
-  <p>Effective for certificates with a notBefore date of July 1, 2020 or later,
-  end entity certificates MUST include an EKU extension containing KeyPurposeId(s)
+  <p>All end entity certificates MUST include an EKU extension containing KeyPurposeId(s)
   describing the intended usage(s) of the certificate, and the EKU extension MUST NOT
   contain the KeyPurposeId anyExtendedKeyUsage.</p>
   <h3 id="53-intermediate-certificates">5.3 Intermediate Certificates</h3>
-  <p>All certificates that are capable of being used to issue new certificates and that directly or transitively chain to a CA certificate included in Mozilla’s root store MUST be operated in accordance with this policy and MUST either be technically constrained or be publicly disclosed and audited.</p>
-  <p>A certificate is deemed as capable of being used to issue new
+  <p>All certificates that are capable of being used to issue new certificates and that directly or transitively chain to a CA certificate included in Mozilla’s root store MUST be operated in accordance with this policy.</p>
+  <p>A certificate is deemed capable of being used to issue new
   certificates if it contains an <a href="https://datatracker.ietf.org/doc/html/rfc5280#section-6.1.4">X.509v3 basicConstraints extension</a>
   with the cA boolean set to true. </p>
   <p>A certificate is deemed to directly or transitively chain to a CA certificate included in Mozilla's root store if:
@@ -609,50 +605,48 @@
   (2) the certificate is signed with a Private Key whose corresponding Public Key is encoded in the SubjectPublicKeyInfo of that CA certificate or intermediate certificate.</p>
   <p>Intermediate certificates created after January 1, 2019, with the exception of cross-certificates that share a private key with a corresponding root certificate:</p>
   <ul class="mzp-u-list-styled">
-    <li>MUST contain an EKU extension;</li>
-    <li>MUST NOT include the anyExtendedKeyUsage KeyPurposeId; <em>and</em></li>
-    <li>MUST NOT include both the id-kp-serverAuth and id-kp-emailProtection KeyPurposeIds in the same certificate.</li>
+  <li>MUST contain an EKU extension;</li>
+  <li>MUST NOT include the anyExtendedKeyUsage KeyPurposeId; <em>and</em></li>
+  <li>MUST NOT include both the id-kp-serverAuth and id-kp-emailProtection KeyPurposeIds in the same certificate.</li>
   </ul>
-  <h4 id="531-technically-constrained">5.3.1 Technically Constrained</h4>
+  <h4 id="531-technically-constrained">5.3.1 Technically Constrained ####</h4>
   <p>We encourage CA operators to technically constrain all intermediate
   certificates. For an intermediate certificate to be considered technically
   constrained, the certificate MUST include an <a href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12">Extended Key Usage
   (EKU)</a> extension specifying the extended key usage(s) allowed for the type of end entity certificates that the
   intermediate CA is authorized to issue. We also encourage CA operators to include only a single KeyPurposeID in the EKU extension of intermediate certificates. The anyExtendedKeyUsage
   KeyPurposeId MUST NOT appear within this extension. </p>
-  <p>If the intermediate CA certificate includes the id-kp-serverAuth extended key usage,
-  then to be considered technically constrained, the certificate MUST be Name Constrained as described in section
-  7.1.5 of version 1.3 or later of the <a href="https://cabforum.org/baseline-requirements-documents/">Baseline Requirements</a>. The id-kp-clientAuth EKU MAY also be present.
-  The conformance requirements defined in section 2.3 of this policy also apply to
+  <p>The conformance requirements defined in section 2.3 of this policy also apply to
   technically constrained intermediate certificates.</p>
+  <p>If the intermediate CA certificate includes the id-kp-serverAuth extended key usage,
+  then to be considered technically constrained, the certificate MUST be name-constrained as described in section
+  7.1.2.5 of the <a href="https://cabforum.org/baseline-requirements-documents/">TLS Baseline Requirements</a>, each entry in permittedSubtrees having been validated according to section
+  3.2.2 of the TLS Baseline Requirements. The id-kp-clientAuth EKU MAY also be present.</p>
   <p>If the intermediate CA certificate includes the id-kp-emailProtection extended key
   usage, then to be considered technically
-  constrained, it MUST include the Name Constraints X.509v3 extension with
+  constrained, it MUST comply with section 7.1.5 of the <a href="https://cabforum.org/smime-br/">S/MIME Baseline Requirements</a> and include the Name Constraints X.509v3 extension with
   constraints on rfc822Name, with at least one name in permittedSubtrees,
-  each such name having its ownership validated according to section
-  3.2.2.4 of the <a href="https://cabforum.org/baseline-requirements-documents/">Baseline Requirements</a>. The values id-kp-serverAuth and anyExtendedKeyUsage MUST NOT be present. id-kp-clientAuth MAY be present. Other values that the CA is allowed to use and are documented in the CA’s CP, CPS, or combined CP/CPS MAY be present.</p>
+  each name having been validated according to section
+  3.2.2 of the <a href="https://cabforum.org/smime-br/">S/MIME Baseline Requirements</a>. The values id-kp-serverAuth and anyExtendedKeyUsage MUST NOT be present. The id-kp-clientAuth EKU MAY be present. Other values that the CA is allowed to use and are documented in the CA’s CP, CPS, or combined CP/CPS MAY be present.</p>
   <h4 id="532-publicly-disclosed-and-audited">5.3.2 Publicly Disclosed and Audited</h4>
-  <p>The operator of a CA certificate included in Mozilla’s root store MUST publicly disclose in the CCADB all CA certificates they issue that chain up to that CA certificate trusted in Mozilla’s root store that are technically capable of issuing working server or email certificates, including those CA certificates that share the same key pair whether they are self-signed, doppelgänger, reissued, cross-signed, or other roots. The CA operator with a certificate included in Mozilla’s root store MUST disclose  such CA certificate within one week of certificate creation, and before any such CA is allowed to issue certificates. Name-constrained CA certificates that are technically capable of issuing working server or email certificates that were exempt from disclosure in previous versions of this policy MUST be disclosed in the CCADB prior to July 1, 2022. </p>
+  <p>The operator of a CA certificate included in Mozilla’s root store MUST publicly disclose in the CCADB all CA certificates it issues that chain up to that CA certificate trusted in Mozilla’s root store that are technically capable of issuing working server or email certificates, including such CA certificates that are revoked but not yet expired and those CA certificates that share the same key pair whether they are self-signed, doppelgänger, reissued, cross-signed, or other roots. The CA operator with a certificate included in Mozilla’s root store MUST disclose such CA certificate in the CCADB within one week of certificate creation, and before any such CA is allowed to issue certificates. Name-constrained CA certificates that are technically capable of issuing working server or email certificates that were exempt from disclosure in previous versions of this policy MUST also be disclosed in the CCADB, but the submission of an audit report under section 3.1 of this policy is not required. </p>
   <p>All disclosure MUST be made freely available and without additional requirements, including, but not limited to, registration, legal agreements, or restrictions on redistribution of the certificates in whole or in part.</p>
   <p>We recognize that technically constraining intermediate
   certificates as described above may not be practical in some cases.
   All certificates that are capable of being used to issue new
   certificates, that are not technically constrained, and that
   directly or transitively chain to a certificate included in
-  Mozilla’s root store MUST be audited in accordance with this policy.
+  Mozilla’s root store MUST be audited in accordance with this policy, and the corresponding audit statements MUST be disclosed in the CCADB according to <a href="https://www.ccadb.org/policy#5-policies-audits-and-practices">section 5 of the CCADB Policy</a>.
   If the CA operator has a currently valid audit report at the time of creation
   of the intermediate certificate, then the new intermediate certificate MUST appear on the
   CA operator's next periodic audit reports.</p>
   <h3 id="54-precertificates">5.4 Precertificates</h3>
   <p>The logging of a precertificate in a Certificate Transparency log is considered by Mozilla to be a binding intent to issue a final certificate, as described in <a href="https://datatracker.ietf.org/doc/html/rfc6962#section-3.1">section 3.1 of RFC 6962</a>. "Final certificate" means a certificate that is not a precertificate. Precertificates are in-scope for enforcing compliance with these requirements. A final certificate is "based on" a precertificate if they have the same serial and issuer, or they have the same serial and the final certificate's issuer matches the precertificate's issuer's issuer. Thus,</p>
   <ul class="mzp-u-list-styled">
-    <li>it is mississuance to issue a final certificate based on a precertificate if they do not exactly match each other according to RFC 6962, section 3.1; <em>and</em></li>
-    <li>if a precertificate implies the existence of a final certificate that does not comply with this policy, it is considered misissuance of the final certificate, even if the certificate does not actually exist.</li>
-  </ul>
-  <p>Effective October 1, 2022,</p>
-  <ul class="mzp-u-list-styled">
-    <li>a CA MUST be able to revoke a certificate presumed to exist, if revocation of the certificate is required under this policy, even if the final certificate does not actually exist; <em>and</em></li>
-    <li>a CA MUST provide CRL and OCSP services and responses in accordance with this policy for all certificates presumed to exist based on the presence of a precertificate, even if the certificate does not actually exist.</li>
+  <li>it is mississuance to issue a final certificate based on a precertificate if they do not exactly match each other according to RFC 6962, section 3.1;</li>
+  <li>if a precertificate implies the existence of a final certificate that does not comply with this policy, it is considered misissuance of the final certificate, even if the certificate does not actually exist;</li>
+  <li>a CA MUST be able to revoke a certificate presumed to exist, if revocation of the certificate is required under this policy, even if the final certificate does not actually exist; <em>and</em></li>
+  <li>a CA MUST provide CRL and OCSP services and responses in accordance with this policy for all certificates presumed to exist based on the presence of a precertificate, even if the certificate does not actually exist.</li>
   </ul>
   <h2 id="6-revocation">6. Revocation</h2>
   <p>CA operators MUST maintain an online 24x7 repository mechanism whereby
@@ -664,152 +658,53 @@
   <p>For end entity certificates, if the CA provides revocation information
   via an Online Certificate Status Protocol (OCSP) service:</p>
   <ul class="mzp-u-list-styled">
-    <li>it MUST update that service at least every four days; </li>
-    <li>responses MUST have a defined value in the nextUpdate field, and it
-        MUST be no more than ten days after the thisUpdate field; <em>and</em></li>
-    <li>the value in the nextUpdate field MUST be before or equal to the
-        notAfter date of all certificates included within the
-        BasicOCSPResponse.certs field or, if the certs field is omitted,
-        before or equal to the notAfter date of the CA certificate which
-        issued the certificate that the BasicOCSPResponse is for.</li>
+  <li>it MUST update that service at least every four days; </li>
+  <li>responses MUST have a defined value in the nextUpdate field, and it
+      MUST be no more than ten days after the thisUpdate field; <em>and</em></li>
+  <li>the value in the nextUpdate field MUST be before or equal to the
+      notAfter date of all certificates included within the
+      BasicOCSPResponse.certs field or, if the certs field is omitted,
+      before or equal to the notAfter date of the CA certificate which
+      issued the certificate that the BasicOCSPResponse is for.</li>
   </ul>
   <p>Section 4.9.12 of a CA operator's CPS (or, if applicable, the CP or CP/CPS) MUST clearly specify the methods that parties may use to demonstrate private key compromise.</p>
   <h3 id="61-tls">6.1 TLS</h3>
   <p>For any certificate in a hierarchy capable of being used for
   TLS-enabled servers, CAs MUST revoke certificates that they have
   issued upon the occurrence of any event listed in the appropriate
-  subsection of section 4.9.1 of the Baseline Requirements,
+  subsection of section 4.9.1 of the <a href="https://cabforum.org/baseline-requirements-documents/">TLS Baseline Requirements</a>,
   according to the timeline defined therein. CAs MUST also revoke
   any certificates issued in violation of the then-current version
-  of these requirements according to the timeline defined in
-  section 4.9.1 of the Baseline Requirements.</p>
+  of this policy according to the timeline defined in
+  section 4.9.1 of the TLS Baseline Requirements.</p>
   <h4 id="611-end-entity-tls-certificate-crlrevocation-reasons">6.1.1 End Entity TLS Certificate CRLRevocation Reasons</h4>
-  <p>This section applies to revocations that are performed after October 1, 2022. Revocation entries that appeared on a CRL prior to October 1, 2022, do NOT need to be changed as a result of this section.</p>
-  <p>When an end entity TLS certificate (i.e. a certificate capable of being used for TLS-enabled servers) is revoked for one of the reasons below, the specified CRLReason MUST be included in the reasonCode extension of the CRL entry corresponding to the end entity TLS certificate. When the CRLReason code is not one of the following, then the reasonCode extension MUST NOT be provided:</p>
+  <p>When an end entity TLS certificate (i.e. a certificate capable of being used for TLS-enabled servers) is revoked for one of the reasons below, the specified CRLReason MUST be included in the reasonCode extension of the CRL entry corresponding to the end entity TLS certificate, as described in sections 4.9.1 and 7.2.2 of the <a href="https://cabforum.org/baseline-requirements-documents/">TLS Baseline Requirements</a>.</p>
   <ul class="mzp-u-list-styled">
-    <li>keyCompromise (RFC 5280 CRLReason #1);</li>
-    <li>privilegeWithdrawn (RFC 5280 CRLReason #9);**</li>
-    <li>cessationOfOperation (RFC 5280 CRLReason #5);</li>
-    <li>affiliationChanged (RFC 5280 CRLReason #3); </em>or</em></li>
-    <li>superseded (RFC 5280 CRLReason #4).</li>
+  <li>keyCompromise (RFC 5280 CRLReason #1);</li>
+  <li>privilegeWithdrawn (RFC 5280 CRLReason #9);</li>
+  <li>cessationOfOperation (RFC 5280 CRLReason #5);</li>
+  <li>affiliationChanged (RFC 5280 CRLReason #3); <em>or</em></li>
+  <li>superseded (RFC 5280 CRLReason #4).</li>
   </ul>
-  <p>The CA operator's subscriber agreement for TLS end entity certificates MUST inform certificate subscribers about the revocation reason options listed above and <a href="https://wiki.mozilla.org/CA/Revocation_Reasons">provide explanation about when to choose each option</a>. Tools that the CA operator provides to the certificate subscriber MUST allow for these options to be easily specified when the certificate subscriber requests revocation of their certificate, with the default value being that no revocation reason is provided (i.e. the default corresponds to the CRLReason “unspecified (0)” which results in no reasonCode extension being provided in the CRL). </p>
-  <p>** The privilegeWithdrawn reasonCode does not need to be made available to the certificate subscriber as a revocation reason option, because the use of this reasonCode is determined by the CA operator and not the subscriber.</p>
-  <p>If the certificate is revoked for a reason not listed below, then the reasonCode extension MUST NOT be provided in the CRL.</p>
-  <p><strong>keyCompromise</strong> </p>
-  <p>The CRLReason keyCompromise MUST be used when one or more of the following occurs:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the CA operator obtains verifiable evidence that the certificate subscriber’s private key corresponding to the public key in the certificate suffered a key compromise;</li>
-    <li>the CA operator is made aware of a demonstrated or proven method that exposes the certificate subscriber’s private key to compromise;</li>
-    <li>there is clear evidence that the specific method used to generate the private key was flawed;</li>
-    <li>the CA operator is made aware of a demonstrated or proven method that can easily compute the certificate subscriber’s private key based on the public key in the certificate (such as a Debian weak key, see https://wiki.debian.org/TLSkeys); <em>or</em></li>
-    <li>the certificate subscriber requests that the CA operator revoke the certificate for this reason, with the scope of revocation being described below.</li>
-  </ul>
-  <p>The scope of revocation depends on whether the certificate subscriber has proven possession of the private key of the certificate. A CSR alone does not prove possession of the certificate’s private key for the purpose of initiating a revocation.</p>
-  <ul class="mzp-u-list-styled">
-    <li>If anyone requesting revocation for keyCompromise has previously demonstrated or can currently <a href="https://wiki.mozilla.org/CA/Revocation_Reasons#Possession_of_Private_Key">demonstrate possession of the private key of the certificate</a>, then the CA operator MUST revoke all instances of that key across all subscribers.</li>
-    <li>If the certificate subscriber requests that the CA operator revoke the certificate for keyCompromise, and has not previously demonstrated and cannot currently demonstrate possession of the associated private key of that certificate, the CA operator MAY revoke all certificates associated with that subscriber that contain that public key. The CA operator MUST NOT assume that it has evidence of private key compromise for the purposes of revoking the certificates of other subscribers, but MAY block issuance of future certificates with that key.</li>
-  </ul>
-  <p>When the CA operator obtains verifiable evidence of private key compromise for a certificate whose CRL entry does not contain a reasonCode extension or has a reasonCode extension with a non-keyCompromise reason, the CA operator SHOULD update the CRL entry to enter keyCompromise as the CRLReason in the reasonCode extension.  Additionally, the CA operator SHOULD update the revocation date in a CRL entry when it is determined that the private key of the certificate was compromised prior to the revocation date that is indicated in the CRL entry for that certificate. </p>
-  <p>Note: <a href="https://wiki.mozilla.org/CA/Revocation_Reasons#Updating_CRL_Entries">Backdating the revocationDate field</a> is an exception to best practice described in RFC 5280 (section 5.3.2); however, this policy specifies the use of the revocationDate field to support TLS implementations that process the revocationDate field as the date when the certificate is first considered to be compromised.</p>
-  <p>Otherwise, the keyCompromise CRLReason MUST NOT be used.</p>
-  <p><strong>privilegeWithdrawn</strong></p>
-  <p>The CRLReason privilegeWithdrawn is intended to be used when there has been a subscriber-side infraction that has not resulted in keyCompromise, such as the certificate subscriber provided misleading information in their certificate request or has not upheld their material obligations under the subscriber agreement or terms of use.</p>
-  <p>Unless the keyCompromise CRLReason is being used, the CRLReason privilegeWithdrawn MUST be used when:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the CA operator obtains evidence that the certificate was misused;</li>
-    <li>the CA operator is made aware that the certificate subscriber has violated one or more of its material obligations under the subscriber agreement or terms of use;</li>
-    <li>the CA operator is made aware that a wildcard certificate has been used to authenticate a fraudulently misleading subordinate fully‐qualified domain name;</li>
-    <li>the CA operator is made aware of a material change in the information contained in the certificate;</li>
-    <li>the CA operator determines or is made aware that any of the information appearing in the certificate is inaccurate; <em>or</em></li>
-    <li>the CA operator is made aware that the original certificate request was not authorized and that the Subscriber does not retroactively grant authorization.</li>
-  </ul>
-  <p>Otherwise, the privilegeWithdrawn CRLReason MUST NOT be used.</p>
-  <p><strong>cessationOfOperation</strong></p>
-  <p>The CRLReason cessationOfOperation is intended to be used when the website with the certificate is shut down prior to the expiration of the certificate, or if the subscriber no longer owns or controls the domain name in the certificate. This revocation reason is intended to be used in the following circumstances:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the certificate subscriber no longer controls, or is no longer authorized to use, all of the domain names in the certificate;</li>
-    <li>the certificate subscriber will no longer be using the certificate because they are discontinuing their website; <em>or</em></li>
-    <li>the CA operator is made aware of any circumstance indicating that use of a fully‐qualified domain name or IP address in the certificate is no longer legally permitted (e.g. a court or arbitrator has revoked a domain name registrant’s right to use the domain name, a relevant licensing or services agreement between the domain name registrant and the applicant has terminated, or the domain name registrant has failed to renew the domain name).</li>
-  </ul>
-  <p>Unless the keyCompromise CRLReason is being used, the CRLReason cessationOfOperation MUST be used when:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the certificate subscriber has requested that their certificate be revoked for this reason; <em>or</em></li>
-    <li>the CA operator has received verifiable evidence that the certificate subscriber no longer controls, or is no longer authorized to use, all of the domain names in the certificate. </li>
-  </ul>
-  <p>Otherwise, the cessationOfOperation CRLReason MUST NOT be used.</p>
-  <p><strong>affiliationChanged</strong> </p>
-  <p>The CRLReason affiliationChanged is intended to be used to indicate that the subject's name or other subject identity information in the certificate has changed, but there is no cause to suspect that the certificate’s private key has been compromised. </p>
-  <p>Unless the keyCompromise CRLReason is being used, the CRLReason affiliationChanged MUST be used when:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the certificate subscriber has requested that their certificate be revoked for this reason; <em>or</em></li>
-    <li>the CA operator has replaced the certificate due to changes in the certificate’s subject information and the CA has not replaced the certificate for the other reasons: keyCompromise, superseded, cessationOfOperation, or privilegeWithdrawn. </li>
-  </ul>
-  <p>Otherwise, the affiliationChanged CRLReason MUST NOT be used.</p>
-  <p><strong>superseded</strong></p>
-  <p>The CRLReason superseded is intended to be used to indicate when:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the certificate subscriber has requested a new certificate to replace an existing certificate; or</li>
-    <li>the CA operator obtains reasonable evidence that the validation of domain authorization or control for any fully‐qualified domain name or IP address in the certificate should not be relied upon; <em>or</em></li>
-    <li>the CA operator has revoked the certificate for compliance reasons such as the certificate does not comply with this policy, the CA/Browser Forum's Baseline Requirements, or the CA operator’s CP or CPS.</li>
-  </ul>
-  <p>Unless the keyCompromise CRLReason is being used, the CRLReason superseded MUST be used when:</p>
-  <ul class="mzp-u-list-styled">
-    <li>the certificate subscriber has requested that their certificate be revoked for this reason; <em>or</em></li>
-    <li>the CA operator has revoked the certificate due to domain authorization or compliance issues other than those related to keyCompromise or privilegeWithdrawn.</li>
-  </ul>
-  <p>Otherwise, the superseded CRLReason MUST NOT be used.</p>
-  <h4 id="612-tls">6.1.2 TLS Certificate CRL Issuing Distribution Points</h4>
+  <p>The keyCompromise,  superseded, and privilegeWithdrawn CRLReasons MUST only be used for the situations listed in the CA/Browser Forum Baseline Requirements as corresponding to these revocation reasons. Otherwise, the keyCompromise, superseded, and privilegeWithdrawn CRLReasons MUST NOT be used. </p>
+  <p>Mozilla’s wiki page, <a href="https://wiki.mozilla.org/CA/Revocation_Reasons">"Revocation Reasons"</a>, provides further details about when the CRLReasons listed above must and must not be used.</p>
+  <h4 id="612-tls-certificate-crl-issuing-distribution-points">6.1.2 TLS Certificate CRL Issuing Distribution Points</h4>
   <p>A CRL whose scope does not include all unexpired certificates that are issued by the CA SHALL contain a critical Issuing Distribution Point extension (OID 2.5.29.28). The distributionPoint field of the extension SHALL include a UniformResourceIdentifier whose value is derived from one of the two following sources:</p>
   <ol class="mzp-u-list-styled">
-    <li>The UniformResourceIdentifier as encoded in the distributionPoint field of an issued certificate's CRL Distribution Points extension (see RFC 5280 section 5.2.5); or</li>
-    <li>The URL as included in the "JSON Array of Partitioned CRLs" field in the CCADB entry corresponding to the certificate for the issuing CA.</li>
+  <li>The UniformResourceIdentifier as encoded in the distributionPoint field of an issued certificate's CRL Distribution Points extension (see RFC 5280 section 5.2.5); or</li>
+  <li>The URL as included in the "JSON Array of Partitioned CRLs" field in the CCADB entry corresponding to the certificate for the issuing CA.</li>
   </ol>
   <h3 id="62-smime">6.2 S/MIME</h3>
-  <p>For any certificate in a hierarchy capable of being used for
-  S/MIME, CA operators MUST revoke certificates upon the occurrence of
-  any of the following events:</p>
-  <ol class="mzp-u-list-styled">
-    <li>the subscriber indicates that the original certificate request
-      was not authorized and does not retroactively grant authorization;</li>
-    <li>the CA operator obtains reasonable evidence that the subscriber’s
-      private key (corresponding to the public key in the certificate)
-      has been compromised or is suspected of compromise;</li>
-    <li>the CA operator obtains reasonable evidence that the certificate
-      has been used for a purpose outside of that indicated
-      in the certificate or in the CA operator's subscriber agreement;</li>
-    <li>the CA operator receives notice or otherwise becomes aware that a
-      subscriber has violated one or more of its material obligations
-      under the subscriber agreement;</li>
-    <li>the CA operator receives notice or otherwise becomes aware of any circumstance
-      indicating that use of the email address in the certificate
-      is no longer legally permitted;</li>
-    <li>the CA operator receives notice or otherwise becomes aware of a material change
-      in the information contained in the certificate;</li>
-    <li>a determination that the certificate was not issued in accordance
-      with the CA operator’s Certificate Policy or Certification Practice Statement;</li>
-    <li>the CA operator determines that any of the information
-      appearing in the certificate is not accurate;</li>
-    <li>the CA operator ceases operations for any reason and has not arranged
-      for another CA operator to provide revocation support for the certificate;</li>
-    <li>the CA private key used in issuing the certificate is suspected
-      to have been compromised;</li>
-    <li>such additional revocation events as the CA operator publishes
-      in its policy documentation; <em>or</em></li>
-    <li>the certificate was issued in violation of the then-current
-      version of these requirements.</li>
-  </ol>
+  <p>For any certificate in a hierarchy capable of being used for S/MIME, CAs MUST revoke certificates that they have issued upon the occurrence of any event listed in the appropriate subsection of section 4.9.1 of the <a href="https://cabforum.org/smime-br/">S/MIME Baseline Requirements</a>, according to the timeline defined therein. CAs MUST also revoke any certificates issued in violation of the then-current version of this policy according to the timeline defined in section 4.9.1 of the S/MIME Baseline Requirements.</p>
   <h2 id="7-root-store-changes">7. Root Store Changes</h2>
-  <p>Changes that are motivated by a security concern such as certificate
-  misissuance or a root or intermediate compromise MUST be treated as a
-  security-sensitive, and a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS&amp;component=CA%20Certificate%20Compliance&amp;groups=crypto-core-security">secure bug filed in Bugzilla</a>.</p>
+  <p>Changes that are motivated by a security concern, such as a root or intermediate CA compromise, MUST be treated as
+  security-sensitive, and a <a href="https://wiki.mozilla.org/CA/Vulnerability_Disclosure">Vulnerability Disclosure</a> MUST be filed as a secure bug in <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&amp;component=CA%20Security%20Vulnerability&amp;groups=ca-program-security&amp;product=CA%20Program">Bugzilla</a>.</p>
   <h3 id="71-inclusions">7.1 Inclusions</h3>
   <p>We will determine which CA certificates are included in Mozilla's root store
-  based on the risks of
-  such inclusion to typical users of our products. We will consider adding
+  based on the <a href="https://wiki.mozilla.org/CA/Root_Inclusion_Considerations">risks of such inclusion to typical users of our products</a>. We will consider adding
   additional CA certificates to the default certificate set upon request only by
   an authorized representative of the subject CA. We will make such decisions
-  through a public process.</p>
+  through a <a href="https://wiki.mozilla.org/CA/Application_Process">public process</a>.</p>
   <p>We will not charge any fees to have a CA operator’s certificate(s)
   included in Mozilla's root store.</p>
   <p>We reserve the right to not include certificates from a particular CA operator in
@@ -818,41 +713,40 @@
   security, e.g. by knowingly issuing certificates without the knowledge of the
   entities whose information is referenced in those certificates ('MITM certificates').
   Mozilla is under no obligation to explain the reasoning behind any inclusion decision.</p>
-  <p>Before being included, CA operators MUST provide evidence that their CA certificates fully comply with the current Mozilla Root Store Requirements and Baseline Requirements, and have continually, from the time of CA private key creation, complied with the then-current Mozilla Root Store Policy and Baseline Requirements. </p>
+  <p>Before being included, CA operators MUST provide evidence that their CA certificates fully comply with the current Mozilla Root Store Requirements and the S/MIME or TLS Baseline Requirements, and have continually, from the time of CA private key creation, complied with the then-current Mozilla Root Store Policy and the S/MIME or TLS Baseline Requirements, as applicable. </p>
   <p>To request that its certificate(s) be added to Mozilla's root store, a CA operator
-  SHOULD submit a formal request by submitting a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS&amp;component=CA%20Certificate%20Root%20Program">bug report</a>
-  into the mozilla.org Bugzilla system, filed against the "CA
-  Certificate Root Program" component of the "NSS" product. Mozilla’s wiki
+  SHOULD submit a formal request by submitting a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&amp;product=CA%20Program&amp;component=CA%20Certificate%20Root%20Program">bug report</a>
+  into <a href="https://bugzilla.mozilla.org">Bugzilla</a>, filed against the "CA
+  Certificate Root Program" component of the "CA Program" product. Mozilla’s wiki
   page, "<a href="https://wiki.mozilla.org/CA/Application_Process">Applying for root inclusion in Mozilla products</a>", provides
   further details about how to submit a formal request. The request
   MUST be made by an authorized representative of the subject CA operator, and
   MUST include the following:</p>
   <ol class="mzp-u-list-styled">
-    <li>the certificate data (or links to the data) for the CA
-        certificate(s) requested for inclusion;</li>
-    <li>for each CA certificate requested for inclusion, whether or not
-        the CA issues certificates for each of the following purposes
-        within the certificate hierarchy associated with the CA
-        certificate:
-        <ul>
-          <li>TLS-enabled servers</li>
-          <li>digitally-signed and/or encrypted email;</li>
-        </ul>
-    </li>
-    <li>for each CA certificate requested for inclusion, whether the CA
-        issues Extended Validation certificates within the certificate hierarchy
-        associated with the CA certificate and, if so, the EV policy
-        OID associated with the CA certificate;</li>
-    <li>a Certificate Policy and Certification Practice Statement (or
-        links to a CP and CPS) or equivalent disclosure document(s)
-        for the CA or CAs in question; </li>
-    <li>an auditor-witnessed root key generation ceremony report and contiguous
-        period-of-time audit reports performed thereafter no less frequently than
-        annually; <em>and</em></li>
-    <li>information as to how the CA operator has fulfilled the requirements
-        stated above regarding its verification of certificate signing
-        requests and its conformance to a set of acceptable operational
-        criteria.</li>
+  <li>the certificate data (or links to the data) for the CA
+      certificate(s) requested for inclusion;</li>
+  <li>for each CA certificate requested for inclusion, whether or not
+      the CA issues certificates for each of the following purposes
+      within the certificate hierarchy associated with the CA
+      certificate:<ul>
+  <li>TLS-enabled servers</li>
+  <li>digitally-signed and/or encrypted email;</li>
+  </ul>
+  </li>
+  <li>for each CA certificate requested for inclusion, whether the CA
+      issues Extended Validation certificates within the certificate hierarchy
+      associated with the CA certificate and, if so, the CA/Browser Forum EV policy
+      OID of 2.23.140.1.1 associated with the CA certificate;</li>
+  <li>a Certificate Policy and Certification Practice Statement (or
+      links to a CP and CPS) or equivalent disclosure document(s)
+      for the CA or CAs in question; </li>
+  <li>an auditor-witnessed root key generation ceremony report and contiguous
+      period-of-time audit reports performed thereafter no less frequently than
+      annually; <em>and</em></li>
+  <li>information as to how the CA operator has fulfilled the requirements
+      stated above regarding its verification of certificate signing
+      requests and its conformance to a set of acceptable operational
+      criteria.</li>
   </ol>
   <p>We will reject requests where the CA operator does not provide such
   information within a reasonable period of time after submitting its
@@ -861,33 +755,30 @@
   <p>Changes MAY be made to CA certificates that are included in
   Mozilla's root store as follows:</p>
   <ol class="mzp-u-list-styled">
-    <li>enabling a trust bit in a CA certificate that is currently
+  <li>enabling a trust bit in a CA certificate that is currently
       included, MAY only be done after careful consideration of the
       CA operator’s current policies, practices, and audits,
       and MAY be requested by a representative of the CA or a
-      representative of Mozilla by submitting a bug report into the
-      mozilla.org Bugzilla system, as described in Mozilla’s wiki
+      representative of Mozilla by submitting a bug report into <a href="https://bugzilla.mozilla.org">Bugzilla</a>, as described in Mozilla’s wiki
       page, "<a href="https://wiki.mozilla.org/CA/Application_Process">Applying for root inclusion in Mozilla products</a>";</li>
-    <li>enabling EV in a CA certificate that is currently included,
+  <li>enabling EV in a CA certificate that is currently included,
       MAY only be done after careful consideration of the CA operator’s current
       policies, practices, and audits,
       and MAY be requested by a representative of the CA operator or a
-      representative of Mozilla by submitting a bug report into the
-      mozilla.org Bugzilla system, as described in Mozilla’s wiki
+      representative of Mozilla by submitting a bug report into <a href="https://bugzilla.mozilla.org">Bugzilla</a>, as described in Mozilla’s wiki
       page, "<a href="https://wiki.mozilla.org/CA/Application_Process">Applying for root inclusion in Mozilla products</a>";</li>
-    <li>disabling a CA certificate is the act of turning off one or more of the
+  <li>disabling a CA certificate is the act of turning off one or more of the
       trust bits (websites or email), and MAY be
       requested by a representative of the CA operator or a representative of
-      Mozilla by submitting a bug report into the mozilla.org Bugzilla
-      system, as described in the <a href="https://wiki.mozilla.org/CA/Certificate_Change_Process">Root Change Process</a>; <em>and</em></li>
-    <li>a representative of the CA operator or a representative of Mozilla MAY
+      Mozilla by submitting a bug report into <a href="https://bugzilla.mozilla.org">Bugzilla</a>, as described in the <a href="https://wiki.mozilla.org/CA/Certificate_Change_Process">Root Change Process</a>; <em>and</em></li>
+  <li>a representative of the CA operator or a representative of Mozilla MAY
       request that a CA certificate be removed by submitting a bug
-      report into the mozilla.org Bugzilla system, as described in the
+      report into <a href="https://bugzilla.mozilla.org">Bugzilla</a>, as described in the
       <a href="https://wiki.mozilla.org/CA/Certificate_Change_Process">Root Change Process</a>.</li>
   </ol>
   <h3 id="73-removals">7.3 Removals</h3>
-  <p>Mozilla MAY, at its sole discretion, decide to disable (partially or fully) or
-  remove a certificate at any time and for any reason. This MAY happen
+  <p>Mozilla MAY, at its sole discretion, decide to disable (partially or fully), or
+  remove a certificate, at any time and for any reason. This MAY happen
   immediately or on a planned future date. Mozilla will
   disable or remove a certificate if the CA operator demonstrates ongoing or
   egregious practices that do not maintain the expected level of service
@@ -911,19 +802,21 @@
   <p>If Mozilla disables or removes a CA operator’s certificate(s) from Mozilla’s
   root store based on a CA operator’s actions (or failure to act) that are
   contrary to this policy, Mozilla will publicize
-  that fact (for example, in newsgroups on the
-  news.mozilla.org server, and on our websites) and MAY also alert
-  relevant news or government organizations such as US-CERT.</p>
+  that fact (for example, on the <a href="https://groups.google.com/a/mozilla.org/g/dev-security-policy">Mozilla dev-security-policy list</a>, and on our websites) and MAY also alert
+  relevant news, government, or industry organizations.</p>
+  <h3 id="74-root-ca-lifecycles">7.4 Root CA Lifecycles</h3>
+  <p>For a root CA certificate trusted for server authentication, Mozilla will remove the websites trust bit when the CA key material is more than 15 years from the CA key material generation date. For a root CA certificate trusted for secure email, Mozilla will set the "Distrust for S/MIME After Date" for the CA certificate to 18 years from the CA key material generation date. The CA key material generation date SHALL be determined by reference to the auditor-witnessed key generation ceremony report. If the CA operator cannot provide the key generation ceremony report for a root CA certificate created before July 1, 2012, then Mozilla will use the “Valid From” date in the root CA certificate to establish the key material generation date. For transition purposes, root CA certificates in the Mozilla root store will be distrusted according to the schedule located at https://wiki.mozilla.org/CA/Root_CA_Lifecycles, which is subject to change if underlying algorithms become more susceptible to cryptanalytic attack or if other circumstances arise that make this schedule obsolete.</p>
+  <p>CA operators are strongly urged to apply to Mozilla for inclusion of their next generation root certificate at least 2 years before the distrust date of the CA certificate they wish to replace.</p>
   <h2 id="8-ca-operational-changes">8. CA Operational Changes</h2>
   <p>CA operators SHALL NOT assume that trust is transferable. All CA operators whose certificates
   are included in Mozilla's root store MUST <a href="mailto:certificates@mozilla.org">notify Mozilla</a> before:</p>
   <ul class="mzp-u-list-styled">
-    <li>ownership or control of the CA’s certificate(s) changes;</li>
-    <li>an organization other than the CA operator obtains control of an unconstrained
-    intermediate certificate (as defined in section 5.3 of this policy) that
-    directly or transitively chains to a certificate included in Mozilla's root store - see <a href="https://wiki.mozilla.org/CA/External_Sub_CAs">Process for non-Technically-Constrained Subordinate CAs</a>;</li>
-    <li>ownership or control of the CA’s operations changes; <em>or</em></li>
-    <li>there is a change in the CA's operations that could affect the CA's ability to comply with the requirements of this Policy.</li>
+  <li>ownership or control of the CA’s certificate(s) changes;</li>
+  <li>an organization other than the CA operator obtains control of an unconstrained
+  intermediate certificate (as defined in section 5.3 of this policy) that
+  directly or transitively chains to a certificate included in Mozilla's root store - see <a href="https://wiki.mozilla.org/CA/External_Sub_CAs">Process for non-Technically-Constrained Subordinate CAs</a>;</li>
+  <li>ownership or control of the CA’s operations changes; <em>or</em></li>
+  <li>there is a change in the CA's operations that could affect the CA's ability to comply with the requirements of this Policy.</li>
   </ul>
   <p>CA operators SHOULD err on the side of notification if there is any doubt. Mozilla will
   normally keep commercially sensitive information confidential. Throughout any
@@ -969,62 +862,54 @@
   even during the physical relocation of a CA's online operations to a new data
   center and moving parts of an offline root certificate from one location to
   another. As such, a CA operator MUST always ensure that physical access to CA equipment
-  is limited to authorized individuals, the equipment is operated under multiple
-  person control, and unauthorized CA system usage is able to be detected at all
+  is limited to authorized individuals, the equipment is operated under multi-person control, and unauthorized CA system usage is able to be detected at all
   times. The auditor MUST confirm that there are appropriate procedures in place
   to ensure that the requirements are met and that those procedures are followed.</p>
   <p>The following steps MUST be taken by the organization(s) concerned:</p>
   <ul class="mzp-u-list-styled">
-    <li>ensure that annual audit statements are current;</li>
-    <li>notify Mozilla of the pending change;</li>
-    <li>create a transfer plan (and legal agreement if more than one organization is
-      involved) and have it reviewed by the auditors;</li>
-    <li>stop new certificate issuance at the current site before the transfer begins;</li>
-    <li>have an audit performed at the current site to confirm when the root
-      certificate is ready for transfer, and ensure that key material is
-      properly secured;</li>
-    <li>have the transfer ceremony witnessed by auditors and video recorded,
-      with a physical exchange of the HSM or ciphertext containing the associated key
-      material and certificates, and the multi-party authorization keys;</li>
-    <li>perform an audit at the new site to confirm that the transfer was successful,
-      that the private key remained secure throughout the transfer, and that the root
-      certificate is ready to resume issuance. This requirement MAY be met by
-      including the transferred root certificate and key in the new owner's regular
-      audits or by getting a point-in-time audit; <em>and</em></li>
-    <li>send links to the updated CP, CPS, and the updated audit statements, opinion
-      letter, or point-in-time audit statement to Mozilla.</li>
+  <li>ensure that annual audit statements are current;</li>
+  <li>notify Mozilla of the pending change;</li>
+  <li>create a transfer plan (and legal agreement if more than one organization is
+  involved) and have it reviewed by the auditors;</li>
+  <li>stop new certificate issuance at the current site before the transfer begins;</li>
+  <li>have an audit performed at the current site to confirm when the root
+  certificate is ready for transfer, and ensure that key material is
+  properly secured;</li>
+  <li>have the transfer ceremony witnessed by auditors and video recorded,
+  with a physical exchange of the HSM or ciphertext containing the associated key
+  material and certificates, and the multi-party authorization keys;</li>
+  <li>perform an audit at the new site to confirm that the transfer was successful,
+  that the private key remained secure throughout the transfer, and that the root
+  certificate is ready to resume issuance. This requirement MAY be met by
+  including the transferred root certificate and key in the new owner's regular
+  audits or by getting a point-in-time audit; <em>and</em></li>
+  <li>send links to the updated CP, CPS, and the updated audit statements, opinion
+  letter, or point-in-time audit statement to Mozilla.</li>
   </ul>
   <p>The regular annual audit statements MUST still happen in a timely manner.</p>
-  <p>The organization(s) concerned MUST immediately <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS&amp;component=CA%20Certificate%20Compliance&amp;groups=crypto-core-security">send a security report to
-  Mozilla</a> if a problem occurs.</p>
+  <p>If a security issue arises during key transfer, then the organization(s) concerned MUST immediately file a <a href="https://wiki.mozilla.org/CA/Vulnerability_Disclosure">Vulnerability Disclosure</a> in Bugzilla using a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?bug_type=task&amp;component=CA%20Security%20Vulnerability&amp;groups=ca-program-security&amp;product=CA%20Program">secure bug</a>.</p>
   <h2 id="84-externally-operated-subordinate-cas">8.4 Externally-Operated Subordinate CAs</h2>
   <p>The operator of a root CA certificate that is included in Mozilla’s root store is at all times completely and ultimately accountable for every certificate signed under that root CA certificate, whether directly or through subordinate CAs or cross-certified CAs. The operator of the root CA certificate SHALL ensure that the operator of each subordinate or cross-certified CA fully and continually adheres to this policy.</p>
   <p>The root CA operator MUST complete Mozilla’s <a href="https://wiki.mozilla.org/CA/External_Sub_CAs">Process for non-Technically-Constrained Subordinate CAs</a> (including successful review and approval by Mozilla) before a new externally-operated subordinate CA begins issuing certificates under any of the following conditions:</p>
   <ul class="mzp-u-list-styled">
-    <li>the subordinate CA operator will obtain a unconstrained (per section 5.3.1 of this policy) CA certificate, and the subordinate CA operator is not approved by Mozilla to issue the type of certificates (email, TLS, or EV TLS), which they will be able to issue under the new CA certificate;</li>
-    <li>the root CA operator is cross-signing a CA certificate of a CA operator who is not currently in Mozilla’s root store; <em>or</em></li>
-    <li>the root CA operator is cross-signing a CA certificate of another CA operator who is currently in Mozilla’s root store, but the other CA operator has not been approved for the same trust bits (email or websites) or EV, and those trust bits or EV will be recognized under the cross-signed certificate that it will be receiving.</li>
+  <li>the subordinate CA operator will obtain a unconstrained (per section 5.3.1 of this policy) CA certificate, and the subordinate CA operator is not approved by Mozilla to issue the type of certificates (email, TLS, or EV TLS), which they will be able to issue under the new CA certificate;</li>
+  <li>the root CA operator is cross-signing a CA certificate of a CA operator who is not currently in Mozilla’s root store; <em>or</em></li>
+  <li>the root CA operator is cross-signing a CA certificate of another CA operator who is currently in Mozilla’s root store, but the other CA operator has not been approved for the same trust bits (email or websites) or EV, and those trust bits or EV will be recognized under the cross-signed certificate that it will be receiving.</li>
   </ul>
   <p>We reserve the right to not approve subordinate CA certificates. This includes (but is not limited to) cases where we believe that approval of a subordinate CA operator would cause undue risks to users’ security. Mozilla is under no obligation to explain the reasoning behind such decisions.</p>
   <p>When any of the following conditions apply, the root CA operator is not required to perform Mozilla’s <a href="https://wiki.mozilla.org/CA/External_Sub_CAs">Process for non-Technically-Constrained Subordinate CAs</a> before the subordinate CA certificate begins issuing certificates:</p>
   <ul class="mzp-u-list-styled">
-    <li>the subordinate CA will be operated directly by the root CA operator under the exact same policies and practices of the root CA operator and within the same scope of audit reporting, and no new organizations will be involved in the management or operation of the CA;</li>
-    <li>the CA certificate is technically constrained as described in section 5.3.1 of this policy;</li>
-    <li>the subordinate CA operator:
-      <ul>
-        <li>has previously undergone the <a href="https://wiki.mozilla.org/CA/External_Sub_CAs">Process for non-Technically-Constrained Subordinate CAs</a>; </li>
-        <li>has been approved for the type of certificates to be issued (email, TLS, or EV TLS); <em>and</em></li>
-        <li>will operate under the same policies and practices as the previous review, and under the same scope of audit reporting as the prior subordinate CA certificate. (Newer versions of policies and practices MAY be used, provided that the subordinate CA operator follows the same versions of the policies for both the existing and new CA certificates.)</li>
-      </ul>
-    </li>
-    <li>as of June 1, 2022, the subordinate CA operator was already trusted for issuing the same type of certificates under an existing subordinate CA certificate that directly or transitively chains to a certificate included in Mozilla’s root store; <em>or</em></li>
-    <li>the root CA operator is cross-signing a CA certificate of another CA operator that is currently in Mozilla’s root store, and that other CA operator:</li>
-      <ul>
-        <li>will only be able to issue the same type of certificate (email, TLS, or EV TLS) that they are already approved for in Mozilla’s root store; <em>and</em> </li>
-        <li>will operate both the cross-signed certificate and their CA certificate(s) under the same policies, practices, and scope of audit that their CA certificate was approved for. Newer versions of policies and practices MAY be used, provided that the cross-signed CA operator follows the same versions of the policies for both the cross-signed certificate and their CA certificate(s).</li>
-      </ul>
-    </li>
+  <li>the subordinate CA will be operated directly by the root CA operator under the exact same policies and practices of the root CA operator and within the same scope of audit reporting, and no new organizations will be involved in the management or operation of the CA;</li>
+  <li>the CA certificate is technically constrained as described in section 5.3.1 of this policy;</li>
+  <li>the subordinate CA operator:</li>
+  <li>has previously undergone the <a href="https://wiki.mozilla.org/CA/External_Sub_CAs">Process for non-Technically-Constrained Subordinate CAs</a>; </li>
+  <li>has been approved for the type of certificates to be issued (email, TLS, or EV TLS); <em>and</em></li>
+  <li>will operate under the same policies and practices as the previous review, and under the same scope of audit reporting as the prior subordinate CA certificate. (Newer versions of policies and practices MAY be used, provided that the subordinate CA operator follows the same versions of the policies for both the existing and new CA certificates.)</li>
+  <li>as of June 1, 2022, the subordinate CA operator was already trusted for issuing the same type of certificates under an existing subordinate CA certificate that directly or transitively chains to a certificate included in Mozilla’s root store; <em>or</em></li>
+  <li>the root CA operator is cross-signing a CA certificate of another CA operator that is currently in Mozilla’s root store, and that other CA operator:</li>
+  <li>will only be able to issue the same type of certificate (email, TLS, or EV TLS) that they are already approved for in Mozilla’s root store; <em>and</em> </li>
+  <li>will operate both the cross-signed certificate and their CA certificate(s) under the same policies, practices, and scope of audit that their CA certificate was approved for. Newer versions of policies and practices MAY be used, provided that the cross-signed CA operator follows the same versions of the policies for both the cross-signed certificate and their CA certificate(s).</li>
   </ul>
-  <hr>
+  <hr />
   <p>Any copyright in this document is <a href="https://creativecommons.org/publicdomain/zero/1.0/">dedicated to the Public Domain</a>.</p>
 {% endblock %}


### PR DESCRIPTION
## One-line summary
Publishes the latest version of our CA root store policy.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1851326


## Testing
http://localhost:8000/en-US/about/governance/policies/security-group/certs/policy/

Compare to https://github.com/mozilla/pkipolicy/blob/2.9/rootstore/policy.md