### PR TITLE
Update to Glean 4.0.0

### DIFF
--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -713,6 +713,6 @@ event data.
 .. _data preferences page: https://www.mozilla.org/privacy/websites/data-preferences/
 .. _websites privacy notice: https://www.mozilla.org/privacy/websites/
 .. _STMO dashboard: https://sql.telemetry.mozilla.org/dashboard/bedrock-landing-page-dashboard?p_date=d_last_30_days
-.. _event monitoring dashboard: https://mozilla.cloud.looker.com/dashboards/1452?Event+Name=%22page_load%22&App+Name=www.mozilla.org&Window+Start+Time=28+days&Channel=
+.. _event monitoring dashboard: https://mozilla.cloud.looker.com/dashboards/1452?Event+Name=%22glean.page_load%22&App+Name=www.mozilla.org&Window+Start+Time=28+days&Channel=non-prod
 .. _Glean Dictionary: https://dictionary.telemetry.mozilla.org/apps/bedrock
 .. _events ping: https://dictionary.telemetry.mozilla.org/apps/bedrock/pings/events

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.23.6",
         "@mozilla-protocol/core": "^18.0.0",
-        "@mozilla/glean": "^4.0.0-pre.3",
+        "@mozilla/glean": "^4.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2143,9 +2143,9 @@
       "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "4.0.0-pre.3",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0-pre.3.tgz",
-      "integrity": "sha512-Uer5Z5HXoejsJsK7neFacRtT8187BO/MiMUoIU6YnWBaB83k46tnGw504g6X6eg4ZCsUXcMcS4E5yKtw5JzlLw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0.tgz",
+      "integrity": "sha512-sxSnyKMat2SS6V0U443Z6PoeDJ44aK6mSrQfpC8fTP7NK0Pm3KldPLylaKvskgrC+rGyMkme7Q+KLpTNLBOVUw==",
       "dependencies": {
         "fflate": "^0.8.0",
         "tslib": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.23.6",
     "@babel/preset-env": "^7.23.6",
     "@mozilla-protocol/core": "^18.0.0",
-    "@mozilla/glean": "^4.0.0-pre.3",
+    "@mozilla/glean": "^4.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",


### PR DESCRIPTION
## One-line summary

Glean 4.0 is out of beta so this just updates us to the main release version. No other changes

## Issue / Bugzilla link

N/A

## Testing

- `npm install`
- `npm start`