### PR TITLE
Add linebreak to VPN banner strings

### DIFF
--- a/l10n/en/banners/vpn-holidays.ftl
+++ b/l10n/en/banners/vpn-holidays.ftl
@@ -7,7 +7,8 @@
 banner-vpn-holidays-title = { -brand-name-mozilla-vpn }
 
 # strong tag is for visual formatting only.
-banner-vpn-holidays-take-20-percent-off = This holiday season <strong>take 20% off the first year</strong>
+# <br> tag is a line-break for visual formatting only.
+banner-vpn-holidays-take-20-percent-off = This holiday season <br> <strong>take 20% off the first year</strong>
 
 # Variables:
 #   $coupon_code (string) - Inserts a coupon code that can be used to apply a discount at checkout e.g. 'HOLIDAY20'.


### PR DESCRIPTION
## One-line summary
Adding linebreak to VPN holiday banner string

![image](https://github.com/mozilla/bedrock/assets/42309026/f9efabd9-e069-4fe4-a892-fc2b2190e207)

## Issue
https://github.com/mozilla-l10n/www-l10n/pull/366#discussion_r1401414623

## Testing
http://localhost:8000/en-US/products/vpn/?entrypoint_experiment=vpn-holidays-na-test&entrypoint_variation=1