### PR TITLE
Remove IE from `test_browsers.py` test file

### DIFF
--- a/tests/functional/firefox/browsers/compare/test_browsers.py
+++ b/tests/functional/firefox/browsers/compare/test_browsers.py
@@ -8,7 +8,7 @@ from pages.firefox.browsers.compare import BrowserComparisonPage
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("slug", [("chrome"), ("edge"), ("safari"), ("opera"), ("brave"), ("ie")])
+@pytest.mark.parametrize("slug", [("chrome"), ("edge"), ("safari"), ("opera"), ("brave")])
 def test_menu_list_is_displayed(slug, base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     page.browser_menu_list.click()
@@ -17,7 +17,7 @@ def test_menu_list_is_displayed(slug, base_url, selenium):
 
 @pytest.mark.skip_if_firefox(reason="Download button only visible to non-Firefox users")
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("slug", [("chrome"), ("edge"), ("safari"), ("opera"), ("brave"), ("ie")])
+@pytest.mark.parametrize("slug", [("chrome"), ("edge"), ("safari"), ("opera"), ("brave")])
 def test_download_buttons_are_displayed(slug, base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     assert page.primary_download_button.is_displayed


### PR DESCRIPTION
## One-line summary
I forgot to remove IE from the comparison pages test file, so doing that here

Sibling PR: https://github.com/mozilla/bedrock/pull/14167
