### PR TITLE
Remove second Monitor CTA from Firefox products page [#14188]

### DIFF
--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -73,18 +73,6 @@
       </h2>
         <p>{% if LANG == 'en-US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>
         <p><a class="mzp-c-cta-link" href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Check for breaches">{% if LANG == 'en-US' %}Check for breaches now{% else %}{{ ftl('firefox-products-check-for-breaches') }}{% endif %}</a></p>
-      {% if LANG != 'en-US' %}
-        <p id="qa-monitor-button-wrapper">
-          {{ monitor_fxa_button(
-            entrypoint='mozilla.org-firefox-products',
-            button_text=ftl('firefox-products-sign-up-for-breach-alerts'),
-            class_name='mzp-c-cta-link',
-            is_button_class=False,
-            optional_parameters={'utm_campaign': 'firefox-products'},
-            optional_attributes={'data-cta-text': 'Sign up for breach alerts', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'card'}
-          ) }}
-        </p>
-      {% endif %}
     </div>
 
     <div class="c-landing-grid-item">

--- a/tests/functional/firefox/test_products.py
+++ b/tests/functional/firefox/test_products.py
@@ -10,12 +10,6 @@ from pages.firefox.products import FirefoxProductsPage
 
 
 @pytest.mark.nondestructive
-def test_monitor_button_displayed(base_url, selenium):
-    page = FirefoxProductsPage(selenium, base_url).open()
-    assert page.is_monitor_button_displayed
-
-
-@pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
     page = FirefoxProductsPage(selenium, base_url).open()
     page.join_firefox_form.type_email("success@example.com")

--- a/tests/pages/firefox/products.py
+++ b/tests/pages/firefox/products.py
@@ -2,20 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from selenium.webdriver.common.by import By
-
 from pages.base import BasePage
 from pages.regions.join_firefox_form import JoinFirefoxForm
 
 
 class FirefoxProductsPage(BasePage):
     _URL_TEMPLATE = "/{locale}/firefox/products/"
-
-    _monitor_button_locator = (By.CSS_SELECTOR, "#qa-monitor-button-wrapper a.js-fxa-product-button")
-
-    @property
-    def is_monitor_button_displayed(self):
-        return self.is_element_displayed(*self._monitor_button_locator)
 
     @property
     def join_firefox_form(self):


### PR DESCRIPTION
## One-line summary

So it turns out simply hiding the second CTA in https://github.com/mozilla/bedrock/pull/14189 wasn't such an easy fix after all. That second CTA has been part of the page for a long time and we had functional tests to verify it was displayed. Removing it for one locale made that test fail. We could have updated the test to skip en-US but it was decided to simply remove the second CTA for all locales (and remove the test as well).

## Issue / Bugzilla link

#14188 

## Testing
http://localhost:8000/firefox/products/

Make sure functional tests pass: `$ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/test_products.py`