### PR TITLE
String fixes for Developer Edition pages [#14243, #14244]

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -29,7 +29,7 @@
   <section class="mzp-l-content mzp-t-content-md t-center">
       <div class="mzp-c-logo mzp-t-logo-xl mzp-t-product-developer mzp-l-logo-center"></div>
       <h1>
-        {{ ftl('firefox-developer-welcome-to-firefox-browser', fallback='firefox-developer-welcome-to-the-all-new') }}
+        {{ ftl('firefox-developer-welcome-to-firefox-developer-edition', fallback='firefox-developer-welcome-to-firefox-browser') }}
       </h1>
   </section>
 

--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -11,7 +11,7 @@
   image=resp_img('img/firefox/developer/stylo-engine.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
   block_class='mzp-t-split-nospace'
 ) %}
-  <h2 class="mzp-u-title-xs">{{ ftl('firefox-developer-firefox-browser') }}</h2>
+  <h2 class="mzp-u-title-xs">{{ ftl('firefox-developer-firefox-developer-edition') }}</h2>
   <h3 class="mzp-u-title-sm">{{ ftl('firefox-developer-made-for-developers') }}</h3>
   <p>{{ ftl('firefox-developer-all-the-latest-v2', fallback='firefox-developer-all-the-latest') }}</p>
   <p>{{ ftl('firefox-developer-a-separate-profile') }}</p>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -55,7 +55,7 @@
 <main>
   <div class="mzp-l-content mzp-t-content-md t-center">
     <div class="mzp-c-logo mzp-t-logo-xl mzp-t-product-developer mzp-l-logo-center"></div>
-    <h1>{{ ftl('firefox-developer-firefox-browser') }}</h1>
+    <h1>{{ ftl('firefox-developer-firefox-developer-edition') }}</h1>
     <p>{{ ftl('firefox-developer-welcome-to-your-new-favorite') }}</p>
 
     {{ download_firefox('alpha', platform='desktop', dom_id='intro-download', download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
@@ -25,7 +25,7 @@
   <section class="c-mdn-header mzp-t-dark">
     <div class="mzp-l-content mzp-t-content-md c-mdn-header-content">
       <div class="mzp-c-notification-bar mzp-t-success">
-        <p>{{ ftl('developer-mdnplus-congrats-you-now-have-latest') }}</p>
+        <p>{{ ftl('developer-mdnplus-congrats-you-now-have-latest-v2', fallback='developer-mdnplus-congrats-you-now-have-latest') }}</p>
       </div>
 
       <h1 class="c-mdn-header-title">{{ ftl('developer-mdnplus-more-mdn-your-mdn') }}</h1>

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -73,7 +73,7 @@
       </section>
 
       <section class="mzp-c-card mzp-c-card-extra-small">
-        <img src="{{ static('protocol/img/logos/firefox/browser/beta/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-beta-title') }}" width="347" height="64" class="mzp-c-card-image">
+        <img src="{{ static('protocol/img/logos/firefox/browser/beta/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-beta-title-v2') }}" width="347" height="64" class="mzp-c-card-image">
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ ftl('installer-help-firefox-beta-desc') }}
@@ -83,7 +83,7 @@
       </section>
 
       <section class="mzp-c-card mzp-c-card-extra-small">
-        <img src="{{ static('protocol/img/logos/firefox/browser/developer/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-developer-title') }}" width="347" height="64" class="mzp-c-card-image">
+        <img src="{{ static('protocol/img/logos/firefox/browser/developer/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-developer-title-v2') }}" width="347" height="64" class="mzp-c-card-image">
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ ftl('installer-help-firefox-developer-desc') }}
@@ -93,7 +93,7 @@
       </section>
 
       <section class="mzp-c-card mzp-c-card-extra-small">
-        <img src="{{ static('protocol/img/logos/firefox/browser/nightly/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-nightly-title') }}" width="347" height="64" class="mzp-c-card-image">
+        <img src="{{ static('protocol/img/logos/firefox/browser/nightly/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-nightly-title-v2') }}" width="347" height="64" class="mzp-c-card-image">
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ ftl('installer-help-firefox-nightly-desc') }}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -66,7 +66,7 @@
         <img src="{{ static('protocol/img/logos/firefox/browser/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-release-title') }}" width="347" height="64" class="mzp-c-card-image">
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
-            {{ ftl('installer-help-firefox-release-desc', trackers=2000) }}
+            {{ ftl('installer-help-firefox-release-desc-v2', fallback='installer-help-firefox-release-desc', trackers=2000) }}
           </p>
           {{ download_firefox(platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang, button_class='mzp-t-secondary mzp-t-md', alt_copy=ftl('download-button-download-now')) }}
         </div>

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -8,7 +8,10 @@
 
 firefox-developer-page-title = { -brand-name-firefox-developer-edition }
 firefox-developer-firefox-developer-edition-desc = { -brand-name-firefox-developer-edition } is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging
-firefox-developer-firefox-browser = { -brand-name-firefox } { -brand-name-developer-edition }
+firefox-developer-firefox-developer-edition = { -brand-name-firefox-developer-edition }
+
+# Obsolete string (expires: 2024-05-14)
+firefox-developer-firefox-browser = { -brand-name-firefox-browser } { -brand-name-developer-edition }
 firefox-developer-welcome-to-your-new-favorite = Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.
 firefox-developer-speak-up = Speak up
 firefox-developer-feedback-makes-us = Feedback makes us better. Tell us how we can improve the browser and Developer tools.
@@ -20,7 +23,6 @@ firefox-developer-design-code-test = Design. Code. Test. Refine.
 
 # Line break for visual formatting
 firefox-developer-build-and-perfect = Build and Perfect your sites<br> with { -brand-name-firefox-devtools }
-
 firefox-developer-inspector = Inspector
 firefox-developer-inspect-and-refine = Inspect and refine code to build pixel-perfect layouts.
 firefox-developer-learn-about-page-inspector = Learn more about Page Inspector
@@ -71,27 +73,28 @@ firefox-developer-fonts-panel = Fonts Panel
 firefox-developer-the-new-fonts-panel = The new fonts panel in { -brand-name-firefox-devtools } gives developers quick access to all of the information they need about the fonts being used in an element. It also includes valuable information such as the font source, weight, style and more.
 firefox-developer-firefox-developer-edition-sends = { -brand-name-firefox-developer-edition } automatically sends feedback to { -brand-name-mozilla }.
 firefox-developer-download-the-firefox-browser = Download the { -brand-name-firefox } browser made for developers
-firefox-developer-welcome-to-the-all-new = Welcome to the all-new { -brand-name-firefox-quantum }: { -brand-name-developer-edition }
 firefox-developer-firefox-has-been-rebuilt = { -brand-name-firefox } has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.
-firefox-developer-welcome-to-firefox-browser = Welcome to { -brand-name-firefox } { -brand-name-developer-edition }
+firefox-developer-welcome-to-firefox-developer-edition = Welcome to { -brand-name-firefox-developer-edition }
+
+# Obsolete string (expires: 2024-05-14)
+firefox-developer-welcome-to-firefox-browser = Welcome to { -brand-name-firefox-browser } { -brand-name-developer-edition }
 firefox-developer-made-for-developers = The browser made for developers
 firefox-developer-all-the-latest-v2 = All the latest developer tools in beta in addition to features like the Multi-line Console Editor and WebSocket Inspector.
 firefox-developer-a-separate-profile = A <strong>separate profile and path</strong> so you can easily run it alongside Release or { -brand-name-beta } { -brand-name-firefox }.
 firefox-developer-preferences-tailored = Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.
-firefox-developer-congrats-you-now-have-latest-v2 = You now have the latest version of { -brand-name-firefox } { -brand-name-developer-edition }.
+firefox-developer-congrats-you-now-have-latest-v2 = You now have the latest version of { -brand-name-firefox-developer-edition }.
+
 # Obsolete string (expires: 2024-05-14)
 firefox-developer-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox-browser } { -brand-name-developer-edition }.
-
 
 # Variables:
 #   $attrs (string) - link to the most recent Firefox Developer Edition release notes
 firefox-developer-view-the-release = View the <a { $attrs }>release notes</a> (English only) to see what’s new.
-# this is a link to https://firefox-source-docs.mozilla.org/devtools-user/
 firefox-developer-developer-tools-user = Developer Tools User Docs
 firefox-developer-mdn-web-docs = { -brand-name-mdn-web-docs }
 firefox-developer-resources-for-developers = Resources for Developers, by Developers
 firefox-developer-mdn-references = { -brand-name-mdn } References
-firefox-developer-mdn-is-a = { -brand-name-mdn } is an open-source, collaborative project documenting Web platform technologies, including CSS, HTML, JavaScript and Web APIs.
+firefox-developer-mdn-is-a = { -brand-name-mdn } is an open-source, collaborative project documenting web platform technologies, including CSS, HTML, JavaScript and web APIs.
 firefox-developer-mdn-curriculum = { -brand-name-mdn } Curriculum
 firefox-developer-a-structured-guide = A structured guide to the essential skills and practices for being a successful front-end developer, along with recommended learning resources.
 firefox-developer-mdn-plus = { -brand-name-mdn-plus }

--- a/l10n/en/firefox/installer-help.ftl
+++ b/l10n/en/firefox/installer-help.ftl
@@ -17,13 +17,18 @@ installer-help-firefox-release-title = { -brand-name-firefox-browser }
 
 # Variables:
 #   $trackers (number) - number of trackers blocked by Firefox (currently in the thousands)
+installer-help-firefox-release-desc-v2 = Get the latest. Automatic privacy is here. Download { -brand-name-firefox } to block over { $trackers } trackers.
+
+# Obsolete string (expires: 2024-05-14)
+# Variables:
+#   $trackers (number) - number of trackers blocked by Firefox (currently in the thousands)
 installer-help-firefox-release-desc = Get the latest. Automatic privacy is here. Download { -brand-name-firefox-browser } to block over { $trackers } trackers.
 
-installer-help-firefox-beta-title = { -brand-name-firefox } { -brand-name-beta }
+installer-help-firefox-beta-title-v2 = { -brand-name-firefox } { -brand-name-beta }
 installer-help-firefox-beta-desc = Test about-to-be released features in the most stable pre-release build.
-installer-help-firefox-developer-title = { -brand-name-firefox } { -brand-name-developer-edition }
+installer-help-firefox-developer-title-v2 = { -brand-name-firefox } { -brand-name-developer-edition }
 installer-help-firefox-developer-desc = Build, test, scale and more with the only browser built just for developers.
-installer-help-firefox-nightly-title = { -brand-name-firefox-browser } { -brand-name-nightly }
+installer-help-firefox-nightly-title-v2 = { -brand-name-firefox } { -brand-name-nightly }
 installer-help-firefox-nightly-desc = Peek at our next generation web browser, and help us make it the best browser it can be.
 installer-help-need-help = Need help installing?
 

--- a/l10n/en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl
@@ -6,7 +6,10 @@
 
 # HTML page title
 developer-mdnplus-page-title = { -brand-name-firefox-developer-edition }
-developer-mdnplus-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox } { -brand-name-developer-edition }.
+developer-mdnplus-congrats-you-now-have-latest-v2 = Congrats. You now have the latest version of { -brand-name-firefox-developer-edition }.
+
+# Obsolete string (expires: 2024-05-14)
+developer-mdnplus-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox-browser } { -brand-name-developer-edition }.
 
 # Main title
 developer-mdnplus-more-mdn-your-mdn = More { -brand-name-mdn }. <em>Your</em> { -brand-name-mdn }.


### PR DESCRIPTION
## One-line summary
Some strings got merged that needed new IDs to prevent mismatch errors. This restores (or deletes) the old strings and assigns new IDs to the new ones.

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/387

## Testing
http://localhost:8000/en-US/firefox/developer/
http://localhost:8000/en-US/firefox/99.0a2/firstrun/
http://localhost:8000/en-US/firefox/99.0a2/whatsnew/
http://localhost:8000/en-US/firefox/installer-help/