### PR TITLE
Update research redirect [#14351]

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -568,5 +568,5 @@ redirectpatterns = (
     redirect(r"^rise25/?$", "/rise25/nominate/"),
     # Issue 14351
     redirect(r"^research/?$", "https://foundation.mozilla.org/research/"),
-    redirect(r"^research/cc/?$", "https://foundation.mozilla.org/research/"),
+    redirect(r"^research/cc/?$", "https://foundation.mozilla.org/research/library/?topics=187"),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1288,7 +1288,7 @@ URLS = flatten(
         url_test("/{santa-locator,santalocator}/", "/"),
         # Issue 14351
         url_test("/research/", "https://foundation.mozilla.org/research/"),
-        url_test("/research/cc/", "https://foundation.mozilla.org/research/"),
+        url_test("/research/cc/", "https://foundation.mozilla.org/research/library/?topics=187"),
         # Issue 14222
         url_test("/firefox/browsers/", "/firefox/"),
     )


### PR DESCRIPTION
## One-line summary
Updates the redirect for /research/cc/ to point to the appropriate category page (now that we have the URL).

## Issue / Bugzilla link
#14351 


## Testing
http://localhost:8000/research/cc/ should redirect to `https://foundation.mozilla.org/research/library/?topics=187`