### PR TITLE
Update release notes page title for developer edition - Fixes #13142

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -98,7 +98,11 @@
       <div class="intro">
         <div class="container">
           {% if not primary_heading %}
-            {% set primary_heading = '{0} <br> Release Notes'|f(product_name)|safe %}
+            {% if product_name == 'Firefox Beta' %}
+              {% set primary_heading = 'Firefox Beta and Developer Edition <br> Release Notes'|safe %}
+            {% else %}
+              {% set primary_heading = '{0} <br> Release Notes'|f(product_name)|safe %}
+            {% endif %}
           {% endif %}
           {% if release.product == 'Firefox for Android' %}
             {% set feedback_url='https://input.mozilla.org/feedback/android/' + release.version + '?utm_source=releasenotes' %}


### PR DESCRIPTION
## One-line summary
Update release notes page title for developer edition


## Significant changes and points to review
This PR modifies the title of the release notes page for the Developer Edition to improve clarity. The updated title now reads "Firefox Beta and Developer Edition Release Notes" to reflect that it is the correct page for both browsers.



## Issue / Bugzilla link
#13142


## Testing
All tests passed