### PR TITLE
Bump @sentry/browser to v7.111.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^2.0.1",
-        "@sentry/browser": "^7.88.0",
+        "@sentry/browser": "^7.111.0",
         "babel-loader": "^9.1.3",
         "caniuse-lite": "^1.0.30001605",
         "clean-webpack-plugin": "^4.0.0",
@@ -2248,87 +2248,102 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.88.0.tgz",
-      "integrity": "sha512-lbK6jgO1I0M96nZQ99mcLSZ55ebwPAP6LhEWhkmc+eAfy97VpiY+qsbmgsmOzCEPqMmEUCEcI0rEZ7fiye2v2Q==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.111.0.tgz",
+      "integrity": "sha512-xaKgPPDEirOan7c9HwzYA1KK87kRp/qfIx9ZKLOEtxwy6nqoMuSByGqSwm1Oqfcjpbd7y6/y+7Bw+69ZKNVLDQ==",
       "dependencies": {
-        "@sentry/core": "7.88.0",
-        "@sentry/types": "7.88.0",
-        "@sentry/utils": "7.88.0"
+        "@sentry/core": "7.111.0",
+        "@sentry/types": "7.111.0",
+        "@sentry/utils": "7.111.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.111.0.tgz",
+      "integrity": "sha512-3KPBIpiegTYmuVw9gA2aKuliAQONS3Ny1kJc9x5kz6XQGuLFxqlh6KzoCVaKfQJeq2WJqRNeR4KFFuNGuB3H8w==",
+      "dependencies": {
+        "@sentry/core": "7.111.0",
+        "@sentry/replay": "7.111.0",
+        "@sentry/types": "7.111.0",
+        "@sentry/utils": "7.111.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.88.0.tgz",
-      "integrity": "sha512-xXQdcYhsS+ourzJHjXNjZC9zakuc97udmpgaXRjEP7FjPYclIx+YXwgFBdHM2kzAwZLFOsEce5dr46GVXUDfZw==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.111.0.tgz",
+      "integrity": "sha512-CgXly8rsdu4loWVKi2RqpInH3C2cVBuaYsx4ZP5IJpzSinsUAMyyr3Pc0PZzCyoVpBBXGBGj/4HhFsY3q6Z0Vg==",
       "dependencies": {
-        "@sentry/core": "7.88.0",
-        "@sentry/types": "7.88.0",
-        "@sentry/utils": "7.88.0"
+        "@sentry/core": "7.111.0",
+        "@sentry/types": "7.111.0",
+        "@sentry/utils": "7.111.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.88.0.tgz",
-      "integrity": "sha512-il4x3PB99nuU/OJQw2RltgYYbo8vtnYoIgneOeEiw4m0ppK1nKkMkd3vDRipGL6E/0i7IUmQfYYy6U10J5Rx+g==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.111.0.tgz",
+      "integrity": "sha512-x7S9XoJh+TbMnur4eBhPpCVo+p7udABBV2gQk+Iw6LP9e8EFKmGmNyl76vSsT6GeFJ7mwxDEKfuwbVoLBjIvHw==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.88.0",
-        "@sentry-internal/tracing": "7.88.0",
-        "@sentry/core": "7.88.0",
-        "@sentry/replay": "7.88.0",
-        "@sentry/types": "7.88.0",
-        "@sentry/utils": "7.88.0"
+        "@sentry-internal/feedback": "7.111.0",
+        "@sentry-internal/replay-canvas": "7.111.0",
+        "@sentry-internal/tracing": "7.111.0",
+        "@sentry/core": "7.111.0",
+        "@sentry/replay": "7.111.0",
+        "@sentry/types": "7.111.0",
+        "@sentry/utils": "7.111.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.88.0.tgz",
-      "integrity": "sha512-Jzbb7dcwiCO7kI0a1w+32UzWxbEn2OcZWzp55QMEeAh6nZ/5CXhXwpuHi0tW7doPj+cJdmxMTMu9LqMVfdGkzQ==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.111.0.tgz",
+      "integrity": "sha512-/ljeMjZu8CSrLGrseBi/7S2zRIFsqMcvfyG6Nwgfc07J9nbHt8/MqouE1bXZfiaILqDBpK7BK9MLAAph4mkAWg==",
       "dependencies": {
-        "@sentry/types": "7.88.0",
-        "@sentry/utils": "7.88.0"
+        "@sentry/types": "7.111.0",
+        "@sentry/utils": "7.111.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.88.0.tgz",
-      "integrity": "sha512-em5dPKLPG7c/HGDbpIj3aHrWbA4iMwqjevqTzn+++KNO1YslkOosCaGsb1whU3AL1T9c3aIFIhZ4u3rNo+DxcA==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.111.0.tgz",
+      "integrity": "sha512-cSbI4A4hrO0sZ0ynvLQauPg8YyaDOQkhGkyvbws8W9WgfxR8X827bY9S0f1TPfgaFiVcKb0iRaAwyXHg3pyzOg==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.88.0",
-        "@sentry/core": "7.88.0",
-        "@sentry/types": "7.88.0",
-        "@sentry/utils": "7.88.0"
+        "@sentry-internal/tracing": "7.111.0",
+        "@sentry/core": "7.111.0",
+        "@sentry/types": "7.111.0",
+        "@sentry/utils": "7.111.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.88.0.tgz",
-      "integrity": "sha512-FvwvmX1pWAZKicPj4EpKyho8Wm+C4+r5LiepbbBF8oKwSPJdD2QV1fo/LWxsrzNxWOllFIVIXF5Ed3nPYQWpTw==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.111.0.tgz",
+      "integrity": "sha512-Oti4pgQ55+FBHKKcHGu51ZUxO1u52G5iVNK4mbtAN+5ArSCy/2s1H8IDJiOMswn3acfUnCR0oB/QsbEgAPZ26g==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.88.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.88.0.tgz",
-      "integrity": "sha512-ukminfRmdBXTzk49orwJf3Lu3hR60ZRHjE2a4IXwYhyDT6JJgJqgsq1hzGXx0AyFfyS4WhfZ6QUBy7fu3BScZQ==",
+      "version": "7.111.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.111.0.tgz",
+      "integrity": "sha512-CB5rz1EgCSwj3xoXogsCZ5pQtfERrURc/ItcCuoaijUhkD0iMq5MCNWMHW3mBsBrqx/Oba+XGvDu0t/5+SWwBg==",
       "dependencies": {
-        "@sentry/types": "7.88.0"
+        "@sentry/types": "7.111.0"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^2.0.1",
-    "@sentry/browser": "^7.88.0",
+    "@sentry/browser": "^7.111.0",
     "babel-loader": "^9.1.3",
     "caniuse-lite": "^1.0.30001605",
     "clean-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
## One-line summary

- Bumps @sentry/browser to v7.111.0.
- ~Also updates some deprecated function names in preparation for [migration of v7 -> v8](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub) in the near future.~

## Issue / Bugzilla link

N/A

## Testing

Set `SENTRY_FRONTEND_DSN=https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331` in your .env if you would like to test that Sentry initializes locally. You'll also need a browser with DNT disabled.

The main thing to check for is that no JS errors show in the console when `sentry.js` is executed.