### PR TITLE
Add appropriate CDN to CSP for OneTrust banner in Pocket Mode

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -123,6 +123,7 @@ if IS_POCKET_MODE:
         "www.mozilla.org",
         "www.googletagmanager.com",
         "www.google-analytics.com",
+        "cdn.cookielaw.org",  # See https://github.com/mozilla/bedrock/issues/14118
     ]
     _csp_script_src = [
         # TODO fix use of OptanonWrapper() so that we don't need this


### PR DESCRIPTION
## One-line summary

https://github.com/mozilla/bedrock/issues/14118 shows some new CSP errors for the One Trust banner on dev (and we'll likely see them on stage and prod when the OT JS is working properly again. This fixes the CSP error.


## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/14118
