### PR TITLE
Improve subnav & breadcrumb alignment

### DIFF
--- a/media/css/firefox/features/article.scss
+++ b/media/css/firefox/features/article.scss
@@ -9,31 +9,6 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/callout';
 @import '~@mozilla-protocol/core/protocol/css/components/breadcrumb';
 
-.mzp-c-breadcrumb {
-    padding-top: $spacing-md;
-    padding-bottom: $spacing-md;
-
-    .mzp-c-breadcrumb-item a {
-        color: inherit;
-
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-
-    @media #{$mq-md} {
-        .mzp-c-breadcrumb-list {
-            padding: 8px 64px;
-        }
-    }
-
-    @media #{$mq-lg} {
-        .mzp-c-breadcrumb-list {
-            padding: 8px 96px;
-        }
-    }
-}
-
 .feature-article-container {
     padding-top: $spacing-2xl;
     position: relative;

--- a/media/css/firefox/features/article.scss
+++ b/media/css/firefox/features/article.scss
@@ -9,6 +9,31 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/callout';
 @import '~@mozilla-protocol/core/protocol/css/components/breadcrumb';
 
+.mzp-c-breadcrumb {
+    padding-top: $spacing-md;
+    padding-bottom: $spacing-md;
+
+    .mzp-c-breadcrumb-item a {
+        color: inherit;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    @media #{$mq-md} {
+        .mzp-c-breadcrumb-list {
+            padding: 8px 64px;
+        }
+    }
+
+    @media #{$mq-lg} {
+        .mzp-c-breadcrumb-list {
+            padding: 8px 96px;
+        }
+    }
+}
+
 .feature-article-container {
     padding-top: $spacing-2xl;
     position: relative;

--- a/media/css/products/vpn/resource-center.scss
+++ b/media/css/products/vpn/resource-center.scss
@@ -82,6 +82,11 @@ $image-path: '/media/protocol/img';
     color: #666;
 }
 
+#outer-wrapper .mzp-c-breadcrumb {
+    // when stacked with subnav of the same color this makes it stand out
+    background: none;
+}
+
 .vpn-article-container {
     background: url('/media/img/products/vpn/resource-center/resource_center_article_gradient.svg');
     background-repeat: no-repeat;

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -175,3 +175,24 @@
         }
     }
 }
+
+// * -------------------------------------------------------------------------- */
+// Overrides to align with subnav https://github.com/mozilla/bedrock/issues/14081
+
+    nav.mzp-c-breadcrumb {
+        padding: $spacing-md 0;
+
+        .mzp-c-breadcrumb-list {
+            max-width: $content-max;
+            margin: 0 auto;
+            padding: 0 $spacing-lg;
+
+            @media #{$mq-md} {
+                padding: 0 $layout-lg;
+            }
+
+            @media #{$mq-lg} {
+                padding: 0 $layout-xl;
+            }
+        }
+    }

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -13,12 +13,22 @@
         inset 0 10px 3px -10px rgba(29, 17, 51, 0.12);
 
     .mzp-l-content {
-        padding-top: 0;
-        padding-bottom: $spacing-md;
+        max-width: none;
+        padding: $spacing-md 0;
     }
 
     .c-sub-navigation-content {
-        padding-top: $spacing-md;
+        max-width: $content-max;
+        margin: 0 auto;
+        padding: 0 $spacing-lg;
+        
+        @media #{$mq-md} {
+            padding: 0 $layout-lg;
+        }
+
+        @media #{$mq-lg} {
+            padding: 0 $layout-xl;
+        }
     }
 
     .c-sub-navigation-icon {


### PR DESCRIPTION
## One-line summary

Improves the default breadcrumb styling and adjusts subnav to better align all the navigation components.

## Significant changes and points to review

TL;DR: The subnav & breadcrumbs were aligned as part of the content, not matching the nav masthead above. This aims to reset the content-like styling for these additional nav components, and apply the same layout as the main nav above them.

WIP

not sure i like the looks of "aligned with nav" now on various pages, where the alignment with content underneath looked probably better? 🤷 
 — feel free to browse around locally, i've picked some good examples below in "testing", where are some nice examples of different content alignment, and how that interacts with the repositioned subnav…

- monkey-patched breadcrumb overrides to _sub-navigation.scss as it's compiled into base everywhere important
   - (b/c breadcrumbs are included w/o any styling, implying default protocol, so to override this a "cheap" place ideally loaded everywhere is needed; this just avoids adding a new component and including it in a dozen places…)
- BTW changes VPN breadcrumbs colour for contrast with subnav

## Issue / Bugzilla link

Fixes #14081
Fixes #13462
Supersedes #14253

## Testing

http://localhost:8000/en-US/firefox/features/private/
http://localhost:8000/en-US/firefox/new/
http://localhost:8000/en-US/firefox/enterprise/
http://localhost:8000/en-US/firefox/channel/desktop/
http://localhost:8000/en-US/products/vpn/
http://localhost:8000/en-US/products/vpn/resource-center/is-a-vpn-safe/