### PR TITLE
Add CTA creative hero variations (Fixes #13915)

### DIFF
--- a/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v1.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v1.html
@@ -1,0 +1,43 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="c-hero-text">
+  <h1>Der Browser, den du selber wählst</h1>
+  <div class="hero-text-flex-wrapper">
+    <p class="is-firefox">
+      Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
+      Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
+      findest.
+    </p>
+    <p class="not-firefox">
+      Wenn du Firefox wählst, triffst du eine bewusste Entscheidung. Besserer Datenschutz, mehr Transparenz und
+      ein gesünderes Web.
+    </p>
+    {{ cta_group('hero-v1') }}
+  </div>
+</div>
+{{ picture(
+    url='img/firefox/challenge-the-default/hero-image-mobile.png',
+    sources=[
+      {
+        'media': '(max-width: 1023px)',
+        'srcset': {
+          'img/firefox/challenge-the-default/hero-image-mobile.png': 'default'
+        }
+      },
+      {
+        'media': '(min-width: 1024px)',
+        'srcset': {
+          'img/firefox/challenge-the-default/hero-image-desktop.png': 'default'
+        }
+      },
+    ],
+    optional_attributes={
+      'loading': 'eager',
+      'class': 'c-hero-image',
+      'alt': 'Image of a seagull sitting on a no birds allowed sign'
+    }
+)}}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v2.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v2.html
@@ -1,0 +1,21 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="c-hero-text">
+  <h1>Nicht alle <br>Wege <span class="icon-firefox"></span> führen nach Chrome.</h1>
+  <div class="hero-text-flex-wrapper">
+    <p class="is-firefox">
+      Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
+      Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
+      findest.
+    </p>
+    <p class="not-firefox">
+      Wenn du Firefox wählst, triffst du eine bewusste Entscheidung. Besserer Datenschutz, mehr Transparenz und
+      ein gesünderes Web.
+    </p>
+    {{ cta_group('hero-v2') }}
+  </div>
+</div>

--- a/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v3.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v3.html
@@ -1,0 +1,21 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="c-hero-text">
+  <h1>Safari ist ein toller Browser, um <span class="icon-firefox"></span> Firefox runterzuladen.</h1>
+  <div class="hero-text-flex-wrapper">
+    <p class="is-firefox">
+      Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
+      Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
+      findest.
+    </p>
+    <p class="not-firefox">
+      Wenn du Firefox wählst, triffst du eine bewusste Entscheidung. Besserer Datenschutz, mehr Transparenz und
+      ein gesünderes Web.
+    </p>
+    {{ cta_group('hero-v3') }}
+  </div>
+</div>

--- a/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v4.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v4.html
@@ -1,0 +1,21 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="c-hero-text">
+  <h1>Neues Device. Neuer Browser. Neue <span class="icon-firefox"></span> Standards.</h1>
+  <div class="hero-text-flex-wrapper">
+    <p class="is-firefox">
+      Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
+      Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
+      findest.
+    </p>
+    <p class="not-firefox">
+      Wenn du Firefox wählst, triffst du eine bewusste Entscheidung. Besserer Datenschutz, mehr Transparenz und
+      ein gesünderes Web.
+    </p>
+    {{ cta_group('hero-v4') }}
+  </div>
+</div>

--- a/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v5.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/includes/hero-v5.html
@@ -1,0 +1,21 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+<div class="c-hero-text">
+  <h1>Du entscheidest, was <span class="icon-firefox"></span> Standard ist.</h1>
+  <div class="hero-text-flex-wrapper">
+    <p class="is-firefox">
+      Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
+      Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
+      findest.
+    </p>
+    <p class="not-firefox">
+      Wenn du Firefox wählst, triffst du eine bewusste Entscheidung. Besserer Datenschutz, mehr Transparenz und
+      ein gesünderes Web.
+    </p>
+    {{ cta_group('hero-v5') }}
+  </div>
+</div>

--- a/bedrock/firefox/templates/firefox/challenge-the-default/landing.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/landing.html
@@ -38,7 +38,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {%- endmacro %}
 
 {% block content %}
-<main class="firefox-home">
+<main class="firefox-home" {% if variant %}data-variant="{{ variant }}"{% endif %}>
+  {% if variant not in ["2", "3", "4", "5"] %}
   <div class="ctd-mobile-banner">
     {{ resp_img(
         url='img/firefox/challenge-the-default/logo-firefox.svg',
@@ -51,6 +52,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     }}
     <div class="ctd-logo-sprite"></div>
   </div>
+  {% endif %}
   <section class="ctd-hero-wrapper">
     <div class="hidden hero-easter-egg">
       <svg class="toggle-easter-egg" id="elBstU1fviJ1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -133,6 +135,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       <div class="hero-wrapper">
         <div class="c-hero-top">
           <div class="c-hero-top-images">
+            {% if variant not in ["2", "3", "4", "5"] %}
               {{ resp_img(
                 url='img/firefox/challenge-the-default/logo-firefox.svg',
                 optional_attributes={
@@ -143,6 +146,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
                 })
               }}
               <div class="ctd-logo-sprite"></div>
+            {% endif %}
           </div>
           <div class="c-hero-top-controls" aria-hidden="true">
               <span class="hero-control-btn minimize"></span>
@@ -151,14 +155,21 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </div>
         </div>
         <div class="hero-content-wrapper">
+          {% if variant in ["1", "2", "3", "4", "5"] %}
+            {% include 'firefox/challenge-the-default/includes/hero-v' + variant + '.html' %}
+          {% else %}
           <div class="c-hero-text">
             <h1>Der Browser, den du selber wählst</h1>
             <div class="hero-text-flex-wrapper">
-              <p class="is-firefox">Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
-              Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
-              findest.</p>
-              <p class="not-firefox">Mit Firefox entscheidest du dich gegen den Standard und für konsequenten Datenschutz, mehr Transparenz und eine
-              Non-Profit im Rücken.</p>
+              <p class="is-firefox">
+                Eigentlich bewerben wir an dieser Stelle Firefox. Da du den aber schon nutzt, verraten wir dir stattdessen ein
+                Geheimnis: Wir haben ein paar Überraschungen auf dieser Seite versteckt. Klick doch mal rum und guck, ob du etwas
+                findest.
+              </p>
+              <p class="not-firefox">
+                Wenn du Firefox wählst, triffst du eine bewusste Entscheidung. Besserer Datenschutz, mehr Transparenz und
+                ein gesünderes Web.
+              </p>
               {{ cta_group('hero') }}
             </div>
           </div>
@@ -184,11 +195,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
                 'alt': 'Image of a seagull sitting on a no birds allowed sign'
               }
           )}}
+          {% endif %}
         </div>
       </div>
     </div>
   </section>
-
     <section class="mzp-l-content mzp-t-content-xl c-ctd-features">
       <h2>Unsere <br>Lieblingsfeatures</h2>
       <ul class="mzp-l-columns mzp-t-columns-four">

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -822,7 +822,7 @@ class FirefoxHomeView(L10nTemplateView):
     ftl_files_map = {"firefox/home/index-master.html": ["firefox/home"], "firefox/challenge-the-default/landing-switch.html": ["firefox/home"]}
 
     # place expected ?v= values in this list
-    variations = []
+    variations = ["1", "2", "3", "4", "5"]
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -838,11 +838,6 @@ class FirefoxHomeView(L10nTemplateView):
 
     def get_template_names(self):
         locale = l10n_utils.get_locale(self.request)
-        variant = self.request.GET.get("v", None)
-
-        # ensure variant matches pre-defined value
-        if variant not in self.variations:
-            variant = None
 
         if locale == "de":
             template_name = "firefox/challenge-the-default/landing-switch.html"

--- a/media/css/firefox/challenge-the-default/_hero.scss
+++ b/media/css/firefox/challenge-the-default/_hero.scss
@@ -30,7 +30,7 @@ $campaign-red: #ff6a75;
 
     p {
         @include font-size(24px);
-        color: $color-white;
+        color: $color-black;
         font-weight: 600;
         text-align: center;
     }
@@ -223,9 +223,10 @@ $campaign-red: #ff6a75;
 
         p {
             @include font-size(18px);
-            font-weight: 600;
             color: $color-marketing-gray-70;
-            margin-bottom: $layout-sm;
+            font-weight: 600;
+            margin-bottom: $spacing-xl;
+            max-width: $content-md;
         }
 
         .mzp-c-button {
@@ -252,5 +253,90 @@ $campaign-red: #ff6a75;
     // issue 13317
     .fx-unsupported-message {
         @include bidi(((text-align, left, right),));
+    }
+}
+
+// Hero variations for ad conversion see issue 13915
+
+main[data-variant="2"] {
+    .ctd-hero-wrapper,
+    .c-ctd-hero {
+        background: #2AC3A2;
+    }
+}
+
+main[data-variant="3"],
+main[data-variant="4"] {
+    .ctd-hero-wrapper,
+    .c-ctd-hero {
+        background: #FFBDC5;
+    }
+}
+
+main[data-variant="2"],
+main[data-variant="3"],
+main[data-variant="4"],
+main[data-variant="5"] {
+    .c-hero-top {
+        border-color: transparent;
+    }
+
+    .c-ctd-hero {
+        .minimize {
+            background-image: url('/media/img/firefox/challenge-the-default/minimize-black.svg');
+        }
+
+        .expand {
+            background-image: url('/media/img/firefox/challenge-the-default/open-black.svg');
+        }
+
+        .close {
+            background-image: url('/media/img/firefox/challenge-the-default/close-black.svg');
+        }
+
+        .hero-content-wrapper {
+            display: block;
+        }
+
+        .c-hero-text {
+            h1 {
+                @include font-size(38px);
+
+                br {
+                    display: none;
+                }
+            }
+
+            @media #{$mq-md} {
+                max-width: 100%;
+            }
+
+            @media #{$mq-lg} {
+                h1 {
+                    @include font-size(100px);
+
+                    br {
+                        display: inline-block;
+                    }
+                }
+            }
+        }
+    }
+
+    .icon-firefox {
+        @include background-size(40px 40px);
+        background-image: url('/media/protocol/img/logos/firefox/browser/logo.svg');
+        background-position: top left;
+        background-repeat: no-repeat;
+        display: inline-block;
+        height: 40px;
+        vertical-align: middle;
+        width: 40px;
+
+        @media #{$mq-lg} {
+            @include background-size(90px 90px);
+            height: 90px;
+            width: 90px;
+        }
     }
 }

--- a/media/css/firefox/challenge-the-default/index.scss
+++ b/media/css/firefox/challenge-the-default/index.scss
@@ -138,7 +138,6 @@ html:not(.is-firefox) {
     }
 }
 
-
 .ctd-logo-sprite {
     @include image-replaced;
     animation: ctd-sprite 1.25s steps(25);

--- a/media/img/firefox/challenge-the-default/close-black.svg
+++ b/media/img/firefox/challenge-the-default/close-black.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="22" viewBox="0 0 21 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 20L19 3" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
+<path d="M19 20L2 3" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/challenge-the-default/minimize-black.svg
+++ b/media/img/firefox/challenge-the-default/minimize-black.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="22" viewBox="0 0 21 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 20L19 20" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/media/img/firefox/challenge-the-default/open-black.svg
+++ b/media/img/firefox/challenge-the-default/open-black.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="22" viewBox="0 0 21 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2.25" y="3.25" width="16.5" height="16.5" stroke="#000000" stroke-width="2.5"/>
+</svg>

--- a/media/js/firefox/family/fx-is-default.es6.js
+++ b/media/js/firefox/family/fx-is-default.es6.js
@@ -22,18 +22,22 @@ const FirefoxDefault = {
     },
 
     init: () => {
+        const main = document.querySelector('main');
+
         if (!FirefoxDefault.isSupported()) {
             return;
         }
+
         return new window.Promise(function (resolve) {
-            FirefoxDefault.isDefaultBrowser()
-                .then(function () {
-                    document
-                        .querySelector('main')
-                        .classList.add('is-firefox-default');
-                    resolve();
-                })
-                .catch(() => resolve());
+            Mozilla.UITour.ping(() => {
+                main.classList.add('set-default-supported');
+                FirefoxDefault.isDefaultBrowser()
+                    .then(function () {
+                        main.classList.add('is-firefox-default');
+                        resolve();
+                    })
+                    .catch(() => resolve());
+            });
         });
     }
 };

--- a/tests/unit/spec/firefox/family/fx-is-default.js
+++ b/tests/unit/spec/firefox/family/fx-is-default.js
@@ -14,8 +14,13 @@ import FirefoxDefault from '../../../../../media/js/firefox/family/fx-is-default
 describe('fx-is-default.js', function () {
     beforeEach(function () {
         window.Mozilla.UITour = sinon.stub();
+        window.Mozilla.UITour.ping = sinon.stub();
         window.Mozilla.UITour.getConfiguration = sinon.stub();
         document.body.append(document.createElement('main'));
+
+        spyOn(window.Mozilla.UITour, 'ping').and.callFake((callback) => {
+            callback();
+        });
     });
 
     afterEach(function () {


### PR DESCRIPTION
## One-line summary

Adds 4 new variations to the CTD page hero for ad testing

## Issue / Bugzilla link

#13915

## Testing

- http://localhost:8000/de/firefox/?v=1 (control)
- http://localhost:8000/de/firefox/?v=2 (chrome)
- http://localhost:8000/de/firefox/?v=3 (safari)
- http://localhost:8000/de/firefox/?v=4 (new device)
- http://localhost:8000/de/firefox/?v=5 (standard)