### PR TITLE
Add Content Moderation & AMO Policies legal docs

### DIFF
--- a/bedrock/legal/templates/legal/content-moderation.html
+++ b/bedrock/legal/templates/legal/content-moderation.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ ftl('legal-content-moderation') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -66,5 +66,10 @@ urlpatterns = (
         LegalDocView.as_view(template_name="legal/report-infringement.html", legal_doc_name="report_infringement"),
         name="legal.report-infringement",
     ),
+    path(
+        "content-moderation/",
+        LegalDocView.as_view(template_name="legal/content-moderation.html", legal_doc_name="content_moderation_practices"),
+        name="legal.content-moderation",
+    ),
     path("defend-mozilla-trademarks/", views.fraud_report, name="legal.fraud-report"),
 )

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -24,7 +24,7 @@
     <p>
       Transparency is a key part of how Mozilla approaches user trust. As an open source project that relies on open development,
       we build transparency into the way we write our code. Additionally, our product documentation and notices describe how our
-      products work and how we handle user data.
+      products work and how we handle user data. Our <a href="{{ url('legal.content-moderation') }}">Content Moderation page</a> provides more detail on how we handle content moderation generally.
     </p>
     <p>
       With this transparency in mind, we publish bi-annual transparency reports. Most industry transparency reports offer insights

--- a/l10n/en/mozorg/about/legal.ftl
+++ b/l10n/en/mozorg/about/legal.ftl
@@ -37,3 +37,4 @@ legal-report-copyright = Report Copyright or Trademark Infringement
 legal-hubs = { -brand-name-mozilla-hubs }
 legal-hubs-terms = { -brand-name-mozilla-hubs } Terms of Service
 legal-mozilla-subscription-services = { -brand-name-mozilla } Subscription Services
+legal-content-moderation = Content Moderation Practices


### PR DESCRIPTION
## One-line summary

Adding two new pages from the legal-docs repository.

>[!NOTE]
> Not sure if you'll need to do this from your side, but I had to run `bin/bootstrap.sh` to sync the legal-docs database

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/14299


## Testing
http://localhost:8000/en-US/about/legal/content-moderation/ (links from http://localhost:8000/en-US/about/policy/transparency/)
