### PR TITLE
Fix download button alignment on CTD campaign page (Fixes #13920)

### DIFF
--- a/media/css/firefox/challenge-the-default/_hero.scss
+++ b/media/css/firefox/challenge-the-default/_hero.scss
@@ -233,6 +233,7 @@ $campaign-red: #ff6a75;
             line-height: 1.2;
         }
 
+        .c-button-download-thanks,
         .mzp-c-button-download-privacy-link {
             text-align: left;
         }


### PR DESCRIPTION
## One-line summary

Fixes Firefox download button to be left aligned along with the hero copy.

## Issue / Bugzilla link

#13920

## Testing

Test in a non-Firefox browser: http://localhost:8000/de/firefox/