### PR TITLE
Fix punctuation on developer edition page

### DIFF
--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -77,7 +77,7 @@ firefox-developer-congrats-you-now-have-firefox = Congrats. You now have { -bran
 firefox-developer-this-isnt-just-an-update = This isn’t just an update. This is { -brand-name-firefox-quantum }: A brand new { -brand-name-firefox } that has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.
 firefox-developer-welcome-to-firefox-browser = Welcome to { -brand-name-firefox-browser } { -brand-name-developer-edition }
 firefox-developer-made-for-developers = The browser made for developers
-firefox-developer-all-the-latest-v2 = All the latest developer tools in beta, in addition to features like the Multi-line Console Editor and WebSocket Inspector.
+firefox-developer-all-the-latest-v2 = All the latest developer tools in beta in addition to features like the Multi-line Console Editor and WebSocket Inspector.
 
 # Obsolete string
 firefox-developer-all-the-latest = All the latest developer tools in beta, plus <strong>experimental features</strong> like the Multi-line Console Editor and WebSocket Inspector.


### PR DESCRIPTION
## One-line summary

Remove comma as requested in mozilla-l10n/www-l10n#371

## Significant changes and points to review

              Remove the comma before `in addition to features ...`

_Originally posted by @peiying2 in https://github.com/mozilla-l10n/www-l10n/pull/371#discussion_r1446787146_
