### PR TITLE
Update glean.js to v3.0.0 and glean_parser to 10.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^2.0.5",
+        "@mozilla/glean": "^3.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2131,9 +2131,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
-      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-3.0.0.tgz",
+      "integrity": "sha512-sOg5syi2DaYlSxOdPFrrnSfkXeNdKy56vAJDTBh8q5rSb5ABIsFqdGWVieft82FYFQCZCnHs++5EcECLstqeKA==",
       "dependencies": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",
@@ -11968,9 +11968,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "@mozilla/glean": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.5.tgz",
-      "integrity": "sha512-9OKK+bUuhfIrDOt5CK/mXQdZ76uSjX68H25JlX0yXBw0b8k+Ft1vdA7ToTjlL4vkgrOymhPLfwMCmEsc1/kX5Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-3.0.0.tgz",
+      "integrity": "sha512-sOg5syi2DaYlSxOdPFrrnSfkXeNdKy56vAJDTBh8q5rSb5ABIsFqdGWVieft82FYFQCZCnHs++5EcECLstqeKA==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^2.0.5",
+    "@mozilla/glean": "^3.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -436,9 +436,9 @@ freezegun==1.2.2 \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f
     # via -r requirements/dev.in
-glean-parser==8.1.1 \
-    --hash=sha256:5fdd123d9711032a4e2acfa7983cbbfa6a53a29f7270dbe52be9e5ee1790a0f8 \
-    --hash=sha256:6d49e0c0aac34a1e9eda7fc63b12f1513efed1c827e0ac94078493114049021e
+glean-parser==10.0.3 \
+    --hash=sha256:d57359629d295f9ee570068a2846966892e3fedb722259ecbcd8cc376d299b51 \
+    --hash=sha256:f8fddd87b24552541318ac037e33750d27d0045131e4f8a60ec13a159fcbdd5c
     # via -r requirements/prod.txt
 greenlet==0.4.17 \
     --hash=sha256:1023d7b43ca11264ab7052cb09f5635d4afdb43df55e0854498fc63070a0b206 \
@@ -770,7 +770,6 @@ markupsafe==2.0.1 \
     # via
     #   -r requirements/prod.txt
     #   django-jinja-markdown
-    #   glean-parser
     #   jinja2
 markus[datadog]==4.2.0 \
     --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -28,7 +28,7 @@ envcat==0.1.1
 everett==3.2.0
 fluent.runtime==0.4.0
 fluent.syntax==0.19.0
-glean-parser==8.1.1  # Must match the required version in the Glean NPM package.
+glean-parser==10.0.3  # Must match the required version in the Glean NPM package.
 greenlet==0.4.17  # Pinned for stability but subdep of Meinheld
 gunicorn==19.7.1
 honcho==1.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -261,9 +261,9 @@ fluent-syntax==0.19.0 \
     # via
     #   -r requirements/prod.in
     #   fluent-runtime
-glean-parser==8.1.1 \
-    --hash=sha256:5fdd123d9711032a4e2acfa7983cbbfa6a53a29f7270dbe52be9e5ee1790a0f8 \
-    --hash=sha256:6d49e0c0aac34a1e9eda7fc63b12f1513efed1c827e0ac94078493114049021e
+glean-parser==10.0.3 \
+    --hash=sha256:d57359629d295f9ee570068a2846966892e3fedb722259ecbcd8cc376d299b51 \
+    --hash=sha256:f8fddd87b24552541318ac037e33750d27d0045131e4f8a60ec13a159fcbdd5c
     # via -r requirements/prod.in
 greenlet==0.4.17 \
     --hash=sha256:1023d7b43ca11264ab7052cb09f5635d4afdb43df55e0854498fc63070a0b206 \
@@ -574,7 +574,6 @@ markupsafe==2.0.1 \
     --hash=sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872
     # via
     #   django-jinja-markdown
-    #   glean-parser
     #   jinja2
 markus[datadog]==4.2.0 \
     --hash=sha256:156398b7de56db4e8ef420a80fcce1c49b6d3d41405874a3e128cb209cf4bfd8 \


### PR DESCRIPTION
## One-line summary

No major changes for us. This new version just temporarily removes web extension support, until the major glean.js refactor for the web is complete.

## Issue / Bugzilla link

N/A

## Testing

- `make preflight`
- `npm start`

http://localhost:8000/en-US/