### PR TITLE
Update old `/technology` redirect (Fixes #14364)

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -492,8 +492,8 @@ redirectpatterns = (
             "utm_campaign": "builders-redirect",
         },
     ),
-    # Issue 6824
-    redirect(r"^technology/?$", "https://labs.mozilla.org/"),
+    # Issue 6824, 14364
+    redirect(r"^technology/?$", "https://future.mozilla.org/"),
     # Issue 8668
     redirect(r"^contact/communities(/.*)?", "https://community.mozilla.org/groups/"),
     # Issue 8641

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1100,8 +1100,8 @@ URLS = flatten(
                 "utm_campaign": "builders-redirect",
             },
         ),
-        # Issue 6824
-        url_test("/technology/", "https://labs.mozilla.org/"),
+        # Issue 6824, 14364
+        url_test("/technology/", "https://future.mozilla.org/"),
         # Issue 8419
         url_test("/firefox/this-browser-comes-highly-recommended/", "/firefox/developer/"),
         # Issue 8420


### PR DESCRIPTION
## One-line summary

Updates redirection for removed page now leading to dead site / 404s.

## Significant changes and points to review

The `/technology` URL is still being linked to from external sites for historic reasons as it used to be hard-coded in blog templates for the past couple of years, and now leads to 404 which doesn't look good (see https://github.com/mozilla/One-Mozilla-blog/issues/74 …), so while maintaining old dead links might sound crazy, having this redirect lead people somewhere useful has actual value.

## Issue / Bugzilla link

#14364 