### PR TITLE
Add Linux/ARM64 Firefox Nightly builds to firefox/all (Fixes #14414)

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -39,6 +39,7 @@ class FirefoxDesktop(_ProductDetails):
             ("win-msi", "Windows 32-bit MSI"),
             ("osx", "macOS"),
             ("linux64", "Linux 64-bit"),
+            ("linux64-aarch64", "Linux ARM64/AArch64"),
             ("linux", "Linux 32-bit"),
         ]
     )
@@ -46,7 +47,7 @@ class FirefoxDesktop(_ProductDetails):
     # Recommended/modern vs traditional/legacy platforms
     platform_classification = OrderedDict(
         [
-            ("recommended", ("win64", "win64-msi", "win64-aarch64", "osx", "linux64")),
+            ("recommended", ("win64", "win64-msi", "win64-aarch64", "osx", "linux64", "linux64-aarch64")),
             ("traditional", ("linux", "win", "win-msi")),
         ]
     )
@@ -89,6 +90,10 @@ class FirefoxDesktop(_ProductDetails):
                     platforms[platform] = self.platform_labels[platform]
         else:
             platforms = self.platform_labels.copy()
+
+        # Linux ARM64/AArch64 installers are only currently available for Nightly builds.
+        if channel != "nightly":
+            del platforms["linux64-aarch64"]
 
         return list(platforms.items())
 

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -344,7 +344,7 @@
     <li>
       <h2 class="c-help-title">{{ ftl('firefox-all-arm64-installers') }}</h2>
       <p class="c-help-desc">
-        {{ ftl('firefox-all-arm64-installers-optimized') }}
+        {{ ftl('firefox-all-arm64-installers-optimized-v2', fallback='firefox-all-arm64-installers-optimized') }}
       </p>
     </li>
   </ul>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -231,7 +231,7 @@ class TestFirefoxAll(TestCase):
 
         desktop_nightly_builds = len(self.firefox_desktop.get_filtered_full_builds("nightly"))
         assert len(doc('.c-locale-list[data-product="desktop_nightly"] > li')) == desktop_nightly_builds
-        assert len(doc('.c-locale-list[data-product="desktop_nightly"] > li[data-language="en-US"] > ul > li > a')) == 8
+        assert len(doc('.c-locale-list[data-product="desktop_nightly"] > li[data-language="en-US"] > ul > li > a')) == 9
 
         desktop_esr_builds = len(self.firefox_desktop.get_filtered_full_builds("esr"))
         assert len(doc('.c-locale-list[data-product="desktop_esr"] > li')) == desktop_esr_builds

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -185,14 +185,15 @@ class TestDownloadButtons(TestCase):
         )
 
         list = doc(".download-list li")
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr("class") == "os_win"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
         assert pq(list[3]).attr("class") == "os_win-msi"
         assert pq(list[4]).attr("class") == "os_osx"
         assert pq(list[5]).attr("class") == "os_linux64"
-        assert pq(list[6]).attr("class") == "os_linux"
+        assert pq(list[6]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[7]).attr("class") == "os_linux"
         # stub disabled for now for non-en-US locales
         # bug 1339870
         # assert 'stub' in pq(pq(list[1]).find('a')[0]).attr('href')
@@ -468,14 +469,15 @@ class TestDownloadList(TestCase):
 
         # Check that links classes are ordered as expected.
         list = doc(".download-platform-list li")
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr("class") == "os_win"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
         assert pq(list[3]).attr("class") == "os_osx"
         assert pq(list[4]).attr("class") == "os_linux64"
-        assert pq(list[5]).attr("class") == "os_linux"
-        assert pq(list[6]).attr("class") == "os_win-msi"
+        assert pq(list[5]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[6]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_win-msi"
 
         links = doc(".download-platform-list a")
 

--- a/l10n/en/firefox/all.ftl
+++ b/l10n/en/firefox/all.ftl
@@ -39,7 +39,11 @@ firefox-all-test-your-sites-against = Test your sites against soon-to-be-release
 firefox-all-count-on-stability-and = Count on stability and ease of use with this { -brand-name-firefox } browser built for enterprise.
 firefox-all-windows-installers-for = Windows installers for corporate IT that simplify the configuration, deployment and management of the { -brand-name-firefox-browser }.
 firefox-all-arm64-installers = ARM64/AArch64 installers
+firefox-all-arm64-installers-optimized-v2 = ARM64/AArch64 installers optimized for Windows and Linux PCs.
+
+# Obsolete string (expires: 2024-06-04)
 firefox-all-arm64-installers-optimized = ARM64/AArch64 installers optimized for Snapdragon-powered { -brand-name-windows } PCs.
+
 firefox-all-product-send-link = Send a download link to your phone
 
 # Variables:

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -73,6 +73,7 @@ ul.download-list {
 .download-button .os_win64-aarch64,
 .download-button .os_linux,
 .download-button .os_linux64,
+.download-button .os_linux64-aarch64,
 .android .download-button-desktop,
 .download-button .os_win,
 .download-button .os_win-msi,


### PR DESCRIPTION
## One-line summary

Adds "Linux ARM64/AArch64" as an installer option for Firefox Nightly on the `/firefox/all/` page.

## Issue / Bugzilla link

#14414

## Testing

- [ ] Linux ARM builds are available for Nightly only at http://localhost:8000/en-US/firefox/all/#product-desktop-nightly