### PR TITLE
Migrate to Glean events from custom pings (Fixes #13639)

### DIFF
--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -345,11 +345,8 @@ See the `Glean Book`_ for more developer reference documentation.
 
 Glean is currently behind a feature switch called ``SWITCH_GLEAN_ANALYTICS``.
 When the switch is enabled pages will load the Glean JavaScript bundle,
-which will do things like register page views and capture link clicks. Our
-implementation leverages the same HTML data attributes that we use for
-:abbr:`GTM (Google Tag Manager)` when tracking link clicks, so any attributes
-you add for :abbr:`GTM (Google Tag Manager)` should also be captured by Glean
-automatically.
+which will do things like record page hits and link click events that we want
+to measure.
 
 Debugging pings
 ---------------
@@ -386,9 +383,8 @@ Defining metrics and pings
 All of the data we send to the Glean pipeline is defined in
 :abbr:`YAML (Yet Another Markup Language)` schema files in the ``./glean/``
 project root directory. The ``metrics.yaml`` file defines all the different
-metrics types we record, and the ``pings.yaml`` file defines the name of each
-ping event we use to send collections of individual metrics. These are all
-automatically documented in ``./glean/docs/``.
+metrics types and events we record, and the ``pings.yaml`` file defines
+any custom pings we use to send collections of individual metrics.
 
 .. Note::
 
@@ -408,50 +404,50 @@ It will also first lint the schema files.
 
 .. Important::
 
-    All metrics and pings we record using Glean must first undergo a `data review`_
+    All metrics and events we record using Glean must first undergo a `data review`_
     before being made active in production. Therefore anytime we make new additions
     to these files, those changes should also undergo review.
 
-Using Glean pings in individual page bundles
+Using Glean events in individual page bundles
 --------------------------------------------
 
 Our analytics code for Glean lives in a single bundle in the base template,
 which is intended to be shared across all web pages. This bundle automatically
-initializes Glean and records page view pings. It also creates some helpers
-that can be used across different page bundles to record interaction pings
+initializes Glean and records page hit events. It also creates some helpers
+that can be used across different page bundles to record interaction events
 such as link clicks and form submissions.
 
-The ``Mozilla.Glean.pagePing()`` helper can be used to record pings that are
+The ``Mozilla.Glean.pageEvent()`` helper can be used to record events that are
 specific to a page, such as successful form completions:
 
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.pagePing({
+        window.Mozilla.Glean.pageEvent({
             label: 'newsletter-sign-up-success',
             type: 'mozilla-and-you' // type is optional
         });
     }
 
-It can also be used to record non-interaction pings that are not directly
+It can also be used to record non-interaction events that are not directly
 initiated by a visitor:
 
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.pagePing({
+        window.Mozilla.Glean.pageEvent({
             label: 'firefox-default',
             nonInteraction: true
         });
     }
 
-The ``Mozilla.Glean.clickPing()`` helper can be used to record click pings
+The ``Mozilla.Glean.clickEvent()`` helper can be used to record click events
 that are specific to an element in a page, such as a link or button.
 
 .. code-block:: javascript
 
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.clickPing({
+        window.Mozilla.Glean.clickEvent({
             label: 'firefox-download',
             type: 'macOS, release, en-US', // type is optional
             position: 'primary' // position is optional

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -7,8 +7,7 @@ page:
     lifetime: application
     send_in_pings:
       - page-view
-      - interaction
-      - non-interaction
+      - events
     description: |
       The time a page was viewed.
     data_sensitivity:
@@ -25,8 +24,7 @@ page:
     lifetime: application
     send_in_pings:
       - page-view
-      - interaction
-      - non-interaction
+      - events
     description: |
       The URL path of the page that was viewed, excluding locale.
     data_sensitivity:
@@ -43,8 +41,7 @@ page:
     lifetime: application
     send_in_pings:
       - page-view
-      - interaction
-      - non-interaction
+      - events
     description: |
       The locale of the page that was viewed.
     data_sensitivity:
@@ -61,8 +58,7 @@ page:
     lifetime: application
     send_in_pings:
       - page-view
-      - interaction
-      - non-interaction
+      - events
     description: |
       Query parameters associated with the URL of
       the page that was viewed.
@@ -89,8 +85,7 @@ page:
     lifetime: application
     send_in_pings:
       - page-view
-      - interaction
-      - non-interaction
+      - events
     description: |
       The referring URL that linked to the page that was viewed.
     data_sensitivity:
@@ -109,8 +104,7 @@ page:
       lifetime: application
       send_in_pings:
         - page-view
-        - interaction
-        - non-interaction
+        - events
       data_sensitivity:
         - technical
       bugs:
@@ -120,18 +114,28 @@ page:
       notification_emails:
         - marketing-websites-team@mozilla.com
       expires: never
-  page_event:
+  page_hit:
     type: event
     lifetime: ping
-    send_in_pings:
-      - interaction
-      - non-interaction
+    description: |
+      An event which is sent every time a page is loaded.
+    data_sensitivity:
+      - web_activity
+      - technical
+    bugs:
+      - https://github.com/mozilla/bedrock/issues/10746
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1767442
+    notification_emails:
+      - marketing-websites-team@mozilla.com
+    expires: never
+  interaction:
+    type: event
+    lifetime: ping
     description: |
       An event containing metrics related to a page level
-      completion or state that want to measure. This can be
-      sent in either an interaction and non-interaction ping,
-      depending upon the use-case. Examples: form completion,
-      scroll events, banner impressions.
+      user interaction state that we want to measure.
+      Examples: form completion, scroll events.
     data_sensitivity:
       - web_activity
     bugs:
@@ -145,23 +149,49 @@ page:
       label:
         description: |
           The label used to describe the event.
-          Example: 'Newsletters: mozilla-and-you'
+          Example: 'newsletter-sign-up-success'
         type: string
       type:
         description: |
           The type of event.
-          Example: 'Newsletter Signup Success'
+          Example: 'mozilla-and-you'
+        type: string
+  non_interaction:
+    type: event
+    lifetime: ping
+    description: |
+      An event containing metrics related to a page level
+      non-user initiated state that we want to measure.
+      Examples: banner impressions, conditional messaging.
+    data_sensitivity:
+      - web_activity
+      - technical
+    bugs:
+      - https://github.com/mozilla/bedrock/issues/10746
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1767442
+    notification_emails:
+      - marketing-websites-team@mozilla.com
+    expires: never
+    extra_keys:
+      label:
+        description: |
+          The label used to describe the event.
+          Example: 'banner-impression'
+        type: string
+      type:
+        description: |
+          The type of event.
+          Example: 'get-firefox-banner'
         type: string
 
 element:
   clicked:
     type: event
     lifetime: ping
-    send_in_pings:
-      - interaction
     description: |
-      An event containing metrics related to which element
-      in the page was clicked.
+      An event containing metrics related to an element
+      in the page that was clicked.
     data_sensitivity:
       - web_activity
     bugs:

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -114,9 +114,8 @@ page:
       notification_emails:
         - marketing-websites-team@mozilla.com
       expires: never
-  page_hit:
+  hit:
     type: event
-    lifetime: ping
     description: |
       An event which is sent every time a page is loaded.
     data_sensitivity:
@@ -131,7 +130,6 @@ page:
     expires: never
   interaction:
     type: event
-    lifetime: ping
     description: |
       An event containing metrics related to a page level
       user interaction state that we want to measure.
@@ -158,7 +156,6 @@ page:
         type: string
   non_interaction:
     type: event
-    lifetime: ping
     description: |
       An event containing metrics related to a page level
       non-user initiated state that we want to measure.
@@ -188,7 +185,6 @@ page:
 element:
   clicked:
     type: event
-    lifetime: ping
     description: |
       An event containing metrics related to an element
       in the page that was clicked.

--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -3,34 +3,7 @@ $schema: moz://mozilla.org/schemas/glean/pings/2-0-0
 
 page-view:
   description: |
-    A ping which is sent everytime a page is viewed.
-  include_client_id: true
-  send_if_empty: false
-  bugs:
-    - https://github.com/mozilla/bedrock/issues/10746
-  data_reviews:
-    - https://bugzilla.mozilla.org/show_bug.cgi?id=1767442
-  notification_emails:
-    - marketing-websites-team@mozilla.com
-
-interaction:
-  description: |
-    A ping which is sent when a page element is
-    interacted with.
-  include_client_id: true
-  send_if_empty: false
-  bugs:
-    - https://github.com/mozilla/bedrock/issues/10746
-  data_reviews:
-    - https://bugzilla.mozilla.org/show_bug.cgi?id=1767442
-  notification_emails:
-    - marketing-websites-team@mozilla.com
-
-non-interaction:
-  description: |
-    A ping which is sent when a non-user initiated event
-    occurs. Examples: a specific banner impression is
-    displayed, a video auto-plays on scroll.
+    A ping which is sent every time a page is viewed.
   include_client_id: true
   send_if_empty: false
   bugs:

--- a/media/js/base/send-to-device.es6.js
+++ b/media/js/base/send-to-device.es6.js
@@ -178,7 +178,7 @@ SendToDevice.prototype.onFormSuccess = function () {
 
     // Glean
     if (typeof window.Mozilla.Glean !== 'undefined') {
-        window.Mozilla.Glean.pagePing({
+        window.Mozilla.Glean.pageEvent({
             label: 'send-to-device-success',
             type: 'email-address'
         });

--- a/media/js/glean/elements.es6.js
+++ b/media/js/glean/elements.es6.js
@@ -4,10 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { interaction as interactionPing } from '../libs/glean/pings.js';
 import * as element from '../libs/glean/element.js';
 
-function clickPing(obj) {
+function clickEvent(obj) {
     if (typeof obj !== 'object' && typeof obj.label !== 'string') {
         return;
     }
@@ -28,10 +27,9 @@ function clickPing(obj) {
 
     try {
         element.clicked.record(data);
-        interactionPing.submit();
     } catch (e) {
         //do nothing
     }
 }
 
-export { clickPing };
+export { clickEvent };

--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -6,8 +6,8 @@
 
 import Glean from '@mozilla/glean/web';
 
-import { initPageView, pagePing } from './page.es6';
-import { clickPing } from './elements.es6';
+import { initPageView, pageEvent } from './page.es6';
+import { clickEvent } from './elements.es6';
 import Utils from './utils.es6';
 
 const shouldInitialize = Utils.hasValidURLScheme(window.location.href);
@@ -51,22 +51,14 @@ function initHelpers() {
 
     // Create a global for external bundles to fire interaction pings.
     window.Mozilla.Glean = {
-        pagePing: (obj) => {
+        pageEvent: (obj) => {
             if (shouldInitialize) {
-                try {
-                    pagePing(obj);
-                } catch (e) {
-                    //do nothing
-                }
+                pageEvent(obj);
             }
         },
-        clickPing: (obj) => {
+        clickEvent: (obj) => {
             if (shouldInitialize) {
-                try {
-                    clickPing(obj);
-                } catch (e) {
-                    //do nothing
-                }
+                clickEvent(obj);
             }
         }
     };

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -49,7 +49,7 @@ function initPageView() {
         }
     }
 
-    page.pageHit.record();
+    page.hit.record();
 
     pageViewPing.submit();
 }

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -6,11 +6,7 @@
 
 import * as page from '../libs/glean/page.js';
 import Utils from './utils.es6';
-import {
-    pageView as pageViewPing,
-    interaction as interactionPing,
-    nonInteraction as nonInteractionPing
-} from '../libs/glean/pings.js';
+import { pageView as pageViewPing } from '../libs/glean/pings.js';
 
 const defaultParams = {
     utm_source: '',
@@ -53,10 +49,12 @@ function initPageView() {
         }
     }
 
+    page.pageHit.record();
+
     pageViewPing.submit();
 }
 
-function pagePing(obj) {
+function pageEvent(obj) {
     if (typeof obj !== 'object' && typeof obj.label !== 'string') {
         return;
     }
@@ -70,16 +68,18 @@ function pagePing(obj) {
         data['type'] = obj.type;
     }
 
-    page.pageEvent.record(data);
-
-    if (
-        typeof obj.nonInteraction === 'boolean' &&
-        obj.nonInteraction === true
-    ) {
-        nonInteractionPing.submit();
-    } else {
-        interactionPing.submit();
+    try {
+        if (
+            typeof obj.nonInteraction === 'boolean' &&
+            obj.nonInteraction === true
+        ) {
+            page.nonInteraction.record(data);
+        } else {
+            page.interaction.record(data);
+        }
+    } catch (e) {
+        //do nothing
     }
 }
 
-export { initPageView, pagePing };
+export { initPageView, pageEvent };

--- a/media/js/newsletter/newsletter.es6.js
+++ b/media/js/newsletter/newsletter.es6.js
@@ -71,7 +71,7 @@ const NewsletterForm = {
 
         // Glean
         if (typeof window.Mozilla.Glean !== 'undefined') {
-            window.Mozilla.Glean.pagePing({
+            window.Mozilla.Glean.pageEvent({
                 label: 'newsletter-sign-up-success',
                 type: newsletters.join(', ')
             });

--- a/media/js/products/relay/waitlist.es6.js
+++ b/media/js/products/relay/waitlist.es6.js
@@ -79,7 +79,7 @@ const WaitlistForm = {
 
         // Glean
         if (typeof window.Mozilla.Glean !== 'undefined') {
-            window.Mozilla.Glean.pagePing({
+            window.Mozilla.Glean.pageEvent({
                 label: 'newsletter-sign-up-success',
                 type: newsletter
             });

--- a/media/js/products/vpn/invite.es6.js
+++ b/media/js/products/vpn/invite.es6.js
@@ -55,7 +55,7 @@ const WaitListForm = {
 
         // Glean
         if (typeof window.Mozilla.Glean !== 'undefined') {
-            window.Mozilla.Glean.pagePing({
+            window.Mozilla.Glean.pageEvent({
                 label: 'newsletter-sign-up-success',
                 type: newsletter
             });

--- a/tests/unit/spec/glean/elements.js
+++ b/tests/unit/spec/glean/elements.js
@@ -10,36 +10,28 @@
  */
 
 import { testResetGlean } from '@mozilla/glean/testing';
-import { clickPing } from '../../../../media/js/glean/elements.es6';
+import { clickEvent } from '../../../../media/js/glean/elements.es6';
 import * as element from '../../../../media/js/libs/glean/element.js';
-import { interaction as interactionPing } from '../../../../media/js/libs/glean/pings.js';
 
 describe('elements.js', function () {
     beforeEach(async function () {
         await testResetGlean('moz-bedrock-test');
     });
 
-    describe('clickPing', function () {
-        it('should send an interaction ping when clickPing is called', async function () {
-            const ping = interactionPing.testBeforeNextSubmit(
-                async function () {
-                    const snapshot = await element.clicked.testGetValue();
-                    expect(snapshot.length).toEqual(1);
-                    const click = snapshot[0];
-                    expect(click.extra.label).toEqual('Firefox Download');
-                    expect(click.extra.type).toEqual('macOS, release, en-US');
-                    expect(click.extra.position).toEqual('primary');
-                }
-            );
-
-            clickPing({
+    describe('clickEvent', function () {
+        it('should send an interaction ping when clickEvent is called', async function () {
+            clickEvent({
                 label: 'Firefox Download',
                 type: 'macOS, release, en-US',
                 position: 'primary'
             });
 
-            // Wait for the validation to finish.
-            await expectAsync(ping).toBeResolved();
+            const snapshot = await element.clicked.testGetValue();
+            expect(snapshot.length).toEqual(1);
+            const click = snapshot[0];
+            expect(click.extra.label).toEqual('Firefox Download');
+            expect(click.extra.type).toEqual('macOS, release, en-US');
+            expect(click.extra.position).toEqual('primary');
         });
     });
 });

--- a/tests/unit/spec/glean/page.js
+++ b/tests/unit/spec/glean/page.js
@@ -11,12 +11,7 @@
 
 import * as page from '../../../../media/js/libs/glean/page.js';
 import Utils from '../../../../media/js/glean/utils.es6';
-import { initPageView, pagePing } from '../../../../media/js/glean/page.es6';
-import {
-    pageView as pageViewPing,
-    interaction as interactionPing,
-    nonInteraction as nonInteractionPing
-} from '../../../../media/js/libs/glean/pings.js';
+import { initPageView, pageEvent } from '../../../../media/js/glean/page.es6';
 import { testResetGlean } from '@mozilla/glean/testing';
 
 describe('page.js', function () {
@@ -28,24 +23,19 @@ describe('page.js', function () {
     });
 
     it('should register a page view correctly', async function () {
-        const ping = pageViewPing.testBeforeNextSubmit(async function () {
-            const path = await page.path.testGetValue();
-            expect(path).toEqual('/firefox/new/');
-
-            const locale = await page.locale.testGetValue();
-            expect(locale).toEqual('en-US');
-
-            const referrer = await page.referrer.testGetValue();
-            expect(referrer).toEqual('https://google.com/');
-
-            const httpStatus = await page.httpStatus.testGetValue();
-            expect(httpStatus).toEqual('200');
-        });
-
         initPageView();
 
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const path = await page.path.testGetValue();
+        expect(path).toEqual('/firefox/new/');
+
+        const locale = await page.locale.testGetValue();
+        expect(locale).toEqual('en-US');
+
+        const referrer = await page.referrer.testGetValue();
+        expect(referrer).toEqual('https://google.com/');
+
+        const httpStatus = await page.httpStatus.testGetValue();
+        expect(httpStatus).toEqual('200');
     });
 
     it('should record specific query parameters in the page view', async function () {
@@ -55,54 +45,41 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        const ping = pageViewPing.testBeforeNextSubmit(async function () {
-            const source = await page.queryParams['utm_source'].testGetValue();
-            expect(source).toEqual('test-source');
-
-            const campaign = await page.queryParams[
-                'utm_campaign'
-            ].testGetValue();
-            expect(campaign).toEqual('test-campaign');
-
-            const medium = await page.queryParams['utm_medium'].testGetValue();
-            expect(medium).toEqual('test-medium');
-
-            const content = await page.queryParams[
-                'utm_content'
-            ].testGetValue();
-            expect(content).toEqual('test-content');
-
-            const entrypointExperiment = await page.queryParams[
-                'entrypoint_experiment'
-            ].testGetValue();
-            expect(entrypointExperiment).toEqual('test_entrypoint_experiment');
-
-            const entrypointVariation = await page.queryParams[
-                'entrypoint_variation'
-            ].testGetValue();
-            expect(entrypointVariation).toEqual('1');
-
-            const experiment = await page.queryParams[
-                'experiment'
-            ].testGetValue();
-            expect(experiment).toEqual('test-experiment');
-
-            const variation = await page.queryParams[
-                'variation'
-            ].testGetValue();
-            expect(variation).toEqual('1');
-
-            const v = await page.queryParams['v'].testGetValue();
-            expect(v).toEqual('1');
-
-            const xv = await page.queryParams['xv'].testGetValue();
-            expect(xv).toEqual('test-xv');
-        });
-
         initPageView();
 
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const source = await page.queryParams['utm_source'].testGetValue();
+        expect(source).toEqual('test-source');
+
+        const campaign = await page.queryParams['utm_campaign'].testGetValue();
+        expect(campaign).toEqual('test-campaign');
+
+        const medium = await page.queryParams['utm_medium'].testGetValue();
+        expect(medium).toEqual('test-medium');
+
+        const content = await page.queryParams['utm_content'].testGetValue();
+        expect(content).toEqual('test-content');
+
+        const entrypointExperiment = await page.queryParams[
+            'entrypoint_experiment'
+        ].testGetValue();
+        expect(entrypointExperiment).toEqual('test_entrypoint_experiment');
+
+        const entrypointVariation = await page.queryParams[
+            'entrypoint_variation'
+        ].testGetValue();
+        expect(entrypointVariation).toEqual('1');
+
+        const experiment = await page.queryParams['experiment'].testGetValue();
+        expect(experiment).toEqual('test-experiment');
+
+        const variation = await page.queryParams['variation'].testGetValue();
+        expect(variation).toEqual('1');
+
+        const v = await page.queryParams['v'].testGetValue();
+        expect(v).toEqual('1');
+
+        const xv = await page.queryParams['xv'].testGetValue();
+        expect(xv).toEqual('test-xv');
     });
 
     it('should not record unspecified query params in the page view', async function () {
@@ -112,22 +89,15 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        const ping = pageViewPing.testBeforeNextSubmit(async function () {
-            const unspecifiedParam = await page.queryParams[
-                'unspecified_param'
-            ].testGetValue();
-            expect(unspecifiedParam).toBeUndefined();
-
-            const content = await page.queryParams[
-                'utm_content'
-            ].testGetValue();
-            expect(content).toEqual('test-content');
-        });
-
         initPageView();
 
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const unspecifiedParam = await page.queryParams[
+            'unspecified_param'
+        ].testGetValue();
+        expect(unspecifiedParam).toBeUndefined();
+
+        const content = await page.queryParams['utm_content'].testGetValue();
+        expect(content).toEqual('test-content');
     });
 
     it('should decode known params', async function () {
@@ -136,20 +106,13 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        const ping = pageViewPing.testBeforeNextSubmit(async function () {
-            const source = await page.queryParams['utm_source'].testGetValue();
-            expect(source).toEqual('%');
-
-            const campaign = await page.queryParams[
-                'utm_campaign'
-            ].testGetValue();
-            expect(campaign).toEqual('/');
-        });
-
         initPageView();
 
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const source = await page.queryParams['utm_source'].testGetValue();
+        expect(source).toEqual('%');
+
+        const campaign = await page.queryParams['utm_campaign'].testGetValue();
+        expect(campaign).toEqual('/');
     });
 
     it('should not record known params that contain bad values', async function () {
@@ -159,68 +122,47 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        const ping = pageViewPing.testBeforeNextSubmit(async function () {
-            const source = await page.queryParams['utm_source'].testGetValue();
-            expect(source).toEqual('');
-
-            const campaign = await page.queryParams[
-                'utm_campaign'
-            ].testGetValue();
-            expect(campaign).toEqual('');
-
-            const medium = await page.queryParams['utm_medium'].testGetValue();
-            expect(medium).toEqual('');
-
-            const content = await page.queryParams[
-                'utm_content'
-            ].testGetValue();
-            expect(content).toEqual('test-content');
-
-            const experiment = await page.queryParams[
-                'experiment'
-            ].testGetValue();
-            expect(experiment).toEqual('');
-        });
-
         initPageView();
 
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const source = await page.queryParams['utm_source'].testGetValue();
+        expect(source).toEqual('');
+
+        const campaign = await page.queryParams['utm_campaign'].testGetValue();
+        expect(campaign).toEqual('');
+
+        const medium = await page.queryParams['utm_medium'].testGetValue();
+        expect(medium).toEqual('');
+
+        const content = await page.queryParams['utm_content'].testGetValue();
+        expect(content).toEqual('test-content');
+
+        const experiment = await page.queryParams['experiment'].testGetValue();
+        expect(experiment).toEqual('');
     });
 
-    it('should send a page event (interaction)', async function () {
-        const ping = interactionPing.testBeforeNextSubmit(async function () {
-            const snapshot = await page.pageEvent.testGetValue();
-            expect(snapshot.length).toEqual(1);
-            const event = snapshot[0];
-            expect(event.extra.label).toEqual('mozilla-and-you');
-            expect(event.extra.type).toEqual('Newsletter sign-up success');
+    it('should send an interaction event as expected', async function () {
+        pageEvent({
+            label: 'newsletter-signup-success',
+            type: 'mozilla-and-you'
         });
 
-        pagePing({
-            label: 'mozilla-and-you',
-            type: 'Newsletter sign-up success'
-        });
-
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const snapshot = await page.interaction.testGetValue();
+        expect(snapshot.length).toEqual(1);
+        const event = snapshot[0];
+        expect(event.extra.label).toEqual('newsletter-signup-success');
+        expect(event.extra.type).toEqual('mozilla-and-you');
     });
 
-    it('should send a page event (non-interaction)', async function () {
-        const ping = nonInteractionPing.testBeforeNextSubmit(async function () {
-            const snapshot = await page.pageEvent.testGetValue();
-            expect(snapshot.length).toEqual(1);
-            const event = snapshot[0];
-            expect(event.extra.label).toEqual('Firefox default');
-            expect(event.extra.type).toEqual('');
-        });
-
-        pagePing({
-            label: 'Firefox default',
+    it('should send a non-interaction event as expected', async function () {
+        pageEvent({
+            label: 'firefox-default',
             nonInteraction: true
         });
 
-        // Wait for the validation to finish.
-        await expectAsync(ping).toBeResolved();
+        const snapshot = await page.nonInteraction.testGetValue();
+        expect(snapshot.length).toEqual(1);
+        const event = snapshot[0];
+        expect(event.extra.label).toEqual('firefox-default');
+        expect(event.extra.type).toEqual('');
     });
 });


### PR DESCRIPTION
## One-line summary

Migrates from using custom pings to standard events for recording page hits, interaction, non-interaction and element clicked events.

## Significant changes and points to review

Note: I've kept our custom page view ping for now, which I can remove later after I've updated a few queries that use it. The other custom pings I think we're fine to lose now as they are not really used yet.

## Issue / Bugzilla link

#13639

## Testing

http://localhost:8000/en-US/ 

- [ ] Loading the home page should see two pings created (the old custom ping and the new page hit event)
- [ ] Completing the newsletter subscription form at the end of the home page should see one ping (interaction event)