### PR TITLE
Share page: add event tracking to copy button [#14199]

### DIFF
--- a/media/js/firefox/share-page.es6.js
+++ b/media/js/firefox/share-page.es6.js
@@ -24,4 +24,19 @@ function copyText() {
         textCopiedMessage.style.display = 'none';
         copyButtonText.style.display = 'block';
     }, 2500);
+
+    // UA
+    window.dataLayer.push({
+        event: 'in-page-interaction',
+        eAction: 'button click',
+        eLabel: 'Copy and share'
+    });
+
+    // GA4
+    window.dataLayer.push({
+        event: 'widget_action',
+        type: 'copy',
+        action: 'click',
+        name: 'Copy and share'
+    });
 }

--- a/media/js/firefox/share-page.es6.js
+++ b/media/js/firefox/share-page.es6.js
@@ -28,7 +28,7 @@ function copyText() {
     // UA
     window.dataLayer.push({
         event: 'in-page-interaction',
-        eAction: 'button click',
+        eAction: 'copy',
         eLabel: 'Copy and share'
     });
 
@@ -36,7 +36,7 @@ function copyText() {
     window.dataLayer.push({
         event: 'widget_action',
         type: 'copy',
-        action: 'click',
+        action: 'copy',
         name: 'Copy and share'
     });
 }


### PR DESCRIPTION
## One-line summary
Adds a custom event to the "Copy and share" button on the /firefox/share/ page.

I'm not sure what actions/labels are appropriate for this particular interaction... if the ones I set aren't correct, I'm open to suggestion.

## Issue / Bugzilla link
#14199 

## Testing
http://localhost:8000/de/firefox/share/
http://localhost:8000/fr/firefox/share/