### PR TITLE
Track conversions in GA4 for when Firefox is set to default browser  #13238

### DIFF
--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -326,6 +326,36 @@ You do NOT need to include ``datalayer-productdownload-init.es6.js`` in the page
 in the site bundle.
 
 
+Default Browser
+~~~~~~~~~~~~~~~
+
+Trigger this event when a user sets their default browser to Firefox. It's an important conversion for us!
+
+.. code-block:: javascript
+
+    window.dataLayer.push({
+        event: 'default_browser_set',
+    });
+
+
+User Scoped Custom Dimensions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using GA4 through GTM there isn’t a way to set user scoped custom dimensions without an accompanying event.
+The custom event we use for this is `dimension_set`.
+
+.. code-block:: javascript
+
+    window.dataLayer.push({
+        event: 'dimension_set',
+        firefox_isDefault: true
+    });
+
+User scoped custom dimensions must be configured in GA4. The list of supported custom dimensions is:
+
+- firefox_isDefault (boolean)
+
+
 How can visitors opt out of GA?
 -------------------------------
 

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -348,12 +348,12 @@ The custom event we use for this is `dimension_set`.
 
     window.dataLayer.push({
         event: 'dimension_set',
-        firefox_isDefault: true
+        firefox_is_default: true
     });
 
 User scoped custom dimensions must be configured in GA4. The list of supported custom dimensions is:
 
-- firefox_isDefault (boolean)
+- firefox_is_default (boolean)
 
 
 How can visitors opt out of GA?

--- a/media/js/firefox/set-as-default/thanks.js
+++ b/media/js/firefox/set-as-default/thanks.js
@@ -35,7 +35,7 @@
         });
         window.dataLayer.push({
             event: 'dimension_set',
-            firefox_isDefault: true
+            firefox_is_default: true
         });
     }
 
@@ -83,7 +83,7 @@
                 // GA4
                 window.dataLayer.push({
                     event: 'dimension_set',
-                    firefox_isDefault: true
+                    firefox_is_default: true
                 });
             })
             .catch(function (canSetDefaultBrowserInBackground) {
@@ -106,7 +106,7 @@
                 // GA4
                 window.dataLayer.push({
                     event: 'dimension_set',
-                    firefox_isDefault: false
+                    firefox_is_default: false
                 });
             });
     }

--- a/media/js/firefox/set-as-default/thanks.js
+++ b/media/js/firefox/set-as-default/thanks.js
@@ -27,7 +27,16 @@
 
     function onDefaultSwitch() {
         document.querySelector('main').classList.add('is-firefox-default');
+        // UA
         trackEvent('default-changed', 'success');
+        // GA4
+        window.dataLayer.push({
+            event: 'default_browser_set'
+        });
+        window.dataLayer.push({
+            event: 'dimension_set',
+            firefox_isDefault: true
+        });
     }
 
     function checkForDefaultSwitch() {
@@ -41,6 +50,7 @@
             });
     }
 
+    // UA
     function trackEvent(action, label) {
         window.dataLayer.push({
             event: 'in-page-interaction',
@@ -68,7 +78,13 @@
                 document
                     .querySelector('main')
                     .classList.add('is-firefox-default');
+                // UA
                 trackEvent('visited', 'firefox-default');
+                // GA4
+                window.dataLayer.push({
+                    event: 'dimension_set',
+                    firefox_isDefault: true
+                });
             })
             .catch(function (canSetDefaultBrowserInBackground) {
                 /**
@@ -85,7 +101,13 @@
                         timer = setInterval(checkForDefaultSwitch, 1000);
                     }, 1500);
                 }
+                // UA
                 trackEvent('visited', 'firefox-not-default');
+                // GA4
+                window.dataLayer.push({
+                    event: 'dimension_set',
+                    firefox_isDefault: false
+                });
             });
     }
 

--- a/media/js/firefox/whatsnew/whatsnew-116-eu.js
+++ b/media/js/firefox/whatsnew/whatsnew-116-eu.js
@@ -37,7 +37,7 @@
         // GA4
         window.dataLayer.push({
             event: 'dimension_set',
-            firefox_isDefault: true
+            firefox_is_default: true
         });
     }
 
@@ -55,7 +55,7 @@
         // GA4
         window.dataLayer.push({
             event: 'dimension_set',
-            firefox_isDefault: false
+            firefox_is_default: false
         });
     }
 

--- a/media/js/firefox/whatsnew/whatsnew-116-eu.js
+++ b/media/js/firefox/whatsnew/whatsnew-116-eu.js
@@ -27,10 +27,17 @@
         clearTimeout(timeout);
         document.querySelector('.wnp-main-cta').classList.add('hide');
 
+        // UA
         window.dataLayer.push({
             event: 'non-interaction',
             eAction: 'whatsnew-116',
             eLabel: 'firefox-default'
+        });
+
+        // GA4
+        window.dataLayer.push({
+            event: 'dimension_set',
+            firefox_isDefault: true
         });
     }
 
@@ -38,10 +45,17 @@
         clearTimeout(timeout);
         document.querySelector('.wnp-main-cta').classList.add('show');
 
+        // UA
         window.dataLayer.push({
             event: 'non-interaction',
             eAction: 'whatsnew-116',
             eLabel: 'firefox-not-default'
+        });
+
+        // GA4
+        window.dataLayer.push({
+            event: 'dimension_set',
+            firefox_isDefault: false
         });
     }
 

--- a/media/js/firefox/whatsnew/whatsnew-118.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-118.es6.js
@@ -23,7 +23,7 @@ const FirefoxDefault = {
                     // GA4
                     window.dataLayer.push({
                         event: 'dimension_set',
-                        firefox_isDefault: true
+                        firefox_is_default: true
                     });
                     resolve();
                 } else {
@@ -37,7 +37,7 @@ const FirefoxDefault = {
                     // GA4
                     window.dataLayer.push({
                         event: 'dimension_set',
-                        firefox_isDefault: false
+                        firefox_is_default: false
                     });
                     reject();
                 }

--- a/media/js/firefox/whatsnew/whatsnew-118.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-118.es6.js
@@ -9,17 +9,36 @@ const FirefoxDefault = {
         return new window.Promise((resolve, reject) => {
             FirefoxDefault.tourTimeout = setTimeout(function () {
                 // UITour was too slow to reply
-                FirefoxDefault.showAltCTAButton();
                 resolve();
             }, 1000);
             Mozilla.UITour.getConfiguration('appinfo', (details) => {
                 if (details.defaultBrowser) {
                     // UITour reports Firefox is default browser
-                    FirefoxDefault.showAltCTAButton();
+                    // UA
+                    window.dataLayer.push({
+                        event: 'non-interaction',
+                        eAction: 'whatsnew-118',
+                        eLabel: 'firefox-default'
+                    });
+                    // GA4
+                    window.dataLayer.push({
+                        event: 'dimension_set',
+                        firefox_isDefault: true
+                    });
                     resolve();
                 } else {
                     // UITour reports Firefox is not default browser
-                    FirefoxDefault.showSetDefaultButton();
+                    // UA
+                    window.dataLayer.push({
+                        event: 'non-interaction',
+                        eAction: 'whatsnew-118',
+                        eLabel: 'firefox-not-default'
+                    });
+                    // GA4
+                    window.dataLayer.push({
+                        event: 'dimension_set',
+                        firefox_isDefault: false
+                    });
                     reject();
                 }
             });
@@ -33,23 +52,11 @@ const FirefoxDefault = {
     showSetDefaultButton: () => {
         clearTimeout(FirefoxDefault.tourTimeout);
         document.querySelector('main').classList.add('fx-not-default');
-
-        window.dataLayer.push({
-            event: 'non-interaction',
-            eAction: 'whatsnew-118',
-            eLabel: 'firefox-not-default'
-        });
     },
 
     showAltCTAButton: () => {
         clearTimeout(FirefoxDefault.tourTimeout);
         document.querySelector('main').classList.add('is-firefox-default');
-
-        window.dataLayer.push({
-            event: 'non-interaction',
-            eAction: 'whatsnew-118',
-            eLabel: 'firefox-default'
-        });
     },
 
     init: () => {
@@ -58,21 +65,10 @@ const FirefoxDefault = {
             document.querySelector('main').classList.add('fx-not-default');
             return;
         }
-        return new window.Promise(function (resolve, reject) {
-            FirefoxDefault.isDefaultBrowser()
-                .then(
-                    function () {
-                        FirefoxDefault.showAltCTAButton();
-                        resolve();
-                    },
-                    function () {
-                        document;
-                        FirefoxDefault.showSetDefaultButton();
-                        resolve();
-                    }
-                )
-                .catch(() => reject());
-        });
+
+        FirefoxDefault.isDefaultBrowser()
+            .then(FirefoxDefault.showAltCTAButton)
+            .catch(FirefoxDefault.showSetDefaultButton);
     }
 };
 


### PR DESCRIPTION
## One-line summary

Track conversions in GA4 for when Firefox is set to default browser.

## Significant changes and points to review

- Set the custom user dimensions indicating if Firefox is default.
- Send the conversion event when the default is changed.
- Add docs for `default_browser_set` and `dimension_set`
- Fix bug on WNP 118 where dimension was reported twice

## Issue / Bugzilla link

#13238

## Testing

Local testing can be done to make sure the dataLayer has the expected data:

http://localhost:8000/en-GB/firefox/118.0/whatsnew/
http://localhost:8000/en-GB/firefox/116.0/whatsnew/
http://localhost:8000/en-US/firefox/set-as-default/thanks/
