### PR TITLE
Update bedrock to build using Node v20 (Fixes #13938)

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: "Install JS dependencies"
         run: npm ci
       - name: "Run JS tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --require-hashes --no-cache-dir -r requirements/prod.txt
 ########
 # assets builder and dev server
 #
-FROM node:18-slim AS assets
+FROM node:20-slim AS assets
 
 ENV PATH=/app/node_modules/.bin:$PATH
 WORKDIR /app


### PR DESCRIPTION
## One-line summary

Updated bedrock to build using Node v20 in both Docker and CI

## Issue / Bugzilla link

#13938

## Testing

Successful test run: https://github.com/mozilla/bedrock/actions/runs/7016709616