### PR TITLE
Upgrade upload-artifact action to v4, based on Node 20

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: ./bin/integration_tests/cleanup_after_functional_tests.sh
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: results-${{github.run_id}}

--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: ./bin/integration_tests/cleanup_after_functional_tests.sh
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: results-${{github.run_id}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: results-${{github.run_id}}-${{matrix.label}}

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -39,7 +39,7 @@ jobs:
             CONTAINER_ID=$(docker ps -alq)
             docker cp $CONTAINER_ID:/app/python_coverage .
       - name: Store coverage as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-results
           path: python_coverage


### PR DESCRIPTION
Even though V4 has [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes), particuarly around how uploads with non-unique names are no longer automatically combined this won't be a problem here, I think

Resolves #14147
