### PR TITLE
Remove non existant JS bundle from VPN resource article pages (Fixes #13905)

### DIFF
--- a/bedrock/products/templates/products/vpn/more/base-article.html
+++ b/bedrock/products/templates/products/vpn/more/base-article.html
@@ -60,7 +60,3 @@
     {% endcall %}
   </div>
 {% endblock %}
-
-{% block js %}
-  {{ js_bundle('mozilla-vpn-article') }}
-{% endblock %}


### PR DESCRIPTION
## One-line summary

Seems like this bundle no longer exists.

## Issue / Bugzilla link

#13905

## Testing

http://localhost:8000/tr/products/vpn/more/what-is-a-vpn/