### PR TITLE
Support CSP reporting for a configurable proportion of page requests

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -258,6 +258,13 @@ if DEV:
 CSP_REPORT_ONLY = config("CSP_REPORT_ONLY", default="false", parser=bool)
 CSP_REPORT_URI = config("CSP_REPORT_URI", default="") or None
 
+# Report violations on a small proportion of requests
+CSP_REPORT_PERCENTAGE = config(
+    "CSP_REPORT_PERCENTAGE",
+    default="0",
+    parser=float,
+)
+
 CSP_EXTRA_FRAME_SRC = config("CSP_EXTRA_FRAME_SRC", default="", parser=ListOf(str))
 if CSP_EXTRA_FRAME_SRC:
     CSP_CHILD_SRC += tuple(CSP_EXTRA_FRAME_SRC)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -577,7 +577,7 @@ MIDDLEWARE = [
 
 ENABLE_CSP_MIDDLEWARE = config("ENABLE_CSP_MIDDLEWARE", default="true", parser=bool)
 if ENABLE_CSP_MIDDLEWARE:
-    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+    MIDDLEWARE.append("csp.contrib.rate_limiting.RateLimitedCSPMiddleware")
 
 INSTALLED_APPS = [
     # Django contrib apps

--- a/bin/manual_qa/seek_csp_report_uri.py
+++ b/bin/manual_qa/seek_csp_report_uri.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import sys
+from collections import defaultdict
+
+import requests
+
+
+def check_for_report_uri(url, sample_size):
+    print(f"Checking {url}")
+    results = defaultdict(int)
+    for _ in range(sample_size):
+        resp = requests.get(url)
+
+        if "Content-Security-Policy" in resp.headers:
+            header = resp.headers["Content-Security-Policy"]
+            if "report-uri" in header:
+                results["report-uri present"] += 1
+            else:
+                results["report-uri not present"] += 1
+        else:
+            results["No CSP header"] += 1
+
+    print(f"{sample_size} requests made")
+    print(results)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        print(
+            "Usage: seek_scp_report_uri.py URL OPTIONAL_SAMPLE_SIZE\n",
+            "e.g. seek_scp_report_uri.py https://example.com/path/ 200",
+        )
+        sys.exit(1)
+
+    try:
+        url = sys.argv[1]
+    except IndexError:
+        print("A URL must be provided to check, ideally one not behind a CDN")
+        sys.exit(1)
+
+    try:
+        sample_size = int(sys.argv[2])
+    except ValueError:
+        print("A sample size must be provided as an integer")
+        sys.exit(1)
+    except IndexError:
+        sample_size = 100
+
+    check_for_report_uri(url, sample_size)

--- a/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml
+++ b/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml
@@ -4,7 +4,7 @@
 # If you need to add a secret, please consult with SRE or MEAO backend to
 # learn how to do this.
 # 
-# If you are looking for BOUNCER_URL or the related STUB_ATTRIBUTION_HMAC_KEY, 
+# If you are looking for BOUNCER_URL or the related STUB_ATTRIBUTION_HMAC_KEY,
 # please note that these are set in GCP Secrets, and never set here.
 
 ALLOWED_HOSTS: .allizom.org,.moz.works,.run.app
@@ -21,5 +21,7 @@ PROD_DETAILS_STORAGE: product_details.storage.PDDatabaseStorage
 RUN_SUPERVISOR: "True"
 SECURE_SSL_REDIRECT: "True"
 SENTRY_DSN: https://97ec0cd426714b728e92f3b3aa62f00b@o1069899.ingest.sentry.io/6260338
+CSP_REPORT_URI: https://o1069899.ingest.us.sentry.io/api/6260338/security/?sentry_key=97ec0cd426714b728e92f3b3aa62f00b
+CSP_REPORT_PERCENTAGE: "0.75"
 SITE_MODE: Mozorg
 SWITCH_NEWSLETTER_MAINTENANCE_MODE: "False"


### PR DESCRIPTION
## One-line summary

This changeset adds support for including a CSP report-uri in a certain percentage of pages, so that we can get an idea of whether pages have inappropriate CSP set, but without saturating our logging service, Sentry.

NB: the relevant config to enable this on Dev, Stage and Prod will be in a separate PR, and that work needs to be merged to make this changeset do anything.


## Issue / Bugzilla link

Resolves #14451

## Testing

I've added a script called `seek_csp_report_uri.py` which we can use to check the proportion of headers being set, either locally or on an actual server.

Here's some testing I've done with it:

With `CSP_REPORT_PERCENTAGE` not set as an env var
```
[steve] ~/Code/bedrock $ ./bin/manual_qa/seek_csp_report_uri.py http://localhost:8000/en-US/ 100
Checking http://localhost:8000/en-US/
100 requests made
defaultdict(<class 'int'>, {'report-uri not present': 100})
```

With `CSP_REPORT_PERCENTAGE`  set to 0.005 (which is what we'd start with in production)

```[steve] ~/Code/bedrock $ ./bin/manual_qa/seek_csp_report_uri.py http://localhost:8000/en-US/ 1000
Checking http://localhost:8000/en-US/
1000 requests made
defaultdict(<class 'int'>, {'report-uri not present': 995, 'report-uri present': 5})
```

On [mozorg-demo-8](https://www-demo8.allizom.org) with `CSP_REPORT_PERCENTAGE` set to 0.75:
```
[steve] ~/Code/bedrock $ ./bin/manual_qa/seek_csp_report_uri.py https://www-demo8.allizom.org/en-US/ 100
Checking https://www-demo8.allizom.org/en-US/
100 requests made
defaultdict(<class 'int'>, {'report-uri present': 74, 'report-uri not present': 26})
```

On pocket-demo-4 with `CSP_REPORT_PERCENTAGE` not set:

```
[steve] ~/Code/bedrock $ ./bin/manual_qa/seek_csp_report_uri.py https://www-demo4.tekcopteg.com/en-US/ 100                                       [14451-csp-fractional-reporting]
Checking https://www-demo4.tekcopteg.com/en-US/
100 requests made
defaultdict(<class 'int'>, {'report-uri not present': 100})
```

If you want to do the same
* Pull this branch
* Install `kent-server` (a fake Sentry from @willkg) with `pipx install kent`) and run it in it own shell: `kent-server run -p 8011` 
* in your `.env` file set:
```
CSP_REPORT_URI=http://public@127.0.0.1:8011/1/security
CSP_REPORT_PERCENTAGE="0.55"  # 55% of requests get the report-uri in the CSP header
```
 * Start your runserver in a separate shell
 * In a third shell, run the script to check your localhost's headers 200 times: `./bin/manual_qa/seek_csp_report_uri.py http://localhost:8000/en-US/ 200` and look at the results
