### PR TITLE
Fix hard-coded strings in VPN pages (Fixes #13935, #13934)

### DIFF
--- a/bedrock/products/templates/products/vpn/features.html
+++ b/bedrock/products/templates/products/vpn/features.html
@@ -327,7 +327,7 @@
       {% endcall %}
 
       {% call picto(
-        title='We never log, track or share your network data',
+        title=ftl('vpn-features-we-never-log'),
         image=resp_img(
           url='img/products/vpn/features/icons/eye.svg',
           optional_attributes={

--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -119,14 +119,14 @@
       <p>
         {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
         <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="{{ position }}">
-          Get Mozilla VPN
+          {{ ftl('vpn-shared-subscribe-link') }}
         </a>
       </p>
-      <p class="c-guarantee">30-day money-back guarantee</p>
+      <p class="c-guarantee">{{ ftl('vpn-shared-features-guarantee') }}</p>
     {% else %}
       <p>
         <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist">
-          Join the Waitlist
+          {{ ftl('vpn-shared-waitlist-link') }}
         </a>
       </p>
     {% endif %}


### PR DESCRIPTION
## One-line summary

Looks like there were still some hard coded English strings in the redesigned VPN pages. Thankfully the strings were already exposed, so an easy fix.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13935
https://github.com/mozilla/bedrock/issues/13934

## Testing

- http://localhost:8000/it/products/vpn/
- http://localhost:8000/it/products/vpn/features/