### PR TITLE
Update Rise25 nomination page URL [#14200]

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -561,4 +561,6 @@ redirectpatterns = (
     redirect(r"/VendorDPA/?$", "https://assets.mozilla.net/pdf/VendorDPA.pdf", re_flags="i"),
     # Issue 14221
     redirect(r"^firefox/products/?$", "/products/"),
+    # Issue 14255
+    redirect(r"^rise25/?$", "/rise25/nominate/"),
 )

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -160,7 +160,7 @@ urlpatterns = (
         active_locales=["en-US", "de", "fr", "it"],
     ),
     path("antiharassment-tool/", views.anti_harassment_tool_view, name="mozorg.antiharassment-tool"),
-    page("rise25/", "mozorg/rise25/landing.html"),
+    page("rise25/nominate/", "mozorg/rise25/landing.html"),
     page("rise25/thanks/", "mozorg/rise25/thanks.html"),
 )
 

--- a/media/js/mozorg/rise25/rise25.js
+++ b/media/js/mozorg/rise25/rise25.js
@@ -29,7 +29,7 @@ window.onYouTubeIframeAPIReady = function () {
 
     function generateTweet() {
         var tweetUrl = encodeURIComponent(
-            'https://www.mozilla.org/rise25/?utm_campaign=rise25&utm_medium=organicsocial&utm_source=twitter&utm_content=rise25-share'
+            'https://www.mozilla.org/rise25/nominate/?utm_campaign=rise25&utm_medium=organicsocial&utm_source=twitter&utm_content=rise25-share'
         );
         var tweetText = encodeURIComponent(
             'Mozilla is on the hunt for 25 visionaries making AI better for the people — not big corporations. \n\nWinners will be honored at the upcoming Rise25 awards in Dublin, Ireland. Submit your nomination today! \n\n'
@@ -44,7 +44,7 @@ window.onYouTubeIframeAPIReady = function () {
 
     function generateFacebookShare() {
         var shareUrl = encodeURIComponent(
-            'https://www.mozilla.org/rise25/?utm_campaign=rise25&utm_medium=organicsocial&utm_source=facebook&utm_content=rise25-share'
+            'https://www.mozilla.org/rise25/nominate/?utm_campaign=rise25&utm_medium=organicsocial&utm_source=facebook&utm_content=rise25-share'
         );
         var shareText = encodeURIComponent(
             'Mozilla is on the hunt for 25 visionaries making AI better for the people — not big corporations. \n\nWinners will be honored at the upcoming Rise25 awards in Dublin, Ireland. Submit your nomination today! \n\n'
@@ -59,7 +59,9 @@ window.onYouTubeIframeAPIReady = function () {
 
     function handleCopyLink(e) {
         e.preventDefault;
-        navigator.clipboard.writeText('https://www.mozilla.com/rise25/');
+        navigator.clipboard.writeText(
+            'https://www.mozilla.com/rise25/nominate/'
+        );
 
         var copyText = e.currentTarget.querySelector('.social-share-copy');
         var copiedText = e.currentTarget.querySelector('.social-share-copied');
@@ -93,7 +95,7 @@ window.onYouTubeIframeAPIReady = function () {
     (function () {
         var subject = encodeURIComponent('Who will you nominate for Rise 25?');
         var body = encodeURIComponent(
-            'Mozilla is searching for 25 visionaries making AI better for the people — not big corporations. Seeking individuals across 5 categories: Advocates, Builders, Artists, Entrepreneurs, and Change Agents. \n\nWinners will be honored at the upcoming Rise25 awards in Dublin, Ireland. Nominations close March 29. Get your nomination in today! \n\nNominate someone: https://www.mozilla.org/rise25/'
+            'Mozilla is searching for 25 visionaries making AI better for the people — not big corporations. Seeking individuals across 5 categories: Advocates, Builders, Artists, Entrepreneurs, and Change Agents. \n\nWinners will be honored at the upcoming Rise25 awards in Dublin, Ireland. Nominations close March 29. Get your nomination in today! \n\nNominate someone: https://www.mozilla.org/rise25/nominate/'
         );
         for (var index = 0; index < emailShare.length; index++) {
             var element = emailShare[index];

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1277,5 +1277,7 @@ URLS = flatten(
         ),
         # Issue 14221
         url_test("/firefox/products/", "/products/"),
+        # Issue 14255
+        url_test("/rise25/", "/rise25/nominate/"),
     )
 )


### PR DESCRIPTION
## One-line summary

The /rise25/ URL previously had a permanent redirect to rise25.mozilla.org. That redirect gets cached by the browser and is hard to overcome from our end, so basically anyone who visited that URL in the past months while that redirect was in place will be unable to reach the new page. The simplest fix is to move the new page to another URL.

## Testing

http://localhost:8000/rise25/nominate/

Make sure I didn't miss any references or links to the previous URL.