### PR TITLE
Extend Rise25 nomination deadline [#14200]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/rise25/landing.html
+++ b/bedrock/mozorg/templates/mozorg/rise25/landing.html
@@ -39,7 +39,7 @@
       dedicated to supporting responsible AI initiatives that benefit humanity. Know
       an innovator making a difference with AI?</p>
     <div class="r25-hero-cta">
-      <strong class="r25-hero-notice">Call for nominees closes on<br> <time datetime="2024-03-29">March 29, 2024</time></strong>
+      <strong class="r25-hero-notice">Call for nominees extended to<br> <time datetime="2024-04-12">April 12, 2024</time></strong>
 
       <a href="#nominate" class="r25-c-button t-fancy">Nominate <span>someone</span></a>
 


### PR DESCRIPTION
## One-line summary
Nomination deadline is being extended two more weeks.

## Issue / Bugzilla link
#14200 

## Testing
http://localhost:8000/rise25/