### PR TITLE
Create new Fluent string for monitor name change (Issue #14008)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/download-faq.html
+++ b/bedrock/products/templates/products/vpn/includes/download-faq.html
@@ -23,7 +23,7 @@
       <summary>
         <h3>{{ ftl('vpn-download-faq-working') }}</h3>
       </summary>
-      <p>{{ ftl('vpn-download-faq-visual-indicators', connected='https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected', monitor='https://monitor.mozilla.org/') }}</p>
+      <p>{{ ftl('vpn-download-faq-visual-indicators-v2', fallback='vpn-download-faq-visual-indicators', connected='https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected', monitor='https://monitor.mozilla.org/') }}</p>
     </details>
     <details>
       <summary>

--- a/l10n/en/products/vpn/platform-post-download.ftl
+++ b/l10n/en/products/vpn/platform-post-download.ftl
@@ -56,7 +56,14 @@ vpn-download-faq-working = How do I know the VPN is working?
 # Variables:
 #   $connected (url) - link to https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected
 #   $monitor (url) link to https://monitor.mozilla.org/
-vpn-download-faq-visual-indicators = { -brand-name-mozilla-vpn } displays visual indicators of its current status both in the toolbar and the application’s home screen, making it easy to know whether your online activity is protected or not. These indicators allow you to confirm when your navigation is private and secure. Additionally, while connected, you can visit <a href="{ $monitor }">https://monitor.mozilla.org/</a> to confirm if your IP address is masked. For more details, please see <a href="{ $connected }">How can I tell if { -brand-name-mozilla-vpn } is connected?</a>.
+vpn-download-faq-visual-indicators-v2 = { -brand-name-mozilla-vpn } displays visual indicators of its current status both in the toolbar and the application’s home screen, making it easy to know whether your online activity is protected or not. These indicators allow you to confirm when your navigation is private and secure. Additionally, while connected, you can visit <a href="{ $monitor }">https://monitor.mozilla.org/</a> to confirm if your IP address is masked. For more details, please see <a href="{ $connected }">How can I tell if { -brand-name-mozilla-vpn } is connected?</a>.
+
+# Obsolete string
+# Variables:
+#   $connected (url) - link to https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected
+#   $monitor (url) link to https://monitor.firefox.com/
+vpn-download-faq-visual-indicators = { -brand-name-mozilla-vpn } displays visual indicators of its current status both in the toolbar and the application’s home screen, making it easy to know whether your online activity is protected or not. These indicators allow you to confirm when your navigation is private and secure. Additionally, while connected, you can visit <a href="{ $monitor }">https://monitor.firefox.com/</a> to confirm if your IP address is masked. For more details, please see <a href="{ $connected }">How can I tell if { -brand-name-mozilla-vpn } is connected?</a>.
+
 vpn-download-faq-add-device = How do I add another device?
 
 # Variables:


### PR DESCRIPTION
## One-line summary

Small follow up fix for https://github.com/mozilla/bedrock/issues/14008 where a new Fluent string ID should have been used.

## Issue / Bugzilla link

#14008

## Testing

http://localhost:8000/en-US/products/vpn/download/mac/thanks/