### PR TITLE
Add Formulaic legal pages

### DIFF
--- a/bedrock/legal/templates/legal/formulaic-content-policies.html
+++ b/bedrock/legal/templates/legal/formulaic-content-policies.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ ftl('legal-formulaic-content-policies') }}{% endblock %}

--- a/bedrock/legal/templates/legal/formulaic-privacy-notice.html
+++ b/bedrock/legal/templates/legal/formulaic-privacy-notice.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ ftl('legal-formulaic-privacy-notice') }}{% endblock %}

--- a/bedrock/legal/templates/legal/formulaic-tos.html
+++ b/bedrock/legal/templates/legal/formulaic-tos.html
@@ -1,0 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ ftl('legal-formulaic-tos') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -76,5 +76,20 @@ urlpatterns = (
         LegalDocView.as_view(template_name="legal/amo-policies.html", legal_doc_name="amo_policies"),
         name="legal.amo-policies",
     ),
+    path(
+        "formulaic-content-policies/",
+        LegalDocView.as_view(template_name="legal/formulaic-content-policies.html", legal_doc_name="formulaic_content_policies"),
+        name="legal.formulaic-content-policies",
+    ),
+    path(
+        "formulaic-tos/",
+        LegalDocView.as_view(template_name="legal/formulaic-tos.html", legal_doc_name="formulaic_tos"),
+        name="legal.formulaic-tos",
+    ),
+    path(
+        "formulaic-privacy-notice/",
+        LegalDocView.as_view(template_name="legal/formulaic-privacy-notice.html", legal_doc_name="formulaic_privacy_notice"),
+        name="legal.formulaic-privacy-notice",
+    ),
     path("defend-mozilla-trademarks/", views.fraud_report, name="legal.fraud-report"),
 )

--- a/l10n/en/mozorg/about/legal.ftl
+++ b/l10n/en/mozorg/about/legal.ftl
@@ -39,3 +39,6 @@ legal-hubs-terms = { -brand-name-mozilla-hubs } Terms of Service
 legal-mozilla-subscription-services = { -brand-name-mozilla } Subscription Services
 legal-content-moderation = Content Moderation Practices
 legal-amo-policies = AMO Policies
+legal-formulaic-content-policies = Formulaic Content Policies
+legal-formulaic-privacy-notice = Formulaic Privacy Notice
+legal-formulaic-tos = Formulaic Terms of Service


### PR DESCRIPTION
## One-line summary
Added 3 legal pages for Formulaic.app 

>[!NOTE]
> Not sure if you'll need to do this from your side, but I had to run `bin/bootstrap.sh` to sync the legal-docs database

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/14346


## Testing

- [ ] http://localhost:8000/en-US/about/legal/formulaic-content-policies/
- [ ] http://localhost:8000/en-US/about/legal/formulaic-privacy-notice/
- [ ] http://localhost:8000/en-US/about/legal/formulaic-tos/
