### PR TITLE
Omit macOS attribution for ESR links (Fixes #14216)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -167,8 +167,20 @@ if (typeof window.Mozilla === 'undefined') {
                 ) !== -1
             ) {
                 version = link.getAttribute('data-download-version');
-                // Append attribution params to Windows and macOS links
-                if (version && /win|osx/.test(version)) {
+
+                // Append attribution params to Windows links.
+                if (version && /win/.test(version)) {
+                    link.href = Mozilla.StubAttribution.appendToDownloadURL(
+                        link.href,
+                        data
+                    );
+                }
+                // Append attribution params to macOS links (excluding ESR for now).
+                if (
+                    version &&
+                    /osx/.test(version) &&
+                    !/product=firefox-esr/.test(link.href)
+                ) {
                     link.href = Mozilla.StubAttribution.appendToDownloadURL(
                         link.href,
                         data

--- a/media/js/firefox/all/all-downloads-unified.js
+++ b/media/js/firefox/all/all-downloads-unified.js
@@ -288,7 +288,16 @@
         var url = e.target.href;
         var version = el.getAttribute('data-download-version');
 
-        if (version && /win|osx/.test(version)) {
+        if (version && /win/.test(version)) {
+            url = FirefoxDownloader.setAttributionURL(e.target.href);
+        }
+
+        // Exclude macOS ESR links for now.
+        if (
+            version &&
+            /osx/.test(version) &&
+            !/product=firefox-esr/.test(url)
+        ) {
             url = FirefoxDownloader.setAttributionURL(e.target.href);
         }
 

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -865,6 +865,8 @@ describe('stub-attribution.js', function () {
             'https://download.mozilla.org/?product=firefox-beta-latest&os=osx&lang=en-US';
         const macOSDevUrl =
             'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US';
+        const macOSEsrUrl =
+            'https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US';
         const macOSUrl =
             'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US';
 
@@ -882,6 +884,7 @@ describe('stub-attribution.js', function () {
                     <li><a id="link-macos-nightly" class="download-link" data-download-version="osx" href="${macOSNightlyUrl}">Download</a></li>
                     <li><a id="link-macos-beta" class="download-link" data-download-version="osx" href="${macOSBetaUrl}">Download</a></li>
                     <li><a id="link-macos-dev" class="download-link" data-download-version="osx" href="${macOSDevUrl}">Download</a></li>
+                    <li><a id="link-macos-esr" class="download-link" data-download-version="osx" href="${macOSEsrUrl}">Download</a></li>
                     <li><a id="link-macos" class="download-link" data-download-version="osx" href="${macOSUrl}">Download</a></li>
                 </ul>`;
 
@@ -962,6 +965,9 @@ describe('stub-attribution.js', function () {
             );
             expect(document.getElementById('link-macos-dev').href).toEqual(
                 'https://download.mozilla.org/?product=firefox-devedition-latest&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+            expect(document.getElementById('link-macos-esr').href).toEqual(
+                'https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US'
             );
             expect(document.getElementById('link-macos').href).toEqual(
                 'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'


### PR DESCRIPTION
## One-line summary

Excludes attribution data from macOS ESR links

## Issue / Bugzilla link

#14216

## Testing

- [x] http://localhost:8000/en-US/firefox/enterprise/
- [x] http://localhost:8000/en-US/firefox/all/#product-desktop-esr