### PR TITLE
Update to glean.js 5.0.0-pre.0

### DIFF
--- a/media/js/glean/init.es6.js
+++ b/media/js/glean/init.es6.js
@@ -6,7 +6,6 @@
 
 import Glean from '@mozilla/glean/web';
 import GleanMetrics from '@mozilla/glean/metrics';
-import { BrowserSendBeaconUploader } from '@mozilla/glean/web';
 import { recordCustomPageMetrics, pageEvent } from './page.es6';
 import { clickEvent } from './elements.es6';
 import Utils from './utils.es6';
@@ -26,8 +25,7 @@ function initGlean() {
 
     Glean.initialize('bedrock', Utils.isTelemetryEnabled(), {
         channel: channel,
-        serverEndpoint: endpoint,
-        httpClient: BrowserSendBeaconUploader // use sendBeacon since Firefox does not yet support keepalive using fetch()
+        serverEndpoint: endpoint
     });
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.23.6",
         "@mozilla-protocol/core": "^19.0.0",
-        "@mozilla/glean": "^4.0.0-pre.3",
+        "@mozilla/glean": "^5.0.0-pre.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
@@ -2143,9 +2143,9 @@
       "integrity": "sha512-2kitmeSKbSixV41OUgYAp/nbhXd8ftY4FEG/QKsoinSg7njawQuNCM5NwPWiP9wdhGinxVJU5FBblif7FB5srA=="
     },
     "node_modules/@mozilla/glean": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-4.0.0.tgz",
-      "integrity": "sha512-sxSnyKMat2SS6V0U443Z6PoeDJ44aK6mSrQfpC8fTP7NK0Pm3KldPLylaKvskgrC+rGyMkme7Q+KLpTNLBOVUw==",
+      "version": "5.0.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.0-pre.0.tgz",
+      "integrity": "sha512-kn3cWRJt08yEla9miubARaOt3JPmZvjRaxaakQAjD1Cb7iJmdfKxXMQ1qRsZDvX30H5DmuwO7D6fRQJDhRZW9g==",
       "dependencies": {
         "fflate": "^0.8.0",
         "tslib": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@babel/core": "^7.23.6",
     "@babel/preset-env": "^7.23.6",
     "@mozilla-protocol/core": "^19.0.0",
-    "@mozilla/glean": "^4.0.0-pre.3",
+    "@mozilla/glean": "^5.0.0-pre.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",


### PR DESCRIPTION
## One-line summary

This adds support for sessions, plus sendBeacon is now the default uploader. Glean is only enabled when Dev=True currently, so testing out this change should be safe.

## Issue / Bugzilla link

N/A

## Testing

- `npm install`
- `npm start`