### PR TITLE
Remove `/gameon` redirect and config

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -103,8 +103,6 @@ redirectpatterns = (
     # wm.o/videos/
     redirect(r"webmaker/?$", "https://webmaker.org"),
     redirect(r"webmaker/videos/?$", "https://webmaker.org/videos/"),
-    # Bug 819317 /gameon/ -> gameon.m.o
-    redirect(r"gameon/?$", "https://gameon.mozilla.org"),
     # Bug 822817 /telemetry/ ->
     # https://wiki.mozilla.org/Telemetry/FAQ
     redirect(r"telemetry/?$", "https://wiki.mozilla.org/Telemetry/FAQ"),

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -406,7 +406,6 @@ SUPPORTED_NONLOCALES = [
     "images",
     "contribute.json",
     "credits",
-    "gameon",
     "robots.txt",
     ".well-known",
     "telemetry",


### PR DESCRIPTION
## One-line summary

Removes defunct redirect to gameon.m.o

## Significant changes and points to review

Also removes former nonlocale page config

## Issue / Bugzilla link

resolves #14249

## Testing

localhost:8000/gameon