### PR TITLE
[Jan 8] Include attribution data with macOS Nightly links (Fixes #12761)

### DIFF
--- a/docs/attribution/0002-firefox-desktop.rst
+++ b/docs/attribution/0002-firefox-desktop.rst
@@ -13,9 +13,9 @@ that enables Mozilla to link website attributable referral data (including Googl
 Analytics data) to a user's Firefox profile. When a website visitor lands on
 www.mozilla.org and clicks to download Firefox, we pass attribution data about
 their visit to the Firefox installer for inclusion in `Telemetry`_. This is to
-enable Mozilla to better understand how things like changes to our website and
-different marketing campaigns can affect installation rates, as well as overall
-product retention. The data also gives us an insight into how many installations
+enable Mozilla to better understand how changes to our website and different
+marketing campaigns can affect installation rates, as well as overall product
+retention. The data also gives us an insight into how many installations
 originate from www.mozilla.org, as opposed to elsewhere on the internet.
 
 Scope and requirements
@@ -23,10 +23,9 @@ Scope and requirements
 
 - Attribution was originally only possible via the Firefox stub installer on Windows
   (hence the name *stub attribution*), however it now also works on full installer
-  links, and across all Windows desktop release channels.
-- Attribution is still limited to devices running a Windows OS. The flow does not
-  yet work for macOS and Linux users. It also does not work for Android or iOS
-  devices.
+  links, and across all desktop release channels.
+- Attribution now also works on macOS. The flow does not yet work for Linux, Android
+  or iOS devices.
 - Attribution will only be passed if a website visitor has their
   `Do Not Track (DNT)`_ preference disabled in their browser. Visitors can opt-out
   by enabling DNT. This is covered in our `privacy policy`_.

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -174,6 +174,17 @@ if (typeof window.Mozilla === 'undefined') {
                         data
                     );
                 }
+                // Append attribution params to macOS Firefox Nightly links.
+                if (
+                    version &&
+                    /osx/.test(version) &&
+                    link.href.indexOf('product=firefox-nightly-latest') !== -1
+                ) {
+                    link.href = Mozilla.StubAttribution.appendToDownloadURL(
+                        link.href,
+                        data
+                    );
+                }
             } else if (
                 link.href &&
                 link.href.indexOf('/firefox/download/thanks/') !== -1
@@ -492,7 +503,7 @@ if (typeof window.Mozilla === 'undefined') {
 
     /**
      * Determines if requirements for stub attribution to work are satisfied.
-     * Stub attribution is only applicable to Windows users who get the stub installer.
+     * Stub attribution is only applicable to Windows/macOS users on desktop.
      * @return {Boolean}.
      */
     StubAttribution.meetsRequirements = function () {
@@ -508,7 +519,7 @@ if (typeof window.Mozilla === 'undefined') {
             return false;
         }
 
-        if (window.site.platform !== 'windows') {
+        if (!/windows|osx/i.test(window.site.platform)) {
             return false;
         }
 

--- a/media/js/firefox/all/all-downloads-unified.js
+++ b/media/js/firefox/all/all-downloads-unified.js
@@ -272,7 +272,7 @@
     };
 
     /**
-     * Append Firefox attribution params for windows downloads.
+     * Append Firefox attribution params for Windows and macOS downloads.
      */
     FirefoxDownloader.onDownloadButtonClick = function (e) {
         e.preventDefault();
@@ -281,6 +281,15 @@
         var version = el.getAttribute('data-download-version');
 
         if (version && /win/.test(version)) {
+            url = FirefoxDownloader.setAttributionURL(e.target.href);
+        }
+
+        // macOS Nightly only for now.
+        if (
+            version &&
+            /osx/.test(version) &&
+            url.indexOf('product=firefox-nightly-latest') !== -1
+        ) {
             url = FirefoxDownloader.setAttributionURL(e.target.href);
         }
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -252,8 +252,13 @@ describe('stub-attribution.js', function () {
             expect(Mozilla.StubAttribution.meetsRequirements()).toBeFalsy();
         });
 
-        it('should return false if platform is not windows', function () {
-            window.site.platform = 'osx';
+        it('should return false if platform is not windows or macOS', function () {
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
+            window.site.platform = 'linux';
+            expect(Mozilla.StubAttribution.meetsRequirements()).toBeFalsy();
+            window.site.platform = 'ios';
+            expect(Mozilla.StubAttribution.meetsRequirements()).toBeFalsy();
+            window.site.platform = 'android';
             expect(Mozilla.StubAttribution.meetsRequirements()).toBeFalsy();
         });
 
@@ -264,6 +269,12 @@ describe('stub-attribution.js', function () {
 
         it('should return true for windows users who satisfy all other requirements', function () {
             window.site.platform = 'windows';
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
+            expect(Mozilla.StubAttribution.meetsRequirements()).toBeTruthy();
+        });
+
+        it('should return true for macOS users who satisfy all other requirements', function () {
+            window.site.platform = 'osx';
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             expect(Mozilla.StubAttribution.meetsRequirements()).toBeTruthy();
         });
@@ -847,6 +858,8 @@ describe('stub-attribution.js', function () {
             'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US';
         const win64DevUrl =
             'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US';
+        const macOSNightlyUrl =
+            'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US';
 
         beforeEach(function () {
             const downloadMarkup = `<ul class="download-list">
@@ -859,6 +872,7 @@ describe('stub-attribution.js', function () {
                     <li><a id="link-dev-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winDevUrl}">Download</a></li>
                     <li><a id="link-dev-direct-win" class="download-link" data-download-version="win" href="${winDevUrl}">Download</a></li>
                     <li><a id="link-dev-direct-win64" class="download-link" data-download-version="win64" href="${win64DevUrl}">Download</a></li>
+                    <li><a id="link-macos-nightly" class="download-link" data-download-version="osx" href="${macOSNightlyUrl}">Download</a></li>
                 </ul>`;
 
             document.body.insertAdjacentHTML('beforeend', downloadMarkup);
@@ -927,6 +941,11 @@ describe('stub-attribution.js', function () {
                 document.getElementById('link-dev-direct-win64').href
             ).toEqual(
                 'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+
+            // macOS Nightly links
+            expect(document.getElementById('link-macos-nightly').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
         });
 


### PR DESCRIPTION
## One-line summary

Enables Firefox desktop attribution for macOS download/installer links (Nightly only for now).

## Issue / Bugzilla link

#12761

## Testing

> [!IMPORTANT]
> Test in a browser with DNT disabled

1. Next, open https://www-demo3.allizom.org/en-US/firefox/channel/desktop/.
2. Verify that the Nightly download link also contains `attribution_code` and `attribution_sig` parameters.
3. Verify that the Beta / Dev download links do not contain attribution params.