### PR TITLE
Fix text alignment in a section of careers page (issue #14078)

### DIFF
--- a/bedrock/careers/templates/careers/home.html
+++ b/bedrock/careers/templates/careers/home.html
@@ -272,7 +272,7 @@
   <section class="c-careers-mozillians c-careers-section">
     <div class="overlay"></div>
     <div class="c-mozillians-content">
-      <h2>See yourself on one of our teams?</h2>
+      <h2 class="c-careers-section-title">See yourself on one of our teams?</h2>
       <p class="c-careers-button-wrapper">
         <a href="{{ url('careers.listings') }}" data-cta-type="button" class="mzp-c-button mzp-t-dark">Find your role</a>
       </p>


### PR DESCRIPTION
## One-line summary
This PR addresses the alignment issue in the  "_See yourself on one of our teams?_" section text.


## Significant changes and points to review
I added a `c-careers-section-title` class to the corresponding heading tag. This ensures that the text behaves consistently with other section titles.


## Issue / Bugzilla link
#14078


## Testing
http://localhost:8000/en-US/careers/
