### PR TITLE
Add a security.txt URI

### DIFF
--- a/bedrock/mozorg/templates/mozorg/security.txt
+++ b/bedrock/mozorg/templates/mozorg/security.txt
@@ -1,0 +1,3 @@
+Email: security@mozilla.org
+Main info: https://www.mozilla.org/en-US/security/
+Bounty program: https://www.mozilla.org/en-US/security/bug-bounty/

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -59,6 +59,18 @@ class TestRobots(TestCase):
         self.assertEqual(response.get("Content-Type"), "text/plain")
 
 
+class TestSecurityDotTxt(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+        self.view = views.SecurityDotTxt()
+
+    def test_no_redirect(self):
+        response = self.client.get("/.well-known/security.txt", HTTP_HOST="www.mozilla.org")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get("Content-Type"), "text/plain")
+        self.assertContains(response, "security@mozilla.org")
+
+
 @override_settings(DEV=False)
 @patch("bedrock.mozorg.views.l10n_utils.render", return_value=HttpResponse())
 class TestHomePageLocales(TestCase):

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -109,6 +109,7 @@ urlpatterns = (
     page("moss/mission-partners/", "mozorg/moss/mission-partners.html"),
     page("moss/secure-open-source/", "mozorg/moss/secure-open-source.html"),
     path("robots.txt", views.Robots.as_view(), name="robots.txt"),
+    path(".well-known/security.txt", views.SecurityDotTxt.as_view(), name="security.txt"),
     # namespaces
     path("2004/em-rdf", views.namespaces, {"namespace": "em-rdf"}),
     path("2005/app-update", views.namespaces, {"namespace": "update"}),

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -65,6 +65,13 @@ class Robots(RequireSafeMixin, TemplateView):
         return {"disallow_all": not hostname == "www.mozilla.org"}
 
 
+class SecurityDotTxt(RequireSafeMixin, TemplateView):
+    # https://github.com/mozilla/bedrock/issues/14173
+    # served under .well-known/security.txt
+    template_name = "mozorg/security.txt"
+    content_type = "text/plain"
+
+
 NAMESPACES = {
     "addons-bl": {
         "namespace": "http://www.mozilla.org/2006/addons-blocklist",

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -409,6 +409,7 @@ SUPPORTED_NONLOCALES = [
     "credits",
     "gameon",
     "robots.txt",
+    ".well-known",
     "telemetry",
     "webmaker",
     "contributor-data",


### PR DESCRIPTION

## One-line summary

Adds a page at `.well-known/security.txt` as requested by the security team. Does not redirect to en-US, the same as robots.txt does

```
Email: security@mozilla.org
Main info: https://www.mozilla.org/en-US/security/
Bounty program: https://www.mozilla.org/en-US/security/bug-bounty/
```

## Issue / Bugzilla link

Resolves #14173

## Testing
* See https://www-demo6.allizom.org/.well-known/security.txt 