### PR TITLE
Update /truecolors/ vanity redirects to point directly to /firefox/

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -541,17 +541,7 @@ redirectpatterns = (
     # Issue 9984
     redirect(r"^/about/legal/fraud-report/?$", "/about/legal/defend-mozilla-trademarks/"),
     # Issue 11204
-    redirect(
-        r"^(truecolou?rs|turningred)/?$",
-        "https://truecolors.firefox.com/",
-        merge_query=True,
-        query={
-            "utm_campaign": "firefox-disney-us",
-            "utm_medium": "web",
-            "utm_source": "redirect",
-            "utm_content": "mozilla.org-turningred",
-        },
-    ),
+    redirect(r"^(truecolou?rs|turningred)/?$", "firefox"),
     # Issue 11991
     redirect(r"^transparency/?$", "mozorg.about.policy.transparency.index"),
     redirect(r"^santa-locator/?$", "mozorg.santa-locator"),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1182,24 +1182,12 @@ URLS = flatten(
         # issue 12156
         url_test("/privacy/{mozilla-vpn,firefox-relay}/", "/privacy/subscription-services/"),
         # Issue 11204
-        url_test(
-            "/{truecolors,truecolours,turningred}/",
-            "https://truecolors.firefox.com/",
-            query={
-                "utm_campaign": "firefox-disney-us",
-                "utm_medium": "web",
-                "utm_source": "redirect",
-                "utm_content": "mozilla.org-turningred",
-            },
-        ),
+        url_test("/{truecolors,truecolours,turningred}/", "/firefox/"),
         url_test(
             "/{truecolors,truecolours,turningred}/?utm_source=dude",
-            "https://truecolors.firefox.com/",
+            "/firefox/",
             query={
-                "utm_campaign": "firefox-disney-us",
-                "utm_medium": "web",
                 "utm_source": "dude",
-                "utm_content": "mozilla.org-turningred",
             },
         ),
         # Issue 11991


### PR DESCRIPTION
## One-line summary
Update /truecolors/ vanity redirects to point directly to /firefox/

## Significant changes and points to review
 /truecolors/  redirects directly to /firefox/ 


## Issue / Bugzilla link
#12613 


## Testing
https://truecolors.firefox.com/.