### PR TITLE
Ensure the lang-fixup redirects set a Vary header for Accept-Language

### DIFF
--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -64,7 +64,9 @@ class BedrockLangCodeFixupMiddleware(MiddlewareMixin):
         if request.GET:
             dest += f"?{request.GET.urlencode()}"
 
-        return HttpResponseRedirect(dest)
+        response = HttpResponseRedirect(dest)
+        response["Vary"] = "Accept-Language"
+        return response
 
     def process_request(self, request):
         # Initially see if we can separate a lang code from the rest of the URL

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -233,6 +233,7 @@ def test_BedrockLangCodeFixupMiddleware(
     if resp:
         assert resp.status_code == 302
         assert resp.headers["location"] == expected_dest
+        assert resp.headers["vary"].lower() == "accept-language"
     else:
         # the request will have been annotated by the middleware
         assert request.locale == expected_request_locale


### PR DESCRIPTION
Previously, we relied on similar code deep in lib.l10n_utils.render, but BedrockLangFixupMiddleware runs way before then, so we need(ed) to add the Vary header here, too.

The orginal code in l10n_utils.render still has value, because it handles the fallback for a missing/unactive language to en-US

## Issue / Bugzilla link

Resolves #14498 

## Testing

Check the headers when you go to /  and it redirects to /en-US/ (or whatever your browser's local language is)
 