### PR TITLE
Test with lazy-apps = false

### DIFF
--- a/wsgi/uwsgi.ini
+++ b/wsgi/uwsgi.ini
@@ -13,7 +13,7 @@ endif =
 die-on-term = true  ; Shutdown on SIGTERM (default is respawn)
 enable-threads = true  ; Support multithreading
 harakiri = 30  ; Kill hung requests after 30 seconds
-lazy-apps = true  ; Load apps in each worker instead of the master
+lazy-apps = false  ; true = Load apps in each worker instead of the master
 max-requests = 2000  ; reload workers after the specified amount of managed requests
 need-app = true  ; Fail if app can't be loaded
 single-interpreter = true


### PR DESCRIPTION
When testing on dev we found that spawning workers took about 4-5 seconds per worker, so 4 workers would take about 20 seconds to spin up, causing a lot of health check flapping and pod churn. Locally testing pre-forking allowed for much faster start-up times, so we'll test this on dev.

