### PR TITLE
Add moz-fluent-linter to pre-commit 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,12 @@ repos:
     hooks:
       - id: black
         language_version: python3
+  - repo: https://github.com/mozilla-l10n/moz-fluent-linter
+    rev: v0.4.4
+    hooks:
+      - id: fluent_linter
+        files: \.ftl$
+        args: [--config, .github/l10n/linter_config.yml, l10n/en/]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,11 +74,11 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/mozilla-l10n/moz-fluent-linter
-    rev: v0.4.4
+    rev: v0.4.5
     hooks:
       - id: fluent_linter
         files: \.ftl$
-        args: [--config, .github/l10n/linter_config.yml, l10n/en/]
+        args: [--config, .github/l10n/linter_config.yml, l10n/en/, l10n/en-US/, l10n-pocket/en/]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0
     hooks:

--- a/bedrock/base/tests/urls.py
+++ b/bedrock/base/tests/urls.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from django.core.exceptions import (
     BadRequest,
     PermissionDenied,

--- a/l10n/en-US/firefox/features/bookmarks.ftl
+++ b/l10n/en-US/firefox/features/bookmarks.ftl
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 ### URL: https://www-dev.allizom.org/firefox/features/bookmarks/
 
 features-bookmarks-customize-that-bookmark = Futz with that bookmark


### PR DESCRIPTION
## One-line summary

This linter runs during our pull requests, so this can help catch things earlier.

The only thing I'm sure about is what to do with the other l10n linting we do? There's 4 different linting commands being run in `./bin/run-tests.sh`. Can we remove any with this addition?

## Testing

Run `pre-commit run --all-files`. Make a change to an `.ftl` file that causes an error, like using a capital letter or underscore in a string identifier and run.
