### PR TITLE
Update newsletter IDs to match Braze migration

### DIFF
--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -545,28 +545,17 @@ class TestFirefoxURL(TestCase):
             "",
             {"newsletter_id": "download-firefox-mobile"},
         ),
+        # Android and iOS platforms should have the same newsletter_id since they share the same email template.
         (
             "platform='android'",
-            {"newsletter_id": "download-firefox-android"},
-        ),
-        (
-            "platform='ios'",
-            {"newsletter_id": "download-firefox-ios"},
-        ),
-        (
-            "platform='all'",
             {"newsletter_id": "download-firefox-mobile"},
         ),
         (
-            "message_set='fx-android', platform='android'",
-            {"newsletter_id": "get-android-embed"},
+            "platform='ios'",
+            {"newsletter_id": "download-firefox-mobile"},
         ),
         (
-            "message_set='fx-android', platform='ios'",
-            {"newsletter_id": "download-firefox-ios"},
-        ),
-        (
-            "message_set='fx-android'",
+            "platform='all'",
             {"newsletter_id": "download-firefox-mobile"},
         ),
         (
@@ -575,27 +564,11 @@ class TestFirefoxURL(TestCase):
         ),
         (
             "message_set='fx-whatsnew'",
-            {"newsletter_id": "download-firefox-mobile-whatsnew"},
-        ),
-        (
-            "message_set='fx-focus'",
-            {"newsletter_id": "download-focus-mobile-whatsnew"},
-        ),
-        (
-            "message_set='fx-klar'",
-            {"newsletter_id": "download-klar-mobile-whatsnew"},
-        ),
-        (
-            "message_set='download-firefox-rocket'",
-            {"newsletter_id": "download-firefox-rocket"},
+            {"newsletter_id": "download-firefox-mobile"},
         ),
         (
             "message_set='firefox-mobile-welcome'",
             {"newsletter_id": "firefox-mobile-welcome"},
-        ),
-        (
-            "message_set='lockwise-welcome-download'",
-            {"newsletter_id": "lockwise-welcome-download"},
         ),
     ],
 )

--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -32,12 +32,6 @@
   "download-firefox-android": {
     "title": "{{ ftl('newsletters-download-firefox-for-android')|striptags }}"
   },
-  "download-firefox-androidsn": {
-    "title": "{{ ftl('newsletters-get-firefox-for-android')|striptags }}"
-  },
-  "download-firefox-androidsnus": {
-    "title": "{{ ftl('newsletters-get-firefox-for-android')|striptags }}"
-  },
   "download-firefox-ios": {
     "title": "{{ ftl('newsletters-download-firefox-for-ios')|striptags }}"
   },
@@ -109,12 +103,6 @@
   "marketplace": {
     "description": "{{ ftl('newsletters-discover-the-latest')|striptags }}",
     "title": "{{ ftl('newsletters-firefox-os')|striptags }}"
-  },
-  "marketplace-android": {
-    "title": "{{ ftl('newsletters-android')|striptags }}"
-  },
-  "marketplace-desktop": {
-    "title": "{{ ftl('newsletters-desktop')|striptags }}"
   },
   "mobile": {
     "description": "{{ ftl('newsletters-keep-up-with-releases')|striptags }}",

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -944,15 +944,6 @@ SEND_TO_DEVICE_LOCALES = ["de", "en-GB", "en-US", "es-AR", "es-CL", "es-ES", "es
 SEND_TO_DEVICE_MESSAGE_SETS = {
     "default": {
         "email": {
-            "android": "download-firefox-android",
-            "ios": "download-firefox-ios",
-            "all": "download-firefox-mobile",
-        }
-    },
-    "fx-android": {
-        "email": {
-            "android": "get-android-embed",
-            "ios": "download-firefox-ios",
             "all": "download-firefox-mobile",
         }
     },
@@ -963,32 +954,12 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
     },
     "fx-whatsnew": {
         "email": {
-            "all": "download-firefox-mobile-whatsnew",
-        }
-    },
-    "fx-focus": {
-        "email": {
-            "all": "download-focus-mobile-whatsnew",
-        }
-    },
-    "fx-klar": {
-        "email": {
-            "all": "download-klar-mobile-whatsnew",
-        }
-    },
-    "download-firefox-rocket": {
-        "email": {
-            "all": "download-firefox-rocket",
+            "all": "download-firefox-mobile",
         }
     },
     "firefox-mobile-welcome": {
         "email": {
             "all": "firefox-mobile-welcome",
-        }
-    },
-    "lockwise-welcome-download": {
-        "email": {
-            "all": "lockwise-welcome-download",
         }
     },
 }

--- a/docs/send-to-device.rst
+++ b/docs/send-to-device.rst
@@ -52,7 +52,7 @@ The Jinja macro supports parameters as follows (* indicates a required parameter
 +======================+========================================================================+======================+====================================================================+
 |    platform*         | Platform ID for the receiving device. Defaults to 'all'.               | String               | 'all', 'android', 'ios'                                            |
 +----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+
-|    message_set*      | ID for the email that should be received. Defaults to 'default'.       | String               | 'default', 'fx-mobile-download-desktop', 'download-firefox-rocket' |
+|    message_set*      | ID for the email that should be received. Defaults to 'default'.       | String               | 'default', 'fx-mobile-download-desktop', 'fx-whatsnew'             |
 +----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+
 |    dom_id*           | HTML form ID. Defaults to 'send-to-device'.                            | String               | 'send-to-device'                                                   |
 +----------------------+------------------------------------------------------------------------+----------------------+--------------------------------------------------------------------+

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -203,9 +203,6 @@ newsletters-get-all-the-knowledge = Get all the knowledge you need to stay safer
 newsletters-about-labs = About Labs
 
 # Name for the newsletter in Newsletter subscription page
-newsletters-desktop = Desktop
-
-# Name for the newsletter in Newsletter subscription page
 newsletters-mozillians = Mozillians
 
 # Description for the newsletter in Newsletter subscription page (Mozillians)
@@ -384,9 +381,6 @@ newsletters-welcome-emails = Welcome emails
 
 # Description for the newsletter in Newsletter subscription page (Welcome emails)
 newsletter-welcome-emails-that-get-you = Welcome emails that get you started using our products and services.
-
-# Name for the newsletter in Newsletter subscription page
-newsletters-android = { -brand-name-android }
 
 # Headline for https://www-dev.allizom.org/newsletter/knowledge-is-power
 newsletters-subscribe-to-the-newsletter = Subscribe to the newsletter

--- a/tests/unit/spec/newsletter/data.js
+++ b/tests/unit/spec/newsletter/data.js
@@ -824,12 +824,6 @@ const stringData = {
     'download-firefox-android': {
         title: 'Download Firefox for Android'
     },
-    'download-firefox-androidsn': {
-        title: 'Get Firefox for Android'
-    },
-    'download-firefox-androidsnus': {
-        title: 'Get Firefox for Android'
-    },
     'download-firefox-ios': {
         title: 'Download Firefox for iOS'
     },
@@ -916,12 +910,6 @@ const stringData = {
     marketplace: {
         description: 'Discover the latest, coolest HTML5 apps on Firefox OS.',
         title: 'Firefox OS'
-    },
-    'marketplace-android': {
-        title: 'Android'
-    },
-    'marketplace-desktop': {
-        title: 'Desktop'
     },
     mobile: {
         description:


### PR DESCRIPTION
## One-line summary

This drops some old unused newsletter IDs and combines the android/iOS since they use the same email template. This also replaces the "download-firefox-mobile-whatsnew" email to use the "download-firefox-mobile" email which we were already doing in Acoustic but this simplifies the set up for Braze, dropping the need to create extra events and campaigns for these.


