### PR TITLE
Retire light-theme footer in Firefox pages

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -102,9 +102,7 @@
       {% block content %}{% endblock %}
 
       {% block site_footer %}
-        {% with theme_class='mzp-t-light' %}
-          {% include 'includes/protocol/footer/footer.html' %}
-        {% endwith %}
+        {% include 'includes/protocol/footer/footer.html' %}
       {% endblock %}
 
       {% block sticky_promo %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base.html
@@ -24,4 +24,11 @@
 
   {% include 'firefox/whatsnew/includes/release-notes.html' %}
 </main>
+
+{% endblock %}
+
+{% block site_footer %}
+  {% with theme_class='mzp-t-light' %}
+    {% include 'includes/protocol/footer/footer.html' %}
+  {% endwith %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary
We're moving a lot of our content and persona to be within a pan-Mozilla umbrella, and that includes making sure we have a consistent theme within our website, as well.

We typically had a light-theme footer placed in Firefox pages, and we're going to be switching it to the typical dark-theme footer we have across the rest of the site.

> [!NOTE]
> We will not be removing the light-theme footer in Whats New pages until WNP125 releases (April 16th).


## Significant changes and points to review
There wasn't much that needed changing except only allowing the light-theme to be used in the Whats New page, so I removed the `theme_class` from the `base-protocol.html` file and instead added it to the `/whatsnew/base.html` file.



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/14251


## Testing

- [ ] http://localhost:8000/en-US/firefox/ (should now be dark-theme -- snoop around other Firefox pages to check as well)
- [ ] http://localhost:8000/en-US/firefox/whatsnew/ (light-theme should still be active)
- [ ] http://localhost:8000/en-US/firefox/123.0/whatsnew/