### PR TITLE
Update names for "Ad Targeting Guidelines" (legal docs)

### DIFF
--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -62,7 +62,7 @@ firefox_monitor_notices = PrivacyDocView.as_view(template_name="privacy/notices/
 mdn_plus = PrivacyDocView.as_view(template_name="privacy/notices/mdn-plus.html", legal_doc_name="mdn_plus_privacy")
 
 ad_targeting_guidelines = PrivacyDocView.as_view(
-    template_name="privacy/notices/ad-targeting-guidelines.html", legal_doc_name="AdTargeting_Guidelines"
+    template_name="privacy/notices/ad-targeting-guidelines.html", legal_doc_name="adtargeting_guidelines"
 )
 
 subscription_services = PrivacyDocView.as_view(


### PR DESCRIPTION
The file was renamed to lowercase in https://github.com/mozilla/legal-docs/commit/802a6062457c0285a0266cfdb16d59b3ddda904c

The system should already pick up the file, but it's worth updating the reference to match the GitHub file.

The files is displayed here: https://www.mozilla.org/en-US/privacy/ad-targeting-guidelines/ (or [here on stage](https://www-dev.allizom.org/en-US/privacy/ad-targeting-guidelines/))