### PR TITLE
Escape content in /firefox/nightly/notes/feed/ using CDATA (Fixes #13830)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
+++ b/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
@@ -24,12 +24,12 @@
     <id>{{ note.link|absolute_url }}</id>
     <link rel="alternate" type="text/html" href="{{ note.link|absolute_url }}"/>
     <updated>{{ note.modified.isoformat() }}</updated>
-    <content type="xhtml">
-      <div xmlns="http://www.w3.org/1999/xhtml">
+    <content type="html">
+      <![CDATA[
         {{ note.version }} / {{ note.tag|replace('HTML5', 'Web Platform') }}
         {%- if note.bug %} / <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ note.bug }}">Bug {{ note.bug }}</a>{% endif %}
         {{ note.note|markdown|safe }}
-      </div>
+      ]]>
     </content>
   </entry>
   {% endfor %}


### PR DESCRIPTION
## One-line summary

Fixes parsing error in Nightly RSS feed. There are more improvements we could make to this feed, but this hopefully fixes the parsing error (leaving only a few warnings with a couple of individual entries)

## Issue / Bugzilla link

#13830

## Testing

http://www-demo1.allizom.org/en-US/firefox/nightly/notes/feed/

https://validator.w3.org/feed/#validate_by_uri