### PR TITLE
Add a signpost to help developers know which port to use to access bedrock locally

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -292,6 +292,12 @@ To test a single app, specify the app by name in the command above. e.g.::
 Make it run
 ===========
 
+
+.. ATTENTION::
+   Regardless of whether you run Bedrock via Docker or directly on your machine,
+   the URL of the site is ``http://localhost:8000`` - `not` ``8080``
+
+
 Docker
 ------
 


### PR DESCRIPTION
<img width="796" alt="Screenshot 2024-01-10 at 16 49 37" src="https://github.com/mozilla/bedrock/assets/101457/6d6f970d-b895-49bb-806d-dd97b5469a0b">
