### PR TITLE
Update Pocket’s OneTrust script [fix #14122]

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -102,11 +102,7 @@ if IS_POCKET_MODE:
     DEV_LANGUAGES = PROD_LANGUAGES
     LANGUAGE_CODE = "en"  # Pocket uses `en` not `en-US`
 
-    COOKIE_CONSENT_SCRIPT_SRC = (
-        "https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
-        if DEV
-        else "https://cdn.cookielaw.org/consent/a7ff9c31-9f59-421f-9a8e-49b11a3eb24e/otSDKStub.js"
-    )
+    COOKIE_CONSENT_SCRIPT_SRC = "https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
     COOKIE_CONSENT_DATA_DOMAIN = "a7ff9c31-9f59-421f-9a8e-49b11a3eb24e-test" if DEV else "a7ff9c31-9f59-421f-9a8e-49b11a3eb24e"
 
     SNOWPLOW_APP_ID = "pocket-web-mktg-dev" if DEV else "pocket-web-mktg"


### PR DESCRIPTION
## One-line summary
Updates Pocket's `COOKIE_CONSENT_SCRIPT_SRC` to always return the dev URL, removing the deprecated prod URL.

## Issue / Bugzilla link
#14122 