### PR TITLE
Remove `mozilla_monitor` conditionals

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/best-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/best-browser.html
@@ -80,11 +80,7 @@
         {{ ftl('best-browser-last-but-not-least') }}
       </p>
       <p>
-        {% if ftl_has_messages('best-browser-firefox-is-offering-v2') and switch('mozilla-monitor-brand-name') %}
-          {{ ftl('best-browser-firefox-is-offering-v2', monitor='href="https://monitor.mozilla.org/"') }}
-        {% else %}
-          {{ ftl('best-browser-firefox-is-offering', monitor='https://monitor.mozilla.org/') }}
-        {% endif %}
+        {{ ftl('best-browser-firefox-is-offering-v2', monitor='href="https://monitor.mozilla.org/"') }}
       </p>
       <blockquote aria-hidden="true" role="presentation">
       <p>

--- a/bedrock/firefox/templates/firefox/privacy/book.html
+++ b/bedrock/firefox/templates/firefox/privacy/book.html
@@ -228,13 +228,7 @@
     <ol>
       <li>{{ ftl('privacy-book-search-your-name') }}</li>
       <li>{{ ftl('privacy-book-dont-have-time') }}</li>
-      <li>
-        {% if switch('mozilla-monitor-brand-name') %}
-          {{ ftl('privacy-book-breach-alert-if-v2', fallback='privacy-book-breach-alert-if') }}
-        {% else %}
-          {{ ftl('privacy-book-breach-alert-if') }}
-        {% endif %}
-      </li>
+      <li>{{ ftl('privacy-book-breach-alert-if-v2') }}</li>
     </ol>
   {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/privacy/passwords.html
+++ b/bedrock/firefox/templates/firefox/privacy/passwords.html
@@ -79,11 +79,7 @@
     {% set url_monitor = 'href="https://monitor.mozilla.org/" rel="external noopener"' %}
 
     <p>
-      {% if switch('mozilla-monitor-brand-name') %}
-        {{ ftl('privacy-passwords-use-mozilla-monitor', fallback='privacy-passwords-use-firefox-monitor', url_monitor=url_monitor) }}
-      {% else %}
-        {{ ftl('privacy-passwords-use-firefox-monitor', url_monitor=url_monitor) }}
-      {% endif %}
+        {{ ftl('privacy-passwords-use-mozilla-monitor', url_monitor=url_monitor) }}
     </p>
 
     <h2>{{ ftl('privacy-passwords-security-questions-my') }}</h2>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -148,27 +148,19 @@
       image=resp_img('img/firefox/privacy/products/monitor.svg', optional_attributes={ 'class': 'mzp-c-split-media-asset'}),
       media_class='mzp-l-split-h-center'
     ) %}
-      {% set mozilla_monitor = switch('mozilla-monitor-brand-name') %}
-      <div class="mzp-c-wordmark mzp-t-wordmark-md {% if mozilla_monitor %}t-product-mozilla-monitor{% else %}mzp-t-product-monitor{% endif %}">
+
+      <div class="mzp-c-wordmark mzp-t-wordmark-md t-product-mozilla-monitor">
         <h2>
-          {% if mozilla_monitor %}
-            {{ ftl('firefox-privacy-hub-mozilla-monitor', fallback='firefox-privacy-hub-firefox-monitor') }}
-          {% else %}
-            {{ ftl('firefox-privacy-hub-firefox-monitor') }}
-          {% endif %}
+          {{ ftl('firefox-privacy-hub-mozilla-monitor') }}
         </h2>
       </div>
       <p>
-        {% if mozilla_monitor %}
           {% if LANG == 'en-US' %}
             When you enter your email address in Mozilla Monitor, we forget it immediately after we’ve checked to see where your
             personal details have been exposed — unless you authorize us to continue monitoring your info for future exposures.
           {% else %}
-            {{ ftl('firefox-privacy-hub-when-you-enter-your-email-v2', fallback='firefox-privacy-hub-when-you-enter-your-email') }}
+            {{ ftl('firefox-privacy-hub-when-you-enter-your-email-v2') }}
           {% endif %}
-        {% else %}
-          {{ ftl('firefox-privacy-hub-when-you-enter-your-email') }}
-        {% endif %}
       </p>
       <p>
         <a class="mzp-c-cta-link" href="https://monitor.mozilla.org/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-monitor" data-cta-text="Check for breaches" data-cta-position="secondary">

--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -8,14 +8,8 @@
 
 {% extends "firefox/welcome/base.html" %}
 
-{% set mozilla_monitor = switch('mozilla-monitor-brand-name') %}
-
 {%- block page_title -%}
-  {%- if mozilla_monitor -%}
-    {{ ftl('welcome-page1-more-than-a-browser-mozilla', fallback='welcome-page1-more-than-a-browser-firefox') }}
-  {%- else -%}
-    {{ ftl('welcome-page1-more-than-a-browser-firefox') }}
-  {%- endif -%}
+    {{ ftl('welcome-page1-more-than-a-browser-mozilla') }}
 {%- endblock -%}
 
 {% block page_desc %}{{ ftl('welcome-page1-take-the-next-step-to-protect') }}{% endblock %}
@@ -33,7 +27,7 @@
 {% set _utm_campaign = 'welcome-1-monitor' %}
 {% set _cta_type = 'lifecycle-monitor' %}
 
-{% set hero_title = ftl('welcome-page1-stay-ahead-of-hackers-check-v2', fallback='welcome-page1-stay-ahead-of-hackers-check') if mozilla_monitor else ftl('welcome-page1-stay-ahead-of-hackers-check') %}
+{% set hero_title = ftl('welcome-page1-stay-ahead-of-hackers-check-v2')%}
 
 {% set _utm_content = 'stay-ahead-hackers' %}
 
@@ -62,20 +56,12 @@
 {% block content_primary %}
 <div class="body-primary">
   <h2 class="body-primary-title">
-    {% if mozilla_monitor %}
-      <img src="{{ static('img/logos/mozilla/monitor/wordmark.svg') }}" width="256" height="" alt="{{ ftl('welcome-page1-mozilla-monitor') }}">
-    {% else %}
-      <img src="{{ static('protocol/img/logos/firefox/monitor/logo-word-hor.svg') }}" width="256" height="" alt="{{ ftl('welcome-page1-firefox-monitor') }}">
-    {% endif %}
+    <img src="{{ static('img/logos/mozilla/monitor/wordmark.svg') }}" width="256" height="" alt="{{ ftl('welcome-page1-mozilla-monitor') }}">
   </h2>
 
   <div class="body-primary-body">
     <p>
-      {% if mozilla_monitor %}
-        {{ ftl('welcome-page1-mozilla-monitor-shows-you', fallback='welcome-page1-firefox-monitor-shows-you') }}
-      {% else %}
-        {{ ftl('welcome-page1-firefox-monitor-shows-you') }}
-      {% endif %}
+      {{ ftl('welcome-page1-mozilla-monitor-shows-you') }}
     </p>
   </div>
 </div>

--- a/bedrock/firefox/templates/firefox/welcome/page7.html
+++ b/bedrock/firefox/templates/firefox/welcome/page7.html
@@ -116,29 +116,20 @@
         {% endif %}
       </h3>
       <div class="c-picto-block-body">
-        {% set mozilla_monitor = switch('mozilla-monitor-brand-name') %}
         <p>
-          {% if mozilla_monitor %}
             {% if LANG == "en-US" %}
               Mozilla Monitor lets you see if you’ve been part of a data breach. And if you have, it automatically gets your private info back for you and continually monitors your identity for new leaks.
             {% else %}
-              {{ ftl('page7-firefox-monitor-lets-you-find-v2', fallback='page7-firefox-monitor-lets-you-find') }}
+              {{ ftl('page7-firefox-monitor-lets-you-find-v2')}}
             {% endif %}
-          {% else %}
-            {{ ftl('page7-firefox-monitor-lets-you-find') }}
-          {% endif %}
         </p>
         <a href="https://monitor.mozilla.org/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
           <strong>
-            {% if mozilla_monitor %}
               {% if LANG == "en-US" %}
                 Check for breaches now
               {% else %}
-                {{ ftl('page7-get-mozilla-monitor', fallback='page7-get-firefox-monitor') }}
+                {{ ftl('page7-get-mozilla-monitor') }}
               {% endif %}
-            {% else %}
-              {{ ftl('page7-get-firefox-monitor') }}
-            {% endif %}
           </strong>
         </a>
       </div>

--- a/bedrock/firefox/templates/firefox/welcome/page8.html
+++ b/bedrock/firefox/templates/firefox/welcome/page8.html
@@ -57,13 +57,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" width="48px" alt="">
       </div>
-      {% set mozilla_monitor = switch('mozilla-monitor-brand-name') %}
+
       <h3 class="c-picto-block-title">
-        {% if mozilla_monitor %}
-          {{ ftl('welcome-page8-mozilla-monitor', fallback='welcome-page8-firefox-monitor') }}
-        {% else %}
-          {{ ftl('welcome-page8-firefox-monitor') }}
-        {% endif %}
+          {{ ftl('welcome-page8-mozilla-monitor')}}
       </h3>
       <div class="c-picto-block-body">
       {% if LANG == "en-US" %}

--- a/bedrock/mozorg/templates/mozorg/account.html
+++ b/bedrock/mozorg/templates/mozorg/account.html
@@ -82,7 +82,7 @@
           {% endif %}
         </ul>
 
-        <a href="https://monitor.mozilla.org/{{ referrals }}" rel="external noopener"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm t-product-mozilla-monitor">{{ ftl('firefox-accounts-mozilla-monitor', fallback='firefox-accounts-firefox-monitor') }}</h4></a>
+        <a href="https://monitor.mozilla.org/{{ referrals }}" rel="external noopener"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm t-product-mozilla-monitor">{{ ftl('firefox-accounts-mozilla-monitor') }}</h4></a>
         <ul class="mzp-u-list-styled">
           <li>{% if LANG == 'en-US' %}Get automated removal of your exposed info from sites that are selling it{% else %}{{ ftl('firefox-accounts-get-email-alerts') }}{% endif %}</li>
         </ul>

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -118,35 +118,23 @@
                   link_url=url('firefox.browsers.mobile.index'),
                 )}}
 
-                {% if switch('mozilla-monitor-brand-name') %}
-                  {% if LANG == 'en-US' %}
-                    {% set title = 'Reclaim your stolen info from hackers'%}
-                    {% set desc = 'Mozilla Monitor lets you see if you’ve been part of a data breach and automatically gets your stolen info back.' %}
-                  {% else %}
-                    {% set title = ftl('newsletters-check-for-data-breaches') %}
-                    {% set desc = ftl('newsletters-mozilla-monitor-is-a-free', fallback='newsletters-firefox-monitor-is-a-free') %}
-                  {% endif %}
-
-                  {{ card(
-                    title=title,
-                    ga_title=title,
-                    desc=desc,
-                    cta=ftl('newsletters-sign-in-to-monitor'),
-                    image=resp_img('img/newsletter/confirm/mozilla-monitor.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-                    aspect_ratio='mzp-has-aspect-16-9',
-                    link_url='https://monitor.mozilla.org/',
-                  )}}
+                {% if LANG == 'en-US' %}
+                  {% set title = 'Reclaim your stolen info from hackers'%}
+                  {% set desc = 'Mozilla Monitor lets you see if you’ve been part of a data breach and automatically gets your stolen info back.' %}
                 {% else %}
-                  {{ card(
-                    title=ftl('newsletters-check-for-data-breaches'),
-                    ga_title='Check for data breaches',
-                    desc=ftl('newsletters-firefox-monitor-is-a-free'),
-                    cta=ftl('newsletters-sign-in-to-monitor'),
-                    image=resp_img('img/newsletter/confirm/monitor.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-                    aspect_ratio='mzp-has-aspect-16-9',
-                    link_url='https://monitor.mozilla.org/',
-                  )}}
+                  {% set title = ftl('newsletters-check-for-data-breaches') %}
+                  {% set desc = ftl('newsletters-mozilla-monitor-is-a-free')%}
                 {% endif %}
+
+                {{ card(
+                  title=title,
+                  ga_title=title,
+                  desc=desc,
+                  cta=ftl('newsletters-sign-in-to-monitor'),
+                  image=resp_img('img/newsletter/confirm/mozilla-monitor.png', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
+                  aspect_ratio='mzp-has-aspect-16-9',
+                  link_url='https://monitor.mozilla.org/',
+                )}}
 
                 {{ card(
                   title=ftl('newsletters-meet-our-parent-brand'),

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -69,9 +69,6 @@
 -brand-name-firefox-devtools = Firefox DevTools
 -brand-name-firefox-lockwise = Firefox Lockwise
 
-# Obsolete brand name
--brand-name-firefox-monitor = Firefox Monitor
-
 -brand-name-firefox-private-network = Firefox Private Network
 -brand-name-firefox-relay-premium = Firefox Relay Premium
 -brand-name-firefox-relay = Firefox Relay

--- a/l10n/en/firefox/accounts.ftl
+++ b/l10n/en/firefox/accounts.ftl
@@ -62,9 +62,6 @@ firefox-accounts-get-it-all-on-every = Get it all on every device, without feeli
 firefox-accounts-firefox-browser = { -brand-name-firefox-browser }
 firefox-accounts-mozilla-monitor = { -brand-name-mozilla-monitor }
 
-# Obsolete string
-firefox-accounts-firefox-monitor = { -brand-name-firefox-monitor }
-
 firefox-accounts-mozilla-relay = { -brand-name-firefox-relay }
 firefox-accounts-mozilla-vpn = { -brand-name-mozilla-vpn }
 firefox-accounts-pocket = { -brand-name-pocket }

--- a/l10n/en/firefox/browsers/best-browser.ftl
+++ b/l10n/en/firefox/browsers/best-browser.ftl
@@ -32,11 +32,6 @@ best-browser-last-but-not-least = Last but not least, a safe browser should offe
 # $monitor (url) - link to https://www.mozilla.org/products/monitor/
 best-browser-firefox-is-offering-v2 = { -brand-name-firefox } is offering something new to keep you safe: <a { $monitor }>{ -brand-name-mozilla-monitor }</a>. It’s a free service that will alert you if there are any public hacks on your accounts and let you know if your accounts got hacked in the past. Another neat feature is the Green Lock. It looks like a small green icon at the top left side of the browser window. If you’re on { -brand-name-firefox } and see the green lock, it means the website is encrypted and secure. If the lock is grey, you might want to think twice about entering any sensitive information.
 
-# Obsolete string
-# Variables:
-# $monitor (url) - link to https://monitor.mozilla.org
-best-browser-firefox-is-offering = { -brand-name-firefox } is offering something new to keep you safe: <a href="{ $monitor }">{ -brand-name-firefox-monitor }</a>. It’s a free service that will alert you if there are any public hacks on your accounts and let you know if your accounts got hacked in the past. Another neat feature is the Green Lock. It looks like a small green icon at the top left side of the browser window. If you’re on { -brand-name-firefox } and see the green lock, it means the website is encrypted and secure. If the lock is grey, you might want to think twice about entering any sensitive information.
-
 best-browser-we-visit-hundreds-or = We visit hundreds or even thousands of websites each day, and you can’t expect users to make security and privacy decisions for each of these sites. That is why a browser that gives you more control is so important - because it offers real, meaningful protection.
 best-browser-a-browser-that-minds = A browser that minds its business.
 best-browser-privacy-on-the-web = Privacy on the web is a hot button issue. If privacy is number one on your list of priorities, you want to look for a browser that takes that seriously. When choosing the best private browser for you, look at the tracking policy and how a browser handles your data. These seem like technical questions, but they’re the reason some browsers are more private than others.

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -160,9 +160,6 @@ firefox-desktop-download-questions = Questions? <a { $attrs }>{ -brand-name-mozi
 
 firefox-desktop-download-watch-for-hackers-with-v3 = Watch for hackers with { -brand-name-mozilla-monitor }, protect your email address with { -brand-name-firefox-relay }, and more.
 
-# Obsolete string
-firefox-desktop-download-watch-for-hackers-with-v2 = Watch for hackers with { -brand-name-firefox-monitor }, protect your email address with { -brand-name-firefox-relay }, and more.
-
 ## URL: https://www-dev.allizom.org/firefox/download/thanks/
 
 firefox-desktop-download-almost-there = Almost there!

--- a/l10n/en/firefox/privacy-hub.ftl
+++ b/l10n/en/firefox/privacy-hub.ftl
@@ -94,13 +94,8 @@ firefox-privacy-hub-more-than-s-trackers-blocked = More than { $trackers } track
 
 firefox-privacy-hub-mozilla-monitor = { -brand-name-mozilla-monitor }
 
-# Obsolete string
-firefox-privacy-hub-firefox-monitor = { -brand-name-firefox-monitor }
-
 firefox-privacy-hub-when-you-enter-your-email-v2 = When you enter your email address in { -brand-name-mozilla-monitor }, we forget it immediately after we’ve checked for a match in known data breaches — unless you authorize us to continue monitoring new breaches for your personal information.
 
-# Obsolete string
-firefox-privacy-hub-when-you-enter-your-email = When you enter your email address in { -brand-name-firefox-monitor }, we forget it immediately after we’ve checked for a match in known data breaches — unless you authorize us to continue monitoring new breaches for your personal information.
 firefox-privacy-hub-check-for-breaches = Check for breaches
 firefox-privacy-hub-firefox-lockwise = { -brand-name-firefox-lockwise }
 firefox-privacy-hub-the-passwords-and-credentials = The passwords and credentials you save in { -brand-name-firefox-lockwise } are encrypted on all your devices, so not even we can see them.

--- a/l10n/en/firefox/privacy/book.ftl
+++ b/l10n/en/firefox/privacy/book.ftl
@@ -110,9 +110,6 @@ privacy-book-dont-have-time = <strong>Don’t have time?</strong> Set up a { -br
 
 privacy-book-breach-alert-if-v2 = <strong>Breach alert:</strong> If your data actually becomes public through a known breach, it is crucial to react as quickly as possible and change your passwords. { -brand-name-mozilla-monitor } is a handy tool that will send you a message if that happens.
 
-# Obsolete string
-privacy-book-breach-alert-if = <strong>Breach alert:</strong> If your data actually becomes public through a known breach, it is crucial to react as quickly as possible and change your passwords. { -brand-name-firefox-monitor } is a handy tool that will send you a message if that happens.
-
 privacy-book-stay-safe-online = Stay safe online:
 
 privacy-book-there-are-a = There are a bunch of tools that can help improve your level of privacy and security. And that’s great! However, you’ll still require passwords to protect your accounts. Would you expect the newest high-end home security system to protect you from burglars if you had no apartment door? Here’s what to do:

--- a/l10n/en/firefox/privacy/passwords.ftl
+++ b/l10n/en/firefox/privacy/passwords.ftl
@@ -50,10 +50,6 @@ privacy-passwords-when-an-attacker = When an attacker steals the password databa
 #   $url_monitor (string) - link to https://monitor.mozilla.org/ with additional attributes for analytics
 privacy-passwords-use-mozilla-monitor = Use <a { $url_monitor }>{ -brand-name-mozilla-monitor }</a> to keep an eye on email addresses associated with your accounts. If your email address appears in a known corporate data breach, you’ll be alerted and provided steps to follow to protect the affected account.
 
-# Obsolete string
-#   $url_monitor (string) - link to https://monitor.mozilla.org/ with additional attributes for analytics
-privacy-passwords-use-firefox-monitor = Use <a { $url_monitor }>{ -brand-name-firefox-monitor }</a> to keep an eye on email addresses associated with your accounts. If your email address appears in a known corporate data breach, you’ll be alerted and provided steps to follow to protect the affected account.
-
 privacy-passwords-security-questions-my = Security Questions: My mother’s maiden name is “Ff926AKa9j6Q”
 privacy-passwords-finally-most-websites = Finally, most websites let you recover your password if you’ve forgotten it. Usually these systems make you answer some “security questions” before you can reset your password. <strong>The answers to these questions need to be just as secret as your password.</strong> Otherwise, an attacker can guess the answers and set your password to something they know.
 privacy-passwords-randomness-can-be = Randomness can be a problem, since the security questions that sites often use are also things people tend to know about you, like your birthplace, your birthday, or your relatives’ names, or that can be gleaned from sources such as social media. The good news is that the website doesn’t care whether the answer is real or not — you can lie! But lie productively: <strong>Give answers to the security questions that are long and random,</strong> like your passwords.

--- a/l10n/en/firefox/welcome/page1.ftl
+++ b/l10n/en/firefox/welcome/page1.ftl
@@ -15,21 +15,13 @@ welcome-page1-take-the-next-step-to-protect = Take the next step to protect your
 
 welcome-page1-stay-ahead-of-hackers-check-v2 = Stay ahead of hackers. Check for data breaches with { -brand-name-mozilla-monitor }.
 
-# Obsolete string
-welcome-page1-stay-ahead-of-hackers-check = Stay ahead of hackers. Check for data breaches with { -brand-name-firefox-monitor }.
 welcome-page1-youre-on-track-to-stay-protected = You’re on track to stay protected
 welcome-page1-youve-got-the-web-browser = You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
 welcome-page1-check-your-breach-report = Check Your Breach Report
 
 welcome-page1-mozilla-monitor = { -brand-name-mozilla-monitor }
 
-# Obsolete string
-welcome-page1-firefox-monitor = { -brand-name-firefox-monitor }
-
 welcome-page1-mozilla-monitor-shows-you = { -brand-name-mozilla-monitor } shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
-
-# Obsolete string
-welcome-page1-firefox-monitor-shows-you = { -brand-name-firefox-monitor } shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
 
 welcome-page1-stay-ahead-of-hackers = Stay ahead of hackers
 

--- a/l10n/en/firefox/welcome/page1.ftl
+++ b/l10n/en/firefox/welcome/page1.ftl
@@ -7,9 +7,6 @@
 # HTML page title
 welcome-page1-more-than-a-browser-mozilla = More than a browser - { -brand-name-mozilla-monitor } is your lookout for hackers
 
-# Outdated string
-welcome-page1-more-than-a-browser-firefox = More than a browser - { -brand-name-firefox-monitor } is your lookout for hackers
-
 # HTML page description
 welcome-page1-take-the-next-step-to-protect = Take the next step to protect your privacy online with the { -brand-name-firefox } family of products.
 

--- a/l10n/en/firefox/welcome/page7.ftl
+++ b/l10n/en/firefox/welcome/page7.ftl
@@ -22,12 +22,6 @@ page7-stay-ahead-of-hackers = Stay ahead of hackers
 
 page7-firefox-monitor-lets-you-find-v2 = { -brand-name-mozilla-monitor } lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)
 
-# Obsolete string
-page7-firefox-monitor-lets-you-find = { -brand-name-firefox-monitor } lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)
-
 page7-get-mozilla-monitor = Get { -brand-name-mozilla-monitor }
-
-# Obsolete string
-page7-get-firefox-monitor = Get { -brand-name-firefox-monitor }
 
 page7-why-am-i-seeing-this = Why am I seeing this?

--- a/l10n/en/firefox/welcome/page8.ftl
+++ b/l10n/en/firefox/welcome/page8.ftl
@@ -21,9 +21,6 @@ welcome-page8-see-whats-blocked = See what’s blocked
 
 welcome-page8-mozilla-monitor = { -brand-name-mozilla-monitor }
 
-# Obsolete string
-welcome-page8-firefox-monitor = { -brand-name-firefox-monitor }
-
 welcome-page8-see-what-youve-been = See if you’ve been involved in known online data breaches and take action to resolve them.
 welcome-page8-go-to-monitor = Go to { -brand-name-monitor }
 welcome-page8-firefox-send = { -brand-name-firefox-send }

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -156,9 +156,6 @@ newsletters-check-for-data-breaches = Check for data breaches
 
 newsletters-mozilla-monitor-is-a-free = { -brand-name-mozilla-monitor } is a free service that lets you see if you’ve been involved in an online data breach.
 
-# Obsolete string
-newsletters-firefox-monitor-is-a-free = { -brand-name-firefox-monitor } is a free service that lets you see if you’ve been involved in an online data breach.
-
 newsletters-sign-in-to-monitor = Sign In to { -brand-name-monitor }
 newsletters-meet-our-parent-brand = Meet our parent brand
 newsletters-mozilla-the-non-for-profit = { -brand-name-mozilla }, the not-for-profit behind { -brand-name-firefox }, puts people over profit in everything we say, build, and do.

--- a/l10n/en/navigation.ftl
+++ b/l10n/en/navigation.ftl
@@ -118,9 +118,6 @@ navigation-firefox-nightly = { -brand-name-firefox-nightly }
 navigation-firefox-reality = { -brand-name-firefox-reality }
 navigation-firefox-lockwise = { -brand-name-firefox-lockwise }
 
-# Obsolete string
-navigation-firefox-monitor = { -brand-name-firefox-monitor }
-
 navigation-firefox-send = { -brand-name-firefox-send }
 navigation-pocket = { -brand-name-pocket }
 navigation-common-voice = { -brand-name-common-voice }


### PR DESCRIPTION
## One-line summary
Removed the conditional since Mozilla Monitor has been out for quite some time now, and it's time to retire any of the old and obsolete Firefox Monitor strings and references.

Sibling PR for switch: https://github.com/mozmeao/www-config/pull/560


## Significant changes and points to review

- [ ] Removed conditionals from relevant HTML files
- [ ] Removed obsolete Firefox Monitor strings from relative Fluent files


## Issue / Bugzilla link
fixes https://github.com/mozilla/bedrock/issues/14492


## Testing

- [ ] http://localhost:8000/en-US/account/
- [ ] http://localhost:8000/en-US/firefox/welcome/1/
- [ ] http://localhost:8000/en-US/firefox/welcome/7
- [ ] http://localhost:8000/en-US/firefox/welcome/8
- [ ] http://localhost:8000/en-US/privacy/products/
- [ ] http://localhost:8000/en-US/products/
- [ ] http://localhost:8000/en-US/firefox/privacy/safe-passwords/
- [ ] http://localhost:8000/en-US/firefox/browsers/best-browser/
- [ ] http://localhost:8000/en-US/firefox/privacy/book/
