### PR TITLE
Fix img 404 in JS tests

### DIFF
--- a/tests/unit/spec/pocket/updates-signup.js
+++ b/tests/unit/spec/pocket/updates-signup.js
@@ -76,7 +76,7 @@ describe('updates-signup.es6.js', function () {
                     </div>
                 </div>
                 <div class="mzp-c-split-media mzp-l-split-h-center mzp-l-split-media-overflow">
-                    <img src="/media/img/pocket/pocket-update-signup.png" alt="" class="mzp-c-split-media-asset">
+                    <img src="/img/placeholder.png" alt="" class="mzp-c-split-media-asset">
                 </div>
             </div>
 


### PR DESCRIPTION
## One-line summary

Fixes a 404 img warning when running JS tests and local dev server is not running:

```
16 10 2023 13:54:23.152:WARN [web-server]: 404: /media/img/pocket/pocket-update-signup.png
16 10 2023 13:54:23.165:WARN [web-server]: 404: /media/img/pocket/pocket-update-signup.png
16 10 2023 13:54:23.168:WARN [web-server]: 404: /media/img/pocket/pocket-update-signup.png
16 10 2023 13:54:23.170:WARN [web-server]: 404: /media/img/pocket/pocket-update-signup.png
```

## Issue / Bugzilla link

N/A

## Testing

- `npm test`