### PR TITLE
Rename PDFs for EU WNP126 [#14512]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-eu.html
@@ -19,42 +19,42 @@
   {% set main_heading = 'Modifiez vos PDF dans Firefox' %}
   {% set main_tagline = 'Dites adieu à la frustration de devoir imprimer ou remplir vos PDF dans d’autres applications. Vous pouvez désormais modifier vos PDF directement dans Firefox.'%}
   {% set main_cta = 'L’essayer' %}
-  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-pdf-fr.pdf' %}
+  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-fr.pdf' %}
   {% set img_width = '620' %}
   {% set img_height = '235' %}
 {% elif LANG == 'de' %}
   {% set main_heading = 'Bearbeite PDFs in Firefox' %}
   {% set main_tagline = 'Verabschiede dich vom Ausdrucken deiner PDFs, um sie auszufüllen. Jetzt kannst du PDFs einfach mit dem integrierten PDF-Editor von Firefox bearbeiten.'%}
   {% set main_cta = 'Jetzt ausprobieren' %}
-  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-pdf-de.pdf' %}
+  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-de.pdf' %}
   {% set img_width = '620' %}
   {% set img_height = '235' %}
 {% elif LANG == 'es-ES' %}
   {% set main_heading = 'Edita PDFs en Firefox' %}
   {% set main_tagline = 'Dí adiós al fastidio de tener que imprimir o completar los PDFs en otros programas. Ahora puedes modificarlos  directamente desde el editor de PDF integrado de Firefox.'%}
   {% set main_cta = 'Pruébalo ahora' %}
-  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-pdf-es.pdf' %}
+  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-es.pdf' %}
   {% set img_width = '620' %}
   {% set img_height = '235' %}
 {% elif LANG == 'it' %}
   {% set main_heading = 'Modifica i tuoi PDF su Firefox' %}
   {% set main_tagline = 'Dì ciao per sempre al fastidio di stampare o compilare i tuoi documenti in PDF su altri programmi. Ora puoi modificarli direttamente su Firefox grazie all’editor integrato.'%}
   {% set main_cta = 'Provalo ora' %}
-  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-pdf-it.pdf' %}
+  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-it.pdf' %}
   {% set img_width = '652' %}
   {% set img_height = '235' %}
 {% elif LANG == 'pl' %}
   {% set main_heading = 'Edytuj pliki PDF w Firefoksie' %}
   {% set main_tagline = 'Pożegnaj się z ciągłymi problemami z drukowaniem i edytowaniem plików PDF w innych programach. Teraz załatwisz wszystko bezpośrednio we wbudowanym w Firefoksa edytorze plików PDF.'%}
   {% set main_cta = 'Wypróbuj już teraz' %}
-  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-pdf-pl.pdf' %}
+  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-pl.pdf' %}
   {% set img_width = '652' %}
   {% set img_height = '235' %}
 {% else %}
   {% set main_heading = 'Edit PDFs in Firefox' %}
   {% set main_tagline = 'Say goodbye to the hassle of trying to print or fill out your PDFs in other programs. Now you can edit documents easily with Firefox’s built-in PDF editor.'%}
   {% set main_cta = 'Try it now' %}
-  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-pdf-en.pdf' %}
+  {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-en.pdf' %}
   {% set img_width = '480' %}
   {% set img_height = '222' %}
 {% endif %}


### PR DESCRIPTION
## One-line summary
The PDFs for DE, ES and PL needed some corrections but they were already cached by the CDN. So renaming the files will bust the cache, and all of them got renamed for consistency.

## Issue / Bugzilla link
#14512 

## Testing
http://localhost:8000/de/firefox/126.0/whatsnew/
http://localhost:8000/es-ES/firefox/126.0/whatsnew/
http://localhost:8000/pl/firefox/126.0/whatsnew/
http://localhost:8000/fr/firefox/126.0/whatsnew/
http://localhost:8000/it/firefox/126.0/whatsnew/
http://localhost:8000/en-GB/firefox/126.0/whatsnew/