### PR TITLE
Enable attribution for all macOS Firefox download links (Fixes #12761)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -167,21 +167,8 @@ if (typeof window.Mozilla === 'undefined') {
                 ) !== -1
             ) {
                 version = link.getAttribute('data-download-version');
-                // Append attribution params to Windows 32bit, 64bit, and MSI installer links.
-                if (version && /win/.test(version)) {
-                    link.href = Mozilla.StubAttribution.appendToDownloadURL(
-                        link.href,
-                        data
-                    );
-                }
-                // Append attribution params to macOS Firefox pre-release links.
-                if (
-                    version &&
-                    /osx/.test(version) &&
-                    /product=firefox-beta-latest|product=firefox-devedition-latest|product=firefox-nightly-latest/.test(
-                        link.href
-                    )
-                ) {
+                // Append attribution params to Windows and macOS links
+                if (version && /win|osx/.test(version)) {
                     link.href = Mozilla.StubAttribution.appendToDownloadURL(
                         link.href,
                         data

--- a/media/js/firefox/all/all-downloads-unified.js
+++ b/media/js/firefox/all/all-downloads-unified.js
@@ -288,18 +288,7 @@
         var url = e.target.href;
         var version = el.getAttribute('data-download-version');
 
-        if (version && /win/.test(version)) {
-            url = FirefoxDownloader.setAttributionURL(e.target.href);
-        }
-
-        // Only macOS pre-release channels for now.
-        if (
-            version &&
-            /osx/.test(version) &&
-            /product=firefox-beta-latest|product=firefox-devedition-latest|product=firefox-nightly-latest/.test(
-                url
-            )
-        ) {
+        if (version && /win|osx/.test(version)) {
             url = FirefoxDownloader.setAttributionURL(e.target.href);
         }
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -865,6 +865,8 @@ describe('stub-attribution.js', function () {
             'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US';
         const macOSDevUrl =
             'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US';
+        const macOSUrl =
+            'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US';
 
         beforeEach(function () {
             const downloadMarkup = `<ul class="download-list">
@@ -880,6 +882,7 @@ describe('stub-attribution.js', function () {
                     <li><a id="link-macos-nightly" class="download-link" data-download-version="osx" href="${macOSNightlyUrl}">Download</a></li>
                     <li><a id="link-macos-beta" class="download-link" data-download-version="osx" href="${macOSBetaUrl}">Download</a></li>
                     <li><a id="link-macos-dev" class="download-link" data-download-version="osx" href="${macOSDevUrl}">Download</a></li>
+                    <li><a id="link-macos" class="download-link" data-download-version="osx" href="${macOSUrl}">Download</a></li>
                 </ul>`;
 
             document.body.insertAdjacentHTML('beforeend', downloadMarkup);
@@ -950,7 +953,7 @@ describe('stub-attribution.js', function () {
                 'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
 
-            // macOS pre-release links
+            // macOS links
             expect(document.getElementById('link-macos-nightly').href).toEqual(
                 'https://download.mozilla.org/?product=firefox-nightly-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
@@ -959,6 +962,9 @@ describe('stub-attribution.js', function () {
             );
             expect(document.getElementById('link-macos-dev').href).toEqual(
                 'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+            expect(document.getElementById('link-macos').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
         });
 

--- a/tests/unit/spec/firefox/all/all-downloads-unified.js
+++ b/tests/unit/spec/firefox/all/all-downloads-unified.js
@@ -213,6 +213,8 @@ describe('all-downloads-unified.js', function () {
                 'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US';
             const macOSDevUrl =
                 'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US';
+            const macOSUrl =
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US';
 
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(true);
             expect(Mozilla.FirefoxDownloader.setAttributionURL(winUrl)).toEqual(
@@ -232,6 +234,11 @@ describe('all-downloads-unified.js', function () {
                 Mozilla.FirefoxDownloader.setAttributionURL(macOSDevUrl)
             ).toEqual(
                 'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US&attribution_code=some-attribution-code&attribution_sig=some-attribution-signature'
+            );
+            expect(
+                Mozilla.FirefoxDownloader.setAttributionURL(macOSUrl)
+            ).toEqual(
+                'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US&attribution_code=some-attribution-code&attribution_sig=some-attribution-signature'
             );
         });
 


### PR DESCRIPTION
## One-line summary

Enables Firefox desktop attribution for all macOS download links (removing pre-release restrictions).

> [!Important]
> Aim is to merge this and deploy around 9am ET on Tuesday 20th

## Issue / Bugzilla link

#12761

## Testing

> [!Note]
> Test in a macOS browser with DNT disabled. For the `/firefox/all/` page you'll need to inspect the network request when clicking download to see the attribution params added in the request. For the other pages you should be able to see the `attribution_sig` and `attribution_code` params added to the download link HTML.

- [ ] http://localhost:8000/en-US/firefox/new/
- [ ] http://localhost:8000/en-US/firefox/all/