### PR TITLE
Redirect Firefox 125.0 release notes [fix #14467]

### DIFF
--- a/bedrock/releasenotes/redirects.py
+++ b/bedrock/releasenotes/redirects.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from bedrock.redirects.util import redirect
+
+redirectpatterns = (
+    # issue 14467
+    redirect(r"^firefox/125.0/releasenotes/?$", "/firefox/125.0.1/releasenotes/"),
+)

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1302,5 +1302,7 @@ URLS = flatten(
         url_test("/research/cc/", "https://foundation.mozilla.org/research/library/?topics=187"),
         # Issue 14222
         url_test("/firefox/browsers/", "/firefox/"),
+        # issue 14467
+        url_test("/firefox/125.0/releasenotes/", "/firefox/125.0.1/releasenotes/"),
     )
 )


### PR DESCRIPTION
## One-line summary
Redirects `/firefox/125.0/releasenotes/` to `/firefox/125.0.1/releasenotes/`

## Issue / Bugzilla link
#14467 

## Testing
http://localhost:8000/firefeox/125.0/releasenotes/