### PR TITLE
Fix release notes header branding [fix #14214]

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -8,7 +8,8 @@
 
 {% if release.product == 'Firefox for Android' %}
   {% set page_id = 'data-gtm-page-id="/firefox/android/auroranotes/"' %}
-  {% set product_class = 'mzp-t-dark mzp-t-product-nightly' %}
+  {% set header_class = 'mzp-t-dark t-nightly' %}
+  {% set brand_product = 'nightly' %}
   {% set download_button_primary %}
     {{ download_firefox('nightly', platform='android', alt_copy='Download Firefox for Android Nightly', dom_id="download-android-nightly-primary") }}
   {% endset %}
@@ -18,7 +19,8 @@
   {% set download_all_link = firefox_url('android', 'all', channel='nightly') %}
 {% elif release.product == 'Firefox' %}
   {% set page_id = 'data-gtm-page-id="/firefox/auroranotes/"' %}
-  {% set product_class = 'mzp-t-dark mzp-t-product-developer t-aurora' %}
+  {% set header_class = 'mzp-t-dark' %}
+  {% set brand_product = 'developer t-aurora' %}
   {% set download_title = 'Build, test, scale and more with the only browser built just for developers.' %}
   {% set download_button_primary %}
     {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy='Download Firefox Developer Edition', dom_id="download-dev-edition-primary") }}

--- a/bedrock/firefox/templates/firefox/releases/beta-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/beta-notes.html
@@ -6,7 +6,8 @@
 
 {% extends "firefox/releases/notes.html" %}
 
-{% set product_class = 'mzp-t-product-beta' %}
+{% set header_class = 't-beta' %}
+{% set brand_product = 'beta' %}
 
 {% if release.product == 'Firefox for Android' %}
   {% set page_id = 'data-gtm-page-id="/firefox/android/beta/releasenotes"' %}

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -8,7 +8,8 @@
 
 {% set page_id = 'data-gtm-page-id="/firefox/auroranotes/"' %}
 {% set product_name = 'Firefox Developer Edition' %}
-{% set product_class = 'mzp-t-dark mzp-t-product-developer' %}
+{% set header_class = 'mzp-t-dark t-developer' %}
+{% set brand_product = 'developer' %}
 {% set download_button_primary %}
  {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy='Download Firefox Developer Edition', dom_id="download-dev-edition-primary") }}
 {% endset %}

--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -19,7 +19,8 @@
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/nightly/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/nightly/apple-touch-icon.png') }}{% endblock %}
 
-{% set product_class = 'mzp-t-dark mzp-t-product-nightly' %}
+{% set header_class = 'mzp-t-dark t-nightly' %}
+{% set brand_product = 'nightly' %}
 {% set page_id = 'data-gtm-page-id="/firefox/nightly/releasenotes"' %}
 
 {% if release.is_latest %}

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -17,10 +17,13 @@
 {# product_name may be over-ridden with more appropriate content to avoid bad names like: Firefox Release Release #}
 {% set product_name = product_name|default(release.product + ' ' + release.channel) %}
 
-{# product_class is the class or classes applied to theme components for Release, Beta, Nightly, etc #}
-{# product_class may be over-ridden where the default firefox release theme is not apprpriate #}
-{% set product_class = product_class|default('mzp-t-product-firefox') %}
+{# brand_product is appended to the class `mzp-t-product-` to set the product logo (release, beta, nightly, etc) #}
+{% set brand_product = brand_product|default('firefox') %}
 
+{# header_class is applied to the page header as an additional style hook if needed #}
+{% set header_class = header_class|default('') %}
+
+{# theme_class is applied to the body as an additional style hook if needed #}
 {% set theme_class = '' %}
 {% set ver = release.major_version_int %}
 {% if release.product != 'Firefox for iOS' %}
@@ -115,10 +118,10 @@
             heading_level=1,
             title=primary_heading,
             desc=call_out_desc|safe,
-            class='mzp-t-firefox mzp-t-background-tertiary ' + product_class,
+            class='mzp-t-firefox mzp-t-background-tertiary ' + header_class,
             include_cta=True,
             brand=True,
-            brand_product='firefox',
+            brand_product=brand_product,
             brand_type='logo',
             brand_size='lg',
           ) %}
@@ -346,9 +349,9 @@
 
     {% call callout_compact(
       title=download_title,
-      class='mzp-t-firefox mzp-t-background-secondary ' + product_class,
+      class='mzp-t-firefox mzp-t-background-secondary ' + header_class,
       brand=True,
-      brand_product='firefox',
+      brand_product=brand_product,
       brand_type='logo',
       brand_size='lg'
     ) %}

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -12,22 +12,26 @@ $image-path: '/media/protocol/img';
 @import '../protocol/components/sub-navigation';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-nightly';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-beta';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-developer';
+
 
 // * -------------------------------------------------------------------------- */
 // Call out / page header
 
-.mzp-c-callout.mzp-t-product-firefox,
-.mzp-c-callout.mzp-t-product-beta {
+.mzp-c-callout.t-firefox,
+.mzp-c-callout.t-beta {
     background: $color-marketing-gray-20;
 }
 
 // nightly header gradient
-.mzp-c-callout.mzp-t-product-nightly {
+.mzp-c-callout.t-nightly {
     background: linear-gradient(#000, #001e44);
 }
 
 // developer header gradient
-.mzp-c-callout.mzp-t-product-developer {
+.mzp-c-callout.t-developer {
     background: linear-gradient(#000, #001e44);
 }
 
@@ -38,7 +42,7 @@ $image-path: '/media/protocol/img';
 
 .t-quantum {
     // firefox release
-    .mzp-c-callout.mzp-t-product-firefox .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-firefox {
         background-image: url('/media/img/firefox/releasenotes/release-quantum.png');
 
         @media #{$mq-high-res} {
@@ -47,7 +51,7 @@ $image-path: '/media/protocol/img';
     }
 
     // firefox beta
-    .mzp-c-callout.mzp-t-product-beta .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-beta {
         background-image: url('/media/img/firefox/releasenotes/beta-quantum.png');
 
         @media #{$mq-high-res} {
@@ -56,7 +60,7 @@ $image-path: '/media/protocol/img';
     }
 
     // firefox nightly
-    .mzp-c-callout.mzp-t-product-nightly .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-nightly {
         background-image: url('/media/img/firefox/releasenotes/nightly-quantum.png');
 
         @media #{$mq-high-res} {
@@ -65,7 +69,7 @@ $image-path: '/media/protocol/img';
     }
 
     // firefox developer edition
-    .mzp-c-callout.mzp-t-product-developer .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-developer {
         background-image: url('/media/img/firefox/releasenotes/developer-quantum.png');
 
         @media #{$mq-high-res} {
@@ -74,7 +78,7 @@ $image-path: '/media/protocol/img';
     }
 
     // pre-dev edition firefox aurora
-    .mzp-c-callout.mzp-t-product-developer.t-aurora .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-developer.t-aurora {
         background-image: url('/media/img/firefox/releasenotes/aurora.png');
 
         @media #{$mq-high-res} {
@@ -85,7 +89,7 @@ $image-path: '/media/protocol/img';
 
 .t-pre-quantum {
     // firefox release
-    .mzp-c-callout.mzp-t-product-firefox .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-firefox {
         background-image: url('/media/img/firefox/releasenotes/firefox-old.png');
 
         @media #{$mq-high-res} {
@@ -94,7 +98,7 @@ $image-path: '/media/protocol/img';
     }
 
     // firefox beta
-    .mzp-c-callout.mzp-t-product-beta .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-beta {
         background-image: url('/media/img/firefox/releasenotes/beta-old.png');
 
         @media #{$mq-high-res} {
@@ -103,7 +107,7 @@ $image-path: '/media/protocol/img';
     }
 
     // firefox nightly
-    .mzp-c-callout.mzp-t-product-nightly .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-nightly {
         background-image: url('/media/img/firefox/releasenotes/nightly-old.png');
 
         @media #{$mq-high-res} {
@@ -112,7 +116,7 @@ $image-path: '/media/protocol/img';
     }
 
     // firefox developer edition
-    .mzp-c-callout.mzp-t-product-developer .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-developer {
         background-image: url('/media/img/firefox/releasenotes/developer-old.png');
 
         @media #{$mq-high-res} {
@@ -121,7 +125,7 @@ $image-path: '/media/protocol/img';
     }
 
     // pre-dev edition firefox aurora
-    .mzp-c-callout.mzp-t-product-developer.t-aurora .mzp-c-callout-title {
+    .mzp-c-logo.mzp-t-product-developer.t-aurora {
         background-image: url('/media/img/firefox/releasenotes/aurora.png');
 
         @media #{$mq-high-res} {
@@ -358,23 +362,6 @@ $image-path: '/media/protocol/img';
     @media #{$mq-md} {
         text-align: center;
     }
-}
-
-// * -------------------------------------------------------------------------- */
-// Compact call out
-
-.mzp-c-callout-compact {
-    margin-top: $layout-md;
-}
-
-// nightly footer gradient
-.mzp-c-callout-compact.mzp-t-product-nightly {
-    background: linear-gradient(#001e44, #002d66);
-}
-
-// developer footer gradient
-.mzp-c-callout-compact.mzp-t-product-developer {
-    background: linear-gradient(#001e44, #002d66);
 }
 
 // * -------------------------------------------------------------------------- */


### PR DESCRIPTION
## One-line summary

Updates templates and styles to display the correct product logo on release notes for each Firefox channel, including older legacy logos. This was a regression we missed when updating to Protocol 19 and the refactored callout that no longer has baked-in logos.

## Issue / Bugzilla link

#14214 
https://bugzilla.mozilla.org/show_bug.cgi?id=1880831


## Testing
Appropriate logos should appear:

http://localhost:8000/en-US/firefox/30.0a2/releasenotes/ - Aurora
http://localhost:8000/en-US/firefox/50.0a2/releasenotes/ - Developer, pre-Quantum

http://localhost:8000/en-US/firefox/55.0beta/releasenotes/ - Beta, pre-Quantum
http://localhost:8000/en-US/firefox/60.0beta/releasenotes/ - Beta, Quantum
http://localhost:8000/en-US/firefox/120.0/releasenotes/ - Beta, current

http://localhost:8000/en-US/firefox/55.0a1/releasenotes/ - Nightly, pre-Quantum
http://localhost:8000/en-US/firefox/60.0a1/releasenotes/ - Nightly, Quantum
http://localhost:8000/en-US/firefox/120.0a1/releasenotes/ - Nightly, current

http://localhost:8000/en-US/firefox/50.0/releasenotes/ - Release, pre-Quantum
http://localhost:8000/en-US/firefox/60.0/releasenotes/ - Release, Quantum
http://localhost:8000/en-US/firefox/120.0/releasenotes/ - Release, current