### PR TITLE
Update Dockerfile chown separators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ COPY ./tests ./tests
 
 RUN bin/run-sync-all.sh
 
-RUN chown webdev.webdev -R .
+RUN chown webdev:webdev -R .
 
 # for bpython
 RUN mkdir /home/webdev/
@@ -136,7 +136,7 @@ COPY --from=assets /app/assets /app/assets
 RUN honcho run --env docker/envfiles/prod.env docker/bin/build_staticfiles.sh
 
 # Change User
-RUN chown webdev.webdev -R .
+RUN chown webdev:webdev -R .
 USER webdev
 
 # build args


### PR DESCRIPTION
## One-line summary

Silencing warnings by abandoning 20th century syntax;)

## Significant changes and points to review

This is now POSIX-friendly to be more futureproof…

## Testing

[runs/8623777967/job/23637585321?pr=14438#step:4:5445](https://github.com/mozilla/bedrock/actions/runs/8623777967/job/23637585321?pr=14438#step:4:5445) (before)
vs.
[/runs/8623995234/job/23638213885?pr=14439#step:4:5495](https://github.com/mozilla/bedrock/actions/runs/8623995234/job/23638213885?pr=14439#step:4:5495) (after)