### PR TITLE
Add mobile install data links to docs

### DIFF
--- a/docs/attribution/0003-firefox-mobile.rst
+++ b/docs/attribution/0003-firefox-mobile.rst
@@ -45,3 +45,13 @@ Would render:
 https://apps.apple.com/us/app/apple-store/id1055677337?pt=373246&ct=firefox-home&mt=8
 https://play.google.com/store/apps/details?id=org.mozilla.focus&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dfirefox-home&hl=en
 ```
+
+Where can I find mobile attribution data?
+-----------------------------------------
+
+You can find Firefox Android client attribution data in `Looker`_. Firefox iOS data
+is currently only available in `App Store Connect`_, however this will also be added to
+Looker in the near future.
+
+.. _Looker: https://mozilla.cloud.looker.com/looks/1997
+.. _App Store Connect: https://appstoreconnect.apple.com/


### PR DESCRIPTION
## One-line summary

Adds links in our docs for where to find install referral data for Firefox on mobile

## Issue / Bugzilla link

N/A

## Testing

`make livedocs`