### PR TITLE
Bump Glean.js to v2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^2.0.4",
+        "@mozilla/glean": "^2.0.5",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2130,9 +2130,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.4.tgz",
-      "integrity": "sha512-nvXocG6PC946Wk7VAgcjk1dM3r6XGbvBNR1pmE1BWcHh76uKFksThZAZTvZMeMpk/IptZ8Y4D0bqNaTiQKmUYA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
+      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
       "dependencies": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",
@@ -11967,9 +11967,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "@mozilla/glean": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.4.tgz",
-      "integrity": "sha512-nvXocG6PC946Wk7VAgcjk1dM3r6XGbvBNR1pmE1BWcHh76uKFksThZAZTvZMeMpk/IptZ8Y4D0bqNaTiQKmUYA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
+      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^2.0.4",
+    "@mozilla/glean": "^2.0.5",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",


### PR DESCRIPTION
## One-line summary

https://github.com/mozilla/glean.js/releases/tag/v2.0.5

## Issue / Bugzilla link

N/A

## Testing

- `npm install`
- `npm start`