### PR TITLE
Remove links to Mozillians.org from leadership pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
@@ -42,8 +42,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
               href="https://twitter.com/MitchellBaker">@MitchellBaker</a></li>
           <li><a class="url website" itemprop="url" rel="me external"
               href="https://blog.lizardwrangler.com">lizardwrangler.com</a></li>
-          <li><a class="url profile" itemprop="url" rel="me external" href="https://mozillians.org/u/mitchell/">Mozillians
-              profile</a></li>
         </ul>
 
         <ul class="utility">

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/mofo.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/mofo.html
@@ -31,7 +31,6 @@
         <ul class="elsewhere">
           <li><a class="url twitter" itemprop="url" rel="me external" href="https://twitter.com/msurman">@msurman</a></li>
           <li><a class="url website" itemprop="url" rel="me external" href="https://commonspace.wordpress.com/">Website</a></li>
-          <li><a class="url profile" itemprop="url" rel="me external" href="https://mozillians.org/u/surman/">Mozillians profile</a></li>
         </ul>
 
         <ul class="utility">
@@ -159,7 +158,6 @@
 
         <ul class="elsewhere">
           <li><a class="url twitter" itemprop="url" rel="me external" href="https://twitter.com/ashleyboyd">@ashleyboyd</a></li>
-          <li><a class="url profile" itemprop="url" rel="me external" href="https://mozillians.org/u/ashleywarrenboyd">Mozillians profile</a></li>
         </ul>
 
         <ul class="utility">
@@ -220,7 +218,6 @@
 
         <ul class="elsewhere">
           <li><a class="url twitter" itemprop="url" rel="me external" href="https://twitter.com/angelaplohman">@angelaplohman</a></li>
-          <li><a class="url profile" itemprop="url" rel="me external" href="https://mozillians.org/u/aplohman/">Mozillians profile</a></li>
         </ul>
 
         <ul class="utility">


### PR DESCRIPTION
These links seem pretty old and are of low value because Mozillians.org now redirects to people.m.o which in turn needs a user to be authenticated in order to see profiles.

Mark's link redirected to a valid people.m.o page, but behind auth Angela and Ashley's profiles had moved to a different slug on people.m.o.

Also, the link for Mitchell's profile was wrong and was pointing to one with a similar slug but not her actual people.m.o profile

## Issue / Bugzilla link

Resolves #14059


## Testing

* Check http://localhost:8000/en-US/about/leadership/ for Mitchell
* Check http://localhost:8000/en-US/about/leadership/#foundation for Mark, Angela and Ashley 