### PR TITLE
Careers: update applicant privacy notice [fix #14348]

### DIFF
--- a/bedrock/careers/templates/careers/position.html
+++ b/bedrock/careers/templates/careers/position.html
@@ -64,7 +64,7 @@
     </div>
   </div>
 
-  <p><a rel="external" href="https://docs.google.com/document/d/e/2PACX-1vTEeCImDA-kqr0wm3JwfOv_2MS5FZ8oyL2pEWfVsZbeO87E41r2wePoOhppQ4qX6w/pub">Applicant Privacy Notice</a></p>
+  <p><a rel="external" href="https://assets.mozilla.net/pdf/Mozilla_Workforce_Privacy_Notice_21-Mar-2024.pdf">Applicant Privacy Notice</a></p>
 </section>
 </div>
 


### PR DESCRIPTION
## One-line summary
Updates the link to the applicant privacy notice on job postings.

## Issue / Bugzilla link
#14348 

## Testing
http://localhost:8000/en-US/careers/listings/

Any single job listing should have the link at the bottom, but what listings you have locally will depend on when you last synced from Greenhouse.