### PR TITLE
Update emissions data scope totals

### DIFF
--- a/bedrock/mozorg/templates/mozorg/sustainability/emissions-data.html
+++ b/bedrock/mozorg/templates/mozorg/sustainability/emissions-data.html
@@ -160,7 +160,7 @@
                 </tr>
                 <tr class="c-total">
                     <th scope="row">Total</th>
-                    <td>12,222</td>
+                    <td>14,222</td>
                     <td>13,604</td>
                     <td>7,350</td>
                     <td>15,281</td>
@@ -243,10 +243,10 @@
                 </tr>
                 <tr class="scope-total">
                     <th scope="row" >Scope 2 total</th>
-                    <td>1,159</td>
-                    <td>768</td>
-                    <td>830</td>
-                    <td>371</td>
+                    <td>460</td>
+                    <td>120</td>
+                    <td>382</td>
+                    <td>178</td>
                 </tr>
 
                 <!-- Scope 3 -->
@@ -326,10 +326,10 @@
                 <tr class="c-total">
                     <th scope="row" rowspan="1">Total</th>
                     <td></td>
-                    <td>14,923</td>
-                    <td>14,253</td>
-                    <td>7,796</td>
-                    <td>15,473</td>
+                    <td>14,222</td>
+                    <td>13,604</td>
+                    <td>7,350</td>
+                    <td>15,281</td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## One-line summary
Was informed that some of the totals in the Sustainability report's Emissions Data page had incorrect numbers, and I updated them based on the changes.

Spreadsheet w/ updated totals highlighted in green (see Table 1 and Table 2 tabs): https://docs.google.com/spreadsheets/d/1pxIGISOZC15MVehvglIkH7GFRCx7KF9mrKqKlTwc2Xw/edit#gid=0

## Testing
http://localhost:8000/en-US/sustainability/emissions-data/