### PR TITLE
Fix bug 1857050: Remove extra h4 opening tag where a closing one was needed

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
@@ -609,7 +609,7 @@
   <li>MUST NOT include the anyExtendedKeyUsage KeyPurposeId; <em>and</em></li>
   <li>MUST NOT include both the id-kp-serverAuth and id-kp-emailProtection KeyPurposeIds in the same certificate.</li>
   </ul>
-  <h4 id="531-technically-constrained">5.3.1 Technically Constrained<h4>
+  <h4 id="531-technically-constrained">5.3.1 Technically Constrained</h4>
   <p>We encourage CA operators to technically constrain all intermediate
   certificates. For an intermediate certificate to be considered technically
   constrained, the certificate MUST include an <a href="https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12">Extended Key Usage


### PR DESCRIPTION
See [bug 1857050](https://bugzilla.mozilla.org/show_bug.cgi?id=1857050#c2) and https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/#531-technically-constrained