### PR TITLE
Copy fix for private browsing

### DIFF
--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -13,7 +13,7 @@
 <p>{{ ftl('features-private-browsing-if-you-share-a-computer') }}</p>
 
 <h2>{{ ftl('features-private-browsing-what-does-private-browsing-do') }}</h2>
-<p>{{ ftl('features-private-browsing-private-browsing-mode-opens') }}</p>
+<p>{{ ftl('features-private-browsing-private-browsing-mode-opens-v2', fallback='features-private-browsing-private-browsing-mode-opens') }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/l10n/en/firefox/features/private-browsing-2023.ftl
+++ b/l10n/en/firefox/features/private-browsing-2023.ftl
@@ -14,6 +14,7 @@ features-private-browsing-firefox-protects = { -brand-name-firefox } protects yo
 
 features-private-browsing-if-you-share-a-computer = If you share a computer with other people or if you want to limit how much data websites can collect about you, you can use private browsing mode in { -brand-name-firefox }. Private browsing erases the digital tracks you leave behind when you browse online — think of them like footprints through the woods.
 features-private-browsing-what-does-private-browsing-do = What does private browsing do?
+features-private-browsing-private-browsing-mode-opens-v2 = Private browsing mode opens a new browser window. When you close the last private browsing window, your browsing history and any tracking cookies from websites you visited will be erased. <strong>{ -brand-name-firefox } Pro Tip:</strong> Don’t forget to close all your private browsing windows when you’re done!
 features-private-browsing-private-browsing-mode-opens = Private browsing mode opens a new browser window. When you close it, your browsing history for that window and any tracking cookies from websites you visited will be erased. <strong>{ -brand-name-firefox } Pro Tip:</strong> Don’t forget to close the private browsing window when you’re done!
 
 # Used as an accessible text alternative for an image


### PR DESCRIPTION
Copy fix, as suggested in the issue #14579


Now looks like:

<img width="833" alt="Screenshot 2024-05-17 at 15 26 33" src="https://github.com/mozilla/bedrock/assets/101457/d8806db7-4ebd-4086-a03e-8fe0cb4f21e0">



## Issue / Bugzilla link

Resolves #14579

## Testing

* Visit http://localhost:8000/en-US/firefox/features/private-browsing/