### PR TITLE
Fix typo in Italian WNP126 page

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-eu.html
@@ -38,7 +38,7 @@
   {% set img_height = '235' %}
 {% elif LANG == 'it' %}
   {% set main_heading = 'Modifica i tuoi PDF su Firefox' %}
-  {% set main_tagline = 'Dì ciao per sempre al fastidio di stampare o compilare i tuoi documenti in PDF su altri programmi. Ora puoi modificarli direttamente su Firefox grazie all’editor integrato.'%}
+  {% set main_tagline = 'Di’ ciao per sempre al fastidio di stampare o compilare i tuoi documenti in PDF su altri programmi. Ora puoi modificarli direttamente su Firefox grazie all’editor integrato.'%}
   {% set main_cta = 'Provalo ora' %}
   {% set pdf_link = 'https://assets.mozilla.net/wnp126-eu/firefox-wnp-edit-pdf-it.pdf' %}
   {% set img_width = '652' %}


### PR DESCRIPTION
A friend reported this typo: `di’` is the imperative form, so it needs an apostrophe, not an accent.