### PR TITLE
Fix Protocol static asset paths in try-pictute-in-picture.scss

### DIFF
--- a/media/css/mozorg/try-picture-in-picture.scss
+++ b/media/css/mozorg/try-picture-in-picture.scss
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
 $brand-theme: "firefox";
 
 @import "~@mozilla-protocol/core/protocol/css/includes/lib";
-@import "~@mozilla-protocol/core/protocol/css/components/notification-bar";
 @import "~@mozilla-protocol/core/protocol/css/components/video";
 @import "~@mozilla-protocol/core/protocol/css/templates/multi-column";
 


### PR DESCRIPTION
## One-line summary

The 404 images path was in notification-bar.scss, which doesn't seem to be used in the page anyway. I removed that import, but added the correct image and font paths just to be safe.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13718

## Testing

http://localhost:8000/en-US/try-picture-in-picture/
