### PR TITLE
Update wnp120-na

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx120-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx120-na.html
@@ -41,46 +41,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <section class="wnp-content-main">
   <div class="mzp-l-content mzp-t-content-lg">
     <h2 class="wnp-main-title">Make holiday shopping a breeze with Firefox</h2>
-    {% if variant == "1" %}
-        <div class="mzp-c-video">
-          <a class="video-play js-video-play" href="https://youtu.be/An2LHqi4Xkg" data-id="An2LHqi4Xkg"
-            data-video-title="Shop with confidence using Fakespot by Mozilla " title="Play the video">
-            <img src="{{ static('img/firefox/whatsnew/whatsnew120-na/video-thumbnail.png') }}" alt="" width="769" height="432">
-          </a>
-        </div>
-      {% endif %}
-    <div class="mzp-l-columns mzp-t-columns-three">
-       {% call picto(
-        title="See which reviews are real before buying your gifts",
-        heading_level=4,
-        class='box-one',
-        image=picture(
-          url='img/firefox/whatsnew/whatsnew120-na/light/headphones.svg',
-           sources=[
-            {
-              "media": "(prefers-color-scheme: light)",
-              "srcset": {
-                "img/firefox/whatsnew/whatsnew120-na/light/headphones.svg": "default",
-              }
-            },
-            {
-              "media": "(prefers-color-scheme: dark)",
-              "srcset": {
-                "img/firefox/whatsnew/whatsnew120-na/dark/headphones.svg": "default",
-              }
-            }
-          ],
-          optional_attributes={
-            'class': 'mzp-c-picto-image',
-            'loading': 'lazy'
-          }
-        ),
-        body=True,
-      ) %}
-        <a class="mzp-c-button mzp-t-secondary" href="{{ install_fakespot_url }}" target="_blank" rel="external noopener">
-        {% include 'firefox/whatsnew/includes/fx120/fakespot.svg' %}<span>Install Fakespot</span></a>
-      {% endcall %}
-
+    <div class="mzp-l-columns mzp-t-columns-two">
       {% call picto(
         title="Take your shopping research on-the-go",
         heading_level=4,

--- a/media/js/firefox/whatsnew/whatsnew-120-experiment-na.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-120-experiment-na.es6.js
@@ -41,8 +41,8 @@ const initTrafficCop = () => {
             id: 'wnp-120-expiriment-na',
             cookieExpires: 0,
             variations: {
-                'v=1': 50, // Fakespot video
-                'v=2': 50 // no video
+                'v=1': 0, // Fakespot video
+                'v=2': 100 // no video
             }
         });
         murtaugh.init();


### PR DESCRIPTION
## Summary
- Removes Fakespot column on NA WNP 120 
- Sends all traffic to v2 of the TrafficCop expiriement


![image](https://github.com/mozilla/bedrock/assets/30009669/c5452c36-591b-4cde-8367-c7d2553317f6)




## Issue / Bugzilla link
n/a


## Testing
localhost:8000/en-US/firefox/120.0/whatsnew/