### PR TITLE
Update Mitchell Baker's title in homepage

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -76,7 +76,7 @@
       <blockquote>
         <p>{{ ftl('home-the-health-of') }}
         </p>
-        <cite>{{ ftl('home-mitchell-baker') }}</cite>
+        <cite>{{ ftl('home-mitchell-baker-v2', fallback="home-mitchell-baker") }}</cite>
       </blockquote>
     </div>
   </div>

--- a/l10n/en/mozorg/home-new.ftl
+++ b/l10n/en/mozorg/home-new.ftl
@@ -12,7 +12,11 @@ home-were-not-normal = We’re not a normal tech company. The things we create p
 
 # Quotes around string to represent it being a quote by Mitchell Baker
 home-the-health-of = “The health of the internet and online life is why we exist.”
+
+# Obsolete string
 home-mitchell-baker = Mitchell Baker, { -brand-name-mozilla } CEO
+
+home-mitchell-baker-v2 = Mitchell Baker, Executive Chair of the Board, { -brand-name-mozilla-foundation }
 
 home-mozilla-makes-privacy = { -brand-name-mozilla } makes privacy-respecting products
 home-product-firefox-browsing = Private & secure browsing


### PR DESCRIPTION
## One-line summary

Mitchell Baker's title has changed from CEO to Executive Chair of the Board for MoFo, so we've updated her quote on the homepage to reflect that change.

## Testing
- http://localhost:8000/en-US/
