### PR TITLE
Add missing data-cta-text values

### DIFF
--- a/bedrock/careers/templates/careers/benefits.html
+++ b/bedrock/careers/templates/careers/benefits.html
@@ -16,7 +16,7 @@
           set us apart from other companies in our industry.</p>
 
         <p class="c-careers-button-wrapper">
-          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button">See our open roles</a>
+          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button" data-cta-text="See our open roles">See our open roles</a>
         </p>
       </div>
     </div>

--- a/bedrock/careers/templates/careers/home.html
+++ b/bedrock/careers/templates/careers/home.html
@@ -163,7 +163,7 @@
       </p>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.diversity') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">Read more</a>
+        <a href="{{ url('careers.diversity') }}" data-cta-type="button" data-cta-text="Read more" class="mzp-c-button mzp-t-secondary">Read more</a>
       </p>
     </div>
   </section>
@@ -264,7 +264,7 @@
       </ul>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.benefits') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">Read more about our benefits</a>
+        <a href="{{ url('careers.benefits') }}" data-cta-type="button" data-cta-text="Read more about our benefits" class="mzp-c-button mzp-t-secondary">Read more about our benefits</a>
       </p>
     </div>
   </section>
@@ -274,7 +274,7 @@
     <div class="c-mozillians-content">
       <h2>See yourself on one of our teams?</h2>
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.listings') }}" data-cta-type="button" class="mzp-c-button mzp-t-dark">Find your role</a>
+        <a href="{{ url('careers.listings') }}" data-cta-type="button" data-cta-text="Find your role" class="mzp-c-button mzp-t-dark">Find your role</a>
       </p>
     </div>
   </section>
@@ -377,7 +377,7 @@
       </ul>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.teams') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">View all teams</a>
+        <a href="{{ url('careers.teams') }}" data-cta-type="button" data-cta-text="View all teams" class="mzp-c-button mzp-t-secondary">View all teams</a>
       </p>
     </div>
   </section>
@@ -400,7 +400,7 @@
       </div>
 
       <p class="c-careers-button-wrapper">
-        <a href="{{ url('careers.locations') }}" data-cta-type="button" class="mzp-c-button mzp-t-secondary">Read more about the future of work at Mozilla</a>
+        <a href="{{ url('careers.locations') }}" data-cta-type="button" data-cta-text="Read more about the future of work at Mozilla" class="mzp-c-button mzp-t-secondary">Read more about the future of work at Mozilla</a>
       </p>
     </div>
   </section>

--- a/bedrock/careers/templates/careers/locations.html
+++ b/bedrock/careers/templates/careers/locations.html
@@ -15,7 +15,7 @@
           choose where they do it.</p>
 
         <div class="c-careers-button-wrapper">
-          <a href="https://blog.mozilla.org/careers/future-of-work-at-mozilla/" class="mzp-c-button mzp-t-dark" data-cta-type="button">Read more about how we work</a>
+          <a href="https://blog.mozilla.org/careers/future-of-work-at-mozilla/" class="mzp-c-button mzp-t-dark" data-cta-type="button" data-cta-text="Read more about how we work">Read more about how we work</a>
         </div>
       </div>
     </div>
@@ -49,7 +49,7 @@
 
       <ul class="c-careers-locations-list">
         <li>
-          <a href="{{ url('mozorg.contact.spaces.berlin') }}" data-cta-type="button">
+          <a href="{{ url('mozorg.contact.spaces.berlin') }}" data-cta-type="button" data-cta-text="Berlin">
             <div class="c-careers-locations-image-wrapper">
               <img src="{{ static('img/careers/locations/mozilla-berlin.png') }}" alt="" width="200" height="200">
             </div>
@@ -57,7 +57,7 @@
           </a>
         </li>
         <li>
-          <a href="{{ url('mozorg.contact.spaces.toronto') }}" data-cta-type="button">
+          <a href="{{ url('mozorg.contact.spaces.toronto') }}" data-cta-type="button" data-cta-text="Toronto">
             <div class="c-careers-locations-image-wrapper">
               <img src="{{ static('img/careers/locations/mozilla-toronto.png') }}" alt="" width="200" height="200">
             </div>

--- a/bedrock/careers/templates/careers/teams.html
+++ b/bedrock/careers/templates/careers/teams.html
@@ -15,7 +15,7 @@
           builders and creators working together to keep the internet open and
           accessible to all.</p>
         <div class="c-careers-button-wrapper">
-          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button">See our open roles</a>
+          <a href="{{ url('careers.listings') }}" class="mzp-c-button mzp-t-dark" data-cta-type="button" data-cta-text="See our open roles">See our open roles</a>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -89,8 +89,8 @@
         </tbody>
       </table>
 
-      <p>{{ ftl('compare-brave-the-brave-browser-like-so', opera='href="%s" data-cta-type="link"'|safe|format(url('firefox.browsers.compare.opera')),
-                 edge='href="%s" data-cta-type="link"'|safe|format(url('firefox.browsers.compare.edge'))) }}</p>
+      <p>{{ ftl('compare-brave-the-brave-browser-like-so', opera='href="%s" data-cta-text="Opera" data-cta-type="link"'|safe|format(url('firefox.browsers.compare.opera')),
+                 edge='href="%s" data-cta-text="Edge" data-cta-type="link"'|safe|format(url('firefox.browsers.compare.edge'))) }}</p>
 
       <p>{{ ftl('compare-brave-brave-differentiates-itself') }}</p>
 
@@ -102,9 +102,9 @@
 
       <p>{{ ftl('compare-brave-on-the-other-side-of-the-coin', attrs='href="https://addons.mozilla.org/firefox/addon/ublock-origin/" rel="external noopener" data-cta-text="uBlock Origin" data-cta-type="link"'|safe) }}</p>
 
-      <p>{{ ftl('compare-brave-there-are-a-few-of-braves', lockwise='href="%s" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')),
+      <p>{{ ftl('compare-brave-there-are-a-few-of-braves', lockwise='href="%s" data-cta-text="password manager" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')),
           extension='href="https://addons.mozilla.org/addon/https-everywhere/" rel="external noopener" data-cta-text="HTTPS Everywhere" data-cta-type="link"'|safe,
-          privacy='href="%s" data-cta-type="link"'|safe|format(url('firefox.privacy.products'))) }}</p>
+          privacy='href="%s" data-cta-text="privacy products" data-cta-type="link"'|safe|format(url('firefox.privacy.products'))) }}</p>
 
       <p>{{ ftl('compare-brave-the-bottom-line-is-that-even') }}</p>
 
@@ -241,7 +241,7 @@
         <p>
           {{ ftl('compare-brave-the-firefox-browser-also-gives-v3',
                 fallback='compare-brave-the-firefox-browser-also-gives',
-                accounts='href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts')),
+                accounts='href="%s" data-cta-text="accounts" data-cta-type="link"'|safe|format(url('firefox.accounts')),
                 monitor='href="https://monitor.mozilla.org/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
                 breaches='href="https://monitor.mozilla.org/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe
           ) }}
@@ -250,7 +250,7 @@
         <p>
           {{ ftl('compare-brave-the-firefox-browser-also-gives-v2',
                   fallback='compare-brave-the-firefox-browser-also-gives',
-                  accounts='href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts')),
+                  accounts='href="%s" data-cta-text="accounts" data-cta-type="link"'|safe|format(url('firefox.accounts')),
                   monitor='href="https://monitor.mozilla.org/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe,
                   breaches='href="https://monitor.mozilla.org/breaches" rel="external noopener" data-cta-text="Data breaches" data-cta-type="link"'|safe
           ) }}

--- a/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
@@ -108,7 +108,7 @@
         {% endif %}
       </p>
 
-      <p>{{ ftl('compare-chrome-weve-also-recently-restated-v2', attrs='href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-chrome-weve-also-recently-restated-v2', attrs='href="%s" data-cta-text="Privacy Notices"  data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       <p>{{ ftl('compare-chrome-google-chrome-is-by-all-accounts') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/edge.html
@@ -93,11 +93,11 @@
 
       <p>{{ ftl('compare-edge-edge-is-integrated-into-the') }}</p>
 
-      <p>{{ ftl('compare-edge-at-firefox-we-pride-ourselves', fallback='compare-edge-at-firefox-our-privacy-fallback', attrs='href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-edge-at-firefox-we-pride-ourselves', fallback='compare-edge-at-firefox-our-privacy-fallback', attrs='href="%s" data-cta-text="Privacy Notices"  data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       <img src="{{ static('img/firefox/compare/compare-privacy-eyes.svg') }}" alt="" height="217" width="320" class="compare-details-image">
 
-      <p>{{ ftl('compare-edge-your-privacy-protections-shows', attrs='href="%s" data-cta-text="Privacy Protections" data-cta-type="link"'|safe|format(url('firefox.privacy.products'))) }}</p>
+      <p>{{ ftl('compare-edge-your-privacy-protections-shows', attrs='href="%s" data-cta-text="Privacy Protections" data-cta-text="Privacy Products" data-cta-type="link"'|safe|format(url('firefox.privacy.products'))) }}</p>
 
       <p>{{ ftl('compare-edge-in-firefox-private-browsing') }}</p>
 
@@ -180,7 +180,7 @@
 
       <p>{{ ftl('compare-edge-edge-has-some-nice-ui-features') }}</p>
 
-      <p>{{ ftl('compare-edge-firefox-features-a-scrolling', attrs='href="%s" data-cta-type="link"'|safe|format(url('firefox.pocket'))) }}</p>
+      <p>{{ ftl('compare-edge-firefox-features-a-scrolling', attrs='href="%s" data-cta-text="Pocket" data-cta-type="link"'|safe|format(url('firefox.pocket'))) }}</p>
 
       <p>{{ ftl('compare-edge-firefox-and-edge-both-offer', fallback='compare-edge-firefox-and-edge-both-offer-fallback') }}</p>
 
@@ -236,7 +236,7 @@
 
       <p>{{ ftl('compare-edge-with-internet-explorer-microsoft', fallback='compare-edge-with-internet-explorer-fallback') }}</p>
 
-      <p>{{ ftl('compare-edge-firefox-has-been-available', attrs='href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts'))) }}</p>
+      <p>{{ ftl('compare-edge-firefox-has-been-available', attrs='href="%s" data-cta-text="Accounts" data-cta-type="link"'|safe|format(url('firefox.accounts'))) }}</p>
 
       <p>{{ ftl('compare-edge-edge-also-allows-you-to-connect', fallback='compare-edge-edge-also-allows-you-to-fallback') }}</p>
 
@@ -249,7 +249,7 @@
         <h2>{{ ftl('compare-shared-overall-assessment') }}</h2>
       </header>
 
-      <p>{{ ftl('compare-edge-aside-from-sucking-up-a-lot', attrs='href="%s" data-cta-type="link"'|safe|format(url('mozorg.home'))) }}</p>
+      <p>{{ ftl('compare-edge-aside-from-sucking-up-a-lot', attrs='href="%s" data-cta-text="Home" data-cta-type="link"'|safe|format(url('mozorg.home'))) }}</p>
 
       <p>{{ ftl('compare-edge-the-bottom-line-is-that-while') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -93,14 +93,14 @@
           </tbody>
         </table>
 
-      <p>{{ ftl('compare-ie-if-you-havent-moved-on-from-using', attrs='href="https://www.telegraph.co.uk/technology/2019/02/08/stop-using-internet-explorer-warns-microsofts-security-chief/" rel="external noopener" data-cta-type="link"'|safe) }}</p>
+      <p>{{ ftl('compare-ie-if-you-havent-moved-on-from-using', attrs='href="https://www.telegraph.co.uk/technology/2019/02/08/stop-using-internet-explorer-warns-microsofts-security-chief/" rel="external noopener" data-cta-text="Stop using IE" data-cta-type="link"'|safe) }}</p>
 
       <p>{{ ftl('compare-ie-microsoft-is-no-longer-supporting') }}</p>
 
       <img src="{{ static('img/firefox/compare/compare-privacy-locks.svg') }}" alt="" height="217" width="320" class="compare-details-image">
 
-      <p>{{ ftl('compare-ie-so-whats-the-solution-if-your', fallback='compare-ie-so-whats-the-solution-if-your-fallback', lockwise='href="%s" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')),
-                 privacy='href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-ie-so-whats-the-solution-if-your', fallback='compare-ie-so-whats-the-solution-if-your-fallback', lockwise='href="%s" data-cta-text="Password Manager" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')),
+                 privacy='href="%s" data-cta-text="Privacy Notices" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       {% include '/firefox/browsers/compare/includes/download-menu-list.html' %}
 
@@ -178,8 +178,8 @@
       <p>{{ ftl('compare-ie-really-the-only-reasons-to-use') }}</p>
 
       <p>
-        {{ ftl('compare-ie-on-the-other-end-of-the-spectrum', fallback='compare-ie-on-the-other-end-of-the-spectrum-fallback', pocket='href="%s" data-cta-type="link"'|safe|format(url('firefox.pocket')),
-                 products='href="%s" data-cta-type="link"'|safe|format(url('firefox'))) }}
+        {{ ftl('compare-ie-on-the-other-end-of-the-spectrum', fallback='compare-ie-on-the-other-end-of-the-spectrum-fallback', pocket='href="%s" data-cta-text="Pocket" data-cta-type="link"'|safe|format(url('firefox.pocket')),
+                 products='href="%s" data-cta-text="Firefox" data-cta-type="link"'|safe|format(url('firefox'))) }}
       </p>
 
       {% include '/firefox/browsers/compare/includes/download-menu-list.html' %}
@@ -245,7 +245,7 @@
 
       <p>
         {# Download link should be locale neutral. See issue #7982 #}
-        {{ ftl('compare-ie-our-opinion-is-just-to-go-with', attrs='href="/firefox/download/thanks/" data-cta-type="link"'|safe) }}
+        {{ ftl('compare-ie-our-opinion-is-just-to-go-with', attrs='href="/firefox/download/thanks/" data-cta-text="Download" data-cta-type="link"'|safe) }}
       </p>
 
       <div class="compare-content compare-version-disclaimer">

--- a/bedrock/firefox/templates/firefox/browsers/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/opera.html
@@ -93,7 +93,7 @@
 
       <p>{{ ftl('compare-opera-operas-privacy-policy-lacks', fallback='compare-opera-operas-privacy-policy-lacks-fallback') }}</p>
 
-      <p>{{ ftl('compare-opera-firefoxs-privacy-policy-is', attrs = 'href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
+      <p>{{ ftl('compare-opera-firefoxs-privacy-policy-is', attrs = 'href="%s" data-cta-text="Privacy notices" data-cta-type="link"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       <p>{{ ftl('compare-opera-as-far-as-actual-privacy-protections') }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -101,7 +101,7 @@
 
       <p>{{ ftl('compare-safari-our-private-browsing-mode', attrs='href="https://addons.mozilla.org/firefox/addon/facebook-container/" rel="external noopener" data-cta-text="Facebook Container" data-cta-type="link"'|safe) }}</p>
 
-      <p>{{ ftl('compare-safari-as-far-as-security-goes-firefox', lockwise='href="%s" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')), monitor='href="https://monitor.mozilla.org/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe) }}</p>
+      <p>{{ ftl('compare-safari-as-far-as-security-goes-firefox', lockwise='href="%s" data-cta-text="Password manager" data-cta-type="link"'|safe|format(url('firefox.features.password-manager')), monitor='href="https://monitor.mozilla.org/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe) }}</p>
 
       <p>{{ ftl('compare-safari-if-you-choose-to-use-safari') }}</p>
 
@@ -238,7 +238,7 @@
 
       <p>{{ ftl('compare-safari-firefox-and-safari-both-provide') }}</p>
 
-      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v3', fallback='compare-safari-firefox-also-offers-a-similar-updated', attrs = 'href="%s" data-cta-type="link"'|safe|format(url('firefox.accounts'))) }}</p>
+      <p>{{ ftl('compare-safari-firefox-also-offers-a-similar-updated-v3', fallback='compare-safari-firefox-also-offers-a-similar-updated', attrs = 'href="%s" data-cta-text="Accounts" data-cta-type="link"'|safe|format(url('firefox.accounts'))) }}</p>
 
       <p>{{ ftl('compare-safari-the-firefox-app-for-ios-and', ios='href="%s" rel="external noopener" data-cta-text="iOS" data-cta-type="link"'|safe|format(app_store_url('firefox')),
               android='href="%s" rel="external noopener" data-cta-text="Android" data-cta-type="link"'|safe|format(play_store_url('firefox'))) }}</p>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -166,7 +166,7 @@
         {% endif %}
       </p>
       <p>
-        <a class="mzp-c-cta-link" href="https://monitor.mozilla.org/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-monitor" data-cta-position="secondary">
+        <a class="mzp-c-cta-link" href="https://monitor.mozilla.org/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-monitor" data-cta-text="Check for breaches" data-cta-position="secondary">
         {{ ftl('firefox-privacy-hub-check-for-breaches') }}
         </a>
       </p>
@@ -183,7 +183,7 @@
       </div>
       <p>{{ ftl('firefox-privacy-hub-surf-stream-and-get-work') }}</p>
       <p>
-        <a class="mzp-c-cta-link" href="{{ url('products.vpn.landing' )}}" data-cta-type="fxa-vpn" data-cta-position="secondary">
+        <a class="mzp-c-cta-link" href="{{ url('products.vpn.landing' )}}" data-cta-type="vpn" data-cta-text="VPN" data-cta-position="secondary">
           {{ ftl('firefox-privacy-hub-get-mozilla-vpn') }}
         </a>
       </p>

--- a/bedrock/products/templates/products/vpn/pricing-refresh.html
+++ b/bedrock/products/templates/products/vpn/pricing-refresh.html
@@ -81,8 +81,8 @@
     </details>
 
     <details id="faq-information" class="c-faq-item mzp-is-anchor-link">
-      {% set privacy_principles = 'href="%s" data-cta-type="link"'|safe|format(url('privacy.principles')) %}
-      {% set privacy_notice = 'href="%s" data-cta-type="link"'|safe|format(url('privacy.notices.subscription-services')) %}
+      {% set privacy_principles = 'href="%s" data-cta-text="Privacy principles" data-cta-type="link"'|safe|format(url('privacy.principles')) %}
+      {% set privacy_notice = 'href="%s" data-cta-text="Privacy notice" data-cta-type="link"'|safe|format(url('privacy.notices.subscription-services')) %}
 
       <summary class="c-faq-item-heading">
         <h3>{{ ftl('vpn-pricing-what-information') }}</h3>
@@ -92,7 +92,7 @@
 
     <details id="faq-subscriptions" class="c-faq-item mzp-is-anchor-link">
 
-      {% set manage_url = 'href="%s" data-cta-type="link"'|safe|format(('https://vpn.mozilla.org/r/vpn/subscription' + _params)) %}
+      {% set manage_url = 'href="%s" data-cta-text="Manage VPN" data-cta-type="link"'|safe|format(('https://vpn.mozilla.org/r/vpn/subscription' + _params)) %}
 
       <summary class="c-faq-item-heading">
         <h3>{{ ftl('vpn-pricing-how-do-i-manage') }}</h3>

--- a/lib/l10n_utils/templatetags/fluent.py
+++ b/lib/l10n_utils/templatetags/fluent.py
@@ -27,6 +27,11 @@ ATTRS_ALLOWED_IN_FLUENT_STRINGS = [
     "rel",
     "title",
     "target",
+    "data-link-text",
+    "data-link-position",
+    "data-cta-text",
+    "data-cta-type",
+    "data-cta-position",
 ]
 
 


### PR DESCRIPTION
## One-line summary

This PR adds the `data-cta-text` attribute to any elements with a `data-cta-type` attribute defined.

## Significant changes and points to review

- Add `data-cta-text` values to tags with` data-cta-type` defined
- Fix #13749 where data attributes were not being output by Fluent templates

## Issue / Bugzilla link

In #14056 we standardized on requiring a "text" value to trigger link and cta click events. 
Fix #13749

## Testing

- Here is an example of one of the pages with the bug from 13749: http://localhost:8000/en-US/firefox/browsers/compare/brave/
- Maybe make sure I didn't add a `data-cta-text` if there already was one? 
- No missing quotes or spelling mistakes.