### PR TITLE
Update mana link on MPL license policy page [fix #13720]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/mpl/license-policy.html
+++ b/bedrock/mozorg/templates/mozorg/mpl/license-policy.html
@@ -24,7 +24,7 @@
       <li>New files in, or modifications to, an existing, consistently-licensed area of code should be under the same license as the existing code.</li>
       <li>New projects should be under the <a href="{{ url('mozorg.mpl.2.0.index') }}">MPL 2.0</a> or <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a> - see below for guidance on choosing which.</li>
       <li>You must consult <a href='#Filing_Bugs'>the licensing team</a> before importing third-party code which is not under the MPL or Apache 2.0.</li>
-      <li>Mozilla employees can consult the <a href="https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=130927170">Licensing & Contributor Agreements Runbook</a> for more details.</li>
+      <li>Mozilla employees can consult the <a href="https://mozilla-hub.atlassian.net/l/cp/bgfp6Be7">Licensing & Contributor Agreements Runbook</a> for more details.</li>
     </ul>
   </section>
 


### PR DESCRIPTION
## One-line summary

Updates the link from the old Mana URL to the new Confluence URL.

## Issue / Bugzilla link

#13720 

## Testing

http://localhost:8000/MPL/license-policy/