### PR TITLE
Hotfix broken redirects

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -574,6 +574,4 @@ redirectpatterns = (
     # redirects that don't need a lang code prefix
     redirect(r"^diversity/?$", "mozorg.diversity.2022.index", locale_prefix=False),
     redirect(r"^webvision/?$", "mozorg.about.webvision.summary", locale_prefix=True, prepend_locale=False),
-    # Diversity redirect that does need a lang prefix - must come after the non-prefixed one
-    redirect(r"^diversity/?$", "mozorg.diversity.2022.index", locale_prefix=True, permanent=False),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -574,4 +574,6 @@ redirectpatterns = (
     # redirects that don't need a lang code prefix
     redirect(r"^diversity/?$", "mozorg.diversity.2022.index", locale_prefix=False),
     redirect(r"^webvision/?$", "mozorg.about.webvision.summary", locale_prefix=True, prepend_locale=False),
+    # Diversity redirect that does need a lang prefix - must come after the non-prefixed one
+    redirect(r"^diversity/?$", "mozorg.diversity.2022.index", locale_prefix=True, permanent=False),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -572,7 +572,6 @@ redirectpatterns = (
     redirect(r"^research/?$", "https://foundation.mozilla.org/research/"),
     redirect(r"^research/cc/?$", "https://foundation.mozilla.org/research/library/?topics=187"),
     # redirects that don't need a lang code prefix
-    redirect(r"^contact/spaces/paris/$", "mozorg.contact.spaces.spaces-landing", locale_prefix=False),
     redirect(r"^diversity/$", "mozorg.diversity.2022.index", locale_prefix=False),
     redirect(r"^webvision/?$", "mozorg.about.webvision.summary", locale_prefix=True, prepend_locale=False),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -572,6 +572,6 @@ redirectpatterns = (
     redirect(r"^research/?$", "https://foundation.mozilla.org/research/"),
     redirect(r"^research/cc/?$", "https://foundation.mozilla.org/research/library/?topics=187"),
     # redirects that don't need a lang code prefix
-    redirect(r"^diversity/$", "mozorg.diversity.2022.index", locale_prefix=False),
+    redirect(r"^diversity/?$", "mozorg.diversity.2022.index", locale_prefix=False),
     redirect(r"^webvision/?$", "mozorg.about.webvision.summary", locale_prefix=True, prepend_locale=False),
 )

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -206,18 +206,23 @@ class TestMozorgRedirects(TestCase):
         self.assertEqual(resp.redirect_chain[1], ("/en-US/contact/spaces/", 302))
 
     def test_diversity_redirect(self):
-        resp = self.client.get("/diversity/", follow=True, headers={"accept-language": "en"})
-        # Note that we now 301 straight to the lang-prefixed version of the destination of the redirect
-        self.assertEqual(resp.redirect_chain[0], ("/diversity/2022/", 301))
-        self.assertEqual(resp.redirect_chain[1], ("/en-US/diversity/2022/", 302))
+        for path in ("/diversity/", "/diversity"):
+            with self.subTest(path):
+                resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
+                # Note that we now 301 straight to the lang-prefixed version of the destination of the redirect
+                self.assertEqual(resp.redirect_chain[0], ("/diversity/2022/", 301))
+                self.assertEqual(resp.redirect_chain[1], ("/en-US/diversity/2022/", 302))
 
     def test_webvision_redirect(self):
         # Since the webvision URL requires a WebvisionDoc to exist, we test this
         # here instead of in the redirects tests.
         WebvisionDoc.objects.create(name="summary", content="")
-        resp = self.client.get("/webvision/", follow=True, headers={"accept-language": "en"})
-        self.assertEqual(resp.redirect_chain[0], ("/about/webvision/", 301))
-        self.assertEqual(resp.redirect_chain[1], ("/en-US/about/webvision/", 302))
+
+        for path in ("/webvision/", "/webvision"):
+            with self.subTest(path):
+                resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
+                self.assertEqual(resp.redirect_chain[0], ("/about/webvision/", 301))
+                self.assertEqual(resp.redirect_chain[1], ("/en-US/about/webvision/", 302))
 
 
 class TestMiecoEmail(TestCase):

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -205,13 +205,20 @@ class TestMozorgRedirects(TestCase):
         self.assertEqual(resp.redirect_chain[0], ("/contact/spaces/", 301))
         self.assertEqual(resp.redirect_chain[1], ("/en-US/contact/spaces/", 302))
 
-    def test_diversity_redirect(self):
+    def test_diversity_redirect__no_lang_code(self):
         for path in ("/diversity/", "/diversity"):
             with self.subTest(path):
                 resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
                 # Note that we now 301 straight to the lang-prefixed version of the destination of the redirect
                 self.assertEqual(resp.redirect_chain[0], ("/diversity/2022/", 301))
                 self.assertEqual(resp.redirect_chain[1], ("/en-US/diversity/2022/", 302))
+
+    def test_diversity_redirect__with_lang_code(self):
+        for path in ("/en-US/diversity/", "/en-US/diversity"):
+            with self.subTest(path):
+                resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
+                # Note that we now 301 straight to the lang-prefixed version of the destination of the redirect
+                self.assertEqual(resp.redirect_chain[0], ("/en-US/diversity/2022/", 302))
 
     def test_webvision_redirect(self):
         # Since the webvision URL requires a WebvisionDoc to exist, we test this

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -205,20 +205,13 @@ class TestMozorgRedirects(TestCase):
         self.assertEqual(resp.redirect_chain[0], ("/contact/spaces/", 301))
         self.assertEqual(resp.redirect_chain[1], ("/en-US/contact/spaces/", 302))
 
-    def test_diversity_redirect__no_lang_code(self):
+    def test_diversity_redirect(self):
         for path in ("/diversity/", "/diversity"):
             with self.subTest(path):
                 resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
                 # Note that we now 301 straight to the lang-prefixed version of the destination of the redirect
                 self.assertEqual(resp.redirect_chain[0], ("/diversity/2022/", 301))
                 self.assertEqual(resp.redirect_chain[1], ("/en-US/diversity/2022/", 302))
-
-    def test_diversity_redirect__with_lang_code(self):
-        for path in ("/en-US/diversity/", "/en-US/diversity"):
-            with self.subTest(path):
-                resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
-                # Note that we now 301 straight to the lang-prefixed version of the destination of the redirect
-                self.assertEqual(resp.redirect_chain[0], ("/en-US/diversity/2022/", 302))
 
     def test_webvision_redirect(self):
         # Since the webvision URL requires a WebvisionDoc to exist, we test this


### PR DESCRIPTION
* Drop duplicated redirect for Paris space

* Fix redirect when /diversity lacks a trailing slash; expand tests for diversity and webvision redirects

