### PR TITLE
Remove link validation check in firefox/all functional test

### DIFF
--- a/tests/functional/firefox/test_all.py
+++ b/tests/functional/firefox/test_all.py
@@ -15,7 +15,6 @@ def test_firefox_release(base_url, selenium):
     product.select_platform("Windows 64-bit")
     product.select_language("English (US)")
     assert page.is_desktop_download_button_displayed
-    assert page.is_desktop_download_link_valid
     assert "product=firefox-latest-ssl" and "os=win64" and "lang=en-US" in page.desktop_download_link
 
 
@@ -27,7 +26,6 @@ def test_firefox_beta(base_url, selenium):
     product.select_platform("macOS")
     product.select_language("German — Deutsch")
     assert page.is_desktop_download_button_displayed
-    assert page.is_desktop_download_link_valid
     assert "product=firefox-beta-latest-ssl" and "os=osx" and "lang=de" in page.desktop_download_link
 
 
@@ -39,7 +37,6 @@ def test_firefox_developer(base_url, selenium):
     product.select_platform("Linux 64-bit")
     product.select_language("English (US)")
     assert page.is_desktop_download_button_displayed
-    assert page.is_desktop_download_link_valid
     assert "product=firefox-devedition-latest-ssl" and "os=linux64" and "lang=en-US" in page.desktop_download_link
 
 
@@ -51,7 +48,6 @@ def test_firefox_nightly(base_url, selenium):
     product.select_platform("Windows 32-bit")
     product.select_language("German — Deutsch")
     assert page.is_desktop_download_button_displayed
-    assert page.is_desktop_download_link_valid
     assert "product=firefox-nightly-latest-ssl" and "os=win" and "lang=de" in page.desktop_download_link
 
 
@@ -63,7 +59,6 @@ def test_firefox_esr(base_url, selenium):
     product.select_platform("Linux 32-bit")
     product.select_language("English (US)")
     assert page.is_desktop_download_button_displayed
-    assert page.is_desktop_download_link_valid
     assert "product=firefox-esr-latest-ssl" and "os=linux" and "lang=en-US" in page.desktop_download_link
 
 

--- a/tests/pages/firefox/all.py
+++ b/tests/pages/firefox/all.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.conf import settings
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
@@ -50,10 +48,6 @@ class FirefoxAllPage(BasePage):
     @property
     def is_desktop_download_button_displayed(self):
         return self.is_element_displayed(*self._desktop_download_button_locator)
-
-    @property
-    def is_desktop_download_link_valid(self):
-        return settings.BOUNCER_URL in self.find_element(*self._desktop_download_button_locator).get_attribute("href")
 
     def select_product(self, value):
         el = self.find_element(*self._product_locator)


### PR DESCRIPTION
## One-line summary

This is causing integrations tests to fail when checking `settings.BOUNCER_URL`. The front-end code already does link validation when generating the download button href, so I think this check is pretty redundant anyways?

## Issue / Bugzilla link

N/A

## Testing

`pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/test_all.py`