### PR TITLE
Update main menu "Innovation" item link

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
@@ -13,7 +13,7 @@
 {% endif %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="https://labs.mozilla.org/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-innovation">{{ ftl('navigation-v2-innovation') }}</a>
+  <a class="c-menu-title" href="https://future.mozilla.org/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-innovation">{{ ftl('navigation-v2-innovation') }}</a>
   <div class="c-menu-panel" id="c-menu-panel-innovation">
     <div class="c-menu-panel-container">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-innovation">{{ ftl('navigation-v2-close-innovation-menu') }}</button>


### PR DESCRIPTION
## One-line summary

Fixes the top-level URL for "Innovation" from abandoned https://labs.mozilla.org to currently most relevant https://future.mozilla.org

## Significant changes and points to review

The site labs.mozilla.org is now empty, generally returning 404 errors and not redirecting elsewhere or showing any sunset information so it feels broken.

While the "Innovation" items now generally link to `future.m.o`, the top level nav item still points to `labs.m.o` — and while not "clickable" with JS handling the submenu instead, it can still be right-clicked e.g. to open in a new tab and acts a top-level item for nonJS UAs and crawlers alike, so this should be updated to be usable even for these edge cases.

The linked issues added menu item references to `future.m.o` so I think it is a safe link target for the top level menu item too.

## Issue / Bugzilla link

Followup of #13994 and #13996