### PR TITLE
Fix fonts CSP for staging

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -248,6 +248,7 @@ CSP_IMG_SRC = CSP_DEFAULT_SRC + _csp_img_src
 
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + _csp_script_src
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + _csp_style_src
+CSP_FONT_SRC = CSP_DEFAULT_SRC + _csp_font_src
 CSP_CHILD_SRC = CSP_DEFAULT_SRC + _csp_child_src
 CSP_CONNECT_SRC = CSP_DEFAULT_SRC + _csp_connect_src
 
@@ -264,7 +265,6 @@ if CSP_EXTRA_FRAME_SRC:
 
 # support older browsers (mainly Safari)
 CSP_FRAME_SRC = CSP_CHILD_SRC
-CSP_FONT_SRC = _csp_font_src
 
 # 4. SETTINGS WHICH APPLY REGARDLESS OF SITE MODE
 if DEV:

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -154,10 +154,7 @@ if IS_POCKET_MODE:
     _csp_connect_extra_for_dev = [
         "com-getpocket-prod1.mini.snplow.net",
     ]
-    _csp_font_src = [
-        "'self'",
-        "assets.getpocket.com",
-    ]
+    _csp_font_src = []
 
 else:
     # Mozorg mode
@@ -217,9 +214,7 @@ else:
         "cjms.services.mozilla.com",
     ]
     _csp_connect_extra_for_dev = []
-    _csp_font_src = [
-        "'self'",
-    ]
+    _csp_font_src = []
 
 sys.stdout.write(f"Using SITE_MODE of '{site_mode}'\n")
 


### PR DESCRIPTION
## One-line summary

Expands `CSP_FONT_SRC` the same way addt'l hosts are added to e.g. `CSP_STYLE_SRC` to avoid surprises when run from different hosts as moz.works or run.app… (loaded from the same absolute URIs as styles, so to match the hosts…)

## Significant changes and points to review

The other rules start with defaults and add more values. Fonts are the exception to this, only specifying its values. This change makes it more consistent, also starting out with defaults (thus also covering anything needed for both mozorg & pocket mode straight away), that make the effective rule a bit wider than used to be — but basically matches what's in `style-src` anyways so that should be okay~ish.

This could be further optimised to only add `self` for prod, and the extra defaults only for dev or with extra defaults set only etc., but this is the least complicated change, even though the (prod) output is probably a little excessive:

### before:
- mozorg:
   - dev: `font-src 'self';`
   - prod: `font-src 'self';`
- pocket:
   - dev: `font-src 'self' assets.getpocket.com;`
   - prod: `font-src 'self' assets.getpocket.com;`

### after:
- mozorg:
   - dev: `font-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com *.allizom.org;`
   - prod: `font-src 'self' *.mozilla.net *.mozilla.org *.mozilla.com;`
- pocket:
   - dev: `font-src 'self' *.getpocket.com *.allizom.org;`
   - prod: `font-src 'self' *.getpocket.com;`

_(basically leaving out `font-src` completely and falling back to `default-src` would have the same effect, but this still retains the possibility to add more rules to the policy in settings, that's why the result is so verbose.)_

@stevejalim You can either try this in staging alone, or base the PR to be part of #14453 branch if you want to test it together, should be clean merge one way or another.

## Issue / Bugzilla link

Fixes #9869

## Testing

https://bedrock-stage.gcp.moz.works/ vs. http://localhost:8000/en-GB/
https://dev.tekcopteg.com/en/ vs. http://localhost:8000/en/