### PR TITLE
Add referral tags to home & account product links

### DIFF
--- a/bedrock/mozorg/templates/mozorg/account.html
+++ b/bedrock/mozorg/templates/mozorg/account.html
@@ -9,6 +9,7 @@
 {% extends "base-protocol-mozilla.html" %}
 
 {% set _entrypoint = 'mozilla.org-firefox-accounts' %}
+{% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=account' %}
 
 {% block page_title %}{{ ftl('mozilla-accounts-get-a-mozilla-account', fallback='firefox-accounts-get-a-firefox-account') }}{% endblock %}
 
@@ -81,26 +82,15 @@
           {% endif %}
         </ul>
 
-        <a href="https://monitor.mozilla.org/">
-          {% set mozilla_monitor = switch('mozilla-monitor-brand-name') %}
-          <h4 class="mzp-c-wordmark mzp-t-wordmark-sm {% if mozilla_monitor %}t-product-mozilla-monitor{% else %}mzp-t-product-monitor{% endif %}">
-            {% if mozilla_monitor %}
-              {{ ftl('firefox-accounts-mozilla-monitor', fallback='firefox-accounts-firefox-monitor') }}
-            {% else %}
-              {{ ftl('firefox-accounts-firefox-monitor') }}
-            {% endif %}
-          </h4>
-        </a>
+        <a href="https://monitor.mozilla.org/{{ referrals }}" rel="external noopener"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm t-product-mozilla-monitor">{{ ftl('firefox-accounts-mozilla-monitor', fallback='firefox-accounts-firefox-monitor') }}</h4></a>
         <ul class="mzp-u-list-styled">
           <li>{% if LANG == 'en-US' %}Get automated removal of your exposed info from sites that are selling it{% else %}{{ ftl('firefox-accounts-get-email-alerts') }}{% endif %}</li>
         </ul>
 
-        {% if ftl_has_messages('firefox-accounts-protect-your-identity') %}
-        <a href="https://relay.firefox.com/"> <h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-relay">{{ ftl('firefox-accounts-firefox-relay') }}</h4></a>
+        <a href="https://relay.firefox.com/{{ referrals }}" rel="external noopener"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-relay">{{ ftl('firefox-accounts-firefox-relay') }}</h4></a>
         <ul class="mzp-u-list-styled">
           <li>{{ ftl('firefox-accounts-protect-your-identity') }}</li>
         </ul>
-        {% endif %}
 
         <a href="{{ url('products.vpn.landing') }}"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-vpn">{{ ftl('firefox-accounts-mozilla-vpn') }}</h4></a>
         <ul class="mzp-u-list-styled">
@@ -112,13 +102,11 @@
           {% endif %}
         </ul>
 
-        <a href="https://getpocket.com/"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-pocket">{{ ftl('firefox-accounts-pocket') }}</h4></a>
-        {% if ftl_has_messages('firefox-accounts-protect-your-identity') %}
+        <a href="https://getpocket.com/{{ referrals }}" rel="external noopener"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-pocket">{{ ftl('firefox-accounts-pocket') }}</h4></a>
         <ul class="mzp-u-list-styled">
           <li>{{ ftl('firefox-accounts-save-articles') }}</li>
           <li>{{ ftl('firefox-accounts-read-in-a') }}</li>
         </ul>
-        {% endif %}
       </div>
 
       <p class="c-accounts-tagline">{{ ftl('firefox-accounts-get-it-all-on-every') }}</p>

--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -49,7 +49,7 @@
   {% endif %}
 {% endblock %}
 
-{% set utm_params = '?utm_source=www.mozilla.org&utm_campaign=homepage&utm_medium=referral' %}
+{% set utm_params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage' %}
 
 {% block content %}
 
@@ -172,7 +172,7 @@
             ),
             body=True,
             ) %}
-          <a href="https://monitor.mozilla.org/" class="mzp-c-button mzp-t-secondary" id="homepage-get-monitor" data-cta-text="Get Mozilla Monitor" data-cta-type="link" rel="external noopener">{{ ftl('home-cta-get-monitor')}}</a>
+          <a href="https://monitor.mozilla.org/{{ utm_params }}" rel="external noopener" class="mzp-c-button mzp-t-secondary" id="homepage-get-monitor" data-cta-text="Get Mozilla Monitor" data-cta-type="link">{{ ftl('home-cta-get-monitor')}}</a>
         {% endcall %}
       {% endif %}
     </ul>
@@ -206,7 +206,7 @@
     ) %}
     <h2>{{ ftl('home-is-mozilla-a-corporation')}}</h2>
     <p>{{ ftl('home-mozilla-consists-of') }}</p>
-    <a href="https://foundation.mozilla.org/" class="mzp-c-button" rel="external noopener">
+    <a href="https://foundation.mozilla.org/{{ utm_params }}" rel="external noopener" class="mzp-c-button">
       <span>{{ ftl('home-learn-about-mofo') }}</span>
       <img src="{{ static('img/home/2023/external-link-white.png') }}" alt="" class="external-link-white">
       <img src="{{ static('img/home/2023/external-link-black.png') }}" alt="" class="external-link-black">


### PR DESCRIPTION
## One-line summary

Adds most prominent missing `utm_params` to products / own external links.

## Significant changes and points to review

- This is just the low-hanging fruit for #14432 with most impact, will look around some more for less prominent locations eventually, too.
- Also removes some passé branding switches, leaving that to ftl fallbacks now.
- Removes some /account ftl conditional logic that mostly doesn't work, when at it.

## Issue / Bugzilla link

#14432

## Testing

http://localhost:8000/en-GB/
http://localhost:8000/en-GB/account/