### PR TITLE
Fix color contrast issue on link focus in /new modal (Fixes #13585)

### DIFF
--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -1380,6 +1380,11 @@ button.mzp-c-cta-link {
     .mzp-c-button-download-container {
         margin-bottom: 0;
 
+        // Issue 13585
+        .mzp-c-button:focus {
+            color: $color-link-hover;
+        }
+
         // Hide the privacy link as there's already a one visible prior to clicking download.
         .mzp-c-button-download-privacy-link {
             display: none;


### PR DESCRIPTION
## One-line summary

Fixes focus color contrast bug

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13585

## Testing

http://localhost:8000/en-US/firefox/new/
