### PR TITLE
Fix bug with Relay plan toggle

### DIFF
--- a/media/css/products/relay/components/matrix.scss
+++ b/media/css/products/relay/components/matrix.scss
@@ -310,11 +310,12 @@ small.c-matrix-footer-period {
     }
 }
 
-.c-toggle-input:hover + .c-toggle-label span {
+.c-toggle-input:hover + .c-toggle-label span,
+.c-toggle-input:focus + .c-toggle-label span {
     color: $color-blue-50;
 }
 
-.c-toggle-input:focus + .c-toggle-label span {
+.c-toggle-input:checked:focus + .c-toggle-label span {
     border: 2px solid $color-blue-50;
 }
 


### PR DESCRIPTION
## One-line summary

CSS tweak to Relay plan toggles

## Significant changes and points to review

It's been bothering me that the blue outline moves to the selected plan on mouse down and the white background moves on mouse up. 

<img width="207" alt="Screenshot 2023-09-15 at 09 41 23" src="https://github.com/mozilla/bedrock/assets/854701/09c6bda7-654f-4f0c-9a35-37dfab47506c">

This moves them together on mouse down.

## Issue / Bugzilla link

n/a

## Testing

Toggles appear in the pricing matrix on large screens:

http://localhost:8000/en-US/products/relay/