### PR TITLE
Update D&I report link [fix #13709]

### DIFF
--- a/bedrock/careers/templates/careers/diversity.html
+++ b/bedrock/careers/templates/careers/diversity.html
@@ -16,7 +16,7 @@
         media_after=False
         ) %}
           <h1>Inclusion, diversity, equity, and accountability</h1>
-          <p><a href="{{ url('mozorg.diversity.2021.index') }}" class="mzp-c-button">View our 2021 D&I Report</a></p>
+          <p><a href="{{ url('mozorg.diversity.2022.index') }}" class="mzp-c-button">View our 2022 D&I Report</a></p>
       {% endcall %}
     </div>
   </header>


### PR DESCRIPTION
## One-line summary
We were still linking to the 2021 report but the 2022 report has been published (some time ago, actually). This updates the link.


## Issue / Bugzilla link
#13709 


## Testing
http://localhost:8000/careers/diversity/