### PR TITLE
Fix copypaste error

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/features.html
@@ -164,7 +164,7 @@
     {% endcall %}
 
     {% call picto(
-      title=ftl('firefox-developer-visual-editing'),
+      title=ftl('firefox-developer-performance'),
       body=True,
       image=resp_img(
         url='img/firefox/developer/feature-performance.svg',


### PR DESCRIPTION
## One-line summary

[On the landing page](https://www.mozilla.org/en-US/firefox/developer/) of firefox developer edition, one section is showing wrong header, probably due to copy and paste error in template.

## Significant changes and points to review

None

## Issue / Bugzilla link

None

## Testing

None