### PR TITLE
Fix HackerOne URLs

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -78,13 +78,11 @@
     <dt id="eligible-bugs">Which domains and web applications will be considered to be part of the bug bounty?</dt>
     <dd>
       <p>Only a limited subset of our websites are eligible for monetary
-        payouts. Please see our <a href="https://hackerone.com/mozilla_critical_services/policy_scopes">HackerOne Mozilla Critical Services</a>
-        and <a href="https://hackerone.com/mozilla_core_services/policy_scopes">HackerOne Mozilla Core Services</a>
-        policy pages for additional information. Note that some low severity
+        payouts. Please see our HackerOne Mozilla <a href="https://hackerone.com/mozilla/policy_scopes">policy page</a>
+        for additional information. Note that some low severity
         issues are not eligible for monetary awards based on their impact. We
-        will recognize the reporter by thanking them on each program's Thanks
-        page, <a href="https://hackerone.com/mozilla_critical_services/thanks">Critical services program Thanks page</a>
-        and <a href="https://hackerone.com/mozilla_core_services/thanks">Core services program Thanks page</a>.</p>
+        will recognize the reporter by thanking them on the <a href="https://hackerone.com/mozilla/thanks">Thanks
+        page</a>.</p>
     </dd>
 
     <dt id="dos-bugs">Why don’t you provide a reward for denial-of-service bugs?</dt>
@@ -101,7 +99,7 @@
     <dt id="what-next">Once I have found a vulnerability, what next?</dt>
     <dd>
       <p>The sooner we can reproduce the bug, the sooner we can fix it
-        and send you your bounty. Please submit all bugs to our HackerOne programs, <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a>.
+        and send you your bounty. Please submit all bugs to our HackerOne program <a href="https://hackerone.com/mozilla">Mozilla</a>.
         <strong>Do not send vulnerabilities via email and please avoid using video.</strong></p>
 
       <p>There are three main things you can provide which will help us

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -14,6 +14,6 @@
     <h1 class="mzp-c-article-title">Eligible Websites &amp; Services</h1>
   </header>
 
-  <p>All eligible websites and services can be found in the scope tab of the <a href="https://hackerone.com/mozilla_critical_services/policy_scopes">HackerOne Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services/policy_scopes">HackerOne Mozilla Core Services</a> policy pages.</p>
+  <p>All eligible websites and services can be found in the scope tab of the <a href="https://hackerone.com/mozilla/policy_scopes">HackerOne Mozilla policy page</a>.</p>
 
 {% endblock %}

--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -22,6 +22,6 @@
   <p>On behalf of the Mozilla and the millions of people who visit our sites, use Firefox and our other products we would like to thank them for their hard work in helping to make us more secure.</p>
   <p>As of this date, we have paid out over <b>$4,000,000</b> across all of our bounties. Congratulations to everybody who has participated!</p>
   <p>If your name is on the list incorrectly or you feel you should be on the list please feel free to mail us at <a href="mailto:security@mozilla.org">security@mozilla.org</a>.</p>
-  <p><strong>Our Web bug bounty program has been migrated to HackerOne.</strong> Therefore, we will discontinue adding researchers on this page. Starting from May 2023, researchers will be recognized on our HackerOne pages, <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
+  <p><strong>Our Web bug bounty program has been migrated to HackerOne.</strong> Therefore, we will discontinue adding researchers on this page. Starting from May 2023, researchers will be recognized on our <a href="https://hackerone.com/mozilla/thanks">HackerOne Thanks</a> page.</p>
   {% include "security/partials/hall-of-famers-list.html" %}
 {% endblock %}

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -18,6 +18,6 @@
 
   <p>The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who find unique and original bugs in our web infrastructure.</p>
 
-  <p><strong>We have migrated our web bug bounty program to HackerOne.</strong> Please visit our policy pages to learn more and to submit reports. <a href="https://hackerone.com/mozilla_critical_services">Mozilla Critical Services</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
+  <p><strong>We have migrated our web bug bounty program to HackerOne.</strong> Please visit our policy pages to learn more and to submit reports. <a href="https://hackerone.com/mozilla">Mozilla HackerOne Program</a> and <a href="https://hackerone.com/mozilla_core_services">Mozilla Core Services</a></p>
 
 {% endblock %}


### PR DESCRIPTION
## One-line summary
HackerOne updated the program to a single program under the name `mozilla`. 


## Significant changes and points to review
- Identical to existing [PR from Frida](https://github.com/fkiriakos07/bedrock/tree/fix-hackerone-links). The links were invalid at the time, but the program has been updated by HackerOne.


## Issue / Bugzilla link



## Testing
