### PR TITLE
Update WNP24 monitor link utms (Issue #14296)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-na-static.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-na-static.html
@@ -54,7 +54,7 @@
       it away.
     </p>
 
-    <a href="https://monitor.mozilla.org/?utm_medium=firefox-desktop&utm_source=whatsnew&utm_campaign=welcome-page124&utm_content=v2-us" class="wnp-main-cta mzp-c-button mzp-t-product" data-cta-text="Start with a free scan" data-cta-type="button" target="_blank" rel="noopener">
+    <a href="https://monitor.mozilla.org/?utm_medium=firefox-desktop&utm_source=whatsnew&utm_campaign=whatsnew-page124&utm_content=v2-us" class="wnp-main-cta mzp-c-button mzp-t-product" data-cta-text="Start with a free scan" data-cta-type="button" target="_blank" rel="noopener">
       Start with a free scan
     </a>
   </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-na-video.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-na-video.html
@@ -58,7 +58,8 @@
       it away.
     </p>
 
-    <a href="https://monitor.mozilla.org/?utm_medium=firefox-desktop&utm_source=whatsnew&utm_campaign=welcome-page124&utm_content=v1-us" class="wnp-main-cta mzp-c-button mzp-t-product" data-cta-text="Start with a free scan" data-cta-type="button" target="_blank" rel="noopener">
+    {% set utm_content = 'v1-us' if variant == '1' else 'us' %}
+    <a href="https://monitor.mozilla.org/?utm_medium=firefox-desktop&utm_source=whatsnew&utm_campaign=whatsnew-page124&utm_content={{ utm_content }}" class="wnp-main-cta mzp-c-button mzp-t-product" data-cta-text="Start with a free scan" data-cta-type="button" target="_blank" rel="noopener">
       Start with a free scan
     </a>
   </div>

--- a/tests/functional/firefox/whatsnew/test_whatsnew_124.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_124.py
@@ -9,7 +9,7 @@ from pages.firefox.whatsnew.whatsnew_124 import FirefoxWhatsNew124Page
 
 @pytest.mark.skip_if_not_firefox(reason="Whatsnew pages are shown to Firefox only.")
 @pytest.mark.nondestructive
-@pytest.mark.parametrize("params", [("?v=1"), ("?v=2")])
+@pytest.mark.parametrize("params", [("?v=1&geo=us"), ("?v=2&geo=us")])
 def test_monitor_free_scan_button_displayed(params, base_url, selenium):
     page = FirefoxWhatsNew124Page(selenium, base_url, params=params).open()
     assert page.is_monitor_free_scan_button_displayed


### PR DESCRIPTION
## One-line summary

Updates UTMs for Monitor CTA on WNP 124.

## Issue / Bugzilla link

#14296

## Testing

- http://localhost:8000/en-US/firefox/124.0/whatsnew/
- http://localhost:8000/en-US/firefox/124.0/whatsnew/?v=1
- http://localhost:8000/en-US/firefox/124.0/whatsnew/?v=2