### PR TITLE
Fix set-as-default URL link

### DIFF
--- a/bedrock/firefox/templates/firefox/family/includes/modules/privacy.html
+++ b/bedrock/firefox/templates/firefox/family/includes/modules/privacy.html
@@ -22,7 +22,7 @@
         <ul class="mzp-u-list-styled">
           <li>Keep data private by turning off location services for apps.</li>
           <li>Opt into “Ask app not to track” if your kid is using an iPhone.</li>
-          <li>Set Firefox as the <a href="{{ url('firefox.set-as-default') }}">default browser</a>
+          <li>Set Firefox as the <a href="{{ url('firefox.set-as-default.landing') }}">default browser</a>
             to <a rel="external" href="https://support.mozilla.org/kb/introducing-total-cookie-protection-standard-mode?{{ utm_params }}">block ad trackers</a>
             from sneaking data.</li>
         </ul>


### PR DESCRIPTION
## One-line summary

Fixes https://mozilla.sentry.io/issues/4876118599/?alert_rule_id=10555963&alert_timestamp=1705421496699&alert_type=email&environment=production&notification_uuid=468fc484-3edb-4ff9-a087-3a58f5af0e10&project=6260211&referrer=alert_email

## Testing

http://localhost:8000/en-US/firefox/family/