### PR TITLE
Add attribution params to Firefox pre-release download links on macOS (Issue #12761)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -174,11 +174,13 @@ if (typeof window.Mozilla === 'undefined') {
                         data
                     );
                 }
-                // Append attribution params to macOS Firefox Nightly links.
+                // Append attribution params to macOS Firefox pre-release links.
                 if (
                     version &&
                     /osx/.test(version) &&
-                    link.href.indexOf('product=firefox-nightly-latest') !== -1
+                    /product=firefox-beta-latest|product=firefox-devedition-latest|product=firefox-nightly-latest/.test(
+                        link.href
+                    )
                 ) {
                     link.href = Mozilla.StubAttribution.appendToDownloadURL(
                         link.href,

--- a/media/js/firefox/all/all-downloads-unified.js
+++ b/media/js/firefox/all/all-downloads-unified.js
@@ -284,11 +284,13 @@
             url = FirefoxDownloader.setAttributionURL(e.target.href);
         }
 
-        // macOS Nightly only for now.
+        // Only macOS pre-release channels for now.
         if (
             version &&
             /osx/.test(version) &&
-            url.indexOf('product=firefox-nightly-latest') !== -1
+            /product=firefox-beta-latest|product=firefox-devedition-latest|product=firefox-nightly-latest/.test(
+                url
+            )
         ) {
             url = FirefoxDownloader.setAttributionURL(e.target.href);
         }

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -861,6 +861,10 @@ describe('stub-attribution.js', function () {
             'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US';
         const macOSNightlyUrl =
             'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US';
+        const macOSBetaUrl =
+            'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US';
+        const macOSDevUrl =
+            'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US';
 
         beforeEach(function () {
             const downloadMarkup = `<ul class="download-list">
@@ -874,6 +878,8 @@ describe('stub-attribution.js', function () {
                     <li><a id="link-dev-direct-win" class="download-link" data-download-version="win" href="${winDevUrl}">Download</a></li>
                     <li><a id="link-dev-direct-win64" class="download-link" data-download-version="win64" href="${win64DevUrl}">Download</a></li>
                     <li><a id="link-macos-nightly" class="download-link" data-download-version="osx" href="${macOSNightlyUrl}">Download</a></li>
+                    <li><a id="link-macos-beta" class="download-link" data-download-version="osx" href="${macOSBetaUrl}">Download</a></li>
+                    <li><a id="link-macos-dev" class="download-link" data-download-version="osx" href="${macOSDevUrl}">Download</a></li>
                 </ul>`;
 
             document.body.insertAdjacentHTML('beforeend', downloadMarkup);
@@ -944,9 +950,15 @@ describe('stub-attribution.js', function () {
                 'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
 
-            // macOS Nightly links
+            // macOS pre-release links
             expect(document.getElementById('link-macos-nightly').href).toEqual(
                 'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+            expect(document.getElementById('link-macos-beta').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+            expect(document.getElementById('link-macos-dev').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
         });
 

--- a/tests/unit/spec/firefox/all/all-downloads-unified.js
+++ b/tests/unit/spec/firefox/all/all-downloads-unified.js
@@ -205,11 +205,33 @@ describe('all-downloads-unified.js', function () {
         });
 
         it('should return a well formatted attribution link if data exists', function () {
-            const url =
+            const winUrl =
                 'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US';
+            const macOSNightlyUrl =
+                'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US';
+            const macOSBetaUrl =
+                'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US';
+            const macOSDevUrl =
+                'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US';
+
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(true);
-            expect(Mozilla.FirefoxDownloader.setAttributionURL(url)).toEqual(
+            expect(Mozilla.FirefoxDownloader.setAttributionURL(winUrl)).toEqual(
                 'https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=some-attribution-code&attribution_sig=some-attribution-signature'
+            );
+            expect(
+                Mozilla.FirefoxDownloader.setAttributionURL(macOSNightlyUrl)
+            ).toEqual(
+                'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US&attribution_code=some-attribution-code&attribution_sig=some-attribution-signature'
+            );
+            expect(
+                Mozilla.FirefoxDownloader.setAttributionURL(macOSBetaUrl)
+            ).toEqual(
+                'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US&attribution_code=some-attribution-code&attribution_sig=some-attribution-signature'
+            );
+            expect(
+                Mozilla.FirefoxDownloader.setAttributionURL(macOSDevUrl)
+            ).toEqual(
+                'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US&attribution_code=some-attribution-code&attribution_sig=some-attribution-signature'
             );
         });
 


### PR DESCRIPTION
## One-line summary

Enables Firefox attribution links for all macOS pre-release channels.

> [!Important]
> This needs to go live on Monday 22nd Jan for QA.

## Issue / Bugzilla link

#12761

## Testing

> [!Note]
> Test in a macOS browser with DNT disabled. For the `/firefox/all/` page you'll need to inspect the network request when clicking download to see the attribution params added in the request. For the other pages you should be able to see the `attribution_sig` and `attribution_code` params added to the download link HTML.

- [x] http://localhost:8000/en-US/firefox/channel/desktop/
- [x] http://localhost:8000/en-US/firefox/developer/
- [x] http://localhost:8000/en-US/firefox/all/#product-desktop-beta
- [x] http://localhost:8000/en-US/firefox/all/#product-desktop-developer
- [x] http://localhost:8000/en-US/firefox/all/#product-desktop-nightly