### PR TITLE
Update Github Actions to use Node 20 runtime

### DIFF
--- a/.github/actions/slack/action.yaml
+++ b/.github/actions/slack/action.yaml
@@ -54,7 +54,7 @@ runs:
         esac" >> $GITHUB_ENV
 
     - id: slack-notification
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v1.25.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
       with:

--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack that tests are starting
         uses: ./.github/actions/slack
         with:
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Fetch codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run CDN tests
         run: ./bin/integration_tests/functional_tests.sh
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notify-of-test-run-start, cdn-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack of test-run outcome
         uses: ./.github/actions/slack
         with:

--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # this means that it is a full history clone, not a shallow one
           # heroku push fails with a shallow clone

--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack that tests are starting
         uses: ./.github/actions/slack
         with:
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Fetch codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run functional download tests
         run: ./bin/integration_tests/functional_tests.sh
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notify-of-test-run-start, download-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack of test-run outcome
         uses: ./.github/actions/slack
         with:

--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Python dependencies

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ jobs:
   notify-of-test-run-start:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack that tests are starting
         uses: ./.github/actions/slack
         with:
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Fetch codebase
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Sets specific env vars IF we're on testing against dev/main only
         if: ${{ github.event.inputs.branch == 'main'}}
         run: |
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [notify-of-test-run-start, integration-tests]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Notify via Slack of test-run outcome
         uses: ./.github/actions/slack
         with:

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -29,8 +29,8 @@ jobs:
   test-python:
     runs-on: ubuntu-20.04  # For consistency with above
     steps:
-      - uses: actions/setup-python@v4
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"  # matches current Python in production
       - name: "Run Python tests (on Docker)"

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install chromium-browser firefox xvfb
-      - uses: actions/setup-node@v3
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: "Install JS dependencies"

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -44,7 +44,7 @@ jobs:
           name: coverage-results
           path: python_coverage
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           # A CodeCov token is normally NOT needed for public repos, but this workaround is suggested here:
           # https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/18

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install chromium-browser firefox xvfb
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
         with:
           node-version: 20
       - name: "Install JS dependencies"
@@ -29,8 +29,8 @@ jobs:
   test-python:
     runs-on: ubuntu-20.04  # For consistency with above
     steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
         with:
           python-version: "3.11"  # matches current Python in production
       - name: "Run Python tests (on Docker)"

--- a/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run PR-opening script
         shell: bash
         run: SITE_MODE=Mozorg FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh

--- a/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_pocket_fluent_strings_to_l10n_org.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run PR opening script
         shell: bash
         run: SITE_MODE=Pocket FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh


### PR DESCRIPTION
## One-line summary

Update our GHAs to use the latest node-20-based workflow, as the node-16 ones are deprecated and we don't want to be caught out if they stop working.


## Issue / Bugzilla link

Resolves #14147 

## Testing

Some of these we can run directly from the branch, but really we should just merge and see how they are. The only that looks like it _might_ need a bit of tuning is `upload_artifact` and we'll see that as soon as this PR hits `main`