### PR TITLE
Allow more time before retries of CDN tests, plus one extra retry

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -55,6 +55,8 @@ jobs:
       PYTEST_PROCESSES: auto
       SAUCELABS_API_KEY: ""
       SAUCELABS_USERNAME: ""
+      RERUNS_ALLOWED: 3
+      RERUNS_DELAY_SECS: 60
 
     # Note we use if: always() below to keep things going, rather than
     # continue-on-error, because that approach falsely marks the overall

--- a/bin/integration_tests/run_integration_tests.sh
+++ b/bin/integration_tests/run_integration_tests.sh
@@ -14,6 +14,8 @@ set -xe
 : ${BROWSER_NAME:="firefox"}
 : ${TESTS_PATH:="tests"}
 : ${RESULTS_PATH:="${TESTS_PATH}/results"}
+: ${RERUNS_ALLOWED:="2"}
+: ${RERUNS_DELAY_SECS:="1"}
 
 # Common arguments
 if [ "${DRIVER}" = "SauceLabs" ]; then
@@ -27,7 +29,8 @@ CMD="${CMD} -r a"
 CMD="${CMD} --verbose"
 CMD="${CMD} --workers ${PYTEST_PROCESSES}"
 CMD="${CMD} --base-url ${BASE_URL}"
-CMD="${CMD} --reruns 2"
+CMD="${CMD} --reruns ${RERUNS_ALLOWED}"
+CMD="${CMD} --reruns-delay ${RERUNS_DELAY_SECS}"
 CMD="${CMD} --html ${RESULTS_PATH}/index.html"
 CMD="${CMD} --junitxml ${RESULTS_PATH}/junit.xml"
 if [ -n "${DRIVER}" ]; then CMD="${CMD} --driver ${DRIVER}"; fi


### PR DESCRIPTION
Sometimes the CDN tests fail, even with the default 2 retries. This changeset allows us to pass custom params for the number of retries as well as how long to back off for between retries, in the hope that we get more successes for the CDN tests.

## Issue / Bugzilla link

No ticket

## Testing

Might just have to be eyeballs until it hits main