### PR TITLE
Track JS widgets in GA4 (#13238)

### DIFF
--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -77,33 +77,58 @@ When a banner is shown:
 
 .. code-block:: javascript
 
-    dataLayer.push({
+    // UA
+    window.dataLayer.push({
         'eLabel': 'Banner Impression',
         'data-banner-name': '<banner name>', //ex. Fb-Video-Compat
         'data-banner-impression': '1',
         'event': 'non-interaction'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'banner',
+        action: 'display',
+        name: '<banner name>', //ex. Fb-Video-Compat
+        non_interaction: true
     });
 
 When an element in the banner is clicked:
 
 .. code-block:: javascript
 
-    dataLayer.push({
-        'eLabel': 'Banner Clickthrough',
+    // UA
+    window.dataLayer.push({
+        'eLabel': 'Banner Click (OK)',
         'data-banner-name': '<banner name>', //ex. Fb-Video-Compat
         'data-banner-click': '1',
         'event': 'in-page-interaction'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'banner',
+        action: 'clickthrough',
+        name: '<banner name>', //ex. Fb-Video-Compat
     });
 
 When a banner is dismissed:
 
 .. code-block:: javascript
 
+    // UA
     dataLayer.push({
         'eLabel': 'Banner Dismissal',
         'data-banner-name': '<banner name>', //ex. Fb-Video-Compat
         'data-banner-dismissal': '1',
         'event': 'in-page-interaction'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'banner',
+        action: 'dismiss',
+        name: '<banner name>' //ex. Fb-Video-Compat
     });
 
 
@@ -339,6 +364,97 @@ There are two ways to use TrackProductDownload:
 You do NOT need to include ``datalayer-productdownload-init.es6.js`` in the page bundle, it is already included
 in the site bundle.
 
+Widget Action
+~~~~~~~~~~~~~
+
+We are using the custom event ``widget_action`` to track the behaviour of javascript widgets.
+
+
+.. list-table:: How do you chose between ``widget_action`` and ``cta_click``?
+   :widths: 50 50
+   :header-rows: 1
+
+   * - widget_action
+     - cta_click
+   * - The action is specific or unique.
+
+       *(Only the language switcher changes the page language.)*
+     - The action is "click".
+   * - The user does not leave the page.
+     - It sends the user somewhere else.
+   * - It requires Javascript to work.
+     - No JS required.
+   * - It can perform several actions.
+
+       *(A modal can be opened and closed.)*
+     - It does one action.
+   * - There could be several on the page doing different things.
+
+       *(An accordion list of FAQs)*
+     - There could be several on the page doing the same thing.
+
+       *(A download button in the header and footer.)*
+
+Properties for use with `widget_action`  (not all widgets will use all options):
+
+- type
+    - **Required.**
+    - The type of widget.
+    - Examples: "modal", "protection report", "affiliate notification", "help icon".
+    - *Avoid “button” or “link”. If you want to track a link or button use `cta_click`.*
+- action
+    - **Required.**
+    - The thing that happened.
+    - Examples: "open", "accept", "timeout", "vote up".
+    - *Avoid “click”. If you want to track a click use `cta_click`.*
+- name
+    - Give the widget a name.
+    - This can help you group actions from the same widget, or make it easier to find
+      the widget in the reports.
+    - The dashes are not required but they're allowed if you want to match the element
+      class or ID.
+    - Examples: "dad-joke-banner", "focus-qr-code", "Join Firefox Modal"
+- label
+    - How is this action labeled to the user?
+    - Examples: "Okay", "Check your protection report", "Get the app"
+- non_interaction (boolean)
+    - True if the action was triggered by something other than a user gesture.
+    - If it's not included we assume the value is *false*
+
+To use ``widget_action`` push your event to the ``dataLayer``:
+
+.. code-block:: js
+
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'banner',
+        action: 'accept',
+        name: 'dad-jokes-banner'
+    });
+
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'modal',
+        action: 'open',
+        name: 'help-icon'
+        label: 'Get Browser Help'
+    });
+
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'vote',
+        action: 'helpful',
+        name: 'vpn-resource-center'
+        label: 'What is an IP address?'
+    });
+
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'details',
+        action: 'open',
+        name: 'relay-faq'
+        label: 'Where is Relay available?'
+    });
 
 Default Browser
 ~~~~~~~~~~~~~~~

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -370,30 +370,30 @@ Widget Action
 We are using the custom event ``widget_action`` to track the behaviour of javascript widgets.
 
 
-.. list-table:: How do you chose between ``widget_action`` and ``cta_click``?
-   :widths: 50 50
-   :header-rows: 1
+**How do you chose between ``widget_action`` and ``cta_click``?**
 
-   * - widget_action
-     - cta_click
-   * - The action is specific or unique.
++-------------------------------------------------+-------------------------------------------------+
+| widget_action                                   | cta_click                                       |
++=================================================+=================================================+
+| The action is specific or unique.               | The action is "click".                          |
+|                                                 |                                                 |
+| *(Only the language switcher changes*           |                                                 |
+| *the page language.)*                           |                                                 |
++-------------------------------------------------+-------------------------------------------------+
+| The user does not leave the page.               | It sends the user somewhere else.               |
++-------------------------------------------------+-------------------------------------------------+
+| It requires Javascript to work.                 | No JS required.                                 |
++-------------------------------------------------+-------------------------------------------------+
+| It can perform several actions.                 | It does one action.                             |
+|                                                 |                                                 |
+| *(A modal can be opened and closed.)*           |                                                 |
++-------------------------------------------------+-------------------------------------------------+
+| There could be several on the page              | There could be several on the page              |
+| doing different things.                         | doing the same thing.                           |
+|                                                 |                                                 |
+| *(An accordion list of FAQs)*                   | *(A download button in the header and footer.)* |
++-------------------------------------------------+-------------------------------------------------+
 
-       *(Only the language switcher changes the page language.)*
-     - The action is "click".
-   * - The user does not leave the page.
-     - It sends the user somewhere else.
-   * - It requires Javascript to work.
-     - No JS required.
-   * - It can perform several actions.
-
-       *(A modal can be opened and closed.)*
-     - It does one action.
-   * - There could be several on the page doing different things.
-
-       *(An accordion list of FAQs)*
-     - There could be several on the page doing the same thing.
-
-       *(A download button in the header and footer.)*
 
 Properties for use with `widget_action`  (not all widgets will use all options):
 
@@ -414,7 +414,7 @@ Properties for use with `widget_action`  (not all widgets will use all options):
     - The dashes are not required but they're allowed if you want to match the element
       class or ID.
     - Examples: "dad-joke-banner", "focus-qr-code", "Join Firefox Modal"
-- label
+- text
     - How is this action labeled to the user?
     - Examples: "Okay", "Check your protection report", "Get the app"
 - non_interaction (boolean)
@@ -437,7 +437,7 @@ To use ``widget_action`` push your event to the ``dataLayer``:
         type: 'modal',
         action: 'open',
         name: 'help-icon'
-        label: 'Get Browser Help'
+        text: 'Get Browser Help'
     });
 
     window.dataLayer.push({
@@ -445,7 +445,7 @@ To use ``widget_action`` push your event to the ``dataLayer``:
         type: 'vote',
         action: 'helpful',
         name: 'vpn-resource-center'
-        label: 'What is an IP address?'
+        text: 'What is an IP address?'
     });
 
     window.dataLayer.push({
@@ -453,7 +453,7 @@ To use ``widget_action`` push your event to the ``dataLayer``:
         type: 'details',
         action: 'open',
         name: 'relay-faq'
-        label: 'Where is Relay available?'
+        text: 'Where is Relay available?'
     });
 
 Default Browser

--- a/media/js/base/banners/mozilla-banner.js
+++ b/media/js/base/banners/mozilla-banner.js
@@ -41,12 +41,19 @@ if (typeof window.Mozilla === 'undefined') {
         // Set a cookie to not display it again.
         Banner.setCookie(Banner.id);
 
-        // Track the event in GA.
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eLabel: 'Banner Dismissal',
             'data-banner-name': Banner.id,
             'data-banner-dismissal': '1'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'banner',
+            action: 'dismiss',
+            name: Banner.id
         });
     };
 
@@ -70,6 +77,15 @@ if (typeof window.Mozilla === 'undefined') {
 
         // display the banner
         _pageBanner.classList.add('c-banner-is-visible');
+
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'banner',
+            action: 'display',
+            name: Banner.id,
+            non_interaction: true
+        });
 
         // wire up close button
         _pageBanner

--- a/media/js/base/protocol/init-lang-switcher.es6.js
+++ b/media/js/base/protocol/init-lang-switcher.es6.js
@@ -10,9 +10,15 @@
 import MzpLangSwitcher from '@mozilla-protocol/core/protocol/js/lang-switcher';
 
 MzpLangSwitcher.init(function (previousLanguage, newLanguage) {
+    // UA
     window.dataLayer.push({
         event: 'change-language',
         languageSelected: newLanguage,
         previousLanguage: previousLanguage
+    });
+    //GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        action: 'change to' + newLanguage
     });
 });

--- a/media/js/base/protocol/init-lang-switcher.es6.js
+++ b/media/js/base/protocol/init-lang-switcher.es6.js
@@ -19,6 +19,7 @@ MzpLangSwitcher.init(function (previousLanguage, newLanguage) {
     //GA4
     window.dataLayer.push({
         event: 'widget_action',
-        action: 'change to' + newLanguage
+        type: 'language selector',
+        action: 'change to: ' + newLanguage
     });
 });

--- a/media/js/firefox/all/all-downloads-unified-init.es6.js
+++ b/media/js/firefox/all/all-downloads-unified-init.es6.js
@@ -25,10 +25,18 @@ import MzpModal from '@mozilla-protocol/core/protocol/js/modal';
                 className: 'help-modal'
             });
 
+            // UA
             window.dataLayer.push({
                 event: 'in-page-interaction',
                 eAction: 'link click',
                 eLabel: eventLabel
+            });
+            // GA4
+            window.dataLayer.push({
+                event: 'widget_action',
+                type: 'modal',
+                action: 'open',
+                name: eventLabel
             });
         }
 

--- a/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
+++ b/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
@@ -99,7 +99,7 @@ kittenButton.addEventListener(
         window.dataLayer.push({
             event: 'widget_action',
             type: 'easter egg',
-            action: 'click',
+            action: 'discover',
             name: 'kitten modal'
         });
     },
@@ -154,7 +154,7 @@ for (let index = 0; index < toggles.length; index++) {
             window.dataLayer.push({
                 event: 'widget_action',
                 type: 'easter egg',
-                action: 'click',
+                action: 'discover',
                 name: 'animated toggles'
             });
         },
@@ -188,7 +188,7 @@ heroClose.addEventListener(
         window.dataLayer.push({
             event: 'widget_action',
             type: 'easter egg',
-            action: 'click',
+            action: 'discover',
             name: 'close hero'
         });
     },

--- a/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
+++ b/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
@@ -99,7 +99,7 @@ kittenButton.addEventListener(
         window.dataLayer.push({
             event: 'widget_action',
             type: 'easter egg',
-            action: 'discover',
+            action: 'click',
             name: 'kitten modal'
         });
     },
@@ -154,7 +154,7 @@ for (let index = 0; index < toggles.length; index++) {
             window.dataLayer.push({
                 event: 'widget_action',
                 type: 'easter egg',
-                action: 'discover',
+                action: 'click',
                 name: 'animated toggles'
             });
         },
@@ -188,7 +188,7 @@ heroClose.addEventListener(
         window.dataLayer.push({
             event: 'widget_action',
             type: 'easter egg',
-            action: 'discover',
+            action: 'click',
             name: 'close hero'
         });
     },

--- a/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
+++ b/media/js/firefox/challenge-the-default/challenge-the-default.es6.js
@@ -49,10 +49,19 @@ for (let index = 0; index < summaries.length; index++) {
             }
 
             if (!parent.hasAttribute('open')) {
+                // UA
                 window.dataLayer.push({
                     event: 'in-page-interaction',
                     eAction: 'Open details',
                     eLabel: label
+                });
+
+                // GA4
+                window.dataLayer.push({
+                    event: 'widget_action',
+                    type: 'details',
+                    action: 'open',
+                    label: label
                 });
             }
         },
@@ -79,9 +88,19 @@ kittenButton.addEventListener(
                 kittenButton.focus();
             }
         });
+
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'Kitten modal'
+        });
+
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'easter egg',
+            action: 'discover',
+            name: 'kitten modal'
         });
     },
     false
@@ -126,9 +145,17 @@ for (let index = 0; index < toggles.length; index++) {
                 input.parentElement.classList.toggle('animate-slide');
             }
             checkToggles();
+            // UA
             window.dataLayer.push({
                 event: 'in-page-interaction',
                 eAction: 'Toggle change'
+            });
+            // GA4
+            window.dataLayer.push({
+                event: 'widget_action',
+                type: 'easter egg',
+                action: 'discover',
+                name: 'animated toggles'
             });
         },
         false
@@ -152,9 +179,17 @@ heroClose.addEventListener(
             heroEasterEgg.classList.toggle('hidden');
         }, 4500);
 
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'Hero close'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'easter egg',
+            action: 'discover',
+            name: 'close hero'
         });
     },
     false
@@ -181,9 +216,17 @@ function isWednesday() {
         wednesdayWrapper.classList.remove('animate-wednesday');
     }, 5000);
 
+    // UA
     window.dataLayer.push({
         event: 'in-page-interaction',
         eAction: 'Wednesday Lizard View'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'easter egg',
+        action: 'discover',
+        name: 'wednesday lizard'
     });
 }
 

--- a/media/js/firefox/family/banner.es6.js
+++ b/media/js/firefox/family/banner.es6.js
@@ -20,16 +20,32 @@ function showBanner() {
     document.removeEventListener('scroll', showBanner);
     dadJokesBanner.classList.remove('hide-banner');
     dadJokesBanner.classList.add('fade-in-banner');
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'banner',
+        action: 'display',
+        name: 'dad-jokes-banner',
+        non_interaction: true
+    });
     // allow dismissal click
     dadJokesBannerClose.addEventListener('click', hideBanner);
 }
 
 function hideBanner() {
+    // UA
     window.dataLayer.push({
         eLabel: 'Banner Dismissal',
         'data-banner-name': 'firefox-for-families-banner',
         'data-banner-dismissal': '1',
         event: 'in-page-interaction'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'banner',
+        action: 'accept',
+        name: 'dad-jokes-banner'
     });
     // start emoji animation according to user preference
     const userPrefAnimation = motionAllowed()

--- a/media/js/firefox/new/common/thanks-direct.js
+++ b/media/js/firefox/new/common/thanks-direct.js
@@ -70,10 +70,18 @@
         requestComplete = true;
 
         // Fire GA event to log attribution success
+        // UA
         window.dataLayer.push({
             event: 'non-interaction',
             eAction: 'direct-attribution',
             eLabel: 'success'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'direct-attribution',
+            action: 'success',
+            non_interaction: true
         });
 
         beginFirefoxDownload();
@@ -88,10 +96,18 @@
         requestComplete = true;
 
         // Fire GA event to log attribution timeout
+        // UA
         window.dataLayer.push({
             event: 'non-interaction',
             eAction: 'direct-attribution',
             eLabel: 'timeout'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'direct-attribution',
+            action: 'timeout',
+            non_interaction: true
         });
 
         beginFirefoxDownload();

--- a/media/js/firefox/new/desktop/download.js
+++ b/media/js/firefox/new/desktop/download.js
@@ -188,10 +188,18 @@
     function handleOpenProtectionReport(e) {
         e.preventDefault();
 
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'link click',
             eLabel: 'See your protection report'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'protection report',
+            action: 'open',
+            label: 'See your protection report'
         });
 
         Mozilla.UITour.showProtectionReport();

--- a/media/js/firefox/new/desktop/join-modal.js
+++ b/media/js/firefox/new/desktop/join-modal.js
@@ -20,11 +20,19 @@
             className: 'join-firefox-modal'
         });
 
-        // Count the click in GA
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'link click',
             eLabel: 'Current Firefox user downloading Firefox'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'modal',
+            action: 'open',
+            name: 'join-firefox-modal',
+            label: "You've already got the browser"
         });
     }
 

--- a/media/js/firefox/privacy/products.js
+++ b/media/js/firefox/privacy/products.js
@@ -12,10 +12,18 @@
     function handleOpenProtectionReport(e) {
         e.preventDefault();
 
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'link click',
             eLabel: 'See what Firefox has blocked for you'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'protection report',
+            action: 'open',
+            label: 'See what Firefox has blocked for you'
         });
 
         Mozilla.UITour.showProtectionReport();

--- a/media/js/firefox/welcome/welcome6.es6.js
+++ b/media/js/firefox/welcome/welcome6.es6.js
@@ -30,10 +30,18 @@ trigger.addEventListener(
             closeText: window.Mozilla.Utils.trans('global-close')
         });
 
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'link click',
             eLabel: 'Get Firefox for mobile'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'modal',
+            action: 'open',
+            name: 'Get Firefox for mobile'
         });
     },
     false

--- a/media/js/firefox/welcome/welcome8.js
+++ b/media/js/firefox/welcome/welcome8.js
@@ -9,21 +9,38 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'link click',
             eLabel: 'View your protection report'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'protection report',
+            action: 'open',
+            label: 'View your protection report'
         });
         Mozilla.UITour.showProtectionReport();
     }
 
     function handleOpenProtectionReportLink(e) {
         e.preventDefault();
+        // UA
         window.dataLayer.push({
             event: 'in-page-interaction',
             eAction: 'link click',
             eLabel: 'See what`s blocked'
         });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'protection report',
+            action: 'open',
+            label: "See what's blocked"
+        });
+
         Mozilla.UITour.showProtectionReport();
     }
 

--- a/media/js/landing/landing-shared.js
+++ b/media/js/landing/landing-shared.js
@@ -10,9 +10,16 @@
     // test to see if users are clicking on the wordmark in the header of the SEM landing pages
     function handleWordmarkClick(event) {
         var label = event.target.innerText;
+        // UA
         window.dataLayer.push({
             event: 'sem-wordmark-click',
             label: label + ' SEM landing page'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'sem-wordmark-click',
+            label: label
         });
     }
 

--- a/media/js/products/shared/affiliate-init.es6.js
+++ b/media/js/products/shared/affiliate-init.es6.js
@@ -49,11 +49,18 @@ function handleOptOutClick(e) {
             notification.classList.remove('show');
             unbindNotificationEvents();
 
+            // UA
             window.dataLayer.push({
                 eLabel: 'Banner Click (Reject)',
                 'data-banner-name': 'Affiliate notification',
                 'data-banner-click': '1',
                 event: 'in-page-interaction'
+            });
+            // GA4
+            window.dataLayer.push({
+                event: 'widget_action',
+                type: 'affiliate notification',
+                action: 'reject'
             });
         })
         .catch((e) => {
@@ -67,11 +74,18 @@ function handleOkClick(e) {
     notification.classList.remove('show');
     unbindNotificationEvents();
 
+    // UA
     window.dataLayer.push({
         eLabel: 'Banner Click (OK)',
         'data-banner-name': 'Affiliate notification',
         'data-banner-click': '1',
         event: 'in-page-interaction'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'affiliate notification',
+        action: 'accept'
     });
 }
 
@@ -81,11 +95,18 @@ function handleCloseNotification(e) {
     notification.classList.remove('show');
     unbindNotificationEvents();
 
+    // UA
     window.dataLayer.push({
         eLabel: 'Banner Dismissal',
         'data-banner-name': 'Affiliate notification',
         'data-banner-dismissal': '1',
         event: 'in-page-interaction'
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'affiliate notification',
+        action: 'dismiss'
     });
 }
 
@@ -96,11 +117,19 @@ function showOptOutNotification() {
         notification.classList.add('show');
         bindNotificationEvents();
 
+        // UA
         window.dataLayer.push({
             eLabel: 'Banner Impression',
             'data-banner-name': 'Affiliate notification',
             'data-banner-impression': '1',
             event: 'non-interaction'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'widget_action',
+            type: 'affiliate notification',
+            action: 'impression',
+            non_interaction: true
         });
     }
 }

--- a/media/js/products/vpn/resource-center-article.es6.js
+++ b/media/js/products/vpn/resource-center-article.es6.js
@@ -9,10 +9,18 @@ const upvoteBtn = document.querySelector('.vpn-c-vote-btn.up');
 const downvoteBtn = document.querySelector('.vpn-c-vote-btn.down');
 
 function trackVoteInteraction(url, vote) {
+    // UA
     window.dataLayer.push({
         event: 'vpn-article-vote',
         label: url,
         value: vote
+    });
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'vote',
+        action: vote,
+        label: 'Was this article helpful?'
     });
 }
 


### PR DESCRIPTION
## One-line summary

Track JS widgets in GA4 with `widget_action`

## Significant changes and points to review

We currently track JS widgets using a mix of `in-page-interaction`, `non-interaction` and the old UA category/action/label to track user interactions with JS widgets on the page.

This is a generic event meant as a catch-all for existing and future interactions with JS widgets that are not conversions.

- Do the event name, properties, and how to use it make sense?
- Have all the appropriate events been instrumented?
- Is the documentation sufficient?
- Basically, before we're stuck with this forever is there anything that is going to be confusing or annoying?

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13238

## Testing

Files can be viewed locally to see what is being written to the DataLayer.