### PR TITLE
Update Firefox Translation supported languages [fix #14548]

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -22,17 +22,25 @@
 <h2>{{ ftl('features-translate-what-languages-are-currently') }}</h2>
 <p>{{ ftl('features-translate-the-languages-below-are-what') }}</p>
 
-<ul class="mzp-u-list-styled">
+<ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
-  <li>Spanish</li>
-  <li>English</li>
-  <li>German</li>
   <li>Bulgarian</li>
-  <li>Portuguese</li>
-  <li>Italian</li>
-  <li>French</li>
-  <li>Polish</li>
   <li>Dutch</li>
+  <li>English</li>
+  <li>Estonian</li>
+  <li>Finnish</li>
+  <li>French</li>
+  <li>German</li>
+  <li>Greek</li>
+  <li>Hungarian</li>
+  <li>Italian</li>
+  <li>Polish</li>
+  <li>Portuguese</li>
+  <li>Russian</li>
+  <li>Slovenian</li>
+  <li>Spanish</li>
+  <li>Turkish</li>
+  <li>Ukrainian</li>
 {% else %}
   {% for lang in context_test -%}
     {% set name = context_test[lang] %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -800,17 +800,7 @@ def firefox_welcome_page1(request):
 
 @require_safe
 def firefox_features_translate(request):
-    translate_langs = [
-        "es-ES",
-        "en-US",
-        "de",
-        "bg",
-        "pt-PT",
-        "it",
-        "fr",
-        "pl",
-        "nl",
-    ]
+    translate_langs = ["bg", "nl", "en-US", "et", "fi", "fr", "de", "el", "hu", "it", "pl", "pt-PT", "ru", "sl", "es-ES", "tr", "uk"]
 
     names = get_translations_native_names(sorted(translate_langs))
 

--- a/media/css/firefox/features/article.scss
+++ b/media/css/firefox/features/article.scss
@@ -74,6 +74,11 @@ $image-path: '/media/protocol/img';
         @include text-title-2xs;
     }
 
+    .c-lang-list {
+        columns: 2;
+        column-gap: $spacing-lg;
+    }
+
     .footnote {
         @include text-body-sm;
     }
@@ -85,6 +90,11 @@ $image-path: '/media/protocol/img';
             margin: $spacing-xl ($spacing-2xl * -1);
             padding: $spacing-xl $spacing-2xl;
         }
+
+        .c-lang-list {
+            columns: 3;
+        }
+
     }
 }
 


### PR DESCRIPTION
## One-line summary
Updates the list of supported languages on /firefox/features/translate/. Also reformats the list into columns since it's getting long, and sorts them alphabetically (in English at least) since I'm not sure what order they even were originally, it seemed pretty random.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link
#14548 


## Testing
http://localhost:8000/firefox/features/translate/