### PR TITLE
Add a git hook that reminds developers if dependencies have just been updated after a pull/merge 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,4 +181,13 @@ preflight:
 clean-local-deps:
 	pip uninstall mdx_outline -y && pip freeze | xargs pip uninstall -y
 
-.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod run-pocket run-pocket-prod build-prod test-cdn compile-requirements check-requirements install-local-python-deps preflight clean-local-deps
+# Done explicitly to avoid surprises
+install-custom-git-hooks:
+	cp bin/custom-git-hooks/post-merge .git/hooks/post-merge
+	chmod u+x .git/hooks/post-merge
+
+# Done explicitly to avoid surprises
+uninstall-custom-git-hooks:
+	rm .git/hooks/post-merge
+
+.PHONY: all clean build pull docs livedocs build-docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod run-pocket run-pocket-prod build-prod test-cdn compile-requirements check-requirements install-local-python-deps preflight clean-local-deps install-custom-git-hooks uninstall-custom-git-hooks

--- a/bin/custom-git-hooks/README.txt
+++ b/bin/custom-git-hooks/README.txt
@@ -1,0 +1,6 @@
+To install these, copy them into .git/hooks and remove the .uninstalled suffix.
+
+There are also a Makefile commands to ease this:
+
+    make install-custom-git-hooks
+    make uninstall-custom-git-hooks

--- a/bin/custom-git-hooks/post-merge
+++ b/bin/custom-git-hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import subprocess
+
+WARNING = "\033[93m"
+COMMAND = "\033[1m\033[92m"
+RESET = "\033[0m"
+
+
+def check_for_dependency_changes():
+    diff_pre_merge_head_with_current_head = "git diff ORIG_HEAD HEAD --quiet --exit-code -- package*.json requirements/*.txt"
+    exit_code = subprocess.call(diff_pre_merge_head_with_current_head.split())
+
+    if exit_code == 1:
+        print(
+            WARNING,
+            "Dependency files have changed! Remember to install new dependencies with",
+            COMMAND,
+            "make preflight",
+            RESET,
+        )
+
+
+if __name__ == "__main__":
+    check_for_dependency_changes()


### PR DESCRIPTION
## Summary

Sometimes it's easy to miss that dependencies (Node and/or Python) need updating after a pull on `main`. This changeset adds a git hook that, when installed, will fire after a merge and print out a reminder message if deps need updating:

<img width="808" alt="Screenshot 2024-04-06 at 21 02 06" src="https://github.com/mozilla/bedrock/assets/101457/289e85d8-ec8c-499a-9eee-0886ee9e9582">

(The pull contained more than just the files in the screenshot - it's a cropped screenshot)

It also adds commands to the `Makefile` to, er, make it easy to install and uninstall this custom hook

## Testing

I've tested this a fair bit locally, but the more testing the better, particularly if you _don't_ use git on the CLI 

* [x] Install the hook: `make install-custom-git-hooks`
* [x] Reset your git history back to before dependency-changes landed: `git reset --hard 3f2862423`
* [x] Pull in those changes from the remote, assuming you have the github.com/mozilla/bedrock origin set as `mozilla` : `git pull mozilla main`  else you can do `git pull origin main`
* [x] Confirm you see the message
* [x] Reset your git history back to a very recent commit with no dependency changes: `git reset --hard HEAD~1`
* [x] Pull in from the remote again
* [x] Confirm you _don't_ see the message
* [x] Uninstall the hook: `make uninstall-custom-git-hooks`
* [x] Reinstall the hook: `make install-custom-git-hooks` - assuming you want to use it!
