### PR TITLE
Restore deleted monitor setting (Fixes #13716)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2128,3 +2128,6 @@ RELAY_PLANS_BY_COUNTRY_AND_LANGUAGE = {
         "US": {"en": "US"},  # United States
     },
 }
+
+# Monitor Breach Scan URL
+MONITOR_BREACH_SCAN_URL = config("MONITOR_BREACH_SCAN_URL", default="https://monitor.firefox.com/scan")


### PR DESCRIPTION
Fixes https://github.com/mozilla/bedrock/issues/13716

http://localhost:8000/en-US/products/monitor/