### PR TITLE
Update monitor page legal footer links

### DIFF
--- a/bedrock/products/templates/products/monitor/includes/sub-footer.html
+++ b/bedrock/products/templates/products/monitor/includes/sub-footer.html
@@ -8,7 +8,8 @@
   <div class="mzp-l-content">
     <ul class="c-sub-footer-list">
       <li><a href="{{ url('mozorg.about.index') }}">{{ ftl('monitor-shared-footer-about-mozilla') }}</a></li>
-      <li><a href="{{ url('privacy.notices.firefox-monitor') }}">{{ ftl('monitor-shared-footer-terms-and-privacy') }}</a></li>
+      <li><a href="{{ url('legal.terms.subscription-services') }}">{{ ftl('monitor-shared-footer-terms-of-service') }}</a></li>
+      <li><a href="{{ url('privacy.notices.subscription-services') }}">{{ ftl('monitor-shared-footer-privacy-policy') }}</a></li>
       <li><a href="https://github.com/mozilla/blurts-server">{{ ftl('monitor-shared-footer-github') }}</a></li>
     </ul>
   </div>

--- a/l10n/en/products/monitor/shared.ftl
+++ b/l10n/en/products/monitor/shared.ftl
@@ -15,5 +15,11 @@ monitor-shared-sub-nav-all-breaches = All breaches
 ## Footer
 
 monitor-shared-footer-about-mozilla = About { -brand-name-mozilla }
+
+monitor-shared-footer-terms-of-service = Terms of Service
+monitor-shared-footer-privacy-policy = Privacy Policy
+
+# Outdated string
 monitor-shared-footer-terms-and-privacy = Terms & Privacy
+
 monitor-shared-footer-github = GitHub


### PR DESCRIPTION
## One-line summary

Legal / product have requested that we switch to using two separate links for ToS and Pivacy Policy.

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/products/monitor/