### PR TITLE
Add VPN button to navbar on in resource center [fix #13622]

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -136,7 +136,7 @@
 {% macro vpn_nav_cta(link_text, alt_link_text, download_link_text, utm_source, utm_campaign) -%}
   <div class="vpn-nav-cta">
     {% if vpn_available %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="#pricing" data-cta-type="button" data-cta-text="Scroll to pricing" data-cta-position="navigation">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="#pricing" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="navigation">
         {{ ftl('vpn-shared-subscribe-link') }}
       </a>
     {% else %}
@@ -198,5 +198,26 @@
     <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.landing') }}">
       {{ ftl(alt_link_text) }}
     </a>
+  </div>
+{%- endmacro %}
+
+{% macro vpn_resource_center_cta(referral_id, link_text, alt_link_text, class_name) -%}
+  <div class="vpn-nav-cta">
+    {% if vpn_available %}
+      {{ vpn_product_referral_link(
+        referral_id=referral_id,
+        page_anchor='#pricing',
+        link_text=link_text,
+        class_name=class_name,
+        optional_attributes= {
+          'data-cta-text' : 'Get Mozilla VPN',
+          'data-cta-type' : 'button',
+        }
+      ) }}
+    {% else %}
+      <a class="{{ class_name }}" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation">
+        {{ alt_link_text }}
+      </a>
+    {% endif %}
   </div>
 {%- endmacro %}

--- a/bedrock/products/templates/products/vpn/resource-center/base-article.html
+++ b/bedrock/products/templates/products/vpn/resource-center/base-article.html
@@ -5,6 +5,7 @@
 #}
 
 {% from 'macros-protocol.html' import split %}
+{% from "products/vpn/includes/macros.html" import vpn_resource_center_cta with context %}
 
 {% extends "products/vpn/base.html" %}
 
@@ -14,6 +15,19 @@
 {% endblock page_css %}
 
 {% block page_title%}{% block article_title %}{% endblock article_title %}{% endblock page_title%}
+
+{% block site_header %}
+  {% with
+    custom_nav_cta=vpn_resource_center_cta(
+      referral_id='vpn-resource-center-article',
+      link_text=ftl('vpn-shared-subscribe-link'),
+      alt_link_text=ftl('vpn-shared-waitlist-link'),
+      class_name='mzp-c-button mzp-t-secondary mzp-t-md',
+    )
+  %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
 
 {% block content %}
 <nav class="mzp-c-breadcrumb">
@@ -77,16 +91,12 @@
     block_class='mzp-t-content-lg',
   ) %}
     <h2 class="resource-center-cta-title">{{ ftl('vpn-resource-center-obsessed-with') }}</h2>
-       {{ vpn_product_referral_link(
-          referral_id='vpn-resource-center-article',
-          page_anchor='#pricing',
-          link_text=ftl('vpn-resource-center-get-mozilla-vpn'),
-          class_name='mzp-c-button mzp-t-product',
-          optional_attributes= {
-            'data-cta-text' : 'Get Mozilla VPN',
-            'data-cta-type' : 'button',
-          }
-        ) }}
+      {{ vpn_resource_center_cta(
+        referral_id='vpn-resource-center-article',
+        link_text=ftl('vpn-shared-subscribe-link'),
+        alt_link_text=ftl('vpn-shared-waitlist-link'),
+        class_name='mzp-c-button mzp-t-product',
+      ) }}
   {% endcall %}
 {% endblock content %}
 

--- a/bedrock/products/templates/products/vpn/resource-center/landing.html
+++ b/bedrock/products/templates/products/vpn/resource-center/landing.html
@@ -5,6 +5,7 @@
 #}
 
 {% from 'macros-protocol.html' import call_out, split %}
+{% from "products/vpn/includes/macros.html" import vpn_resource_center_cta with context %}
 
 {% extends "products/vpn/base.html" %}
 
@@ -17,6 +18,19 @@
 {% endblock page_css %}
 
 {% block page_title%}{{ ftl('vpn-resource-center-title') }}{% endblock page_title %}
+
+{% block site_header %}
+  {% with
+    custom_nav_cta=vpn_resource_center_cta(
+      referral_id='vpn-resource-center',
+      link_text=ftl('vpn-shared-subscribe-link'),
+      alt_link_text=ftl('vpn-shared-waitlist-link'),
+      class_name='mzp-c-button mzp-t-secondary mzp-t-md',
+    )
+  %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
 
 {% block content %}
 <div class="mzp-l-content">
@@ -60,17 +74,15 @@
   ) %}
     <h1 class="resource-center-wordmark mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-vpn">{{ ftl('vpn-resource-center-mozilla-vpn') }}</h1>
     <h2 class="mzp-c-call-out-title">{{ ftl('vpn-resource-center-start-protecting') }}</h2>
-    {{ vpn_product_referral_link(
-        referral_id='vpn-resource-center',
-        page_anchor='#pricing',
-        link_text=vpn_saving(country_code=country_code, lang=LANG, ftl_string='vpn-shared-save-percent-on'),
-        class_name='mzp-c-button mzp-t-product',
-        optional_attributes= {
-          'data-cta-text' : 'Get Mozilla VPN',
-          'data-cta-type' : 'button',
-        }
-      )}}
+    {{ vpn_resource_center_cta(
+      referral_id='vpn-resource-center',
+      link_text=vpn_saving(country_code=country_code, lang=LANG, ftl_string='vpn-shared-save-percent-on'),
+      alt_link_text=ftl('vpn-shared-waitlist-link'),
+      class_name='mzp-c-button mzp-t-product',
+    ) }}
+    {% if vpn_available %}
     <p class="resource-center-cta-desc"><em>{{ ftl('vpn-shared-when-you-subscribe') }}</em></p>
+    {% endif %}
   {% endcall %}
 
   {% if second_article_group %}
@@ -90,16 +102,12 @@
       block_class='mzp-t-content-lg',
     ) %}
       <h2 class="resource-center-cta-title">{{ ftl('vpn-resource-center-obsessed-with') }}</h2>
-      {{ vpn_product_referral_link(
-          referral_id='vpn-resource-center',
-          page_anchor='#pricing',
-          link_text=ftl('vpn-resource-center-get-mozilla-vpn'),
-          class_name='mzp-c-button mzp-t-product',
-          optional_attributes= {
-            'data-cta-text' : 'Get Mozilla VPN',
-            'data-cta-type' : 'button',
-          }
-        ) }}
+      {{ vpn_resource_center_cta(
+        referral_id='vpn-resource-center-article',
+        link_text=ftl('vpn-shared-subscribe-link'),
+        alt_link_text=ftl('vpn-shared-waitlist-link'),
+        class_name='mzp-c-button mzp-t-product',
+      ) }}
     {% endcall %}
   {% endif %}
 </div>

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -306,6 +306,7 @@ def _filter_articles(articles_list, category):
 def resource_center_landing_view(request):
     ARTICLE_GROUP_SIZE = 6
     template_name = "products/vpn/resource-center/landing.html"
+    vpn_available_in_country = vpn_available(request)
     active_locales = locales_with_available_content(
         classification=CONTENT_CLASSIFICATION_VPN,
         content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
@@ -342,6 +343,7 @@ def resource_center_landing_view(request):
 
     ctx = {
         "active_locales": active_locales,
+        "vpn_available": vpn_available_in_country,
         "category_list": category_list,
         "first_article_group": first_article_group,
         "second_article_group": second_article_group,
@@ -361,6 +363,7 @@ def resource_center_article_view(request, slug):
 
     template_name = "products/vpn/resource-center/article.html"
     requested_locale = l10n_utils.get_locale(request)
+    vpn_available_in_country = vpn_available(request)
 
     active_locales_for_this_article = ContentfulEntry.objects.get_active_locales_for_slug(
         classification=CONTENT_CLASSIFICATION_VPN,
@@ -397,6 +400,7 @@ def resource_center_article_view(request, slug):
     ctx.update(
         {
             "active_locales": active_locales_for_this_article,
+            "vpn_available": vpn_available_in_country,
             "related_articles": [x.data for x in article.get_related_entries()],
         }
     )


### PR DESCRIPTION
## One-line summary
Replaces the default Firefox button (in non-Firefox browsers) with a VPN button on VPN resource center pages. The button should switch to a "join the waitlist" button in non-VPN countries.

Also updates the CTA button in the resource center footer to use the same macro so it includes the logic to switch to the waitlist button in non-VPN countries.

## Issue / Bugzilla link
#13622 

## Testing
http://localhost:8000/products/vpn/resource-center/ - landing page
http://localhost:8000/products/vpn/resource-center/what-is-a-vpn/ - article page
http://localhost:8000/products/vpn/resource-center/what-is-a-vpn/?geo=CN - non-VPN country