### PR TITLE
Remove extra quotation mark from L10N string

### DIFF
--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -18,7 +18,7 @@ firefox-desktop-download-firefox = { -brand-name-firefox-browser }
 
 # Variables:
 #   $update_url (url) - link to https://support.mozilla.org/kb/update-firefox-latest-release
-firefox-desktop-out-of-date = An even newer { -brand-name-firefox } is available. <a { $update_url }">Update to the latest version</a>
+firefox-desktop-out-of-date = An even newer { -brand-name-firefox } is available. <a { $update_url }>Update to the latest version</a>
 
 firefox-desktop-download-get-the-browser = Get the browser that protects what’s important
 # shady is slang which suggests something is untrustworthy


### PR DESCRIPTION
## One-line summary
Got a review comment in the `www-l10n` repo to remove a leftover quotation mark in the Fluent string ID for the yellow notification banner's anchor link

https://github.com/mozilla-l10n/www-l10n/pull/359

## Testing
http://localhost:8000/en-US/firefox/new/?reason=outdated