### PR TITLE
Add new supported EU countries to Relay #13656

### DIFF
--- a/bedrock/products/templates/products/relay/includes/bundle.html
+++ b/bedrock/products/templates/products/relay/includes/bundle.html
@@ -5,9 +5,9 @@
 #}
 
 
-{% set monthly_price = relay_monthly_price(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
+{% set monthly_price = relay_monthly_price_formatted(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
 
-{% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+{% set savings = relay_bundle_savings() %}
 
 <div class="mzp-l-content">
   <div class="mzp-c-emphasis-box mzp-t-dark t-bundle">

--- a/bedrock/products/templates/products/relay/includes/macros.html
+++ b/bedrock/products/templates/products/relay/includes/macros.html
@@ -17,6 +17,7 @@
 {%- endmacro %}
 
 {% macro toggle(position, product) -%}
+  {# the Relay/VPN bundle does not have a monthly price, so cannot use this macro #}
   {% set group = 'plan-{position}-{product}'.format(position=position, product=product) %}
 
   <span class="c-toggle-track"></span>
@@ -29,7 +30,7 @@
     <span>{{ ftl('plan-matrix-price-period-yearly') }}</span>
   </label>
 
-  {% set monthly_price_monthly = relay_monthly_price(plan='monthly', country_code=country_code, lang=LANG, product=product) %}
+  {% set monthly_price_monthly = relay_monthly_price_formatted(plan='monthly', country_code=country_code, lang=LANG, product=product) %}
   <em class="c-toggle-price c-toggle-price-monthly">{{ ftl('plan-matrix-price-monthly-calculated', monthly_price=monthly_price_monthly) }}</em>
   <small class="c-matrix-footer-period c-matrix-footer-period-monthly">{{ ftl('plan-matrix-price-period-monthly-footnote-1') }}</small>
   {{ relay_subscribe_link(
@@ -50,7 +51,7 @@
     })
   }}
 
-  {% set monthly_price_yearly = relay_monthly_price(plan='yearly', country_code=country_code, lang=LANG, product=product) %}
+  {% set monthly_price_yearly = relay_monthly_price_formatted(plan='yearly', country_code=country_code, lang=LANG, product=product) %}
   <em class="c-toggle-price c-toggle-price-yearly">{{ ftl('plan-matrix-price-monthly-calculated', monthly_price=monthly_price_yearly) }}</em>
   <small class="c-matrix-footer-period c-matrix-footer-period-yearly">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
   {{ relay_subscribe_link(

--- a/bedrock/products/templates/products/relay/includes/matrix.html
+++ b/bedrock/products/templates/products/relay/includes/matrix.html
@@ -6,7 +6,7 @@
 
 {% from "products/relay/includes/macros.html" import waitlist, toggle with context %}
 
-{% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+{% set savings = relay_bundle_savings() %}
 
 <section>
   <table class="c-matrix-desktop">
@@ -121,7 +121,7 @@
         <td>
           <div class="c-matrix-footer">
             {% if bundle_available %}
-              {% set vpn_monthly_price_yearly = relay_monthly_price(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
+              {% set vpn_monthly_price_yearly = relay_monthly_price_formatted(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
               <p class="c-matrix-footer-vpn-savings">{{ ftl('plan-matrix-price-vpn-discount-promo-v2', savings=savings) }}</p>
               <em class="c-matrix-footer-vpn-price">{{ ftl('plan-matrix-price-monthly-calculated', monthly_price=vpn_monthly_price_yearly) }}</em>
               <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>
@@ -228,7 +228,7 @@
         </ul>
       <div class="c-matrix-footer">
         {% if bundle_available %}
-          {% set vpn_monthly_price_yearly = relay_monthly_price(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
+          {% set vpn_monthly_price_yearly = relay_monthly_price_formatted(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
           <p class="c-matrix-footer-vpn-savings">{{ ftl('plan-matrix-price-vpn-discount-promo-v2', savings=savings) }}</p>
           <em class="c-matrix-footer-vpn-price">{{ ftl('plan-matrix-price-monthly-calculated', monthly_price=vpn_monthly_price_yearly) }}</em>
           <small class="c-matrix-footer-period">{{ ftl('plan-matrix-price-period-yearly-footnote-1') }}</small>

--- a/bedrock/products/templates/products/relay/landing.html
+++ b/bedrock/products/templates/products/relay/landing.html
@@ -104,7 +104,7 @@
   <section id="pricing" class="mzp-l-content t-pricing">
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
-    {% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+    {% set savings = relay_bundle_savings() %}
     <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body-v2', savings=savings) }}</p>
     {% include 'products/relay/includes/matrix.html' %}
   </section>

--- a/bedrock/products/templates/products/relay/premium.html
+++ b/bedrock/products/templates/products/relay/premium.html
@@ -38,7 +38,7 @@
   ) %}
     <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-premium">{{ ftl('relay-shared-firefox-relay') }}</div>
     <h1 class="c-hero-title">{{ ftl('premium-promo-hero-headline') }}</h1>
-    {% set monthly_price = relay_monthly_price(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
+    {% set monthly_price = relay_monthly_price_formatted(product='relay-bundle', plan='yearly', country_code=country_code, lang=LANG) %}
     <p class="c-hero-body">{{ ftl('premium-promo-hero-body-3') }}</p>
     <p><a href="#pricing" class="mzp-c-button mzp-t-product" data-cta-type="button" data-cta-text="Get Started" data-cta-position="primary">{{ ftl('hero-section-cta') }}</a></p>
     <p class="c-hero-availability">{{ ftl('premium-promo-availability-warning-4') }}</p>
@@ -57,7 +57,7 @@
   <div class="mzp-l-content">
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
-    {% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+    {% set savings = relay_bundle_savings() %}
     <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body-v2', savings=savings) }}</p>
     {% include 'products/relay/includes/matrix.html' %}
   </div>

--- a/bedrock/products/templates/products/relay/pricing.html
+++ b/bedrock/products/templates/products/relay/pricing.html
@@ -30,7 +30,7 @@
     <h2 class="u-hidden">{{ ftl('plan-matrix-title') }}</h2>
     <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-relay mzp-l-wordmark-center">{{ ftl('relay-shared-firefox-relay') }}</div>
     <h3 class="c-pricing-sub">{{ ftl('plan-matrix-offer-title') }}</h3>
-    {% set savings = relay_bundle_savings(country_code=country_code, lang=LANG) %}
+    {% set savings = relay_bundle_savings() %}
     <p class="c-pricing-intro">{{ ftl('plan-matrix-offer-body-v2', savings=savings) }}</p>
     {% include 'products/relay/includes/matrix.html' %}
   </div>

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -2017,8 +2017,8 @@ class TestRelayEmailSubscribeLink(TestCase):
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay email yearly" '
-            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LXUdlJNcmPzuWtRKTYg7mpZ','brand' : 'relay',"
-            "'plan' : 'relay-email','period' : 'yearly','price' : '11.88','discount' : '12.00','currency' : 'USD'}\">Get Relay email yearly</a>"
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LXUdlJNcmPzuWtRKTYg7mpZ', 'brand' : 'relay', "
+            "'plan' : 'relay-email', 'period' : 'yearly', 'price' : '11.88', 'discount' : '12.00', 'currency' : 'USD'}\">Get Relay email yearly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2034,8 +2034,8 @@ class TestRelayEmailSubscribeLink(TestCase):
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1LXUdlJNcmPzuWtRKTYg7mpZ'
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral" data-action="https://accounts.firefox.com/" class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button '
-            "ga-begin-checkout\" data-ga-item=\"{'id' : 'price_1LXUdlJNcmPzuWtRKTYg7mpZ','brand' : 'relay','plan' : 'relay-email','period' : "
-            "'yearly','price' : '11.88','discount' : '12.00','currency' : 'USD'}\">Get Started</a>"
+            "ga-begin-checkout\" data-ga-item=\"{'id' : 'price_1LXUdlJNcmPzuWtRKTYg7mpZ', 'brand' : 'relay', 'plan' : 'relay-email', 'period' : "
+            "'yearly', 'price' : '11.88', 'discount' : '12.00', 'currency' : 'USD'}\">Get Started</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2055,8 +2055,8 @@ class TestRelayEmailSubscribeLink(TestCase):
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay email monthly" '
-            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LYC79JNcmPzuWtRU7Q238yL','brand' : 'relay',"
-            "'plan' : 'relay-email','period' : 'monthly','price' : '1.99','discount' : '0.00','currency' : 'EUR'}\">Get Relay email monthly</a>"
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LYC79JNcmPzuWtRU7Q238yL', 'brand' : 'relay', "
+            "'plan' : 'relay-email', 'period' : 'monthly', 'price' : '1.99', 'discount' : '0.00', 'currency' : 'EUR'}\">Get Relay email monthly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2672,8 +2672,8 @@ class TestRelayPhoneSubscribeLink(TestCase):
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay phone monthly" '
-            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Li0w8JNcmPzuWtR2rGU80P3','brand' : 'relay',"
-            "'plan' : 'relay-phone','period' : 'monthly','price' : '4.99','discount' : '0.00','currency' : 'USD'}\">Get Relay phone monthly</a>"
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Li0w8JNcmPzuWtR2rGU80P3', 'brand' : 'relay', "
+            "'plan' : 'relay-phone', 'period' : 'monthly', 'price' : '4.99', 'discount' : '0.00', 'currency' : 'USD'}\">Get Relay phone monthly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2693,8 +2693,8 @@ class TestRelayPhoneSubscribeLink(TestCase):
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay phone yearly" '
-            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Li15WJNcmPzuWtRIh0F4VwP','brand' : 'relay',"
-            "'plan' : 'relay-phone','period' : 'yearly','price' : '47.88','discount' : '12.00','currency' : 'USD'}\">Get Relay phone yearly</a>"
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Li15WJNcmPzuWtRIh0F4VwP', 'brand' : 'relay', "
+            "'plan' : 'relay-phone', 'period' : 'yearly', 'price' : '47.88', 'discount' : '12.00', 'currency' : 'USD'}\">Get Relay phone yearly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2744,8 +2744,8 @@ class TestRelayBundleSubscribeLink(TestCase):
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay bundle yearly" '
-            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LwoSDJNcmPzuWtR6wPJZeoh','brand' : 'relay',"
-            "'plan' : 'relay-bundle','period' : 'yearly','price' : '83.88','discount' : '55.92','currency' : 'USD'}\">Get Relay bundle yearly</a>"
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LwoSDJNcmPzuWtR6wPJZeoh', 'brand' : 'relay', "
+            "'plan' : 'relay-bundle', 'period' : 'yearly', 'price' : '83.88', 'discount' : '55.92', 'currency' : 'USD'}\">Get Relay bundle yearly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2763,7 +2763,7 @@ class TestRelayMonthlyPriceFormatted(TestCase):
         req = self.rf.get("/")
         req.locale = "en-US"
         return render(
-            f"""{{{{ relay_monthly_price_formatted('{product}', '{plan}', '{country_code}','{lang}') }}}}""",
+            f"""{{{{ relay_monthly_price_formatted('{product}', '{plan}', '{country_code}', '{lang}') }}}}""",
             {"request": req},
         )
 

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -2002,26 +2002,6 @@ class TestRelayEmailSubscribeLink(TestCase):
         )
 
     def test_relay_subscribe_link_email_yearly(self):
-        """Should return expected markup for yearly email subscription link"""
-        markup = self._render(
-            link_text="Get Relay email yearly",
-            product="relay-email",
-            plan="yearly",
-            country_code="DE",
-            lang="de",
-            optional_parameters={"utm_campaign": "relay-product-page"},
-            optional_attributes={"data-cta-text": "Get Relay email yearly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
-        )
-        expected = (
-            '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1LYC7xJNcmPzuWtRcdKXCVZp'
-            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
-            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay email yearly" data-cta-type="fxa-relay" '
-            'data-cta-position="primary">Get Relay email yearly</a>'
-        )
-        self.assertEqual(markup, expected)
-
-    def test_relay_subscribe_link_email_yearly_with_analytics(self):
         """Should return expected markup for yearly email subscription link with analytics"""
         markup = self._render(
             link_text="Get Relay email yearly",
@@ -2042,7 +2022,7 @@ class TestRelayEmailSubscribeLink(TestCase):
         )
         self.assertEqual(markup, expected)
 
-    def test_relay_subscribe_link_email_yearly_no_options_with_analytics(self):
+    def test_relay_subscribe_link_email_yearly_no_options(self):
         """Should return expected markup for yearly email subscription link with analytics"""
         markup = self._render(
             product="relay-email",
@@ -2060,26 +2040,6 @@ class TestRelayEmailSubscribeLink(TestCase):
         self.assertEqual(markup, expected)
 
     def test_relay_subscribe_link_email_monthly(self):
-        """Should return expected markup for monthly email subscription link"""
-        markup = self._render(
-            link_text="Get Relay email monthly",
-            product="relay-email",
-            plan="monthly",
-            country_code="US",
-            lang="en-US",
-            optional_parameters={"utm_campaign": "relay-product-page"},
-            optional_attributes={"data-cta-text": "Get Relay email monthly", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
-        )
-        expected = (
-            '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1LXUcnJNcmPzuWtRpbNOajYS'
-            "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
-            '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay email monthly" data-cta-type="fxa-relay" '
-            'data-cta-position="primary">Get Relay email monthly</a>'
-        )
-        self.assertEqual(markup, expected)
-
-    def test_relay_subscribe_link_email_monthly_with_analytics(self):
         """Should return expected markup for monthly email subscription link including analytics"""
         markup = self._render(
             link_text="Get Relay email monthly",
@@ -2096,7 +2056,7 @@ class TestRelayEmailSubscribeLink(TestCase):
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay email monthly" '
             "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LYC79JNcmPzuWtRU7Q238yL','brand' : 'relay',"
-            "'plan' : 'relay-email','period' : 'monthly','price' : '1.99','discount' : '0','currency' : 'EUR'}\">Get Relay email monthly</a>"
+            "'plan' : 'relay-email','period' : 'monthly','price' : '1.99','discount' : '0.00','currency' : 'EUR'}\">Get Relay email monthly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2202,7 +2162,7 @@ class TestRelayEmailSubscribeLink(TestCase):
             country_code="BE",
             lang="en-US",
         )
-        self.assertIn("plan=price_1LYCdLJNcmPzuWtR0J1EHoJ0", markup)
+        self.assertIn("plan=price_1LYBuLJNcmPzuWtRn58XQcky", markup)
 
     def test_relay_subscribe_link_email_yearly_be_en(self):
         """Should return expected Stripe Plan ID for yearly email subscription link (BE / en-US)"""
@@ -2212,7 +2172,7 @@ class TestRelayEmailSubscribeLink(TestCase):
             country_code="BE",
             lang="en-US",
         )
-        self.assertIn("plan=price_1LYCdtJNcmPzuWtRVm4jLzq2", markup)
+        self.assertIn("plan=price_1LYBwcJNcmPzuWtRpgoWcb03", markup)
 
     # CH
 
@@ -2284,7 +2244,7 @@ class TestRelayEmailSubscribeLink(TestCase):
             country_code="CH",
             lang="en-US",
         )
-        self.assertIn("plan=price_1LYCqOJNcmPzuWtRuIXpQRxi", markup)
+        self.assertIn("plan=price_1LYCvpJNcmPzuWtRq9ci2gXi", markup)
 
     def test_relay_subscribe_link_email_yearly_ch_en(self):
         """Should return expected Stripe Plan ID for yearly email subscription link (CH / en-US)"""
@@ -2294,7 +2254,7 @@ class TestRelayEmailSubscribeLink(TestCase):
             country_code="CH",
             lang="en-US",
         )
-        self.assertIn("plan=price_1LYCqyJNcmPzuWtR3Um5qDPu", markup)
+        self.assertIn("plan=price_1LYCwMJNcmPzuWtRm6ebmq2N", markup)
 
     # DE
 
@@ -2614,27 +2574,27 @@ class TestRelayEmailMonthlyPrice(TestCase):
     def _render(self, product, plan, country_code, lang):
         req = self.rf.get("/")
         req.locale = "en-US"
-        return render(f"{{{{ relay_monthly_price('{product}', '{plan}', '{country_code}', '{lang}') }}}}", {"request": req})
+        return render(f"{{{{ relay_monthly_price_formatted('{product}', '{plan}', '{country_code}', '{lang}') }}}}", {"request": req})
 
-    def test_relay_monthly_price_usd(self):
+    def test_relay_monthly_price_formatted_usd(self):
         """Should return expected markup"""
         markup = self._render(product="relay-email", plan="monthly", country_code="US", lang="en-US")
         expected = "$1.99"
         self.assertEqual(markup, expected)
 
-    def test_relay_monthly_price_usd_ca(self):
+    def test_relay_monthly_price_formatted_usd_ca(self):
         """Should return expected markup"""
         markup = self._render(product="relay-email", plan="monthly", country_code="CA", lang="en-CA")
         expected = "US$1.99"
         self.assertEqual(markup, expected)
 
-    def test_relay_monthly_price_euro(self):
+    def test_relay_monthly_price_formatted_euro(self):
         """Should return expected markup"""
         markup = self._render(product="relay-email", plan="monthly", country_code="DE", lang="de")
         expected = "1,99\xa0€"  # \xa0 is a non breaking space
         self.assertEqual(markup, expected)
 
-    def test_relay_monthly_price_chf(self):
+    def test_relay_monthly_price_formatted_chf(self):
         """Should return expected markup"""
         markup = self._render(product="relay-email", plan="monthly", country_code="CH", lang="fr")
         expected = "2,00\xa0CHF"  # \xa0 is a non breaking space
@@ -2711,8 +2671,9 @@ class TestRelayPhoneSubscribeLink(TestCase):
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1Li0w8JNcmPzuWtR2rGU80P3'
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay phone monthly" data-cta-type="fxa-relay" '
-            'data-cta-position="primary">Get Relay phone monthly</a>'
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay phone monthly" '
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Li0w8JNcmPzuWtR2rGU80P3','brand' : 'relay',"
+            "'plan' : 'relay-phone','period' : 'monthly','price' : '4.99','discount' : '0.00','currency' : 'USD'}\">Get Relay phone monthly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2731,8 +2692,9 @@ class TestRelayPhoneSubscribeLink(TestCase):
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_KGizMiBqUJdYoY?plan=price_1Li15WJNcmPzuWtRIh0F4VwP'
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay phone yearly" data-cta-type="fxa-relay" '
-            'data-cta-position="primary">Get Relay phone yearly</a>'
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay phone yearly" '
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Li15WJNcmPzuWtRIh0F4VwP','brand' : 'relay',"
+            "'plan' : 'relay-phone','period' : 'yearly','price' : '47.88','discount' : '12.00','currency' : 'USD'}\">Get Relay phone yearly</a>"
         )
         self.assertEqual(markup, expected)
 
@@ -2781,7 +2743,180 @@ class TestRelayBundleSubscribeLink(TestCase):
             '<a href="https://accounts.firefox.com/subscriptions/products/prod_MIex7Q079igFZJ?plan=price_1LwoSDJNcmPzuWtR6wPJZeoh'
             "&entrypoint=www.mozilla.org-relay-product-page&form_type=button&service=9ebfe2c2f9ea3c58&utm_source=www.mozilla.org-relay-product-page"
             '&utm_medium=referral&utm_campaign=relay-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
-            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button" data-cta-text="Get Relay bundle yearly" data-cta-type="fxa-relay" '
-            'data-cta-position="primary">Get Relay bundle yearly</a>'
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Relay bundle yearly" '
+            "data-cta-type=\"fxa-relay\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1LwoSDJNcmPzuWtR6wPJZeoh','brand' : 'relay',"
+            "'plan' : 'relay-bundle','period' : 'yearly','price' : '83.88','discount' : '55.92','currency' : 'USD'}\">Get Relay bundle yearly</a>"
         )
+        self.assertEqual(markup, expected)
+
+
+class TestRelayMonthlyPriceFormatted(TestCase):
+    rf = RequestFactory()
+
+    def _render(
+        self,
+        product="relay-email",
+        plan="yearly",
+        country_code=None,
+        lang=None,
+    ):
+        req = self.rf.get("/")
+        req.locale = "en-US"
+        return render(
+            f"""{{{{ relay_monthly_price_formatted('{product}', '{plan}', '{country_code}','{lang}') }}}}""",
+            {"request": req},
+        )
+
+    def test_relay_monthly_price_formatted_email_monthly_us_en(self):
+        """Should return price for montly email plan for display in USD in USA"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="US",
+            lang="en-US",
+        )
+        expected = "$1.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_us_en(self):
+        """Should return price for yearly email plan for display in USD in USA"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="US",
+            lang="en-US",
+        )
+        expected = "$0.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_monthly_ca_en(self):
+        """Should return price for montly email plan for display in USD in Canada"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CA",
+            lang="en-CA",
+        )
+        expected = "US$1.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_ca_en(self):
+        """Should return price for yearly email plan for display in USD in Canada"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CA",
+            lang="en-CA",
+        )
+        expected = "US$0.99"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_monthly_de_de(self):
+        """Should return price for montly email plan for display in German in Germany"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="DE",
+            lang="de",
+        )
+        expected = "1,99\xa0€"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_de_de(self):
+        """Should return price for yearly email plan for display in German in Germany"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="DE",
+            lang="de",
+        )
+        expected = "0,99\xa0€"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_monthly_dk_en(self):
+        """Should return price for montly email plan for display in English in Denmark"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="DK",
+            lang="en-US",
+        )
+        expected = "DKK15.00"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_dk_en(self):
+        """Should return price for yearly email plan for display in English in Denmark"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="DK",
+            lang="en-US",
+        )
+        expected = "DKK7.00"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_monthly_dk_da(self):
+        """Should return price for montly email plan for display in Danish in Denmark"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="DK",
+            lang="da",
+        )
+        expected = "15,00\xa0kr."
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_dk_da(self):
+        """Should return price for yearly email plan for display in Danish in Denmark"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="DK",
+            lang="da",
+        )
+        expected = "7,00\xa0kr."
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_monthly_it_ch(self):
+        """Should return price for montly email plan for display in Italian in Switzerland"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="CH",
+            lang="it",
+        )
+        expected = "2,00\xa0CHF"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_it_ch(self):
+        """Should return price for yearly email plan for display in Italian in Switzerland"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="CH",
+            lang="it",
+        )
+        expected = "1,00\xa0CHF"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_monthly_pl_pl(self):
+        """Should return price for montly email plan for display in Polish in Poland"""
+        markup = self._render(
+            product="relay-email",
+            plan="monthly",
+            country_code="PL",
+            lang="pl",
+        )
+        expected = "8,00\xa0zł"
+        self.assertEqual(markup, expected)
+
+    def test_relay_monthly_price_formatted_email_yearly_pl_pl(self):
+        """Should return price for yearly email plan for display in Polish in Poland"""
+        markup = self._render(
+            product="relay-email",
+            plan="yearly",
+            country_code="PL",
+            lang="pl",
+        )
+        expected = "5,00\xa0zł"
         self.assertEqual(markup, expected)

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -40,11 +40,13 @@ def vpn_available(request):
 def relay_available(product, request):
     country = get_country_from_request(request)
     if product == "relay-bundle":
-        country_list = settings.VPN_COUNTRY_CODES
+        country_list = settings.RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE["bundle"]
     elif product == "relay-phone":
-        country_list = settings.RELAY_PHONE_COUNTRY_CODES
+        country_list = settings.RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE["phone"]
+    elif product == "relay-email":
+        country_list = settings.RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE["email"]
     else:
-        country_list = settings.RELAY_EMAIL_COUNTRY_CODES
+        raise Exception("Unrecognized product passed to relay_available()")
 
     return country in country_list
 
@@ -421,11 +423,12 @@ def relay_landing_page(request):
         "products/relay/bundle",
         "products/relay/shared",
     ]
+
+    country = get_country_from_request(request)
+    vpn_available_in_country = vpn_available(request)
     relay_email_available_in_country = relay_available("relay-email", request)
     relay_phone_available_in_country = relay_available("relay-phone", request)
-    vpn_available_in_country = vpn_available(request)
-    country = get_country_from_request(request)
-    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE["bundle"]
 
     context = {
         "email_available": relay_email_available_in_country,
@@ -440,11 +443,12 @@ def relay_landing_page(request):
 def relay_premium_page(request):
     template_name = "products/relay/premium.html"
     ftl_files = ["products/relay/premium", "products/relay/features", "products/relay/matrix", "products/relay/bundle", "products/relay/shared"]
+
+    country = get_country_from_request(request)
+    vpn_available_in_country = vpn_available(request)
     relay_email_available_in_country = relay_available("relay-email", request)
     relay_phone_available_in_country = relay_available("relay-phone", request)
-    vpn_available_in_country = vpn_available(request)
-    country = get_country_from_request(request)
-    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE["bundle"]
 
     context = {
         "email_available": relay_email_available_in_country,
@@ -459,11 +463,12 @@ def relay_premium_page(request):
 def relay_pricing_page(request):
     template_name = "products/relay/pricing.html"
     ftl_files = ["products/relay/matrix", "products/relay/shared"]
+
+    country = get_country_from_request(request)
+    vpn_available_in_country = vpn_available(request)
     relay_email_available_in_country = relay_available("relay-email", request)
     relay_phone_available_in_country = relay_available("relay-phone", request)
-    vpn_available_in_country = vpn_available(request)
-    country = get_country_from_request(request)
-    relay_bundle_available_in_country = vpn_available_in_country and country in settings.VPN_RELAY_BUNDLE_COUNTRY_CODES
+    relay_bundle_available_in_country = vpn_available_in_country and country in settings.RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE["bundle"]
 
     context = {
         "email_available": relay_email_available_in_country,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1837,565 +1837,264 @@ RELAY_EMAIL_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_KEq0LXqs7vysQT
 RELAY_PHONE_PRODUCT_ID = config("RELAY_PRODUCT_ID", default="prod_LviM2I0paxH1DZ" if DEV else "prod_KGizMiBqUJdYoY")
 RELAY_VPN_BUNDLE_PRODUCT_ID = config("VPN_RELAY_BUNDLE_PRODUCT_ID", default="prod_MQ9Zf1cyI81XS2" if DEV else "prod_MIex7Q079igFZJ")
 
-# Relay email subscription plan IDs by currency/language
-RELAY_EMAIL_PLAN_ID_MATRIX = {
-    "chf": {  # Swiss franc
-        "de": {  # German
-            "monthly": {
-                "id": "price_1LYCqOJNcmPzuWtRuIXpQRxi",
-                "price": 2.00,
-                "currency": "CHF",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "CHF",
-                    "discount": "0",
-                    "price": "2.00",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYCqyJNcmPzuWtR3Um5qDPu",
-                "price": 1.00,
-                "currency": "CHF",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "CHF",
-                    "discount": "6.00",
-                    "price": "12.00",
-                    "period": "yearly",
-                },
-            },
+
+# Selected Stripe data
+# The "source of truth" is the Stripe data, this copy is used for
+# directing users to the correct Stripe purchase page.
+RELAY_STRIPE_PLAN_DATA = {
+    "email": {
+        "periods": "monthly_and_yearly",
+        "prices": {
+            "CHF": {"monthly": 2.00, "monthly_when_yearly": 1.00, "saving": 45},
+            "CZK": {"monthly": 47.0, "monthly_when_yearly": 23.0, "saving": 50},
+            "DKK": {"monthly": 15.0, "monthly_when_yearly": 7.00, "saving": 50},
+            "EUR": {"monthly": 1.99, "monthly_when_yearly": 0.99, "saving": 50},
+            "PLN": {"monthly": 8.00, "monthly_when_yearly": 5.00, "saving": 48},
+            "USD": {"monthly": 1.99, "monthly_when_yearly": 0.99, "saving": 50},
         },
-        "fr": {  # French
-            "monthly": {
-                "id": "price_1LYCvpJNcmPzuWtRq9ci2gXi",
-                "price": 2.00,
+        "countries_and_regions": {
+            "de-CH": {  # German-speaking Switzerland
                 "currency": "CHF",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "CHF",
-                    "discount": "0",
-                    "price": "2.00",
-                    "period": "monthly",
-                },
+                "monthly_id": "price_1LYCqOJNcmPzuWtRuIXpQRxi",
+                "yearly_id": "price_1LYCqyJNcmPzuWtR3Um5qDPu",
             },
-            "yearly": {
-                "id": "price_1LYCwMJNcmPzuWtRm6ebmq2N",
-                "price": 1.00,
+            "fr-CH": {  # French-speaking Switzerland
                 "currency": "CHF",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "CHF",
-                    "discount": "6.00",
-                    "price": "12.00",
-                    "period": "yearly",
-                },
+                "monthly_id": "price_1LYCvpJNcmPzuWtRq9ci2gXi",
+                "yearly_id": "price_1LYCwMJNcmPzuWtRm6ebmq2N",
             },
-        },
-        "it": {  # Italian
-            "monthly": {
-                "id": "price_1LYCiBJNcmPzuWtRxtI8D5Uy",
-                "price": 2.00,
+            "it-CH": {  # Italian-speaking Switzerland
                 "currency": "CHF",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "CHF",
-                    "discount": "0",
-                    "price": "2.00",
-                    "period": "monthly",
-                },
+                "monthly_id": "price_1LYCiBJNcmPzuWtRxtI8D5Uy",
+                "yearly_id": "price_1LYClxJNcmPzuWtRWjslDdkG",
             },
-            "yearly": {
-                "id": "price_1LYClxJNcmPzuWtRWjslDdkG",
-                "price": 1.00,
-                "currency": "CHF",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "CHF",
-                    "discount": "6.00",
-                    "price": "12.00",
-                    "period": "yearly",
-                },
+            "BG": {  # Bulgaria
+                "currency": "EUR",
+                "monthly_id": "price_1NOSjBJNcmPzuWtRMQwYp5u1",
+                "yearly_id": "price_1NOSkTJNcmPzuWtRpbKwsLcw",
+            },
+            "CY": {  # Cyprus
+                "currency": "EUR",
+                "monthly_id": "price_1NH9saJNcmPzuWtRpffF5I59",
+                "yearly_id": "price_1NH9rKJNcmPzuWtRzDiXCeEG",
+            },
+            "CZ": {  # Czech Republic / Czechia
+                "currency": "CZK",
+                "monthly_id": "price_1NNkAlJNcmPzuWtRxsfrXacj",
+                "yearly_id": "price_1NNkDHJNcmPzuWtRHnQmCDGP",
+            },
+            "DE": {  # Germany
+                "currency": "EUR",
+                "monthly_id": "price_1LYC79JNcmPzuWtRU7Q238yL",
+                "yearly_id": "price_1LYC7xJNcmPzuWtRcdKXCVZp",
+            },
+            "DK": {  # Denmark
+                "currency": "DKK",
+                "monthly_id": "price_1NNfPCJNcmPzuWtR3SNA8gqG",
+                "yearly_id": "price_1NNfLoJNcmPzuWtRpmLc9lst",
+            },
+            "EE": {  # Estonia
+                "currency": "EUR",
+                "monthly_id": "price_1NHA1tJNcmPzuWtRvSeyiVYH",
+                "yearly_id": "price_1NHA2TJNcmPzuWtR10yknZHf",
+            },
+            "ES": {  # Spain
+                "currency": "EUR",
+                "monthly_id": "price_1LYCWmJNcmPzuWtRtopZog9E",
+                "yearly_id": "price_1LYCXNJNcmPzuWtRu586XOFf",
+            },
+            "FI": {  # Finland
+                "currency": "EUR",
+                "monthly_id": "price_1LYBn9JNcmPzuWtRI3nvHgMi",
+                "yearly_id": "price_1LYBq1JNcmPzuWtRmyEa08Wv",
+            },
+            "FR": {  # France
+                "currency": "EUR",
+                "monthly_id": "price_1LYBuLJNcmPzuWtRn58XQcky",
+                "yearly_id": "price_1LYBwcJNcmPzuWtRpgoWcb03",
+            },
+            "GB": {  # United Kingdom
+                "currency": "USD",
+                "monthly_id": "price_1LYCHpJNcmPzuWtRhrhSYOKB",
+                "yearly_id": "price_1LYCIlJNcmPzuWtRQtYLA92j",
+            },
+            "GR": {  # Greece
+                "currency": "EUR",
+                "monthly_id": "price_1NHA5CJNcmPzuWtR1JSmxqFA",
+                "yearly_id": "price_1NHA4lJNcmPzuWtRniS23IuE",
+            },
+            "HR": {  # Croatia
+                "currency": "EUR",
+                "monthly_id": "price_1NOSznJNcmPzuWtRH7CEeAwA",
+                "yearly_id": "price_1NOT0WJNcmPzuWtRpeNDEjvC",
+            },
+            "HU": {  # Hungary
+                "currency": "EUR",
+                "monthly_id": "price_1NOOJAJNcmPzuWtRV7Kmwmdm",
+                "yearly_id": "price_1NOOKvJNcmPzuWtR2DEWIRE4",
+            },
+            "IE": {  # Ireland
+                "currency": "EUR",
+                "monthly_id": "price_1LhdrkJNcmPzuWtRvCc4hsI2",
+                "yearly_id": "price_1LhdprJNcmPzuWtR7HqzkXTS",
+            },
+            "IT": {  # Italy
+                "currency": "EUR",
+                "monthly_id": "price_1LYCMrJNcmPzuWtRTP9vD8wY",
+                "yearly_id": "price_1LYCN2JNcmPzuWtRtWz7yMno",
+            },
+            "LT": {  # Lithuania
+                "currency": "EUR",
+                "monthly_id": "price_1NHACcJNcmPzuWtR5ZJeVtJA",
+                "yearly_id": "price_1NHADOJNcmPzuWtR2PSMBMLr",
+            },
+            "LU": {  # Luxembourg
+                "currency": "EUR",
+                "monthly_id": "price_1NHAFZJNcmPzuWtRm5A7w5qJ",
+                "yearly_id": "price_1NHAF8JNcmPzuWtRG1FiPK0N",
+            },
+            "LV": {  # Latvia
+                "currency": "EUR",
+                "monthly_id": "price_1NHAASJNcmPzuWtRpcliwx0R",
+                "yearly_id": "price_1NHA9lJNcmPzuWtRLf7DV6GA",
+            },
+            "MT": {  # Malta
+                "currency": "EUR",
+                "monthly_id": "price_1NH9yxJNcmPzuWtRChanpIQU",
+                "yearly_id": "price_1NH9y3JNcmPzuWtRIJkQos9q",
+            },
+            "NL": {  # Netherlands
+                "currency": "EUR",
+                "monthly_id": "price_1LYCdLJNcmPzuWtR0J1EHoJ0",
+                "yearly_id": "price_1LYCdtJNcmPzuWtRVm4jLzq2",
+            },
+            "PL": {  # Poland
+                "currency": "PLN",
+                "monthly_id": "price_1NNKGJJNcmPzuWtRTlP7GKWW",
+                "yearly_id": "price_1NNfCvJNcmPzuWtRCvFppHqt",
+            },
+            "PT": {  # Portugal
+                "currency": "EUR",
+                "monthly_id": "price_1NHAI1JNcmPzuWtRx8jXjkrQ",
+                "yearly_id": "price_1NHAHWJNcmPzuWtRCRMnWyvK",
+            },
+            "RO": {  # Romania
+                "currency": "EUR",
+                "monthly_id": "price_1NOOEnJNcmPzuWtRicUvOyUy",
+                "yearly_id": "price_1NOOEJJNcmPzuWtRyHqMe2jb",
+            },
+            "SE": {  # Sweden
+                "currency": "EUR",
+                "monthly_id": "price_1LYBblJNcmPzuWtRGRHIoYZ5",
+                "yearly_id": "price_1LYBeMJNcmPzuWtRT5A931WH",
+            },
+            "SI": {  # Slovenia
+                "currency": "EUR",
+                "monthly_id": "price_1NHALmJNcmPzuWtR2nIoAzEt",
+                "yearly_id": "price_1NHAL9JNcmPzuWtRSZ3BWQs0",
+            },
+            "SK": {  # Slovakia
+                "currency": "EUR",
+                "monthly_id": "price_1NHAJsJNcmPzuWtR71WX0Pz9",
+                "yearly_id": "price_1NHAKYJNcmPzuWtRtETl30gb",
+            },
+            "US": {  # United States
+                "currency": "USD",
+                "monthly_id": "price_1LXUcnJNcmPzuWtRpbNOajYS",
+                "yearly_id": "price_1LXUdlJNcmPzuWtRKTYg7mpZ",
             },
         },
     },
-    "euro": {  # Euro
-        "de": {  # German
-            "monthly": {
-                "id": "price_1LYC79JNcmPzuWtRU7Q238yL",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYC7xJNcmPzuWtRcdKXCVZp",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
+    "phone": {
+        "periods": "monthly_and_yearly",
+        "prices": {
+            "USD": {"monthly": 4.99, "monthly_when_yearly": 3.99, "saving": 20},
         },
-        "es": {  # Spanish
-            "monthly": {
-                "id": "price_1LYCWmJNcmPzuWtRtopZog9E",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYCXNJNcmPzuWtRu586XOFf",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
-        },
-        "fr": {  # French
-            "monthly": {
-                "id": "price_1LYBuLJNcmPzuWtRn58XQcky",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYBwcJNcmPzuWtRpgoWcb03",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
-        },
-        "it": {  # Italian
-            "monthly": {
-                "id": "price_1LYCMrJNcmPzuWtRTP9vD8wY",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYCN2JNcmPzuWtRtWz7yMno",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
-        },
-        "nl": {  # Dutch
-            "monthly": {
-                "id": "price_1LYCdLJNcmPzuWtR0J1EHoJ0",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYCdtJNcmPzuWtRVm4jLzq2",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
-        },
-        "ga": {  # Irish
-            "monthly": {
-                "id": "price_1LhdrkJNcmPzuWtRvCc4hsI2",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LhdprJNcmPzuWtR7HqzkXTS",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
-        },
-        "sv": {  # Sweedish
-            "monthly": {
-                "id": "price_1LYBblJNcmPzuWtRGRHIoYZ5",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYBeMJNcmPzuWtRT5A931WH",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
-        },
-        "fi": {  # Finnish
-            "monthly": {
-                "id": "price_1LYBn9JNcmPzuWtRI3nvHgMi",
-                "price": 1.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYBq1JNcmPzuWtRmyEa08Wv",
-                "price": 0.99,
-                "currency": "EUR",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "EUR",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
+        "countries_and_regions": {
+            "US": {  # United States
+                "currency": "USD",
+                "monthly_id": "price_1Li0w8JNcmPzuWtR2rGU80P3",
+                "yearly_id": "price_1Li15WJNcmPzuWtRIh0F4VwP",
+            }
         },
     },
-    "usd": {
-        "en": {
-            "monthly": {
-                "id": "price_1LiMjeKb9q6OnNsLzwixHuRz" if DEV else "price_1LXUcnJNcmPzuWtRpbNOajYS",
-                "price": 1.99,
-                "currency": "USD",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "USD",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LiMlBKb9q6OnNsL7tvrtI7y" if DEV else "price_1LXUdlJNcmPzuWtRKTYg7mpZ",
-                "price": 0.99,
-                "currency": "USD",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "USD",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
+    "bundle": {
+        "periods": "yearly",
+        "prices": {
+            "USD": {"monthly_when_yearly": 6.99, "saving": 40},
         },
-        "gb": {
-            "monthly": {
-                "id": "price_1LYCHpJNcmPzuWtRhrhSYOKB",
-                "price": 1.99,
+        "countries_and_regions": {
+            "US": {  # United States
                 "currency": "USD",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "USD",
-                    "discount": "0",
-                    "price": "1.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1LYCIlJNcmPzuWtRQtYLA92j",
-                "price": 0.99,
-                "currency": "USD",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-email",
-                    "currency": "USD",
-                    "discount": "12.00",
-                    "price": "11.88",
-                    "period": "yearly",
-                },
-            },
+                "yearly_id": "price_1LwoSDJNcmPzuWtR6wPJZeoh",
+            }
         },
     },
 }
 
-# Relay email map countries to languages
-RELAY_EMAIL_PLAN_COUNTRY_LANG_MAPPING = {
-    # Austria
-    "AT": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
-    },
-    # Belgium
-    "BE": {
-        "fr": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fr"],
-        "de": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["nl"],
-    },
-    # Switzerland
-    "CH": {
-        "fr": RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["fr"],
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["de"],
-        "it": RELAY_EMAIL_PLAN_ID_MATRIX["chf"]["it"],
-    },
-    # Germany
-    "DE": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["de"],
-    },
-    # Spain
-    "ES": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["es"],
-    },
-    # France
-    "FR": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fr"],
-    },
-    # Ireland
-    "IE": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["ga"],
-    },
-    # Italy
-    "IT": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["it"],
-    },
-    # Netherlands
-    "NL": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["nl"],
-    },
-    # Sweden
-    "SE": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["sv"],
-    },
-    # Finland
-    "FI": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["euro"]["fi"],
-    },
-    # USA
-    "US": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["en"],
-    },
-    # Great Britian
-    "GB": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
-    },
-    # Canada
-    "CA": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["en"],
-    },
-    # New Zealand
-    "NZ": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
-    },
-    # Malaysia
-    "MY": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
-    },
-    # Singapore
-    "SG": {
-        "default": RELAY_EMAIL_PLAN_ID_MATRIX["usd"]["gb"],
-    },
-}
-
-# Countries where Relay Email Masking is available
-RELAY_EMAIL_COUNTRY_CODES = [
-    "CA",  # Canada
-    "GB",  # United Kingdom of Great Britain and Northern Island
-    "MY",  # Malaysia
-    "NZ",  # New Zealand
-    "SG",  # Singapore
-    "US",  # United States of America
-    # EU Countries
-    "AT",  # Austria
-    "BE",  # Belgium
-    "CH",  # Switzerland
-    "DE",  # Germany
-    "ES",  # Spain
-    "FI",  # Finland
-    "FR",  # France
-    "IE",  # Ireland
-    "IT",  # Italy
-    "NL",  # Netherlands
-    "SE",  # Sweden
-]
-
-# Relay phone subscription plan IDs by currency/language
-RELAY_PHONE_PLAN_ID_MATRIX = {
-    "usd": {
-        "en": {
-            "monthly": {
-                "id": "price_1LDqw3Kb9q6OnNsL6XIDst28" if DEV else "price_1Li0w8JNcmPzuWtR2rGU80P3",
-                "price": 4.99,
-                "currency": "USD",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-phone",
-                    "currency": "USD",
-                    "discount": "0",
-                    "price": "4.99",
-                    "period": "monthly",
-                },
-            },
-            "yearly": {
-                "id": "price_1Lhd35Kb9q6OnNsL9bAxjUGq" if DEV else "price_1Li15WJNcmPzuWtRIh0F4VwP",
-                "price": 3.99,
-                "currency": "USD",
-                "analytics": {
-                    "brand": "relay",
-                    "plan": "relay-phone",
-                    "currency": "USD",
-                    "discount": "12.00",
-                    "price": "47.88",
-                    "period": "monthly",
-                },
-            },
+# Map of Relay-supported countries to languages and their plans
+# The top-level key is the plan,
+# The second-level key is a country code, such as "ca" for Canada
+# The third-level key is a language, such as "en" for English. The first language
+#   key is the default for that country. Multiple keys are only needed when
+#   there are multiple plans for a country (Belgium and Switzerland), distinguished by
+#   the language. In the 2023 EU expansion, we instead created a plan per country, so
+#   only one third-level entry is needed, and the language is not used.
+# The third-level value is a country, such as "US" for the United States,
+#   or a reigonal language, such as "de-CH" for German (Switzerland). This is an
+#   index into the _STRIPE_PLAN_DATA. Multiple entries may point to the same Stripe
+#   country data.
+RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE = {
+    "email": {
+        "AT": {"de": "DE"},  # Austria
+        "BE": {  # Belgium
+            "fr": "FR",  # default
+            "de": "DE",
+            "nl": "NL",
         },
+        "BG": {"bg": "BG"},  # Bulgaria
+        "CA": {"en": "US"},  # Canada
+        "CH": {  # Switzerland
+            "fr": "fr-CH",  # default
+            "de": "de-CH",
+            "it": "it-CH",
+        },
+        "CY": {"el": "CY"},  # Cyprus
+        "CZ": {"cs": "CZ"},  # Czech Republic / Czechia
+        "DE": {"de": "DE"},  # Germany
+        "DK": {"da": "DK"},  # Denmark
+        "EE": {"et": "EE"},  # Estonia
+        "ES": {"es": "ES"},  # Spain
+        "FI": {"fi": "FI"},  # Finland
+        "FR": {"fr": "FR"},  # France
+        "GB": {"en": "GB"},  # United Kingdom
+        "GR": {"el": "GR"},  # Greece
+        "HR": {"hr": "HR"},  # Croatia
+        "HU": {"hu": "HU"},  # Hungary
+        "IE": {"en": "IE"},  # Ireland
+        "IT": {"it": "IT"},  # Italy
+        "LT": {"lt": "LT"},  # Lithuania
+        "LU": {"fr": "LU"},  # Luxembourg
+        "LV": {"lv": "LV"},  # Latvia
+        "MT": {"en": "MT"},  # Malta
+        "MY": {"en": "GB"},  # Malaysia
+        "NL": {"nl": "NL"},  # Netherlands
+        "NZ": {"en": "GB"},  # New Zealand
+        "PL": {"pl": "PL"},  # Poland
+        "PT": {"pt": "PT"},  # Portugal
+        "RO": {"ro": "RO"},  # Romania
+        "SE": {"sv": "SE"},  # Sweden
+        "SG": {"en": "GB"},  # Singapore
+        "SI": {"sl": "SI"},  # Slovenia
+        "SK": {"sk": "SK"},  # Slovakia
+        "US": {"en": "US"},  # United States
+    },
+    "phone": {
+        "CA": {"en": "US"},  # Canada
+        "US": {"en": "US"},  # United States
+    },
+    "bundle": {
+        "CA": {"en": "US"},  # Canada
+        "US": {"en": "US"},  # United States
     },
 }
-
-# Relay phone subscription map countries to languages
-RELAY_PHONE_PLAN_COUNTRY_LANG_MAPPING = {
-    "US": {
-        "default": RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
-    },
-    "CA": {
-        "default": RELAY_PHONE_PLAN_ID_MATRIX["usd"]["en"],
-    },
-}
-
-# Countries where Relay Phone Masking is available
-RELAY_PHONE_COUNTRY_CODES = [
-    "CA",  # Canada
-    "US",  # United States of America
-]
-
-# Relay VPN bundle plan IDs by currency/language
-RELAY_VPN_BUNDLE_PLAN_ID_MATRIX = {
-    "usd": {
-        "en": {
-            "yearly": {
-                "id": "price_1Lwp7uKb9q6OnNsLQYzpzUs5" if DEV else "price_1LwoSDJNcmPzuWtR6wPJZeoh",
-                "price": "6.99",
-                "currency": "USD",
-                "saving": 0.4,
-                "analytics": {
-                    "brand": "relay",
-                    "name": "relay-vpn",
-                    "currency": "USD",
-                    "discount": "55.92",
-                    "price": "83.88",
-                    "variant": "yearly",
-                },
-            },
-        }
-    },
-}
-
-# Relay VPN bundle map countries to languages
-RELAY_VPN_BUNDLE_COUNTRY_LANG_MAPPING = {
-    "US": {
-        "default": RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
-    },
-    "CA": {
-        "default": RELAY_VPN_BUNDLE_PLAN_ID_MATRIX["usd"]["en"],
-    },
-}
-
-# Countries where Relay & VPN bundle is available
-RELAY_VPN_BUNDLE_COUNTRY_CODES = [
-    "CA",  # Canada
-    "US",  # United States of America
-]
-
-# Monitor Breach Scan URL
-MONITOR_BREACH_SCAN_URL = config("MONITOR_BREACH_SCAN_URL", default="https://monitor.firefox.com/scan")


### PR DESCRIPTION
## One-line summary of changes

Add new supported EU countries to Relay

## Significant changes and points to review

- import [new data structure](https://github.com/mozilla/fx-private-relay/blob/168105a471a4590e6379d663b59b0d3e7e15cd62/privaterelay/plans.py#L250-L439) from Relay
- update templatetags to account for new data structure
- add function to create ga-data object
- update tests to consider analytics will always be there
- add tests for currency formatting
- change tests which expected a different default region for multi region countries
- add some error messages when product is unrecognized instead of falling back

The tests need to be updated to test all the new locales, but I thought it'd be good to merge with the old ones so we can tell I didn't break anything with the new data structure. So, [PR to follow with updated tests](#13667).

## Issue / Bugzilla link

#13656 

## Testing

Try some random language and geo combinations and see if you can break it:
http://localhost:8000/en-US/products/relay/?geo=US

`py.test bedrock/products`