### PR TITLE
Add GreenletExit to list of unactionable exceptions that we don't send to Sentry

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -20,6 +20,7 @@ from django.utils.functional import lazy
 import markus
 import sentry_sdk
 from everett.manager import ListOf
+from greenlet import GreenletExit
 from sentry_processor import DesensitizationProcessor
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
@@ -1071,6 +1072,7 @@ SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
 SENTRY_IGNORE_ERRORS = (
     BrokenPipeError,
     ConnectionResetError,
+    GreenletExit,
 )
 
 


### PR DESCRIPTION
GreenletExits are currently at ~38k/day and eating quota, but we don't believe they are actually a problem as the traceback suggests it's a switch going on.

This changeset will stop them being sent to Sentry altogether.

Please only approve/merge if you agree that this is wise. We can still do further investigation into GreenletExceptions afterwards, but we won't have any fresh data/examples