### PR TITLE
Track experiments in GA4 (#13238)

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -164,19 +164,33 @@ The variable values may be provided by the analytics team.
 .. code-block:: javascript
 
     if (href.indexOf('v=a') !== -1) {
+        // UA
         window.dataLayer.push({
             'data-ex-variant': 'de-page',
             'data-ex-name': 'Berlin-Campaign-Landing-Page'
         });
+        // GA4
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: 'Berlin-Campaign-Landing-Page',
+            variant: 'de-page',
+        });
     } else if (href.indexOf('v=b') !== -1) {
+        // UA
         window.dataLayer.push({
             'data-ex-variant': 'campaign-page',
             'data-ex-name': 'Berlin-Campaign-Landing-Page'
         });
+        // GA4
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: 'Berlin-Campaign-Landing-Page',
+            variant: 'campaign-page',
+        });
     }
 
 Make sure any buttons and interaction which are being compared as part of the
-test and will report into :abbr:`GA (Google Analytics)`.
+test will report into :abbr:`GA (Google Analytics)`.
 
 Viewing the data
 ~~~~~~~~~~~~~~~~~~

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -112,15 +112,29 @@ A/B tests
 
 .. code-block:: javascript
 
-    if(href.indexOf('v=a') !== -1) {
+    if (href.indexOf('v=a') !== -1) {
+        // UA
         window.dataLayer.push({
             'data-ex-variant': 'de-page',
             'data-ex-name': 'Berlin-Campaign-Landing-Page'
         });
+        // GA4
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: 'Berlin-Campaign-Landing-Page',
+            variant: 'de-page',
+        });
     } else if (href.indexOf('v=b') !== -1) {
+        // UA
         window.dataLayer.push({
             'data-ex-variant': 'campaign-page',
             'data-ex-name': 'Berlin-Campaign-Landing-Page'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: 'Berlin-Campaign-Landing-Page',
+            variant: 'campaign-page',
         });
     }
 

--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -48,9 +48,16 @@
                 var validParams = analytics.getAMOExperiment(params);
 
                 if (validParams) {
+                    // UA
                     dataLayer.push({
                         'data-ex-name': validParams['experiment'],
                         'data-ex-variant': validParams['variation']
+                    });
+                    // GA4
+                    dataLayer.push({
+                        event: 'experiment_view',
+                        id: validParams['experiment'],
+                        variant: validParams['variation']
                     });
                 }
             }

--- a/media/js/firefox/set-as-default/landing.js
+++ b/media/js/firefox/set-as-default/landing.js
@@ -13,19 +13,40 @@
     var initTrafficCop = function () {
         if (href.indexOf('v=') !== -1) {
             if (href.indexOf('v=1') !== -1) {
+                // UA
                 window.dataLayer.push({
                     'data-ex-variant': 'v1-pointed',
                     'data-ex-name': 'firefox-set-as-default-experiment'
                 });
+                // GA4
+                window.dataLayer.push({
+                    event: 'experiment_view',
+                    id: 'v1-pointed',
+                    variant: 'firefox-set-as-default-experiment'
+                });
             } else if (href.indexOf('v=2') !== -1) {
+                // UA
                 window.dataLayer.push({
                     'data-ex-variant': 'v2-privacy',
                     'data-ex-name': 'firefox-set-as-default-experiment'
                 });
+                // GA4
+                window.dataLayer.push({
+                    event: 'experiment_view',
+                    id: 'v2-privacy',
+                    variant: 'firefox-set-as-default-experiment'
+                });
             } else if (href.indexOf('v=3') !== -1) {
+                // UA
                 window.dataLayer.push({
                     'data-ex-variant': 'v3-mission',
                     'data-ex-name': 'firefox-set-as-default-experiment'
+                });
+                // GA4
+                window.dataLayer.push({
+                    event: 'experiment_view',
+                    id: 'v3-mission',
+                    variant: 'firefox-set-as-default-experiment'
                 });
             }
         } else if (TrafficCop) {

--- a/media/js/firefox/whatsnew/whatsnew-119-experiment-eu.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-119-experiment-eu.es6.js
@@ -12,19 +12,40 @@ const href = window.location.href;
 const initTrafficCop = () => {
     if (href.indexOf('v=') !== -1) {
         if (href.indexOf('v=1') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp119-boxes-open',
                 'data-ex-name': 'wnp-119-experiment-eu'
             });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-119-experiment-eu',
+                variant: 'wnp119-boxes-open'
+            });
         } else if (href.indexOf('v=2') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp119-boxes-closed',
                 'data-ex-name': 'wnp-119-experiment-eu'
             });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-119-experiment-eu',
+                variant: 'wnp119-boxes-closed'
+            });
         } else if (href.indexOf('v=3') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp119-relay',
                 'data-ex-name': 'wnp-119-experiment-eu'
+            });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-119-experiment-eu',
+                variant: 'wnp119-relay'
             });
         }
     } else if (TrafficCop) {

--- a/media/js/firefox/whatsnew/whatsnew-119-experiment-na.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-119-experiment-na.es6.js
@@ -12,14 +12,28 @@ const href = window.location.href;
 const initTrafficCop = () => {
     if (href.indexOf('v=') !== -1) {
         if (href.indexOf('v=1') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp119-boxes',
                 'data-ex-name': 'wnp-119-experiment-na'
             });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-119-experiment-na',
+                variant: 'wnp119-boxes'
+            });
         } else if (href.indexOf('v=2') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp119-addons',
                 'data-ex-name': 'wnp-119-experiment-na'
+            });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-119-experiment-na',
+                variant: 'wnp119-addons'
             });
         }
     } else if (TrafficCop) {

--- a/media/js/firefox/whatsnew/whatsnew-120-experiment-na.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-120-experiment-na.es6.js
@@ -12,14 +12,28 @@ const href = window.location.href;
 const initTrafficCop = () => {
     if (href.indexOf('v=') !== -1) {
         if (href.indexOf('v=1') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp120-video',
                 'data-ex-name': 'wnp-120-experiment-na'
             });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-120-experiment-na',
+                variant: 'wnp120-video'
+            });
         } else if (href.indexOf('v=2') !== -1) {
+            // UA
             window.dataLayer.push({
                 'data-ex-variant': 'wnp120-no-video',
                 'data-ex-name': 'wnp-120-experiment-na'
+            });
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'wnp-120-experiment-na',
+                variant: 'wnp120-no-video'
             });
         }
     } else if (TrafficCop) {


### PR DESCRIPTION
## One-line summary

Track experiments in GA4

## Significant changes and points to review

- push experiment_view event to dataLayer
- add GA4 syntax to a/b testing docs

None of the currently running test are going to be analyzed in GA4 and so don't need the GA4 syntax added. But I do need a bit of data to verify that it's been coded correctly and try to set up reports. So, I added the GA4 code to a few experiments I thought might still be collecting data.

Also, since people tend to copy-paste from existing experiments I thought it was important to get it there on the WNP ;) 

## Issue / Bugzilla link

#13238

## Testing

Testing can be done locally to make sure that the dataLayer has the expected information

http://localhost:8000/en-GB/firefox/119.0/whatsnew/?v=1
http://localhost:8000/en-GB/firefox/119.0/whatsnew/?v=2
http://localhost:8000/en-GB/firefox/119.0/whatsnew/?v=3
http://localhost:8000/en-US/firefox/119.0/whatsnew/?v=1
http://localhost:8000/en-US/firefox/119.0/whatsnew/?v=2
http://localhost:8000/en-US/firefox/120.0/whatsnew/?v=1
http://localhost:8000/en-US/firefox/120.0/whatsnew/?v=2
http://localhost:8000/en-US/firefox/set-as-default/?v=1
http://localhost:8000/en-US/firefox/set-as-default/?v=2
http://localhost:8000/en-US/firefox/set-as-default/?v=3