### PR TITLE
commit access policy: clarify that only current module owners/peers can vouch

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
@@ -45,11 +45,11 @@ Therefore, a good policy balances the use of technical and social controls to mi
   </li>
   <li>
     General access - all of Hg not in level 3 or listed as an exception. Currently, this level is rarely used for Mozilla development.
-    <p>Requirements: one voucher - any Mozilla code module owner.</p>
+    <p>Requirements: one voucher - any current Mozilla code module owner.</p>
   </li>
   <li>
     Hg core product (Firefox/Thunderbird/GeckoView) access.
-    <p>Requirements: two vouchers - module owners or peers of code stored in a repo at this level.</p>
+    <p>Requirements: two vouchers - current module owners or peers of code stored in a repo at this level.</p>
   </li>
 </ol>
 
@@ -90,15 +90,15 @@ This is the lowest level of access. It allows someone to check in to the <a href
 
 <h2 id="Level2">Level 2 - General Access</h2>
 
-<p>Requirements: one voucher - any Mozilla code module owner</p>
+<p>Requirements: one voucher - any current Mozilla code module owner</p>
 
 <p>This access allows one to check in to everywhere in any SCM (Hg or Git) except the core product code in Hg and the exceptions listed above.</p>
 
 <h2 id="Level3">Level 3 - Core Product Access</h2>
 
-<p>Requirements: two vouchers - module owners or peers of code stored at this level, or owners or peers of the "Tree Sheriffs" module</p>
+<p>Requirements: two vouchers - current module owners or peers of code stored at this level, or owners or peers of the "Tree Sheriffs" module</p>
 
-<p>Someone can be upgraded from level 2 to level 3 by being vouched for by a single module owner of level-3-stored code.</p>
+<p>Someone can be upgraded from level 2 to level 3 by being vouched for by a single current module owner of level-3-stored code.</p>
 
 <p>This permission gives access to check into any tree from which executable code becomes part of our core products - Firefox, GeckoView and Thunderbird. This is fundamentally a statement of trust in and familiarity with an individual, and so access to one such tree gives access to all such trees, although social controls may prevent people checking in to certain ones.</p>
 


### PR DESCRIPTION
Updates the Commit Access Policy to make it clear that a vouch is required from a _current_ owner or peer; vouches from former owners/peers are insufficient.