### PR TITLE
Add monitor waitlist switch checking

### DIFF
--- a/bedrock/base/management/commands/update_www_config.py
+++ b/bedrock/base/management/commands/update_www_config.py
@@ -7,6 +7,7 @@ import os
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+import requests
 from envcat import get_env_vars
 
 from bedrock.base.models import ConfigValue
@@ -23,17 +24,29 @@ def get_config_values():
     return get_env_vars(get_config_file_name())
 
 
-def refresh_db_values():
+def refresh_db_values(extra=None):
+    """
+    Refresh the database with the values from the config file.
+
+    :param extra: A list of `ConfigValue` objects to add to the database.
+    :return: The number of configs successfully loaded.
+
+    """
     values = get_config_values()
-    if not values:
-        return 0
 
     ConfigValue.objects.all().delete()
     count = 0
+
     for name, value in values.items():
         if value:
             ConfigValue.objects.create(name=name, value=value)
             count += 1
+
+    if extra:
+        for obj in extra:
+            if obj:
+                ConfigValue.objects.create(name=obj.name, value=obj.value)
+                count += 1
 
     return count
 
@@ -53,12 +66,18 @@ class Command(BaseCommand):
         repo = GitRepo(settings.WWW_CONFIG_PATH, settings.WWW_CONFIG_REPO, branch_name=settings.WWW_CONFIG_BRANCH, name="WWW Config")
         self.output("Updating git repo")
         repo.update()
+
+        # Check monitor API and set the waitlist switch as appropriate.
+        # Note: Doing this here since we want to run this regardless of whether or not there are changes in the config repo.
+        self.output("Checking monitor API...")
+        monitor_waitlist_config = self.set_monitor_waitlist()
+
         if not (options["force"] or repo.has_changes()):
             self.output("No config updates")
             return
 
         self.output("Loading configs into database")
-        count = refresh_db_values()
+        count = refresh_db_values(extra=[monitor_waitlist_config])
 
         if count:
             self.output(f"{count} configs successfully loaded")
@@ -69,3 +88,44 @@ class Command(BaseCommand):
 
         self.output("Saved latest git repo state to database")
         self.output("Done!")
+
+    def set_monitor_waitlist(self):
+        # Grab the existing monitor waitlist value so if something fails with the API, we don't lose it.
+        try:
+            obj = ConfigValue.objects.get(name=settings.MONITOR_SWITCH_WAITLIST)
+        except ConfigValue.DoesNotExist:
+            obj = None
+
+        if not settings.MONITOR_ENDPOINT or not settings.MONITOR_TOKEN:
+            # Nothing to do, leave everything as-is.
+            return obj
+
+        resp = requests.get(
+            settings.MONITOR_ENDPOINT, headers={"Content-Type": "application/json", "Authorization": f"Bearer {settings.MONITOR_TOKEN}"}
+        )
+        if resp.status_code != 200:
+            self.output(f"Error getting monitor data: {repr(resp)}")
+            return obj
+
+        monitor_waitlist_value = settings.MONITOR_SWITCH_WAITLIST_DEFAULT
+        data = resp.json()
+        if data.get("success") is True and (message := data.get("message")):
+            if (scans := message.get("scans")) and (subscribers := message.get("subscribers")):
+                # If either of these are exceeded, we want to turn the waitlist on.
+                scans_exceeded = scans.get("count") > scans.get("quota")
+                subscribers_exceeded = subscribers.get("count") > subscribers.get("quota")
+                if scans_exceeded or subscribers_exceeded:
+                    monitor_waitlist_value = "on"
+                else:
+                    monitor_waitlist_value = "off"
+
+        if obj and obj.value == monitor_waitlist_value:
+            # No change, nothing to do.
+            self.output(f"No change. Monitor waitlist switch is already set to '{monitor_waitlist_value}'")
+            return obj
+
+        obj, created = ConfigValue.objects.update_or_create(name=settings.MONITOR_SWITCH_WAITLIST, defaults={"value": monitor_waitlist_value})
+        self.output(f"{'Created' if created else 'Updated'} switch: {settings.MONITOR_SWITCH_WAITLIST}={monitor_waitlist_value}")
+
+        # Return the `ConfigValue` object so if the repo has changes, we can make sure to persist this record.
+        return obj

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1041,6 +1041,11 @@ WWW_CONFIG_PATH = config("WWW_CONFIG_PATH", default=data_path("www_config"))
 WWW_CONFIG_REPO = config("WWW_CONFIG_REPO", default="https://github.com/mozmeao/www-config.git")
 WWW_CONFIG_BRANCH = config("WWW_CONFIG_BRANCH", default="main")
 
+MONITOR_SWITCH_WAITLIST = "SWITCH_MONITOR_WAITLIST"
+MONITOR_SWITCH_WAITLIST_DEFAULT = "off"
+MONITOR_ENDPOINT = config("MONITOR_ENDPOINT", default="https://monitor.firefox.com/api/v1/stats")
+MONITOR_TOKEN = config("MONITOR_TOKEN", default="")
+
 LEGAL_DOCS_PATH = DATA_PATH / "legal_docs"
 LEGAL_DOCS_REPO = config("LEGAL_DOCS_REPO", default="https://github.com/mozilla/legal-docs.git")
 LEGAL_DOCS_BRANCH = config("LEGAL_DOCS_BRANCH", default="main" if DEV else "prod")


### PR DESCRIPTION
Adds a check to the `update_www_config` management command to check the monitor stats API and enables or disables the monitor waitlist switch.

To test locally run:
`./manage.py update_www_config`
