### PR TITLE
Update Firefox iOS app store link on /firefox/new/ (Fixes #14099)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -12,7 +12,7 @@
                                                   'firefox-desktop-download-just-download-the-browser',
                                                   'firefox-desktop-download-get-more-from-firefox') %}
 {% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-desktop' %}
-{% set ios_url = app_store_url('firefox') %}
+{% set ios_url = 'https://apps.apple.com/app/apple-store/id989804926?pt=373246&ct=mozilla-org-firefox-new&mt=8' %}
 
 {% block string_data %}{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Updates Firefox for iOS app store link so that DS can get aggregate data on the number of installs that came from the /new page.

## Issue / Bugzilla link

#14099

## Testing

http://localhost:8000/en-US/firefox/new/