### PR TITLE
Remove obsolete `data-cta-name` usage

### DIFF
--- a/bedrock/careers/templates/careers/benefits.html
+++ b/bedrock/careers/templates/careers/benefits.html
@@ -16,7 +16,7 @@
           set us apart from other companies in our industry.</p>
 
         <p class="c-careers-button-wrapper">
-          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button" data-cta-name="careers listings">See our open roles</a>
+          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button">See our open roles</a>
         </p>
       </div>
     </div>

--- a/bedrock/careers/templates/careers/home.html
+++ b/bedrock/careers/templates/careers/home.html
@@ -163,7 +163,7 @@
       </p>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.diversity') }}" data-cta-type="button" data-cta-name="careers diversity" class="mzp-c-button mzp-t-secondary">Read more</a>
+        <a href="{{ url('careers.diversity') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">Read more</a>
       </p>
     </div>
   </section>
@@ -264,7 +264,7 @@
       </ul>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.benefits') }}" data-cta-type="button" data-cta-name="careers benefits" class="mzp-c-button mzp-t-secondary">Read more about our benefits</a>
+        <a href="{{ url('careers.benefits') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">Read more about our benefits</a>
       </p>
     </div>
   </section>
@@ -274,7 +274,7 @@
     <div class="c-mozillians-content">
       <h2>See yourself on one of our teams?</h2>
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.listings') }}" data-cta-type="button" data-cta-name="careers listings" class="mzp-c-button mzp-t-dark">Find your role</a>
+        <a href="{{ url('careers.listings') }}" data-cta-type="button" class="mzp-c-button mzp-t-dark">Find your role</a>
       </p>
     </div>
   </section>
@@ -377,7 +377,7 @@
       </ul>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.teams') }}" data-cta-type="button" data-cta-name="careers teams" class="mzp-c-button mzp-t-secondary">View all teams</a>
+        <a href="{{ url('careers.teams') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">View all teams</a>
       </p>
     </div>
   </section>
@@ -400,7 +400,7 @@
       </div>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.locations') }}" data-cta-type="button" data-cta-name="careers locations" class="mzp-c-button mzp-t-secondary">Read more about the future of work at Mozilla</a>
+        <a href="{{ url('careers.locations') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">Read more about the future of work at Mozilla</a>
       </p>
     </div>
   </section>

--- a/bedrock/careers/templates/careers/locations.html
+++ b/bedrock/careers/templates/careers/locations.html
@@ -15,7 +15,7 @@
           choose where they do it.</p>
 
         <div class="c-careers-button-wrapper">
-          <a href="https://blog.mozilla.org/careers/future-of-work-at-mozilla/" class="mzp-c-button mzp-t-dark" data-cta-type="button" data-cta-name="how we work blogpost">Read more about how we work</a>
+          <a href="https://blog.mozilla.org/careers/future-of-work-at-mozilla/" class="mzp-c-button mzp-t-dark" data-cta-type="button">Read more about how we work</a>
         </div>
       </div>
     </div>
@@ -49,7 +49,7 @@
 
       <ul class="c-careers-locations-list">
         <li>
-          <a href="{{ url('mozorg.contact.spaces.berlin') }}" data-cta-type="button" data-cta-name="Berlin office">
+          <a href="{{ url('mozorg.contact.spaces.berlin') }}" data-cta-type="button">
             <div class="c-careers-locations-image-wrapper">
               <img src="{{ static('img/careers/locations/mozilla-berlin.png') }}" alt="" width="200" height="200">
             </div>
@@ -57,7 +57,7 @@
           </a>
         </li>
         <li>
-          <a href="{{ url('mozorg.contact.spaces.toronto') }}" data-cta-type="button" data-cta-name="Toronto office">
+          <a href="{{ url('mozorg.contact.spaces.toronto') }}" data-cta-type="button">
             <div class="c-careers-locations-image-wrapper">
               <img src="{{ static('img/careers/locations/mozilla-toronto.png') }}" alt="" width="200" height="200">
             </div>

--- a/bedrock/careers/templates/careers/teams.html
+++ b/bedrock/careers/templates/careers/teams.html
@@ -15,7 +15,7 @@
           builders and creators working together to keep the internet open and
           accessible to all.</p>
         <div class="c-careers-button-wrapper">
-          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button" data-cta-name="careers listings">See our open roles</a>
+          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button">See our open roles</a>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -89,8 +89,8 @@
         </tbody>
       </table>
 
-      <p>{{ ftl('compare-brave-the-brave-browser-like-so', opera='href="%s" data-cta-type="link" data-cta-name="Opera"'|safe|format(url('firefox.browsers.compare.opera')),
-                 edge='href="%s" data-cta-type="link" data-cta-name="Edge"'|safe|format(url('firefox.browsers.compare.edge'))) }}</p>
+      <p>{{ ftl('compare-brave-the-brave-browser-like-so', opera='href="%s" data-cta-type="link"'|safe|format(url('firefox.browsers.compare.opera')),
+                 edge='href="%s" data-cta-type="link"'|safe|format(url('firefox.browsers.compare.edge'))) }}</p>
 
       <p>{{ ftl('compare-brave-brave-differentiates-itself') }}</p>
 
@@ -102,9 +102,9 @@
 
       <p>{{ ftl('compare-brave-on-the-other-side-of-the-coin', attrs='href="https://addons.mozilla.org/firefox/addon/ublock-origin/" rel="external noopener" data-cta-text="uBlock Origin" data-cta-type="link"'|safe) }}</p>
 
-      <p>{{ ftl('compare-brave-there-are-a-few-of-braves', lockwise='href="%s" data-cta-type="link" data-cta-name="password manager"'|safe|format(url('firefox.features.password-manager')),
+      <p>{{ ftl('compare-brave-there-are-a-few-of-braves', lockwise='href="%s" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')),
           extension='href="https://addons.mozilla.org/addon/https-everywhere/" rel="external noopener" data-cta-text="HTTPS Everywhere" data-cta-type="link"'|safe,
-          privacy='href="%s" data-cta-type="link" data-cta-name="Privacy Report"'|safe|format(url('firefox.privacy.products'))) }}</p>
+          privacy='href="%s" data-cta-type="link"'|safe|format(url('firefox.privacy.products'))) }}</p>
 
       <p>{{ ftl('compare-brave-the-bottom-line-is-that-even') }}</p>
 
@@ -241,7 +241,7 @@
         <p>
           {{ ftl('compare-brave-the-firefox-browser-also-gives-v3',
                 fallback='compare-brave-the-firefox-browser-also-gives',
-                accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
+                accounts='href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts')),
                 monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
                 breaches='href="https://monitor.firefox.com/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe
           ) }}
@@ -250,7 +250,7 @@
         <p>
           {{ ftl('compare-brave-the-firefox-browser-also-gives-v2',
                   fallback='compare-brave-the-firefox-browser-also-gives',
-                  accounts='href="%s" data-cta-type="link" data-cta-name="Firefox Account"'|safe|format(url('firefox.accounts')),
+                  accounts='href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts')),
                   monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
                   breaches='href="https://monitor.firefox.com/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe
           ) }}

--- a/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
@@ -108,7 +108,7 @@
         {% endif %}
       </p>
 
-      <p>{{ ftl('compare-chrome-weve-also-recently-restated-v2', attrs='href="%s" data-cta-type="link" data-cta-name="Privacy Notice"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-chrome-weve-also-recently-restated-v2', attrs='href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       <p>{{ ftl('compare-chrome-google-chrome-is-by-all-accounts') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/edge.html
@@ -93,7 +93,7 @@
 
       <p>{{ ftl('compare-edge-edge-is-integrated-into-the') }}</p>
 
-      <p>{{ ftl('compare-edge-at-firefox-we-pride-ourselves', fallback='compare-edge-at-firefox-our-privacy-fallback', attrs='href="%s" data-cta-type="link" data-cta-name="privacy policy"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-edge-at-firefox-we-pride-ourselves', fallback='compare-edge-at-firefox-our-privacy-fallback', attrs='href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       <img src="{{ static('img/firefox/compare/compare-privacy-eyes.svg') }}" alt="" height="217" width="320" class="compare-details-image">
 
@@ -180,7 +180,7 @@
 
       <p>{{ ftl('compare-edge-edge-has-some-nice-ui-features') }}</p>
 
-      <p>{{ ftl('compare-edge-firefox-features-a-scrolling', attrs='href="%s" data-cta-type="link" data-cta-name="Pocket feature"'|safe|format(url('firefox.pocket'))) }}</p>
+      <p>{{ ftl('compare-edge-firefox-features-a-scrolling', attrs='href="%s" data-cta-type="link"'|safe|format(url('firefox.pocket'))) }}</p>
 
       <p>{{ ftl('compare-edge-firefox-and-edge-both-offer', fallback='compare-edge-firefox-and-edge-both-offer-fallback') }}</p>
 
@@ -236,7 +236,7 @@
 
       <p>{{ ftl('compare-edge-with-internet-explorer-microsoft', fallback='compare-edge-with-internet-explorer-fallback') }}</p>
 
-      <p>{{ ftl('compare-edge-firefox-has-been-available', attrs='href="%s" data-cta-type="link" data-cta-name="free account"'|safe|format(url('firefox.accounts'))) }}</p>
+      <p>{{ ftl('compare-edge-firefox-has-been-available', attrs='href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts'))) }}</p>
 
       <p>{{ ftl('compare-edge-edge-also-allows-you-to-connect', fallback='compare-edge-edge-also-allows-you-to-fallback') }}</p>
 
@@ -249,7 +249,7 @@
         <h2>{{ ftl('compare-shared-overall-assessment') }}</h2>
       </header>
 
-      <p>{{ ftl('compare-edge-aside-from-sucking-up-a-lot', attrs='href="%s" data-cta-type="link" data-cta-name="Mozilla"'|safe|format(url('mozorg.home'))) }}</p>
+      <p>{{ ftl('compare-edge-aside-from-sucking-up-a-lot', attrs='href="%s" data-cta-type="link"'|safe|format(url('mozorg.home'))) }}</p>
 
       <p>{{ ftl('compare-edge-the-bottom-line-is-that-while') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -93,14 +93,14 @@
           </tbody>
         </table>
 
-      <p>{{ ftl('compare-ie-if-you-havent-moved-on-from-using', attrs='href="https://www.telegraph.co.uk/technology/2019/02/08/stop-using-internet-explorer-warns-microsofts-security-chief/" rel="external noopener" data-cta-type="link" data-cta-name="Microsoft security chief warned"'|safe) }}</p>
+      <p>{{ ftl('compare-ie-if-you-havent-moved-on-from-using', attrs='href="https://www.telegraph.co.uk/technology/2019/02/08/stop-using-internet-explorer-warns-microsofts-security-chief/" rel="external noopener" data-cta-type="link"'|safe) }}</p>
 
       <p>{{ ftl('compare-ie-microsoft-is-no-longer-supporting') }}</p>
 
       <img src="{{ static('img/firefox/compare/compare-privacy-locks.svg') }}" alt="" height="217" width="320" class="compare-details-image">
 
-      <p>{{ ftl('compare-ie-so-whats-the-solution-if-your', fallback='compare-ie-so-whats-the-solution-if-your-fallback', lockwise='href="%s" data-cta-type="link" data-cta-name="password manager"'|safe|format(url('firefox.features.password-manager')),
-                 privacy='href="%s" data-cta-type="link" data-cta-name="privacy policy"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-ie-so-whats-the-solution-if-your', fallback='compare-ie-so-whats-the-solution-if-your-fallback', lockwise='href="%s" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')),
+                 privacy='href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       {% include '/firefox/browsers/compare/includes/download-menu-list.html' %}
 
@@ -178,8 +178,8 @@
       <p>{{ ftl('compare-ie-really-the-only-reasons-to-use') }}</p>
 
       <p>
-        {{ ftl('compare-ie-on-the-other-end-of-the-spectrum', fallback='compare-ie-on-the-other-end-of-the-spectrum-fallback', pocket='href="%s" data-cta-type="link" data-cta-name="Pocket"'|safe|format(url('firefox.pocket')),
-                 products='href="%s" data-cta-type="link" data-cta-name="our other Firefox products"'|safe|format(url('firefox'))) }}
+        {{ ftl('compare-ie-on-the-other-end-of-the-spectrum', fallback='compare-ie-on-the-other-end-of-the-spectrum-fallback', pocket='href="%s" data-cta-type="link"'|safe|format(url('firefox.pocket')),
+                 products='href="%s" data-cta-type="link"'|safe|format(url('firefox'))) }}
       </p>
 
       {% include '/firefox/browsers/compare/includes/download-menu-list.html' %}
@@ -245,7 +245,7 @@
 
       <p>
         {# Download link should be locale neutral. See issue #7982 #}
-        {{ ftl('compare-ie-our-opinion-is-just-to-go-with', attrs='href="/firefox/download/thanks/" data-cta-type="link" data-cta-name="download Firefox"'|safe) }}
+        {{ ftl('compare-ie-our-opinion-is-just-to-go-with', attrs='href="/firefox/download/thanks/" data-cta-type="link"'|safe) }}
       </p>
 
       <div class="compare-content compare-version-disclaimer">

--- a/bedrock/firefox/templates/firefox/browsers/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/opera.html
@@ -93,7 +93,7 @@
 
       <p>{{ ftl('compare-opera-operas-privacy-policy-lacks', fallback='compare-opera-operas-privacy-policy-lacks-fallback') }}</p>
 
-      <p>{{ ftl('compare-opera-firefoxs-privacy-policy-is', attrs = 'href="%s" data-cta-type="link" data-cta-name="privacy policy"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-opera-firefoxs-privacy-policy-is', attrs = 'href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       <p>{{ ftl('compare-opera-as-far-as-actual-privacy-protections') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -101,7 +101,7 @@
 
       <p>{{ ftl('compare-safari-our-private-browsing-mode', attrs='href="https://addons.mozilla.org/firefox/addon/facebook-container/" rel="external noopener" data-cta-text="Facebook Container" data-cta-type="link"'|safe) }}</p>
 
-      <p>{{ ftl('compare-safari-as-far-as-security-goes-firefox', lockwise='href="%s" data-cta-type="link" data-cta-name="password manager"'|safe|format(url('firefox.features.password-manager')), monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe) }}</p>
+      <p>{{ ftl('compare-safari-as-far-as-security-goes-firefox', lockwise='href="%s" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')), monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe) }}</p>
 
       <p>{{ ftl('compare-safari-if-you-choose-to-use-safari') }}</p>
 
@@ -238,7 +238,7 @@
 
       <p>{{ ftl('compare-safari-firefox-and-safari-both-provide') }}</p>
 
-      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v3', fallback='compare-safari-firefox-also-offers-a-similar-updated', attrs = 'href="%s" data-cta-type="link" data-cta-name="Mozilla account"'|safe|format(url('firefox.accounts'))) }}</p>
+      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v3', fallback='compare-safari-firefox-also-offers-a-similar-updated', attrs = 'href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts'))) }}</p>
 
       <p>{{ ftl('compare-safari-the-firefox-app-for-ios-and', ios='href="%s" rel="external noopener" data-cta-text="iOS" data-cta-type="link"'|safe|format(app_store_url('firefox')),
               android='href="%s" rel="external noopener" data-cta-text="Android" data-cta-type="link"'|safe|format(play_store_url('firefox'))) }}</p>

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -169,6 +169,21 @@ For all generic CTA links and ``<button>`` elements, add these data attributes
 | ``data-cta-position`` | Location of CTA on the page (e.g. ``primary``, ``secondary``, ``header``) |
 +-----------------------+---------------------------------------------------------------------------+
 
+For all links to accounts.firefox.com use these data attributes (* indicates a required attribute):
+
++-----------------------+----------------------------------------------------------------------------------+
+| Data Attribute        | Expected Value                                                                   |
++=======================+==================================================================================+
+| ``data-cta-type`` *   | fxa-servicename (e.g. ``fxa-sync``, ``fxa-monitor``)                             |
++-----------------------+----------------------------------------------------------------------------------+
+| ``data-cta-text``     | Name or text of the link (e.g. ``Sign Up``, ``Join Now``, ``Start Here``).       |
+|                       |                                                                                  |
+|                       | We use this when the link text is not useful, as is the case with many           |
+|                       | account forms that say, ``Continue``. We replace ``Continue`` with ``Register``. |
++-----------------------+----------------------------------------------------------------------------------+
+| ``data-cta-position`` | Location of CTA on the page (e.g. ``primary``, ``secondary``, ``header``)        |
++-----------------------+----------------------------------------------------------------------------------+
+
 For Firefox download buttons, add these data attributes (* indicates a required attribute).
 Note that ``data-download-name`` and ``data-download-version`` should be included for download
 buttons that serve multiple platforms. For mobile specific store badges, they are not strictly
@@ -187,30 +202,6 @@ required.
 +----------------------------+-------------------------------------------------------------------------------------------------------------+
 | ``data-download-location`` | ``primary``, ``secondary``, ``nav``, ``other``                                                              |
 +----------------------------+-------------------------------------------------------------------------------------------------------------+
-
-For all links to accounts.firefox.com use these data attributes (* indicates a required attribute):
-
-+-----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Data Attribute        | Expected Value                                                                                                                                                                                                                     |
-+=======================+====================================================================================================================================================================================================================================+
-| ``data-cta-type`` *   | fxa-servicename (e.g. ``fxa-sync``, ``fxa-monitor``)                                                                                                                                                                               |
-+-----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``data-cta-text``     | Name or text of the link (e.g. ``Sign Up``, ``Join Now``, ``Start Here``). We use this when the link text is not useful, as is the case with many account forms that say, ``Continue``. We replace ``Continue`` with ``Register``. |
-+-----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``data-cta-position`` | Location of CTA on the page (e.g. ``primary``, ``secondary``, ``header``)                                                                                                                                                          |
-+-----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-
-**Old data-cta structure**
-
-Do not use. Included here because some old pages still use it.
-
-``data-cta-type=""`` and ``data-cta-name=""`` trigger a generic link / button
-click with the following structure:
-
-- Event Category: ``{{page ID}} Interactions``
-- Event Action: ``{{data-cta-type}} click``
-- Event Label: ``{{data-cta-name}}``
 
 
 GA4


### PR DESCRIPTION
## One-line summary

As far as I can tell from GTM and UA, the `data-cta-name` value is not being recorded anywhere. Removing the unused data-attribute does not change how these CTAs are recorded in UA or GA4 and makes our docs less confusing.

## Issue / Bugzilla link

#13238 


