### PR TITLE
Fix footprint scrubber URL

### DIFF
--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -158,7 +158,7 @@ urlpatterns = (
         ftl_files=["mozorg/try-picture-in-picture"],
         active_locales=["en-US", "de", "fr", "it"],
     ),
-    path("antiharassment-tool", views.anti_harassment_tool_view, name="mozorg.antiharassment-tool"),
+    path("antiharassment-tool/", views.anti_harassment_tool_view, name="mozorg.antiharassment-tool"),
 )
 
 if settings.DEV:


### PR DESCRIPTION
Adds trailing slash to `/antiharassment-tool/`