### PR TITLE
Protocol v19.1.0 -- Remove `format` option across newsletters in Bedrock

### DIFF
--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -73,16 +73,6 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
 
         <div id="newsletter-details" class="mzp-c-newsletter-details">
           <input type="hidden" name="country" id="id_country"  aria-required="false">
-
-          <fieldset class="mzp-u-inline">
-            <legend>Format</legend>
-              <label for="format-html" class="mzp-u-inline">
-                <input type="radio" id="format-html" name="format" value="H" checked> HTML
-              </label>
-              <label for="format-text" class="mzp-u-inline">
-                <input type="radio" id="format-text" name="format" value="T"> Text
-              </label>
-          </fieldset>
             <label for="id_terms" class="mzp-u-inline">
               <input id="id_terms" name="terms" required aria-required="true" type="checkbox">
               I have read and agree to these

--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -11,9 +11,8 @@ from django.forms import widgets
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from lib.l10n_utils.fluent import ftl, ftl_lazy
+from lib.l10n_utils.fluent import ftl
 
-FORMATS = (("H", ftl_lazy("newsletter-form-html")), ("T", ftl_lazy("newsletter-form-text")))
 LANGS_TO_STRIP = ["en-US", "es"]
 PARENTHETIC_RE = re.compile(r" \([^)]+\)$")
 

--- a/bedrock/mozorg/templates/mozorg/antiharassment-tool.html
+++ b/bedrock/mozorg/templates/mozorg/antiharassment-tool.html
@@ -100,7 +100,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       {{ newsletter_form.newsletters|safe }}
     </div>
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
-    <input type="hidden" name="format" id="format-html" value="H">
     <input type="hidden" name="country" id="id_country" value="us">
     <input type="hidden" name="lang" id="id_lang" value="en">
     <fieldset class="mzp-c-newsletter-content">
@@ -118,17 +117,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           placeholder="yourname@example.com">
       </div>
       <div id="newsletter-details" class="mzp-c-newsletter-details">
-        <fieldset class="mzp-u-inline">
-          <legend>Format</legend>
-          <p>
-            <label for="format-html" class="mzp-u-inline">
-              <input type="radio" id="format-html" name="format" value="H" checked="">HTML
-            </label>
-            <label for="format-text" class="mzp-u-inline">
-              <input type="radio" id="format-text" name="format" value="T">Text
-            </label>
-          </p>
-        </fieldset>
         <p>
           <label for="privacy" class="mzp-u-inline">
             <input type="checkbox" id="privacy" name="privacy" required="" aria-required="true">I’m okay with Mozilla handling

--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -10,7 +10,7 @@ from django.forms import widgets
 
 from product_details import product_details
 
-from bedrock.mozorg.forms import FORMATS, EmailInput, PrivacyWidget, strip_parenthetical
+from bedrock.mozorg.forms import EmailInput, PrivacyWidget, strip_parenthetical
 from bedrock.newsletter import utils
 from lib.l10n_utils.fluent import ftl, ftl_lazy
 
@@ -130,7 +130,6 @@ class ManageSubscriptionsForm(forms.Form):
     @param kwargs: Other standard form kwargs
     """
 
-    format = forms.ChoiceField(widget=SimpleRadioSelect, choices=FORMATS, initial="H")
     remove_all = forms.BooleanField(required=False)
 
     country = forms.ChoiceField(choices=[], required=False)  # will set choices based on locale
@@ -183,7 +182,6 @@ class NewsletterFooterForm(forms.Form):
     # currently used on /contribute/friends/ (custom markup)
     first_name = forms.CharField(widget=forms.TextInput, required=False)
     last_name = forms.CharField(widget=forms.TextInput, required=False)
-    fmt = forms.ChoiceField(widget=SimpleRadioSelect, choices=FORMATS, initial="H")
     privacy = forms.BooleanField(widget=PrivacyWidget)
     source_url = forms.CharField(required=False)
     newsletters = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple())

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -91,18 +91,6 @@
           </fieldset>
         {% endif %}
 
-        <fieldset class="mzp-u-inline">
-          <legend>{{ ftl('newsletter-form-format') }}</legend>
-          <p>
-            <label for="format-html" class="mzp-u-inline">
-              <input type="radio" id="format-html" name="format" value="H" checked> {{ ftl('newsletter-form-html') }}
-            </label>
-            <label for="format-text" class="mzp-u-inline">
-              <input type="radio" id="format-text" name="format" value="T"> {{ ftl('newsletter-form-text') }}
-            </label>
-          </p>
-        </fieldset>
-
         <p>
           <label for="privacy" class="mzp-u-inline">
             <input type="checkbox" id="privacy" name="privacy" required aria-required="true"> {{ ftl('newsletter-form-im-okay-with-mozilla', url=url('privacy.notices.websites')) }}

--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -84,14 +84,12 @@ class TestNewsletterFooterForm(TestCase):
             "first_name": "Walter",
             "last_name": "Sobchak",
             "privacy": True,
-            "fmt": "H",
             "source_url": "https://accounts.firefox.com",
             "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data.copy())
         self.assertTrue(form.is_valid(), form.errors)
         cleaned_data = form.cleaned_data
-        self.assertEqual(data["fmt"], cleaned_data["fmt"])
         self.assertEqual(data["lang"], cleaned_data["lang"])
         self.assertEqual(data["source_url"], cleaned_data["source_url"])
 
@@ -103,7 +101,6 @@ class TestNewsletterFooterForm(TestCase):
             "first_name": "Walter",
             "last_name": "Sobchak",
             "privacy": True,
-            "fmt": "H",
             "source_url": "about:devtools?dude=abiding",
             "newsletters": [self.newsletter_name],
         }
@@ -120,7 +117,6 @@ class TestNewsletterFooterForm(TestCase):
             "first_name": "Walter",
             "last_name": "Sobchak",
             "privacy": True,
-            "fmt": "H",
             "source_url": "about:devtools" * 20,
             "newsletters": [self.newsletter_name],
         }
@@ -171,7 +167,6 @@ class TestNewsletterFooterForm(TestCase):
         data = {
             "email": "foo@example.com",
             "privacy": True,
-            "fmt": "H",
             "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data.copy())
@@ -186,7 +181,6 @@ class TestNewsletterFooterForm(TestCase):
         data = {
             "email": "foo@example.com",
             "privacy": False,
-            "fmt": "H",
             "newsletters": [self.newsletter_name],
         }
         form = NewsletterFooterForm(self.newsletter_name, locale="en-US", data=data)
@@ -203,7 +197,6 @@ class TestNewsletterFooterForm(TestCase):
             "email": "fred@example.com",
             "lang": "fr",
             "privacy": True,
-            "fmt": "H",
             "newsletters": [],
         }
         form = NewsletterFooterForm("", locale="en-US", data=data.copy())
@@ -216,7 +209,6 @@ class TestNewsletterFooterForm(TestCase):
             "email": "fred@example.com",
             "lang": "fr",
             "privacy": True,
-            "fmt": "H",
             "newsletters": [invalid_newsletter],
         }
         form = NewsletterFooterForm(invalid_newsletter, locale="en-US", data=data.copy())
@@ -231,7 +223,6 @@ class TestNewsletterFooterForm(TestCase):
             "email": "dude@example.com",
             "lang": "en",
             "privacy": "Y",
-            "fmt": "H",
             "newsletters": newsletters,
         }
         form = NewsletterFooterForm(newsletters, "en-US", data=data.copy())

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -85,7 +85,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
         }
         resp = self.ajax_request(data)
         resp_data = json.loads(resp.content)
@@ -103,7 +102,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
             "country": '<svg/onload=alert("NEFARIOUSNESS")>',
         }
@@ -122,24 +120,23 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
         }
         source_url = "https://example.com/bambam"
         resp = self.ajax_request(data, HTTP_REFERER=source_url)
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {"success": True})
-        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", format="H", source_url=source_url)
+        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", source_url=source_url)
 
     @patch("bedrock.newsletter.views.basket")
     def test_use_source_url_with_referer(self, basket_mock):
         """Should use source_url even if there's a good referrer"""
         source_url = "https://example.com/bambam"
-        data = {"newsletters": ["flintstones"], "email": "fred@example.com", "fmt": "H", "privacy": True, "source_url": source_url}
+        data = {"newsletters": ["flintstones"], "email": "fred@example.com", "privacy": True, "source_url": source_url}
         resp = self.ajax_request(data, HTTP_REFERER=source_url + "_WILMA")
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {"success": True})
-        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", format="H", source_url=source_url)
+        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", source_url=source_url)
 
     @patch("bedrock.newsletter.views.basket")
     def test_returns_ajax_success(self, basket_mock):
@@ -147,13 +144,12 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
         }
         resp = self.ajax_request(data)
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {"success": True})
-        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", format="H")
+        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones")
 
     @patch.object(basket, "subscribe")
     def test_returns_ajax_invalid_email(self, subscribe_mock):
@@ -162,7 +158,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
         }
         resp = self.ajax_request(data)
@@ -177,7 +172,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
         }
         resp = self.ajax_request(data)
@@ -207,7 +201,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
         }
         resp = self.request(data=data)
@@ -215,7 +208,7 @@ class TestNewsletterSubscribe(TestCase):
         self.assertFalse(doc("#newsletter-submit"))
         self.assertFalse(doc('input[value="mozilla-and-you"]'))
         self.assertTrue(doc("#newsletter-thanks"))
-        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", format="H")
+        basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones")
 
     @patch("bedrock.newsletter.views.basket")
     def test_returns_failure__invalid_newsletter(self, basket_mock):
@@ -229,7 +222,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["!nv@lid"],
             "email": "fred@example.com",
-            "fmt": "H",
             "privacy": True,
         }
         resp = self.request(data=data)
@@ -248,7 +240,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             "newsletters": ["flintstones"],
             "email": "fred@example.com",
-            "fmt": "H",
         }
         resp = self.request(data=data)
         doc = pq(resp.content)

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -218,7 +218,7 @@ def newsletter_subscribe(request):
         if form.is_valid():
             data = form.cleaned_data
 
-            kwargs = {"format": data["fmt"]}
+            kwargs = {}
             # add optional data
             kwargs.update(
                 {
@@ -258,7 +258,7 @@ def newsletter_subscribe(request):
                 errors.append(ftl("newsletter-form-please-enter-a-valid"))
             if "privacy" in form.errors:
                 errors.append(ftl("newsletter-form-you-must-agree-to"))
-            for fieldname in ("newsletters", "fmt", "lang", "country"):
+            for fieldname in ("newsletters", "lang", "country"):
                 if fieldname in form.errors:
                     errors.extend(form.errors[fieldname])
 

--- a/bedrock/products/templates/products/mozsocial/invite.html
+++ b/bedrock/products/templates/products/mozsocial/invite.html
@@ -34,7 +34,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       {{ newsletter_form.newsletters|safe }}
     </div>
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
-    <input type="hidden" name="format" id="format-html" value="H">
 
     <h1 class="mzp-c-form-header">{{ ftl('mozsocial-invite-welcome-to-mozillasocial') }}</h1>
     <p class="mzp-c-form-subtitle">{{ ftl('mozsocial-invite-please-join-our-waitlist') }}</p>

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -35,7 +35,6 @@
       {{ newsletter_form.newsletters|safe }}
     </div>
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
-    <input type="hidden" name="format" id="format-html" value="H">
 
     <fieldset class="mzp-c-newsletter-content">
       <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">

--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -15,9 +15,6 @@ newsletter-form-yournameexamplecom = yourname@example.com
 newsletter-form-select-country-or-region = Select country or region
 newsletter-form-select-language = Select language
 newsletter-form-your-email-here = YOUR EMAIL HERE
-newsletter-form-format = Format
-newsletter-form-html = HTML
-newsletter-form-text = Text
 newsletter-form-get-firefox-news = Get { -brand-name-firefox } news
 
 # Variables:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.24.3",
         "@babel/preset-env": "^7.24.3",
-        "@mozilla-protocol/core": "^19.0.0",
+        "@mozilla-protocol/core": "^19.1.0",
         "@mozilla/glean": "^5.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
@@ -2169,9 +2169,9 @@
       "dev": true
     },
     "node_modules/@mozilla-protocol/core": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-19.0.0.tgz",
-      "integrity": "sha512-2kitmeSKbSixV41OUgYAp/nbhXd8ftY4FEG/QKsoinSg7njawQuNCM5NwPWiP9wdhGinxVJU5FBblif7FB5srA=="
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-19.1.0.tgz",
+      "integrity": "sha512-QFuebX2lr6kqwkLfL4YU5iSP5473BjAGSbtVnOFrJ2GulFxgJFNuKle3DxEcY7FhMVoy/Czo1pfbiFNQ4XhLXA=="
     },
     "node_modules/@mozilla/glean": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/core": "^7.24.3",
     "@babel/preset-env": "^7.24.3",
-    "@mozilla-protocol/core": "^19.0.0",
+    "@mozilla-protocol/core": "^19.1.0",
     "@mozilla/glean": "^5.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",

--- a/tests/functional/firefox/test_ios_testflight.py
+++ b/tests/functional/firefox/test_ios_testflight.py
@@ -12,8 +12,6 @@ def test_signup_default_values(base_url, selenium):
     page = iOSTestFlightPage(selenium, base_url).open()
     page.expand_form()
     assert "" == page.email
-    assert page.html_format_selected
-    assert not page.text_format_selected
     assert not page.privacy_policy_accepted
     assert not page.terms_accepted
     assert page.is_privacy_policy_link_displayed
@@ -26,7 +24,6 @@ def test_sign_up_success(base_url, selenium):
     assert not page.sign_up_successful
     page.expand_form()
     page.type_email("success@example.com")
-    page.select_text_format()
     page.accept_privacy_policy()
     page.accept_terms()
     page.click_sign_me_up()
@@ -39,7 +36,6 @@ def test_sign_up_failure(base_url, selenium):
     assert not page.is_form_error_displayed
     page.expand_form()
     page.type_email("invalid@email")
-    page.select_text_format()
     page.accept_privacy_policy()
     page.accept_terms()
     page.click_sign_me_up(expected_result="error")

--- a/tests/functional/newsletter/test_monitor_waitlist.py
+++ b/tests/functional/newsletter/test_monitor_waitlist.py
@@ -13,7 +13,6 @@ def test_monitor_waitlist_success(base_url, selenium):
     assert not page.newsletter.sign_up_successful
     page.newsletter.expand_form()
     page.newsletter.type_email("success@example.com")
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up()
     assert page.newsletter.sign_up_successful
@@ -25,7 +24,6 @@ def test_monitor_waitlist_failure(base_url, selenium):
     assert not page.newsletter.is_form_error_displayed
     page.newsletter.expand_form()
     page.newsletter.type_email("failure@example.com")
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up(expected_result="error")
     assert page.newsletter.is_form_error_displayed

--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -67,7 +67,6 @@ def test_newsletter_sign_up_success(page_class, base_url, selenium):
     page.newsletter.expand_form()
     page.newsletter.type_email("success@example.com")
     page.newsletter.select_country("United Kingdom")
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up()
     assert page.newsletter.sign_up_successful
@@ -97,7 +96,6 @@ def test_newsletter_sign_up_failure(page_class, base_url, selenium):
     page.newsletter.expand_form()
     page.newsletter.type_email("failure@example.com")
     page.newsletter.select_country("United Kingdom")
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up(expected_result="error")
     assert page.newsletter.is_form_error_displayed

--- a/tests/functional/newsletter/test_newsletter_family.py
+++ b/tests/functional/newsletter/test_newsletter_family.py
@@ -13,7 +13,6 @@ def test_newsletter_family_success(base_url, selenium):
     assert not page.newsletter.sign_up_successful
     page.newsletter.expand_form()
     page.newsletter.type_email("success@example.com")
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up()
     assert page.newsletter.sign_up_successful
@@ -25,7 +24,6 @@ def test_newsletter_family_failure(base_url, selenium):
     assert not page.newsletter.is_form_error_displayed
     page.newsletter.expand_form()
     page.newsletter.type_email("failure@example.com")
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up(expected_result="error")
     assert page.newsletter.is_form_error_displayed

--- a/tests/pages/firefox/ios_testflight.py
+++ b/tests/pages/firefox/ios_testflight.py
@@ -12,13 +12,11 @@ class iOSTestFlightPage(BasePage):
     _URL_TEMPLATE = "/{locale}/firefox/ios/testflight/"
 
     _email_locator = (By.ID, "id_email")
-    _html_format_locator = (By.ID, "format-html")
     _privacy_policy_checkbox_locator = (By.ID, "id_privacy")
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] a')
     _submit_button_locator = (By.ID, "newsletter-submit")
     _terms_checkbox_locator = (By.ID, "id_terms")
     _terms_link_locator = (By.CSS_SELECTOR, 'label[for="id_terms"] a')
-    _text_format_locator = (By.ID, "format-text")
     _thank_you_locator = (By.ID, "newsletter-thanks")
     _form_details_locator = (By.ID, "newsletter-details")
     _error_list_locator = (By.ID, "newsletter-errors")
@@ -30,10 +28,6 @@ class iOSTestFlightPage(BasePage):
     @property
     def email(self):
         return self.find_element(*self._email_locator).get_attribute("value")
-
-    @property
-    def html_format_selected(self):
-        return self.find_element(*self._html_format_locator).is_selected()
 
     @property
     def is_privacy_policy_link_displayed(self):
@@ -57,10 +51,6 @@ class iOSTestFlightPage(BasePage):
     def sign_up_successful(self):
         return self.is_element_displayed(*self._thank_you_locator)
 
-    @property
-    def text_format_selected(self):
-        return self.find_element(*self._text_format_locator).is_selected()
-
     def accept_privacy_policy(self):
         el = self.find_element(*self._privacy_policy_checkbox_locator)
         assert not el.is_selected(), "Privacy policy has already been accepted"
@@ -79,9 +69,6 @@ class iOSTestFlightPage(BasePage):
             self.wait.until(expected.visibility_of_element_located(self._error_list_locator))
         else:
             self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
-
-    def select_text_format(self):
-        self.find_element(*self._text_format_locator).click()
 
     def type_email(self, value):
         self.find_element(*self._email_locator).send_keys(value)

--- a/tests/pages/regions/newsletter.py
+++ b/tests/pages/regions/newsletter.py
@@ -13,8 +13,6 @@ class NewsletterEmbedForm(Region):
     _email_locator = (By.ID, "id_email")
     _form_details_locator = (By.ID, "newsletter-details")
     _country_locator = (By.ID, "id_country")
-    _html_format_locator = (By.ID, "format-html")
-    _text_format_locator = (By.ID, "format-text")
     _privacy_policy_checkbox_locator = (By.ID, "privacy")
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="privacy"] a')
     _submit_button_locator = (By.ID, "newsletter-submit")
@@ -52,22 +50,6 @@ class NewsletterEmbedForm(Region):
     def select_country(self, value):
         el = self.find_element(*self._country_locator)
         Select(el).select_by_visible_text(value)
-
-    @property
-    def html_format_selected(self):
-        el = self.find_element(*self._html_format_locator)
-        return el.is_selected()
-
-    def select_html_format(self):
-        self.find_element(*self._html_format_locator).click()
-
-    @property
-    def text_format_selected(self):
-        el = self.find_element(*self._text_format_locator)
-        return el.is_selected()
-
-    def select_text_format(self):
-        self.find_element(*self._text_format_locator).click()
 
     @property
     def privacy_policy_accepted(self):

--- a/tests/unit/spec/newsletter/data.js
+++ b/tests/unit/spec/newsletter/data.js
@@ -7,7 +7,6 @@
 const userData = {
     email: 'example@example.com',
     country: 'us',
-    format: 'H',
     lang: 'en',
     newsletters: ['about-mozilla', 'mozilla-and-you', 'mozilla-foundation'],
     has_fxa: true,

--- a/tests/unit/spec/products/vpn/invite.js
+++ b/tests/unit/spec/products/vpn/invite.js
@@ -28,7 +28,6 @@ describe('WaitListForm', function () {
                     </ul>
                 </div>
                 <input type="hidden" name="source_url" value="https://www.mozilla.org/en-US/products/vpn/invite/">
-                <input type="hidden" name="format" id="format-html" value="H">
 
                 <fieldset class="mzp-c-newsletter-content">
                     <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">


### PR DESCRIPTION
## One-line summary

The email marketing team requested we remove the `format` option that allows users to choose whether to receive emails as HTML or as Text-based markup since Braze does not support these options.

> [!NOTE]
> Part of getting this to work bedrock-wide was to upgrade the Newsletter component in Protocol, so we published `v19.1.0` with the latest update.

You should now be able to sign-up for a newsletter without seeing a `format` option, and it should submit successfully

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/14362


## Testing
This should work on any page with a newsletter sign-up, but here are some sample pages that have the newsletter component:

- [ ] http://localhost:8000/en-US/
- [ ] http://localhost:8000/en-US/firefox/developer/
- [ ] http://localhost:8000/en-US/firefox/ios/testflight/
- [ ] http://localhost:8000/en-US/newsletter/knowledge-is-power/
