### PR TITLE
Prefer addEventListener over addListener for media queries (Fixes #13129)

### DIFF
--- a/media/js/base/mozilla-article.js
+++ b/media/js/base/mozilla-article.js
@@ -17,11 +17,20 @@ var MzpSideMenu = require('@mozilla-protocol/core/protocol/js/sidemenu');
     if (_mqWide.matches) {
         window.MzpDetails.init('.side-reference-title');
     }
-    _mqWide.addListener(function (mq) {
+
+    function handleMqChange(mq) {
         if (mq.matches) {
             window.MzpDetails.init('.side-reference-title');
         } else {
             window.MzpDetails.destroy('.side-reference-title');
         }
-    });
+    }
+
+    if (window.matchMedia('all').addEventListener) {
+        // evergreen
+        _mqWide.addEventListener('change', handleMqChange, false);
+    } else if (window.matchMedia('all').addListener) {
+        // IE fallback
+        _mqWide.addListener(handleMqChange);
+    }
 })();

--- a/media/js/base/protocol/protocol-menu.js
+++ b/media/js/base/protocol/protocol-menu.js
@@ -206,7 +206,7 @@
     MzpMenu.handleState = function () {
         _mqWideNav = matchMedia('(min-width: ' + _wideBreakpoint + ')');
 
-        _mqWideNav.addListener(function (mq) {
+        function menuBind(mq) {
             MzpMenu.close();
 
             if (mq.matches) {
@@ -216,7 +216,15 @@
                 MzpMenu.unbindEventsWide();
                 MzpMenu.bindEventsSmall();
             }
-        });
+        }
+
+        if (window.matchMedia('all').addEventListener) {
+            // evergreen
+            _mqWideNav.addEventListener('change', menuBind, false);
+        } else if (window.matchMedia('all').addListener) {
+            // IE fallback
+            _mqWideNav.addListener(menuBind);
+        }
 
         if (MzpMenu.isWideViewport()) {
             MzpMenu.bindEventsWide();

--- a/media/js/base/protocol/protocol-navigation.js
+++ b/media/js/base/protocol/protocol-navigation.js
@@ -106,13 +106,19 @@
                 ')'
         );
 
-        _mqLargeNav.addListener(function (mq) {
+        function makeStickyNav(mq) {
             if (mq.matches) {
                 MzpNavigation.createSticky();
             } else {
                 MzpNavigation.destroySticky();
             }
-        });
+        }
+
+        if (window.matchMedia('all').addEventListener) {
+            _mqLargeNav.addEventListener('change', makeStickyNav, false);
+        } else if (window.matchMedia('all').addListener) {
+            _mqLargeNav.addListener(makeStickyNav);
+        }
 
         if (MzpNavigation.isLargeViewport()) {
             MzpNavigation.createSticky();

--- a/media/js/base/protocol/protocol-sub-navigation.js
+++ b/media/js/base/protocol/protocol-sub-navigation.js
@@ -9,6 +9,14 @@
 
     var subNavTitle = '.c-sub-navigation .c-sub-navigation-title';
 
+    function handleMqChange(mq) {
+        if (mq.matches) {
+            window.MzpDetails.init(subNavTitle);
+        } else {
+            window.MzpDetails.destroy(subNavTitle);
+        }
+    }
+
     // check we have global Supports and Details library
     if (
         typeof window.MzpSupports !== 'undefined' &&
@@ -23,14 +31,13 @@
                 window.MzpDetails.init(subNavTitle);
             }
 
-            // remove details if screen is big
-            _mqWide.addListener(function (mq) {
-                if (mq.matches) {
-                    window.MzpDetails.init(subNavTitle);
-                } else {
-                    window.MzpDetails.destroy(subNavTitle);
-                }
-            });
+            if (window.matchMedia('all').addEventListener) {
+                // evergreen
+                _mqWide.addEventListener('change', handleMqChange, false);
+            } else if (window.matchMedia('all').addListener) {
+                // IE fallback
+                _mqWide.addListener(handleMqChange);
+            }
         }
     }
 })();

--- a/media/js/firefox/family/subnav.js
+++ b/media/js/firefox/family/subnav.js
@@ -10,6 +10,14 @@
     var subNavTitle =
         '.t-firefox-family .c-sub-navigation .c-sub-navigation-title';
 
+    function handleMqChange(mq) {
+        if (mq.matches) {
+            window.MzpDetails.init(subNavTitle);
+        } else {
+            window.MzpDetails.destroy(subNavTitle);
+        }
+    }
+
     // check we have global Supports and Details library
     if (
         typeof window.MzpSupports !== 'undefined' &&
@@ -24,14 +32,13 @@
                 window.MzpDetails.init(subNavTitle);
             }
 
-            // remove details if screen is big
-            _mqWide.addListener(function (mq) {
-                if (mq.matches) {
-                    window.MzpDetails.init(subNavTitle);
-                } else {
-                    window.MzpDetails.destroy(subNavTitle);
-                }
-            });
+            if (window.matchMedia('all').addEventListener) {
+                // evergreen
+                _mqWide.addEventListener('change', handleMqChange, false);
+            } else if (window.matchMedia('all').addListener) {
+                // IE fallback
+                _mqWide.addListener(handleMqChange);
+            }
         }
     }
 })();

--- a/media/js/mozorg/about-transparency.js
+++ b/media/js/mozorg/about-transparency.js
@@ -10,11 +10,20 @@
     if (_mqWide.matches) {
         window.MzpDetails.init('.c-collapsible-section-heading');
     }
-    _mqWide.addListener(function (mq) {
+
+    function handleMqChange(mq) {
         if (mq.matches) {
             window.MzpDetails.init('.c-collapsible-section-heading');
         } else {
             window.MzpDetails.destroy('.c-collapsible-section-heading');
         }
-    });
+    }
+
+    if (window.matchMedia('all').addEventListener) {
+        // evergreen
+        _mqWide.addEventListener('change', handleMqChange, false);
+    } else if (window.matchMedia('all').addListener) {
+        // IE fallback
+        _mqWide.addListener(handleMqChange);
+    }
 })();

--- a/media/js/pocket/mobile-nav.es6.js
+++ b/media/js/pocket/mobile-nav.es6.js
@@ -98,20 +98,18 @@ function handleKeyDown(e) {
 }
 
 export const addMediaQueryListeners = function () {
-    if (typeof mobileMenuQuery.addEventListener === 'function') {
+    function handleMqChange(mq) {
+        if (mq.matches) {
+            init();
+        }
+    }
+
+    if (window.matchMedia('all').addEventListener) {
         // evergreen
-        mobileMenuQuery.addEventListener('change', function (event) {
-            if (event.matches) {
-                init();
-            }
-        });
-    } else if (typeof mobileMenuQuery.addListener === 'function') {
+        mobileMenuQuery.addEventListener('change', handleMqChange, false);
+    } else if (window.matchMedia('all').addListener) {
         // IE fallback
-        mobileMenuQuery.addListener(function (event) {
-            if (event.matches) {
-                init();
-            }
-        });
+        mobileMenuQuery.addListener(handleMqChange);
     }
 };
 


### PR DESCRIPTION
## One-line summary

Prefer `addEventListener` over `addListener` which is deprecated.


## Issue / Bugzilla link

#13129

## Testing

Mozorg mode

- http://localhost:8000/en-US/about/history/ (side menu)
- http://localhost:8000/en-US/ (navigation, sticky nav)
- http://localhost:8000/en-US/products/vpn/ (sub navigation)
- http://localhost:8000/en-US/about/policy/transparency/jul-dec-2022/ (details sections)

Pocket mode

- http://localhost:8000/en/about/ (nav)