### PR TITLE
Add fxa error notification to newsletter recovery page

### DIFF
--- a/bedrock/base/tests/urls.py
+++ b/bedrock/base/tests/urls.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from django.core.exceptions import (
     BadRequest,
     PermissionDenied,

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -16,7 +16,14 @@
 {% endblock %}
 
 {% block content %}
-  <main class="mzp-l-content mzp-t-content-sm">
+  <main>
+    {% if fxa_error %}
+      <div class="mzp-c-notification-bar mzp-t-error">
+        <p>{{ ftl('newsletters-fxa-error-retry') }}</p>
+      </div>
+    {% endif %}
+
+  <div class="mzp-l-content mzp-t-content-sm">
     <h1 class="mzp-u-title-sm">{{ ftl('newsletters-manage-your-newsletter') }}</h1>
 
     <form method="post" action="{{ recovery_url }}" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">
@@ -52,6 +59,7 @@
         </div>
       </div>
     </form>
+  </div>
   </main>
 {% endblock %}
 

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -195,8 +195,9 @@ def recovery(request):
     to manage their subscriptions.
     """
     form = EmailForm()
+    fxa_error = request.GET.get("fxa_error", "0") == "1"
 
-    context = {"form": form, "recovery_url": settings.BASKET_URL + "/news/recover/"}
+    context = {"form": form, "recovery_url": f"{settings.BASKET_URL}/news/recover/", "fxa_error": fxa_error}
 
     # This view is shared between two different templates. For context see bug 1442129.
     if "/newsletter/opt-out-confirmation/" in request.get_full_path():

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -155,6 +155,7 @@ newsletters-your-content-wasnt-relevant = Your content wasn’t relevant to me.
 newsletters-your-email-design = Your email design was too hard to read.
 newsletters-i-didnt-sign-up = I didn’t sign up for this.
 newsletters-please-select-a-reason = Please select a reason for unsubscribing.
+newsletters-fxa-error-retry = We are sorry, but there was a problem directing you to the email preferences. Please try the form below.
 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/newsletter/
@@ -225,7 +226,7 @@ newsletters-insights = Insights
 # Obsolete string
 newsletters-internet-health-report = Internet Health Report
 
-# Description for the newsletter in Newsletter subscription page (Insights))
+# Description for the newsletter in Newsletter subscription page (Insights)
 newsletters-mozilla-published-articles-and-deep = { -brand-name-mozilla } publishes articles and deep dives on issues around internet health and trustworthy AI, including our annual Internet Health Report.
 
 # Obsolete string


### PR DESCRIPTION
## One-line summary

Adds FxA error notification so we can redirect to this page upon error, giving the user a path forward to finding their email subscription page.

## Significant changes and points to review

Please suggest any better wording.

## Testing

Pass the query string to get this error to show up:
http://localhost:8000/en-US/newsletter/recovery/?fxa_error=1

![Screenshot 2023-10-26 at 13-41-53 Newsletter email recovery](https://github.com/mozilla/bedrock/assets/1106/7069400b-1fd1-4e83-a9e0-f45113113a15)
