### PR TITLE
Remove old Glean page hit event (Issue #13431)

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -93,32 +93,18 @@ page:
       - marketing-websites-team@mozilla.com
     expires: never
   http_status:
-      type: string
-      description: |
-        The HTTP status code of the page.
-      lifetime: application
-      send_in_pings:
-        - events
-      data_sensitivity:
-        - technical
-      bugs:
-        - https://github.com/mozilla/bedrock/issues/13581
-      data_reviews:
-        - https://bugzilla.mozilla.org/show_bug.cgi?id=1848981
-      notification_emails:
-        - marketing-websites-team@mozilla.com
-      expires: never
-  hit:
-    type: event
+    type: string
     description: |
-      An event which is sent every time a page is loaded.
+      The HTTP status code of the page.
+    lifetime: application
+    send_in_pings:
+      - events
     data_sensitivity:
-      - web_activity
       - technical
     bugs:
-      - https://github.com/mozilla/bedrock/issues/10746
+      - https://github.com/mozilla/bedrock/issues/13581
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1767442
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1848981
     notification_emails:
       - marketing-websites-team@mozilla.com
     expires: never

--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -14,9 +14,7 @@ import Utils from './utils.es6';
 function initGlean() {
     const pageUrl = window.location.href;
     const endpoint = 'https://www.mozilla.org';
-    const channel = pageUrl.startsWith('https://www.mozilla.org/')
-        ? 'prod'
-        : 'non-prod';
+    const channel = pageUrl.startsWith(endpoint) ? 'prod' : 'non-prod';
 
     /**
      * Ensure telemetry coming from automated testing is tagged

--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -5,12 +5,11 @@
  */
 
 import Glean from '@mozilla/glean/web';
+import GleanMetrics from '@mozilla/glean/metrics';
 import { BrowserSendBeaconUploader } from '@mozilla/glean/web';
-import { initPageView, pageEvent } from './page.es6';
+import { recordCustomPageMetrics, pageEvent } from './page.es6';
 import { clickEvent } from './elements.es6';
 import Utils from './utils.es6';
-
-const shouldInitialize = Utils.isValidHttpUrl(window.location.href);
 
 function initGlean() {
     const pageUrl = window.location.href;
@@ -19,8 +18,10 @@ function initGlean() {
         ? 'prod'
         : 'non-prod';
 
-    // Ensure telemetry coming from automated testing is tagged
-    // https://mozilla.github.io/glean/book/reference/debug/sourceTags.html
+    /**
+     * Ensure telemetry coming from automated testing is tagged
+     * https://mozilla.github.io/glean/book/reference/debug/sourceTags.html
+     */
     if (pageUrl.includes('automation=true')) {
         Glean.setSourceTags(['automation']);
     }
@@ -30,31 +31,44 @@ function initGlean() {
         serverEndpoint: endpoint,
         httpClient: BrowserSendBeaconUploader // use sendBeacon since Firefox does not yet support keepalive using fetch()
     });
+
+    /**
+     * Record some additional page metrics that
+     * aren't in the default page_load event.
+     */
+    recordCustomPageMetrics();
+
+    /**
+     * Manually call Glean's default page_load event. Here
+     * we override `url` and `referrer` since we need to
+     * apply some custom logic to these values before they
+     * are sent.
+     */
+    GleanMetrics.pageLoad({
+        url: Utils.getUrl(),
+        referrer: Utils.getReferrer()
+    });
 }
 
+/**
+ * Creates global helpers on the window.Mozilla.Glean
+ * namespace, so that external JS bundles can trigger
+ * custom interaction events.
+ */
 function initHelpers() {
     if (typeof window.Mozilla === 'undefined') {
         window.Mozilla = {};
     }
 
-    // Create a global for external bundles to fire interaction pings.
     window.Mozilla.Glean = {
         pageEvent: (obj) => {
-            if (shouldInitialize) {
-                pageEvent(obj);
-            }
+            pageEvent(obj);
         },
         clickEvent: (obj) => {
-            if (shouldInitialize) {
-                clickEvent(obj);
-            }
+            clickEvent(obj);
         }
     };
 }
 
-if (shouldInitialize) {
-    initGlean();
-    initPageView();
-}
-
+initGlean();
 initHelpers();

--- a/media/js/glean/page.es6.js
+++ b/media/js/glean/page.es6.js
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import GleanMetrics from '@mozilla/glean/metrics';
 import * as page from '../libs/glean/page.js';
 import Utils from './utils.es6';
 
@@ -21,7 +20,7 @@ const defaultParams = {
     xv: '' // short param for 'experience version'.
 };
 
-function initPageView() {
+function recordCustomPageMetrics() {
     page.viewed.set();
     page.path.set(Utils.getPathFromUrl());
     page.locale.set(Utils.getLocaleFromUrl());
@@ -48,24 +47,6 @@ function initPageView() {
             page.queryParams[param].set(finalParams[param]);
         }
     }
-
-    /**
-     * Manually call Glean's default page_load event. Here
-     * we override `url` and `referrer` since we need to
-     * apply some custom logic to these values before they
-     * are sent.
-     */
-    GleanMetrics.pageLoad({
-        url: Utils.getUrl(),
-        referrer: Utils.getReferrer()
-    });
-
-    /**
-     * This old page hit event can be removed once we're
-     * confident that the new page_load event is working
-     * as expected.
-     */
-    page.hit.record();
 }
 
 function pageEvent(obj) {
@@ -96,4 +77,4 @@ function pageEvent(obj) {
     }
 }
 
-export { initPageView, pageEvent };
+export { recordCustomPageMetrics, pageEvent };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.23.6",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^4.0.0-pre.2",
+        "@mozilla/glean": "^4.0.0-pre.3",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2143,9 +2143,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "4.0.0-pre.2",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0-pre.2.tgz",
-      "integrity": "sha512-XOsBrEBU370DWuoT7nQ85VErPmZpwzxyzms/EnzVavS+dNzCCcaw8nGgiQem2lPbCIunoDbyesj2CNsGPAswCw==",
+      "version": "4.0.0-pre.3",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0-pre.3.tgz",
+      "integrity": "sha512-Uer5Z5HXoejsJsK7neFacRtT8187BO/MiMUoIU6YnWBaB83k46tnGw504g6X6eg4ZCsUXcMcS4E5yKtw5JzlLw==",
       "dependencies": {
         "fflate": "^0.8.0",
         "tslib": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.23.6",
     "@babel/preset-env": "^7.23.6",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^4.0.0-pre.2",
+    "@mozilla/glean": "^4.0.0-pre.3",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",

--- a/tests/unit/spec/glean/page.js
+++ b/tests/unit/spec/glean/page.js
@@ -11,7 +11,10 @@
 
 import * as page from '../../../../media/js/libs/glean/page.js';
 import Utils from '../../../../media/js/glean/utils.es6';
-import { initPageView, pageEvent } from '../../../../media/js/glean/page.es6';
+import {
+    recordCustomPageMetrics,
+    pageEvent
+} from '../../../../media/js/glean/page.es6';
 import { testResetGlean } from '@mozilla/glean/testing';
 
 describe('page.js', function () {
@@ -30,7 +33,7 @@ describe('page.js', function () {
     });
 
     it('should register a page view correctly', async function () {
-        initPageView();
+        recordCustomPageMetrics();
 
         const path = await page.path.testGetValue();
         expect(path).toEqual('/firefox/new/');
@@ -52,7 +55,7 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        initPageView();
+        recordCustomPageMetrics();
 
         const source = await page.queryParams['utm_source'].testGetValue();
         expect(source).toEqual('test-source');
@@ -94,7 +97,7 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        initPageView();
+        recordCustomPageMetrics();
 
         const unspecifiedParam =
             await page.queryParams['unspecified_param'].testGetValue();
@@ -110,7 +113,7 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        initPageView();
+        recordCustomPageMetrics();
 
         const source = await page.queryParams['utm_source'].testGetValue();
         expect(source).toEqual('%');
@@ -126,7 +129,7 @@ describe('page.js', function () {
             new window._SearchParams(query)
         );
 
-        initPageView();
+        recordCustomPageMetrics();
 
         const source = await page.queryParams['utm_source'].testGetValue();
         expect(source).toEqual('');

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -114,16 +114,27 @@ describe('utils.js', function () {
     });
 
     describe('getReferrer', function () {
+        afterEach(function () {
+            Mozilla.Analytics.customReferrer = '';
+        });
+
         it('should return a custom referrer when set', function () {
-            const expected = 'http://www.google.com';
+            const expected = 'http://www.google.com/';
             Mozilla.Analytics.customReferrer = expected;
             expect(Utils.getReferrer()).toEqual(expected);
         });
 
-        it('should return standard document referrer otherwise', function () {
-            const expected = 'http://www.bing.com';
-            Mozilla.Analytics.customReferrer = '';
+        it('should return regular referrer otherwise', function () {
+            const expected = 'http://www.bing.com/';
             expect(Utils.getReferrer(expected)).toEqual(expected);
+        });
+
+        it('should strip newsletter tokens from referrer URLs', function () {
+            const expected =
+                'https://www.mozilla.org/en-US/newsletter/country/a1a2a3a4-abc1-12ab-a123-12345a12345b/?utm_source=test&utm_campaign=test';
+            expect(Utils.getReferrer(expected)).toEqual(
+                'https://www.mozilla.org/en-US/newsletter/country/?utm_source=test&utm_campaign=test'
+            );
         });
     });
 
@@ -143,20 +154,6 @@ describe('utils.js', function () {
                 .getElementsByTagName('html')[0]
                 .setAttribute('data-http-status', '404');
             expect(Utils.getHttpStatus()).toEqual('404');
-        });
-    });
-
-    describe('isValidHttpUrl', function () {
-        it('should return true for non secure URLs', function () {
-            expect(Utils.isValidHttpUrl('http://localhost:8000')).toBeTrue();
-        });
-
-        it('should return true for secure URLs', function () {
-            expect(Utils.isValidHttpUrl('https://www.mozilla.org')).toBeTrue();
-        });
-
-        it('should return false for file URLs', function () {
-            expect(Utils.isValidHttpUrl('file://C:/Users/')).toBeFalse();
         });
     });
 


### PR DESCRIPTION
## One-line summary

Now that we've migrated to using the new default `page_load` event, we can remove the old custom event and much of the logic around it. Some of the older metrics such as `metrics.path`, `metrics.referrer` etc are left in for now, as they are still used by click events for the time being.

Also adds a commit to update to v4.0.0-pre.3, which fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1868748

## Issue / Bugzilla link

#13431

## Testing

1. `npm install`
2. `npm start`
3. Open http://localhost:8000/en-US/ and enter `window.Glean.setLogPings(true)` in the console.
4. Refresh the page and you should now only see one event logged.

New event should contain:

```
  "events": [
    {
      "category": "glean",
      "name": "page_load",
      "timestamp": 0,
      "extra": {
        "url": "http://localhost:8000/en-US/",
        "referrer": "",
        "title": "Internet for people, not profit — Mozilla (US)"
      }
    }
  ],
```