### PR TITLE
Remove format option from newsletter management page (Fixes #14362)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -104,10 +104,6 @@
             {{ form['lang'] }}
             <small>{{ ftl('newsletters-not-all-subscriptions-are') }}</small>
 
-            {{ form.format.label_tag(ftl('newsletters-format')) }}
-            {{ form['format'] }}
-            <small>{{ ftl('newsletters-text-subscribers-will-receive') }}</small>
-
             <aside>
               <p>{{ ftl('newsletters-many-of-our-communications-v2', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
 

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -60,11 +60,6 @@ newsletters-please-select-country = Please select a country or region
 # Form field error message
 newsletters-please-select-language = Please select a language
 
-# Form field label
-newsletters-format = Format:
-
-newsletters-text-subscribers-will-receive = Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
-
 # Variables:
 #   $url (url) - link to https://support.mozilla.org/kb/managing-account-data
 

--- a/media/js/newsletter/management.es6.js
+++ b/media/js/newsletter/management.es6.js
@@ -454,20 +454,6 @@ const NewsletterManagementForm = {
         // Set language and country selection
         _setOption(langOptions, finalLang);
         _setOption(countryOptions, finalCountry);
-
-        // Finally, set the preferred email format
-        if (userData.format) {
-            const text = document.querySelector('input[value="T"]');
-            const html = document.querySelector('input[value="H"]');
-
-            if (userData.format === 'H') {
-                html.checked = true;
-                text.checked = false;
-            } else {
-                text.checked = true;
-                html.checked = false;
-            }
-        }
     },
 
     /**
@@ -507,7 +493,7 @@ const NewsletterManagementForm = {
     /**
      * Redirects for `/newsletter/updated/` page on successful unsubscribe
      * from all newsletters. The `?unsub` param is required to display the
-     * unsubscription survey form.
+     * unsubscribe survey form.
      */
     onUnsubscribeAll: () => {
         const updated = _form.getAttribute('data-updated-url');
@@ -529,6 +515,10 @@ const NewsletterManagementForm = {
         const errors = [];
         errors.push(NewsletterManagementForm.handleFormError(msg));
         NewsletterManagementForm.renderErrorMessages(errors);
+
+        if (!msg && window.console && window.console.error) {
+            console.error(e); // eslint-disable-line no-console
+        }
     },
 
     /**
@@ -645,9 +635,6 @@ const NewsletterManagementForm = {
     serialize: () => {
         const country = _form.querySelector('select[name="country"]').value;
         const lang = _form.querySelector('#id_lang').value;
-        const format = document.querySelector(
-            'input[name="format"]:checked'
-        ).value;
         const newsletters = encodeURIComponent(
             NewsletterManagementForm.getCheckedNewsletters().join(',')
         );
@@ -656,7 +643,7 @@ const NewsletterManagementForm = {
             _form.querySelector('input[name="source_url"]').value
         );
 
-        return `format=${format}&country=${country}&lang=${lang}&newsletters=${newsletters}&optin=Y&source_url=${sourceUrl}`;
+        return `country=${country}&lang=${lang}&newsletters=${newsletters}&optin=Y&source_url=${sourceUrl}`;
     },
 
     /**

--- a/tests/unit/spec/newsletter/management.js
+++ b/tests/unit/spec/newsletter/management.js
@@ -65,11 +65,6 @@ describe('management.es6.js', function () {
                                 <option value="fr">Français</option>
                             </select>
                         </div>
-                        <div>
-                            <label for="id_format_0">Format:</label>
-                            <label for="id_format_0"><input type="radio" name="format" value="H" required="" id="id_format_0" checked="">HTML</label>
-                            <label for="id_format_1"><input type="radio" name="format" value="T" required="" id="id_format_1">Text</label>
-                        </div>
                     </div>
                 </div>
                 <div class="c-column">
@@ -289,7 +284,6 @@ describe('management.es6.js', function () {
             const nonFxaUser = {
                 email: 'example@example.com',
                 country: 'us',
-                format: 'H',
                 lang: 'en',
                 newsletters: [
                     'about-mozilla',
@@ -359,17 +353,13 @@ describe('management.es6.js', function () {
             expect(lang.options[lang.selectedIndex].value).toEqual(
                 userData.lang
             );
-            expect(
-                document.querySelector('input[name="format"]:checked').value
-            ).toEqual(userData.format);
         });
 
         it('should derive country and lang from page locale when missing from user data', function () {
             const country = document.getElementById('id_country');
             const lang = document.getElementById('id_lang');
             const partialUserData = {
-                email: 'example@example.com',
-                format: 'H'
+                email: 'example@example.com'
             };
 
             spyOn(NewsletterManagementForm, 'getPageLocale').and.returnValue(
@@ -381,17 +371,13 @@ describe('management.es6.js', function () {
             );
             expect(country.options[country.selectedIndex].value).toEqual('gb');
             expect(lang.options[lang.selectedIndex].value).toEqual('en');
-            expect(
-                document.querySelector('input[name="format"]:checked').value
-            ).toEqual(partialUserData.format);
         });
 
         it('should default to English / US when page locale info does not match available options', function () {
             const country = document.getElementById('id_country');
             const lang = document.getElementById('id_lang');
             const partialUserData = {
-                email: 'example@example.com',
-                format: 'T'
+                email: 'example@example.com'
             };
 
             spyOn(NewsletterManagementForm, 'getPageLocale').and.returnValue(
@@ -403,9 +389,6 @@ describe('management.es6.js', function () {
             );
             expect(country.options[country.selectedIndex].value).toEqual('us');
             expect(lang.options[lang.selectedIndex].value).toEqual('en');
-            expect(
-                document.querySelector('input[name="format"]:checked').value
-            ).toEqual(partialUserData.format);
         });
 
         it('should default to English / US when user data does not match available options', function () {
@@ -414,7 +397,6 @@ describe('management.es6.js', function () {
             const partialUserData = {
                 email: 'example@example.com',
                 country: 'xx',
-                format: 'T',
                 lang: 'xx'
             };
 
@@ -427,9 +409,6 @@ describe('management.es6.js', function () {
             );
             expect(country.options[country.selectedIndex].value).toEqual('us');
             expect(lang.options[lang.selectedIndex].value).toEqual('en');
-            expect(
-                document.querySelector('input[name="format"]:checked').value
-            ).toEqual(partialUserData.format);
         });
 
         it('should default to English / US when user data does not match available options', function () {
@@ -438,7 +417,6 @@ describe('management.es6.js', function () {
             const partialUserData = {
                 email: 'example@example.com',
                 country: 'xx',
-                format: 'T',
                 lang: 'xx'
             };
 
@@ -451,9 +429,6 @@ describe('management.es6.js', function () {
             );
             expect(country.options[country.selectedIndex].value).toEqual('us');
             expect(lang.options[lang.selectedIndex].value).toEqual('en');
-            expect(
-                document.querySelector('input[name="format"]:checked').value
-            ).toEqual(partialUserData.format);
         });
 
         it('should fuzzy match language codes returned from basket', function () {
@@ -462,7 +437,6 @@ describe('management.es6.js', function () {
             const partialUserData = {
                 email: 'example@example.com',
                 country: 'es',
-                format: 'H',
                 lang: 'es-ES'
             };
 
@@ -475,9 +449,6 @@ describe('management.es6.js', function () {
             );
             expect(country.options[country.selectedIndex].value).toEqual('es');
             expect(lang.options[lang.selectedIndex].value).toEqual('es');
-            expect(
-                document.querySelector('input[name="format"]:checked').value
-            ).toEqual(partialUserData.format);
         });
     });
 
@@ -748,7 +719,6 @@ describe('management.es6.js', function () {
             const nonFxAUser = {
                 email: 'example@example.com',
                 country: 'us',
-                format: 'H',
                 lang: 'en',
                 newsletters: [
                     'about-mozilla',
@@ -796,7 +766,6 @@ describe('management.es6.js', function () {
             const nonFxAUser = {
                 email: 'example@example.com',
                 country: 'us',
-                format: 'H',
                 lang: 'en',
                 newsletters: [
                     'about-mozilla',
@@ -1005,7 +974,7 @@ describe('management.es6.js', function () {
                     `https://basket.mozilla.org/news/user/${TOKEN_MOCK}/`
                 );
                 expect(xhrRequests[0].requestBody).toEqual(
-                    'format=H&country=us&lang=en&newsletters=mozilla-and-you%2Cmozilla-foundation%2Cabout-mozilla&optin=Y&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fexisting%2F'
+                    'country=us&lang=en&newsletters=mozilla-and-you%2Cmozilla-foundation%2Cabout-mozilla&optin=Y&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fexisting%2F'
                 );
                 xhrRequests[0].respond(
                     200,
@@ -1026,7 +995,7 @@ describe('management.es6.js', function () {
                 document.querySelector('button[type="submit"]').click();
 
                 expect(xhrRequests[0].requestBody).toEqual(
-                    'format=H&country=us&lang=en&newsletters=mozilla-and-you%2Cmozilla-foundation%2Ccommon-voice%2Cabout-mozilla&optin=Y&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fexisting%2F'
+                    'country=us&lang=en&newsletters=mozilla-and-you%2Cmozilla-foundation%2Ccommon-voice%2Cabout-mozilla&optin=Y&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fexisting%2F'
                 );
                 xhrRequests[0].respond(
                     200,
@@ -1049,7 +1018,7 @@ describe('management.es6.js', function () {
                 document.querySelector('button[type="submit"]').click();
 
                 expect(xhrRequests[0].requestBody).toEqual(
-                    'format=H&country=us&lang=en&newsletters=mozilla-foundation%2Cabout-mozilla&optin=Y&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fexisting%2F'
+                    'country=us&lang=en&newsletters=mozilla-foundation%2Cabout-mozilla&optin=Y&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fexisting%2F'
                 );
                 xhrRequests[0].respond(
                     200,


### PR DESCRIPTION
## One-line summary

Removes the option to set a preference for text/html based emails.

## Issue / Bugzilla link

#14362

## Testing

1. Get your newsletter token from https://www.mozilla.org/newsletter/recovery/
2. Open the newsletter management page locally via `http://localhost:8000/en-US/newsletter/existing/YOUR_TOKEN_HERE/`
3. Verify the page loads OK and does not render the format option.
4. Change a different option (such as country) and click save preferences, to verify that form submission still works OK.
5. Click "Back to email preferences" on the next page, and verify the management page loads again with your updated preference. 