### PR TITLE
Add bouncer dev to known domains for front-end code checking (Fixes #13699)

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -7,6 +7,7 @@
 const TrackProductDownload = {};
 const prodURL = /^https:\/\/download.mozilla.org/;
 const stageURL = /^https:\/\/bouncer-bouncer.stage.mozaws.net/;
+const devURL = /^https:\/\/dev.bouncer.nonprod.webservices.mozgcp.net/;
 const iTunesURL = /^https:\/\/itunes.apple.com/;
 const appStoreURL = /^https:\/\/apps.apple.com/;
 const playStoreURL = /^https:\/\/play.google.com/;
@@ -27,6 +28,7 @@ TrackProductDownload.isValidDownloadURL = (downloadURL) => {
         if (
             prodURL.test(downloadURL) ||
             stageURL.test(downloadURL) ||
+            devURL.test(downloadURL) ||
             iTunesURL.test(downloadURL) ||
             appStoreURL.test(downloadURL) ||
             playStoreURL.test(downloadURL) ||
@@ -99,7 +101,11 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
     }
 
     let eventObject = {};
-    if (prodURL.test(downloadURL) || stageURL.test(downloadURL)) {
+    if (
+        prodURL.test(downloadURL) ||
+        stageURL.test(downloadURL) ||
+        devURL.test(downloadURL)
+    ) {
         // extract the values we need from the parameters
         const productParam = params.product;
         const productSplit = productParam.split('-');

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -157,11 +157,14 @@ if (typeof window.Mozilla === 'undefined') {
             var directLink;
             // Append stub attribution data to direct download links.
             if (
-                link.href &&
-                (link.href.indexOf('https://download.mozilla.org') !== -1 ||
-                    link.href.indexOf(
-                        'https://bouncer-bouncer.stage.mozaws.net/'
-                    ) !== -1)
+                (link.href &&
+                    (link.href.indexOf('https://download.mozilla.org') !== -1 ||
+                        link.href.indexOf(
+                            'https://bouncer-bouncer.stage.mozaws.net/'
+                        ) !== -1)) ||
+                link.href.indexOf(
+                    'https://dev.bouncer.nonprod.webservices.mozgcp.net'
+                ) !== -1
             ) {
                 version = link.getAttribute('data-download-version');
                 // Append attribution params to Windows 32bit, 64bit, and MSI installer links.

--- a/media/js/firefox/all/all-downloads-unified.js
+++ b/media/js/firefox/all/all-downloads-unified.js
@@ -344,9 +344,11 @@
     FirefoxDownloader.isValidURL = function (url) {
         var bouncerURL = /^https:\/\/download.mozilla.org/;
         var stagingURL = /^https:\/\/bouncer-bouncer.stage.mozaws.net/;
+        var devURL = /^https:\/\/dev.bouncer.nonprod.webservices.mozgcp.net/;
+
         return (
             typeof url === 'string' &&
-            (bouncerURL.test(url) || stagingURL.test(url))
+            (bouncerURL.test(url) || stagingURL.test(url) || devURL.test(url))
         );
     };
 

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -18,9 +18,15 @@ describe('TrackProductDownload.isValidDownloadURL', function () {
         );
         expect(testDownloadURL).toBe(true);
     });
-    it('should recognize bouncer as a valid URL', function () {
+    it('should recognize bouncer stage as a valid URL', function () {
         let testBouncerURL = TrackProductDownload.isValidDownloadURL(
             'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testBouncerURL).toBe(true);
+    });
+    it('should recognize bouncer dev as a valid URL', function () {
+        let testBouncerURL = TrackProductDownload.isValidDownloadURL(
+            'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=osx&lang=en-US'
         );
         expect(testBouncerURL).toBe(true);
     });

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -843,6 +843,10 @@ describe('stub-attribution.js', function () {
             'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win&lang=en-US';
         const win64StageUrl =
             'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win64&lang=en-US';
+        const winDevUrl =
+            'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US';
+        const win64DevUrl =
+            'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US';
 
         beforeEach(function () {
             const downloadMarkup = `<ul class="download-list">
@@ -852,6 +856,9 @@ describe('stub-attribution.js', function () {
                     <li><a id="link-stage-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winStageUrl}">Download</a></li>
                     <li><a id="link-stage-direct-win" class="download-link" data-download-version="win" href="${winStageUrl}">Download</a></li>
                     <li><a id="link-stage-direct-win64" class="download-link" data-download-version="win64" href="${win64StageUrl}">Download</a></li>
+                    <li><a id="link-dev-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winDevUrl}">Download</a></li>
+                    <li><a id="link-dev-direct-win" class="download-link" data-download-version="win" href="${winDevUrl}">Download</a></li>
+                    <li><a id="link-dev-direct-win64" class="download-link" data-download-version="win64" href="${win64DevUrl}">Download</a></li>
                 </ul>`;
 
             document.body.insertAdjacentHTML('beforeend', downloadMarkup);
@@ -903,6 +910,23 @@ describe('stub-attribution.js', function () {
                 document.getElementById('link-stage-direct-win64').href
             ).toEqual(
                 'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+
+            // dev download links
+            expect(
+                document
+                    .getElementById('link-dev-transitional')
+                    .getAttribute('data-direct-link')
+            ).toEqual(
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+            expect(document.getElementById('link-dev-direct-win').href).toEqual(
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+            expect(
+                document.getElementById('link-dev-direct-win64').href
+            ).toEqual(
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
         });
 

--- a/tests/unit/spec/firefox/all/all-downloads-unified.js
+++ b/tests/unit/spec/firefox/all/all-downloads-unified.js
@@ -236,6 +236,12 @@ describe('all-downloads-unified.js', function () {
             expect(Mozilla.FirefoxDownloader.isValidURL(url)).toBeTruthy();
         });
 
+        it('should return true for bouncer dev links', function () {
+            const url =
+                'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=osx&lang=en-US';
+            expect(Mozilla.FirefoxDownloader.isValidURL(url)).toBeTruthy();
+        });
+
         it('should return false for everything else', function () {
             const url =
                 'https://some.other.domain/?product=firefox-latest-ssl&os=osx&lang=en-US';


### PR DESCRIPTION
## One-line summary

Should hopefully fix https://github.com/mozilla/bedrock/actions/runs/6250636612

## Significant changes and points to review

I haven't deployed / tested this, but hopefully the tests should give us enough confidence that things will work ok once on dev.

## Issue / Bugzilla link

#13699

## Testing

To test this locally you'd need to set `BOUNCER_URL=https://dev.bouncer.nonprod.webservices.mozgcp.net/` in your `.env`