### PR TITLE
Fix JS error in GA4 event tracking (Fixes #14177)

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -226,8 +226,11 @@ TrackProductDownload.handleLink = (event) => {
 TrackProductDownload.sendEventFromURL = (downloadURL) => {
     // get event object
     const eventObject = TrackProductDownload.getEventFromUrl(downloadURL);
-    // send for tracking
-    TrackProductDownload.sendEvent(eventObject);
+
+    if (eventObject) {
+        // only send event for tracking if eventObject is valid (issue 14177)
+        TrackProductDownload.sendEvent(eventObject);
+    }
 };
 
 /**


### PR DESCRIPTION
## One-line summary

Fixes an error that is caused when trying to send an event and `getEventFromUrl()` returns a boolean instead of an object.

## Issue / Bugzilla link

#14177

## Testing

1. Open http://localhost:8000/en-US/firefox/122.0/releasenotes/
2. Open the web console and make sure you have "Persist logs" checked.
3. Scroll to the bottom of the page where it says "Get the most recent version" and click "Download Firefox"
4. Verify there is no longer a JS error on click.