### PR TITLE
Add Mozilla Monitor waitlist pages (Fixes #13823)

### DIFF
--- a/bedrock/products/templates/products/monitor/waitlist/base.html
+++ b/bedrock/products/templates/products/monitor/waitlist/base.html
@@ -1,0 +1,58 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends 'base-protocol-mozilla.html' %}
+
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
+{% block body_class %}{{ super() }} monitor-waitlist{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('protocol-newsletter') }}
+  {{ css_bundle('monitor-waitlist') }}
+{% endblock %}
+
+{% block site_header %}
+  {% with
+    hide_nav_download_button=True,
+    hide_nav_get_vpn_button=True
+  %}
+    {% include 'includes/protocol/navigation/navigation.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
+<main class="mzp-t-content-sm">
+  <section class="section-subscribe">
+    <header class="mzp-l-content mzp-t-content-lg">
+      <h1 class="page-title">{% block page_heading %}{% endblock %}</h1>
+      <h2 class="section-title">{{ self.page_desc() }}</h2>
+    </header>
+    <div class="mzp-l-content mzp-t-content-sm">
+    {% if country_code == "US" %}
+      {{ email_newsletter_form(
+        newsletters=newsletter_id,
+        include_title=False,
+        include_country=False,
+        include_language=False,
+        thankyou_head='Thanks!',
+        thankyou_content='If you haven’t previously confirmed a subscription to a Mozilla-related newsletter or waitlist, you may have to do so. Please check your inbox or your spam filter for an email from us.',
+        submit_text='Sign up now',
+        spinner_color='#0c99d5'
+      ) }}
+    {% else %}
+      <p class="c-not-available">
+        Sorry, this service is not currently available in your country.
+      </p>
+    {% endif %}
+    </div>
+  </section>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('newsletter') }}
+{% endblock %}

--- a/bedrock/products/templates/products/monitor/waitlist/plus.html
+++ b/bedrock/products/templates/products/monitor/waitlist/plus.html
@@ -1,0 +1,13 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/monitor/waitlist/base.html" %}
+
+{% block page_title %}More spots for Monitor Plus will be opening soon{% endblock page_title %}
+
+{% block page_desc %}Join the waitlist to get notified as soon as new spots are available.{% endblock %}
+
+{% block page_heading %}More spots for Monitor Plus <br>will be opening soon{% endblock %}

--- a/bedrock/products/templates/products/monitor/waitlist/scan.html
+++ b/bedrock/products/templates/products/monitor/waitlist/scan.html
@@ -1,0 +1,13 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "products/monitor/waitlist/base.html" %}
+
+{% block page_title %}Thank you for your interest in Monitor automatic data removal.{% endblock page_title %}
+
+{% block page_desc %}Join the waitlist to get notified as soon as new spots are available.{% endblock %}
+
+{% block page_heading %}Thank you for your interest in Monitor automatic data removal. We’ve temporarily reached full capacity.{% endblock %}

--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -533,3 +533,28 @@ class TestVPNResourceArticleView(TestCase):
         # Which will 302 as expected
         self.assertEqual(resp.headers["location"], "/en-US/products/vpn/resource-center/slug-2/")
         render_mock.assert_not_called()
+
+
+@patch("bedrock.products.views.l10n_utils.render", return_value=HttpResponse())
+class TestMonitorScanWaitlistPage(TestCase):
+    @override_settings(DEV=False)
+    def test_monitor_scan_waitlist_template(self, render_mock):
+        req = RequestFactory().get("/products/monitor/waitlist-scan/")
+        req.locale = "en-US"
+        view = views.monitor_waitlist_scan_page
+        view(req)
+        ctx = render_mock.call_args[0][2]
+        self.assertEqual(ctx["newsletter_id"], "monitor-waitlist")
+        template = render_mock.call_args[0][1]
+        assert template == "products/monitor/waitlist/scan.html"
+
+    @override_settings(DEV=False)
+    def test_monitor_plus_waitlist_template(self, render_mock):
+        req = RequestFactory().get("/products/monitor/waitlist-plus/")
+        req.locale = "en-US"
+        view = views.monitor_waitlist_plus_page
+        view(req)
+        ctx = render_mock.call_args[0][2]
+        self.assertEqual(ctx["newsletter_id"], "monitor-waitlist")
+        template = render_mock.call_args[0][1]
+        assert template == "products/monitor/waitlist/plus.html"

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -37,6 +37,8 @@ urlpatterns = (
         name="products.vpn.resource-center.article",
     ),
     path("mozsocial/invite/", views.mozsocial_waitlist_page, name="products.mozsocial.invite"),
+    path("monitor/waitlist-plus/", views.monitor_waitlist_plus_page, name="products.monitor.waitlist-plus"),
+    path("monitor/waitlist-scan/", views.monitor_waitlist_scan_page, name="products.monitor.waitlist-scan"),
 )
 
 if settings.DEV:

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -532,3 +532,21 @@ def mozsocial_waitlist_page(request):
     ctx = {"action": settings.BASKET_SUBSCRIBE_URL, "newsletter_form": newsletter_form, "product": "mozilla-social-waitlist"}
 
     return l10n_utils.render(request, template_name, ctx, ftl_files=ftl_files)
+
+
+@require_safe
+def monitor_waitlist_scan_page(request):
+    template_name = "products/monitor/waitlist/scan.html"
+    newsletter_id = "monitor-waitlist"
+    ctx = {"newsletter_id": newsletter_id}
+
+    return l10n_utils.render(request, template_name, ctx)
+
+
+@require_safe
+def monitor_waitlist_plus_page(request):
+    template_name = "products/monitor/waitlist/plus.html"
+    newsletter_id = "monitor-waitlist"
+    ctx = {"newsletter_id": newsletter_id}
+
+    return l10n_utils.render(request, template_name, ctx)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -456,6 +456,8 @@ NOINDEX_URLS = [
     r"^newsletter/newsletter-strings\.json",
     r"^products/vpn/invite/waitlist/",
     r"^products/relay/invite/waitlist/",
+    r"^products/monitor/waitlist-plus/",
+    r"^products/monitor/waitlist-scan/",
     r"/system-requirements/$",
     r".*/(firstrun|thanks)/$",
     r"^readiness/$",

--- a/media/css/products/monitor/waitlist.scss
+++ b/media/css/products/monitor/waitlist.scss
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+.section-subscribe {
+    .mzp-l-content:first-child {
+        padding-bottom: 0;
+    }
+
+    .page-title {
+        @include text-title-md;
+        text-align: center;
+        font-weight: 600;
+
+        br {
+            display: none;
+        }
+
+        @media #{$mq-md} {
+            br {
+                display: block;
+            }
+        }
+    }
+
+    .section-title {
+        @include font-base;
+        @include text-body-xl;
+        text-align: center;
+        font-weight: normal;
+    }
+
+    .c-not-available {
+        @include text-body-xl;
+        text-align: center;
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1311,6 +1311,12 @@
     },
     {
       "files": [
+        "css/products/monitor/waitlist.scss"
+      ],
+      "name": "monitor-waitlist"
+    },
+    {
+      "files": [
         "css/mozorg/try-picture-in-picture.scss"
       ],
       "name": "try-picture-in-picture"

--- a/tests/functional/products/monitor/test_waitlist.py
+++ b/tests/functional/products/monitor/test_waitlist.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.products.monitor.waitlist import MonitorWaitlistPage
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("slug", [("plus"), ("scan")])
+def test_not_available_in_country(slug, base_url, selenium):
+    page = MonitorWaitlistPage(selenium, base_url, slug=slug, params="?geo=GB").open()
+    assert not page.is_newsletter_form_displayed
+    assert page.is_service_not_available_message_displayed
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("slug", [("plus"), ("scan")])
+def test_signup_success(slug, base_url, selenium):
+    page = MonitorWaitlistPage(selenium, base_url, slug=slug, params="?geo=US").open()
+    page.expand_form()
+    page.type_email("success@example.com")
+    page.newsletter.accept_privacy_policy()
+    page.click_sign_up_now()
+    assert page.is_form_success_displayed
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("slug", [("plus"), ("scan")])
+def test_signup_failure(slug, base_url, selenium):
+    page = MonitorWaitlistPage(selenium, base_url, slug=slug, params="?geo=US").open()
+    page.expand_form()
+    page.type_email("failure@example.com")
+    page.newsletter.accept_privacy_policy()
+    page.click_sign_up_now(expected_result="error")
+    assert page.is_form_error_displayed

--- a/tests/pages/products/monitor/waitlist.py
+++ b/tests/pages/products/monitor/waitlist.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+from pages.base import BasePage
+
+
+class MonitorWaitlistPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/products/monitor/waitlist-{slug}/{params}"
+
+    _newsletter_form_locator = (By.ID, "newsletter-form")
+    _email_locator = (By.ID, "id_email")
+    _form_details_locator = (By.ID, "newsletter-details")
+    _privacy_policy_checkbox_locator = (By.ID, "privacy")
+    _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="privacy"] a')
+    _submit_button_locator = (By.ID, "newsletter-submit")
+    _thank_you_locator = (By.ID, "newsletter-thanks")
+    _error_list_locator = (By.ID, "newsletter-errors")
+    _service_not_available_message_locator = (By.CLASS_NAME, "c-not-available")
+
+    def expand_form(self):
+        # scroll newsletter into view before expanding the form
+        self.scroll_element_into_view(*self._newsletter_form_locator)
+        assert not self.is_form_detail_displayed, "Form detail is already displayed"
+        self.find_element(*self._email_locator).send_keys("")
+        self.wait.until(expected.visibility_of_element_located(self._privacy_policy_checkbox_locator))
+
+    @property
+    def is_newsletter_form_displayed(self):
+        return self.is_element_displayed(*self._newsletter_form_locator)
+
+    @property
+    def is_form_detail_displayed(self):
+        return self.is_element_displayed(*self._form_details_locator)
+
+    @property
+    def email(self):
+        return self.find_element(*self._email_locator).get_attribute("value")
+
+    def type_email(self, value):
+        self.find_element(*self._email_locator).send_keys(value)
+
+    @property
+    def privacy_policy_accepted(self):
+        el = self.find_element(*self._privacy_policy_checkbox_locator)
+        return el.is_selected()
+
+    def accept_privacy_policy(self):
+        el = self.find_element(*self._privacy_policy_checkbox_locator)
+        assert not el.is_selected(), "Privacy policy has already been accepted"
+        el.click()
+        assert el.is_selected(), "Privacy policy has not been accepted"
+
+    @property
+    def is_form_success_displayed(self):
+        return self.is_element_displayed(*self._thank_you_locator)
+
+    @property
+    def is_form_error_displayed(self):
+        return self.is_element_displayed(*self._error_list_locator)
+
+    @property
+    def is_service_not_available_message_displayed(self):
+        return self.is_element_displayed(*self._service_not_available_message_locator)
+
+    def click_sign_up_now(self, expected_result=None):
+        self.find_element(*self._submit_button_locator).click()
+        if expected_result == "error":
+            self.wait.until(expected.visibility_of_element_located(self._error_list_locator))
+        else:
+            self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))


### PR DESCRIPTION
## One-line summary

Adds 2 waitlist pages for Monitor. These will be linked to via the monitor.firefox.com

## Issue / Bugzilla link

#13823

## Testing

- http://localhost:8000/en-US/products/monitor/waitlist-plus/
- http://localhost:8000/en-US/products/monitor/waitlist-scan/
