### PR TITLE
Add a warning that Nightly will be updated once/twice a day

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -65,12 +65,15 @@
       <li><a rel="external" href="https://blog.nightly.mozilla.org/">{{ ftl('firefox-channel-nightly-blog') }}</a></li>
       <li><a href="{{ firefox_url('android', 'all', 'nightly') }}">{{ ftl('firefox-channel-all-languages-and-builds') }}</a></li>
     </ul>
+    <p>
     {% if ftl_has_messages('firefox-channel-nightly-is-an-unstable-testing') %}
       {{ ftl('firefox-channel-nightly-is-an-unstable-testing', link=url('privacy.notices.firefox') + '#pre-release') }}
     {% else %}
       {{ ftl('firefox-channel-firefox-nightly-automatically') }}
       <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
+    </p>
+    <p>{{ ftl('firefox-channel-nightly-update-one-or-more-times') }}</p>
   </div>
 </section>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -107,6 +107,7 @@
         <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
+    <p>{{ ftl('firefox-channel-nightly-update-one-or-more-times') }}</p>
   </div>
 </section>
 {% endblock %}

--- a/l10n/en/firefox/channel.ftl
+++ b/l10n/en/firefox/channel.ftl
@@ -63,4 +63,4 @@ firefox-channel-test-beta-versions-of-firefox-ios-long = Test beta versions of {
 firefox-channel-test-flight = { -brand-name-test-flight }
 firefox-channel-test-beta-versions-of-firefox-ios = Test beta versions of { -brand-name-firefox } for { -brand-name-ios } via { -brand-name-apple }’s { -brand-name-test-flight } program.
 firefox-channel-sign-up-now = Sign up now
-firefox-channel-nightly-update-one-or-more-times = Note: { -brand-name-firefox-nightly } will update approximately one or two times each day.
+firefox-channel-nightly-update-one-or-more-times = Note: { -brand-name-firefox-nightly } will update approximately once or twice a day.

--- a/l10n/en/firefox/channel.ftl
+++ b/l10n/en/firefox/channel.ftl
@@ -63,3 +63,4 @@ firefox-channel-test-beta-versions-of-firefox-ios-long = Test beta versions of {
 firefox-channel-test-flight = { -brand-name-test-flight }
 firefox-channel-test-beta-versions-of-firefox-ios = Test beta versions of { -brand-name-firefox } for { -brand-name-ios } via { -brand-name-apple }’s { -brand-name-test-flight } program.
 firefox-channel-sign-up-now = Sign up now
+firefox-channel-nightly-update-one-or-more-times = Note: { -brand-name-firefox-nightly } will update approximately one or two times each day.


### PR DESCRIPTION
## One-line summary
Add a warning/notice that Nightly will be updated once/twice a day 

## Issue / Bugzilla link
#9832 

## Testing
http://127.0.0.1:8000/en-GB/firefox/channel/desktop/
http://127.0.0.1:8000/en-GB/firefox/channel/android/