### PR TITLE
Track stub attribution in GA4

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -562,9 +562,15 @@ if (typeof window.Mozilla === 'undefined') {
 
                     // Send the session ID to GA as non-interaction event.
                     if (data.client_id && data.session_id) {
+                        // UA
                         window.dataLayer.push({
                             event: 'stub-session-id',
                             eLabel: data.session_id
+                        });
+                        // GA4
+                        window.dataLayer.push({
+                            event: 'stub_session_set',
+                            id: data.session_id
                         });
                     }
                 }


### PR DESCRIPTION
## One-line summary

I've been putting off adding stub attribution in GA4 because we can't use the current method we use for extracting client ID once UA is disabled but we might as well start adding what we have currently.

## Significant changes and points to review

Supporting GTM changes are in the `stub_session_set` workspace.
 
## Issue / Bugzilla link

#12801 and https://github.com/mozilla/bedrock/issues/13904

## Testing

[demo4](https://www-demo4.allizom.org/en-US/firefox/)