### PR TITLE
Update /research redirect [fix #14351]

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -99,8 +99,6 @@ redirectpatterns = (
     redirect(r"^about/mission\.html$", "/mission/"),
     # Bug 784411 /about/mission/ -> /mission/
     redirect(r"^about/mission/?$", "/mission/"),
-    # Bug 1171763, 1347752 - /research/ -> research.m.o
-    redirect(r"^research(/.*)?$", "https://research.mozilla.org/"),
     # Bug 800298 /webmaker/ -> wm.o and /webmaker/videos/ ->
     # wm.o/videos/
     redirect(r"webmaker/?$", "https://webmaker.org"),
@@ -568,4 +566,7 @@ redirectpatterns = (
     redirect(r"^stories/?$", "https://blog.mozilla.org/category/products/firefox/"),
     # Issue 14255
     redirect(r"^rise25/?$", "/rise25/nominate/"),
+    # Issue 14351
+    redirect(r"^research/?$", "https://foundation.mozilla.org/research/"),
+    redirect(r"^research/cc/?$", "https://foundation.mozilla.org/research/"),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -879,8 +879,6 @@ URLS = flatten(
         url_test("/products/firefox/{,stuff/}", "/products/"),
         # Bug 784411
         url_test("/about/mission/", "/mission/"),
-        # Bug 1171763, 1347752 - /research/ -> research.m.o
-        url_test("/research/{,projects/,researchers/}", "https://research.mozilla.org/"),
         # Bug 1260423
         url_test("/firefox/choose", "/firefox/new/"),
         url_test("/firefox/{,46.0/,46.0.1/,47.0/,47.0.1/}secondrun", "/firefox/browsers/mobile/"),
@@ -1288,5 +1286,8 @@ URLS = flatten(
         url_test("/firefox/flashback/", "/firefox/"),
         url_test("/landing/firefox/fx100/", "/firefox/"),
         url_test("/{santa-locator,santalocator}/", "/"),
+        # Issue 14351
+        url_test("/research/", "https://foundation.mozilla.org/research/"),
+        url_test("/research/cc/", "https://foundation.mozilla.org/research/"),
     )
 )


### PR DESCRIPTION
## One-line summary
Redirecting vanity URL /research/ to foundation.mozilla.org/research/ (previously went to research.mozilla.org)
Also redirects /research/cc/ to the same URL but that will eventually point somewhere else, but for now it goes to the same place.

## Issue / Bugzilla link
#14351

## Testing
http://localhost:8000/research/
http://localhost:8000/research/cc/