### PR TITLE
Change CTA buttons on /products to use secondary theme styling

### DIFF
--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -66,7 +66,7 @@
       <h3 class="mzp-c-picto-heading"><a href="{{ url('firefox') }}" data-cta-type="link" data-cta-text="Firefox" data-cta-position="heading">{{ ftl('firefox-products-firefox') }}</a></h3>
       <p>{{ ftl('firefox-products-get-the-browsers-that-block') }}</p>
       {% set alt_copy = ftl('download-button-download-firefox') + " " + icon_download|safe %}
-      <div class="show-else">{{ download_firefox_thanks(alt_copy=alt_copy, button_class='mzp-t-lg') }}</div>
+      <div class="show-else">{{ download_firefox_thanks(alt_copy=alt_copy, button_class='mzp-t-secondary mzp-t-lg') }}</div>
       <p class="show-android">{{ google_play_button(href=fx_android_url, id='playStoreLink-firefox') }}</p>
       <p class="show-ios">{{ apple_app_store_button(href=fx_ios_url, id='appStoreLink-firefox') }}</p>
     {% endcall %}
@@ -107,7 +107,7 @@
     ) %}
       <h3 class="mzp-c-picto-heading"><a href="https://relay.firefox.com/{{ referrals }}" data-cta-type="link" data-cta-text="Relay" data-cta-position="heading">{{ ftl('firefox-products-relay') }}</a></h3>
       <p>{{ ftl('firefox-products-protect-your-real') }}</p>
-      <p><a class="mzp-c-button mzp-t-product" href="https://relay.firefox.com/{{ referrals }}#pricing" rel="external noopener" data-cta-type="link" data-cta-text="Get Relay">{{ ftl('firefox-products-get-relay') }} {{ icon_external|safe }}</a>
+      <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://relay.firefox.com/{{ referrals }}#pricing" rel="external noopener" data-cta-type="link" data-cta-text="Get Relay">{{ ftl('firefox-products-get-relay') }} {{ icon_external|safe }}</a>
     {% endcall %}
 
     <!-- Monitor -->
@@ -125,7 +125,7 @@
     ) %}
       <h3 class="mzp-c-picto-heading"><a href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h3>
       <p>{% if country_code == 'US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>
-      <p><a class="mzp-c-button mzp-t-product" href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Check for breaches">{% if LANG == 'en-US' %}Check for breaches now{% else %}{{ ftl('firefox-products-check-for-breaches') }}{% endif %} {{ icon_external|safe }}</a></p>
+      <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Check for breaches">{% if LANG == 'en-US' %}Check for breaches now{% else %}{{ ftl('firefox-products-check-for-breaches') }}{% endif %} {{ icon_external|safe }}</a></p>
     {% endcall %}
 
     <!-- VPN -->
@@ -143,7 +143,7 @@
     ) %}
       <h3 class="mzp-c-picto-heading"><a href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="VPN" data-cta-position="heading">{{ ftl('firefox-products-mozilla-vpn') }}</a></h3>
       <p>{{ ftl('firefox-products-surf-stream-and-get-work-done') }}</p>
-      <p><a class="mzp-c-button mzp-t-product" href="{{ url('products.vpn.landing') + '#pricing' }}" rel="external noopener" data-cta-type="link" data-cta-text="Get VPN">{{ ftl('firefox-products-get-mozilla-vpn') }}</a></p>
+      <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="{{ url('products.vpn.landing') + '#pricing' }}" rel="external noopener" data-cta-type="link" data-cta-text="Get VPN">{{ ftl('firefox-products-get-mozilla-vpn') }}</a></p>
     {% endcall %}
 
     <!-- MDN Plus -->
@@ -162,7 +162,7 @@
     <h3 class="mzp-c-picto-heading"><a href="https://developer.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="MDN Plus" data-cta-position="heading">{{ ftl('firefox-products-mdn-plus') }}</a></h3>
       <p>{{ ftl('firefox-products-resources-for-developers') }}</p>
       <p>
-        <a href="https://developer.mozilla.org/plus/{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product" data-cta-type="link" data-cta-text="Support MDN">{{ ftl('firefox-products-support-mdn') }} {{ icon_external|safe }}</a>
+        <a href="https://developer.mozilla.org/plus/{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-secondary" data-cta-type="link" data-cta-text="Support MDN">{{ ftl('firefox-products-support-mdn') }} {{ icon_external|safe }}</a>
       </p>
     {% endcall %}
 
@@ -181,7 +181,7 @@
     ) %}
       <h3 class="mzp-c-picto-heading"><a href="https://www.thunderbird.net/{{ referrals }}" data-cta-type="link" data-cta-text="Thunderbird" data-cta-position="heading">{{ ftl('firefox-products-thunderbird') }}</a></h3>
       <p>{{ ftl('firefox-products-access-all') }}</p>
-      <p><a class="mzp-c-button mzp-t-product" href="https://www.thunderbird.net/download/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Thunderbird Download">{{ ftl('firefox-products-download-thunderbird') }} {{ icon_download|safe }}</a></p>
+      <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://www.thunderbird.net/download/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Thunderbird Download">{{ ftl('firefox-products-download-thunderbird') }} {{ icon_download|safe }}</a></p>
     {% endcall %}
 
     <!-- Fakespot -->
@@ -199,7 +199,7 @@
     ) %}
       <h3 class="mzp-c-picto-heading"><a href="https://www.fakespot.com/{{ referrals }}" data-cta-type="link" data-cta-text="Fakespot" data-cta-position="heading">{{ ftl('firefox-products-fakespot') }}</a> <span class="mzp-u-title-3xs">{{ ftl('firefox-products-by-mozilla') }}</span></h3>
       <p>{{ ftl('firefox-products-fakespot-has-your') }}</p>
-      <p><a class="mzp-c-button mzp-t-product" href="https://www.fakespot.com/analyzer{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Analyze a url with Fakespot">{{ ftl('firefox-products-analyze') }} {{ icon_external|safe }}</a></p>
+      <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://www.fakespot.com/analyzer{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Analyze a url with Fakespot">{{ ftl('firefox-products-analyze') }} {{ icon_external|safe }}</a></p>
     {% endcall %}
 
     <!-- Pocket -->
@@ -217,7 +217,7 @@
     ) %}
     <h3 class="mzp-c-picto-heading"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" data-cta-type="link" data-cta-text="Pocket" data-cta-position="heading">{{ ftl('firefox-products-pocket') }}</a> <span class="mzp-u-title-3xs">{{ ftl('firefox-products-by-mozilla') }}</span></h3>
       <p>{{ ftl('firefox-products-discover-the-best-content') }}</p>
-      <p class="show-else"><a href="https://getpocket.com/signup{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product" data-cta-type="link" data-cta-text="Pocket sign up">{{ ftl('firefox-products-get-pocket') }} {{ icon_external|safe }}</a></p>
+      <p class="show-else"><a href="https://getpocket.com/signup{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-secondary" data-cta-type="link" data-cta-text="Pocket sign up">{{ ftl('firefox-products-get-pocket') }} {{ icon_external|safe }}</a></p>
       <p class="show-android">{{ google_play_button(href=pocket_android_url, id='playStoreLink-pocket') }}</p>
       <p class="show-ios">{{ apple_app_store_button(href=pocket_ios_url, id='appStoreLink-pocket') }}</p>
     {% endcall %}


### PR DESCRIPTION
## One-line summary

Turn down the volume on /products buttons just a little.

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/products/