### PR TITLE
Add GA4/GTM tracking for send_to_device (#13683)

### DIFF
--- a/media/js/base/send-to-device.es6.js
+++ b/media/js/base/send-to-device.es6.js
@@ -171,9 +171,16 @@ SendToDevice.prototype.onFormSuccess = function () {
 
     this.enableForm();
 
+    // UA
     window.dataLayer.push({
         event: 'send-to-device-success',
         input: 'email-address'
+    });
+
+    // GA4
+    window.dataLayer.push({
+        event: 'send_to_device',
+        method: 'email'
     });
 
     // Glean


### PR DESCRIPTION
## One-line summary

Send the event `send_to_device` from bedrock & receive it in GTM.

## Issue / Bugzilla link

#13683

## Significant changes and points to review

- Added GTM Tag: `GA4 Event - send_to_device`
- Added GTM Trigger: `Event - send_to_device`
- Deleted previous Tag: `GA4 Event - Campaign - Send to Device Success`

## Testing

**Please also test the accompanying GTM changes.**

- [Visit the "ga4 s2d" container in GTM.](https://tagmanager.google.com/#/container/accounts/52671733/containers/1075029/workspaces/1000239) 
- Click the "preview" button to open tag assistant.
- Click "add domain" and enter https://www-demo4.allizom.org/en-US/firefox/mobile/get-app
- Submit the form with "success@example.com" and "failure@example.com"
- In tag assistant check that:
  - the failure did not trigger a `send_to_device` event
  - the success did trigger a `send_to_device` event
  - the event triggered the tag "GA4 Event - send_to_device'