### PR TITLE
Add legal links to redsigned VPN page footer (Fixes #13771)

### DIFF
--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -394,6 +394,10 @@
   </section>
 
   {{ vpn_conditional_cta_refresh('footer') }}
+
+  <footer class="c-footer-legal mzp-l-content mzp-t-content-xl">
+    {% include 'products/vpn/includes/footer-legal.html' %}
+  </footer>
 </main>
 {% endblock %}
 

--- a/bedrock/products/templates/products/vpn/pricing-refresh.html
+++ b/bedrock/products/templates/products/vpn/pricing-refresh.html
@@ -100,6 +100,10 @@
     </details>
 
   </section>
+
+  <footer class="c-footer-legal mzp-l-content mzp-t-content-xl">
+    {% include 'products/vpn/includes/footer-legal.html' %}
+  </footer>
 </main>
 
 {% endblock %}

--- a/media/css/products/vpn/common-refresh.scss
+++ b/media/css/products/vpn/common-refresh.scss
@@ -126,3 +126,8 @@ main {
         }
     }
 }
+
+.c-footer-legal {
+    @include text-body-sm;
+    text-align: center;
+}

--- a/tests/functional/products/vpn/test_landing_refresh.py
+++ b/tests/functional/products/vpn/test_landing_refresh.py
@@ -55,6 +55,7 @@ def test_vpn_available_in_country(country, base_url, selenium):
     # Footer
     assert not page.is_join_waitlist_footer_button_displayed
     assert page.is_get_vpn_footer_button_displayed
+    assert page.is_legal_footer_displayed
 
 
 @pytest.mark.nondestructive
@@ -83,3 +84,4 @@ def test_vpn_not_available_in_country(base_url, selenium):
     # Footer
     assert page.is_join_waitlist_footer_button_displayed
     assert not page.is_get_vpn_footer_button_displayed
+    assert page.is_legal_footer_displayed

--- a/tests/functional/products/vpn/test_pricing_refresh.py
+++ b/tests/functional/products/vpn/test_pricing_refresh.py
@@ -35,6 +35,7 @@ def test_vpn_pricing_available_in_country(country, base_url, selenium):
     assert page.is_get_vpn_monthly_button_displayed
     assert page.is_get_vpn_12_months_button_displayed
     assert not page.is_join_waitlist_button_displayed
+    assert page.is_legal_footer_displayed
 
 
 @pytest.mark.nondestructive
@@ -43,3 +44,4 @@ def test_vpn_pricing_not_available_in_country(base_url, selenium):
     assert not page.is_get_vpn_monthly_button_displayed
     assert not page.is_get_vpn_12_months_button_displayed
     assert page.is_join_waitlist_button_displayed
+    assert page.is_legal_footer_displayed

--- a/tests/pages/products/vpn/landing_refresh.py
+++ b/tests/pages/products/vpn/landing_refresh.py
@@ -34,6 +34,7 @@ class VPNLandingPage(BasePage):
     # Footer
     _get_vpn_footer_button_locator = (By.CSS_SELECTOR, '.c-aside.footer .mzp-c-button[data-cta-text="Get Mozilla VPN"]')
     _join_waitlist_footer_button_locator = (By.CSS_SELECTOR, '.c-aside.footer .mzp-c-button[data-cta-text="Join the VPN Waitlist"]')
+    _legal_footer_locator = (By.CLASS_NAME, "c-footer-legal")
 
     # Hero
 
@@ -94,3 +95,9 @@ class VPNLandingPage(BasePage):
     @property
     def is_join_waitlist_footer_button_displayed(self):
         return self.is_element_displayed(*self._join_waitlist_footer_button_locator)
+
+    # Legal links
+
+    @property
+    def is_legal_footer_displayed(self):
+        return self.is_element_displayed(*self._legal_footer_locator)

--- a/tests/pages/products/vpn/pricing_refresh.py
+++ b/tests/pages/products/vpn/pricing_refresh.py
@@ -13,6 +13,7 @@ class VPNPricingPage(BasePage):
     _get_vpn_monthly_button_locator = (By.CSS_SELECTOR, '.c-pricing-block .mzp-c-button[data-cta-text="Get Mozilla VPN monthly"]')
     _get_vpn_12_months_button_locator = (By.CSS_SELECTOR, '.c-pricing-block .mzp-c-button[data-cta-text="Get Mozilla VPN 12-month"]')
     _join_waitlist_button_locator = (By.CSS_SELECTOR, '.c-pricing-main-header .mzp-c-button[data-cta-text="Join the VPN Waitlist"]')
+    _legal_footer_locator = (By.CLASS_NAME, "c-footer-legal")
 
     @property
     def is_get_vpn_monthly_button_displayed(self):
@@ -25,3 +26,7 @@ class VPNPricingPage(BasePage):
     @property
     def is_join_waitlist_button_displayed(self):
         return self.is_element_displayed(*self._join_waitlist_button_locator)
+
+    @property
+    def is_legal_footer_displayed(self):
+        return self.is_element_displayed(*self._legal_footer_locator)


### PR DESCRIPTION
## One-line summary

At request of VPN folks:

- Adds legal footer links back to footer of the page
- Adds test to ensure they are displayed

## Testing

- http://localhost:8000/en-US/products/vpn/
- http://localhost:8000/en-US/products/vpn/pricing/