### PR TITLE
Removed download CTA in `/firefox/features/` pages for Firefox mobile

### DIFF
--- a/media/js/firefox/features/features-article.es6.js
+++ b/media/js/firefox/features/features-article.es6.js
@@ -8,7 +8,11 @@ const client = Mozilla.Client;
 const footerCta = document.querySelector('.c-feature-footer');
 
 (function () {
-    if (footerCta && client.isFirefoxDesktop) {
+    if (
+        (footerCta && client.isFirefoxDesktop) ||
+        (footerCta && client.isFirefoxAndroid) ||
+        (footerCta && client.isFirefoxiOS)
+    ) {
         footerCta.parentNode.removeChild(footerCta);
     }
 })(window.Mozilla);


### PR DESCRIPTION
## One-line summary
The Firefox download CTA shouldn't show in Firefox mobile apps, but it is on the `/features/` pages, so I patched that up.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/14429


## Testing

Open using your Firefox mobile browser on your phone and go to any of the features pages:

- [ ] https://www-demo5.allizom.org/en-US/firefox/features/
