### PR TITLE
Record link_click event in GA4 #14053

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -10,7 +10,7 @@
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
       <div class="mzp-c-footer-primary-logo">
-        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ ftl('footer-mozilla') }}</a>
+        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-text="Mozilla">{{ ftl('footer-mozilla') }}</a>
       </div>
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section">
@@ -18,14 +18,14 @@
             {{ ftl('footer-company') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('mozorg.about.manifesto') }}" data-link-type="footer" data-link-name="Mozilla Manifesto">{{ ftl('footer-mozilla-manifesto') }}</a></li>
-            <li><a href="{{ press_blog_url() }}?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-name="Press Center">{{ ftl('footer-press-center') }}</a></li>
+            <li><a href="{{ url('mozorg.about.manifesto') }}" data-link-type="footer" data-link-text="Mozilla Manifesto">{{ ftl('footer-mozilla-manifesto') }}</a></li>
+            <li><a href="{{ press_blog_url() }}?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-text="Press Center">{{ ftl('footer-press-center') }}</a></li>
           {% if ftl_has_messages('footer-corporate-blog') %}
-            <li><a href="https://blog.mozilla.org/?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-name="Corporate Blog">{{ ftl('footer-corporate-blog') }}</a></li>
+            <li><a href="https://blog.mozilla.org/?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-text="Corporate Blog">{{ ftl('footer-corporate-blog') }}</a></li>
           {% endif %}
-            <li><a href="{{ url('careers.home') }}" data-link-type="footer" data-link-name="Careers">{{ ftl('footer-careers') }}</a></li>
-            <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact">{{ ftl('footer-contact') }}</a></li>
-            <li><a href="{{ donate_url(content='footer') }}" data-link-type="footer" data-link-name="Donate">{{ ftl('footer-donate', fallback='navigation-donate') }}</a></li>
+            <li><a href="{{ url('careers.home') }}" data-link-type="footer" data-link-text="Careers">{{ ftl('footer-careers') }}</a></li>
+            <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-text="Contact">{{ ftl('footer-contact') }}</a></li>
+            <li><a href="{{ donate_url(content='footer') }}" data-link-type="footer" data-link-text="Donate">{{ ftl('footer-donate', fallback='navigation-donate') }}</a></li>
           </ul>
         </section>
 
@@ -34,11 +34,11 @@
             {{ ftl('footer-resources') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy Hub">{{ ftl('footer-privacy-hub', fallback='footer-privacy') }}</a></li>
+            <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-text="Privacy Hub">{{ ftl('footer-privacy-hub', fallback='footer-privacy') }}</a></li>
           {% if ftl_has_messages('footer-browser-comparison') %}
-            <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-type="footer" data-link-name="Browser Comparison">{{ ftl('footer-browser-comparison') }}</a></li>
+            <li><a href="{{ url('firefox.browsers.compare.index') }}" data-link-type="footer" data-link-text="Browser Comparison">{{ ftl('footer-browser-comparison') }}</a></li>
           {% endif %}
-            <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-type="footer" data-link-name="Brand Standards">{{ ftl('footer-brand-standards') }}</a></li>
+            <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-type="footer" data-link-text="Brand Standards">{{ ftl('footer-brand-standards') }}</a></li>
           </ul>
         </section>
 
@@ -47,9 +47,9 @@
             {{ ftl('footer-support') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-name="Product Help">{{ ftl('footer-product-help', fallback='footer-support') }}</a></li>
-            <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-name="File a Bug">{{ ftl('footer-file-a-bug') }}</a></li>
-            <li><a href="https://pontoon.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-name="Localise Mozilla">{{ ftl('footer-localize-mozilla') }}</a></li>
+            <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="Product Help">{{ ftl('footer-product-help', fallback='footer-support') }}</a></li>
+            <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="File a Bug">{{ ftl('footer-file-a-bug') }}</a></li>
+            <li><a href="https://pontoon.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="Localise Mozilla">{{ ftl('footer-localize-mozilla') }}</a></li>
           </ul>
         </section>
 
@@ -58,32 +58,32 @@
             {{ ftl('footer-developers') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-name="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-type="footer" data-link-name="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
-            <li><a href="{{ url('firefox.channel.android') }}#beta" data-link-type="footer" data-link-name="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly">{{ ftl('footer-nightly') }}</a></li>
-            <li><a href="{{ url('firefox.channel.android') }}#nightly" data-link-type="footer" data-link-name="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
-            <li><a href="{{ url('firefox.enterprise.index') }}" data-link-type="footer" data-link-name="Firefox for Enterprise">{{ ftl('footer-enterprise') }}</a></li>
-            <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-type="footer" data-link-name="Tools">{{ ftl('footer-tools') }}</a></li>
+            <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
+            <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-type="footer" data-link-text="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') }}#beta" data-link-type="footer" data-link-text="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
+            <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-type="footer" data-link-text="Firefox Nightly">{{ ftl('footer-nightly') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') }}#nightly" data-link-type="footer" data-link-text="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
+            <li><a href="{{ url('firefox.enterprise.index') }}" data-link-type="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-enterprise') }}</a></li>
+            <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-type="footer" data-link-text="Tools">{{ ftl('footer-tools') }}</a></li>
           </ul>
         </section>
 
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-mozilla') }}</h5>
           <ul class="mzp-c-footer-links-social">
-            <li><a class="twitter" href="{{ mozilla_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
-            <li><a class="mastodon" href="https://mozilla.social/@Mozilla" rel="me" data-link-type="footer" data-link-name="Mastodon (@mozilla)">{{ ftl('footer-mastodon') }}<span> (@mozilla)</span></a></li>
-            <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>
-            <li><a class="linkedin" href="https://www.linkedin.com/company/mozilla-corporation/" data-link-type="footer" data-link-name="LinkedIn (@mozilla)">{{ ftl('footer-linkedin') }}<span> (@mozilla)</span></a></li>
-            <li><a class="tiktok" href="https://www.tiktok.com/@mozilla" data-link-type="footer" data-link-name="TikTok (@mozilla)">{{ ftl('footer-tiktok') }}<span> (@mozilla)</span></a></li>
-            <li><a class="spotify" href="https://open.spotify.com/show/0vT7LJMeVDxyQ2ZamHKu08?si=_uDRD6bRR_6M5YZyISGXgA" data-link-type="footer" data-link-name="Spotify (@mozilla)">{{ ftl('footer-spotify') }}<span> (@mozilla)</span></a></li>
+            <li><a class="twitter" href="{{ mozilla_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
+            <li><a class="mastodon" href="https://mozilla.social/@Mozilla" rel="me" data-link-type="footer" data-link-text="Mastodon (@mozilla)">{{ ftl('footer-mastodon') }}<span> (@mozilla)</span></a></li>
+            <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-text="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>
+            <li><a class="linkedin" href="https://www.linkedin.com/company/mozilla-corporation/" data-link-type="footer" data-link-text="LinkedIn (@mozilla)">{{ ftl('footer-linkedin') }}<span> (@mozilla)</span></a></li>
+            <li><a class="tiktok" href="https://www.tiktok.com/@mozilla" data-link-type="footer" data-link-text="TikTok (@mozilla)">{{ ftl('footer-tiktok') }}<span> (@mozilla)</span></a></li>
+            <li><a class="spotify" href="https://open.spotify.com/show/0vT7LJMeVDxyQ2ZamHKu08?si=_uDRD6bRR_6M5YZyISGXgA" data-link-type="footer" data-link-text="Spotify (@mozilla)">{{ ftl('footer-spotify') }}<span> (@mozilla)</span></a></li>
           </ul>
 
           <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-firefox') }}</h5>
           <ul class="mzp-c-footer-links-social">
-            <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('footer-twitter') }}<span> (@firefox)</span></a></li>
-            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
-            <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-name="YouTube (@firefoxchannel)">{{ ftl('footer-youtube') }}<span> (@firefoxchannel)</span></a></li>
+            <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@firefox)">{{ ftl('footer-twitter') }}<span> (@firefox)</span></a></li>
+            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-text="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
+            <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-text="YouTube (@firefoxchannel)">{{ ftl('footer-youtube') }}<span> (@firefoxchannel)</span></a></li>
           </ul>
         </section>
       </div>
@@ -94,17 +94,17 @@
       </div>
       <div class="mzp-c-footer-legal">
         <ul class="mzp-c-footer-terms">
-          <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
-          <li><a href="{{ url('privacy.notices.websites') }}#user-choices" data-link-type="footer" data-link-name="Cookies">{{ ftl('footer-websites-cookies') }}</a></li>
-          <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ ftl('footer-websites-legal') }}</a></li>
-          <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-type="footer" data-link-name="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}#user-choices" data-link-type="footer" data-link-text="Cookies">{{ ftl('footer-websites-cookies') }}</a></li>
+          <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-text="Legal">{{ ftl('footer-websites-legal') }}</a></li>
+          <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-type="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
           {% if ftl_has_messages('footer-about-this-site') %}
-            <li><a href="{{ url('mozorg.about.this-site') }}" data-link-type="footer" data-link-name="About this site">{{ ftl('footer-about-this-site') }}</a></li>
+            <li><a href="{{ url('mozorg.about.this-site') }}" data-link-type="footer" data-link-text="About this site">{{ ftl('footer-about-this-site') }}</a></li>
           {% endif %}
         </ul>
         <p class="mzp-c-footer-license" rel="license">
-          {% set moco_link = 'href="%s" data-link-type="footer" data-link-name="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
-          {% set mofo_link = 'href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer" rel="external noopener" data-link-type="footer" data-link-name="Mozilla Foundation"'|safe %}
+          {% set moco_link = 'href="%s" data-link-type="footer" data-link-text="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
+          {% set mofo_link = 'href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer" rel="external noopener" data-link-type="footer" data-link-text="Mozilla Foundation"'|safe %}
           {{ ftl('footer-visit-mozilla-corporations', moco_link=moco_link, mofo_link=mofo_link) }}<br>
           {{ ftl('footer-portions-of-this-content', url=url('foundation.licensing.website-content'), current_year=current_year|string) }}
         </p>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
@@ -15,7 +15,7 @@
         <ul class="mzp-l-rows-four">
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.new') }}" data-link-name="Firefox Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-not-for-profit-backed', fallback='navigation-get-the-browser-that-respects') }}</p>
@@ -25,7 +25,7 @@
         {% if ftl_has_messages('navigation-v2-firefox-for-ios', 'navigation-v2-firefox-for-android') %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-name="Firefox for Android" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-text="Firefox for Android" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-android') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-customizable-mobile') }}</p>
@@ -34,7 +34,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-name="Firefox for iOS" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-text="Firefox for iOS" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-ios') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-mobile-browser') }}</p>
@@ -44,7 +44,7 @@
         {% else %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.index') }}" data-link-name="Firefox for Mobile" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.index') }}" data-link-text="Firefox for Mobile" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-firefox-browser-for-mobile') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-take-speed-privacy-and') }}</p>
@@ -54,7 +54,7 @@
         {% endif %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-name="Firefox Focus" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-text="Firefox Focus" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/focus/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-focus') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-simply-private-mobile') }}</p>
@@ -63,7 +63,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.privacy.index') }}" data-link-name="Privacy Promise" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.privacy.index') }}" data-link-text="Privacy Promise" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img loading="lazy" src="{{ static('img/nav/icons/icon-privacy-promise.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-privacy-promise') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-learn-how-firefox-treats', fallback='navigation-your-right-to-security') }}</p>
@@ -72,7 +72,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://blog.mozilla.org/firefox/?{{ utm_params }}" data-link-name="Firefox Blog" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="https://blog.mozilla.org/firefox/?{{ utm_params }}" data-link-text="Firefox Blog" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-blog', fallback='navigation-firefox-blog') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-read-about-new-firefox-features', fallback='navigation-read-about-new-firefox') }}</p>
@@ -81,7 +81,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-name="Release Notes" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-text="Release Notes" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M2.7 23.6c0 2.4 2 4.4 4.4 4.4h5.6c1.4 0 2.3.5 3.3 1.5 1-1 2-1.5 3.3-1.5h5.6c2.4 0 4.4-2 4.4-4.4V8.4c0-2.4-2-4.4-4.4-4.4h-5.6C18 4 17 4.2 16 5.2c-1-1-2-1.2-3.3-1.2H7.1C4.6 4 2.7 6 2.7 8.4v15.2zm24 0c0 1-.8 1.7-1.7 1.7h-5.6c-1.3 0-2.3.2-3.3 1.2-1-1-2-1.2-3.3-1.2H7.1c-1 0-1.7-.8-1.7-1.7V8.4c0-1 .8-1.7 1.7-1.7h5.6c1.3 0 2.3.5 3.3 1.5 1-1 2-1.5 3.3-1.5h5.6c1 0 1.7.8 1.7 1.7v15.2zM13.3 10.7H8c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7h5.3c.4 0 .7.3.7.7 0 .4-.3.7-.7.7zm-5.3 4h5.3c.4 0 .7-.3.7-.7s-.3-.7-.7-.7H8c-.4 0-.7.3-.7.7s.3.7.7.7zm5.3 4H8c-.4 0-.7-.3-.7-.7s.3-.7.7-.7h5.3c.4 0 .7.3.7.7s-.3.7-.7.7zm-5.3 4h3.4c.4 0 .7-.3.7-.7s-.3-.7-.7-.7H8c-.4 0-.7.3-.7.7s.3.7.7.7z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-release-notes', fallback='navigation-release-notes') }}</h4>
               {% if ftl_has_messages('navigation-v2-get-the-details-on-the') %}
@@ -91,7 +91,7 @@
             </section>
           </li>
         </ul>
-        <p class="c-menu-category-link"><a href="{{ url('firefox.browsers.index') }}" data-link-name="View all Firefox Browsers" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">{{ ftl('navigation-v2-view-all-firefox-browsers') }}</a></p>
+        <p class="c-menu-category-link"><a href="{{ url('firefox.browsers.index') }}" data-link-text="View all Firefox Browsers" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">{{ ftl('navigation-v2-view-all-firefox-browsers') }}</a></p>
       </div>
     </div><!-- close .c-menu-panel-container -->
   </div><!-- close .c-menu-panel -->

--- a/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
@@ -21,7 +21,7 @@
         <ul class="{{ row_count }}">
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://hubs.mozilla.com/?{{ utm_params }}" data-link-name="Mozilla Hubs" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+              <a class="c-menu-item-link" href="https://hubs.mozilla.com/?{{ utm_params }}" data-link-text="Mozilla Hubs" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
                 <img loading="lazy" class="c-menu-item-icon" src="{{ static('img/nav/icons/icon-mozilla-hubs.svg') }}" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-hubs') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-gather-in-this-interactive-online', fallback='navigation-get-together') }}</p>
@@ -30,7 +30,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.developer.index') }}" data-link-name="Firefox Developer Edition" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+              <a class="c-menu-item-link" href="{{ url('firefox.developer.index') }}" data-link-text="Firefox Developer Edition" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/developer/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-developer-edition', fallback='navigation-firefox-developer-edition') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-firefox-browser-built', fallback='navigation-firefox-built-just-for') }}</p>
@@ -39,7 +39,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://developer.mozilla.org/?{{ utm_params }}" data-link-name="MDN Web Docs" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+              <a class="c-menu-item-link" href="https://developer.mozilla.org/?{{ utm_params }}" data-link-text="MDN Web Docs" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M4 26.7c0 .7.6 1.3 1.3 1.3s1.3-.6 1.3-1.3V5.3C6.7 4.6 6.1 4 5.3 4S4 4.6 4 5.3v21.4zm10.7 0c0 .7.6 1.3 1.3 1.3.7 0 1.3-.6 1.3-1.3V8c0-.7-.6-1.3-1.3-1.3-.7 0-1.3.6-1.3 1.3v18.7zm-5.4 0c0 .7.6 1.3 1.3 1.3.7 0 1.3-.6 1.3-1.3V9.3c.1-.7-.5-1.3-1.2-1.3-.8 0-1.4.6-1.4 1.3v17.4zM26.7 28c-.6 0-1.1-.4-1.3-.9l-6-18.7c-.2-.7.2-1.4.9-1.6s1.4.1 1.7.8l6 18.7c.2.7-.2 1.5-.9 1.7h-.4z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mdn-web-docs') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-check-out-the-home-for-web', fallback='navigation-resources-for-developers') }}</p>
@@ -48,7 +48,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://commonvoice.mozilla.org/?{{ utm_params }}" data-link-name="Common Voice" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+              <a class="c-menu-item-link" href="https://commonvoice.mozilla.org/?{{ utm_params }}" data-link-text="Common Voice" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
                 <img loading="lazy" class="c-menu-item-icon" src="{{ static('img/nav/icons/icon-common-voice.svg') }}" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-common-voice') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-donate-your-voice-so-the-future', fallback='navigation-donate-your-voice-to') }}</p>
@@ -58,7 +58,7 @@
         {% if ftl_has_messages('navigation-v2-mozilla-innovation-projects', 'navigation-v2-discover-ways-to-bring') %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://future.mozilla.org/?{{ utm_params }}" data-link-name="Mozilla Innovation Projects" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
+              <a class="c-menu-item-link" href="https://future.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Innovation Projects" data-link-type="nav" data-link-position="topnav" data-link-group="innovation">
                 <img loading="lazy" class="c-menu-item-icon" src="{{ static('img/nav/icons/icon-innovation-projects.svg') }}" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-innovation-projects') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-discover-ways-to-bring') }}</p>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/products.html
@@ -16,7 +16,7 @@
           <li>
             <section class="c-menu-item mzp-has-icon">
               {% set mozilla_monitor = switch('mozilla-monitor-brand-name') %}
-              <a class="c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-name="{% if mozilla_monitor %}Mozilla Monitor{% else %}Firefox Monitor{% endif %}" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+              <a class="c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-text="{% if mozilla_monitor %}Mozilla Monitor{% else %}Firefox Monitor{% endif %}" data-link-type="nav" data-link-position="topnav" data-link-group="products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 {% if mozilla_monitor %}
                   <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-monitor', fallback='navigation-v2-firefox-monitor') }}</h4>
@@ -29,7 +29,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.facebookcontainer.index') }}" data-link-name="Facebook Container" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+              <a class="c-menu-item-link" href="{{ url('firefox.facebookcontainer.index') }}" data-link-text="Facebook Container" data-link-type="nav" data-link-position="topnav" data-link-group="products">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#f80073" d="M27 1H5C2.8 1 1 2.8 1 5v22c0 2.2 1.8 4 4 4h22c2.2 0 4-1.8 4-4V5c0-2.2-1.8-4-4-4z"></path><path fill="#fff" d="M26 8.8l-1.4-1.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8h-2.3V8.9L19 7.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8h-2.3V8.9l-1.4-1.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8H9.2V8.9L7.8 7.4c-.1-.1-.2-.1-.3 0L6 8.8l-.1.1v15c0 .1.1.2.2.2H9c.1 0 .2-.1.2-.2v-2.8h2.3V24c0 .1.1.2.2.2h2.8c.1 0 .2-.1.2-.2v-2.8H17V24c0 .1.1.2.2.2H20c.1 0 .2-.1.2-.2v-2.8h2.3V24c0 .1.1.2.2.2h2.8c.1 0 .2-.1.2-.2V9c.4-.1.3-.2.3-.2zm-14.7 11H9.2v-6.6h2.3v6.6h-.2zm5.6 0h-2.1v-6.6h2.3v6.6h-.2zm5.7 0h-2.1v-6.6h2.3v6.6h-.2z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-facebook-container') }}</h4>
               {% if ftl_has_messages('navigation-v2-help-prevent-facebook-from') %}
@@ -40,7 +40,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-name="Pocket" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+              <a class="c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-text="Pocket" data-link-type="nav" data-link-position="topnav" data-link-group="products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/pocket/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-pocket') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-save-and-discover-the-best', fallback='navigation-save-quality-content') }}</p>
@@ -49,7 +49,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('products.vpn.landing') }}" data-link-name="Mozilla VPN" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+              <a class="c-menu-item-link" href="{{ url('products.vpn.landing') }}" data-link-text="Mozilla VPN" data-link-type="nav" data-link-position="topnav" data-link-group="products">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M26 10.4c-2.5 0-4.7 1.7-5.4 4h-9.3c-.1-.4-.3-.7-.4-1.1l2.4-2.4c.8.4 1.7.7 2.7.7 3.1 0 5.6-2.5 5.6-5.6S19.1.4 16 .4 10.4 2.9 10.4 6c0 1 .2 1.9.7 2.7l-2.4 2.4c-.8-.5-1.7-.7-2.7-.7C2.9 10.4.4 12.9.4 16s2.5 5.6 5.6 5.6c2.5 0 4.7-1.7 5.4-4h9.3c.1.4.3.7.4 1.1l-2.4 2.4c-.8-.4-1.7-.7-2.7-.7-3.1 0-5.6 2.5-5.6 5.6s2.5 5.6 5.6 5.6 5.6-2.5 5.6-5.6c0-1-.2-1.9-.7-2.7l2.4-2.4c.8.4 1.7.7 2.7.7 3.1 0 5.6-2.5 5.6-5.6s-2.5-5.6-5.6-5.6zM16 3.6c1.3 0 2.4 1.1 2.4 2.4S17.3 8.4 16 8.4 13.6 7.3 13.6 6s1.1-2.4 2.4-2.4zM6 18.4c-1.3 0-2.4-1.1-2.4-2.4s1.1-2.4 2.4-2.4c1.3 0 2.4 1.1 2.4 2.4S7.3 18.4 6 18.4zm10 10c-.5 0-1-.2-1.3-.4-.3-.2-.5-.4-.6-.6-.3-.4-.4-.8-.4-1.3s.2-1 .4-1.3c.2-.3.4-.5.6-.6.4-.3.8-.4 1.3-.4 1.3 0 2.4 1.1 2.4 2.4s-1.1 2.2-2.4 2.2zm10-10c-1.3 0-2.4-1.1-2.4-2.4s1.1-2.4 2.4-2.4 2.4 1.1 2.4 2.4-1.1 2.4-2.4 2.4z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-vpn') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-protection-beyond-your-browser', fallback='navigation-protect-your-entire-device') }}</p>
@@ -58,7 +58,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.privacy.products') }}" data-link-name="Hubs" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
+              <a class="c-menu-item-link" href="{{ url('firefox.privacy.products') }}" data-link-text="Hubs" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M27.3 7.6c0-1.5-1.1-2.8-2.6-3L16 3.1 7.2 4.6c-1.5.2-2.6 1.5-2.6 3 0 2.4 0 5.5.2 7 .4 4.5 1.3 7 3.5 9.8 1.9 2.4 4.6 4 7.6 4.4h.4c3-.5 5.7-2 7.6-4.4 2.2-2.8 3-5.3 3.5-9.8-.1-1.6-.1-5.1-.1-7zm-2.9 6.7c-.4 4-1.1 6-2.9 8.4-1.4 1.7-3.3 2.9-5.5 3.3-2.2-.4-4.1-1.6-5.5-3.3-1.8-2.4-2.5-4.4-2.9-8.4-.1-1.1-.1-3.5-.1-6.7 0-.1.1-.2.2-.2L16 6l8.3 1.4c.1 0 .2.1.2.2 0 3.2 0 5.7-.1 6.7zm-13.9-.2c0-.4-.1-1.5-.1-4.3l5.6-.9v14.2c-1.3-.3-2.4-1.1-3.2-2.1-1.4-1.8-2-3.1-2.3-6.9z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-product-promise') }}</h4>
               {% if ftl_has_messages('navigation-v2-learn-how-each-firefox-product') %}
@@ -69,7 +69,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://relay.firefox.com/?{{ utm_params }}" data-link-name="Firefox Relay" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
+              <a class="c-menu-item-link" href="https://relay.firefox.com/?{{ utm_params }}" data-link-text="Firefox Relay" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-relay', fallback='navigation-v2-firefox-relay-beta') }}</h4>
               {% if ftl_has_messages('navigation-v2-sign-up-for-new-accounts') %}
@@ -80,7 +80,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://developer.mozilla.org/en-US/plus?{{ utm_params }}" data-link-name="MDN Plus" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
+              <a class="c-menu-item-link" href="https://developer.mozilla.org/en-US/plus?{{ utm_params }}" data-link-text="MDN Plus" data-link-type="nav" data-link-position="topnav" data-link-group="projects">
                 <img loading="lazy" src="{{ static('img/nav/icons/icon-mdn-plus.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mdn-plus') }}</h4>
               {% if ftl_has_messages('navigation-v2-new-features-and-tools') %}
@@ -90,7 +90,7 @@
             </section>
           </li>
         </ul>
-        <p class="c-menu-category-link"><a href="{{ url('firefox.products.index') }}" data-link-name="View all Products" data-link-type="nav" data-link-position="topnav" data-link-group="products">{{ ftl('navigation-v2-view-all-products') }}</a></p>
+        <p class="c-menu-category-link"><a href="{{ url('firefox.products.index') }}" data-link-text="View all Products" data-link-type="nav" data-link-position="topnav" data-link-group="products">{{ ftl('navigation-v2-view-all-products') }}</a></p>
       </div>
     </div><!-- close .c-menu-panel-container -->
   </div><!-- close .c-menu-panel -->

--- a/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
@@ -15,7 +15,7 @@
         <ul class="mzp-l-rows-four">
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-name="Mozilla Manifesto" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-text="Mozilla Manifesto" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M9.5 28.6h13.1c2.6 0 4.6-2.1 4.6-4.6V8.1c0-2.6-2.1-4.6-4.6-4.6H9.5c-2.6 0-4.6 2.1-4.6 4.6V24c-.1 2.5 2 4.6 4.6 4.6zM7.6 8.1c0-1 .8-1.8 1.8-1.8h13.1c1 0 1.8.8 1.8 1.8V24c0 1-.8 1.8-1.8 1.8h-13c-1 0-1.8-.8-1.8-1.8V8.1zm12.6 2.3h-8.4c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7h8.4c.4 0 .7.3.7.7 0 .4-.3.7-.7.7zm-8.4 4.2h8.4c.4 0 .7-.3.7-.7s-.3-.7-.7-.7h-8.4c-.4 0-.7.3-.7.7s.3.7.7.7zm8.4 4.2h-8.4c-.4 0-.7-.3-.7-.7s.3-.7.7-.7h8.4c.4 0 .7.3.7.7s-.3.7-.7.7zM11.8 23h3.6c.4 0 .7-.3.7-.7s-.3-.7-.7-.7h-3.6c-.4 0-.7.3-.7.7s.3.7.7.7z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-manifesto', fallback='navigation-mozilla-manifesto') }}</h4>
               {% if ftl_has_messages('navigation-v2-learn-about-the-values') %}
@@ -26,7 +26,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://foundation.mozilla.org/?{{ utm_params }}" data-link-name="Mozilla Foundation" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="https://foundation.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Foundation" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M16 9.3V4H2.7v24h26.7V9.3H16zm-8 16H5.3v-2.7H8v2.7zM8 20H5.3v-2.7H8V20zm0-5.3H5.3V12H8v2.7zm0-5.4H5.3V6.7H8v2.6zm5.3 16h-2.7v-2.7h2.7v2.7zm0-5.3h-2.7v-2.7h2.7V20zm0-5.3h-2.7V12h2.7v2.7zm0-5.4h-2.7V6.7h2.7v2.6zm13.4 16H16v-2.7h2.7V20H16v-2.7h2.7v-2.7H16V12h10.7v13.3zM24 14.7h-2.7v2.7H24v-2.7zm0 5.3h-2.7v2.7H24V20z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-foundation') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-meet-the-not-for-profit-behind', fallback='navigation-the-non-profit-behind') }}</p>
@@ -35,7 +35,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-name="Get Involved" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-text="Get Involved" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M12 22.7l4-3.9c-.5-.1-.9-.1-1.3-.1C11.1 18.7 4 20.5 4 24v2.7h12l-4-4zm2.7-6.7c2.9 0 5.3-2.4 5.3-5.3s-2.4-5.3-5.3-5.3-5.3 2.4-5.3 5.3c-.1 2.9 2.3 5.3 5.3 5.3z"></path><path fill="#42435a" d="M20.6 27.3L16 22.7l1.9-1.9 2.8 2.8 6.8-6.9 1.9 1.9-8.8 8.7z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-get-involved', fallback='navigation-get-involved') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-join-the-fight-for-a', fallback='navigation-join-the-fight-for-a') }}</p>
@@ -44,7 +44,7 @@
           </li>
            <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('stories.landing') }}" data-link-name="Stories Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="{{ url('stories.landing') }}" data-link-text="Stories Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                <svg class="c-menu-item-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="#010101" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" transform="translate(2 1.87868)"><path d="m8.3.4h-7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h9l2 4 2-4h2c1.1 0 2-.9 2-2v-6"/><path d="m14.8-.1c.8-.8 2.2-.8 3 0s.8 2.2 0 3l-7.5 7.5-4 1 1-4z"/></g></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-stories') }}</h4>
               {% if ftl_has_messages('navigation-v2-navigation-v2-stories-about-how') %}
@@ -55,7 +55,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('mozorg.about.leadership.index') }}" data-link-name="Leadership" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="{{ url('mozorg.about.leadership.index') }}" data-link-text="Leadership" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M22.7 13.9V2.7H9.3v11.2c0 .5.2.9.7 1.1l5.6 3.3-1.3 3.1-4.5.4 3.5 3-1.1 4.4L16 27l3.9 2.4-1-4.4 3.5-3-4.5-.4-1.3-3.1 5.6-3.3c.2-.4.5-.8.5-1.3zm-5.4 2.4l-1.3.8-1.3-.8V4h2.7v12.3z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-leadership', fallback='navigation-leadership') }}</h4>
               {% if ftl_has_messages('navigation-v2-meet-the-team-thats-building') %}
@@ -66,7 +66,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('careers.home') }}" data-link-name="Careers" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="{{ url('careers.home') }}" data-link-text="Careers" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32"><path fill="#42435a" d="M13.3 21.3V20H4v5.3C4 26.8 5.2 28 6.7 28h18.7c1.5 0 2.7-1.2 2.7-2.7V20h-9.3v1.3h-5.5zm13.4-12h-5.3V6.7L18.7 4h-5.3l-2.7 2.7v2.7H5.3c-1.5 0-2.7 1.2-2.7 2.7v4c0 1.5 1.2 2.7 2.7 2.7h8V16h5.3v2.7h8c1.5 0 2.7-1.2 2.7-2.7v-4c0-1.5-1.2-2.7-2.6-2.7zm-8 0h-5.3V6.7h5.3v2.6z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-careers', fallback='navigation-careers') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-work-for-a-mission-driven-updated', fallback='navigation-work-for-a-mission-driven') }}</p>
@@ -75,7 +75,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://blog.mozilla.org/?{{ utm_params }}" data-link-name="Mozilla Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
+              <a class="c-menu-item-link" href="https://blog.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Blog" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-blog') }}</h4>
               {% if ftl_has_messages('navigation-v2-learn-about-mozilla-and') %}
@@ -87,7 +87,7 @@
 
         </ul>
         <p class="c-menu-category-link">
-          <a href="{{ url('mozorg.about.index') }}" data-link-name="More About Mozilla" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">{{ ftl('navigation-v2-more-about-mozilla') }}</a>
+          <a href="{{ url('mozorg.about.index') }}" data-link-text="More About Mozilla" data-link-type="nav" data-link-position="topnav" data-link-group="who-we-are">{{ ftl('navigation-v2-more-about-mozilla') }}</a>
         </p>
       </div>
     </div><!-- close .c-menu-panel-container -->

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -18,7 +18,7 @@
     <div class="c-navigation-container">
       <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items">{{ ftl('navigation-v2-menu') }}</button>
       <div class="c-navigation-logo">
-        <a href="{{ url('mozorg.home') }}" data-link-name="mozilla home icon" data-link-type="nav">
+        <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-type="nav">
           <img class="c-navigation-logo-image" src="{{ static('protocol/img/logos/mozilla/logo-word-hor.svg') }}" alt="{{ logo_alt }}" width="112" height="32">
         </a>
       </div>

--- a/bedrock/base/templates/includes/sticky-promo.html
+++ b/bedrock/base/templates/includes/sticky-promo.html
@@ -16,23 +16,23 @@
       <h3 class="mzp-c-sticky-promo-title">{{ ftl('firefox-sticky-promo-meet-mozillas-family', fallback='firefox-sticky-promo-meet-our-family-of') }}</h3>
       <ul class="promo-products-list">
         <li>
-          <a data-link-name="Browsers" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="{{ url('firefox.browsers.index') }}">
+          <a data-link-text="Browsers" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="{{ url('firefox.browsers.index') }}">
             <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-browsers') }}
           </a>
-          <a data-link-name="Monitor" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="https://monitor.mozilla.org/{{ promo_referrals }}" rel="external noopener">
+          <a data-link-text="Monitor" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="https://monitor.mozilla.org/{{ promo_referrals }}" rel="external noopener">
             <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-monitor') }}
           </a>
-          <a data-link-name="Pocket" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://getpocket.com/{{ promo_referrals }}">
+          <a data-link-text="Pocket" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://getpocket.com/{{ promo_referrals }}">
             <img loading="lazy" src="{{ static('protocol/img/logos/pocket/logo.svg') }}" width="32" height="29" alt="">
             {{ ftl('firefox-sticky-promo-pocket') }}
           </a>
-          <a data-link-name="Mozilla VPN" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="{{ url('products.vpn.landing') }}">
+          <a data-link-text="Mozilla VPN" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="{{ url('products.vpn.landing') }}">
             <img loading="lazy" src="{{ static('protocol/img/logos/mozilla/vpn/logo-flat-white.svg') }}" width="32" height="35" alt="">
             {{ ftl('firefox-sticky-promo-mozilla-vpn') }}
           </a>
-          <a data-link-name="Relay" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://relay.firefox.com/{{ promo_referrals }}">
+          <a data-link-text="Relay" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://relay.firefox.com/{{ promo_referrals }}">
             <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-relay') }}
           </a>

--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -10,7 +10,7 @@
   CSS Import: @import '~@mozilla-protocol/core/protocol/css/components/billboard';
   Macro Parameters:
     desc (Required): String indicating paragraph text (usually a translation id wrapped in ftl function).
-    ga_title (Required): String providing value for data-link-name attribute on cta.
+    ga_title (Required): String providing value for data-link-text attribute on cta.
     heading_level: Number indicating heading level for title text. Should be based on semantic meaning, not presentational styling.
     link_cta: String indicating link text (usually a translation id wrapped in an ftl function).
     link_url: String or url helper function provides href value for cta link.
@@ -38,7 +38,7 @@
         <h{{ heading_level }} class="mzp-c-billboard-title">{{ title }}</h{{ heading_level }}>
         <p class="mzp-c-billboard-desc">{{ desc }}</p>
         {% if link_url and link_cta %}
-          <a class="mzp-c-cta-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link">{{ link_cta }}</a>
+          <a class="mzp-c-cta-link" href="{{ link_url }}" data-link-text="{{ ga_title }}" data-link-type="link">{{ link_cta }}</a>
         {% endif %}
       </div>
     </div>
@@ -180,7 +180,7 @@
     class: String adding class(es) to the section tag.
     cta: String adding optional call to action for the card.,
     desc: String indicating paragraph text (usually a translation id wrapped in ftl function).,
-    ga_title (Required): String providing value for data-link-name attribute on cta.,
+    ga_title (Required): String providing value for data-link-text attribute on cta.,
     heading_level: Number indicating heading level for title text. Should be based on semantic meaning, not presentational styling
     image (Required): Image to be used in the Card element. Can pass an <img> element, resp_img or picture Python helpers
     link_rel: String for link rel attribute.
@@ -214,7 +214,7 @@
   youtube_id=None
 ) -%}
 <section class="mzp-c-card {% if class %}{{ class }}{% endif %} {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if media_icon %}{{ media_icon }}{% endif %} {% if youtube_id %}mzp-has-video has-video-embed{% endif %}" {% if attributes %}{{attributes|safe}}{% endif %}>
-  <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}  {% if link_target %}target="{{ link_target }}"{% endif %} {% if link_rel %}rel="{{ link_rel }}"{% endif %} {% if link_title %}title="{{ link_title }}"{% endif %}>
+  <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-text="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}  {% if link_target %}target="{{ link_target }}"{% endif %} {% if link_rel %}rel="{{ link_rel }}"{% endif %} {% if link_title %}title="{{ link_title }}"{% endif %}>
     {% if image %}
       <div class="mzp-c-card-media-wrapper">{{ image|safe }}</div>
     {% endif %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -175,7 +175,7 @@
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
         {% if title.href %}
-          <a href="{{ title.href }}" data-link-type="nav" data-link-position="subnav" data-link-name="{{ title.cta_name }}">
+          <a href="{{ title.href }}" data-link-type="nav" data-link-position="subnav" data-link-text="{{ title.cta_name }}">
             {% if title.icon %}<img class="c-sub-navigation-icon" src="{{ title.icon }}" width="24" height="24" alt="">{% endif %}
             {{ title.text }}
           </a>
@@ -191,7 +191,7 @@
             href="{{ link.href }}"
             data-link-type="nav"
             data-link-position="subnav"
-            data-link-name="{{ link.cta_name }}"
+            data-link-text="{{ link.cta_name }}"
             {% if current_page == link.href %} aria-current="page"{% endif %}
           >
             {{ link.text }}

--- a/bedrock/base/tests/test_macros.py
+++ b/bedrock/base/tests/test_macros.py
@@ -27,9 +27,9 @@ regular_link_input = {"text": "Testing link", "href": "/regular", "cta_name": "T
 EXPECTED_NAV_HTML = {
     "title_text": """Testing title""",
     "title_icon": """<img class="c-sub-navigation-icon" src="icon.png" width="24" height="24" alt="">""",
-    "title_link": """<a href="/category" data-link-type="nav" data-link-position="subnav" data-link-name="Test Title">""",
-    "current_link": """<a href="/current" data-link-type="nav" data-link-position="subnav" data-link-name="Test Link" aria-current="page"> Testing current link </a>""",  # noqa: E501
-    "regular_link": """<a href="/regular" data-link-type="nav" data-link-position="subnav" data-link-name="Test Link"> Testing link </a>""",
+    "title_link": """<a href="/category" data-link-type="nav" data-link-position="subnav" data-link-text="Test Title">""",
+    "current_link": """<a href="/current" data-link-type="nav" data-link-position="subnav" data-link-text="Test Link" aria-current="page"> Testing current link </a>""",  # noqa: E501
+    "regular_link": """<a href="/regular" data-link-type="nav" data-link-position="subnav" data-link-text="Test Link"> Testing link </a>""",
     "is_summary": """is-summary""",
     "is_details_default_closed": """is-details is-closed""",
 }

--- a/bedrock/careers/templates/careers/includes/footer.html
+++ b/bedrock/careers/templates/careers/includes/footer.html
@@ -26,17 +26,17 @@
 
     <ul class="c-careers-socials">
       <li>
-        <a href="https://www.instagram.com/mozilla/" class="c-careers-instagram" data-link-name="Instagram">
+        <a href="https://www.instagram.com/mozilla/" class="c-careers-instagram" data-link-text="Instagram">
           <span class="visually-hidden">Instagram</span>
         </a>
         </li>
       <li>
-        <a href="https://twitter.com/mozilla" class="c-careers-twitter" data-link-name="Twitter">
+        <a href="https://twitter.com/mozilla" class="c-careers-twitter" data-link-text="Twitter">
           <span class="visually-hidden">Twitter</span>
         </a>
         </li>
       <li>
-        <a href="https://www.glassdoor.com/Overview/Working-at-Mozilla-EI_IE19129.11,18.htm" class="c-careers-glassdoor" data-link-name="Glassdoor">
+        <a href="https://www.glassdoor.com/Overview/Working-at-Mozilla-EI_IE19129.11,18.htm" class="c-careers-glassdoor" data-link-text="Glassdoor">
           <span class="visually-hidden">Glassdoor</span>
         </a>
         </li>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -38,13 +38,13 @@
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
-        <a href="{{ url('firefox.accounts') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Accounts">
+        <a href="{{ url('firefox.accounts') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox Accounts">
           {{ ftl('sub-navigation-mozilla-account', fallback='sub-navigation-firefox-accounts') }}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.features.sync') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Sync">{{ ftl('sub-navigation-sync') }}</a>
+          <a href="{{ url('firefox.features.sync') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Sync">{{ ftl('sub-navigation-sync') }}</a>
         </li>
       </ul>
     </div>

--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -26,17 +26,17 @@
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
           <h2 class="c-sub-navigation-title is-summary">
-            <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
+            <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
               {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
           <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item">
-              <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
+              <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-text="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
             </li>
             <li class="c-sub-navigation-item">
-              <a href="https://support.mozilla.org/kb/browsing-history-firefox/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=browser-history" data-link-type="nav" data-link-position="subnav" data-link-name="Browsing History">{{ ftl('sub-navigation-browsing-history') }}</a>
+              <a href="https://support.mozilla.org/kb/browsing-history-firefox/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=browser-history" data-link-type="nav" data-link-position="subnav" data-link-text="Browsing History">{{ ftl('sub-navigation-browsing-history') }}</a>
             </li>
           </ul>
         </div>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -50,16 +50,16 @@
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
           <h2 class="c-sub-navigation-title is-summary">
-            <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
+            <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
               {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
           <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item">
-              <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
+              <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-text="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
             </li>
-            <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
+            <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
           </ul>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -21,13 +21,13 @@
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
           <h2 class="c-sub-navigation-title is-summary">
-            <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
+            <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
               {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
           <ul class="c-sub-navigation-list is-details is-closed">
-            <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
+            <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
           </ul>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -36,15 +36,15 @@
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
-        <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
+        <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
          {{ ftl('sub-navigation-firefox') }}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.enterprise.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Enterprise">{{ ftl('sub-navigation-enterprise') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.enterprise.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Enterprise">{{ ftl('sub-navigation-enterprise') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-text="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
       </ul>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -33,15 +33,15 @@
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
-        <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
+        <a href="{{ url('firefox.browsers.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox">
           <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
          {{ ftl('sub-navigation-firefox') }}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.developer.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Developer Edition">{{ ftl('sub-navigation-developer-edition') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.developer.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Developer Edition">{{ ftl('sub-navigation-developer-edition') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Nightly and Beta">{{ ftl('sub-navigation-nightly-and-beta') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-text="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a></li>
       </ul>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -22,16 +22,16 @@
       <div class="mzp-l-content">
         <div class="c-sub-navigation-content">
           <h2 class="c-sub-navigation-title is-summary">
-            <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox">
+            <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox">
               <img class="c-sub-navigation-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" width="24" height="24" alt="">
              {{ ftl('sub-navigation-firefox') }}
             </a>
           </h2>
           <ul class="c-sub-navigation-list is-details is-closed">
             <li class="c-sub-navigation-item">
-              <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-name="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
+              <a href="{{ url('firefox.browsers.what-is-a-browser') }}" data-link-type="nav" data-link-position="subnav" data-link-text="What Is a Browser?">{{ ftl('sub-navigation-what-is-a-browser') }}</a>
             </li>
-            <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
+            <li class="c-sub-navigation-item"><a href="{{ url('firefox.browsers.browser-history') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Browser History">{{ ftl('sub-navigation-browser-history') }}</a></li>
           </ul>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/features/includes/subnav.html
+++ b/bedrock/firefox/templates/firefox/features/includes/subnav.html
@@ -10,19 +10,19 @@
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
-        <a href="{{ url('firefox.features.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Firefox Features">
+        <a href="{{ url('firefox.features.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Firefox Features">
           {{ ftl('sub-navigation-firefox-features') }}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.features.sync') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Sync">{{ ftl('sub-navigation-sync') }}</a>
+          <a href="{{ url('firefox.features.sync') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Sync">{{ ftl('sub-navigation-sync') }}</a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.features.adblocker') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Ad Tracker Blocking">{{ ftl('sub-navigation-ad-tracker-blocking') }}</a>
+          <a href="{{ url('firefox.features.adblocker') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Ad Tracker Blocking">{{ ftl('sub-navigation-ad-tracker-blocking') }}</a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.features.private-browsing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Private Browsing">{{ ftl('sub-navigation-private-browsing') }}</a>
+          <a href="{{ url('firefox.features.private-browsing') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Private Browsing">{{ ftl('sub-navigation-private-browsing') }}</a>
         </li>
       </ul>
     </div>

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -15,7 +15,7 @@
   desc
 ) -%}
 <li class="c-feature-item">
-  <a href="{{ link }}" data-link-name="{{ ga_title }}" data-link-type="link">
+  <a href="{{ link }}" data-link-text="{{ ga_title }}" data-link-type="link">
     <h3 class="c-feature-item-title">{{ title }}</h3>
     <p>{{ desc }}</p>
     <p class="c-feature-item-cta">{{ ftl('ui-learn-more') }}</p>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -57,8 +57,8 @@
         {{ ftl('sub-navigation-firefox') }}
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.faq') }}" data-link-type="nav" data-link-position="subnav" data-link-name="FAQ">{{ ftl('sub-navigation-faq') }}</a></li>
-        <li class="c-sub-navigation-item"><a href="{{ url('firefox.more') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Learn More">{{ ftl('sub-navigation-learn-more') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.faq') }}" data-link-type="nav" data-link-position="subnav" data-link-text="FAQ">{{ ftl('sub-navigation-faq') }}</a></li>
+        <li class="c-sub-navigation-item"><a href="{{ url('firefox.more') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Learn More">{{ ftl('sub-navigation-learn-more') }}</a></li>
       </ul>
     </div>
   </div>
@@ -137,9 +137,9 @@
           {# Direct users on unsupported OSes to the /new/ page, where they can read EOL messaging (see issue 13317) #}
           <li class="mzp-c-menu-list-item menu-desktop-unsupported"><a href="{{ url('firefox.new') }}" class="ga-product-download"  data-cta-type="link" data-cta-text="Firefox Desktop">{{ ftl('firefox-home-desktop') }}</a></li>
           {# Download link should be locale neutral see issue 7982 #}
-          <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" class="ga-product-download" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-name="Trackers">{{ ftl('firefox-home-desktop') }}</a></li>
-          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" class="ga-product-download"  rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android" data-link-name="Trackers"> {{ ftl('firefox-home-android') }}</a></li>
-          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" class="ga-product-download"  rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS" data-link-name="Trackers">{{ ftl('firefox-home-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" class="ga-product-download" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-link-text="Trackers">{{ ftl('firefox-home-desktop') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" class="ga-product-download"  rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android" data-link-text="Trackers"> {{ ftl('firefox-home-android') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" class="ga-product-download"  rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS" data-link-text="Trackers">{{ ftl('firefox-home-ios') }}</a></li>
         </ul>
       </div>
       <p id="test-fbc" class="js-fx-only"><a class="mzp-c-cta-link" href="https://addons.mozilla.org/firefox/addon/facebook-container/{{ referrals }}">{{ ftl('firefox-home-get-the-facebook-container') }}</a></p>
@@ -162,7 +162,7 @@
         </h3>
       </div>
       <h4>{{ ftl('firefox-home-know-when-hackers-strike') }}</h4>
-      <a class="mzp-c-cta-link" href="{{ 'https://monitor.mozilla.org/' + referrals }}" data-link-name="Monitor" data-link-type="link">{{ ftl('firefox-home-start-getting-breach') }}</a>
+      <a class="mzp-c-cta-link" href="{{ 'https://monitor.mozilla.org/' + referrals }}" data-link-text="Monitor" data-link-type="link">{{ ftl('firefox-home-start-getting-breach') }}</a>
     {% endcall %}
 
   {% if ftl_has_messages('firefox-home-protection-for-your-whole') %}
@@ -176,7 +176,7 @@
         <h3>{{ ftl('firefox-home-mozilla-vpn') }}</h3>
       </div>
       <h4>{{ ftl('firefox-home-protection-for-your-whole') }}</h4>
-      <p><a class="mzp-c-cta-link" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Get Mozilla VPN" data-link-name="Mozilla VPN">{{ ftl('firefox-home-get-mozilla-vpn') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="Get Mozilla VPN" data-link-text="Mozilla VPN">{{ ftl('firefox-home-get-mozilla-vpn') }}</a></p>
     {% endcall %}
   {% endif %}
 
@@ -189,7 +189,7 @@
       <div>
         <h3 class="mzp-has-zap-8">{{ ftl('firefox-home-get-the-respect-you') }}</h3>
         <p>{{ ftl('firefox-home-every-single-mozilla', fallback='firefox-home-every-single-firefox') }}</p>
-        <a class="mzp-c-cta-link" href="{{ url('firefox.privacy.index') }}" data-link-name="Promise" data-link-type="link">{{ ftl('ui-learn-more') }}</a>
+        <a class="mzp-c-cta-link" href="{{ url('firefox.privacy.index') }}" data-link-text="Promise" data-link-type="link">{{ ftl('ui-learn-more') }}</a>
       </div>
     {% endcall %}
   </div>
@@ -207,11 +207,11 @@
       <div class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h5 class="mzp-c-menu-list-title">{{ ftl('firefox-home-download-the-app') }}</h5>
         <ul class="mzp-c-menu-list-list" id="menu-pocket">
-          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('android', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for Android" data-link-name="Pocket"> {{ ftl('firefox-home-android') }}</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for iOS" data-link-name="Pocket">{{ ftl('firefox-home-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('android', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for Android" data-link-text="Pocket"> {{ ftl('firefox-home-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for iOS" data-link-text="Pocket">{{ ftl('firefox-home-ios') }}</a></li>
         </ul>
       </div>
-      <p><a class="mzp-c-cta-link" href="https://getpocket.com/signup/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Download for iOS" data-link-name="Pocket">{{ ftl('firefox-home-learn-more-about-pocket') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="https://getpocket.com/signup/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Download for iOS" data-link-text="Pocket">{{ ftl('firefox-home-learn-more-about-pocket') }}</a></p>
     {% endcall %}
 
     {% call split(
@@ -224,7 +224,7 @@
         <h3>{{ ftl('firefox-home-firefox-relay') }}</h3>
       </div>
       <h4>{{ ftl('firefox-home-un-spam-your-life') }}</h4>
-      <a class="mzp-c-cta-link" href="{{ 'https://relay.firefox.com/' + referrals }}" data-link-name="Relay" data-link-type="link">{{ ftl('firefox-home-try-relay') }}</a>
+      <a class="mzp-c-cta-link" href="{{ 'https://relay.firefox.com/' + referrals }}" data-link-text="Relay" data-link-type="link">{{ ftl('firefox-home-try-relay') }}</a>
     {% endcall %}
 
     {% include 'mozorg/includes/mozilla-account-cta-promo.html' %}

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -667,7 +667,7 @@
     {% endif %}
   </p>
 
-  <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
+  <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-text="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
 
   {{ download_firefox_thanks(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_class='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
 </aside>

--- a/bedrock/firefox/templates/firefox/new/desktop/includes/sub_nav.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/includes/sub_nav.html
@@ -10,16 +10,16 @@
       <h2 class="c-sub-navigation-title is-summary">{{ ftl('sub-navigation-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h2>
       <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.features.index') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Features">{{ ftl('sub-navigation-features', fallback='navigation-features') }}</a>
+          <a href="{{ url('firefox.features.index') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Features">{{ ftl('sub-navigation-features', fallback='navigation-features') }}</a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="https://support.mozilla.org/products/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-name="Support">{{ ftl('sub-navigation-support', fallback='navigation-support') }}</a>
+          <a href="https://support.mozilla.org/products/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-text="Support">{{ ftl('sub-navigation-support', fallback='navigation-support') }}</a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="https://addons.mozilla.org/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-name="Addons">{{ ftl('sub-navigation-add-ons') }}</a>
+          <a href="https://addons.mozilla.org/firefox/{{ referrals }}" data-link-type="nav" data-link-position="subnav" data-link-text="Addons">{{ ftl('sub-navigation-add-ons') }}</a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-name="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a>
+          <a href="{{ url('firefox.all') }}" data-link-type="nav" data-link-position="subnav" data-link-text="All Languages">{{ ftl('sub-navigation-all-languages', fallback='download-button-systems-languages') }}</a>
         </li>
       </ul>
     </div>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -385,7 +385,7 @@
   <p>{{ ftl('privacy-book-do-you-have') }}</p>
 
   <h3>Twitter</h3>
-  <a class="twitter" href="https://twitter.com/firefox" data-link-type="privacy-book" data-link-name="Twitter (@firefox)">{{ ftl('privacy-book-twitter') }}<span> (@firefox)</span></a>
+  <a class="twitter" href="https://twitter.com/firefox" data-link-type="privacy-book" data-link-text="Twitter (@firefox)">{{ ftl('privacy-book-twitter') }}<span> (@firefox)</span></a>
 </section>
 
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -57,13 +57,13 @@
       {% set share_url = settings.CANONICAL_URL + canonical_path %}
       <ul class="c-share-options">
         <li>
-          <a class="facebook" data-link-type="social share" data-link-name="Facebook" href="https://www.facebook.com/sharer/sharer.php?s=100&p[url]={{ share_url|urlencode }}">
+          <a class="facebook" data-link-type="social share" data-link-text="Facebook" href="https://www.facebook.com/sharer/sharer.php?s=100&p[url]={{ share_url|urlencode }}">
             {{ ftl('switch-share-to-facebook-updated', fallback='switch-share-to-facebook') }}
           </a>
         </li>
         <li>
           {% set tweet_text = ftl('switch-firefox-makes-switching-fast-tweet') %}
-          <a class="twitter" data-link-type="social share" data-link-name="Twitter" href="https://www.twitter.com/intent/tweet?url={{ share_url|urlencode }}&text={{ tweet_text|urlencode }}">
+          <a class="twitter" data-link-type="social share" data-link-text="Twitter" href="https://www.twitter.com/intent/tweet?url={{ share_url|urlencode }}&text={{ tweet_text|urlencode }}">
             {{ ftl('switch-send-a-tweet') }}
           </a>
         </li>
@@ -74,7 +74,7 @@
           {% set email_end = ftl('switch-check-it-out')|mailtoencode %}
 
           {% set email_body = email_intro + '%0D%0A%0D%0A' + email_start + '%0D%0A%0D%0A' + email_end + '%20' + share_url|urlencode %}
-          <a class="email" data-link-type="social share" data-link-name="Email" href="{{ 'mailto:?subject=%s&body=%s'|format(email_subject, email_body)|e }}">
+          <a class="email" data-link-type="social share" data-link-text="Email" href="{{ 'mailto:?subject=%s&body=%s'|format(email_subject, email_body)|e }}">
             {{ ftl('switch-send-an-email') }}
           </a>
         </li>

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -30,7 +30,7 @@
     <h1 class="mzp-c-call-out-title">{{ ftl('about-mozilla-makes-browsers-apps') }}</h1>
     <p class="mzp-c-call-out-desc">{{ ftl('about-our-mission-keep-the-internet') }}</p>
      <p class="c-call-out-cta">
-        <a id="read-mission-button" class="mzp-c-button" href="{{ url('mozorg.mission') }}" data-link-name="Read Our Mission" data-link-type="button" data-cta-position="primary cta">
+        <a id="read-mission-button" class="mzp-c-button" href="{{ url('mozorg.mission') }}" data-link-text="Read Our Mission" data-link-type="button" data-cta-position="primary cta">
           {{ ftl('about-read-our-mission') }}
         </a>
       </p>

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -77,7 +77,7 @@
       include_cta=True
     ) %}
       <p>
-        <a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-name="Twitter">
+        <a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-text="Twitter">
           {{ ftl('manifesto-share-on-twitter') }}
         </a>
       </p>
@@ -131,7 +131,7 @@
           </li>
         </ol>
         <footer class="content principles-foot">
-          <p><a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-name="Twitter">{{ ftl('manifesto-share-on-twitter') }}</a></p>
+          <p><a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-text="Twitter">{{ ftl('manifesto-share-on-twitter') }}</a></p>
           <p><a class="mzp-c-cta-link" href="{{ url('mozorg.about.manifesto-details') }}">{{ ftl('manifesto-read-the-entire-manifesto') }}</a></p>
         </footer>
       </section>

--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -63,10 +63,10 @@
       </ul>
 
       <ul class="social-links">
-        <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
-        <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
-        <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
-        <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>
+        <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-text="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
+        <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-text="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
+        <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-text="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
+        <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@firefox)">{{ ftl('opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>
       </ul>
     </aside>
   </div>{#-- /.content --#}

--- a/bedrock/products/templates/products/vpn/includes/subnav-refresh.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav-refresh.html
@@ -8,23 +8,23 @@
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
       <h2 class="c-sub-navigation-title is-summary">
-        <a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">
+        <a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Mozilla VPN">
           {{ ftl('vpn-subnav-title') }}
         </a>
       </h2>
       <ul class="c-sub-navigation-list is-details is-closed">
         <li class="c-sub-navigation-item">
-          <a href="{{ url('products.vpn.resource-center.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Learn about VPNs">
+          <a href="{{ url('products.vpn.resource-center.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Learn about VPNs">
             {{ ftl('vpn-subnav-learn-about-vpns') }}
           </a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="{{ url('products.vpn.features') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Features">
+          <a href="{{ url('products.vpn.features') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Features">
             {{ ftl('vpn-subnav-features') }}
           </a>
         </li>
         <li class="c-sub-navigation-item">
-          <a href="{{ url('products.vpn.download') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Download Mozilla VPN">
+          <a href="{{ url('products.vpn.download') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Download Mozilla VPN">
             {{ ftl('vpn-subnav-download-mozilla-vpn') }}
           </a>
         </li>

--- a/bedrock/products/templates/products/vpn/includes/subnav.html
+++ b/bedrock/products/templates/products/vpn/includes/subnav.html
@@ -9,18 +9,18 @@
     <div class="mzp-l-content">
       <div class="c-sub-navigation-content">
         <h2 class="c-sub-navigation-title is-summary">
-          <a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Mozilla VPN">
+          <a href="{{ url('products.vpn.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Mozilla VPN">
             {{ ftl('vpn-subnav-title') }}
           </a>
         </h2>
         <ul class="c-sub-navigation-list is-details is-closed">
           <li class="c-sub-navigation-item">
-            <a href="{{ url('products.vpn.resource-center.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Learn about VPNs">
+            <a href="{{ url('products.vpn.resource-center.landing') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Learn about VPNs">
               {{ ftl('vpn-subnav-learn-about-vpns') }}
             </a>
           </li>
           <li class="c-sub-navigation-item">
-            <a href="{{ url('products.vpn.download') }}" data-link-type="nav" data-link-position="subnav" data-link-name="Download Mozilla VPN">
+            <a href="{{ url('products.vpn.download') }}" data-link-type="nav" data-link-position="subnav" data-link-text="Download Mozilla VPN">
               {{ ftl('vpn-subnav-download-mozilla-vpn') }}
             </a>
           </li>

--- a/bedrock/stories/templates/stories/stories-base-article.html
+++ b/bedrock/stories/templates/stories/stories-base-article.html
@@ -41,7 +41,7 @@
       <div class="c-navigation-container">
         <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items">{{ ftl('navigation-v2-menu') }}</button>
         <div class="c-navigation-logo">
-          <a href="{{ url('mozorg.home') }}" data-link-name="mozilla home icon" data-link-type="nav">
+          <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-type="nav">
             <img class="c-navigation-logo-image" src="{{ static('protocol/img/logos/mozilla/logo-word-hor.svg') }}" alt="{{ logo_alt }}" width="112" height="32">
           </a>
         </div>

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -333,23 +333,24 @@ CTA Click
 Like our UA implementation (documented above) the implementation of ``cta_click`` for GA4 is based of
 the existence of certain data-attributes on an element.
 
-Only one of the following data-attributes is necessary to log the event:
+`data-cta-text` must be present to trigger the event:
 
+- data-cta-text
+  - Defining this is useful to group the link clicks across locales
+  - The value does not need to exactly match the text
+  - Provide something more useful than "click here" or "learn more". If that is the copy you were provided
+    consider asking for copy that is more useful to the users too!
+- data-cta-position (examples: banner, pricing, primary, secondary)
 - data-cta-type (examples: fxa-sync, fxa-monitor, fxa-vpn, monitor, relay, pocket)
   - This is to group CTAs by their destination
   - Do not use this to identify the element (ie. link, button)
-- data-cta-position (examples: banner, pricing, primary, secondary)
-- data-cta-text
-  - If no value is provided the text of the clicked element will be used
-  - Please use this when the link text is not useful.
-  - Also, if it's not useful to us we might be failing our users as well! Don't use text like
-  "click here" or "learn more"
+
 
 .. code-block:: html
 
-    <a href="https://monitor.mozilla.org/&entrypoint={{ _entrypoint }}" data-cta-type="fxa-monitor">Check for breaches</a>
+    <a href="https://monitor.firefox.com/" data-cta-text="Check for breaches" data-cta-type="fxa-monitor">Check for breaches</a>
 
-    <a href="{{ url('firefox.browsers.mobile.get-app') }}" data-cta-position="banner" data-cta-text="Get It Now">Send me a link</a>
+    <a href="{{ url('firefox.browsers.mobile.get-app') }}" data-cta-text="Send Link for Firefox Mobile" data-cta-position="banner">Send me a link</a>
 
     <a href="{{ url('firefox.browsers.mobile.ios') }}" data-cta-text="Firefox for iOS">Firefox for iOS</a>
 
@@ -359,15 +360,28 @@ For all links to accounts.firefox.com use these data attributes (* indicates a r
 +-----------------------+----------------------------------------------------------------------------------+
 | Data Attribute        | Expected Value                                                                   |
 +=======================+==================================================================================+
-| ``data-cta-type`` *   | fxa-servicename (e.g. ``fxa-sync``, ``fxa-monitor``)                             |
+| ``data-cta-text`` *   | Text or name of the link (e.g. ``Sign Up``, ``Join Now``, ``Start Here``).       |
 +-----------------------+----------------------------------------------------------------------------------+
-| ``data-cta-text``     | Name or text of the link (e.g. ``Sign Up``, ``Join Now``, ``Start Here``).       |
-|                       |                                                                                  |
-|                       | We use this when the link text is not useful, as is the case with many           |
-|                       | account forms that say, ``Continue``. We replace ``Continue`` with ``Register``. |
+| ``data-cta-type`` *   | fxa-servicename (e.g. ``fxa-sync``, ``fxa-monitor``)                             |
 +-----------------------+----------------------------------------------------------------------------------+
 | ``data-cta-position`` | Location of CTA on the page (e.g. ``primary``, ``secondary``, ``header``)        |
 +-----------------------+----------------------------------------------------------------------------------+
+
+
+Link Click
+~~~~~~~~~
+
+Our implementation of ``link_click`` for GA4 is based of the existence of certain data-attributes on a
+link element.
+
+`data-link-text` must be present to trigger the event:
+
+- data-link-text (examples: “Monitor”, “Features”, “Instagram (mozilla)”, “Mozilla VPN”)
+- data-link-position (examples: topnav, subnav, sticky-promo, topnav - firefox, footer - company)
+
+```
+<a href="" data-link-text=""></a>
+```
 
 
 Product Download
@@ -416,7 +430,6 @@ Widget Action
 ~~~~~~~~~~~~~
 
 We are using the custom event ``widget_action`` to track the behaviour of javascript widgets.
-
 
 **How do you chose between ``widget_action`` and ``cta_click``?**
 

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -57,9 +57,9 @@ class BasePage(ScrollElementIntoView, Page):
         _products_menu_locator = (By.CSS_SELECTOR, '.c-menu-title[aria-controls="c-menu-panel-products"]')
         _about_menu_locator = (By.CSS_SELECTOR, '.c-menu-title[aria-controls="c-menu-panel-about"]')
         _innovation_menu_locator = (By.CSS_SELECTOR, '.c-menu-title[aria-controls="c-menu-panel-innovation"]')
-        _firefox_desktop_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-name="Firefox Desktop Browser"]')
-        _developer_edition_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-name="Firefox Developer Edition"]')
-        _manifesto_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-name="Mozilla Manifesto"]')
+        _firefox_desktop_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-text="Firefox Desktop Browser"]')
+        _developer_edition_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-text="Firefox Developer Edition"]')
+        _manifesto_page_locator = (By.CSS_SELECTOR, '.c-menu-item-link[data-link-text="Mozilla Manifesto"]')
         _firefox_download_button_locator = (By.CSS_SELECTOR, "#protocol-nav-download-firefox > .download-link")
         _mozilla_vpn_button_locator = (By.CSS_SELECTOR, '.c-navigation-vpn-cta-container > [data-cta-text="Get Mozilla VPN"]')
 


### PR DESCRIPTION
### DO NOT MERGE until GTM changes in #14056 are published.

## One-line summary

Change `data-link-name` to `data-link-text` and add documentation for `link_click` event in GA4.

## Significant changes and points to review

- change `data-link-name` to `data-link-text`
- add docs for GA4 `link_click`
- update docs for `cta_click` to standardize on requiring a value for "text" to trigger both these events

## Issue / Bugzilla link

- parent issue: #14053
- accompanying GTM changes: #14056
- fix #14055

## Testing

- Did I get them all?
- Testing is mostly covered in #14056