### PR TITLE
Enable FxA attribution to be optional (Fixes #14488)

### DIFF
--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -233,21 +233,6 @@ FxaAttribution.getExperimentData = (params) => {
     return null;
 };
 
-FxaAttribution.getCouponData = (params) => {
-    if (typeof params !== 'object') {
-        return null;
-    }
-
-    for (const param in params) {
-        if (Object.prototype.hasOwnProperty.call(params, param)) {
-            if (param === 'coupon' && _validParamChars.test(params[param])) {
-                return { coupon: params[param] };
-            }
-        }
-    }
-    return null;
-};
-
 /**
  * Append an object of accepted parameters to a given URL.
  * Object parameters will erase all existing accepted parameters, whether present or not.
@@ -300,14 +285,6 @@ FxaAttribution.appendToProductURL = (url, data) => {
         }
 
         finalParams = Object.assign(linkParams, data);
-
-        // Only append coupons to FxA /subscribe/ links.
-        if (
-            Object.prototype.hasOwnProperty.call(finalParams, 'coupon') &&
-            url.indexOf('/subscriptions/') === -1
-        ) {
-            delete finalParams['coupon'];
-        }
     } else {
         finalParams = data;
     }
@@ -323,7 +300,6 @@ FxaAttribution.getAttributionData = (urlParams) => {
     let params = {};
     const utmData = FxaAttribution.getUtmData(urlParams);
     const experimentData = FxaAttribution.getExperimentData(urlParams);
-    const couponData = FxaAttribution.getCouponData(urlParams);
 
     // If there are UTM params in the page URL, then
     // validate those as referral data.
@@ -348,11 +324,6 @@ FxaAttribution.getAttributionData = (urlParams) => {
     // Always pass along experiment data.
     if (experimentData) {
         params = Object.assign(params, experimentData);
-    }
-
-    // Always pass a coupon when present as a parameter.
-    if (couponData) {
-        params = Object.assign(params, couponData);
     }
 
     return params;

--- a/media/js/base/fxa-bundle-init.es6.js
+++ b/media/js/base/fxa-bundle-init.es6.js
@@ -6,6 +6,10 @@
 
 import FxaLink from './fxa-link.es6.js';
 import FxaAttribution from './fxa-attribution.es6.js';
+import FxaCoupon from './fxa-coupon.es6.js';
+
+// Pass coupon URL query parameters through to Mozilla account subscription links.
+FxaCoupon.init(window.location.href);
 
 if (typeof window._SearchParams !== 'undefined') {
     const urlParams = new window._SearchParams();

--- a/media/js/base/fxa-coupon.es6.js
+++ b/media/js/base/fxa-coupon.es6.js
@@ -1,0 +1,67 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const FxaCoupon = {};
+
+const _allowedDomains = ['accounts.firefox.com', 'accounts.stage.mozaws.net'];
+
+FxaCoupon.getCoupon = (url) => {
+    const _validParamChars = /^[\w/.%-]+$/;
+    const coupon = url.searchParams.get('coupon');
+
+    if (coupon && _validParamChars.test(coupon)) {
+        return coupon;
+    }
+
+    return null;
+};
+
+FxaCoupon.verifyLink = (url) => {
+    return (
+        _allowedDomains.indexOf(url.hostname) !== -1 &&
+        url.pathname.startsWith('/subscriptions/products/')
+    );
+};
+
+FxaCoupon.init = (url) => {
+    if (!window.URL) {
+        return;
+    }
+
+    try {
+        const pageUrl = new URL(url);
+        const coupon = FxaCoupon.getCoupon(pageUrl);
+
+        // If there is no coupon data, then do nothing.
+        if (!coupon) {
+            return false;
+        }
+
+        const subscriptionLinks = document.querySelectorAll(
+            '.js-fxa-cta-link, .js-fxa-product-cta-link'
+        );
+
+        for (let i = 0; i < subscriptionLinks.length; i++) {
+            const href = subscriptionLinks[i].hasAttribute('href')
+                ? subscriptionLinks[i].href
+                : null;
+
+            if (href) {
+                const url = new URL(href);
+                if (FxaCoupon.verifyLink(url)) {
+                    url.searchParams.append('coupon', coupon);
+                    subscriptionLinks[i].href = url;
+                }
+            }
+        }
+
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+export default FxaCoupon;

--- a/media/js/base/fxa-link.es6.js
+++ b/media/js/base/fxa-link.es6.js
@@ -35,8 +35,8 @@ FxaLink.getHostName = function (url) {
 
 /**
  * Intercept event handler for FxA links and forms, lets the browser drive the FxA Flow using
- * the `showFirefoxAccounts` UITour API. Attaches several UTM parameters from the current page
- * that will be forwarded to the browser and later on to FxA services.
+ * the `showFirefoxAccounts` UITour API. Attaches several UTM parameters from the current link
+ * href that will be forwarded to the browser and later on to FxA services.
  * @param event {Event}
  * @private
  */

--- a/tests/unit/spec/base/fxa-attribution.js
+++ b/tests/unit/spec/base/fxa-attribution.js
@@ -12,10 +12,6 @@
 import FxaAttribution from '../../../../media/js/base/fxa-attribution.es6.js';
 
 describe('fxa-attribution.js', function () {
-    beforeEach(function () {
-        window.Mozilla.dntEnabled = sinon.stub();
-    });
-
     describe('getHostName', function () {
         it('should return a hostname as expected', function () {
             const url1 =
@@ -393,19 +389,6 @@ describe('fxa-attribution.js', function () {
                 'https://accounts.firefox.com/?utm_medium=medium-one&utm_term=term-one&utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one&entrypoint_experiment=test-id&entrypoint_variation=test-variation'
             );
         });
-
-        it('should append coupon parameter when present', function () {
-            const data = {
-                coupon: 'test'
-            };
-
-            const url =
-                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing';
-
-            expect(FxaAttribution.appendToProductURL(url, data)).toEqual(
-                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing&coupon=test'
-            );
-        });
     });
 
     describe('getSearchReferralData', function () {
@@ -540,7 +523,6 @@ describe('fxa-attribution.js', function () {
 
     describe('setFxALinkReferralCookie', function () {
         it('should set a referral cookie as expected', function () {
-            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
             spyOn(Mozilla.Cookies, 'setItem');
             spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
@@ -561,7 +543,6 @@ describe('fxa-attribution.js', function () {
         });
 
         it('should not set a referral cookie if one already exists', function () {
-            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Cookies, 'enabled').and.returnValue(true);
             spyOn(Mozilla.Cookies, 'setItem');
             spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
@@ -718,53 +699,7 @@ describe('fxa-attribution.js', function () {
             );
         });
 
-        it('should pass coupon parameter only to FxA subscription links', function () {
-            const data = {
-                coupon: 'test'
-            };
-            spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
-                false
-            );
-            spyOn(FxaAttribution, 'getSearchReferralData').and.returnValue(
-                null
-            );
-
-            FxaAttribution.init(data);
-
-            const expected = document.getElementById('test-expected');
-            const expectedHref = expected.getAttribute('href');
-            const secondExpected = document.getElementById(
-                'test-second-expected'
-            );
-            const secondExpectedHref = secondExpected.getAttribute('href');
-            const thirdExpected = document.getElementById(
-                'test-third-expected'
-            );
-            const thirdExpectedHref = thirdExpected.getAttribute('href');
-            const fourthExpected = document.getElementById('test-subscription');
-            const fourthExpectedHref = fourthExpected.getAttribute('href');
-
-            const unexpected = document.getElementById('test-not-accounts');
-            const unexpectedHref = unexpected.getAttribute('href');
-
-            expect(expectedHref).toEqual(
-                'https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
-            );
-            expect(secondExpectedHref).toEqual(
-                'https://monitor.mozilla.org/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
-            );
-            expect(thirdExpectedHref).toEqual(
-                'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral'
-            );
-            expect(fourthExpectedHref).toEqual(
-                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=pricing&coupon=test'
-            );
-            expect(unexpectedHref).toEqual(
-                'https://www.mozilla.org/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'
-            );
-        });
-
-        it('should handle padding all accepted query parameters together', function () {
+        it('should handle passing all accepted query parameters together', function () {
             const data = {
                 utm_source: 'source-two',
                 utm_content: 'content-two',
@@ -772,8 +707,7 @@ describe('fxa-attribution.js', function () {
                 utm_term: 'term-two',
                 utm_campaign: 'campaign-two',
                 entrypoint_experiment: 'test-experiment',
-                entrypoint_variation: 'test-variation',
-                coupon: 'test'
+                entrypoint_variation: 'test-variation'
             };
             spyOn(FxaAttribution, 'hasFxALinkReferralCookie').and.returnValue(
                 false
@@ -810,7 +744,7 @@ describe('fxa-attribution.js', function () {
                 'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
             );
             expect(fourthExpectedHref).toEqual(
-                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&data_cta_position=pricing&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation&coupon=test'
+                'https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&data_cta_position=pricing&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two&entrypoint_experiment=test-experiment&entrypoint_variation=test-variation'
             );
             expect(unexpectedHref).toEqual(
                 'https://www.mozilla.org/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page'

--- a/tests/unit/spec/base/fxa-coupon.js
+++ b/tests/unit/spec/base/fxa-coupon.js
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import FxaCoupon from '../../../../media/js/base/fxa-coupon.es6';
+
+describe('fxa-coupon.js', function () {
+    beforeEach(function () {
+        // link to change
+        const links = `<div id="test-links">
+                <a id="test-not-subscription" class="js-fxa-product-cta-link" href="https://accounts.firefox.com/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Mozilla account</a>
+                <a id="test-not-accounts" class="js-fxa-cta-link" href="https://www.mozilla.org/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Mozilla account</a>
+                <a id="test-subscription-stage" class="js-fxa-product-cta-link" href="https://accounts.stage.mozaws.net/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&amp;entrypoint=www.mozilla.org-vpn-product-page&amp;form_type=button&amp;service=e6eb0d1e856335fc&amp;utm_source=www.mozilla.org-vpn-product-page&amp;utm_medium=referral&amp;utm_campaign=vpn-product-page&amp;data_cta_position=pricing">Get Mozilla VPN</a>
+                <a id="test-subscription-prod" class="js-fxa-cta-link" href="https://accounts.firefox.com/subscriptions/products/prod_FvnsFHIfezy3ZI?plan=price_1Iw85dJNcmPzuWtRyhMDdtM7&amp;entrypoint=www.mozilla.org-vpn-product-page&amp;form_type=button&amp;service=e6eb0d1e856335fc&amp;utm_source=www.mozilla.org-vpn-product-page&amp;utm_medium=referral&amp;utm_campaign=vpn-product-page&amp;data_cta_position=pricing">Get Mozilla VPN</a>
+            </div>`;
+
+        document.body.insertAdjacentHTML('beforeend', links);
+    });
+
+    afterEach(function () {
+        const content = document.getElementById('test-links');
+        content.parentNode.removeChild(content);
+    });
+
+    it('should append coupon parameter to Fxa subscription links when present', function () {
+        const url = 'https://www.mozilla.org/en-US/products/vpn/?coupon=TEST';
+
+        FxaCoupon.init(url);
+
+        expect(
+            document.getElementById('test-not-subscription').href
+        ).not.toContain('coupon=TEST');
+        expect(document.getElementById('test-not-accounts').href).not.toContain(
+            'coupon=TEST'
+        );
+        expect(
+            document.getElementById('test-subscription-stage').href
+        ).toContain('coupon=TEST');
+        expect(
+            document.getElementById('test-subscription-prod').href
+        ).toContain('coupon=TEST');
+    });
+});

--- a/tests/unit/spec/base/fxa-form.js
+++ b/tests/unit/spec/base/fxa-form.js
@@ -12,256 +12,374 @@
 import FxaForm from '../../../../media/js/base/fxa-form.es6.js';
 
 describe('fxa-form.js', function () {
-    describe('init', function () {
-        beforeEach(function () {
-            const form = `<form action="https://accounts.firefox.com/" id="fxa-email-form" class="fxa-email-form">
-                    <input type="hidden" name="action" value="email">
-                    <input type="hidden" name="entrypoint" value="mozilla.org-privacy-products" id="fxa-email-form-entrypoint">
-                    <input type="hidden" name="entrypoint_experiment" value="exp" id="fxa-email-form-entrypoint-experiment">
-                    <input type="hidden" name="entrypoint_variation" value="var" id="fxa-email-form-entrypoint-variation">
-                    <input type="hidden" name="form_type" value="email">
-                    <input type="hidden" name="utm_source" value="mozilla.org-privacy-products" id="fxa-email-form-utm-source">
-                    <input type="hidden" name="utm_campaign" value="fxa-embedded-form" id="fxa-email-form-utm-campaign">
-                    <input type="hidden" name="flow_id" value="">
-                    <input type="hidden" name="flow_begin_time" value="">
-                    <input type="hidden" name="device_id" value="">
-                    <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required="">
-                    <button type="submit" class="mzp-c-button mzp-t-primary mzp-t-product" id="fxa-email-form-submit">Continue</button>
-                </form>`;
+    beforeEach(function () {
+        const form = `<form action="https://accounts.firefox.com/" id="fxa-email-form" class="fxa-email-form">
+                <input type="hidden" name="action" value="email">
+                <input type="hidden" name="entrypoint" value="mozilla.org-privacy-products" id="fxa-email-form-entrypoint">
+                <input type="hidden" name="entrypoint_experiment" value="exp" id="fxa-email-form-entrypoint-experiment">
+                <input type="hidden" name="entrypoint_variation" value="var" id="fxa-email-form-entrypoint-variation">
+                <input type="hidden" name="form_type" value="email">
+                <input type="hidden" name="utm_source" value="mozilla.org-privacy-products" id="fxa-email-form-utm-source">
+                <input type="hidden" name="utm_campaign" value="fxa-embedded-form" id="fxa-email-form-utm-campaign">
+                <input type="hidden" name="flow_id" value="">
+                <input type="hidden" name="flow_begin_time" value="">
+                <input type="hidden" name="device_id" value="">
+                <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required="">
+                <button type="submit" class="mzp-c-button mzp-t-primary mzp-t-product" id="fxa-email-form-submit">Continue</button>
+            </form>`;
 
-            const data = {
-                deviceId: '848377ff6e3e4fc982307a316f4ca3d6',
-                flowBeginTime: '1573052386673',
-                flowId: '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
-            };
+        const data = {
+            deviceId: '848377ff6e3e4fc982307a316f4ca3d6',
+            flowBeginTime: '1573052386673',
+            flowId: '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+        };
 
-            const mockResponse = new window.Response(JSON.stringify(data), {
-                status: 200,
-                headers: {
-                    'Content-type': 'application/json'
-                }
-            });
-
-            spyOn(window, 'fetch').and.returnValue(
-                window.Promise.resolve(mockResponse)
-            );
-
-            window.Mozilla.UITour = sinon.stub();
-            window.Mozilla.UITour.showFirefoxAccounts = sinon
-                .stub()
-                .returns(true);
-            window.Mozilla.UITour.ping = sinon.stub().callsArg(0);
-
-            document.body.insertAdjacentHTML('beforeend', form);
+        const mockResponse = new window.Response(JSON.stringify(data), {
+            status: 200,
+            headers: {
+                'Content-type': 'application/json'
+            }
         });
 
-        afterEach(function () {
-            document.querySelectorAll('.fxa-email-form').forEach((e) => {
-                e.parentNode.removeChild(e);
-            });
+        spyOn(window, 'fetch').and.returnValue(
+            window.Promise.resolve(mockResponse)
+        );
+
+        window.Mozilla.UITour = sinon.stub();
+        window.Mozilla.UITour.showFirefoxAccounts = sinon.stub().returns(true);
+        window.Mozilla.UITour.ping = sinon.stub().callsArg(0);
+
+        document.body.insertAdjacentHTML('beforeend', form);
+    });
+
+    afterEach(function () {
+        document.querySelectorAll('.fxa-email-form').forEach((e) => {
+            e.parentNode.removeChild(e);
         });
+    });
 
-        it('should configure the form for Firefox desktop < 80', function () {
-            spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
-                true
-            );
-            spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '79.0'
-            );
+    it('should configure the form for Firefox desktop < 80', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+        spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
+            '79.0'
+        );
 
-            return FxaForm.init().then(() => {
-                const form = document.getElementById('fxa-email-form');
-                expect(form.getAttribute('action')).toEqual(
-                    'https://accounts.firefox.com/'
-                );
-                expect(form.querySelector('[name="flow_id"]').value).toEqual(
-                    '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
-                );
-                expect(
-                    form.querySelector('[name="flow_begin_time"]').value
-                ).toEqual('1573052386673');
-                expect(form.querySelector('[name="device_id"]').value).toEqual(
-                    '848377ff6e3e4fc982307a316f4ca3d6'
-                );
-            });
+        return FxaForm.init().then(() => {
+            const form = document.getElementById('fxa-email-form');
+            expect(form.getAttribute('action')).toEqual(
+                'https://accounts.firefox.com/'
+            );
+            expect(form.querySelector('[name="flow_id"]').value).toEqual(
+                '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+            );
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('1573052386673');
+            expect(form.querySelector('[name="device_id"]').value).toEqual(
+                '848377ff6e3e4fc982307a316f4ca3d6'
+            );
         });
+    });
 
-        it('should configure the form for Firefox desktop >= 80', function () {
-            spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
-                true
-            );
-            spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '80.0'
-            );
+    it('should configure the form for Firefox desktop >= 80', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+        spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
+            '80.0'
+        );
 
-            return FxaForm.init().then(() => {
-                const form = document.getElementById('fxa-email-form');
-                expect(form.getAttribute('action')).toEqual(
-                    'https://accounts.firefox.com/'
-                );
-                expect(form.querySelector('[name="context"]').value).toEqual(
-                    'fx_desktop_v3'
-                );
-                expect(form.querySelector('[name="flow_id"]').value).toEqual(
-                    '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
-                );
-                expect(
-                    form.querySelector('[name="flow_begin_time"]').value
-                ).toEqual('1573052386673');
-                expect(form.querySelector('[name="device_id"]').value).toEqual(
-                    '848377ff6e3e4fc982307a316f4ca3d6'
-                );
-            });
+        return FxaForm.init().then(() => {
+            const form = document.getElementById('fxa-email-form');
+            expect(form.getAttribute('action')).toEqual(
+                'https://accounts.firefox.com/'
+            );
+            expect(form.querySelector('[name="context"]').value).toEqual(
+                'fx_desktop_v3'
+            );
+            expect(form.querySelector('[name="flow_id"]').value).toEqual(
+                '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+            );
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('1573052386673');
+            expect(form.querySelector('[name="device_id"]').value).toEqual(
+                '848377ff6e3e4fc982307a316f4ca3d6'
+            );
         });
+    });
 
-        it('should configure the form for non-Firefox browsers', function () {
-            spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
-                false
+    it('should configure the form for non-Firefox browsers', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
+            false
+        );
+
+        return FxaForm.init().then(() => {
+            const form = document.getElementById('fxa-email-form');
+            expect(form.getAttribute('action')).toEqual(
+                'https://accounts.firefox.com/'
             );
-
-            return FxaForm.init().then(() => {
-                const form = document.getElementById('fxa-email-form');
-                expect(form.getAttribute('action')).toEqual(
-                    'https://accounts.firefox.com/'
-                );
-                expect(form.querySelector('[name="context"]')).toBeNull();
-                expect(form.querySelector('[name="flow_id"]').value).toEqual(
-                    '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
-                );
-                expect(
-                    form.querySelector('[name="flow_begin_time"]').value
-                ).toEqual('1573052386673');
-                expect(form.querySelector('[name="device_id"]').value).toEqual(
-                    '848377ff6e3e4fc982307a316f4ca3d6'
-                );
-            });
+            expect(form.querySelector('[name="context"]')).toBeNull();
+            expect(form.querySelector('[name="flow_id"]').value).toEqual(
+                '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+            );
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('1573052386673');
+            expect(form.querySelector('[name="device_id"]').value).toEqual(
+                '848377ff6e3e4fc982307a316f4ca3d6'
+            );
         });
+    });
 
-        it('should pass through utm parameters from the URL to the form', function () {
-            spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
-                false
+    it('should pass through utm parameters from the URL to the form', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
+            false
+        );
+        /* eslint-disable camelcase */
+        spyOn(FxaForm, 'getUTMParams').and.returnValue({
+            utm_source: 'desktop-snippet',
+            utm_content: 'rel-esr',
+            utm_medium: 'referral',
+            utm_term: 4242,
+            utm_campaign: 'F100_4242_otherstuff_in_here'
+        });
+        /* eslint-enable camelcase */
+
+        return FxaForm.init().then(function () {
+            const form = document.getElementById('fxa-email-form');
+            expect(form.getAttribute('action')).toEqual(
+                'https://accounts.firefox.com/'
             );
+            expect(form.querySelector('[name="flow_id"]').value).toEqual(
+                '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+            );
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('1573052386673');
+            expect(form.querySelector('[name="device_id"]').value).toEqual(
+                '848377ff6e3e4fc982307a316f4ca3d6'
+            );
+            expect(form.querySelector('[name="utm_source"]').value).toEqual(
+                'desktop-snippet'
+            );
+            expect(form.querySelector('[name="utm_campaign"]').value).toEqual(
+                'F100_4242_otherstuff_in_here'
+            );
+            expect(form.querySelector('[name="utm_content"]').value).toEqual(
+                'rel-esr'
+            );
+            expect(form.querySelector('[name="utm_term"]').value).toEqual(
+                '4242'
+            );
+            expect(form.querySelector('[name="utm_medium"]').value).toEqual(
+                'referral'
+            );
+        });
+    });
+
+    it('should pass through utm parameters from the URL to the form into the UITour', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+        spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
+            '80.0'
+        );
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
+            function (callback) {
+                callback({
+                    accurate: true,
+                    distribution: undefined
+                });
+            }
+        );
+        spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
+        /* eslint-disable camelcase */
+        spyOn(FxaForm, 'getUTMParams').and.returnValue({
+            utm_source: 'desktop-snippet',
+            utm_content: 'rel-esr',
+            utm_medium: 'referral',
+            utm_term: 4242,
+            utm_campaign: 'F100_4242_otherstuff_in_here'
+        });
+        /* eslint-enable camelcase */
+
+        return FxaForm.init().then(function () {
+            const form = document.getElementById('fxa-email-form');
+            form.querySelector('#fxa-email-field').value = 'a@a.com';
+            expect(form.getAttribute('action')).toEqual(
+                'https://accounts.firefox.com/'
+            );
+            expect(form.querySelector('[name="flow_id"]').value).toEqual(
+                '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
+            );
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('1573052386673');
+            expect(form.querySelector('[name="device_id"]').value).toEqual(
+                '848377ff6e3e4fc982307a316f4ca3d6'
+            );
+            expect(form.querySelector('[name="utm_source"]').value).toEqual(
+                'desktop-snippet'
+            );
+            expect(form.querySelector('[name="utm_campaign"]').value).toEqual(
+                'F100_4242_otherstuff_in_here'
+            );
+            expect(form.querySelector('[name="utm_content"]').value).toEqual(
+                'rel-esr'
+            );
+            expect(form.querySelector('[name="utm_term"]').value).toEqual(
+                '4242'
+            );
+            expect(form.querySelector('[name="utm_medium"]').value).toEqual(
+                'referral'
+            );
+
+            form.querySelector('#fxa-email-form-submit').click();
             /* eslint-disable camelcase */
-            spyOn(FxaForm, 'getUTMParams').and.returnValue({
-                utm_source: 'desktop-snippet',
-                utm_content: 'rel-esr',
-                utm_medium: 'referral',
-                utm_term: 4242,
-                utm_campaign: 'F100_4242_otherstuff_in_here'
-            });
+            expect(
+                window.Mozilla.UITour.showFirefoxAccounts
+            ).toHaveBeenCalledWith(
+                {
+                    utm_source: 'desktop-snippet',
+                    utm_content: 'rel-esr',
+                    utm_medium: 'referral',
+                    utm_term: 4242,
+                    utm_campaign: 'F100_4242_otherstuff_in_here',
+                    entrypoint_experiment: 'exp',
+                    entrypoint_variation: 'var',
+                    device_id: '848377ff6e3e4fc982307a316f4ca3d6',
+                    flow_id:
+                        '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1',
+                    flow_begin_time: 1573052386673
+                },
+                'mozilla.org-privacy-products',
+                'a@a.com'
+            );
             /* eslint-enable camelcase */
-
-            return FxaForm.init().then(function () {
-                const form = document.getElementById('fxa-email-form');
-                expect(form.getAttribute('action')).toEqual(
-                    'https://accounts.firefox.com/'
-                );
-                expect(form.querySelector('[name="flow_id"]').value).toEqual(
-                    '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
-                );
-                expect(
-                    form.querySelector('[name="flow_begin_time"]').value
-                ).toEqual('1573052386673');
-                expect(form.querySelector('[name="device_id"]').value).toEqual(
-                    '848377ff6e3e4fc982307a316f4ca3d6'
-                );
-                expect(form.querySelector('[name="utm_source"]').value).toEqual(
-                    'desktop-snippet'
-                );
-                expect(
-                    form.querySelector('[name="utm_campaign"]').value
-                ).toEqual('F100_4242_otherstuff_in_here');
-                expect(
-                    form.querySelector('[name="utm_content"]').value
-                ).toEqual('rel-esr');
-                expect(form.querySelector('[name="utm_term"]').value).toEqual(
-                    '4242'
-                );
-                expect(form.querySelector('[name="utm_medium"]').value).toEqual(
-                    'referral'
-                );
-            });
         });
+    });
 
-        it('should pass through utm parameters from the URL to the form into the UITour', function () {
-            spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(
-                true
+    it('should pass through utm parameters from the URL to the form into the UITour', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+        spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
+            '80.0'
+        );
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
+            function (callback) {
+                callback({
+                    accurate: true,
+                    distribution: undefined
+                });
+            }
+        );
+        spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
+        /* eslint-disable camelcase */
+        spyOn(FxaForm, 'getUTMParams').and.returnValue({
+            utm_source: 'desktop-snippet',
+            utm_content: 'rel-esr',
+            utm_medium: 'referral',
+            utm_term: 4242,
+            utm_campaign: 'F100_4242_otherstuff_in_here'
+        });
+        /* eslint-enable camelcase */
+
+        return FxaForm.init().then(function () {
+            const form = document.getElementById('fxa-email-form');
+            form.querySelector('#fxa-email-field').value = 'a@a.com';
+            expect(form.getAttribute('action')).toEqual(
+                'https://accounts.firefox.com/'
             );
-            spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
-                '80.0'
+            expect(form.querySelector('[name="flow_id"]').value).toEqual(
+                '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
             );
-            spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
-                function (callback) {
-                    callback({
-                        accurate: true,
-                        distribution: undefined
-                    });
-                }
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('1573052386673');
+            expect(form.querySelector('[name="device_id"]').value).toEqual(
+                '848377ff6e3e4fc982307a316f4ca3d6'
             );
-            spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
+            expect(form.querySelector('[name="utm_source"]').value).toEqual(
+                'desktop-snippet'
+            );
+            expect(form.querySelector('[name="utm_campaign"]').value).toEqual(
+                'F100_4242_otherstuff_in_here'
+            );
+            expect(form.querySelector('[name="utm_content"]').value).toEqual(
+                'rel-esr'
+            );
+            expect(form.querySelector('[name="utm_term"]').value).toEqual(
+                '4242'
+            );
+            expect(form.querySelector('[name="utm_medium"]').value).toEqual(
+                'referral'
+            );
+
+            form.querySelector('#fxa-email-form-submit').click();
             /* eslint-disable camelcase */
-            spyOn(FxaForm, 'getUTMParams').and.returnValue({
-                utm_source: 'desktop-snippet',
-                utm_content: 'rel-esr',
-                utm_medium: 'referral',
-                utm_term: 4242,
-                utm_campaign: 'F100_4242_otherstuff_in_here'
-            });
+            expect(
+                window.Mozilla.UITour.showFirefoxAccounts
+            ).toHaveBeenCalledWith(
+                {
+                    utm_source: 'desktop-snippet',
+                    utm_content: 'rel-esr',
+                    utm_medium: 'referral',
+                    utm_term: 4242,
+                    utm_campaign: 'F100_4242_otherstuff_in_here',
+                    entrypoint_experiment: 'exp',
+                    entrypoint_variation: 'var',
+                    device_id: '848377ff6e3e4fc982307a316f4ca3d6',
+                    flow_id:
+                        '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1',
+                    flow_begin_time: 1573052386673
+                },
+                'mozilla.org-privacy-products',
+                'a@a.com'
+            );
             /* eslint-enable camelcase */
-            return FxaForm.init().then(function () {
-                const form = document.getElementById('fxa-email-form');
-                form.querySelector('#fxa-email-field').value = 'a@a.com';
-                expect(form.getAttribute('action')).toEqual(
-                    'https://accounts.firefox.com/'
-                );
-                expect(form.querySelector('[name="flow_id"]').value).toEqual(
-                    '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1'
-                );
-                expect(
-                    form.querySelector('[name="flow_begin_time"]').value
-                ).toEqual('1573052386673');
-                expect(form.querySelector('[name="device_id"]').value).toEqual(
-                    '848377ff6e3e4fc982307a316f4ca3d6'
-                );
-                expect(form.querySelector('[name="utm_source"]').value).toEqual(
-                    'desktop-snippet'
-                );
-                expect(
-                    form.querySelector('[name="utm_campaign"]').value
-                ).toEqual('F100_4242_otherstuff_in_here');
-                expect(
-                    form.querySelector('[name="utm_content"]').value
-                ).toEqual('rel-esr');
-                expect(form.querySelector('[name="utm_term"]').value).toEqual(
-                    '4242'
-                );
-                expect(form.querySelector('[name="utm_medium"]').value).toEqual(
-                    'referral'
-                );
+        });
+    });
 
-                form.querySelector('#fxa-email-form-submit').click();
-                /* eslint-disable camelcase */
-                expect(
-                    window.Mozilla.UITour.showFirefoxAccounts
-                ).toHaveBeenCalledWith(
-                    {
-                        utm_source: 'desktop-snippet',
-                        utm_content: 'rel-esr',
-                        utm_medium: 'referral',
-                        utm_term: 4242,
-                        utm_campaign: 'F100_4242_otherstuff_in_here',
-                        entrypoint_experiment: 'exp',
-                        entrypoint_variation: 'var',
-                        device_id: '848377ff6e3e4fc982307a316f4ca3d6',
-                        flow_id:
-                            '75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1',
-                        flow_begin_time: 1573052386673
-                    },
-                    'mozilla.org-privacy-products',
-                    'a@a.com'
-                );
-                /* eslint-enable camelcase */
-            });
+    it('should allow attribution to be skipped', function () {
+        spyOn(window.Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+        spyOn(window.Mozilla.Client, '_getFirefoxVersion').and.returnValue(
+            '80.0'
+        );
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(
+            function (callback) {
+                callback({
+                    accurate: true,
+                    distribution: undefined
+                });
+            }
+        );
+        spyOn(window.Mozilla.UITour, 'showFirefoxAccounts');
+
+        return FxaForm.init(true).then(function () {
+            const form = document.getElementById('fxa-email-form');
+            form.querySelector('#fxa-email-field').value = 'a@a.com';
+            expect(form.querySelector('[name="flow_id"]').value).toEqual('');
+            expect(
+                form.querySelector('[name="flow_begin_time"]').value
+            ).toEqual('');
+            expect(form.querySelector('[name="device_id"]').value).toEqual('');
+            expect(form.querySelector('[name="utm_source"]').value).toEqual(
+                'mozilla.org-privacy-products'
+            );
+            expect(form.querySelector('[name="utm_campaign"]').value).toEqual(
+                'fxa-embedded-form'
+            );
+            expect(form.querySelector('[name="utm_content"]')).toEqual(null);
+            expect(form.querySelector('[name="utm_term"]')).toEqual(null);
+            expect(form.querySelector('[name="utm_medium"]')).toEqual(null);
+
+            form.querySelector('#fxa-email-form-submit').click();
+            expect(
+                window.Mozilla.UITour.showFirefoxAccounts
+            ).toHaveBeenCalledWith(
+                {
+                    utm_source: 'mozilla.org-privacy-products',
+                    utm_campaign: 'fxa-embedded-form'
+                },
+                'mozilla.org-privacy-products',
+                'a@a.com'
+            );
         });
     });
 });


### PR DESCRIPTION
## One-line summary

This PR makes some changes to our FxA / VPN JavaScript code to separate out functionality from non-essential code.

## Significant changes and points to review

- The coupon passing code is now split out from `fxa-attribution.es6.js` to it's own file called `fxa-coupon.es6.js`, so that the attribution code can be called separately and only when needed.
- A `skipAttribution` parameter has been added to `fxa-form.es6.js`. I found this was the easiest path as separating out the Firefox Sync and UITour functionality would require a considerable refactor of what's there.

## Issue / Bugzilla link

#14488

## Testing

This PR doesn't actually change any behavior in our code for now (that will come later).  For now, it's probably sufficient to test to make sure things continue to work as they do currently in prod:

 URL: http://localhost:8000/en-US/products/vpn/?utm_source=test&utm_campaign=test&coupon=FIREFOX105

- [x] Test that both UTM parameters and coupon parameters are forwarded on to each of the "Get subscription" links in the VPN landing page.

URL: http://localhost:8000/en-US/firefox/?utm_source=test&utm_campaign=test

- [x] Test that UTM parameters are forwarded to FxA URL when you enter an email address into the Mozilla Account form and press submit.
- [x] You can also test that the UTM parameters are NOT passed along if you change the code to in `fxa-form-init.es6.js` `FxaForm.init(true);`. Instead, they should default to `utm_source=mozilla.org-firefox-home&utm_campaign=fxa-embedded-form`.