### PR TITLE
Fix #13924: Redirect /foundation/annualreport/ to new SOM report

### DIFF
--- a/bedrock/foundation/urls.py
+++ b/bedrock/foundation/urls.py
@@ -7,7 +7,7 @@ from bedrock.redirects.util import redirect
 
 urlpatterns = (
     # Issue 9727
-    redirect(r"^annualreport/$", "foundation.annualreport.2021.index", name="foundation.annualreport", locale_prefix=False),
+    redirect(r"^annualreport(/2022)?/?$", "https://stateof.mozilla.org/", name="foundation.annualreport", locale_prefix=False),
     # Older annual report financial faqs - these are linked from blog posts
     # was e.g.: http://www.mozilla.org/foundation/documents/mozilla-2008-financial-faq.html
     page("documents/mozilla-2006-financial-faq/", "foundation/documents/mozilla-2006-financial-faq.html"),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1235,5 +1235,7 @@ URLS = flatten(
         url_test("/rise-25/", "https://rise25.mozilla.org/"),
         url_test("/firefox/mobile/get-app/", "/firefox/browsers/mobile/get-app/"),
         url_test("/contact/spaces/paris/", "/contact/spaces/"),
+        # Issue 13924
+        url_test("/foundation/annualreport/{,2022/}", "https://stateof.mozilla.org/"),
     )
 )


### PR DESCRIPTION
Not to be merged until the launch of the new SOM site.