### PR TITLE
Fix Nightly release notes rendering

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -133,8 +133,8 @@
       <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
         <div class="mzp-l-sidebar">
           <h2 class="c-release-summary">
-            <div class="c-release-version">{{ release.version }}</div>
-            <div class="c-release-product">{{ release.product }} {{ release.channel }}</div>
+            <span class="c-release-version">{{ release.version }}</span>
+            <span class="c-release-product">{{ release.product }} {{ release.channel }}</span>
           </h2>
           {% if release.is_public %}
             <p class="c-release-date">{{ release.release_date|l10n_format_date }}</p>

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -408,6 +408,10 @@ $image-path: '/media/protocol/img';
 }
 
 .release-note {
+    .release-note-content{
+        width: 100%;
+    }
+
     .bug-id {
         @include bidi(((text-align, right, left),));
         display: block;

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -168,6 +168,7 @@ $image-path: '/media/protocol/img';
 .c-release-version {
     @include font-base;
     @include text-title-xl;
+    display: block;
 }
 
 .c-release-first-text,
@@ -179,6 +180,7 @@ $image-path: '/media/protocol/img';
     .c-release-product {
         @include font-base;
         @include text-title-2xs;
+        display: block;
     }
 
     .c-release-date {


### PR DESCRIPTION
## One-line summary

This changeset fixes a reflow issue on release notes, which was particularly noticeable on Nightly's notes, because sometimes there is a Bug Id link set to the right side of the note.

High five to @reemhamz for finding a lightweight fix, quickly.

It also fixes a HTML validation bug: `div`s are not allowed in `hX` elements. The fix is visually identical.

## Screenshots

*Release notes before*

<img width="1413" alt="Screenshot 2024-01-18 at 10 32 02" src="https://github.com/mozilla/bedrock/assets/101457/7a2d48e6-1a9d-4b67-8dc7-5b67077af336">


*Release notes after*

<img width="1380" alt="Screenshot 2024-01-18 at 10 32 14" src="https://github.com/mozilla/bedrock/assets/101457/779ddad1-4b02-436b-8c22-28485e7d8e50">



*Also confirming that when the Progressive Rollout and countries list are present, they do not break with this change*

<img width="1027" alt="Screenshot 2024-01-18 at 10 39 24" src="https://github.com/mozilla/bedrock/assets/101457/0b473114-39ca-43a1-a9f3-85cbf1448dd6">

* Invalid HTML in h2 before afterfix*

<img width="264" alt="Screenshot 2024-01-18 at 10 32 52" src="https://github.com/mozilla/bedrock/assets/101457/0302aa24-7ad5-4b3d-af6e-185a1fba7206">

## Issue / Bugzilla link

Resolves #14097 


## Testing

* On `main`, locally go to http://localhost:8000/en-US/firefox/nightly/notes/ 
* If you can't see the reflow, edit one of the notes in devtools to make it very short (less than 1 line long)
* Switch to this branch and repeat: the bad reflow will now not happen and the Bug IDs will be aligned to the right consistently