### PR TITLE
String fixes for Linux download buttons

### DIFF
--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -58,8 +58,8 @@ download-a-different-build = Download a different build
 
 ## Linux
 
-download-button-linux-32 = Download { -brand-name-linux } 32-bit
-download-button-linux-64 = Download { -brand-name-linux } 64-bit
+download-button-linux-32 = Download for Linux 32-bit
+download-button-linux-64 = Download for Linux 64-bit
 
 # Variables
 #   $attrs (attrs) - link to https://support.mozilla.org/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions


### PR DESCRIPTION
## One-line summary

Minor fixes to the Linux button strings, based on feedback in https://github.com/mozilla-l10n/www-l10n/pull/372#discussion_r1474968306