### PR TITLE
Update Firefox Monitor sign-in endpoint (Fixes #13634)

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -897,7 +897,7 @@ def monitor_fxa_button(
 
         {{ monitor_fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Monitor') }}
     """
-    product_url = "https://monitor.firefox.com/oauth/init"
+    product_url = "https://monitor.firefox.com/user/dashboard"
     return _fxa_product_button(
         product_url, entrypoint, button_text, class_name, is_button_class, include_metrics, optional_parameters, optional_attributes
     )

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -1215,7 +1215,7 @@ class TestMonitorFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In to Monitor", "data-cta-type": "fxa-monitor", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://monitor.firefox.com/oauth/init?entrypoint=mozilla.org-firefox-accounts&form_type=button'
+            '<a href="https://monitor.firefox.com/user/dashboard?entrypoint=mozilla.org-firefox-accounts&form_type=button'
             '&utm_source=mozilla.org-firefox-accounts&utm_medium=referral&utm_campaign=skyline" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button '
             'monitor-main-cta-button" data-cta-text="Sign In to Monitor" data-cta-type="fxa-monitor" '


### PR DESCRIPTION
## One-line summary

The Firefox Monitor sign-in end point recently changed when they updated their website, but they didn't put a redirect in it seems. This PR updates our helper to use the new URL

## Issue / Bugzilla link

#13634

## Testing

- http://localhost:8000/en-US/firefox/products/
- http://localhost:8000/en-US/firefox/welcome/1/