### PR TITLE
Test pricing position on VPN landing page

### DIFF
--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -41,6 +41,8 @@ switch('vpn-events-banner') %}
 {% block experiments %}
   {% if holidays_na_banner_experiment %}
     {{ js_bundle('mozilla-vpn-holidays-na-experiment-banner') }}
+  {% elif switch('experiment-vpn-pricing-position') %}
+    {{ js_bundle('mozilla-vpn-landing-pricing-position-experiment') }}
   {% endif %}
 {% endblock %}
 
@@ -162,6 +164,8 @@ switch('vpn-events-banner') %}
       <a href="{{ url('products.vpn.features') }}">{{ ftl('vpn-landing-see-all-the-ways-mozilla-vpn') }}</a>
     </p>
   {% endcall %}
+
+  {% block top_pricing_position %}{% endblock %}
 
   <section class="c-how-vpn-helps mzp-l-content mzp-t-content-xl">
     <h2 class="c-section-title">{{ ftl('vpn-landing-how-a-vpn-helps-you') }}</h2>
@@ -315,6 +319,8 @@ switch('vpn-events-banner') %}
     <p>{{ ftl('vpn-landing-mozilla-is-a-non-profit-backed') }}</p>
   {% endcall %}
 
+  {% block default_pricing_position %}
+  {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
   <section id="pricing" class="mzp-l-content mzp-t-content-xl">
     {% if vpn_available %}
       <header class="c-pricing-main-header">
@@ -333,6 +339,7 @@ switch('vpn-events-banner') %}
       </header>
     {% endif %}
   </section>
+  {% endblock %}
 
   {% include 'products/vpn/includes/press.html' %}
 

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -41,6 +41,8 @@ switch('vpn-events-banner') %}
 {% block experiments %}
   {% if holidays_na_banner_experiment %}
     {{ js_bundle('mozilla-vpn-holidays-na-experiment-banner') }}
+  {% elif switch('experiment-vpn-pricing-position') %}
+    {{ js_bundle('mozilla-vpn-landing-pricing-position-experiment') }}
   {% endif %}
 {% endblock %}
 
@@ -93,7 +95,6 @@ switch('vpn-events-banner') %}
   {% endblock %}
 
   <div class="mzp-l-content mzp-t-content-xl">
-
     {% call vpn_content_media(
       heading=ftl('vpn-landing-privacy-heading'),
       image=resp_img(
@@ -111,6 +112,8 @@ switch('vpn-events-banner') %}
     ) %}
       <p>{{ ftl('vpn-landing-privacy-desc') }}</p>
     {% endcall %}
+
+    {% block top_pricing_position %}{% endblock %}
 
     {% call vpn_content_media(
       heading=ftl('vpn-landing-fast-secure-heading'),
@@ -230,42 +233,43 @@ switch('vpn-events-banner') %}
           </a>
         {% endcall %}
       </div>
-
     {% endif %}
 
-    {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
-    <div id="pricing" class="mzp-is-anchor-link">
-      {% if vpn_available %}
-        {% include 'products/vpn/includes/pricing-plus-relay.html' %}
-      {% else %}
-        <div class="vpn-waitlist-feature-block">
-          {% call vpn_content_block(
-            class_name='vpn-content-block-price t-highlight'
-          ) %}
-          <div class="l-columns-two">
-            <div class="l-column-first">
-              <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="secondary">
-                {{ ftl('vpn-shared-waitlist-link') }}
-              </a>
+    {% block default_pricing_position %}
+      {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+      <div id="pricing" class="mzp-is-anchor-link">
+        {% if vpn_available %}
+          {% include 'products/vpn/includes/pricing-plus-relay.html' %}
+        {% else %}
+          <div class="vpn-waitlist-feature-block">
+            {% call vpn_content_block(
+              class_name='vpn-content-block-price t-highlight'
+            ) %}
+            <div class="l-columns-two">
+              <div class="l-column-first">
+                <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="secondary">
+                  {{ ftl('vpn-shared-waitlist-link') }}
+                </a>
 
-              <p class="availability-copy">
-                {{ ftl('vpn-shared-available-countries-v6') }}
-              </p>
+                <p class="availability-copy">
+                  {{ ftl('vpn-shared-available-countries-v6') }}
+                </p>
+              </div>
+              <div class="l-column-last">
+                <ul class="mzp-u-list-styled vpn-feature-list">
+                  <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-devices', devices=connect_devices) }}</li>
+                  <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-servers', servers=connect_servers, countries=connect_countries) }}</li>
+                  <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-encrypt') }}</li>
+                  <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-bandwidth') }}</li>
+                  <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-activity') }}</li>
+                </ul>
+              </div>
             </div>
-            <div class="l-column-last">
-              <ul class="mzp-u-list-styled vpn-feature-list">
-                <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-devices', devices=connect_devices) }}</li>
-                <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-servers', servers=connect_servers, countries=connect_countries) }}</li>
-                <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-encrypt') }}</li>
-                <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-bandwidth') }}</li>
-                <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-activity') }}</li>
-              </ul>
-            </div>
+            {% endcall %}
           </div>
-          {% endcall %}
-        </div>
-      {% endif %}
-    </div>
+        {% endif %}
+      </div>
+    {% endblock %}
   </div>
 
   <section id="faq" class="vpn-faq mzp-l-content mzp-t-content-lg">

--- a/bedrock/products/templates/products/vpn/variants/landing-1.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-1.html
@@ -1,0 +1,11 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}

--- a/bedrock/products/templates/products/vpn/variants/landing-1.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-1.html
@@ -4,8 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
 {% extends "products/vpn/landing.html" %}

--- a/bedrock/products/templates/products/vpn/variants/landing-2.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-2.html
@@ -4,10 +4,6 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
 {% extends "products/vpn/landing.html" %}
 
 {% block top_pricing_position %}

--- a/bedrock/products/templates/products/vpn/variants/landing-2.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-2.html
@@ -1,0 +1,49 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing.html" %}
+
+{% block top_pricing_position %}
+  {# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+  <div id="pricing" class="mzp-is-anchor-link c-pricing-top">
+    {% if vpn_available %}
+      {% include 'products/vpn/includes/pricing-plus-relay.html' %}
+    {% else %}
+      <div class="vpn-waitlist-feature-block">
+        {% call vpn_content_block(
+          class_name='vpn-content-block-price t-highlight'
+        ) %}
+        <div class="l-columns-two">
+          <div class="l-column-first">
+            <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="secondary">
+              {{ ftl('vpn-shared-waitlist-link') }}
+            </a>
+
+            <p class="availability-copy">
+              {{ ftl('vpn-shared-available-countries-v6') }}
+            </p>
+          </div>
+          <div class="l-column-last">
+            <ul class="mzp-u-list-styled vpn-feature-list">
+              <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-devices', devices=connect_devices) }}</li>
+              <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-servers', servers=connect_servers, countries=connect_countries) }}</li>
+              <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-encrypt') }}</li>
+              <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-bandwidth') }}</li>
+              <li class="vpn-feature-list-item">{{ ftl('vpn-shared-features-activity') }}</li>
+            </ul>
+          </div>
+        </div>
+        {% endcall %}
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block default_pricing_position %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/variants/landing-refresh-1.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-refresh-1.html
@@ -4,8 +4,4 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
 {% extends "products/vpn/landing-refresh.html" %}

--- a/bedrock/products/templates/products/vpn/variants/landing-refresh-1.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-refresh-1.html
@@ -1,0 +1,11 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing-refresh.html" %}

--- a/bedrock/products/templates/products/vpn/variants/landing-refresh-2.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-refresh-2.html
@@ -1,0 +1,35 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "products/vpn/landing-refresh.html" %}
+
+{% block top_pricing_position %}
+{# note: `id=#pricing` is used as an anchor link from android in-product subscription flows, so do not remove (issue 10039) #}
+<section id="pricing" class="mzp-l-content mzp-t-content-xl">
+  {% if vpn_available %}
+    <header class="c-pricing-main-header">
+      <h3 class="c-section-title">{{ ftl('vpn-landing-one-subscription-for-all-your') }}</h3>
+    </header>
+
+    {% include 'products/vpn/includes/pricing-refresh.html' %}
+
+  {% else %}
+    <header class="c-pricing-main-header">
+      <h2 class="c-section-title">{{ ftl('vpn-shared-mozilla-vpn-is-not-yet-available') }}</h2>
+
+      <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist">
+        {{ ftl('vpn-shared-waitlist-link') }}
+      </a>
+    </header>
+  {% endif %}
+</section>
+{% endblock %}
+
+{% block default_pricing_position %}{% endblock %}

--- a/bedrock/products/templates/products/vpn/variants/landing-refresh-2.html
+++ b/bedrock/products/templates/products/vpn/variants/landing-refresh-2.html
@@ -4,10 +4,6 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
 {% extends "products/vpn/landing-refresh.html" %}
 
 {% block top_pricing_position %}

--- a/bedrock/products/tests/test_views.py
+++ b/bedrock/products/tests/test_views.py
@@ -137,6 +137,46 @@ class TestVPNLandingPage(TestCase):
         ctx = render_mock.call_args[0][2]
         self.assertFalse(ctx["relay_bundle_available_in_country"])
 
+    # start pricing position experiment tests
+
+    def test_vpn_landing_refresh_pricing_position_1_template(self, render_mock):
+        req = RequestFactory().get("/products/vpn/?entrypoint_experiment=vpn-pricing-position&entrypoint_variation=1", HTTP_CF_IPCOUNTRY="fr")
+        req.locale = "en-US"
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "products/vpn/variants/landing-refresh-1.html"
+
+    def test_vpn_landing_refresh_pricing_position_2_template(self, render_mock):
+        req = RequestFactory().get("/products/vpn/?entrypoint_experiment=vpn-pricing-position&entrypoint_variation=2", HTTP_CF_IPCOUNTRY="fr")
+        req.locale = "en-US"
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "products/vpn/variants/landing-refresh-2.html"
+
+    def test_vpn_landing_legacy_pricing_position_1_template(self, render_mock):
+        req = RequestFactory().get(
+            "/products/vpn/?entrypoint_experiment=vpn-pricing-position&entrypoint_variation=1&xv=legacy", HTTP_CF_IPCOUNTRY="fr"
+        )
+        req.locale = "en-US"
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "products/vpn/variants/landing-1.html"
+
+    def test_vpn_landing_legacy_pricing_position_2_template(self, render_mock):
+        req = RequestFactory().get(
+            "/products/vpn/?entrypoint_experiment=vpn-pricing-position&entrypoint_variation=2&xv=legacy", HTTP_CF_IPCOUNTRY="fr"
+        )
+        req.locale = "en-US"
+        view = views.vpn_landing_page
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "products/vpn/variants/landing-2.html"
+
+    # end pricing position experiment tests
+
 
 @patch("bedrock.products.views.l10n_utils.render", return_value=HttpResponse())
 class TestVPNPricingPage(TestCase):

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -60,15 +60,24 @@ def vpn_landing_page(request):
     if entrypoint_variation not in ["1", "2"]:
         entrypoint_variation = None
 
-    if entrypoint_experiment != "vpn-holidays-na-test":
+    if entrypoint_experiment not in ["vpn-holidays-na-test", "vpn-pricing-position"]:
         entrypoint_experiment = None
 
     if ftl_file_is_active("products/vpn/landing-2023") and experience != "legacy":
-        template_name = "products/vpn/landing-refresh.html"
+        if entrypoint_experiment == "vpn-pricing-position" and entrypoint_variation in ["1", "2"]:
+            template_name = "products/vpn/variants/landing-refresh-{}.html".format(entrypoint_variation)
+        else:
+            template_name = "products/vpn/landing-refresh.html"
     elif experience == "legacy":
-        template_name = "products/vpn/landing.html"
+        if entrypoint_experiment == "vpn-pricing-position" and entrypoint_variation in ["1", "2"]:
+            template_name = "products/vpn/variants/landing-{}.html".format(entrypoint_variation)
+        else:
+            template_name = "products/vpn/landing.html"
     else:
-        template_name = "products/vpn/landing.html"
+        if entrypoint_experiment == "vpn-pricing-position" and entrypoint_variation in ["1", "2"]:
+            template_name = "products/vpn/variants/landing-{}.html".format(entrypoint_variation)
+        else:
+            template_name = "products/vpn/landing.html"
 
     context = {
         "vpn_available": vpn_available_in_country,

--- a/media/css/products/vpn/landing.scss
+++ b/media/css/products/vpn/landing.scss
@@ -21,6 +21,14 @@ html {
     }
 }
 
+.c-pricing-top {
+    margin-top: $layout-xl;
+
+    @media #{$mq-md} {
+        margin-top: $layout-2xl;
+    }
+}
+
 // * -------------------------------------------------------------------------- */
 // Waitlist Feature Block
 

--- a/media/js/products/vpn/landing-experiment-pricing-position.es6.js
+++ b/media/js/products/vpn/landing-experiment-pricing-position.es6.js
@@ -35,7 +35,4 @@ const initTrafficCop = () => {
     }
 };
 
-// Avoid entering automated tests into random experiments.
-if (isApprovedToRun()) {
-    initTrafficCop();
-}
+initTrafficCop();

--- a/media/js/products/vpn/landing-experiment-pricing-position.es6.js
+++ b/media/js/products/vpn/landing-experiment-pricing-position.es6.js
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrafficCop from '@mozmeao/trafficcop';
+import { isApprovedToRun } from '../../base/experiment-utils.es6.js';
+
+const href = window.location.href;
+
+const initTrafficCop = () => {
+    if (href.indexOf('entrypoint_variation=1') !== -1) {
+        window.dataLayer.push({
+            'data-ex-variant': 'pricing-bottom',
+            'data-ex-name': 'vpn-pricing-position'
+        });
+    } else if (href.indexOf('entrypoint_variation=2') !== -1) {
+        window.dataLayer.push({
+            'data-ex-variant': 'pricing-top',
+            'data-ex-name': 'vpn-pricing-position'
+        });
+    } else if (TrafficCop) {
+        // Avoid entering automated tests into random experiments.
+        if (isApprovedToRun()) {
+            const briscoe = new TrafficCop({
+                id: 'vpn-pricing-position',
+                variations: {
+                    'entrypoint_experiment=vpn-pricing-position&entrypoint_variation=1': 50, // control, pricing at bottom
+                    'entrypoint_experiment=vpn-pricing-position&entrypoint_variation=2': 50 // pricing at top
+                }
+            });
+            briscoe.init();
+        }
+    }
+};
+
+// Avoid entering automated tests into random experiments.
+if (isApprovedToRun()) {
+    initTrafficCop();
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1958,6 +1958,12 @@
     },
     {
       "files": [
+        "js/products/vpn/landing-experiment-pricing-position.es6.js"
+      ],
+      "name": "mozilla-vpn-landing-pricing-position-experiment"
+    },
+    {
+      "files": [
         "js/products/shared/affiliate-init.es6.js"
       ],
       "name": "mozilla-vpn-affiliate"


### PR DESCRIPTION
## One-line summary
Adds an experiment testing the position of the pricing section of the VPN landing page, on both the refreshed design and the old one (still shown to locales that haven't completed translation of the new page).

## Issue / Bugzilla link
https://app.asana.com/0/1204604936721242/1205946965841043/f


## Testing
This is planned to run concurrently with the NA holiday banner test, so it's shown in only countries *outside* the US and CA to avoid collisions. If you're testing locally in the US or CA you'll need to use the `geo` param to evade the banner experiment.

You can use the `xv=legacy` param to get the old page locally.

http://localhost:8000/en-US/products/vpn/?geo=DE
http://localhost:8000/en-US/products/vpn/?geo=DE&xv=legacy

Should redirect to one of two variants:

http://localhost:8000/en-US/products/vpn/?geo=DE&entrypoint_experiment=vpn-pricing-position&entrypoint_variation=1 - pricing at the bottom
http://localhost:8000/en-US/products/vpn/?geo=DE&entrypoint_experiment=vpn-pricing-position&entrypoint_variation=2 - pricing at the top

http://localhost:8000/en-US/products/vpn/?geo=DE&xv=legacy&entrypoint_experiment=vpn-pricing-position&entrypoint_variation=1 - pricing at the bottom, old design
http://localhost:8000/en-US/products/vpn/?geo=DE&xv=legacy&entrypoint_experiment=vpn-pricing-position&entrypoint_variation=2 - pricing at the top, old design
