### PR TITLE
Re-allow Contentful's image CDN in our CSP rules

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -179,6 +179,7 @@ else:
         "www.googletagmanager.com",
         "www.google-analytics.com",
         "creativecommons.org",
+        "images.ctfassets.net",
     ]
     _csp_script_src = [
         # TODO fix things so that we don't need this


### PR DESCRIPTION
## One-line summary

Looks like it was accidentally removed in https://github.com/mozilla/bedrock/pull/14044/files#diff-eaca14ba79bd8caf620f2740e240a03b6e2d192e1df89dc259ec63894da1f62dL184

## Issue / Bugzilla link

Resolves #14074
