### PR TITLE
Updates to NA WNP for Firefox 122 [#14058]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx122-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx122-na.html
@@ -36,7 +36,6 @@
             <th scope="col"><img src="{{ static('img/logos/chrome/logo-chrome.png') }}" height="36" width="36" alt="Chrome"></th>
             <th scope="col"><img src="{{ static('img/logos/edge/logo-edge.png') }}" height="36" width="36" alt="Edge"></th>
             <th scope="col"><img src="{{ static('img/logos/safari/logo-safari.png') }}" height="36" width="36" alt="Safari"></th>
-            <th scope="col"><img src="{{ static('img/logos/ddg/logo-duckduckgo.png') }}" height="36" width="36" alt="DuckDuckGo"></th>
             <th scope="col"><img src="{{ static('img/logos/opera/logo-opera.png') }}" height="36" width="36" alt="Opera"></th>
           </tr>
         </thead>
@@ -47,7 +46,6 @@
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
-            <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
           </tr>
           <tr>
@@ -55,14 +53,12 @@
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
-            <td><span class="compare-icon compare-icon-some">Somewhat</span></td>
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
           </tr>
           <tr>
             <th scope="row">Copy URL without site tracking</th>
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
-            <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
@@ -75,7 +71,6 @@
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-some">Somewhat</span></td>
-            <td><span class="compare-icon compare-icon-some">Somewhat</span></td>
           </tr>
           <tr>
             <th scope="row">Tracker content blocking</th>
@@ -83,7 +78,6 @@
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
-            <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
           </tr>
           <tr>
@@ -92,7 +86,6 @@
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
-            <td><span class="compare-icon compare-icon-yes">Yes</span></td>
             <td><span class="compare-icon compare-icon-no">No</span></td>
           </tr>
         </tbody>

--- a/media/css/firefox/whatsnew/whatsnew-122-na.scss
+++ b/media/css/firefox/whatsnew/whatsnew-122-na.scss
@@ -13,6 +13,10 @@
     text-align: center;
 }
 
+.wnp-main-tagline {
+    @include text-body-xl;
+}
+
 @media #{$mq-md} {
     .wnp-main-title {
         padding-left: $layout-lg;


### PR DESCRIPTION
## One-line summary
Updates for better clarity and accuracy.

* Remove DuckDuckGo.
* Change Safari to “yes” for fingerprinting resistance.
* Increase tagline font size.

## Testing
http://localhost:8000/en-US/firefox/122.0/whatsnew/