### PR TITLE
Fix /careers/diversity/ video error (Fixes #14211)

### DIFF
--- a/bedrock/careers/templates/careers/diversity.html
+++ b/bedrock/careers/templates/careers/diversity.html
@@ -311,5 +311,6 @@
 {% endblock %}
 
 {% block js %}
+  {{ js_bundle('protocol-modal') }}
   {{ js_bundle('careers-hero-video') }}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Adds missing page bundle to fix the JS error on video thumbnail click.

## Issue / Bugzilla link

#14211

## Testing

http://localhost:8000/en-US/careers/diversity/