### PR TITLE
Bump Traffic Cop to v3.0.0 (Fixes #14086)

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -178,7 +178,6 @@ not Traffic Cop should initiate.
 
     if (isApprovedToRun()) {
         const cop = new TrafficCop({
-            id: 'experiment-name',
             variations: {
                 'entrypoint_experiment=experiment-name&entrypoint_variation=a': 10,
                 'entrypoint_experiment=experiment-name&entrypoint_variation=b': 10

--- a/media/js/base/core-datalayer-page-id.js
+++ b/media/js/base/core-datalayer-page-id.js
@@ -15,8 +15,6 @@ if (typeof window.Mozilla === 'undefined') {
     var dataLayer = (window.dataLayer = window.dataLayer || []);
     var Analytics = {};
 
-    Analytics.customReferrer = '';
-
     /** Returns page ID used in Event Category for GA events tracked on page.
      * @param {String} path - URL path name fallback if page ID does not exist.
      * @return {String} GTM page ID.
@@ -32,70 +30,13 @@ if (typeof window.Mozilla === 'undefined') {
             : pathName.replace(/^(\/\w{2}-\w{2}\/|\/\w{2,3}\/)/, '/');
     };
 
-    Analytics.getTrafficCopReferrer = function () {
-        var referrer;
-
-        // if referrer cookie exists, store the value and remove the cookie
-        if (
-            Mozilla.Cookies &&
-            Mozilla.Cookies.hasItem('mozilla-traffic-cop-original-referrer')
-        ) {
-            referrer = Mozilla.Cookies.getItem(
-                'mozilla-traffic-cop-original-referrer'
-            );
-
-            // referrer shouldn't persist
-            Mozilla.Cookies.removeItem(
-                'mozilla-traffic-cop-original-referrer',
-                null,
-                null,
-                false,
-                'lax'
-            );
-        }
-
-        return referrer;
-    };
-
     Analytics.buildDataObject = function () {
         var dataObj = {
             event: 'page-id-loaded',
             pageId: Analytics.getPageId()
         };
 
-        var referrer = Analytics.getTrafficCopReferrer();
-
-        // if original referrer exists, pass it to GTM
-        if (referrer) {
-            // Traffic Cop sets the referrer to 'direct' if document.referer is empty
-            // prior to the redirect, so this value will either be a URL or the string 'direct'.
-            dataObj.customReferrer = referrer;
-
-            // make the custom referrer available to other scripts.
-            Analytics.customReferrer = referrer;
-        }
-
         return dataObj;
-    };
-
-    /**
-     * Returns custom referrer set by Traffic Cop if exists,
-     * else returns standard referrer.
-     * See https://github.com/mozilla/bedrock/issues/13593
-     * @returns {String} referrer
-     */
-    Analytics.getReferrer = function (ref) {
-        var referrer = typeof ref === 'string' ? ref : document.referrer;
-        var customReferrer = Analytics.customReferrer;
-
-        if (customReferrer) {
-            // If customReferrer is returned from TC as "direct",
-            // return an empty string which is the default value
-            // for document.referrer. Otherwise return customReferrer.
-            return customReferrer === 'direct' ? '' : customReferrer;
-        }
-
-        return referrer;
     };
 
     // Push page ID into dataLayer so it's ready when GTM container loads.

--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -80,18 +80,8 @@ FxaAttribution.getFxALinkReferralData = () => {
     return null;
 };
 
-FxaAttribution.getReferrer = (ref) => {
-    const referrer = typeof ref === 'string' ? ref : document.referrer;
-
-    if (typeof window.Mozilla.Analytics !== 'undefined') {
-        return Mozilla.Analytics.getReferrer(referrer);
-    }
-
-    return referrer;
-};
-
 FxaAttribution.getSearchReferralData = (ref) => {
-    const referrer = FxaAttribution.getReferrer(ref);
+    const referrer = typeof ref === 'string' ? ref : document.referrer;
     const google = /^https?:\/\/www\.google\.\w{2,3}(\.\w{2})?\/?/;
     const bing = /^https?:\/\/www\.bing\.com\/?/;
     const yahoo = /^https?:\/\/(\w*\.)?search\.yahoo\.com\/?/;

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -453,16 +453,6 @@ if (typeof window.Mozilla === 'undefined') {
         _checkGA();
     };
 
-    StubAttribution.getReferrer = function (ref) {
-        var referrer = typeof ref === 'string' ? ref : document.referrer;
-
-        if (typeof window.Mozilla.Analytics !== 'undefined') {
-            return Mozilla.Analytics.getReferrer(referrer);
-        }
-
-        return referrer;
-    };
-
     /**
      * Gets utm parameters and referrer information from the web page if they exist.
      * @param {String} ref - Optional referrer to facilitate testing.
@@ -475,7 +465,7 @@ if (typeof window.Mozilla === 'undefined') {
             params.get('experiment') || StubAttribution.experimentName;
         var variation =
             params.get('variation') || StubAttribution.experimentVariation;
-        var referrer = StubAttribution.getReferrer(ref);
+        var referrer = typeof ref === 'string' ? ref : document.referrer;
         var ua = StubAttribution.getUserAgent();
         var clientIDUA = StubAttribution.getUAClientID();
         var clientIDGA4 = StubAttribution.getGtagClientID();

--- a/media/js/firefox/welcome/welcome15-experiment.es6.js
+++ b/media/js/firefox/welcome/welcome15-experiment.es6.js
@@ -24,7 +24,6 @@ const initTrafficCop = () => {
         }
     } else if (TrafficCop) {
         const cop = new TrafficCop({
-            id: 'welcome-15-exp',
             variations: {
                 'v=1': 50,
                 'v=2': 50

--- a/media/js/firefox/whatsnew/whatsnew-119-experiment-eu.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-119-experiment-eu.es6.js
@@ -50,8 +50,6 @@ const initTrafficCop = () => {
         }
     } else if (TrafficCop) {
         const murtaugh = new TrafficCop({
-            id: 'wnp-119-experiment-eu',
-            cookieExpires: 0,
             variations: {
                 'v=1': 33, // Three boxes, open
                 'v=2': 33, // Three boxes, closed

--- a/media/js/firefox/whatsnew/whatsnew-119-experiment-na.es6.js
+++ b/media/js/firefox/whatsnew/whatsnew-119-experiment-na.es6.js
@@ -38,8 +38,6 @@ const initTrafficCop = () => {
         }
     } else if (TrafficCop) {
         const riggs = new TrafficCop({
-            id: 'wnp-119-experiment-na',
-            cookieExpires: 0,
             variations: {
                 'v=1': 50, // Three boxes
                 'v=2': 50 // Addons

--- a/media/js/glean/utils.es6.js
+++ b/media/js/glean/utils.es6.js
@@ -83,10 +83,6 @@ const Utils = {
         const referrer = typeof str === 'string' ? str : document.referrer;
         const url = Utils.filterNewsletterURL(referrer);
 
-        if (typeof window.Mozilla.Analytics !== 'undefined') {
-            return Mozilla.Analytics.getReferrer(url);
-        }
-
         return url;
     },
 

--- a/media/js/products/vpn/landing-experiment-headlines.es6.js
+++ b/media/js/products/vpn/landing-experiment-headlines.es6.js
@@ -50,7 +50,6 @@ const initTrafficCop = () => {
         // Avoid entering automated tests into random experiments.
         if (isApprovedToRun()) {
             const fife = new TrafficCop({
-                id: 'vpn-headlines',
                 variations: {
                     'entrypoint_experiment=vpn-headlines&entrypoint_variation=1': 33, // control
                     'entrypoint_experiment=vpn-headlines&entrypoint_variation=2': 33, // v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mozilla/glean": "^5.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
-        "@mozmeao/trafficcop": "^2.0.1",
+        "@mozmeao/trafficcop": "^3.0.0",
         "@sentry/browser": "^7.111.0",
         "babel-loader": "^9.1.3",
         "caniuse-lite": "^1.0.30001605",
@@ -2211,9 +2211,9 @@
       "integrity": "sha512-Q+fu1VBdG8x/WtJV+5mLXTF5/QJTiHQNWlE4Jf5kqsQw5cEKxjUHLD4qfxcuvwRkbErXyDz1xpWuTglBzIhedw=="
     },
     "node_modules/@mozmeao/trafficcop": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-2.0.1.tgz",
-      "integrity": "sha512-MMoXGx2Evjr3Y8aYFsC8S8DqOduC8oBtUXK4CDtFd/+YaLNAM7DM4gdwLrOAHX2DBRB0J9XOlPSgdzp/JPOGnw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-3.0.0.tgz",
+      "integrity": "sha512-pV3ZCbTwjO8dEcUCFeNLWcQIskSvYxUl1DDMF5GuA5cZhwBesV4WAjPLiM65j8J5LHq5qVYi9aI6F/nOe46oBQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mozilla/glean": "^5.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
-    "@mozmeao/trafficcop": "^2.0.1",
+    "@mozmeao/trafficcop": "^3.0.0",
     "@sentry/browser": "^7.111.0",
     "babel-loader": "^9.1.3",
     "caniuse-lite": "^1.0.30001605",

--- a/tests/unit/spec/base/core-datalayer-page-id.js
+++ b/tests/unit/spec/base/core-datalayer-page-id.js
@@ -10,10 +10,6 @@
  */
 
 describe('core-datalayer-page-id.js', function () {
-    afterEach(function () {
-        Mozilla.Analytics.customReferrer = '';
-    });
-
     describe('getPageId', function () {
         const html = document.documentElement;
 
@@ -38,59 +34,6 @@ describe('core-datalayer-page-id.js', function () {
             expect(Mozilla.Analytics.getPageId('/firefox/new/')).toBe(
                 '/firefox/new/'
             );
-        });
-    });
-
-    describe('getTrafficCopReferrer', function () {
-        it('should return null if the referrer does not exist', function () {
-            spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(false);
-            expect(Mozilla.Analytics.getTrafficCopReferrer()).toBe(undefined);
-        });
-
-        it('should return the referrer if one exists', function () {
-            spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(true);
-            spyOn(Mozilla.Cookies, 'getItem').and.returnValue('direct');
-            expect(Mozilla.Analytics.getTrafficCopReferrer()).toBe('direct');
-        });
-    });
-
-    describe('buildDataObject', function () {
-        it('should contain customReferrer if found in cookie', function () {
-            const expected = 'http://www.google.com';
-            spyOn(Mozilla.Analytics, 'getTrafficCopReferrer').and.returnValue(
-                expected
-            );
-            const obj = Mozilla.Analytics.buildDataObject();
-            expect(obj.customReferrer).toBeDefined();
-            expect(Mozilla.Analytics.customReferrer).toEqual(expected);
-        });
-
-        it('should not contain customReferrer if not found in cookie', function () {
-            spyOn(Mozilla.Analytics, 'getTrafficCopReferrer').and.returnValue(
-                undefined
-            );
-            const obj = Mozilla.Analytics.buildDataObject();
-            expect(obj.customReferrer).not.toBeDefined();
-            expect(Mozilla.Analytics.customReferrer).toEqual('');
-        });
-    });
-
-    describe('getReferrer', function () {
-        it('should return a custom referrer when set', function () {
-            const expected = 'http://www.google.com';
-            Mozilla.Analytics.customReferrer = expected;
-            expect(Mozilla.Analytics.getReferrer()).toEqual(expected);
-        });
-
-        it('should return an empty string if customReferrer is direct', function () {
-            Mozilla.Analytics.customReferrer = 'direct';
-            expect(Mozilla.Analytics.getReferrer()).toEqual('');
-        });
-
-        it('should return standard document referrer otherwise', function () {
-            const expected = 'http://www.bing.com';
-            Mozilla.Analytics.customReferrer = '';
-            expect(Mozilla.Analytics.getReferrer(expected)).toEqual(expected);
         });
     });
 });

--- a/tests/unit/spec/base/fxa-attribution.js
+++ b/tests/unit/spec/base/fxa-attribution.js
@@ -16,10 +16,6 @@ describe('fxa-attribution.js', function () {
         window.Mozilla.dntEnabled = sinon.stub();
     });
 
-    afterEach(function () {
-        Mozilla.Analytics.customReferrer = '';
-    });
-
     describe('getHostName', function () {
         it('should return a hostname as expected', function () {
             const url1 =
@@ -539,20 +535,6 @@ describe('fxa-attribution.js', function () {
                     expected
                 );
             });
-        });
-    });
-
-    describe('getReferrer', function () {
-        it('should return a custom referrer when set', function () {
-            const expected = 'http://www.google.com';
-            Mozilla.Analytics.customReferrer = expected;
-            expect(FxaAttribution.getReferrer()).toEqual(expected);
-        });
-
-        it('should return standard document referrer otherwise', function () {
-            const expected = 'http://www.bing.com';
-            Mozilla.Analytics.customReferrer = '';
-            expect(FxaAttribution.getReferrer(expected)).toEqual(expected);
         });
     });
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -26,10 +26,6 @@ describe('stub-attribution.js', function () {
         window.dataLayer.push = sinon.stub();
     });
 
-    afterEach(function () {
-        Mozilla.Analytics.customReferrer = '';
-    });
-
     describe('init', function () {
         let data = {};
 
@@ -623,22 +619,6 @@ describe('stub-attribution.js', function () {
             Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
             jasmine.clock().tick(2100);
             expect(callback).toHaveBeenCalledWith(false);
-        });
-    });
-
-    describe('getReferrer', function () {
-        it('should return a custom referrer when set', function () {
-            const expected = 'http://www.google.com';
-            Mozilla.Analytics.customReferrer = expected;
-            expect(Mozilla.StubAttribution.getReferrer()).toEqual(expected);
-        });
-
-        it('should return standard document referrer otherwise', function () {
-            const expected = 'http://www.bing.com';
-            Mozilla.Analytics.customReferrer = '';
-            expect(Mozilla.StubAttribution.getReferrer(expected)).toEqual(
-                expected
-            );
         });
     });
 

--- a/tests/unit/spec/glean/utils.js
+++ b/tests/unit/spec/glean/utils.js
@@ -12,10 +12,6 @@
 import Utils from '../../../../media/js/glean/utils.es6';
 
 describe('utils.js', function () {
-    afterEach(function () {
-        Mozilla.Analytics.customReferrer = '';
-    });
-
     describe('getUrl', function () {
         it('should return the a complete URL including query parameters', function () {
             const url1 = 'https://www.mozilla.org/en-US/';
@@ -114,17 +110,7 @@ describe('utils.js', function () {
     });
 
     describe('getReferrer', function () {
-        afterEach(function () {
-            Mozilla.Analytics.customReferrer = '';
-        });
-
-        it('should return a custom referrer when set', function () {
-            const expected = 'http://www.google.com/';
-            Mozilla.Analytics.customReferrer = expected;
-            expect(Utils.getReferrer()).toEqual(expected);
-        });
-
-        it('should return regular referrer otherwise', function () {
+        it('should return regular referrer', function () {
             const expected = 'http://www.bing.com/';
             expect(Utils.getReferrer(expected)).toEqual(expected);
         });


### PR DESCRIPTION
## One-line summary

- Bumps Traffic Cop to v3.0.0 (which removes use of cookies).
- Removes bedrock code that would try to read the TC custom referrer cookie (we can revisit this in the future to add back to bedrock if we find we need it).
- Removes redundant `id` and `cookieExpires` properties from TC experiment configs.

## Issue / Bugzilla link

#14086

## Testing

First run `make preflight`.

The following URLs should still redirect to a variation as normal:

- [x]  http://localhost:8000/en-US/products/vpn/
- [x] http://localhost:8000/en-US/firefox/119.0/whatsnew/
- [x] http://localhost:8000/en-US/firefox/welcome/15/

The main difference is that each time you hit one of the original URLs above, you may get redirected to a different version than before (since we no longer set a cookie to remember).