### PR TITLE
Add new VPN Fluent files to pontoon

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -333,3 +333,12 @@ locales = [
 [[paths]]
     reference = "en/products/vpn/platform-post-download.ftl"
     l10n = "{locale}/products/vpn/platform-post-download.ftl"
+[[paths]]
+    reference = "en/products/vpn/landing-2023.ftl"
+    l10n = "{locale}/products/vpn/landing-2023.ftl"
+[[paths]]
+    reference = "en/products/vpn/pricing-2023.ftl"
+    l10n = "{locale}/products/vpn/pricing-2023.ftl"
+[[paths]]
+    reference = "en/products/vpn/features.ftl"
+    l10n = "{locale}/products/vpn/features.ftl"


### PR DESCRIPTION
## One-line summary
https://github.com/mozilla/bedrock/pull/13870 added three new Fluent files but we forgot to add them to the pontoon config (which lists individual files but not the whole folder).