### PR TITLE
Added media queries for phones (#13608)

### DIFF
--- a/media/css/mozorg/home/home-new.scss
+++ b/media/css/mozorg/home/home-new.scss
@@ -14,6 +14,14 @@ header {
 
         h1 {
             @include font-size(54px);
+
+            @media #{$mq-xs} {
+               @include font-size(38px);
+            }
+
+            @media #{$mq-md} {
+               @include font-size(54px);
+            }
         }
 
         p {


### PR DESCRIPTION
## One-line summary
The heading text for the German version of homepage had the wrong font size for small resolutions. I fixed it.

## Issue / Bugzilla link
[13608](https://github.com/mozilla/bedrock/issues/13608)