### PR TITLE
Add markus for backend metrics collection

### DIFF
--- a/bedrock/base/__init__.py
+++ b/bedrock/base/__init__.py
@@ -1,3 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import markus
+
+metrics = markus.get_metrics()

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -2,8 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.test import RequestFactory, TestCase
+from contextlib import suppress
+
+from django.test import Client, RequestFactory, TestCase
 from django.test.utils import override_settings
+from django.urls import reverse
+
+from jinja2.exceptions import UndefinedError
+from markus.testing import MetricsMock
 
 from bedrock.base.middleware import LocaleURLMiddleware
 
@@ -53,3 +59,82 @@ class TestLocaleURLMiddleware(TestCase):
         self.middleware.process_request(req)
         self.assertEqual(req.path_info, path)
         self.assertEqual(req.locale, "es-ES")
+
+
+@override_settings(
+    MIDDLEWARE=["bedrock.base.middleware.MetricsStatusMiddleware"],
+    ROOT_URLCONF="bedrock.base.tests.urls",
+)
+class TestMetricsMiddleware(TestCase):
+    def test_200(self):
+        with MetricsMock() as mm:
+            resp = Client().get(reverse("index"))
+            assert resp.status_code == 200
+            mm.assert_incr_once("response.status", tags=["status_code:200"])
+
+    def test_302(self):
+        with MetricsMock() as mm:
+            resp = Client().get(reverse("redirect"))
+            assert resp.status_code == 302
+            mm.assert_incr_once("response.status", tags=["status_code:302"])
+
+    def test_returns_400(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("returns_400"))
+                assert resp.status_code == 400
+            mm.assert_incr_once("response.status", tags=["status_code:400"])
+
+    def test_raises_400_bad_request(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_400_bad_request"))
+                assert resp.status_code == 400
+            mm.assert_incr_once("response.status", tags=["status_code:400"])
+
+    def test_raises_400_multipart_parser_error(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_400_multipart_parser_error"))
+                assert resp.status_code == 400
+            mm.assert_incr_once("response.status", tags=["status_code:400"])
+
+    def test_raises_400_suspicious_operation(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_400_suspicious_operation"))
+                assert resp.status_code == 400
+            mm.assert_incr_once("response.status", tags=["status_code:400"])
+
+    def test_raises_403_permission_denied(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_403_permission_denied"))
+                assert resp.status_code == 403
+            mm.assert_incr_once("response.status", tags=["status_code:403"])
+
+    def test_raises_404(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_404"))
+                assert resp.status_code == 404
+            mm.assert_incr_once("response.status", tags=["status_code:404"])
+
+    def test_returns_404(self):
+        with MetricsMock() as mm:
+            resp = Client().get(reverse("returns_404"))
+            assert resp.status_code == 404
+            mm.assert_incr_once("response.status", tags=["status_code:404"])
+
+    def test_raises_500(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_500"))
+                assert resp.status_code == 500
+            mm.assert_incr_once("response.status", tags=["status_code:500"])
+
+    def test_returns_500(self):
+        with MetricsMock() as mm:
+            resp = Client().get(reverse("returns_500"))
+            assert resp.status_code == 500
+            mm.assert_incr_once("response.status", tags=["status_code:500"])

--- a/bedrock/base/tests/urls.py
+++ b/bedrock/base/tests/urls.py
@@ -1,0 +1,67 @@
+from django.core.exceptions import (
+    BadRequest,
+    PermissionDenied,
+    SuspiciousOperation,
+)
+from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http.multipartparser import MultiPartParserError
+from django.urls import path
+
+
+def index(request):
+    return HttpResponse("test")
+
+
+def redirect(request):
+    return HttpResponseRedirect("/")
+
+
+def returns_400(request):
+    return HttpResponse("400", status=400)
+
+
+def raises_400_bad_request(request):
+    raise BadRequest
+
+
+def raises_400_multipart_parser_error(request):
+    raise MultiPartParserError
+
+
+def raises_400_suspicious_operation(request):
+    raise SuspiciousOperation
+
+
+def raises_403_permission_denied(request):
+    raise PermissionDenied
+
+
+def returns_404(request):
+    return HttpResponse("404", status=404)
+
+
+def raises_404(request):
+    raise Http404
+
+
+def returns_500(request):
+    return HttpResponse("500", status=500)
+
+
+def raises_500(request):
+    raise Exception("500")
+
+
+urlpatterns = [
+    path("", index, name="index"),
+    path("redirect/", redirect, name="redirect"),
+    path("raises_400_bad_request/", raises_400_bad_request, name="raises_400_bad_request"),
+    path("raises_400_multipart_parser_error/", raises_400_multipart_parser_error, name="raises_400_multipart_parser_error"),
+    path("raises_400_suspicious_operation/", raises_400_suspicious_operation, name="raises_400_suspicious_operation"),
+    path("raises_403_permission_denied/", raises_403_permission_denied, name="raises_403_permission_denied"),
+    path("returns_400/", returns_400, name="returns_400"),
+    path("raises_404/", raises_404, name="raises_404"),
+    path("returns_404/", returns_404, name="returns_404"),
+    path("raises_500/", raises_500, name="raises_500"),
+    path("returns_500/", returns_500, name="returns_500"),
+]

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from django.utils.functional import lazy
 
+import markus
 import sentry_sdk
 from everett.manager import ListOf
 from sentry_processor import DesensitizationProcessor
@@ -562,6 +563,7 @@ MIDDLEWARE = [
     "bedrock.redirects.middleware.RedirectsMiddleware",
     "bedrock.base.middleware.LocaleURLMiddleware",
     "bedrock.mozorg.middleware.ClacksOverheadMiddleware",
+    "bedrock.base.middleware.MetricsStatusMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "bedrock.mozorg.middleware.CacheMiddleware",
@@ -1172,6 +1174,29 @@ SENTRY_FRONTEND_DSN = config(
     "SENTRY_FRONTEND_DSN",
     default=SENTRY_DSN,
 )
+
+# Statsd metrics via markus
+if DEBUG:
+    MARKUS_BACKENDS = [
+        {"class": "markus.backends.logging.LoggingMetrics", "options": {"logger_name": "metrics"}},
+    ]
+else:
+    STATSD_HOST = config("STATSD_HOST", default=get_default_gateway_linux())
+    STATSD_PORT = config("STATSD_PORT", default="8125", parser=int)
+    STATSD_NAMESPACE = config("APP_NAME", default="bedrock-local")
+
+    MARKUS_BACKENDS = [
+        {
+            "class": "markus.backends.datadog.DatadogMetrics",
+            "options": {
+                "statsd_host": STATSD_HOST,
+                "statsd_port": STATSD_PORT,
+                "statsd_namespace": STATSD_NAMESPACE,
+            },
+        },
+    ]
+
+markus.configure(backends=MARKUS_BACKENDS)
 
 # Django-CSP settings are in settings/__init__.py, where they are
 # set according to site mode

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -318,6 +318,12 @@ cwcwidth==0.1.6 \
     # via
     #   bpython
     #   curtsies
+datadog==0.46.0 \
+    --hash=sha256:3d7bcda6177b43be4cdb52e16b4bdd4f9005716c0dd7cfea009e018c36bb7a3d \
+    --hash=sha256:e4fbc92a85e2b0919a226896ae45fc5e4b356c0c57f1c2659659dfbe0789c674
+    # via
+    #   -r requirements/prod.txt
+    #   markus
 deprecated==1.2.13 \
     --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
     --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
@@ -768,6 +774,10 @@ markupsafe==2.0.1 \
     #   django-jinja-markdown
     #   glean-parser
     #   jinja2
+markus[datadog]==4.2.0 \
+    --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \
+    --hash=sha256:9dd41ce53b25a3e806b0d065808fec00c4ec945e80cf5a72431bf9b61b44d7fb
+    # via -r requirements/prod.txt
 mdx-outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibility.tar.gz \
     --hash=sha256:a78e112f80628246dd45858fe18404aaa8efb8dc81949bb1fbb87e91f9654afa
     # via -r requirements/prod.txt
@@ -1125,6 +1135,7 @@ requests==2.31.0 \
     #   basket-client
     #   bpython
     #   contentful
+    #   datadog
     #   django-mozilla-product-details
     #   pygithub
     #   pytest-base-url

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -37,6 +37,7 @@ jinja2==3.1.2  # Moved to top-level dep to control its upgrade, to avoid breakin
 jq==1.5.0
 lxml==4.9.3  # Needed as a top-level dep so that it's available for BeautifulSoup, which doesn't explicitly pull it in
 Markdown==3.4.4
+markus[datadog]==4.2.0
 https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibility.tar.gz#egg=mdx_outline
 meinheld==1.0.2
 newrelic==8.10.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -165,6 +165,10 @@ cryptography==41.0.3 \
     #   -r requirements/prod.in
     #   pyjwt
     #   pyopenssl
+datadog==0.46.0 \
+    --hash=sha256:3d7bcda6177b43be4cdb52e16b4bdd4f9005716c0dd7cfea009e018c36bb7a3d \
+    --hash=sha256:e4fbc92a85e2b0919a226896ae45fc5e4b356c0c57f1c2659659dfbe0789c674
+    # via markus
 deprecated==1.2.13 \
     --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
     --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
@@ -572,6 +576,10 @@ markupsafe==2.0.1 \
     #   django-jinja-markdown
     #   glean-parser
     #   jinja2
+markus[datadog]==4.2.0 \
+    --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \
+    --hash=sha256:9dd41ce53b25a3e806b0d065808fec00c4ec945e80cf5a72431bf9b61b44d7fb
+    # via -r requirements/prod.in
 mdx-outline @ https://github.com/mozmeao/mdx_outline/archive/refs/tags/markdown-3.4-compatibility.tar.gz \
     --hash=sha256:a78e112f80628246dd45858fe18404aaa8efb8dc81949bb1fbb87e91f9654afa
     # via -r requirements/prod.in
@@ -788,6 +796,7 @@ requests==2.31.0 \
     #   -r requirements/prod.in
     #   basket-client
     #   contentful
+    #   datadog
     #   django-mozilla-product-details
     #   pygithub
 rich-text-renderer==0.2.7 \


### PR DESCRIPTION
This pull request introduces the "markus" Python package into our codebase, enabling the collection of statsd metrics for backend monitoring and performance analysis via Grafana.

This pull request only implements a single metric, `response.status`, in middleware and wraps all views. This will give us a good idea of the volume of requests actually hitting the server vs what hits cache. More metrics will be added in future commits.