### PR TITLE
Rise25, add image to Twitter card metadata [#14200]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/rise25/landing.html
+++ b/bedrock/mozorg/templates/mozorg/rise25/landing.html
@@ -11,6 +11,7 @@
 {% block page_title %}Rise25 Awards: Call for Nominations{% endblock %}
 {% block page_desc %}We’re seeking 25 visionaries using AI to drive social impact, offering them global recognition at our Dublin awards event.{% endblock %}
 {% block page_image %}{{ static('img/mozorg/rise25/page-image.jpg') }}{% endblock %}
+{% block twitter_card %}summary_large_image{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('protocol-split') }}


### PR DESCRIPTION
## One-line summary

The page extends `base-protocol.html` which defaults to `summary` for Twitter cards. This overrides that with `summary_large_image` so the link preview will include the page image on Twitter.

This was discovered because Slack seems to use Twitter card data to determine whether to show an image or just text. Even though the `og:image` was present, Slack was respecting the Twitter card.

## Testing
http://localhost:8000/rise25/nominate/