### PR TITLE
Fix issue with unclosed img tag in Nightly Feed

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
+++ b/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
@@ -28,7 +28,7 @@
       <div xmlns="http://www.w3.org/1999/xhtml">
         {{ note.version }} / {{ note.tag|replace('HTML5', 'Web Platform') }}
         {%- if note.bug %} / <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ note.bug }}">Bug {{ note.bug }}</a>{% endif %}
-        {{ note.note|markdown|safe }}
+        {{ note.note|markdown(extensions=['bedrock.releasenotes.md_extensions:CloseImgTagExtension'])|safe }}
       </div>
     </content>
   </entry>

--- a/bedrock/releasenotes/md_extensions.py
+++ b/bedrock/releasenotes/md_extensions.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import re
+
+from markdown.extensions import Extension
+from markdown.postprocessors import Postprocessor
+
+UNCLOSED_IMG_TAG_PATTERN = re.compile(
+    r"(?P<unclosed_img_tag><img[^>]*?>)(?<!\/>)(?!<\/img>)",
+    re.MULTILINE,
+)
+
+
+class CloseImgTagPostprocessor(Postprocessor):
+    def run(self, text):
+        return re.sub(UNCLOSED_IMG_TAG_PATTERN, r"\g<unclosed_img_tag></img>", text)
+
+
+class CloseImgTagExtension(Extension):
+    def extendMarkdown(self, md):
+        md.postprocessors.register(CloseImgTagPostprocessor(md), "close_img", 20)

--- a/bedrock/releasenotes/tests/test_md_extensions.py
+++ b/bedrock/releasenotes/tests/test_md_extensions.py
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from ..md_extensions import CloseImgTagPostprocessor
+
+
+@pytest.mark.parametrize(
+    "input_text, expected_correct_text",
+    (
+        (
+            '<p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></p>',
+            '<p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></img></p>',
+        ),
+        (
+            '<p><img alt="Valid img markup" src="https://www.example.org/images/test.png"></img></p>',
+            '<p><img alt="Valid img markup" src="https://www.example.org/images/test.png"></img></p>',
+        ),
+        (
+            '<p><img alt="Valid img markup" src="https://www.example.org/images/test.png"/></p>',
+            '<p><img alt="Valid img markup" src="https://www.example.org/images/test.png"/></p>',
+        ),
+        (
+            """
+            <p><img alt="Valid img markup" src="https://www.example.org/images/test.png"/></p>
+            <p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></p>
+            <p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></p>
+            <p><img alt="Valid img markup" src="https://www.example.org/images/test.png"></img></p>
+            <p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></p>
+            """,
+            """
+            <p><img alt="Valid img markup" src="https://www.example.org/images/test.png"/></p>
+            <p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></img></p>
+            <p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></img></p>
+            <p><img alt="Valid img markup" src="https://www.example.org/images/test.png"></img></p>
+            <p><img alt="Invalid img markup" src="https://www.example.org/images/test.png"></img></p>
+            """,
+        ),
+    ),
+    ids=[
+        "Fixing unclosed img tag",
+        "Leaving closed img tag unchanged",
+        "Leaving self-closing img tag unchanged",
+        "Multiple examples fixed while viable ones left unchanged",
+    ],
+)
+def test_img_closing_extension(input_text, expected_correct_text):
+    pp = CloseImgTagPostprocessor()
+    processed = pp.run(input_text)
+    assert processed == expected_correct_text


### PR DESCRIPTION
This changeset deals with a problem using Markdown to render an XML feed for Nightly. Specifically, we were seeing an <img> tag that was not being closed, which then breaks XML parsing, meaning RSS readers cannot show the content.

## Significant changes and points to review

The changeset adds a new postprocessor that looks for an unclosed <img> tag and closes it.

Rather than change our overall Markdown rendering, the fix has beebn isolated to _just_ the Nightly feed.

## Issue / Bugzilla link
Resolves #13830
Resolves https://bugzilla.mozilla.org/show_bug.cgi?id=1863200



## Testing

(These steps will not work once the current Nightly Release Notes change, but they are around for a week or so from now)

* In an RSS Reader, try to add https://www.mozilla.org/en-US/firefox/nightly/notes/feed/ - it will fail, or at best not render properly - e.g

<img width="578" alt="Screenshot 2023-11-06 at 09 59 15" src="https://github.com/mozilla/bedrock/assets/101457/af182f88-73df-47c9-9e12-0847cec50607">

* Locally, run `./manage.py update_release_notes` to get all the latest release data
* Point the RSS reader at http://localhost:8000/en-US/firefox/nightly/notes/feed/ - it will load the feed without complaint and render it. Scroll down to see the included image which previously broke the feed

[
<img width="1188" alt="Screenshot 2023-11-06 at 09 58 35" src="https://github.com/mozilla/bedrock/assets/101457/75aa5dd6-aa32-4921-bfae-e78aa5a0a16a">
](url)
