### PR TITLE
String fixes for VPN refresh pages

### DIFF
--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -149,7 +149,7 @@
     <ul class="mzp-l-columns mzp-t-columns-three">
       <li>
         <h3 class="c-reason-title">{{ ftl('vpn-landing-keeps-your-data-safe') }}</h3>
-        <p>{{ ftl('vpn-landing-log-into-your-bank-or') }}</p>
+        <p>{{ ftl('vpn-landing-log-in-to-your-bank-or') }}</p>
       </li>
       <li>
         <h3 class="c-reason-title">{{ ftl('vpn-landing-blocks-advertisers-from') }}</h3>
@@ -157,7 +157,7 @@
       </li>
       <li>
         <h3 class="c-reason-title">{{ ftl('vpn-landing-helps-you-access-global') }}</h3>
-        <p>{{ ftl('vpn-landing-check-out-foreign-shows') }}</p>
+        <p>{{ ftl('vpn-landing-check-out-streaming-media') }}</p>
       </li>
     </ul>
   </section>

--- a/l10n/en/products/vpn/features.ftl
+++ b/l10n/en/products/vpn/features.ftl
@@ -16,12 +16,18 @@ vpn-features-convenient = Convenient
 # Variables
 #   $servers (number) - number of VPN servers
 #   $countries (number) - number of available countries
-vpn-features-more-than = More than { $servers } servers in { $countries }+ countries
+vpn-features-more-than = { $servers ->
+    [one] More than { $servers } server in { $countries }+ countries
+   *[other] More than { $servers } servers in { $countries }+ countries
+}
 vpn-features-see-our-list = See our list of servers.
 
 # Variables:
 #   $devices (number) - number of devices users can connect to VPN
-vpn-features-connect-up-to = Connect up to { $devices } devices
+vpn-features-connect-up-to = { $devices ->
+    [one] Connect up to { $devices } device
+   *[other] Connect up to { $devices } devices
+}
 vpn-features-supported-platforms = Supported on Windows, macOS, Android, iOS and Linux operating systems.
 vpn-features-no-bandwidth = No bandwidth restrictions or throttling
 vpn-features-including-no-data = Including no data cap or speed limit.
@@ -58,7 +64,7 @@ vpn-features-set-different-locations = Set different locations for each tab in {
 
 # Variables
 #   $containers (url) - link to https://support.mozilla.org/kb/use-multi-account-containers-mozilla-vpn
-vpn-features-combine-mozilla-vpn-with-containers = Combine { -brand-name-mozilla-vpn } with the Multi-Account Containers { -brand-name-firefox } extension andset different VPN locations per { -brand-name-firefox } tab. <a { $containers }>Learn how</a>.
+vpn-features-combine-mozilla-vpn-with-containers = Combine { -brand-name-mozilla-vpn } with the Multi-Account Containers { -brand-name-firefox } extension and set different VPN locations per { -brand-name-firefox } tab. <a { $containers }>Learn how</a>.
 
 vpn-features-trustworthy = Trustworthy
 vpn-features-money-back = 30-day money-back guarantee
@@ -73,7 +79,7 @@ vpn-features-built-transparently = Built transparently in open source
 
 # Variables
 #   $github (url) - link to https://github.com/mozilla-mobile/mozilla-vpn-client
-vpn-features-made-with-open-source-code = { -brand-name-mozilla-vpn } is made with open-source code, meaning that all thecode is publicly accessible. See our <a { $github }>Github repository</a>.
+vpn-features-made-with-open-source-code = { -brand-name-mozilla-vpn } is made with open-source code, meaning that all the code is publicly accessible. See our <a { $github }>GitHub repository</a>.
 
 vpn-features-reviewed-by-third = Reviewed by third-party security experts
 

--- a/l10n/en/products/vpn/landing-2023.ftl
+++ b/l10n/en/products/vpn/landing-2023.ftl
@@ -11,7 +11,6 @@ vpn-landing-title = { -brand-name-mozilla-vpn }: Protect Your Entire Device
 # Variables:
 #   $countries (number) - number of available countries
 vpn-landing-desc = Use { -brand-name-mozilla-vpn } for full-device protection for all apps. With servers in { $countries }+ countries, you can connect to anywhere, from anywhere.
-
 vpn-landing-powerful-privacy-for-peace = Powerful privacy for peace of mind
 
 vpn-landing-whats-a-vpn = What’s a VPN?
@@ -20,21 +19,27 @@ vpn-landing-see-all-the-ways-mozilla-vpn = See all the ways { -brand-name-mozill
 
 vpn-landing-how-a-vpn-helps-you = How a VPN helps you
 vpn-landing-keeps-your-data-safe = Keeps your data safe on public Wi-Fi
-vpn-landing-log-into-your-bank-or = Log into your bank or doctor’s office from the airport, cafe or anywhere, with peace of mind.
+vpn-landing-log-in-to-your-bank-or = Log in to your bank or doctor’s office from the airport, cafe or anywhere, with peace of mind.
 vpn-landing-blocks-advertisers-from = Blocks advertisers from targeting you
 vpn-landing-hide-your-activity-from = Hide your activity from trackers and malware so you can shop without being watched.
 vpn-landing-helps-you-access-global = Helps you access global content
-vpn-landing-check-out-foreign-shows = Check out foreign shows, websites and live-streams while you’re traveling or at home.
+vpn-landing-check-out-streaming-media = Check out streaming media, websites and live-streams from other countries while you’re traveling or at home.
 vpn-landing-features = Features
 
 # Variables:
-#   $devices (number) - number of allowed devices
-vpn-landing-connect-up-to-devices = Connect up to { $devices } devices
+#   $devices (number) - number of devices users can connect to VPN
+vpn-landing-connect-up-to-devices = { $devices ->
+    [one] Connect up to { $devices } device
+   *[other] Connect up to { $devices } devices
+}
 
 # Variables:
 #   $servers (number) - number of VPN servers
 #   $countries (number) - number of available countries
-vpn-landing-more-than-servers-in-countries = More than { $servers } servers in { $countries }+ countries
+vpn-landing-more-than-servers-in-countries = { $servers ->
+    [one] More than { $servers } server in { $countries }+ countries
+   *[other] More than { $servers } servers in { $countries }+ countries
+}
 vpn-landing-fast-network-speeds-even-while = Fast network speeds even while gaming
 vpn-landing-no-logging-tracking-or-sharing = No logging, tracking or sharing of network data
 vpn-landing-no-bandwidth-restrictions-or = No bandwidth restrictions or throttling

--- a/l10n/en/products/vpn/pricing-2023.ftl
+++ b/l10n/en/products/vpn/pricing-2023.ftl
@@ -15,12 +15,18 @@ vpn-pricing-included-in-subscription = Included in subscription:
 
 # Variables:
 #   $devices (number) - number of devices users can connect to VPN
-vpn-pricing-connect-up-to = Connect up to { $devices } devices
+vpn-pricing-connect-up-to = { $devices ->
+    [one] Connect up to { $devices } device
+   *[other] Connect up to { $devices } devices
+}
 
 # Variables:
 #   $servers (number) - number of VPN servers
 #   $countries (number) - number of available countries
-vpn-pricing-access = Access { $servers }+ servers in { $countries }+ countries
+vpn-pricing-access = { $servers ->
+    [one] Access { $servers } server in { $countries }+ countries
+   *[other] Access { $servers } servers in { $countries }+ countries
+}
 vpn-pricing-money-back = 30-day money-back guarantee (for first-time customers only)
 vpn-pricing-annual = Annual
 vpn-pricing-monthly = Monthly
@@ -32,14 +38,14 @@ vpn-pricing-vpn-not-available = { -brand-name-mozilla-vpn } is not yet available
 vpn-pricing-faqs = FAQs
 vpn-pricing-refund-policy = What is { -brand-name-mozilla-vpn }’s refund policy?
 vpn-pricing-the-first-time-you = The first time you subscribe to { -brand-name-mozilla-vpn } through { -brand-name-mozilla }’s website, if you cancel your account within the first 30 days, you may request a refund and { -brand-name-mozilla } will refund your first subscription term.
-vpn-pricing-if-you-purchased = If you purchased your subscription through in-app purchase from the Apple App Store or the Google Play Store, your payment is subject to the terms and conditions of the App Store. You must direct any billing and refund inquiries for such purchases to Apple or Google, as appropriate.
+vpn-pricing-if-you-purchased = If you purchased your subscription through in-app purchase from the Apple App Store or the Google Play Store, your payment is subject to the terms and conditions of the store. You must direct any billing and refund inquiries for such purchases to Apple or Google, as appropriate.
 
 vpn-pricing-what-information = What information does { -brand-name-mozilla-vpn } keep?
 
 # Variables
 #   $principles (url) - link to https://www.mozilla.org/privacy/principles/
 #   $notice (url) - link to https://www.mozilla.org/privacy/subscription-services/
-vpn-pricing-we-adhere-strictly = We adhere strictly to { -brand-name-mozilla }’s <a { $principles }">Data Privacy Principles</a>. We only collect data required to keep { -brand-name-mozilla-vpn } operational and improve the product over time. We also track campaign and referral data on our mobile app to help { -brand-name-mozilla } understand the effectiveness of our marketing campaigns. Read more in our <a { $notice }>Privacy Notice</a>.
+vpn-pricing-we-adhere-strictly = We adhere strictly to { -brand-name-mozilla }’s <a { $principles }>Data Privacy Principles</a>. We only collect data required to keep { -brand-name-mozilla-vpn } operational and improve the product over time. We also track campaign and referral data on our mobile app to help { -brand-name-mozilla } understand the effectiveness of our marketing campaigns. Read more in our <a { $notice }>Privacy Notice</a>.
 
 vpn-pricing-how-do-i-manage = How do I manage my subscription and change my plan?
 


### PR DESCRIPTION
## One-line summary
Fixes a bunch of strings based on feedback in https://github.com/mozilla-l10n/www-l10n/pull/363

## Testing
http://localhost:8000/products/vpn/
http://localhost:8000/products/vpn/features/
http://localhost:8000/products/vpn/pricing/