### PR TITLE
Remove pageHasVideo GA event property (Fixes #14331)

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -16,7 +16,6 @@
         var dataLayerCore = {
             event: 'core-datalayer-loaded',
             pageHasDownload: analytics.pageHasDownload(),
-            pageHasVideo: analytics.pageHasVideo(),
             pageVersion: analytics.getPageVersion(),
             releaseWindowVersion: analytics.getLatestFxVersion()
         };

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -32,17 +32,6 @@ if (typeof window.Mozilla.Analytics === 'undefined') {
             : 'false';
     };
 
-    /** Returns whether page has video.
-     * @param {String} path - URL path name fallback if page ID does not exist.
-     * @return {String} string.
-     */
-    analytics.pageHasVideo = function () {
-        if (!isModernBrowser) {
-            return 'false';
-        }
-        return document.querySelector('video') !== null ? 'true' : 'false';
-    };
-
     /** Returns page version.
      * @param {String} path - URL path name fallback if page ID does not exist.
      * @return {String} version number from URL.

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -27,22 +27,6 @@ describe('core-datalayer.js', function () {
         });
     });
 
-    describe('pageHasVideo', function () {
-        it('will return "true" when HTML5 video is present on page.', function () {
-            const videoMarkup = '<video id="video-content"></video>';
-
-            document.body.insertAdjacentHTML('beforeend', videoMarkup);
-            expect(Mozilla.Analytics.pageHasVideo()).toBe('true');
-
-            const content = document.getElementById('video-content');
-            content.parentNode.removeChild(content);
-        });
-
-        it('will return "false" when download button is not present on page.', function () {
-            expect(Mozilla.Analytics.pageHasVideo()).toBe('false');
-        });
-    });
-
     describe('getPageVersion', function () {
         it('will return the Firefox version number form the URL if present', function () {
             expect(


### PR DESCRIPTION
## One-line summary

Removes unused property on GA `core-datalayer-loaded` event.

## Issue / Bugzilla link

#14331

## Testing

- Enter `window.dataLayer` in the web console, and confirm the `core-datalayer-loaded` event no longer includes `pageHasVideo`.