### PR TITLE
Ensure the lang-fixup redirects set a Vary header for Accept-Language

### DIFF
--- a/.github/workflows/cdn_tests.yml
+++ b/.github/workflows/cdn_tests.yml
@@ -42,8 +42,10 @@ jobs:
       matrix:
         include:
           - LABEL: "General CDN Tests"
+            SHARD_LABEL: "general-cdn-tests"
             MARK_EXPRESSION: "cdn and not cdnprod"
           - LABEL: "Prod-only CDN Tests"
+            SHARD_LABEL: "prod-only-cdn-tests"
             MARK_EXPRESSION: cdnprod
     env:
       BASE_URL: ${{ github.event.inputs.mozorg_service_hostname || 'https://www.mozilla.org' }} # Mozorg base URL
@@ -77,7 +79,7 @@ jobs:
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{github.run_id}}-${{ matrix.SHARD_LABEL }}
           path: results-${{github.run_id}}
           if-no-files-found: ignore  # this avoids a false "Warning" if there were no issues
 

--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -64,7 +64,9 @@ class BedrockLangCodeFixupMiddleware(MiddlewareMixin):
         if request.GET:
             dest += f"?{request.GET.urlencode()}"
 
-        return HttpResponseRedirect(dest)
+        response = HttpResponseRedirect(dest)
+        response["Vary"] = "Accept-Language"
+        return response
 
     def process_request(self, request):
         # Initially see if we can separate a lang code from the rest of the URL

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -233,6 +233,7 @@ def test_BedrockLangCodeFixupMiddleware(
     if resp:
         assert resp.status_code == 302
         assert resp.headers["location"] == expected_dest
+        assert resp.headers["vary"].lower() == "accept-language"
     else:
         # the request will have been annotated by the middleware
         assert request.locale == expected_request_locale


### PR DESCRIPTION
Previously, we relied on similar code deep in lib.l10n_utils.render, but BedrockLangFixupMiddleware runs way before then, so we need(ed) to add the Vary header here, too.

The orginal code in l10n_utils.render still has value, because it handles the fallback for a missing/unactive language to en-US

## Issue / Bugzilla link

Resolves #14498 

## Testing

Check the headers when you go to /  and it redirects to /en-US/ (or whatever your browser's local language is)
 