### PR TITLE
Show country list specific to a progressive rollout, if data exists

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -400,6 +400,13 @@
       {% if release.channel == 'Nightly' and note.bug -%}
       <span class="bug-id"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ note.bug }}">Bug {{ note.bug }}</a></span>
       {%- endif %}
+      {% if note.progressive_rollout and note.relevant_countries %}
+      <div class="relevant-countries">
+        Currently available in:
+        {% for data in note.relevant_countries %}
+            {{data.name}}{% if not loop.last %}, {% endif %}
+        {% endfor %}
+      </div>{% endif %}
     </div>
     {% if note.progressive_rollout %}
     <div class="release-note-progressive-rollout-indicator">

--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -146,6 +146,7 @@ class Note(RNModel):
     created = None
     modified = None
     progressive_rollout = False
+    relevant_countries = []
 
 
 class MarkdownField(models.TextField):

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -307,17 +307,6 @@ $image-path: '/media/protocol/img';
     margin-right: $spacing-sm;
 }
 
-.bug-id {
-    @include bidi(((text-align, right, left),));
-    display: block;
-    margin-bottom: 0;
-
-    p + &,
-    ul + & {
-        margin-top: -1em;
-    }
-}
-
 .developer-more {
     border-bottom: 2px solid $color-marketing-gray-20;
     margin-bottom: $layout-md;
@@ -419,6 +408,17 @@ $image-path: '/media/protocol/img';
 }
 
 .release-note {
+    .bug-id {
+        @include bidi(((text-align, right, left),));
+        display: block;
+        margin-bottom: 0;
+
+        p + &,
+        ul + & {
+            margin-top: -1em;
+        }
+    }
+
     .release-note-progressive-rollout-indicator {
         @include text-body-md;
         text-align: center;

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -419,6 +419,11 @@ $image-path: '/media/protocol/img';
         }
     }
 
+    .relevant-countries {
+        @include text-body-xs;
+        margin-bottom: $spacing-lg;
+    }
+
     .release-note-progressive-rollout-indicator {
         @include text-body-md;
         text-align: center;


### PR DESCRIPTION
## One-line summary

This changeset adds to the 'Progressive Rollout' behaviour added in https://github.com/mozilla/bedrock/pull/13894

Now, if the source data also includes a list of related countries, they will be shown beneath the note, too:

### Screenshots 

**Note: random countries selected for testing - not real data!**


<img width="1073" alt="Screenshot 2023-11-24 at 14 12 29" src="https://github.com/mozilla/bedrock/assets/101457/3cf63a83-e78c-4c5d-9575-0f9d8f30d3f9">
<img width="650" alt="Screenshot 2023-11-24 at 14 19 30" src="https://github.com/mozilla/bedrock/assets/101457/de234908-16d6-4656-bed2-c124f9aa1cff">



## Issue / Bugzilla link

Resolves #13930 
Contributes to https://github.com/mozilla/nucleus/issues/811

## Testing


* Download and unzip  [bedrock-with-rollout-countries-faked-data.db.zip](https://github.com/mozilla/bedrock/files/13460124/bedrock-with-rollout-countries-faked-data.db.zip), rename it to `bedrock.db` and swap it in for your current `bedrock/data/bedrock.db` file -- I've tweaked some release notes to have the expected/future schema and data
* `npm start`
* Go to http://localhost:8000/en-US/firefox/120.0/releasenotes/ and you'll see one items the Progressive Roll Out badge and three test country names beneath it.

## Points to consider

I wondered about putting the country list inside the badge, but there's a risk that it would get very full very easily. Is there a better place to put the list of countries or is it fine where it is?