### PR TITLE
Update GitHub actions to use Node 20 (Fixes #13827)

### DIFF
--- a/.github/actions/slack/action.yaml
+++ b/.github/actions/slack/action.yaml
@@ -54,7 +54,7 @@ runs:
         esac" >> $GITHUB_ENV
 
     - id: slack-notification
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v1.24.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
       with:

--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack that tests are starting
         uses: ./.github/actions/slack
         with:
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Fetch codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run CDN tests
         run: ./bin/integration_tests/functional_tests.sh
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notify-of-test-run-start, cdn-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack of test-run outcome
         uses: ./.github/actions/slack
         with:

--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # this means that it is a full history clone, not a shallow one
           # heroku push fails with a shallow clone

--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack that tests are starting
         uses: ./.github/actions/slack
         with:
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Fetch codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run functional download tests
         run: ./bin/integration_tests/functional_tests.sh
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notify-of-test-run-start, download-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack of test-run outcome
         uses: ./.github/actions/slack
         with:

--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ jobs:
   notify-of-test-run-start:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack that tests are starting
         uses: ./.github/actions/slack
         with:
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Fetch codebase
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Sets specific env vars IF we're on testing against dev/main only
         if: ${{ github.event.inputs.branch == 'main'}}
         run: |
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notify-of-test-run-start, integration-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack of test-run outcome
         uses: ./.github/actions/slack
         with:

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install chromium-browser firefox xvfb
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: "Install JS dependencies"
@@ -29,7 +29,7 @@ jobs:
   test-python:
     runs-on: ubuntu-20.04  # For consistency with above
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"  # matches current Python in production

--- a/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run PR-opening script
         shell: bash
         run: SITE_MODE=Mozorg FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh

--- a/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run PR opening script
         shell: bash
         run: SITE_MODE=Pocket FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh


### PR DESCRIPTION
## One-line summary

Example warnings: https://github.com/mozilla/bedrock/actions/runs/6643145516

Related blog post: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

## Significant changes and points to review

Not sure how to best test this. Does it make sense to split into smaller PRs, or should we just merge and see how things go?

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13827