### PR TITLE
Add privacy notice for Mozilla accounts (Fixes #13802)

### DIFF
--- a/bedrock/privacy/redirects.py
+++ b/bedrock/privacy/redirects.py
@@ -30,7 +30,4 @@ redirectpatterns = (
     redirect(r"^privacy/betterweb/?$", "privacy.archive.firefox-betterweb-2023-06"),
     redirect(r"^privacy/firefox-fire-tv/?$", "privacy.archive.firefox-fire-tv-2023-06"),
     redirect(r"^privacy/firefox-reality/?$", "privacy.archive.firefox-reality-notice-2023-06"),
-    # temporary
-    # remove test in map_globalconf.py as well
-    redirect(r"^privacy/mozilla-accounts/?$", "privacy.notices.firefox", permanent=False, anchor="firefox-accounts"),
 )

--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -31,6 +31,7 @@
 {% set navigation_bar = [
   (url('privacy'), 'privacy-home', ftl('privacy-index-mozilla-privacy')),
   (url('privacy.notices.websites'), 'privacy-websites', ftl('privacy-index-mozilla-websites-communications')),
+  (url('privacy.notices.mozilla-accounts'), 'mozilla-accounts', ftl('privacy-index-mozilla-accounts')),
   (url('privacy.notices.subscription-services'), 'subscription-services', ftl('privacy-index-mozilla-subscription-services')),
   (url('privacy.notices.firefox'), 'privacy-quantum', ftl('privacy-index-firefox-browser')),
   (focus_url, 'privacy-focus', focus_name),

--- a/bedrock/privacy/templates/privacy/notices/base-notice.html
+++ b/bedrock/privacy/templates/privacy/notices/base-notice.html
@@ -23,6 +23,9 @@
 {% block lead_in %}
   {% if doc.select('[datetime]') %}
     {{ doc.select('body > section > [datetime] ~ p')|join|safe }}
+    {% if doc.select('body > section > ul') %}
+      {{ doc.select('body > section > ul')|htmlattr(class="mzp-u-list-styled")|join|safe }}
+    {% endif %}
   {% else %}
     {{ doc.select('body > section > p')|join|safe }}
   {% endif %}

--- a/bedrock/privacy/templates/privacy/notices/mozilla-accounts.html
+++ b/bedrock/privacy/templates/privacy/notices/mozilla-accounts.html
@@ -1,0 +1,11 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "privacy/notices/base-notice.html" %}
+
+{% set body_id = "mozilla-accounts" %}
+
+{% block article_header_logo %}{{ static('img/trademarks/logo-mozm.png') }}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -25,6 +25,7 @@ urlpatterns = (
     path("mdn-plus/", views.mdn_plus, name="privacy.notices.mdn-plus"),
     path("ad-targeting-guidelines/", views.ad_targeting_guidelines, name="privacy.notices.ad-targeting-guidelines"),
     path("subscription-services/", views.subscription_services, name="privacy.notices.subscription-services"),
+    path("mozilla-accounts/", views.mozilla_accounts, name="privacy.notices.mozilla-accounts"),
     page("archive/", "privacy/archive/index.html", ftl_files=["privacy/index"], active_locales=["en-US"]),
     page("archive/firefox/2006-10/", "privacy/archive/firefox-2006-10.html", ftl_files=["privacy/index"], active_locales=["en-US"]),
     page("archive/firefox/2008-06/", "privacy/archive/firefox-2008-06.html", ftl_files=["privacy/index"], active_locales=["en-US"]),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -69,6 +69,8 @@ subscription_services = PrivacyDocView.as_view(
     template_name="privacy/notices/subscription-services.html", legal_doc_name="subscription_services_privacy_notice"
 )
 
+mozilla_accounts = PrivacyDocView.as_view(template_name="privacy/notices/mozilla-accounts.html", legal_doc_name="mozilla_accounts_privacy_notice")
+
 
 def privacy(request):
     doc = load_legal_doc("mozilla_privacy_policy", l10n_utils.get_locale(request))

--- a/l10n/en/privacy/index.ftl
+++ b/l10n/en/privacy/index.ftl
@@ -49,3 +49,6 @@ privacy-index-firefox-fire-tv = { -brand-name-firefox } for { -brand-name-fire-t
 privacy-index-mdn-plus = { -brand-name-mdn-plus }
 privacy-index-hubs = { -brand-name-mozilla-hubs }
 privacy-index-mozilla-subscription-services = { -brand-name-mozilla } Subscription Services
+
+# This is title case since it appears in a menu, so does not use the normal brand name terms for "Mozilla accounts".
+privacy-index-mozilla-accounts = { -brand-name-mozilla } Accounts

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1236,8 +1236,6 @@ URLS = flatten(
         # Issue 13672
         url_test("/VendorDPA/", "https://assets.mozilla.net/pdf/VendorDPA.pdf"),
         url_test("/vendordpa/", "https://assets.mozilla.net/pdf/VendorDPA.pdf"),
-        # temporary
-        url_test("/privacy/mozilla-accounts/", "/privacy/firefox/#firefox-accounts", status_code=requests.codes.found),
         # Issue 13732
         url_test("/firefox/welcome/3/", "/firefox/accounts/"),
         # Issue 13754


### PR DESCRIPTION
## One-line summary

Adds new privacy notice page for Mozilla accounts

# DO NOT MERGE until Nov 1st.

## Issue / Bugzilla link

#13802

## Testing

http://localhost:8000/en-US/privacy/mozilla-accounts/