### PR TITLE
Add meta desc for VPN resource center articles in Contentful (Fixes #13836)

### DIFF
--- a/bedrock/products/templates/products/vpn/resource-center/article.html
+++ b/bedrock/products/templates/products/vpn/resource-center/article.html
@@ -6,13 +6,20 @@
 
 {% extends 'products/vpn/resource-center/base-article.html' %}
 
+{%- block page_desc -%}
+  {% if info.seo.description %}{{ info.seo.description }}{% endif %}
+{%- endblock -%}
+
 {% block article_category %}
   {% if info.category %}{{ info.category }}{% endif %}
 {% endblock %}
+
 {% block article_title %}{{ info.title }}{% endblock %}
+
 {% block article_slug %}{{ info.slug }}{% endblock %}
+
 {% block vpn_article %}
-{% for entry in entries -%}
-  {{ entry.body|external_html }}
-{% endfor %}
+  {% for entry in entries -%}
+    {{ entry.body|external_html }}
+  {% endfor %}
 {% endblock vpn_article %}


### PR DESCRIPTION
## One-line summary

Populates values `<meta name="description">` and `<meta property="og:description">` using the `info.seo.description` field in Contentful.

## Issue / Bugzilla link

#13836

## Testing

http://localhost:8000/en-US/products/vpn/resource-center/