### PR TITLE
Updating Firefox Accounts strings to Mozilla accounts

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -117,7 +117,12 @@
       {% if intro_text %}
         {{ intro_text }}
       {% else %}
-        {{ ftl('fxa-form-enter-your-email') }}
+        {% if switch('moz-accounts-update') %}
+          {{ ftl('fxa-form-enter-your-email-v2', fallback='fxa-form-enter-your-email') }}
+        {% else %}
+          {{ ftl('fxa-form-enter-your-email') }}
+        {% endif %}
+
       {% endif %}
       </p>
     </header>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -11,14 +11,18 @@
 {% set _entrypoint = 'mozilla.org-firefox-accounts' %}
 
 {%- block page_title -%}
-  {{ ftl('firefox-accounts-get-a-firefox-account') }}
+  {% if switch('moz-accounts-update') %}
+    {{ ftl('mozilla-accounts-get-a-mozilla-account', fallback='firefox-accounts-get-a-firefox-account') }}
+  {% else %}
+    {{ ftl('firefox-accounts-get-a-firefox-account') }}
+  {% endif %}
 {%- endblock -%}
 {%- block page_desc -%}
   {{ ftl('firefox-accounts-securely-sync-your') }}
 {%- endblock -%}
 
 {% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
-{% block page_favicon %}{{ static('img/favicons/firefox/favicon.ico') }}{% endblock %}
+{% block page_favicon %}{{ static('img/favicons/mozilla/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/apple-touch-icon.png') }}{% endblock %}
 
@@ -40,8 +44,12 @@
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.accounts') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Accounts">
-          <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
-          {{ ftl('sub-navigation-mozilla-accounts') }}
+          <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/mozilla/logo.svg') }}" width="24" height="24" alt="">
+          {% if switch('moz-accounts-update') %}
+            {{ ftl('sub-navigation-mozilla-accounts', fallback='sub-navigation-firefox-accounts') }}
+          {% else %}
+            {{ ftl('sub-navigation-firefox-accounts') }}
+          {% endif %}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
@@ -80,7 +88,13 @@
         </div>
 
         <div class="c-manage">
-          <p>{{ ftl('mozilla-accounts-already') }}</p>
+
+          {% if switch('moz-accounts-update') %}
+            <p>{{ ftl('mozilla-accounts-already', fallback='firefox-accounts-already') }}</p>
+          {% else %}
+            <p>{{ ftl('firefox-accounts-already') }}</p>
+          {% endif %}
+
           <a href="https://accounts.firefox.com/settings" id="manage">{{ ftl('firefox-accounts-manage') }}</a>
         </div>
       </div>
@@ -88,7 +102,12 @@
     <div class="mzp-c-split-body">
 
       <div class="accounts-products">
-        <h2>{{ ftl('mozilla-account-sign-in-to', fallback='firefox-accounts-meet-our-family-of') }}</h2>
+
+        {% if switch('moz-accounts-update') %}
+            <h2>{{ ftl('mozilla-account-sign-in-to', fallback='firefox-account-sign-in-to') }}</h2>
+          {% else %}
+            <h2>{{ ftl('firefox-account-sign-in-to') }}</h2>
+          {% endif %}
 
         <a href="{{ url('firefox.browsers.index') }}"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-firefox">{{ ftl('firefox-accounts-firefox-browser') }}</h4></a>
         <ul class="mzp-u-list-styled">

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -41,7 +41,7 @@
       <h2 class="c-sub-navigation-title is-summary">
         <a href="{{ url('firefox.accounts') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Accounts">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
-          {{ ftl('sub-navigation-firefox-accounts') }}
+          {{ ftl('sub-navigation-mozilla-accounts') }}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
@@ -80,7 +80,7 @@
         </div>
 
         <div class="c-manage">
-          <p>{{ ftl('firefox-accounts-already') }}</p>
+          <p>{{ ftl('mozilla-accounts-already') }}</p>
           <a href="https://accounts.firefox.com/settings" id="manage">{{ ftl('firefox-accounts-manage') }}</a>
         </div>
       </div>
@@ -88,7 +88,7 @@
     <div class="mzp-c-split-body">
 
       <div class="accounts-products">
-        <h2>{{ ftl('firefox-accounts-sign-in-to', fallback='firefox-accounts-meet-our-family-of') }}</h2>
+        <h2>{{ ftl('mozilla-account-sign-in-to', fallback='firefox-accounts-meet-our-family-of') }}</h2>
 
         <a href="{{ url('firefox.browsers.index') }}"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-firefox">{{ ftl('firefox-accounts-firefox-browser') }}</h4></a>
         <ul class="mzp-u-list-styled">

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -237,7 +237,7 @@
 
       <p>{{ ftl('compare-brave-the-ability-to-sync-your-passwords') }}</p>
 
-      <p>{{ ftl('compare-brave-the-firefox-browser-also-gives', accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
+      <p>{{ ftl('compare-brave-the-firefox-browser-also-gives-v2', accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
           monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
           breaches='href="https://monitor.firefox.com/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe) }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -237,9 +237,15 @@
 
       <p>{{ ftl('compare-brave-the-ability-to-sync-your-passwords') }}</p>
 
-      <p>{{ ftl('compare-brave-the-firefox-browser-also-gives-v2', accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
+          {% if switch('moz-accounts-update') %}
+            <p>{{ ftl('compare-brave-the-firefox-browser-also-gives-v2', fallback='compare-brave-the-firefox-browser-also-gives', accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
           monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
           breaches='href="https://monitor.firefox.com/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe) }}</p>
+          {% else %}
+            <p>{{ ftl('compare-brave-the-firefox-browser-also-gives', accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
+          monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
+          breaches='href="https://monitor.firefox.com/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe) }}</p>
+          {% endif %}
 
       <p>{{ ftl('compare-brave-brave-also-recently-gained') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -182,16 +182,15 @@
 
       <p>{{ ftl('compare-safari-like-safari-firefox-encourages', attrs='href="https://addons.mozilla.org" rel="external noopener" data-cta-text="add-ons and extensions" data-cta-type="link"'|safe) }}</p>
 
-
-    {% if ftl_has_messages('compare-safari-also-when-you-sign-up-for-updated-v2', 'compare-safari-firefox-is-also-great-for-video', 'compare-safari-screenshots-is-another-popular') %}
-      <p>{{ ftl('compare-safari-also-when-you-sign-up-for-updated-v2', pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe) }}</p>
+      {% if switch('moz-accounts-update') %}
+        <p>{{ ftl('compare-safari-also-when-you-sign-up-for-updated-v2', fallback='compare-safari-also-when-you-sign-up-for-updated', pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe) }}</p>
+        {% else %}
+          {{ ftl('compare-safari-also-when-you-sign-up-for-updated', pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe) }}
+      {% endif %}
 
       <p>{{ ftl('compare-safari-firefox-is-also-great-for-video') }}</p>
 
       <p>{{ ftl('compare-safari-screenshots-is-another-popular', attrs='href="https://screenshots.firefox.com" rel="external noopener" data-cta-text="Screenshots" data-cta-type="link"'|safe) }}</p>
-    {% else %}
-      <p>{{ ftl('compare-safari-also-when-you-sign-up-for', fallback='compare-safari-also-when-you-sign-up-for-fallback', pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe, send='href="https://send.firefox.com/" rel="external noopener" data-cta-text="Send" data-cta-type="link"'|safe ) }}</p>
-    {% endif %}
 
       <p>{{ ftl('compare-safari-both-browsers-have-a-lot') }}</p>
 
@@ -243,7 +242,11 @@
 
       <p>{{ ftl('compare-safari-firefox-and-safari-both-provide') }}</p>
 
-      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v2', fallback='compare-safari-firefox-also-offers-a-similar', attrs = 'href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts'))) }}</p>
+      {% if switch('moz-accounts-update') %}
+        <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v2', fallback='compare-safari-firefox-also-offers-a-similar-updated', attrs = 'href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts'))) }}</p>
+      {% else %}
+        <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated', attrs = 'href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts'))) }}</p>
+      {% endif %}
 
       <p>{{ ftl('compare-safari-the-firefox-app-for-ios-and', ios='href="%s" rel="external noopener" data-cta-text="iOS" data-cta-type="link"'|safe|format(app_store_url('firefox')),
               android='href="%s" rel="external noopener" data-cta-text="Android" data-cta-type="link"'|safe|format(play_store_url('firefox'))) }}</p>

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -183,8 +183,8 @@
       <p>{{ ftl('compare-safari-like-safari-firefox-encourages', attrs='href="https://addons.mozilla.org" rel="external noopener" data-cta-text="add-ons and extensions" data-cta-type="link"'|safe) }}</p>
 
 
-    {% if ftl_has_messages('compare-safari-also-when-you-sign-up-for-updated', 'compare-safari-firefox-is-also-great-for-video', 'compare-safari-screenshots-is-another-popular') %}
-      <p>{{ ftl('compare-safari-also-when-you-sign-up-for-updated', pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe) }}</p>
+    {% if ftl_has_messages('compare-safari-also-when-you-sign-up-for-updated-v2', 'compare-safari-firefox-is-also-great-for-video', 'compare-safari-screenshots-is-another-popular') %}
+      <p>{{ ftl('compare-safari-also-when-you-sign-up-for-updated-v2', pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe) }}</p>
 
       <p>{{ ftl('compare-safari-firefox-is-also-great-for-video') }}</p>
 
@@ -243,7 +243,7 @@
 
       <p>{{ ftl('compare-safari-firefox-and-safari-both-provide') }}</p>
 
-      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated', fallback='compare-safari-firefox-also-offers-a-similar', attrs = 'href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts'))) }}</p>
+      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v2', fallback='compare-safari-firefox-also-offers-a-similar', attrs = 'href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts'))) }}</p>
 
       <p>{{ ftl('compare-safari-the-firefox-app-for-ios-and', ios='href="%s" rel="external noopener" data-cta-text="iOS" data-cta-type="link"'|safe|format(app_store_url('firefox')),
               android='href="%s" rel="external noopener" data-cta-text="Android" data-cta-type="link"'|safe|format(play_store_url('firefox'))) }}</p>

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -12,7 +12,11 @@
 {% block article_content %}
 <p>{{ ftl('password-manager-firefox-securely-stores-your') }}</p>
 
-<p>{{ ftl('password-manager-with-a-free-mozilla-account', fxa=url('firefox.accounts')) }}</p>
+  {% if switch('moz-accounts-update') %}
+      <p>{{ ftl('password-manager-with-a-free-mozilla-account', fallback='password-manager-with-a-free-firefox-account', fxa=url('firefox.accounts')) }}</p>
+    {% else %}
+      <p>{{ ftl('password-manager-with-a-free-firefox-account', fxa=url('firefox.accounts')) }}</p>
+  {% endif %}
 
 <h2>{{ ftl('password-manager-password-autofill-for-easy-logins') }}</h2>
 <p>{{ ftl('password-manager-firefox-can-automatically-fill-in') }}</p>

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -12,7 +12,7 @@
 {% block article_content %}
 <p>{{ ftl('password-manager-firefox-securely-stores-your') }}</p>
 
-<p>{{ ftl('password-manager-with-a-free-firefox-account', fxa=url('firefox.accounts')) }}</p>
+<p>{{ ftl('password-manager-with-a-free-mozilla-account', fxa=url('firefox.accounts')) }}</p>
 
 <h2>{{ ftl('password-manager-password-autofill-for-easy-logins') }}</h2>
 <p>{{ ftl('password-manager-firefox-can-automatically-fill-in') }}</p>

--- a/bedrock/firefox/templates/firefox/features/sync.html
+++ b/bedrock/firefox/templates/firefox/features/sync.html
@@ -11,7 +11,7 @@
 
 {% block article_content %}
 <p>{{ ftl('features-sync-with-firefox-you-can-pick-up-where') }}</p>
-<p>{{ ftl('features-sync-sign-up-for-a-free-firefox-account', fxa=url('firefox.accounts')) }}</p>
+<p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account', fxa=url('firefox.accounts')) }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/bedrock/firefox/templates/firefox/features/sync.html
+++ b/bedrock/firefox/templates/firefox/features/sync.html
@@ -11,7 +11,13 @@
 
 {% block article_content %}
 <p>{{ ftl('features-sync-with-firefox-you-can-pick-up-where') }}</p>
-<p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account', fxa=url('firefox.accounts')) }}</p>
+
+  {% if switch('moz-accounts-update') %}
+    <p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account', fallback='features-sync-sign-up-for-a-free-firefox-account', fxa=url('firefox.accounts')) }}</p>
+  {% else %}
+    <p>{{ ftl('features-sync-sign-up-for-a-free-firefox-account', fxa=url('firefox.accounts')) }}</p>
+  {% endif %}
+
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -115,8 +115,13 @@
         base_el='li',
         body=True
       ) %}
-        <p>{{ ftl('firefox-privacy-hub-if-you-have-a-firefox-account') }}</p>
-      {% endcall %}
+          {% if switch('moz-accounts-update') %}
+            <p>{{ ftl('firefox-privacy-hub-if-you-have-a-mozilla-account', fallback='firefox-privacy-hub-if-you-have-a-firefox-account') }}</p>
+          {% else %}
+            <p>{{ ftl('firefox-privacy-hub-if-you-have-a-firefox-account') }}</p>
+          {% endif %}
+
+        {% endcall %}
     </ul>
   </div>
 
@@ -202,25 +207,62 @@
 
     <section class="privacy-products-accounts mzp-l-content mzp-l-columns mzp-t-columns-two">
       <div>
-        <h2 class="mzp-c-card-feature-title">{{ ftl('firefox-privacy-hub-your-firefox-account') }}</h2>
+        <h2 class="mzp-c-card-feature-title">
+
+          {% if switch('moz-accounts-update') %}
+            {{ ftl('firefox-privacy-hub-your-mozilla-account', fallback='firefox-privacy-hub-your-firefox-account') }}
+          {% else %}
+            {{ ftl('firefox-privacy-hub-your-firefox-account') }}
+          {% endif %}
+
+
+        </h2>
         <div class="mzp-c-card-feature-desc">
-          {{ ftl('firefox-privacy-hub-all-the-information-synced') }}
+
+          {% if switch('moz-accounts-update') %}
+            {{ ftl('firefox-privacy-hub-all-the-information-synced-v2', fallback='firefox-privacy-hub-all-the-information-synced') }}
+          {% else %}
+            {{ ftl('firefox-privacy-hub-all-the-information-synced') }}
+          {% endif %}
+
         </div>
       </div>
       <div class="mzp-c-emphasis-box">
-        {{ fxa_email_form(
-          entrypoint=_entrypoint,
-          form_title=ftl('firefox-privacy-hub-take-your-privacy-and-bookmarks'),
-          button_class='mzp-c-button mzp-t-primary mzp-t-product',
-          style='trailhead',
-          utm_campaign=_utm_campaign)
-        }}
+
+        {% if switch('moz-accounts-update') %}
+          {{ fxa_email_form(
+            entrypoint=_entrypoint,
+            form_title=ftl('firefox-privacy-hub-take-your-privacy-and-bookmarks-v2', fallback='firefox-privacy-hub-take-your-privacy-and-bookmarks'),
+            button_class='mzp-c-button mzp-t-primary mzp-t-product',
+            style='trailhead',
+            utm_campaign=_utm_campaign)
+          }}
+        {% else %}
+          {{ fxa_email_form(
+            entrypoint=_entrypoint,
+            form_title=ftl('firefox-privacy-hub-take-your-privacy-and-bookmarks'),
+            button_class='mzp-c-button mzp-t-primary mzp-t-product',
+            style='trailhead',
+            utm_campaign=_utm_campaign)
+          }}
+          {% endif %}
+
 
         <p class="fxa-signin">
-        {{ ftl('firefox-privacy-hub-already-have-an-account',
-          sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': _utm_campaign}),
-          class_name='js-fxa-cta-link js-fxa-product-button',
-          learn_more=url('firefox.accounts') )}}
+          {% if switch('moz-accounts-update') %}
+            {{ ftl('firefox-privacy-hub-already-have-an-account-v2', fallback='firefox-privacy-hub-already-have-an-account',
+              sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': _utm_campaign}),
+              class_name='js-fxa-cta-link js-fxa-product-button',
+              learn_more=url('firefox.accounts') )}}
+          {% else %}
+            {{ ftl('firefox-privacy-hub-already-have-an-account',
+              sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': _utm_campaign}),
+              class_name='js-fxa-cta-link js-fxa-product-button',
+              learn_more=url('firefox.accounts') )}}
+          {% endif %}
+
+
+
         </p>
       </div>
     </section>

--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -122,7 +122,7 @@
   },
   "mozilla-accounts": {
     "description": "{{ ftl('newsletters-get-tips-from-mozilla')|striptags }}",
-    "title": "{{ ftl('newsletters-firefox-accounts')|striptags }}"
+    "title": "{{ ftl('newsletters-mozilla-accounts')|striptags }}"
   },
   "mozilla-and-you": {
     "description": "{{ ftl('newsletters-get-how-tos')|striptags }}",

--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -122,7 +122,7 @@
   },
   "mozilla-accounts": {
     "description": "{{ ftl('newsletters-get-tips-from-mozilla')|striptags }}",
-    "title": "{{ ftl('newsletters-mozilla-accounts')|striptags }}"
+    "title": "{{ ftl('newsletters-mozilla-accounts', fallback='newsletters-firefox-accounts')|striptags }}"
   },
   "mozilla-and-you": {
     "description": "{{ ftl('newsletters-get-how-tos')|striptags }}",

--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -109,7 +109,7 @@
             <small>{{ ftl('newsletters-text-subscribers-will-receive') }}</small>
 
             <aside>
-              <p>{{ ftl('newsletters-many-of-our-communications', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
+              <p>{{ ftl('newsletters-many-of-our-communications-v2', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
 
               <p>{{ ftl('newsletters-to-get-access-to-the-whole', url=url('firefox.accounts')) }}</p>
 

--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -109,7 +109,11 @@
             <small>{{ ftl('newsletters-text-subscribers-will-receive') }}</small>
 
             <aside>
-              <p>{{ ftl('newsletters-many-of-our-communications-v2', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
+              {% if switch('moz-accounts-update') %}
+                <p>{{ ftl('newsletters-many-of-our-communications-v2', fallback='newsletters-many-of-our-communications', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
+              {% else %}
+                <p>{{ ftl('newsletters-many-of-our-communications', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
+              {% endif %}
 
               <p>{{ ftl('newsletters-to-get-access-to-the-whole', url=url('firefox.accounts')) }}</p>
 

--- a/bedrock/products/templates/products/relay/faq.html
+++ b/bedrock/products/templates/products/relay/faq.html
@@ -98,7 +98,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <h3> {{ ftl('faq-question-acceptable-use-question') }}</h3>
           <p> {{ ftl('faq-question-acceptable-use-answer-a-html', url=url('legal.terms.acceptable-use')) }}</p>
           <ul class="mzp-u-list-styled">
-            <li>{{ ftl('faq-question-acceptable-use-answer-measure-account') }}</li>
+            <li>{{ ftl('faq-question-acceptable-use-answer-measure-account-v2') }}</li>
             <li>{{ ftl('faq-question-acceptable-use-answer-measure-unlimited-payment-2') }}</li>
             <li>{{ ftl('faq-question-acceptable-use-answer-measure-rate-limit-2') }}</li>
           </ul>

--- a/bedrock/products/templates/products/relay/faq.html
+++ b/bedrock/products/templates/products/relay/faq.html
@@ -98,7 +98,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <h3> {{ ftl('faq-question-acceptable-use-question') }}</h3>
           <p> {{ ftl('faq-question-acceptable-use-answer-a-html', url=url('legal.terms.acceptable-use')) }}</p>
           <ul class="mzp-u-list-styled">
-            <li>{{ ftl('faq-question-acceptable-use-answer-measure-account-v2') }}</li>
+
+            {% if switch('moz-accounts-update') %}
+            <li>{{ ftl('faq-question-acceptable-use-answer-measure-account-v2', fallback='faq-question-acceptable-use-answer-measure-account') }}</li>
+            {% else %}
+            <li>{{ ftl('faq-question-acceptable-use-answer-measure-account') }}</li>
+            {% endif %}
+
             <li>{{ ftl('faq-question-acceptable-use-answer-measure-unlimited-payment-2') }}</li>
             <li>{{ ftl('faq-question-acceptable-use-answer-measure-rate-limit-2') }}</li>
           </ul>

--- a/bedrock/products/templates/products/vpn/includes/download-faq.html
+++ b/bedrock/products/templates/products/vpn/includes/download-faq.html
@@ -29,7 +29,13 @@
       <summary>
         <h3>{{ ftl('vpn-download-faq-add-device') }}</h3>
       </summary>
-      <p>{{ ftl('vpn-download-faq-adding-another-v3', fallback='vpn-download-faq-adding-another-v2', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
+
+      {% if switch('moz-accounts-update') %}
+        <p>{{ ftl('vpn-download-faq-adding-another-v3', fallback='vpn-download-faq-adding-another-v2', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
+      {% else %}
+        <p>{{ ftl('vpn-download-faq-adding-another-v2', fallback='vpn-download-faq-adding-another', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
+      {% endif %}
+
     </details>
     <details>
       <summary>

--- a/bedrock/products/templates/products/vpn/includes/download-faq.html
+++ b/bedrock/products/templates/products/vpn/includes/download-faq.html
@@ -29,7 +29,7 @@
       <summary>
         <h3>{{ ftl('vpn-download-faq-add-device') }}</h3>
       </summary>
-      <p>{{ ftl('vpn-download-faq-adding-another-v2', fallback='vpn-download-faq-adding-another', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
+      <p>{{ ftl('vpn-download-faq-adding-another-v3', fallback='vpn-download-faq-adding-another-v2', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
     </details>
     <details>
       <summary>

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -112,6 +112,8 @@
 -brand-name-mozilla-monitor = Mozilla Monitor
 -brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-thunderbird = Thunderbird
+-brand-name-mozilla-account = Mozilla account
+-brand-name-mozilla-accounts = Mozilla accounts
 
 ## Mozilla projects (short names)
 

--- a/l10n/en/firefox/accounts.ftl
+++ b/l10n/en/firefox/accounts.ftl
@@ -13,10 +13,17 @@ firefox-accounts-securely-sync-your = Securely sync your passwords, bookmarks an
 firefox-accounts-enter-your-email-address = Enter your email address to get started.
 firefox-accounts-already-have-an-account = Already have an account?
 firefox-accounts-sign-in = Sign In
+
+# Obsolete string
 firefox-accounts-already = You already have a { -brand-name-firefox-account }. Congrats!
+
+mozilla-accounts-already = You already have a { -brand-name-mozilla-account }. Congrats!
 firefox-accounts-manage = Manage your account
 
-# This is followed by a list of things you can do with your Firefox account
+# This is followed by a list of things you can do with your Mozilla account
+mozilla-account-sign-in-to = Sign in to your { -brand-name-mozilla-account } to:
+
+# Obsolete string
 firefox-accounts-sign-in-to = Sign in to your { -brand-name-firefox-account } to:
 
 # Obsolete string

--- a/l10n/en/firefox/accounts.ftl
+++ b/l10n/en/firefox/accounts.ftl
@@ -5,6 +5,9 @@
 ### URL: https://www-dev.allizom.org/firefox/accounts/
 
 # HTML page title
+mozilla-accounts-get-a-mozilla-account = Get a { -brand-name-mozilla-account } – Keep your data private, safe and synced
+
+# Obsolete string
 firefox-accounts-get-a-firefox-account = Get a { -brand-name-firefox-account } – Keep your data private, safe and synced
 
 # HTML page description

--- a/l10n/en/firefox/browsers/compare/brave.ftl
+++ b/l10n/en/firefox/browsers/compare/brave.ftl
@@ -55,6 +55,9 @@ compare-brave-the-ability-to-sync-your-passwords = The ability to sync your pass
 #   $accounts (string) - link to /firefox/accounts/ with additional attributes for analytics
 #   $monitor (string) - link to monitor.firefox.com with additional attributes for analytics
 #   $breaches (string) - link to monitor.firefox.com/breaches with additional attributes for analytics
+compare-brave-the-firefox-browser-also-gives-v2 = The { -brand-name-firefox } browser also gives users the ability to sign up for a free <a { $accounts }>{ -brand-name-mozilla-account }</a>. Having a { -brand-name-mozilla-account } is the key to unlocking syncing across devices, plus you get the added benefit of products like <a { $monitor }>{ -brand-name-firefox-monitor }</a> which monitors your email addresses and alerts you if any of your information has been involved in any known <a { $breaches }>data breaches</a>.
+
+# Obsolete string
 compare-brave-the-firefox-browser-also-gives = The { -brand-name-firefox } browser also gives users the ability to sign up for a free <a { $accounts }>{ -brand-name-firefox-account }</a>. Having a { -brand-name-firefox } account is the key to unlocking syncing across devices, plus you get the added benefit of products like <a { $monitor }>{ -brand-name-firefox-monitor }</a> which monitors your email addresses and alerts you if any of your information has been involved in any known <a { $breaches }>data breaches</a>.
 
 # "Basic Attention Token" is a brand name.

--- a/l10n/en/firefox/browsers/compare/safari.ftl
+++ b/l10n/en/firefox/browsers/compare/safari.ftl
@@ -45,6 +45,11 @@ compare-safari-like-safari-firefox-encourages = Like { -brand-name-safari }, { -
 
 # Variables:
 #   $pocket (string) - link to getpocket.com with additional attributes for analytics
+compare-safari-also-when-you-sign-up-for-updated-v2 = Also, when you sign up for a { -brand-name-mozilla-account }, you get access to unique services like <a { $pocket }>{ -brand-name-pocket }</a> that integrate directly into the browser. The { -brand-name-pocket } for { -brand-name-firefox } button lets you save web pages and videos to { -brand-name-pocket } in just one click, so you can read a clean, distraction-free version whenever and wherever you want — even offline.
+
+# Obsolete string
+# Variables:
+#   $pocket (string) - link to getpocket.com with additional attributes for analytics
 compare-safari-also-when-you-sign-up-for-updated = Also, when you sign up for a { -brand-name-firefox } account, you get access to unique services like <a { $pocket }>{ -brand-name-pocket }</a> that integrate directly into the browser. The { -brand-name-pocket } for { -brand-name-firefox } button lets you save web pages and videos to { -brand-name-pocket } in just one click, so you can read a clean, distraction-free version whenever and wherever you want — even offline.
 
 # Obsolete string
@@ -70,6 +75,12 @@ compare-safari-screenshots-is-another-popular = <a { $attrs }>Screenshots</a> is
 compare-safari-firefox-and-safari-both-provide = { -brand-name-firefox } and { -brand-name-safari } both provide a seamless experience when moving from desktop to mobile browsing or vice versa. For { -brand-name-safari }, one of its main strengths is its continuity features. It syncs your bookmarks, tabs, history and more to iCloud so they’re available on all your devices. That means you can open a tab on your { -brand-name-iphone } and have it also appear on your { -brand-name-mac } laptop with just a click.
 compare-safari-both-browsers-have-a-lot = Both browsers have a lot of crossover features, as well as some unique functions. It’s worth mentioning, if you take a lot of screenshots, you’ll wonder how you ever lived without this handy feature that’s built right into { -brand-name-firefox }. But if you’re just looking for a fast, private browser for surfing and shopping, then you may want to give { -brand-name-firefox } a try — especially if you’ve been exclusively using { -brand-name-safari } because it came preloaded as the default browser on your computer. Eventually, you’ll discover which one is more suited to your needs.
 
+# Variables:
+#   $attrs (string) - link to /firefox/accounts/ with additional attributes for analytics
+compare-safari-firefox-also-offers-a-similar-updated-v2 = { -brand-name-firefox } also offers a similar sync feature when you sign up for a free <a { $attrs }>{ -brand-name-mozilla-account }</a> that enables users to easily synchronize their bookmarks, browsing history, preferences, passwords, filled forms, add-ons, and the last 25 opened tabs across multiple computers. What sets { -brand-name-firefox } apart from { -brand-name-safari } is that it is available on any desktop or mobile platform, { -brand-name-ios }, { -brand-name-android }, { -brand-name-windows } or { -brand-name-mac }, boosting its portability across any device you may own.
+
+
+# Obsolete string
 # Variables:
 #   $attrs (string) - link to /firefox/accounts/ with additional attributes for analytics
 compare-safari-firefox-also-offers-a-similar-updated = { -brand-name-firefox } also offers a similar sync feature when you sign up for a free <a { $attrs }>{ -brand-name-firefox-account }</a> that enables users to easily synchronize their bookmarks, browsing history, preferences, passwords, filled forms, add-ons, and the last 25 opened tabs across multiple computers. What sets { -brand-name-firefox } apart from { -brand-name-safari } is that it is available on any desktop or mobile platform, { -brand-name-ios }, { -brand-name-android }, { -brand-name-windows } or { -brand-name-mac }, boosting its portability across any device you may own.

--- a/l10n/en/firefox/features/password-manager-2023.ftl
+++ b/l10n/en/firefox/features/password-manager-2023.ftl
@@ -14,7 +14,12 @@ password-manager-firefox-securely-stores-your = { -brand-name-firefox } securely
 
 # Variables:
 #   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
-password-manager-with-a-free-firefox-account = With a <a href="{ $fxa }">free { -brand-name-firefox-account }</a> you can securely sync your passwords across all your devices.
+password-manager-with-a-free-mozilla-account = With a <a href="{ $fxa }">free { -brand-name-mozilla-account }</a> you can securely sync your passwords across all your devices.
+
+# Obsolete string
+# Variables:
+#   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
+password-manager-with-a-free-firefox-account = With a <a href="{ $fxa }">free { -brand-name-firefox } account</a> you can securely sync your passwords across all your devices.
 password-manager-password-autofill-for-easy-logins = Password autofill for easy logins
 password-manager-firefox-can-automatically-fill-in = { -brand-name-firefox } can automatically fill in your saved username and password. If you have more than one login for a site, you can just select the account you want and we’ll take it from there.
 

--- a/l10n/en/firefox/features/sync-2023.ftl
+++ b/l10n/en/firefox/features/sync-2023.ftl
@@ -13,7 +13,11 @@ features-sync-with-firefox-you-can-pick-up-where = With { -brand-name-firefox },
 
 # Variables:
 #   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
-features-sync-sign-up-for-a-free-firefox-account = <a href="{ $fxa }">Sign up for a free { -brand-name-firefox-account }</a> and you’ll be able to sync your data everywhere you use your { -brand-name-firefox } browser.
+
+features-sync-sign-up-for-a-free-mozilla-account = <a href="{ $fxa }">Sign up for a free { -brand-name-mozilla-account } </a> and you’ll be able to sync your data everywhere you use your { -brand-name-firefox } browser.
+
+# Obsolete string
+features-sync-sign-up-for-a-free-firefox-account = <a href="{ $fxa }">Sign up for a free { -brand-name-firefox } account</a> and you’ll be able to sync your data everywhere you use your { -brand-name-firefox } browser.
 
 # Variables:
 #   $privacy (url) = link to https://www.mozilla.org/firefox/privacy/

--- a/l10n/en/firefox/privacy-hub.ftl
+++ b/l10n/en/firefox/privacy-hub.ftl
@@ -75,6 +75,9 @@ firefox-privacy-hub-meet-four-of-the-most-common = Meet four of the most common 
 firefox-privacy-hub-always-in-your-control = Always in your control
 firefox-privacy-hub-want-to-customize-what = Want to customize what gets blocked? Your settings are only one click away.
 firefox-privacy-hub-protection-beyond-tracking = Protection beyond tracking
+firefox-privacy-hub-if-you-have-a-mozilla-account = If you have a { -brand-name-mozilla-account }, you can also see how we’re helping you protect your personal info and passwords.
+
+# Obsolete string
 firefox-privacy-hub-if-you-have-a-firefox-account = If you have a { -brand-name-firefox-account }, you can also see how we’re helping you protect your personal info and passwords.
 
 # Variables:
@@ -93,10 +96,28 @@ firefox-privacy-hub-send-a-file = Send a file
 firefox-privacy-hub-pocket = { -brand-name-pocket }
 firefox-privacy-hub-pocket-recommends-high = { -brand-name-pocket } recommends high-quality, human-curated articles without collecting your browsing history or sharing your personal information with advertisers.
 firefox-privacy-hub-get-pocket = Get { -brand-name-pocket }
+firefox-privacy-hub-your-mozilla-account = Your { -brand-name-mozilla-account }
+
+# Obsolete string
 firefox-privacy-hub-your-firefox-account = Your { -brand-name-firefox-account }
+
+firefox-privacy-hub-all-the-information-synced-v2 = All the information synced through your { -brand-name-mozilla-account } — from browser history to passwords — is encrypted. And your account password is the only key.
+
+# Obsolete string
 firefox-privacy-hub-all-the-information-synced = All the information synced through your { -brand-name-firefox-account } — from browser history to passwords — is encrypted. And your account password is the only key.
+
+firefox-privacy-hub-take-your-privacy-and-bookmarks-v2 = Take your privacy and bookmarks everywhere with a { -brand-name-mozilla-account }.
+
+# Obsolete string
 firefox-privacy-hub-take-your-privacy-and-bookmarks = Take your privacy and bookmarks everywhere with a { -brand-name-firefox-account }.
 
+# Variables:
+#   $signin (string) - anchor link url and attributes
+#   $class_name (string) - CSS class name for sign in link
+#   $learn_more (url) - link to https://www.mozilla.org/firefox/accounts/
+firefox-privacy-hub-already-have-an-account-v2 = Already have an account? <a { $sign_in } class="{ $class_name }">Sign In</a> or <a href="{ $learn_more }">learn more</a> about joining { -brand-name-mozilla }.
+
+# Obsolete string
 # Variables:
 #   $signin (string) - anchor link url and attributes
 #   $class_name (string) - CSS class name for sign in link

--- a/l10n/en/fxa_form.ftl
+++ b/l10n/en/fxa_form.ftl
@@ -2,7 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Obsolete string
 fxa-form-enter-your-email = <strong>Enter your email</strong> to access { -brand-name-firefox-accounts }.
+
+fxa-form-enter-your-email-v2 = <strong>Enter your email</strong> to create a  { -brand-name-mozilla-account }.
 
 # Variables:
 #   $url1 (url) - link to https://accounts.firefox.com/legal/terms

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -78,6 +78,10 @@ newsletters-text-subscribers-will-receive = Text subscribers will receive an ema
 
 # Variables:
 #   $url (url) - link to https://support.mozilla.org/kb/managing-account-data
+
+newsletters-many-of-our-communications-v2 = Many of our communications are related to an account you’ve signed up for, such as { -brand-name-mozilla-accounts }, { -brand-name-mdn-web-docs }, or Add-on Developer. To manage one of your accounts or see a list of all the accounts, visit our <a href="{ $url }">account management support page</a>.
+
+# Obsolete string
 newsletters-many-of-our-communications = Many of our communications are related to an account you’ve signed up for, such as { -brand-name-firefox-accounts }, { -brand-name-mdn-web-docs }, or Add-on Developer. To manage one of your accounts or see a list of all the accounts, visit our <a href="{ $url }">account management support page</a>.
 
 # Variables:
@@ -413,6 +417,9 @@ newsletters-webmaker = { -brand-name-webmaker }
 newsletters-special-announcements-helping-you = Special announcements helping you get the most out of { -brand-name-webmaker }.
 
 # Name for the newsletter in Newsletter subscription page (Firefox Accounts)
+newsletters-mozilla-accounts = { -brand-name-mozilla-accounts }
+
+# Obsolete string
 newsletters-firefox-accounts = { -brand-name-firefox-accounts }
 
 # Description for the newsletter in Newsletter subscription page (Firefox Accounts)

--- a/l10n/en/products/relay/faq.ftl
+++ b/l10n/en/products/relay/faq.ftl
@@ -67,7 +67,11 @@ faq-question-acceptable-use-question = What are the acceptable uses of { -brand-
 #   $url (url) - link to Mozilla's Acceptable Use Policy, i.e. https://www.mozilla.org/about/legal/acceptable-use/
 #   $attrs (string) - specific attributes added to external links
 faq-question-acceptable-use-answer-a-html = { -brand-name-firefox-relay } has the same <a href="{ $url }" { $attrs }>conditions of use as all { -brand-name-mozilla } products</a>. We have a zero-tolerance policy when it comes to using { -brand-name-relay } for malicious purposes like spam, resulting in the termination of a user’s account. We take measures to prevent users from violating our conditions by:
+faq-question-acceptable-use-answer-measure-account-v2 = Requiring a { -brand-name-mozilla-account } with a verified email address
+
+# Obsolete string
 faq-question-acceptable-use-answer-measure-account = Requiring a { -brand-name-firefox-account } with a verified email address
+
 faq-question-acceptable-use-answer-measure-unlimited-payment-2 = Requiring payment for a user to create more than five masks
 faq-question-acceptable-use-answer-measure-rate-limit-2 = Rate-limiting the number of masks that can be generated in one day
 #   $url (url) - link to the Terms of Service, i.e. https://www.mozilla.org/about/legal/terms/firefox-relay/

--- a/l10n/en/products/vpn/platform-post-download.ftl
+++ b/l10n/en/products/vpn/platform-post-download.ftl
@@ -61,6 +61,11 @@ vpn-download-faq-add-device = How do I add another device?
 
 # Variables:
 #   $subscription - link to https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription
+vpn-download-faq-adding-another-v3 = Adding another device is as simple as downloading and installing the { -brand-name-mozilla-vpn } software and then signing into your existing { -brand-name-mozilla-account } on the new device. For more details, please see <a href="{ $subscription }">How to add devices to your { -brand-name-mozilla-vpn } subscription</a>.
+
+# Obsolete string
+# Variables:
+#   $subscription - link to https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription
 vpn-download-faq-adding-another-v2 = Adding another device is as simple as downloading and installing the { -brand-name-mozilla-vpn } software and then signing into your existing { -brand-name-firefox-account } on the new device. For more details, please see <a href="{ $subscription }">How to add devices to your { -brand-name-mozilla-vpn } subscription</a>.
 
 vpn-download-faq-best-practices = What are some VPN best practices?

--- a/l10n/en/sub_navigation.ftl
+++ b/l10n/en/sub_navigation.ftl
@@ -41,7 +41,11 @@ sub-navigation-android-addons = { -brand-name-android } Addons
 
 sub-navigation-android-add-ons = { -brand-name-android } Add-ons
 sub-navigation-chromebook = { -brand-name-chromebook }
+
+# Obsolete string
 sub-navigation-firefox-accounts = { -brand-name-firefox-accounts }
+
+sub-navigation-mozilla-accounts = { -brand-name-mozilla-accounts }
 sub-navigation-sync = { -brand-name-sync }
 sub-navigation-windows = { -brand-name-windows }
 sub-navigation-windows-64-bit = { -brand-name-windows } 64-bit

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -24,7 +24,6 @@ $image-path: '/media/protocol/img';
 
 .c-accounts-form {
     .mzp-c-form-title {
-        @include font-firefox;
         @include text-title-sm;
     }
 
@@ -56,6 +55,7 @@ $image-path: '/media/protocol/img';
 .accounts-products {
     h2 {
         @include text-title-xs;
+        @include font-base;
     }
 
     h4 {


### PR DESCRIPTION
## One-line summary
We're rebranding Firefox Accounts to Mozilla accounts (lowercase).

- [Guidelines](https://www.figma.com/file/7nsOBSt3VTeCimDqavQT9J/Mozilla-Accounts-Content-Guidelines?type=design&node-id=1901%3A5540&mode=design&t=YvuKYZyKufJwhOFC-1) 
- [Spreadsheet](https://docs.google.com/spreadsheets/d/1QTxMYZacS5WMGbcC4SaJmnAnQ3nqHw-_GyA_ai-rrF8/edit#gid=1586368493)



## Testing

- Set `Dev=False` in `.env`
- Set `SWITCH_MOZ_ACCOUNTS_UPDATE=True` in `.env`

This is also running on a dev server: http://www-demo6.allizom.org/

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->

Name | URL
-- | --
Homepage banner | https://www.mozilla.org/
Firefox accounts page | https://www.mozilla.org/en-US/firefox/accounts/
Email Preference Page | https://www.mozilla.org/en-US/newsletter/existing/?utm_source=pref_footer
Firefox Sync page | https://www.mozilla.org/en-US/firefox/sync/
Brave comparison page | https://www.mozilla.org/en-US/firefox/browsers/compare/brave/
Safari comparison page | https://www.mozilla.org/en-US/firefox/browsers/compare/safari/
Features page | https://www.mozilla.org/en-US/firefox/features/
Password manager page | https://www.mozilla.org/en-US/firefox/features/password-manager/
Relay FAQ page | https://www-dev.allizom.org/en-US/products/relay/faq/
VPN windows download page | https://www.mozilla.org/en-US/products/vpn/download/windows/thanks/
VPN mac download page | https://www.mozilla.org/en-US/products/vpn/download/mac/thanks/
Firefox Privacy Products page | https://www.mozilla.org/en-US/firefox/privacy/products/




