### PR TITLE
Instrument actions on CTD page (Fix #13911)

### DIFF
--- a/bedrock/firefox/templates/firefox/challenge-the-default/landing.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/landing.html
@@ -31,11 +31,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% block sub_navigation %}
 {% endblock %}
 
-{% set cta_group %}
-  <a href="{{ url('firefox.set-as-default.thanks')}}" class="is-not-default mzp-c-button mzp-t-lg">Firefox als Standardbrowser festlegen</a>
-  <a href="{{ url('firefox.browsers.mobile.index') }}" class="is-default mzp-c-button mzp-t-lg">Firefox fürs Handy entdecken</a>
-  {{ download_firefox_thanks(button_class='not-firefox', alt_copy='Jetzt Firefox wählen', locale_in_transition=True) }}
-{% endset %}
+{% macro cta_group(position) -%}
+  <a href="{{ url('firefox.set-as-default.thanks')}}" class="is-not-default mzp-c-button mzp-t-lg" data-cta-type="button" data-cta-text="Set as default" data-cta-position="{{ position }}">Firefox als Standardbrowser festlegen</a>
+  <a href="{{ url('firefox.browsers.mobile.index') }}" class="is-default mzp-c-button mzp-t-lg" data-cta-type="button" data-cta-text="Firefox for Mobile" data-cta-position="{{ position }}">Firefox fürs Handy entdecken</a>
+  {{ download_firefox_thanks(button_class='not-firefox', alt_copy='Jetzt Firefox wählen', download_location=position, locale_in_transition=True) }}
+{%- endmacro %}
 
 {% block content %}
 <main class="firefox-home">
@@ -159,7 +159,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
               findest.</p>
               <p class="not-firefox">Mit Firefox entscheidest du dich gegen den Standard und für konsequenten Datenschutz, mehr Transparenz und eine
               Non-Profit im Rücken.</p>
-              {{ cta_group }}
+              {{ cta_group('hero') }}
             </div>
           </div>
           {{ picture(
@@ -400,7 +400,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         </section>
         <div class="comparison-cta">
           <h3>Du entscheidest, was Standard ist</h3>
-          {{ cta_group }}
+          {{ cta_group('comparison') }}
         </div>
       </div>
     </section>
@@ -494,8 +494,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   <section class="mzp-l-content mzp-t-content-md c-ctd-footer">
     <h3>Mach mit!</h3>
-    <p>Wenn du das Internet gemeinsam mit uns besser machen willst, <a href="https://community.mozilla.org/" target="_blank" rel="noopener noreferrer">werde Teil unserer Community</a>.</p>
-    {{ cta_group }}
+    <p>Wenn du das Internet gemeinsam mit uns besser machen willst, <a href="https://community.mozilla.org/" target="_blank" rel="noopener noreferrer" data-cta-type="link" data-cta-text="Community">werde Teil unserer Community</a>.</p>
+    {{ cta_group('footer') }}
     <p class="text-bottom mobile">Powered by Mozilla <br>Aus Liebe zum Web seit 1998</p>
     <p class="text-bottom desktop">Powered by Mozilla. Aus Liebe zum Web seit 1998.</p>
   </section>

--- a/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
+++ b/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
@@ -15,6 +15,7 @@ const heroClose = document.querySelector('.close');
 const animatedButton = document.querySelector('.animated-button');
 const heroEasterEgg = document.querySelector('.hero-easter-egg');
 const animatedLogos = document.querySelectorAll('.ctd-logo-sprite');
+const summaries = document.querySelectorAll('summary');
 let toggleWrapper;
 
 for (let index = 0; index < animatedLogos.length; index++) {
@@ -27,6 +28,33 @@ for (let index = 0; index < animatedLogos.length; index++) {
             setTimeout(() => {
                 logo.style.animation = '';
             }, 4500);
+        },
+        false
+    );
+}
+
+for (let index = 0; index < summaries.length; index++) {
+    const summary = summaries[index];
+    summary.addEventListener(
+        'click',
+        function (e) {
+            let parent = e.target;
+            const label = e.target.innerText;
+            // closest is not supported in IE
+            // but neither is details/summary element so they won't have anything to click on
+            if (parent.nodeName !== 'details' && Element.prototype.closest) {
+                parent = parent.closest('details');
+            } else if (!Element.prototype.closest) {
+                return false;
+            }
+
+            if (!parent.hasAttribute('open')) {
+                window.dataLayer.push({
+                    event: 'in-page-interaction',
+                    eAction: 'Open details',
+                    eLabel: label
+                });
+            }
         },
         false
     );
@@ -50,6 +78,10 @@ kittenButton.addEventListener(
             onDestroy: () => {
                 kittenButton.focus();
             }
+        });
+        window.dataLayer.push({
+            event: 'in-page-interaction',
+            eAction: 'Kitten modal'
         });
     },
     false
@@ -94,6 +126,10 @@ for (let index = 0; index < toggles.length; index++) {
                 input.parentElement.classList.toggle('animate-slide');
             }
             checkToggles();
+            window.dataLayer.push({
+                event: 'in-page-interaction',
+                eAction: 'Toggle change'
+            });
         },
         false
     );
@@ -115,6 +151,11 @@ heroClose.addEventListener(
             heroWrapper.classList.remove('animate-close');
             heroEasterEgg.classList.toggle('hidden');
         }, 4500);
+
+        window.dataLayer.push({
+            event: 'in-page-interaction',
+            eAction: 'Hero close'
+        });
     },
     false
 );
@@ -139,6 +180,11 @@ function isWednesday() {
         lizardImage.style.display = 'none';
         wednesdayWrapper.classList.remove('animate-wednesday');
     }, 5000);
+
+    window.dataLayer.push({
+        event: 'in-page-interaction',
+        eAction: 'Wednesday Lizard View'
+    });
 }
 
 // check toggle state on page load


### PR DESCRIPTION
## One-line summary

Instrument actions on CTD page.

## Significant changes and points to review

- add data attributes to CTA buttons
- add data attributes to link
- send events for easter egg interactions
- send events for summary elements

I only instrumented opening of things, not closing/dismissal of things because that just felt like tracking the same action twice to me.

## Issue / Bugzilla link

#13911

## Testing

http://localhost:8000/de/firefox/

- open the browser console
- click a bunch of stuff
- print the dataLayer to the console to make the clicks have been recorded

