### PR TITLE
More string fixes for Linux download buttons

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -85,9 +85,9 @@
               {% elif plat.os == 'ios' %}
                 {{ ftl('download-button-firefox-ios') }}
               {% elif plat.os == 'linux' %}
-                {{ ftl('download-button-linux-32') }}
+                {{ ftl('download-button-linux-32-v2') }}
               {% elif plat.os == 'linux64' %}
-                {{ ftl('download-button-linux-64') }}
+                {{ ftl('download-button-linux-64-v2') }}
               {% else %}
                 {% if channel == 'beta' %}
                   {{ ftl('download-button-firefox-beta') }}

--- a/bedrock/firefox/templates/firefox/includes/macros.html
+++ b/bedrock/firefox/templates/firefox/includes/macros.html
@@ -59,13 +59,13 @@
     <div class="firefox-platform-button">
       <a class="download-link os_linux mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" data-link-type="download" data-display-name="Linux 32-bit" data-download-version="linux" data-download-os="Desktop" data-download-location="{{ position }}">
         <strong class="download-title">
-          {{ ftl('download-button-linux-32') }}
+          {{ ftl('download-button-linux-32-v2') }}
         </strong>
       </a>
 
       <a class="download-link os_linux64 mzp-t-xl mzp-c-button mzp-t-product ga-product-download" id="{{ id }}-64" href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" data-link-type="download" data-display-name="Linux 64-bit" data-download-version="linux64" data-download-os="Desktop" data-download-location="{{ position }}">
         <strong class="download-title">
-          {{ ftl('download-button-linux-64') }}
+          {{ ftl('download-button-linux-64-v2') }}
         </strong>
       </a>
 

--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -69,9 +69,9 @@
         <div class="show-linux">
           <div class="c-linux-button-group">
             <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}"
-              class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-32') }}</a>
+              class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-32-v2') }}</a>
             <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}"
-              class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-64') }}</a>
+              class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-64-v2') }}</a>
           </div>
           {% set attrs = 'href="https://support.mozilla.org/kb/install-firefox-linux%s#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener"
           data-cta-type="link" data-cta-text="You can set up our APT repository instead"'|safe|format(referrals) %}

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -82,8 +82,8 @@
       </p>
       <div class="show-linux">
         <div class="c-linux-button-group">
-          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-32') }}</a>
-          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-64') }}</a>
+          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-32-v2') }}</a>
+          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-64-v2') }}</a>
         </div>
         {% set attrs = 'href="https://support.mozilla.org/kb/install-firefox-linux%s#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener" data-cta-type="link" data-cta-text="You can set up our APT repository instead"'|safe|format(referrals) %}
         <p class="linux-deb-text">{{ ftl('download-button-using-debian', attrs=attrs) }}</p>

--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -58,8 +58,14 @@ download-a-different-build = Download a different build
 
 ## Linux
 
-download-button-linux-32 = Download for Linux 32-bit
-download-button-linux-64 = Download for Linux 64-bit
+# Obsolete string
+download-button-linux-32 = Download { -brand-name-linux } 32-bit
+
+# Obsolete string
+download-button-linux-64 = Download { -brand-name-linux } 64-bit
+
+download-button-linux-32-v2 = Download for Linux 32-bit
+download-button-linux-64-v2 = Download for Linux 64-bit
 
 # Variables
 #   $attrs (attrs) - link to https://support.mozilla.org/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions


### PR DESCRIPTION
## One-line summary
Oops, I hadn't realized the previous strings had already been exposed to localizers, so the fixed ones need new IDs.

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/374#pullrequestreview-1858425577
