### PR TITLE
Extend 126beta WNP to 127beta [fix #14435]

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -383,7 +383,7 @@ class TestWhatsNew(TestCase):
 
     # end dev edition whatsnew tests
 
-    # begin beta whatsnew tests
+    # begin 126 beta whatsnew tests
 
     @override_settings(DEV=True)
     def test_fx_126_0_0beta_en_US(self, render_mock):
@@ -421,7 +421,47 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/index.html"]
 
-    # end beta whatsnew tests
+    # end 126 beta whatsnew tests
+
+    # begin 127 beta whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_127_0_0beta_en_US(self, render_mock):
+        """Should use whatsnew-fx126beta-en-US template for en-US locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-US"
+        self.view(req, version="127.0beta")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx126beta-en-US.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_127_0_0beta_en_CA(self, render_mock):
+        """Should use whatsnew-fx126beta-en-CA template for en-CA locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "en-CA"
+        self.view(req, version="127.0beta")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx126beta-en-CA.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_127_0_0beta_de(self, render_mock):
+        """Should use whatsnew-fx126beta-de template for de locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "de"
+        self.view(req, version="127.0beta")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/whatsnew-fx126beta-de.html"]
+
+    @override_settings(DEV=True)
+    def test_fx_127_0_0beta_pl(self, render_mock):
+        """Should use default template for pl locale"""
+        req = self.rf.get("/firefox/whatsnew/")
+        req.locale = "pl"
+        self.view(req, version="127.0beta")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/index.html"]
+
+    # end 127 beta whatsnew tests
 
     @override_settings(DEV=True)
     def test_rv_prefix(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -480,7 +480,7 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
         elif channel == "beta":
-            if version.startswith("126."):
+            if version.startswith("126.") or version.startswith("127."):
                 if locale.startswith("en-"):
                     if locale == "en-GB" or country == "GB":
                         template = "firefox/whatsnew/whatsnew-fx126beta-en-GB.html"


### PR DESCRIPTION
## One-line summary
Nimbus tooling is going to ride the beta train for another cycle so we need to extend the WNP for the next version. I kept it simple and didn't duplicate or rename the files, just expanded the view condition and added more tests.

## Issue / Bugzilla link
#14435 

## Testing
http://localhost:8000/en-US/firefox/127.0beta/whatsnew/
http://localhost:8000/en-CA/firefox/127.0beta/whatsnew/
http://localhost:8000/en-GB/firefox/127.0beta/whatsnew/
http://localhost:8000/fr/firefox/127.0beta/whatsnew/
http://localhost:8000/de/firefox/127.0beta/whatsnew/