### PR TITLE
Fix string change without new ID in products.ftl

### DIFF
--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -216,7 +216,7 @@
       ),
     ) %}
     <h3 class="mzp-c-picto-heading"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" data-cta-type="link" data-cta-text="Pocket" data-cta-position="heading">{{ ftl('firefox-products-pocket') }}</a></h3>
-      <p>{{ ftl('firefox-products-discover-the-best-content') }}</p>
+      <p>{{ ftl('firefox-products-discover-the-best-content-v2', fallback='firefox-products-discover-the-best-content') }}</p>
       <p class="show-else"><a href="https://getpocket.com/signup{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-secondary" data-cta-type="link" data-cta-text="Pocket sign up">{{ ftl('firefox-products-get-pocket') }} {{ icon_external|safe }}</a></p>
       <p class="show-android">{{ google_play_button(href=pocket_android_url, id='playStoreLink-pocket') }}</p>
       <p class="show-ios">{{ apple_app_store_button(href=pocket_ios_url, id='appStoreLink-pocket') }}</p>

--- a/l10n/en/firefox/products.ftl
+++ b/l10n/en/firefox/products.ftl
@@ -69,5 +69,7 @@ firefox-products-analyze = Analyze a URL
 ## Pocket
 
 firefox-products-pocket = { -brand-name-pocket }
-firefox-products-discover-the-best-content = Discover the best content on the web — and consume it wherever and whenever you want. Made by { -brand-name-mozilla }.
+firefox-products-discover-the-best-content-v2 = Discover the best content on the web — and consume it wherever and whenever you want. Made by { -brand-name-mozilla }.
+# Obsolete string (expires: 2024-07-08)
+firefox-products-discover-the-best-content = Discover the best content on the web — and consume it wherever and whenever you want.
 firefox-products-get-pocket = Get { -brand-name-pocket }


### PR DESCRIPTION
The original string was changed without a new ID (adding `Made by Mozilla`). This is restoring the previous version of the message, and adding a new one with the updated text.

CC @alexgibson 