### PR TITLE
Fix sitemap generation

### DIFF
--- a/bedrock/sitemaps/management/commands/update_sitemaps.py
+++ b/bedrock/sitemaps/management/commands/update_sitemaps.py
@@ -7,6 +7,8 @@ from django.core.management.base import BaseCommand
 from bedrock.sitemaps.utils import update_sitemaps
 
 
+# Note that this command is only called by www-sitemap-generator, which uses the Docker image
+# of Bedrock to regenerate sitemap data
 class Command(BaseCommand):
     args = ""
     help = "Update XML sitemaps based on the list of localized pages."

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -120,6 +120,15 @@ def get_static_urls():
     for key, values in resolvers.get_resolver(None).reverse_dict.lists():
         for value in values:
             path = value[0][0][0]
+
+            # Re: https://github.com/mozilla/bedrock/issues/14480
+            # Since the refactor to use Django's i18n mechanism, not our
+            # original Prefixer, resolved URLs are automatically prepended
+            # with settings.LANGUAGE_CODE, which downstream use of this data
+            # is not expecting. The simplest fix is to drop that part of the path.
+            _lang_prefix = f"{settings.LANGUAGE_CODE}/"
+            path = path.replace(_lang_prefix, "", 1)
+
             # Exclude pages that we don't want be indexed by search engines.
             # Some other URLs are also unnecessary for the sitemap.
             if any(exclude.search(path) for exclude in excludes):


### PR DESCRIPTION
Since the refactor to use Django's i18n mechanism in #14256, not our original `Prefixer`, resolved URLs are automatically prepended with `settings.LANGUAGE_CODE`, which means the `update_sitemaps` management command (used by www-sitemap-generator) creates a sitemap.json containing paths prefixed with `en-US/`, which downstream use of this data for sitemap generation is not expecting. 

The simplest fix was to drop that part of the path.

## Issue / Bugzilla link

Resolves #14480

## Testing

Tricky to test end-to-end, or to write meaningful tests for, but I have extracted three examples of the sitemap.json file, showing that this changeset generates an identical (except for ordering of array elements) version of the data:

* `main` currently generates this: [broken_sitemap.json](https://github.com/mozilla/bedrock/files/15039955/broken_sitemap.json)  (36090 lines and en-US prefixing every path)
* The commit immediately to the i18n-refactor merge (b54650acf) generates this: [original_sitemap.json](https://github.com/mozilla/bedrock/files/15039958/original_sitemap.json)  (15146 lines, with no lang-code prefix on paths)
* The fixed version of the sitemap.json looks like this [fixed_sitemap.json](https://github.com/mozilla/bedrock/files/15039959/fixed_sitemap.json) (15146 lines and no lang-code prefix on paths)

