### PR TITLE
Small fixes to Moz accounts promo

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -131,9 +131,6 @@
       <div class="mzp-c-field mzp-l-stretch">
         <label class="mzp-c-field-label" for="fxa-email-field">{{ ftl('fxa-form-email-address') }}</label>
         <input type="email" name="email" id="fxa-email-field" class="mzp-c-field-control" placeholder="user@example.com" required>
-        <p class="mzp-c-field-info">
-          {{ ftl('fxa-form-by-proceeding', url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy') }}
-        </p>
       </div>
 
       <div class="mzp-c-button-container mzp-l-stretch">
@@ -152,7 +149,11 @@
         {% endif %}
         </button>
       </div>
+
     </div>
+    <p class="mzp-c-field-info">
+      {{ ftl('fxa-form-by-proceeding', url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy') }}
+    </p>
 
   </form>
 {%- endmacro %}

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -28,6 +28,7 @@ $promo-sm-mq: 400px;
         text-align: center;
 
     }
+
     @media (min-width: $promo-md-mq) {
         padding: $layout-lg;
 
@@ -44,10 +45,12 @@ $promo-sm-mq: 400px;
         color: $color-white;
         letter-spacing: -2px;
         margin-bottom: $layout-md;
+        text-align: left;
 
         .gradient-text {
             background: linear-gradient(to right, #ffd741 19%, #ff4540 42%, #f26fff 63%, #9a53fa 80%);
             background-clip: text;
+            -webkit-background-clip: text; // for Chrome web browser
             color: transparent;
         }
 
@@ -91,6 +94,10 @@ $promo-sm-mq: 400px;
     .accounts-cta {
         color: $color-white;
         margin-top: 0;
+    }
+
+    .accounts-signin {
+        margin-bottom: 0;
     }
 
     .accounts-cta {
@@ -173,20 +180,21 @@ $promo-sm-mq: 400px;
             @include bidi(((margin-left, auto, 0),));
             @include bidi(((margin-right, 0, auto),));
         }
+    }
 
     .fxa-email-field-container {
         display: flex;
         flex-direction: column;
-        align-items: center;
-
-        #fxa-email-field {
-            width: 100%;
-            min-width: 230px;
-            max-width: 100%;
-        }
 
         .mzp-c-field {
             padding-bottom: 0;
+
+            #fxa-email-field {
+                width: 100%;
+                min-width: 230px;
+                line-height: 1;
+                max-width: 100%;
+            }
         }
 
         .mzp-c-button-container {
@@ -213,4 +221,3 @@ $promo-sm-mq: 400px;
             }
         }
     }
-}

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -20,7 +20,7 @@ $promo-sm-mq: 400px;
     display: flex;
     justify-content: space-between;
     flex-direction: column;
-    padding: $spacing-xl;
+    padding: $spacing-lg;
 
     .promo-product-wrapper {
         display: flex;
@@ -73,6 +73,7 @@ $promo-sm-mq: 400px;
         #fxa-email-form {
             color: $color-white;
             margin-top: $spacing-xl;
+            max-width: 100%;
 
             .mzp-c-form-header {
                 display: none;
@@ -83,6 +84,10 @@ $promo-sm-mq: 400px;
         .accounts-signin {
             @include text-body-xs;
             text-align: left;
+        }
+
+        .mzp-c-field-info {
+            margin-top: $spacing-md;
         }
 
         @media (min-width: $promo-md-mq) {
@@ -185,23 +190,24 @@ $promo-sm-mq: 400px;
         display: flex;
         align-items: flex-start;
         flex-direction: column;
+        min-width: 230px;
 
         .mzp-c-field {
             padding-bottom: 0;
+            width: 100%;
 
             #fxa-email-field {
-                width: 100%;
+                width: 395px;
                 min-width: 230px;
-                line-height: 1;
                 max-width: 100%;
+                line-height: 1;
             }
         }
 
         .mzp-c-button-container {
             display: flex;
-            flex-direction: column;
             margin-bottom: 0;
-            margin-top: $spacing-lg;
+            margin-top: $spacing-md;
             width: 100%;
 
             #fxa-email-form-submit {
@@ -209,16 +215,16 @@ $promo-sm-mq: 400px;
             }
         }
 
-
+        // remove media query if Jodie approves current design
         @media (min-width: $promo-md-mq) {
-            flex-direction: row;
             align-items: baseline; // change to `center` when removing old form styles from `browser-products.scss`
 
 
                 .mzp-c-button-container {
                     // add `@include bidi(((margin-left, $spacing-lg, margin-right, 0),))` when removing old form styles from `browser-products.scss`
-                    margin-top: 0;
-                    width: unset;
+                    &::before {
+                        content: none;
+                    }
                 }
             }
         }

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -215,12 +215,9 @@ $promo-sm-mq: 400px;
             }
         }
 
-        // remove media query if Jodie approves current design
+
         @media (min-width: $promo-md-mq) {
-            align-items: baseline; // change to `center` when removing old form styles from `browser-products.scss`
-
-
-                .mzp-c-button-container {
+           .mzp-c-button-container {
                     // add `@include bidi(((margin-left, $spacing-lg, margin-right, 0),))` when removing old form styles from `browser-products.scss`
                     &::before {
                         content: none;

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -39,13 +39,20 @@ $promo-sm-mq: 400px;
 
     h2 {
         @include font-base;
-        @include text-title-xl;
+        @include font-size(56px);
+        line-height: 1;
         color: $color-white;
+        letter-spacing: -2px;
+        margin-bottom: $layout-md;
 
         .gradient-text {
             background: linear-gradient(to right, #ffd741 19%, #ff4540 42%, #f26fff 63%, #9a53fa 80%);
             background-clip: text;
             color: transparent;
+        }
+
+        @media (min-width: $promo-md-mq) {
+            @include font-size(66px);
         }
 
         @media (max-width: $promo-sm-mq) {
@@ -91,6 +98,10 @@ $promo-sm-mq: 400px;
         margin-top: $spacing-2xl;
         text-align: center;
 
+        a {
+            @include font-base;
+        }
+
         small {
             a {
                 text-decoration: underline;
@@ -114,6 +125,7 @@ $promo-sm-mq: 400px;
     .products-list {
         display: flex;
         justify-content: center;
+        margin-bottom: 0;
 
         li {
             flex-shrink: 0;
@@ -130,6 +142,7 @@ $promo-sm-mq: 400px;
             img {
                 width: 45px;
                 height: 45px;
+                display: block;
             }
 
             span {
@@ -179,6 +192,10 @@ $promo-sm-mq: 400px;
         .mzp-c-button-container {
             margin-bottom: 0;
             margin-top: $spacing-lg;
+
+            #fxa-email-form-submit {
+                @include font-base;
+            }
 
             &.mzp-l-stretch {
                 align-items: center;

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -24,9 +24,8 @@ $promo-sm-mq: 400px;
 
     .promo-product-wrapper {
         display: flex;
+        align-items: flex-start;
         flex-direction: column;
-        text-align: center;
-
     }
 
     @media (min-width: $promo-md-mq) {
@@ -41,6 +40,7 @@ $promo-sm-mq: 400px;
     h2 {
         @include font-base;
         @include font-size(56px);
+        @include bidi(((text-align, left, right),));
         line-height: 1;
         color: $color-white;
         letter-spacing: -2px;
@@ -68,7 +68,7 @@ $promo-sm-mq: 400px;
         @include font-base;
         display: flex;
         flex-direction: column;
-        align-items: center;
+        align-items: flex-start;
 
         #fxa-email-form {
             color: $color-white;
@@ -82,7 +82,7 @@ $promo-sm-mq: 400px;
         .mzp-c-field-info,
         .accounts-signin {
             @include text-body-xs;
-            text-align: center;
+            text-align: left;
         }
 
         @media (min-width: $promo-md-mq) {
@@ -101,9 +101,8 @@ $promo-sm-mq: 400px;
     }
 
     .accounts-cta {
-        margin: 0 auto;
+        align-self: flex-start;
         margin-top: $spacing-2xl;
-        text-align: center;
 
         a {
             @include font-base;
@@ -139,11 +138,11 @@ $promo-sm-mq: 400px;
             margin-left: 20px;
 
             &.product-item-firefox {
-               @include bidi(((margin-left, 20px, margin-right, 20px),));
+               @include bidi(((margin-left, 0, margin-right, 20px),));
             }
 
             &.product-item-monitor {
-                @include bidi(((margin-right, 20px, margin-left, 0),));
+                @include bidi(((margin-right, 0, margin-left, 0),));
             }
 
             img {
@@ -162,11 +161,11 @@ $promo-sm-mq: 400px;
                 margin-left: 10px;
 
                 &.product-item-firefox {
-                    @include bidi(((margin-left, 10px, margin-right, 10px),));
+                    @include bidi(((margin-left, 0, margin-right, 10px),));
                 }
 
                 &.product-item-monitor {
-                    @include bidi(((margin-right, 10px, margin-left, 0),));
+                    @include bidi(((margin-right, 0, margin-left, 0),));
                 }
 
                 img {
@@ -184,6 +183,7 @@ $promo-sm-mq: 400px;
 
     .fxa-email-field-container {
         display: flex;
+        align-items: flex-start;
         flex-direction: column;
 
         .mzp-c-field {
@@ -198,25 +198,27 @@ $promo-sm-mq: 400px;
         }
 
         .mzp-c-button-container {
+            display: flex;
+            flex-direction: column;
             margin-bottom: 0;
             margin-top: $spacing-lg;
+            width: 100%;
 
             #fxa-email-form-submit {
                 @include font-base;
             }
-
-            &.mzp-l-stretch {
-                align-items: center;
-            }
         }
+
 
         @media (min-width: $promo-md-mq) {
             flex-direction: row;
             align-items: baseline; // change to `center` when removing old form styles from `browser-products.scss`
 
+
                 .mzp-c-button-container {
                     // add `@include bidi(((margin-left, $spacing-lg, margin-right, 0),))` when removing old form styles from `browser-products.scss`
                     margin-top: 0;
+                    width: unset;
                 }
             }
         }


### PR DESCRIPTION
## One-line summary
Had a conversation w/ the branding team and they requested a few changes for the upcoming Mozilla accounts banner

## Significant changes and points to review
- [x] Reduce `letter-spacing`
- [x] Reduce `line-height`
- [x] Add more space between heading and content beneath it
- [x] Change CTA font to Inter
- [x] Bigger font-size for the heading
- [x] Make input and CTA the same height -- (I updated the input's `line-height` to match the default set in Protocol)
- [x] Left-align title in mobile

Since this design was pretty bespoke to begin with, we're making these unique changes to match what's coming out in sibling websites such as SUMO and Mozilla Blog.

## Testing
- [ ] http://localhost:8000/en-US/firefox/
- [ ] http://localhost:8000/en-US/firefox/browsers/
- [ ] http://localhost:8000/en-US/firefox/products
- [ ] http://localhost:8000/en-US/firefox/browsers/mobile

Demo server:

- [ ] https://www-demo3.allizom.org/en-US/firefox/
- [ ] https://www-demo3.allizom.org/en-US/firefox/browsers
- [ ] https://www-demo3.allizom.org/en-US/firefox/products
- [ ] https://www-demo3.allizom.org/en-US/firefox/browsers/mobile