### PR TITLE
update social-content-policies page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
@@ -42,8 +42,7 @@
   <p>
     Mozilla will respond to takedown requests that comply with the Digital Millennium Copyright Act (DMCA).
     If you believe that content shared on the Mozilla.Social server infringes a copyright owned by you, or
-    by someone that you legally represent, you may submit a takedown notice, using the procedures outlined
-    on <a href="{{ url('legal.report-infringement') }}">Mozilla’s copyright page</a>.
+    by someone that you legally represent, you may submit a takedown notice using this <a href="https://mozilla.social/en-US/about/legal/report-infringement-form" target="_blank" rel="external noopener">form</a>. For more information about our copyright policy and review process, see <a href="{{ url('legal.report-infringement') }}">Mozilla’s copyright page</a>.
   </p>
 
   <h3>What happens next?</h3>
@@ -100,7 +99,7 @@
   <p>
     If you are a trademark owner or a trademark owner’s authorized agent, and you believe that content
     posted on Mozilla.Social infringes one or more of your trademarks, please send us a
-    “<strong>Trademark Notice</strong>”. We handle Trademark Notices similarly to how we handle notices of
+    “<strong>Trademark notice</strong>” using this <a href="https://mozilla.social/en-US/about/legal/report-infringement-form" target="_blank" rel="external noopener">form</a>. We handle Trademark Notices similarly to how we handle notices of
     copyright infringement, and require that they contain each of the following items:
   </p>
 

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/social-content-policies.html
@@ -42,7 +42,7 @@
   <p>
     Mozilla will respond to takedown requests that comply with the Digital Millennium Copyright Act (DMCA).
     If you believe that content shared on the Mozilla.Social server infringes a copyright owned by you, or
-    by someone that you legally represent, you may submit a takedown notice using this <a href="https://mozilla.social/en-US/about/legal/report-infringement-form" target="_blank" rel="external noopener">form</a>. For more information about our copyright policy and review process, see <a href="{{ url('legal.report-infringement') }}">Mozilla’s copyright page</a>.
+    by someone that you legally represent, you may submit a takedown notice using this <a href="https://reports.mozilla.social/infringement-form" target="_blank" rel="external noopener">form</a>. For more information about our copyright policy and review process, see <a href="{{ url('legal.report-infringement') }}">Mozilla’s copyright page</a>.
   </p>
 
   <h3>What happens next?</h3>
@@ -99,7 +99,7 @@
   <p>
     If you are a trademark owner or a trademark owner’s authorized agent, and you believe that content
     posted on Mozilla.Social infringes one or more of your trademarks, please send us a
-    “<strong>Trademark notice</strong>” using this <a href="https://mozilla.social/en-US/about/legal/report-infringement-form" target="_blank" rel="external noopener">form</a>. We handle Trademark Notices similarly to how we handle notices of
+    “<strong>Trademark notice</strong>” using this <a href="https://reports.mozilla.social/infringement-form" target="_blank" rel="external noopener">form</a>. We handle Trademark Notices similarly to how we handle notices of
     copyright infringement, and require that they contain each of the following items:
   </p>
 


### PR DESCRIPTION
Moz.social team requested an update to this page: https://www.mozilla.org/en-US/about/governance/policies/social-content-policies/ that add the specific moz.social infringement form

http://localhost:8000/en-US/about/governance/policies/social-content-policies/