### PR TITLE
Remove redundant product landing tests [#14220]

### DIFF
--- a/tests/functional/products/test_landing.py
+++ b/tests/functional/products/test_landing.py
@@ -9,30 +9,6 @@ import pytest
 from pages.products.landing import ProductsPage
 
 
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_firefox_download_menu_list_displays(base_url, selenium):
-    page = ProductsPage(selenium, base_url).open()
-    page.firefox_menu_list.click()
-    assert page.firefox_menu_list.list_is_open
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_focus_download_menu_list_displays(base_url, selenium):
-    page = ProductsPage(selenium, base_url).open()
-    page.focus_menu_list.click()
-    assert page.focus_menu_list.list_is_open
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_pocket_download_menu_list_displays(base_url, selenium):
-    page = ProductsPage(selenium, base_url).open()
-    page.pocket_menu_list.click()
-    assert page.pocket_menu_list.list_is_open
-
-
 @pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
     page = ProductsPage(selenium, base_url).open()

--- a/tests/pages/products/landing.py
+++ b/tests/pages/products/landing.py
@@ -2,34 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.join_firefox_form import JoinFirefoxForm
-from pages.regions.menu_list import MenuList
 
 
 class ProductsPage(BasePage):
     _URL_TEMPLATE = "/{locale}/products/"
-
-    _firefox_menu_list_locator = (By.ID, "menu-browsers-wrapper")
-    _focus_menu_list_locator = (By.ID, "menu-focus-wrapper")
-    _pocket_menu_list_locator = (By.ID, "menu-pocket-wrapper")
-
-    @property
-    def firefox_menu_list(self):
-        el = self.find_element(*self._firefox_menu_list_locator)
-        return MenuList(self, root=el)
-
-    @property
-    def focus_menu_list(self):
-        el = self.find_element(*self._focus_menu_list_locator)
-        return MenuList(self, root=el)
-
-    @property
-    def pocket_menu_list(self):
-        el = self.find_element(*self._pocket_menu_list_locator)
-        return MenuList(self, root=el)
 
     @property
     def join_firefox_form(self):


### PR DESCRIPTION
## One-line summary

The products page was updated in #14407 and removed the menu lists, but functional tests were still expecting them. This removes those redundant tests.

## Testing
`py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/products/test_landing.py`