### PR TITLE
Update VPN hero copy when banner is active (Fixes #13761)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -78,11 +78,18 @@
     {% if vpn_available %}
       <p class="c-main-cta">
         <a class="mzp-c-button mzp-t-product mzp-t-xl" href="#pricing" data-cta-type="button" data-cta-text="Save on Mozilla VPN" data-cta-position="primary">
-          {{ vpn_saving(country_code=country_code, lang=LANG, bundle_relay=False, ftl_string='vpn-shared-save-percent-on') }}
+          {# Remove these conditionals once cybersecurity month banner is removed see issue 13761 #}
+          {% if show_cyber_security_banner %}
+            Get Mozilla VPN
+          {% else %}
+            {{ vpn_saving(country_code=country_code, lang=LANG, bundle_relay=False, ftl_string='vpn-shared-save-percent-on') }}
+          {% endif %}
         </a>
+        {% if not show_cyber_security_banner %}
         <small>
           *with an annual subscription
         </small>
+        {% endif %}
       </p>
 
     {% else %}


### PR DESCRIPTION
## One-line summary

Simplifies the hero copy when banner is active to make discount less confusing

## Issue / Bugzilla link

#13761

## Testing

http://localhost:8000/en-US/products/vpn/