### PR TITLE
Add extra GA events for WNP 124 EU (Issue #14181)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-de-voices-share.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-de-voices-share.html
@@ -91,5 +91,5 @@
 
 {% block js %}
   {{ js_bundle('video-inline-embed') }}
-  {{ js_bundle('firefox_whatsnew_124_eu_voices') }}
+  {{ js_bundle('firefox_whatsnew_124_eu_voices_share') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-de-voices-video.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx124-de-voices-video.html
@@ -72,4 +72,5 @@
 
 {% block js %}
   {{ js_bundle('video-inline-embed') }}
+  {{ js_bundle('firefox_whatsnew_124_eu_voices_static') }}
 {% endblock %}

--- a/media/js/firefox/whatsnew/whatsnew-124-eu-compare.js
+++ b/media/js/firefox/whatsnew/whatsnew-124-eu-compare.js
@@ -26,19 +26,6 @@
         document.querySelector('.wnp-loading').classList.add('hide');
         document.querySelector('.is-not-default').classList.add('hide');
         document.querySelector('.is-default').classList.add('show');
-
-        // UA
-        window.dataLayer.push({
-            event: 'non-interaction',
-            eAction: 'whatsnew-124-eu-compare',
-            eLabel: 'firefox-default'
-        });
-
-        // GA4
-        window.dataLayer.push({
-            event: 'dimension_set',
-            firefox_is_default: true
-        });
     }
 
     function showNotDefault() {
@@ -46,19 +33,6 @@
         document.querySelector('.wnp-loading').classList.add('hide');
         document.querySelector('.is-default').classList.add('hide');
         document.querySelector('.is-not-default').classList.add('show');
-
-        // UA
-        window.dataLayer.push({
-            event: 'non-interaction',
-            eAction: 'whatsnew-124-eu-compare',
-            eLabel: 'firefox-not-default'
-        });
-
-        // GA4
-        window.dataLayer.push({
-            event: 'dimension_set',
-            firefox_is_default: false
-        });
     }
 
     function initDefault() {

--- a/media/js/firefox/whatsnew/whatsnew-124-eu-events.js
+++ b/media/js/firefox/whatsnew/whatsnew-124-eu-events.js
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function init() {
+    'use strict';
+
+    // Log account status
+    Mozilla.Client.getFxaDetails((details) => {
+        if (details.setup) {
+            // UA
+            window.dataLayer.push({
+                event: 'non-interaction',
+                eAction: 'whatsnew-124-eu',
+                eLabel: 'firefox-signed-in'
+            });
+
+            // GA4
+            window.dataLayer.push({
+                event: 'dimension_set',
+                firefox_is_signed_in: true
+            });
+        } else {
+            // UA
+            window.dataLayer.push({
+                event: 'non-interaction',
+                eAction: 'whatsnew-124-eu',
+                eLabel: 'firefox-signed-out'
+            });
+
+            // GA4
+            window.dataLayer.push({
+                event: 'dimension_set',
+                firefox_is_signed_in: false
+            });
+        }
+    });
+
+    // Log default status
+    Mozilla.UITour.getConfiguration('appinfo', (details) => {
+        if (details.defaultBrowser) {
+            // UA
+            window.dataLayer.push({
+                event: 'non-interaction',
+                eAction: 'whatsnew-124-eu',
+                eLabel: 'firefox-default'
+            });
+
+            // GA4
+            window.dataLayer.push({
+                event: 'dimension_set',
+                firefox_is_default: true
+            });
+        } else {
+            // UA
+            window.dataLayer.push({
+                event: 'non-interaction',
+                eAction: 'whatsnew-124-eu',
+                eLabel: 'firefox-not-default'
+            });
+
+            // GA4
+            window.dataLayer.push({
+                event: 'dimension_set',
+                firefox_is_default: false
+            });
+        }
+    });
+}
+
+if (
+    typeof window.Mozilla.Client !== 'undefined' &&
+    typeof window.Mozilla.UITour !== 'undefined' &&
+    window.Mozilla.Client.isFirefoxDesktop
+) {
+    init();
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1638,15 +1638,23 @@
     },
     {
       "files": [
+        "js/firefox/whatsnew/whatsnew-124-eu-events.js",
         "js/firefox/whatsnew/whatsnew-124-eu-compare.js"
       ],
       "name": "firefox_whatsnew_124_eu_compare"
     },
     {
       "files": [
+        "js/firefox/whatsnew/whatsnew-124-eu-events.js",
         "js/firefox/whatsnew/whatsnew-124-eu-voices.es6.js"
       ],
-      "name": "firefox_whatsnew_124_eu_voices"
+      "name": "firefox_whatsnew_124_eu_voices_share"
+    },
+    {
+      "files": [
+        "js/firefox/whatsnew/whatsnew-124-eu-events.js"
+      ],
+      "name": "firefox_whatsnew_124_eu_voices_static"
     },
     {
       "files": [


### PR DESCRIPTION
## One-line summary

Adds some additional GA events to WNP 124 for the EU team

## Issue / Bugzilla link

#14181)

## Testing

- http://localhost:8000/de/firefox/124.0/whatsnew/?v=1
- http://localhost:8000/de/firefox/124.0/whatsnew/?v=2
- http://localhost:8000/de/firefox/124.0/whatsnew/?v=3