### PR TITLE
Add GA4 client ID to stub attribution

### DIFF
--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -85,7 +85,7 @@ class TestDownloadButtons(TestCase):
 
     def test_button_locale_in_transition(self):
         """
-        If the locale_in_transition parameter is True, the link to scene2 should include the locale
+        If the locale_in_transition parameter is True, the link to /thanks should include the locale
         """
         rf = RequestFactory()
         get_request = rf.get("/fake")

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -66,7 +66,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "b9946a63da74d1f2909b7bd5dd0e1ba4f46f3701a86f2c10bafcd5ee2bc9f918",
+            "0fadfe08229c0a3563f7fbc3368a9801d259755bf25a1f604abe0fec30c1170a",
         )
 
     def test_no_valid_param_data(self):
@@ -105,7 +105,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "b9946a63da74d1f2909b7bd5dd0e1ba4f46f3701a86f2c10bafcd5ee2bc9f918",
+            "0fadfe08229c0a3563f7fbc3368a9801d259755bf25a1f604abe0fec30c1170a",
         )
 
     def test_some_valid_param_data(self):
@@ -135,7 +135,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "ed0705c22e56e7ed8152b08abd3df72a897ae00b30f7c802aa4a19e3a8c77503",
+            "2c936780cada1e1f6c5b900e5fa0659f64d908e2938f7c91be3de593656c6097",
         )
 
     def test_campaign_data_too_long(self):
@@ -159,8 +159,7 @@ class TestStubAttributionCode(TestCase):
             "campaign": "The|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in"
             "|thatThe|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe"
             "|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides"
-            "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know"
-            "|about|you|b_",
+            "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides_",
             "content": "A144_A000_0000000",
             "experiment": "(not set)",
             "variation": "(not set)",
@@ -184,7 +183,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "16010b2f9581e4ba48689125b7f35e4f4420399da1f0f245e814da071c726991",
+            "aefd88209faa9cd73964bdcd3720bffea66fa904ae56da0f297a6051fb0fb13f",
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -240,7 +239,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "98c68dcf0ff6086b9e546dda753a830127afc4981745a32a6b6c3dfe81295877",
+            "20dfb63379a9ed9ae9f74acf4c6bbc1496597eca7cec4987ad89ad161cbfd810",
         )
 
     def test_handles_referrer(self):
@@ -270,7 +269,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "ed0705c22e56e7ed8152b08abd3df72a897ae00b30f7c802aa4a19e3a8c77503",
+            "2c936780cada1e1f6c5b900e5fa0659f64d908e2938f7c91be3de593656c6097",
         )
 
     def test_handles_referrer_no_source(self):
@@ -303,7 +302,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "cf22590be0114f16651dc61cb470269245164d50273e2f17199347c6ae6c716e",
+            "8b7a62992b0acd8610df3aed80b504ff78c7f2ed081568ed6d7e91ea62d5b85c",
         )
 
     def test_handles_referrer_utf8(self):
@@ -339,7 +338,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "b9946a63da74d1f2909b7bd5dd0e1ba4f46f3701a86f2c10bafcd5ee2bc9f918",
+            "0fadfe08229c0a3563f7fbc3368a9801d259755bf25a1f604abe0fec30c1170a",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -50,6 +50,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id": "(not set)",
+            "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
         }
@@ -75,6 +76,7 @@ class TestStubAttributionCode(TestCase):
             "experiment": "dfb</p>s",
             "variation": "ef&bvcv",
             "client_id": "14</p>4538.1610<t>957",
+            "client_id_ga4": "14</p>4538.1610<t>957",
             "session_id": "2w</br>123bg<u>957",
             "dlsource": "fs<a>44fn</a>",
         }
@@ -87,6 +89,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id": "(not set)",
+            "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
         }
@@ -116,6 +119,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id": "(not set)",
+            "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
         }
@@ -145,6 +149,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
+            "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
         }
@@ -161,6 +166,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
+            "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
         }
@@ -205,6 +211,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "1",
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
+            "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
         }
@@ -217,6 +224,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "1",
             "ua": "chrome",
             "client_id": "1456954538.1610960957",
+            "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
         }
@@ -246,6 +254,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id": "(not set)",
+            "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
         }
@@ -278,6 +287,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id": "(not set)",
+            "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
         }
@@ -313,6 +323,7 @@ class TestStubAttributionCode(TestCase):
             "variation": "(not set)",
             "ua": "(not set)",
             "client_id": "(not set)",
+            "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
         }

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -53,6 +53,7 @@ STUB_VALUE_NAMES = [
     ("variation", "(not set)"),
     ("ua", "(not set)"),
     ("client_id", "(not set)"),
+    ("client_id_ga4", "(not set)"),
     ("session_id", "(not set)"),
     ("dlsource", "mozorg"),
 ]

--- a/docs/attribution/0002-firefox-desktop.rst
+++ b/docs/attribution/0002-firefox-desktop.rst
@@ -178,6 +178,37 @@ that is used to sign the attribution code must be set via an environment variabl
     It only needs to match the value used to verify data passed to the stub installer
     for full end-to-end testing via Telemetry.
 
+
+Manual testing for code reviews
+-------------------------------
+
+You might not need to test all these depending on what is changing this is an exhaustive
+testing guide. This guide assumes demo1, make sure you're testing on the right URL.
+
+1. Use Chrome on Windows or MacOS with DNT and adblocking disabled.
+2. Open https://www-demo1.allizom.org/en-US/?utm_source=ham&utm_campaign=pineapple
+3. Using Dev Tools, open the Application tab and inspect cookies.
+4. Look for a cookie called `moz-stub-attribution-code` and copy the value (it should be a base64 encoded string).
+5. Decode the base64 string (e.g. using https://base64decode.org) and check that:
+    - `dlsource` parameter value is mozorg
+    - `client_id`, `client_id_ga4` and `session_id` parameters exist
+    - `client_id` and `client_id_ga4` should look something like 0700077325.1656063224
+      (the numbers will differ but the format with the middle period should look the same).
+    - `source` and `campaign` have the values ham and pineapple, respectively.
+    - The ua value should be chrome (assuming you tested in Chrome).
+    - Everything else should be (not set).
+6. Inspect the "Download Firefox" button in the top right and verify the download URL contains `attribution_code` and `attribution_sig` params.
+7. Click "Download Firefox".
+8. Inspect the "Try downloading again" link and check for the `attribution_code` and `attribution_sig` params.
+   - decode the value of `attribution_code` to check it has the expected values
+
+Other places on the site you may want to check:
+
+- `firefox/all`_ (inspect the network request to check that the attribution params were added on click)
+- `firefox/new`_
+- `firefox/enterprise`_
+
+
 .. _Telemetry: https://telemetry.mozilla.org/
 .. _privacy policy: https://www.mozilla.org/privacy/websites/
 .. _Application Logic Flow Chart: https://www.figma.com/file/q5mJpicWBpzAYuQ3fV00ix/Firefox-Stub-Attribution-Flow?node-id=0%3A1&t=EFe91WQzQ7cXHSiB-1
@@ -186,3 +217,6 @@ that is used to sign the attribution code must be set via an environment variabl
 .. _Return to AMO: https://wiki.mozilla.org/Add-ons/QA/Testplan/Return_to_AMO
 .. _Do Not Track (DNT): https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature
 .. _DNT helper: https://github.com/mozmeao/dnt-helper
+.. _firefox/all: https://www-demo1.allizom.org/en-US/firefox/all/
+.. _firefox/new: https://www-demo1.allizom.org/en-US/firefox/new/
+.. _firefox/enterprise: https://www-demo1.allizom.org/en-US/firefox/enterprise/

--- a/media/js/firefox/new/common/thanks-direct.js
+++ b/media/js/firefox/new/common/thanks-direct.js
@@ -125,7 +125,7 @@
         !Mozilla.StubAttribution.hasCookie()
     ) {
         // Wait for GA to load so that we can pass along visit ID.
-        Mozilla.StubAttribution.waitForGoogleAnalytics(function () {
+        Mozilla.StubAttribution.waitForGoogleAnalyticsThen(function () {
             var data = Mozilla.StubAttribution.getAttributionData();
 
             // make sure we check referrer for AMO (issue 11467)

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -13,6 +13,7 @@
 
 describe('stub-attribution.js', function () {
     const GA_CLIENT_ID = '1456954538.1610960957';
+    const GA4_CLIENT_ID = '4442748357.1686074738';
     const GA_SESSION_ID = '1668161374';
     const STUB_SESSION_ID = '1234567890';
     const DLSOURCE = 'mozorg';
@@ -42,6 +43,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -51,8 +53,11 @@ describe('stub-attribution.js', function () {
             spyOn(window.dataLayer, 'push');
 
             // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getGAClientID').and.returnValue(
+            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
                 GA_CLIENT_ID
+            );
+            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
+                GA4_CLIENT_ID
             );
         });
 
@@ -101,7 +106,7 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
-                'isFirefoxNewScene2'
+                'isFirefoxDownloadThanks'
             ).and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
@@ -114,6 +119,7 @@ describe('stub-attribution.js', function () {
                 Mozilla.StubAttribution.requestAuthentication
             ).toHaveBeenCalledWith(data);
             expect(window.dataLayer.push).toHaveBeenCalledWith({
+                // TODO: add check for GA4 event
                 event: 'stub-session-id',
                 eLabel: STUB_SESSION_ID
             });
@@ -136,7 +142,7 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
-                'isFirefoxNewScene2'
+                'isFirefoxDownloadThanks'
             ).and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
@@ -166,7 +172,7 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
-                'isFirefoxNewScene2'
+                'isFirefoxDownloadThanks'
             ).and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
@@ -182,7 +188,7 @@ describe('stub-attribution.js', function () {
             ).not.toHaveBeenCalled();
         });
 
-        it('should do nothing if page is scene2 of /firefox/new/', function () {
+        it('should do nothing if page is download/thanks', function () {
             spyOn(
                 Mozilla.StubAttribution,
                 'withinAttributionRate'
@@ -196,7 +202,7 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
-                'isFirefoxNewScene2'
+                'isFirefoxDownloadThanks'
             ).and.returnValue(true);
             spyOn(
                 Mozilla.StubAttribution,
@@ -226,7 +232,7 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'hasCookie').and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
-                'isFirefoxNewScene2'
+                'isFirefoxDownloadThanks'
             ).and.returnValue(false);
             spyOn(
                 Mozilla.StubAttribution,
@@ -292,6 +298,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -309,6 +316,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -324,6 +332,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -339,6 +348,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -354,6 +364,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -371,6 +382,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://example.com/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -386,6 +398,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://example.com/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -401,6 +414,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://example.com/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -416,6 +430,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -435,6 +450,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -452,6 +468,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -469,6 +486,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
             /* eslint-enable camelcase */
@@ -477,18 +495,18 @@ describe('stub-attribution.js', function () {
         });
     });
 
-    describe('isFirefoxNewScene2', function () {
-        it('should return true if the page is scene 2 of /firefox/new/', function () {
+    describe('isFirefoxDownloadThanks', function () {
+        it('should return true if the page is firefox/download/thanks/', function () {
             const url =
                 'https://www.mozilla.org/en-US/firefox/download/thanks/';
             expect(
-                Mozilla.StubAttribution.isFirefoxNewScene2(url)
+                Mozilla.StubAttribution.isFirefoxDownloadThanks(url)
             ).toBeTruthy();
 
             const url2 =
                 'https://www.mozilla.org/en-US/firefox/download/thanks/?foo=bar';
             expect(
-                Mozilla.StubAttribution.isFirefoxNewScene2(url2)
+                Mozilla.StubAttribution.isFirefoxDownloadThanks(url2)
             ).toBeTruthy();
         });
     });
@@ -536,19 +554,75 @@ describe('stub-attribution.js', function () {
         });
     });
 
-    describe('waitForGoogleAnalytics', function () {
+    describe('waitForGoogleAnalyticsThen', function () {
         beforeEach(function () {
-            // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getGAClientID').and.returnValue(
-                GA_CLIENT_ID
-            );
+            jasmine.clock().install();
         });
 
+        afterEach(function () {
+            jasmine.clock().uninstall();
+        });
         it('should fire a callback when GA client ID and session ID are found', function () {
+            // stub out UA client ID
+            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
+                GA_CLIENT_ID
+            );
+            // stub out GA4 client ID
+            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
+                GA4_CLIENT_ID
+            );
             const callback = jasmine.createSpy('callback');
 
-            Mozilla.StubAttribution.waitForGoogleAnalytics(callback);
+            Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
             expect(callback).toHaveBeenCalledWith(true);
+        });
+
+        it('should fire a callback when UA client ID is found but GA4 client ID is not', function () {
+            // stub out UA client ID
+            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
+                GA_CLIENT_ID
+            );
+            // stub out GA4 client ID
+            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
+                null
+            );
+            const callback = jasmine.createSpy('callback');
+
+            Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
+            jasmine.clock().tick(2100);
+            expect(callback).toHaveBeenCalledWith(true);
+        });
+
+        it('should fire a callback when UA client ID is not found but GA4 client ID is found', function () {
+            // stub out UA client ID
+            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
+                null
+            );
+            // stub out GA4 client ID
+            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
+                GA4_CLIENT_ID
+            );
+            const callback = jasmine.createSpy('callback');
+
+            Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
+            jasmine.clock().tick(2100);
+            expect(callback).toHaveBeenCalledWith(true);
+        });
+
+        it('should fire a callback when it times out looking for UA and GA4 ids', function () {
+            // stub out UA client ID
+            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
+                null
+            );
+            // stub out GA4 client ID
+            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
+                null
+            );
+            const callback = jasmine.createSpy('callback');
+
+            Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
+            jasmine.clock().tick(2100);
+            expect(callback).toHaveBeenCalledWith(false);
         });
     });
 
@@ -571,8 +645,11 @@ describe('stub-attribution.js', function () {
     describe('getAttributionData', function () {
         beforeEach(function () {
             // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getGAClientID').and.returnValue(
+            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
                 GA_CLIENT_ID
+            );
+            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
+                GA4_CLIENT_ID
             );
         });
 
@@ -597,6 +674,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
             };
@@ -629,6 +707,7 @@ describe('stub-attribution.js', function () {
                 referrer: 'https://www.mozilla.org/en-US/',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
             };
@@ -661,6 +740,7 @@ describe('stub-attribution.js', function () {
                 referrer: '',
                 ua: 'chrome',
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
             };
@@ -695,6 +775,7 @@ describe('stub-attribution.js', function () {
                 experiment: 'firefox-new',
                 variation: 1,
                 client_id: GA_CLIENT_ID,
+                client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
             };
@@ -1181,8 +1262,8 @@ describe('stub-attribution.js', function () {
         });
     });
 
-    describe('getGAClientID', function () {
-        it('should return a valid Google Analytics client ID', function () {
+    describe('getUAClientID', function () {
+        it('should return a valid UA client ID', function () {
             window.ga = sinon.stub();
             window.ga.getAll = sinon.stub().returns([
                 {
@@ -1190,12 +1271,12 @@ describe('stub-attribution.js', function () {
                 }
             ]);
 
-            expect(Mozilla.StubAttribution.getGAClientID()).toEqual(
+            expect(Mozilla.StubAttribution.getUAClientID()).toEqual(
                 GA_CLIENT_ID
             );
         });
 
-        it('should return a null if Google Analytics client ID is invalid', function () {
+        it('should return a null if UA client ID is invalid', function () {
             window.ga = sinon.stub();
             window.ga.getAll = sinon.stub().returns([
                 {
@@ -1203,14 +1284,14 @@ describe('stub-attribution.js', function () {
                 }
             ]);
 
-            expect(Mozilla.StubAttribution.getGAClientID()).toBeNull();
+            expect(Mozilla.StubAttribution.getUAClientID()).toBeNull();
         });
 
-        it('should return a null if accessing Google Analytics object throws an error', function () {
+        it('should return a null if accessing ga object throws an error', function () {
             window.ga = sinon.stub().throws(function () {
                 return new Error();
             });
-            expect(Mozilla.StubAttribution.getGAClientID()).toBeNull();
+            expect(Mozilla.StubAttribution.getUAClientID()).toBeNull();
         });
     });
 
@@ -1223,8 +1304,8 @@ describe('stub-attribution.js', function () {
         });
     });
 
-    describe('getGtagData', function () {
-        it('should return a valid Google Analytics client ID and session ID', function () {
+    describe('getGtagClientID', function () {
+        it('should return a valid GA4 client ID', function () {
             const dataLayer = [
                 {
                     event: 'page-id-loaded',
@@ -1254,7 +1335,7 @@ describe('stub-attribution.js', function () {
                     h: {
                         event: 'gtagApiGet',
                         gtagApiResult: {
-                            client_id: GA_CLIENT_ID,
+                            client_id: GA4_CLIENT_ID,
                             session_id: GA_SESSION_ID
                         },
                         'gtm.uniqueEventId': 11
@@ -1270,14 +1351,13 @@ describe('stub-attribution.js', function () {
                 }
             ];
 
-            expect(Mozilla.StubAttribution.getGtagData(dataLayer)).toEqual({
-                client_id: GA_CLIENT_ID,
-                session_id: GA_SESSION_ID
-            });
+            expect(Mozilla.StubAttribution.getGtagClientID(dataLayer)).toEqual(
+                GA4_CLIENT_ID
+            );
         });
     });
 
-    it('should return null values if client ID and session ID are not found', function () {
+    it('should return null if GA4 client ID is not found', function () {
         const dataLayer = [
             {
                 event: 'page-id-loaded',
@@ -1299,9 +1379,13 @@ describe('stub-attribution.js', function () {
             }
         ];
 
-        expect(Mozilla.StubAttribution.getGtagData(dataLayer)).toEqual({
-            client_id: null,
-            session_id: null
+        expect(Mozilla.StubAttribution.getGtagClientID(dataLayer)).toBeNull();
+    });
+
+    it('should return a null if accessing GTAG API throws an error', function () {
+        window.dataLayer = sinon.stub().throws(function () {
+            return new Error();
         });
+        expect(Mozilla.StubAttribution.getGtagClientID()).toBeNull();
     });
 });


### PR DESCRIPTION
## One-line summary

Send GA4 client ID to stub attribution as `client_id_ga4`.

I'm sorry to say this has a bit of urgency. It cannot be merged until the stub attribution server is updated but we should get a jump start on reviewing it - especially since we want a VERY THROUGH review.

## Significant changes and points to review

- stub attribution now waits for both UA and GTM API before executing
- GA4 client ID is retrieved from GTM API
- data sent to stub attribution now includes the GA4 client ID as `client_id_ga4`
- updated and added tests
- tried to standardize on UA/GA4 when talking about the old and new versions
- tried to be explicit about when we're interacting with GTM rather than UA/GA4 directly
- changed references to scene2 to download/thanks
- added some steps for code review into the docs

## Issue / Bugzilla link

Fix #12801 

## Testing

I worked on this over a couple weeks so you should not assume I was on the top of my game while writing this code.

- currently deployed on demo9
- steps to test are included in the PR
- do we have good test coverage?
