### PR TITLE
Update to Glean 4.0.0-pre.2

### DIFF
--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -5,11 +5,12 @@
  */
 
 import Glean from '@mozilla/glean/web';
+import { BrowserSendBeaconUploader } from '@mozilla/glean/web';
 import { initPageView, pageEvent } from './page.es6';
 import { clickEvent } from './elements.es6';
 import Utils from './utils.es6';
 
-const shouldInitialize = Utils.hasValidURLScheme(window.location.href);
+const shouldInitialize = Utils.isValidHttpUrl(window.location.href);
 
 function initGlean() {
     const pageUrl = window.location.href;
@@ -26,7 +27,8 @@ function initGlean() {
 
     Glean.initialize('bedrock', Utils.isTelemetryEnabled(), {
         channel: channel,
-        serverEndpoint: endpoint
+        serverEndpoint: endpoint,
+        httpClient: BrowserSendBeaconUploader // use sendBeacon since Firefox does not yet support keepalive using fetch()
     });
 }
 

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import GleanMetrics from '@mozilla/glean/metrics';
 import * as page from '../libs/glean/page.js';
 import Utils from './utils.es6';
 
@@ -27,7 +28,7 @@ function initPageView() {
     page.referrer.set(Utils.getReferrer());
     page.httpStatus.set(Utils.getHttpStatus());
 
-    const params = Utils.getQueryParamsFromURL();
+    const params = Utils.getQueryParamsFromUrl();
     const finalParams = {};
 
     // validate only known & trusted query params
@@ -48,6 +49,22 @@ function initPageView() {
         }
     }
 
+    /**
+     * Manually call Glean's default page_load event. Here
+     * we override `url` and `referrer` since we need to
+     * apply some custom logic to these values before they
+     * are sent.
+     */
+    GleanMetrics.pageLoad({
+        url: Utils.getUrl(),
+        referrer: Utils.getReferrer()
+    });
+
+    /**
+     * This old page hit event can be removed once we're
+     * confident that the new page_load event is working
+     * as expected.
+     */
     page.hit.record();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^3.0.0",
+        "@mozilla/glean": "^4.0.0-pre.2",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2131,12 +2131,11 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-3.0.0.tgz",
-      "integrity": "sha512-sOg5syi2DaYlSxOdPFrrnSfkXeNdKy56vAJDTBh8q5rSb5ABIsFqdGWVieft82FYFQCZCnHs++5EcECLstqeKA==",
+      "version": "4.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0-pre.2.tgz",
+      "integrity": "sha512-XOsBrEBU370DWuoT7nQ85VErPmZpwzxyzms/EnzVavS+dNzCCcaw8nGgiQem2lPbCIunoDbyesj2CNsGPAswCw==",
       "dependencies": {
         "fflate": "^0.8.0",
-        "jose": "^4.0.4",
         "tslib": "^2.3.1",
         "uuid": "^9.0.0"
       },
@@ -6442,14 +6441,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -11968,12 +11959,11 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "@mozilla/glean": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-3.0.0.tgz",
-      "integrity": "sha512-sOg5syi2DaYlSxOdPFrrnSfkXeNdKy56vAJDTBh8q5rSb5ABIsFqdGWVieft82FYFQCZCnHs++5EcECLstqeKA==",
+      "version": "4.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0-pre.2.tgz",
+      "integrity": "sha512-XOsBrEBU370DWuoT7nQ85VErPmZpwzxyzms/EnzVavS+dNzCCcaw8nGgiQem2lPbCIunoDbyesj2CNsGPAswCw==",
       "requires": {
         "fflate": "^0.8.0",
-        "jose": "^4.0.4",
         "tslib": "^2.3.1",
         "uuid": "^9.0.0"
       }
@@ -15188,11 +15178,6 @@
           }
         }
       }
-    },
-    "jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^3.0.0",
+    "@mozilla/glean": "^4.0.0-pre.2",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",

--- a/tests/unit/spec/glean/page.js
+++ b/tests/unit/spec/glean/page.js
@@ -48,7 +48,7 @@ describe('page.js', function () {
     it('should record specific query parameters in the page view', async function () {
         const query =
             'utm_source=test-source&utm_campaign=test-campaign&utm_medium=test-medium&utm_content=test-content&entrypoint_experiment=test_entrypoint_experiment&entrypoint_variation=1&experiment=test-experiment&variation=1&v=1&xv=test-xv';
-        spyOn(Utils, 'getQueryParamsFromURL').and.returnValue(
+        spyOn(Utils, 'getQueryParamsFromUrl').and.returnValue(
             new window._SearchParams(query)
         );
 
@@ -90,7 +90,7 @@ describe('page.js', function () {
     it('should not record unspecified query params in the page view', async function () {
         const query =
             'unspecified_param=test-unspecified-param&utm_content=test-content';
-        spyOn(Utils, 'getQueryParamsFromURL').and.returnValue(
+        spyOn(Utils, 'getQueryParamsFromUrl').and.returnValue(
             new window._SearchParams(query)
         );
 
@@ -106,7 +106,7 @@ describe('page.js', function () {
 
     it('should decode known params', async function () {
         const query = 'utm_source=%25&utm_campaign=%2F';
-        spyOn(Utils, 'getQueryParamsFromURL').and.returnValue(
+        spyOn(Utils, 'getQueryParamsFromUrl').and.returnValue(
             new window._SearchParams(query)
         );
 
@@ -122,7 +122,7 @@ describe('page.js', function () {
     it('should not record known params that contain bad values', async function () {
         const query =
             'utm_source=<script>yikes</script>&utm_campaign=%5Ctest&utm_medium=%3Ctest&utm_content=test-content&experiment';
-        spyOn(Utils, 'getQueryParamsFromURL').and.returnValue(
+        spyOn(Utils, 'getQueryParamsFromUrl').and.returnValue(
             new window._SearchParams(query)
         );
 

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -11,9 +11,38 @@
 
 import Utils from '../../../../media/js/glean/utils.es6';
 
-describe('utilsjs', function () {
+describe('utils.js', function () {
     afterEach(function () {
         Mozilla.Analytics.customReferrer = '';
+    });
+
+    describe('getUrl', function () {
+        it('should return the a complete URL including query parameters', function () {
+            const url1 = 'https://www.mozilla.org/en-US/';
+            expect(Utils.getUrl(url1)).toEqual(url1);
+
+            const url2 =
+                'https://www.mozilla.org/en-US/firefox/new/?utm_source=test&utm_campaign=test';
+            expect(Utils.getUrl(url2)).toEqual(url2);
+        });
+
+        it('should remove newsletter tokens from know URLs', function () {
+            const url1 =
+                'https://www.mozilla.org/en-US/newsletter/existing/a1a2a3a4-abc1-12ab-a123-12345a12345b/?utm_source=test&utm_campaign=test';
+            expect(Utils.getUrl(url1)).toEqual(
+                'https://www.mozilla.org/en-US/newsletter/existing/?utm_source=test&utm_campaign=test'
+            );
+
+            const url2 =
+                'https://www.mozilla.org/en-US/newsletter/country/a1a2a3a4-abc1-12ab-a123-12345a12345b/?utm_source=test&utm_campaign=test';
+            expect(Utils.getUrl(url2)).toEqual(
+                'https://www.mozilla.org/en-US/newsletter/country/?utm_source=test&utm_campaign=test'
+            );
+
+            const url3 =
+                'https://www.mozilla.org/en-US/newsletter/existing/?utm_source=test&utm_campaign=test';
+            expect(Utils.getUrl(url3)).toEqual(url3);
+        });
     });
 
     describe('getPathFromUrl', function () {
@@ -64,12 +93,12 @@ describe('utilsjs', function () {
         });
     });
 
-    describe('getQueryParamsFromURL', function () {
+    describe('getQueryParamsFromUrl', function () {
         it('should return an object made up of params from a query string', function () {
             const query =
                 'utm_source=test-source&utm_campaign=test-campaign&utm_medium=test-medium&utm_content=test-content&entrypoint_experiment=test_entrypoint_experiment&entrypoint_variation=1&experiment=test-experiment&variation=1&v=1&xv=test-xv';
 
-            expect(Utils.getQueryParamsFromURL(query).params).toEqual({
+            expect(Utils.getQueryParamsFromUrl(query).params).toEqual({
                 utm_source: 'test-source',
                 utm_campaign: 'test-campaign',
                 utm_medium: 'test-medium',
@@ -117,19 +146,17 @@ describe('utilsjs', function () {
         });
     });
 
-    describe('hasValidURLScheme', function () {
+    describe('isValidHttpUrl', function () {
         it('should return true for non secure URLs', function () {
-            expect(Utils.hasValidURLScheme('http://localhost:8000')).toBeTrue();
+            expect(Utils.isValidHttpUrl('http://localhost:8000')).toBeTrue();
         });
 
         it('should return true for secure URLs', function () {
-            expect(
-                Utils.hasValidURLScheme('https://www.mozilla.org')
-            ).toBeTrue();
+            expect(Utils.isValidHttpUrl('https://www.mozilla.org')).toBeTrue();
         });
 
         it('should return false for file URLs', function () {
-            expect(Utils.hasValidURLScheme('file://C:/Users/')).toBeFalse();
+            expect(Utils.isValidHttpUrl('file://C:/Users/')).toBeFalse();
         });
     });
 


### PR DESCRIPTION
## One-line summary

This PR tests out a pre-release of Glean 4.0.0 with the following changes:

- Uses `sendBeacon()` as an event uploader for improved data accuracy.
- Records the new default `page_load` event, which will be a new standardized format for page load metrics that can be used in automated dashboard creation.

## Significant changes and points to review

- This is a pre-release version of Glean, but since were only using it right now when `Dev=True`, it should be safe enough for us to use in testing.
- I've left the old page hit event in for now (so you should see two event pings on page load). I'll remove the old event once we're confident that data looks OK.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/13431

## Testing

1. `npm install`
2. `npm start`
3. Open http://localhost:8000/en-US/ and enter `window.Glean.setLogPings(true)` in the console.
4. Refresh the page and you should see two events logged.

New event should contain:

```
  "events": [
    {
      "category": "glean",
      "name": "page_load",
      "timestamp": 0,
      "extra": {
        "url": "http://localhost:8000/en-US/",
        "referrer": "",
        "title": "Internet for people, not profit — Mozilla (US)"
      }
    }
  ],
```

The old event should contain:

```
  "events": [
    {
      "category": "page",
      "name": "hit",
      "timestamp": 0
    }
  ],
```