### PR TITLE
Move ReleaseNotes.notes from being a custom NotesField

### DIFF
--- a/bedrock/releasenotes/migrations/0001_initial.py
+++ b/bedrock/releasenotes/migrations/0001_initial.py
@@ -4,6 +4,8 @@
 
 from django.db import migrations, models
 
+import django_extensions.db.fields.json as json_module
+
 import bedrock.releasenotes.models
 
 
@@ -28,7 +30,7 @@ class Migration(migrations.Migration):
                 ("system_requirements", bedrock.releasenotes.models.MarkdownField(blank=True)),
                 ("created", models.DateTimeField()),
                 ("modified", models.DateTimeField()),
-                ("notes", bedrock.releasenotes.models.NotesField(blank=True)),
+                ("notes", json_module.JSONField(blank=True)),
             ],
         ),
     ]

--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -161,16 +161,6 @@ class MarkdownField(models.TextField):
         return value
 
 
-class NotesField(JSONField):
-    """Field that returns a list of Note objects instead of dicts"""
-
-    def from_db_value(self, value, expression, connection):
-        if not value:
-            return value
-
-        return process_notes(self.to_python(value))
-
-
 class ProductReleaseQuerySet(models.QuerySet):
     def product(self, product_name, channel_name=None, version=None):
         if product_name.lower() == "firefox extended support release":
@@ -242,7 +232,7 @@ class ProductRelease(models.Model):
     system_requirements = MarkdownField(blank=True)
     created = models.DateTimeField()
     modified = models.DateTimeField()
-    notes = NotesField(blank=True)
+    notes = JSONField(blank=True)
 
     objects = ProductReleaseManager()
 
@@ -320,6 +310,11 @@ class ProductRelease(models.Model):
     def equivalent_desktop_release(self):
         if self.product == "Firefox for Android":
             return self.equivalent_release_for_product("Firefox")
+
+    def get_notes(self):
+        if not self.notes:
+            return self.notes
+        return process_notes(self.notes)
 
 
 @memoize(LONG_RN_CACHE_TIMEOUT)

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -81,7 +81,7 @@ class TestReleaseViews(TestCase):
         """
         mock_release = get_release_or_404.return_value
         mock_release.major_version = "34"
-        mock_release.notes.return_value = []
+        mock_release.get_notes.return_value = []
 
         views.release_notes(self.request, "27.0")
         get_release_or_404.assert_called_with("27.0", "Firefox", True)

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -92,7 +92,7 @@ class TestReleaseModel(TestCase):
 
     def test_note_fixed_in_release(self):
         rel = models.get_release("firefox", "55.0a1")
-        note = rel.notes[11]
+        note = rel.get_notes()[11]
         with self.activate_locale("en-US"):
             assert note.fixed_in_release.get_absolute_url() == "/en-US/firefox/55.0a1/releasenotes/"
 
@@ -110,7 +110,7 @@ class TestReleaseModel(TestCase):
         assert rel.version_obj.major == 57
 
         # notes
-        note = rel.notes[0]
+        note = rel.get_notes()[0]
         # datetime conversion
         assert note.created.year == 2017
         # datetime conversion
@@ -126,14 +126,14 @@ class TestReleaseModel(TestCase):
         Should also only include public notes."""
         assert models.get_release("firefox for android", "56.0.3") is None
         rel = models.get_release("firefox", "57.0a1")
-        assert len(rel.notes) == 4
+        assert len(rel.get_notes()) == 4
 
     @override_settings(DEV=True)
     def test_is_public_field_processor_dev_true(self):
         """Should always be true when DEV is true."""
         models.get_release("firefox for android", "56.0.3")
         rel = models.get_release("firefox", "57.0a1")
-        assert len(rel.notes) == 6
+        assert len(rel.get_notes()) == 6
 
     @override_settings(DEV=True)
     def test_invalid_version(self):

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -98,7 +98,7 @@ def release_notes(request, version, product="Firefox"):
 
     # add MDN link to all non-iOS releases. bug 1553566
     # avoid adding duplicate notes
-    release_notes = copy(release.notes)
+    release_notes = copy(release.get_notes())
     if release.product != "Firefox for iOS":
         release_notes.insert(
             0,
@@ -206,7 +206,7 @@ def nightly_feed(request):
         except NoReverseMatch:
             continue
 
-        for note in release.notes:
+        for note in release.get_notes():
             if note.id in notes:
                 continue
 


### PR DESCRIPTION
... to a simpler JSONField so we can loaddata into it

This is precursor work to moving to sqlite while retaining an export-to-sqlite route.

Editing the migration seems OK, given NotesField was a subclass of JSONField with no schema-related changes.


## Issue / Bugzilla link

Resolves #14574 

## Testing

- [ ] Pull the branch and compare any local releasenotes page with one on Prod -- the notes are still present for Releases, including special ones such as ones tagged "Progressive Rollout"
