### PR TITLE
OS specific FF download pages should always return the same build (Fixes #12192)

### DIFF
--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block site_header %}
-  {% with hide_nav_download_button=True %}
+  {% with hide_nav_cta=True %}
     {% include 'includes/protocol/navigation/navigation.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/chromebook.html
+++ b/bedrock/firefox/templates/firefox/browsers/chromebook.html
@@ -21,6 +21,12 @@
 
 {% set android_url = firefox_adjust_url('android', 'firefox-browsers-chromebook') %}
 
+{% block site_header %}
+  {% with hide_nav_cta=True %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block sub_navigation %}
  {% include '/firefox/includes/desktop-platform-sub-nav.html' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -35,7 +35,7 @@
 
 {% block content %}
   <div class="c-hero mzp-t-dark">
-    <div class="hero-content">
+    <div class="hero-content mzp-l-content">
       <div class="mzp-c-logo mzp-t-logo-md mzp-t-product-firefox"></div>
       <p>{{ ftl('windows-64-bit-64-bit') }}</p>
       <h1>{{ ftl('windows-64-bit-a-more-secure-firefox') }}</h1>
@@ -83,7 +83,3 @@ class='mzp-t-product-firefox mzp-t-firefox mzp-t-dark'
 {% endcall %}
 
 {% endblock %}
-
-{% block sticky_promo %}{% endblock %}
-
-{% block js %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -5,6 +5,7 @@
 #}
 
 {% from "macros-protocol.html" import call_out_compact, hero with context %}
+{% from "firefox/includes/macros.html" import firefox_download_desktop_button_windows with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -20,6 +21,14 @@
   {{ css_bundle('windows-64-bit') }}
 {% endblock %}
 
+{% block site_header %}
+  {% with hide_nav_cta=True %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block body_class %}{{ super() }} firefox-windows-64bit{% endblock %}
+
 {% block sub_navigation %}
  {% include '/firefox/includes/desktop-platform-sub-nav.html' %}
 {% endblock %}
@@ -31,7 +40,7 @@
       <p>{{ ftl('windows-64-bit-64-bit') }}</p>
       <h1>{{ ftl('windows-64-bit-a-more-secure-firefox') }}</h1>
       <div class="download-firefox">
-        {{ download_firefox(dom_id='win64-hero-download', download_location='primary cta') }}
+        {{ firefox_download_desktop_button_windows(cta_copy=ftl('windows-64-bit-download-firefox', fallback='download-button-download-firefox'), id='win64-hero-download', build='64') }}
       </div>
     </div>
   </div>
@@ -69,18 +78,12 @@ title=ftl('windows-64-bit-take-control-of-your'),
 class='mzp-t-product-firefox mzp-t-firefox mzp-t-dark'
 ) %}
 <div class="download-firefox">
-  {{ download_firefox(dom_id='win64-bottom-download', download_location='secondary cta') }}
+  {{ firefox_download_desktop_button_windows(cta_copy=ftl('windows-64-bit-download-firefox', fallback='download-button-download-firefox'), id='win64-bottom-download', build='64', position='secondary cta') }}
 </div>
 {% endcall %}
 
 {% endblock %}
 
-{% block sticky_promo %}
-  {% with non_fx_only=True %}
-    {% include '/includes/sticky-promo.html' %}
-  {% endwith %}
-{% endblock %}
+{% block sticky_promo %}{% endblock %}
 
-{% block js %}
-  {{ js_bundle('sticky_promo') }}
-{% endblock %}
+{% block js %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/includes/macros.html
+++ b/bedrock/firefox/templates/firefox/includes/macros.html
@@ -1,0 +1,79 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% macro firefox_download_desktop_button_windows(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-win', build='32', position='primary cta') -%}
+  {% set class_name = 'os_win' if build == '32' else 'os_win64' %}
+  {% set os = 'win' if build == '32' else 'win64' %}
+  <div class="firefox-platform-button-windows">
+    <div class="firefox-platform-button">
+      <a class="download-link {{ class_name }} mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}" href="{{ settings.BOUNCER_URL }}?product=firefox-stub&os={{ os }}&lang={{ LANG }}" data-link-type="download" data-display-name="Windows {{ build }}-bit" data-download-version="{{ os }}" data-download-os="Desktop" data-download-location="{{ position }}">
+        <strong class="download-title">
+          {{ cta_copy }}
+        </strong>
+      </a>
+
+      <small class="mzp-c-button-download-privacy-link">
+        <a href="{{ url('privacy.notices.firefox') }}">
+          {{ ftl('download-button-firefox-privacy-notice') }}
+        </a>
+      </small>
+    </div>
+
+    {# ESR download buttons to display on unsupported systems: issue 13317 #}
+    {% with channel_name = 'Firefox' %}
+      {% include 'firefox/includes/download-unsupported.html' %}
+    {% endwith %}
+  </div>
+{%- endmacro %}
+
+
+{% macro firefox_download_desktop_button_mac(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-osx', position='primary cta') -%}
+  <div class="firefox-platform-button-mac">
+    <div class="firefox-platform-button">
+      <a class="download-link os_osx mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-display-name="macOS" data-download-version="osx" data-download-os="Desktop" data-download-location="{{ position }}">
+        <strong class="download-title">
+          {{ cta_copy }}
+        </strong>
+      </a>
+
+      <small class="mzp-c-button-download-privacy-link">
+        <a href="{{ url('privacy.notices.firefox') }}">
+          {{ ftl('download-button-firefox-privacy-notice') }}
+        </a>
+      </small>
+    </div>
+
+    {# ESR download buttons to display on unsupported systems: issue 13317 #}
+    {% with channel_name = 'Firefox' %}
+      {% include 'firefox/includes/download-unsupported.html' %}
+    {% endwith %}
+  </div>
+{%- endmacro %}
+
+
+{% macro firefox_download_desktop_button_linux(cta_copy=ftl('download-button-download-now'), id='download-button-desktop-release-linux', position='primary cta') -%}
+  <div class="firefox-platform-button-linux">
+    <div class="firefox-platform-button">
+      <a class="download-link os_linux mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" data-link-type="download" data-display-name="Linux 32-bit" data-download-version="linux" data-download-os="Desktop" data-download-location="{{ position }}">
+        <strong class="download-title">
+          {{ cta_copy }}
+        </strong>
+      </a>
+
+      <a class="download-link os_linux64 mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}-64" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" data-link-type="download" data-display-name="Linux 64-bit" data-download-version="linux64" data-download-os="Desktop" data-download-location="{{ position }}">
+        <strong class="download-title">
+          {{ ftl('download-button-download-now') }}
+        </strong>
+      </a>
+
+      <small class="mzp-c-button-download-privacy-link">
+        <a href="{{ url('privacy.notices.firefox') }}">
+          {{ ftl('download-button-firefox-privacy-notice') }}
+        </a>
+      </small>
+    </div>
+  </div>
+{%- endmacro %}

--- a/bedrock/firefox/templates/firefox/new/basic/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_download.html
@@ -64,7 +64,9 @@
     <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox"></div>
     <h1 class="c-download-split-title">{{ hero_title }}</h1>
     <div class="c-intro-download">
-      {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
+      {% block intro_download_button %}
+        {{ download_firefox_thanks(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
+      {% endblock %}
 
       {% block small_links %}
       <ul class="small-links">

--- a/bedrock/firefox/templates/firefox/new/basic/base_platform.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base_platform.html
@@ -28,6 +28,12 @@
 {# else it will fall back to the strings from new/download.ftl specified in base_download #}
 {% endif %}
 
+{% block site_header %}
+  {% with hide_nav_cta=True %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block features %}
   {% if ftl_file_is_active('firefox/new/platform') %}
     <section class="features">

--- a/bedrock/firefox/templates/firefox/new/basic/download_linux.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_linux.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "firefox/includes/macros.html" import firefox_download_desktop_button_linux with context %}
+
 {% extends "firefox/new/basic/base_platform.html" %}
 
 {% block experiments %}{% endblock %}
@@ -17,8 +19,14 @@
   {% set og_desc = ftl('new-platform-faster-page-loading-linux') %}
 {% endif %}
 
+{% block body_class %}{{ super() }} firefox-platform-linux{% endblock %}
+
 {# hero #}
 {% set hero_title =  ftl('new-platform-download-mozilla-linux', fallback='firefox-new-download-firefox-for-linux')|safe %}
+
+{% block intro_download_button %}
+  {{ firefox_download_desktop_button_linux() }}
+{% endblock %}
 
 {# cards #}
 {% set card1_title = ftl('new-platform-privacy-more-than') %}

--- a/bedrock/firefox/templates/firefox/new/basic/download_mac.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_mac.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "firefox/includes/macros.html" import firefox_download_desktop_button_mac with context %}
+
 {% extends "firefox/new/basic/base_platform.html" %}
 
 {% block experiments %}{% endblock %}
@@ -17,8 +19,14 @@
   {% set og_desc = ftl('new-platform-faster-page-loading-mac') %}
 {% endif %}
 
+{% block body_class %}{{ super() }} firefox-platform-mac{% endblock %}
+
 {# hero #}
 {% set hero_title =  ftl('new-platform-download-mozilla-firefox-mac', fallback='firefox-new-download-firefox-for-macos')|safe %}
+
+{% block intro_download_button %}
+  {{ firefox_download_desktop_button_mac() }}
+{% endblock %}
 
 {# cards #}
 {% set card1_title = ftl('new-platform-privacy-comes-first') %}

--- a/bedrock/firefox/templates/firefox/new/basic/download_windows.html
+++ b/bedrock/firefox/templates/firefox/new/basic/download_windows.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% from "firefox/includes/macros.html" import firefox_download_desktop_button_windows with context %}
+
 {% extends "firefox/new/basic/base_platform.html" %}
 
 {% block experiments %}{% endblock %}
@@ -17,8 +19,14 @@
   {% set og_desc = ftl('new-platform-faster-page-loading-windows') %}
 {% endif %}
 
+{% block body_class %}{{ super() }} firefox-platform-windows{% endblock %}
+
 {# hero #}
 {% set hero_title =  ftl('new-platform-download-mozilla-windows', fallback='firefox-new-download-firefox-for-windows') %}
+
+{% block intro_download_button %}
+  {{ firefox_download_desktop_button_windows() }}
+{% endblock %}
 
 {# cards #}
 {% set card1_title = ftl('new-platform-2x-faster') %}

--- a/l10n/en/firefox/browsers/windows-64-bit.ftl
+++ b/l10n/en/firefox/browsers/windows-64-bit.ftl
@@ -36,3 +36,5 @@ windows-64-bit-if-you-see-32-bit-newer = If you see “(32-bit)” and are runni
 # $all (url) - link to https://www.mozilla.org/firefox/all/
 windows-64-bit-if-you-need-to-run = If you need to run 32-bit { -brand-name-firefox } or manually install 64-bit { -brand-name-firefox }, you can simply download and re-run the { -brand-name-windows } (32-bit or 64-bit) { -brand-name-firefox } installer from the <a href="{ $all }">{ -brand-name-firefox } platforms and languages download page.</a>
 windows-64-bit-take-control-of-your = Take control of your browser.
+
+windows-64-bit-download-firefox = Download { -brand-name-firefox } for Windows 64-bit

--- a/media/css/firefox/browsers/windows-64-bit.scss
+++ b/media/css/firefox/browsers/windows-64-bit.scss
@@ -22,6 +22,7 @@ $image-path: '/media/protocol/img';
 
     .hero-content {
         padding-top: $layout-xl;
+        padding-bottom: 0;
 
         .mzp-c-logo {
             margin-left: auto;

--- a/media/css/firefox/browsers/windows-64-bit.scss
+++ b/media/css/firefox/browsers/windows-64-bit.scss
@@ -51,6 +51,10 @@ $image-path: '/media/protocol/img';
             margin-bottom: $spacing-md;
         }
     }
+
+    .download-firefox {
+        padding-bottom: $spacing-lg;
+    }
 }
 
 .mzp-c-article {
@@ -77,7 +81,15 @@ $image-path: '/media/protocol/img';
 .mzp-c-call-out-compact.mzp-t-dark {
     background: $color-purple-90;
 
+    .mzp-l-content {
+        @include grid-column-gap($spacing-sm);
+    }
+
     .mzp-c-call-out-title {
         color: $color-orange-50;
+    }
+
+    .mzp-c-button-download-privacy-link {
+        text-align: center;
     }
 }

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -109,6 +109,23 @@ ul.download-list {
     display: block !important;
 }
 
+// Platform specific Firefox download macros (issue #12192)
+.firefox-platform-button {
+    .download-link.os_linux64 {
+        display: none;
+    }
+
+    .linux.x64 & {
+        .download-link.os_linux {
+            display: none;
+        }
+
+        .download-link.os_linux64 {
+            display: inline-block;
+        }
+    }
+}
+
 // Conditional Firefox download buttons on unsupported
 // operating system versions (issue #13317)
 .fx-unsupported-message {
@@ -201,13 +218,19 @@ ul.download-list {
 .windows.fx-unsupported {
     // Show unsupported message with Firefox ESR download button.
     .download-button .fx-unsupported-message.win,
-    .c-button-download-thanks .fx-unsupported-message.win {
+    .c-button-download-thanks .fx-unsupported-message.win,
+    .firefox-platform-button-windows .fx-unsupported-message.win {
         display: block !important;
     }
 
     // Show Firefox Win32 ESR download buttons for 64-bit CPUs.
     .fx-unsupported-message.win .download-link.os_win {
         display: inline-block !important;
+    }
+
+    // Hide Windows platform specific buttons.
+    .firefox-platform-button-windows .firefox-platform-button {
+        display: none;
     }
 
     &.x64 {
@@ -226,8 +249,14 @@ ul.download-list {
 .osx.fx-unsupported {
     // Show unsupported message with Firefox ESR download button.
     .download-button .fx-unsupported-message.mac,
-    .c-button-download-thanks .fx-unsupported-message.mac {
+    .c-button-download-thanks .fx-unsupported-message.mac,
+    .firefox-platform-button-mac .fx-unsupported-message.mac {
         display: block !important;
+    }
+
+    // Hide Mac platform specific buttons.
+    .firefox-platform-button-mac .firefox-platform-button {
+        display: none;
     }
 }
 

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -148,7 +148,7 @@ if (typeof window.Mozilla === 'undefined') {
 
         // target download buttons and other-platforms modal links.
         var downloadLinks = document.querySelectorAll(
-            '.download-list .download-link, .c-button-download-thanks .download-link, .download-platform-list .download-link'
+            '.download-list .download-link, .c-button-download-thanks .download-link, .download-platform-list .download-link, .firefox-platform-button .download-link'
         );
 
         for (var i = 0; i < downloadLinks.length; i++) {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -764,7 +764,6 @@
     },
     {
       "files": [
-        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/windows-64-bit.scss"
       ],
       "name": "windows-64-bit"

--- a/tests/functional/firefox/browsers/test_windows_64_bit.py
+++ b/tests/functional/firefox/browsers/test_windows_64_bit.py
@@ -11,4 +11,5 @@ from pages.firefox.browsers.windows_64_bit import Windows64BitPage
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = Windows64BitPage(selenium, base_url).open()
-    assert page.download_button.is_displayed
+    assert page.is_windows_64_bit_hero_download_button_displayed
+    assert page.is_windows_64_bit_footer_download_button_displayed

--- a/tests/functional/firefox/new/test_platform.py
+++ b/tests/functional/firefox/new/test_platform.py
@@ -9,18 +9,20 @@ from pages.firefox.new.platform import PlatformDownloadPage
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("slug", ["windows", "mac", "linux"])
-def test_download_buttons_are_displayed(slug, base_url, selenium):
-    page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
-    assert page.download_button.is_displayed
+def test_windows_download_buttons_is_displayed(base_url, selenium):
+    page = PlatformDownloadPage(selenium, base_url, slug="windows").open()
+    assert page.is_windows_download_button_displayed
 
 
-# Firefox and Internet Explorer don't cope well with file prompts whilst using Selenium.
-@pytest.mark.skip_if_firefox(reason="http://saucelabs.com/jobs/5a8a62a7620f489d92d6193fa67cf66b")
-@pytest.mark.skip_if_internet_explorer(reason="https://github.com/SeleniumHQ/selenium/issues/448")
+@pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("slug", ["windows", "mac", "linux"])
-def test_click_download_button(slug, base_url, selenium):
-    page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
-    thank_you_page = page.download_firefox()
-    assert thank_you_page.seed_url in selenium.current_url
+def test_mac_download_buttons_is_displayed(base_url, selenium):
+    page = PlatformDownloadPage(selenium, base_url, slug="mac").open()
+    assert page.is_mac_download_button_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_linux_download_buttons_is_displayed(base_url, selenium):
+    page = PlatformDownloadPage(selenium, base_url, slug="linux").open()
+    assert page.is_linux64_download_button_displayed or page.is_linux_download_button_displayed

--- a/tests/pages/firefox/browsers/windows_64_bit.py
+++ b/tests/pages/firefox/browsers/windows_64_bit.py
@@ -5,15 +5,18 @@
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
-from pages.regions.download_button import DownloadButton
 
 
 class Windows64BitPage(BasePage):
     _URL_TEMPLATE = "/{locale}/firefox/browsers/windows-64-bit/"
 
-    _download_button_locator = (By.ID, "win64-hero-download")
+    _windows_64bit_hero_download_button_locator = (By.ID, "win64-hero-download")
+    _windows_64bit_footer_download_button_locator = (By.ID, "win64-bottom-download")
 
     @property
-    def download_button(self):
-        el = self.find_element(*self._download_button_locator)
-        return DownloadButton(self, root=el)
+    def is_windows_64_bit_hero_download_button_displayed(self):
+        return self.is_element_displayed(*self._windows_64bit_hero_download_button_locator)
+
+    @property
+    def is_windows_64_bit_footer_download_button_displayed(self):
+        return self.is_element_displayed(*self._windows_64bit_footer_download_button_locator)

--- a/tests/pages/firefox/new/platform.py
+++ b/tests/pages/firefox/new/platform.py
@@ -5,23 +5,28 @@
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
-from pages.regions.download_button import DownloadButton
 
 
 class PlatformDownloadPage(BasePage):
     _URL_TEMPLATE = "/{locale}/firefox/{slug}/"
 
-    _download_button_locator = (By.ID, "download-button-thanks")
+    _windows_download_button_locator = (By.ID, "download-button-desktop-release-win")
+    _mac_download_button_locator = (By.ID, "download-button-desktop-release-osx")
+    _linux_download_button_locator = (By.ID, "download-button-desktop-release-linux")
+    _linux64_download_button_locator = (By.ID, "download-button-desktop-release-linux-64")
 
     @property
-    def download_button(self):
-        el = self.find_element(*self._download_button_locator)
-        return DownloadButton(self, root=el)
+    def is_windows_download_button_displayed(self):
+        return self.is_element_displayed(*self._windows_download_button_locator)
 
-    def download_firefox(self):
-        href = self.download_button.platform_link.get_attribute("href")
-        self.set_attribute(self.download_button.platform_link, att_name="href", att_value=href + "?automation=true")
-        self.download_button.click()
-        from pages.firefox.new.thank_you import ThankYouPage
+    @property
+    def is_mac_download_button_displayed(self):
+        return self.is_element_displayed(*self._mac_download_button_locator)
 
-        return ThankYouPage(self.selenium, self.base_url).wait_for_page_to_load()
+    @property
+    def is_linux_download_button_displayed(self):
+        return self.is_element_displayed(*self._linux_download_button_locator)
+
+    @property
+    def is_linux64_download_button_displayed(self):
+        return self.is_element_displayed(*self._linux64_download_button_locator)


### PR DESCRIPTION
## One-line summary

- Updates OS specific download pages so that a single OS build is returned, as opposed to the current behavior where the button will return a link to whichever build matches your current OS.
- I also removed the nav CTA button on these pages to make things less confusing.

## Issue / Bugzilla link

- https://github.com/mozilla/bedrock/issues/12192
- https://bugzilla.mozilla.org/show_bug.cgi?id=1574162

## Testing

Demo: 

https://www-demo1.allizom.org/en-US/firefox/windows/

Local:

- http://localhost:8000/en-US/firefox/windows/
- http://localhost:8000/en-US/firefox/mac/
- http://localhost:8000/en-US/firefox/linux/
- http://localhost:8000/en-US/firefox/browsers/windows-64-bit/
