### PR TITLE
Bump Glean.js to v2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^2.0.3",
+        "@mozilla/glean": "^2.0.4",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2055,9 +2055,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.3.tgz",
-      "integrity": "sha512-xSPWvgjkmOYzaCf5HIXUHAwFGVLDaGCwvCcHqUqSdXROGap86lzPOIK9Nsd0vfBTNoWVFPlkWqOyhbRitazxkQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.4.tgz",
+      "integrity": "sha512-nvXocG6PC946Wk7VAgcjk1dM3r6XGbvBNR1pmE1BWcHh76uKFksThZAZTvZMeMpk/IptZ8Y4D0bqNaTiQKmUYA==",
       "dependencies": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",
@@ -11879,9 +11879,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "@mozilla/glean": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.3.tgz",
-      "integrity": "sha512-xSPWvgjkmOYzaCf5HIXUHAwFGVLDaGCwvCcHqUqSdXROGap86lzPOIK9Nsd0vfBTNoWVFPlkWqOyhbRitazxkQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.4.tgz",
+      "integrity": "sha512-nvXocG6PC946Wk7VAgcjk1dM3r6XGbvBNR1pmE1BWcHh76uKFksThZAZTvZMeMpk/IptZ8Y4D0bqNaTiQKmUYA==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^2.0.3",
+    "@mozilla/glean": "^2.0.4",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",


### PR DESCRIPTION
## One-line summary

https://github.com/mozilla/glean.js/releases/tag/v2.0.4

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13431

## Testing

- `npm install`
- `npm start`