### PR TITLE
Add "Donate" link to 404 pages

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -34,12 +34,12 @@
         {{ ftl('not-found-page-learn-about-mozilla-the-non', about=url('mozorg.about.index')) }}
       </li>
       <li>
-        <img class="list-icon" alt="" src="{{ static('protocol/img/logos/firefox/logo-flat.svg') }}" width="30" height="30">
-        {{ ftl('not-found-page-explore-the-entire-family-for', explore=url('firefox')) }}
-      </li>
-      <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
         {{ ftl('not-found-page-download-the-firefox-browser', download=url('firefox.new')) }}
+      </li>
+      <li>
+        <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
+        {{ ftl('not-found-page-donate-to-mozilla-reclaim-from', donate="https://foundation.mozilla.org/?form=donate-404") }}
       </li>
     </ul>
   </main>

--- a/bedrock/careers/templates/careers/404.html
+++ b/bedrock/careers/templates/careers/404.html
@@ -33,12 +33,12 @@
         <a href="{{ url('mozorg.about.index') }}">Learn</a> about Mozilla, the not-for-profit behind Firefox.
       </li>
       <li>
-        <img class="list-icon" alt="" src="{{ static('protocol/img/logos/firefox/logo-flat.svg') }}" width="30" height="30">
-        <a href="{{ url('firefox') }}">Explore</a> the entire family for Firefox products designed to respect your privacy.
-      </li>
-      <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
         <a href="{{ url('firefox.new') }}">Download</a> the Firefox browser for your mobile device or desktop.
+      </li>
+      <li>
+        <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
+        <a href="https://foundation.mozilla.org/?form=donate-404">Donate</a> to the Mozilla Foundation and reclaim the internet from big tech.
       </li>
     </ul>
   </main>

--- a/l10n/en/404.ftl
+++ b/l10n/en/404.ftl
@@ -14,9 +14,9 @@ not-found-page-go-back = Go Back
 not-found-page-learn-about-mozilla-the-non = <a href="{ $about }">Learn</a> about { -brand-name-mozilla }, the not-for-profit behind { -brand-name-firefox }.
 
 # Variables:
-#   $explore (url) - link to https://www.mozilla.org/firefox/
-not-found-page-explore-the-entire-family-for = <a href={ $explore }>Explore</a> the entire family for { -brand-name-firefox } products designed to respect your privacy.
-
-# Variables:
 #   $download (url) - link to https://www.mozilla.org/firefox/new/
 not-found-page-download-the-firefox-browser = <a href={ $download }>Download</a> the { -brand-name-firefox } browser for your mobile device or desktop
+
+# Variables:
+#   $donate (url) - link to https://foundation.mozilla.org/?form=donate-404
+not-found-page-donate-to-mozilla-reclaim-from = <a href={ $donate }>Donate</a> to the { -brand-name-mozilla-foundation } and reclaim the internet from big tech.


### PR DESCRIPTION
## One-line summary

Adds new "Donate" link to CTAs displayed for 404 error pages.

## Significant changes and points to review

- also removes "Explore" item as per #14209
- removes now unused Fluent string for "Explore" CTA
- adds a new string to localize the "Donate" CTA with no fallback currently present
- doesn't use `donate_url()` as the requested URL has different `?form` param and no tags as per https://github.com/mozilla/bedrock/issues/14209#issuecomment-1965308185
- references "heart" icon (used in Protocol as "Give" CTA etc.) as `"default-browser"`, so in case the metaphor changes upstream in future this CTA might also change its icon meaning;)

## Issue / Bugzilla link

Resolves #14209

## Testing

`run-prod` with `DEBUG=False`:
http://localhost:8000/en-US/foo/bar/404/
http://localhost:8000/en-US/careers/position/foo/404/