### PR TITLE
Remove hard-coded English strings from VPN nav CTA (Fixes #14179)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -152,11 +152,11 @@
     {% if vpn_available %}
       {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
       <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="navigation">
-        Get Mozilla VPN
+        {{ ftl('vpn-shared-subscribe-link') }}
       </a>
     {% else %}
       <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation">
-        Join the Waitlist
+        {{ ftl('vpn-shared-waitlist-link') }}
       </a>
     {% endif %}
   </div>


### PR DESCRIPTION
## One-line summary

Looks like these hard-coded strings were left over from when the redesigned pages were still an en-Us only.

## Issue / Bugzilla link

#14179

## Testing

http://localhost:8000/de/products/vpn/