### PR TITLE
Redirect /technology to future.mozilla.org (Fixes #14364)

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -493,7 +493,7 @@ redirectpatterns = (
         },
     ),
     # Issue 6824
-    redirect(r"^technology/?$", "https://labs.mozilla.org/"),
+    redirect(r"^technology/?$", "https://future.mozilla.org/"),
     # Issue 8668
     redirect(r"^contact/communities(/.*)?", "https://community.mozilla.org/groups/"),
     # Issue 8641

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1101,7 +1101,7 @@ URLS = flatten(
             },
         ),
         # Issue 6824
-        url_test("/technology/", "https://labs.mozilla.org/"),
+        url_test("/technology/", "https://future.mozilla.org/"),
         # Issue 8419
         url_test("/firefox/this-browser-comes-highly-recommended/", "/firefox/developer/"),
         # Issue 8420


### PR DESCRIPTION
## One-line summary

Changes old `/technology/` redirect to point to future.mozilla.org instead of labs.mozilla.org (which is now 404).

## Issue / Bugzilla link

#14364

## Testing

http://localhost:8000/technology/