### PR TITLE
Add download CTA for `fr` and `de` /features/private/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/features/private.html
+++ b/bedrock/firefox/templates/firefox/features/private.html
@@ -16,6 +16,12 @@
 <p>{{ ftl('features-private-firefox-also-protects-your', url='https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features') }}</p>
 <p>{{ ftl('features-private-sidenote-we-are-not-big-tech') }}</p>
 
+{% if LANG in ['fr', 'de'] %}
+  <div class="c-firefox-download">
+    {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
+  </div>
+{% endif %}
+
 <h2>{{ ftl('features-private-what-information-does-firefox') }}</h2>
 <p>{{ ftl('features-private-mozilla-the-maker-of-firefox', url=url('firefox.privacy.index')) }}</p>
 <p>{{ ftl('features-private-read-firefoxs-privacy-notice', url=url('privacy.notices.firefox')) }}</p>

--- a/bedrock/firefox/templates/firefox/features/private.html
+++ b/bedrock/firefox/templates/firefox/features/private.html
@@ -17,8 +17,9 @@
 <p>{{ ftl('features-private-sidenote-we-are-not-big-tech') }}</p>
 
 {% if LANG in ['fr', 'de'] %}
-  <div class="c-firefox-download">
-    {{ download_firefox_thanks(dom_id='download-button-primary', download_location='primary') }}
+  <div class="c-firefox-midpage-cta">
+    <h3>{{ ftl('features-shared-footer-cta-title') }}</h3>
+    {{ download_firefox_thanks(alt_copy=ftl('download-button-download-firefox'), dom_id='features-midpage-download', button_class='mzp-t-product mzp-t-lg', download_location='primary') }}
   </div>
 {% endif %}
 

--- a/media/css/firefox/features/article.scss
+++ b/media/css/firefox/features/article.scss
@@ -87,3 +87,10 @@ $image-path: '/media/protocol/img';
         }
     }
 }
+
+.c-firefox-download {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: $spacing-2xl;
+}

--- a/media/css/firefox/features/article.scss
+++ b/media/css/firefox/features/article.scss
@@ -88,9 +88,7 @@ $image-path: '/media/protocol/img';
     }
 }
 
-.c-firefox-download {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.c-firefox-midpage-cta {
+    text-align: center;
     margin-top: $spacing-2xl;
 }

--- a/media/js/firefox/features/features-article.es6.js
+++ b/media/js/firefox/features/features-article.es6.js
@@ -6,13 +6,18 @@
 
 const client = Mozilla.Client;
 const footerCta = document.querySelector('.c-feature-footer');
+const midPageCta = document.querySelector('.c-firefox-midpage-cta');
 
 (function () {
     if (
         (footerCta && client.isFirefoxDesktop) ||
         (footerCta && client.isFirefoxAndroid) ||
-        (footerCta && client.isFirefoxiOS)
+        (footerCta && client.isFirefoxiOS) ||
+        (midPageCta && client.isFirefoxDesktop) ||
+        (midPageCta && client.isFirefoxAndroid) ||
+        (midPageCta && client.isFirefoxiOS)
     ) {
         footerCta.parentNode.removeChild(footerCta);
+        midPageCta.parentNode.removeChild(midPageCta);
     }
 })(window.Mozilla);

--- a/media/js/firefox/features/features-article.es6.js
+++ b/media/js/firefox/features/features-article.es6.js
@@ -8,16 +8,10 @@ const client = Mozilla.Client;
 const footerCta = document.querySelector('.c-feature-footer');
 const midPageCta = document.querySelector('.c-firefox-midpage-cta');
 
-(function () {
-    if (
-        (footerCta && client.isFirefoxDesktop) ||
-        (footerCta && client.isFirefoxAndroid) ||
-        (footerCta && client.isFirefoxiOS) ||
-        (midPageCta && client.isFirefoxDesktop) ||
-        (midPageCta && client.isFirefoxAndroid) ||
-        (midPageCta && client.isFirefoxiOS)
-    ) {
-        footerCta.parentNode.removeChild(footerCta);
-        midPageCta.parentNode.removeChild(midPageCta);
-    }
-})(window.Mozilla);
+if (midPageCta && client.isFirefox) {
+    midPageCta.parentNode.removeChild(midPageCta);
+}
+
+if (footerCta && client.isFirefox) {
+    footerCta.parentNode.removeChild(footerCta);
+}


### PR DESCRIPTION
## One-line summary
Marketing is testing out a campaign and they'd like to see what adding a Firefox download CTA to `/features/private/` page will result in

## Issue / Bugzilla link

Fixes https://github.com/mozilla/bedrock/issues/14428

## Testing

- [ ] http://localhost:8000/fr/firefox/features/private/
- [ ] http://localhost:8000/de/firefox/features/private/