### PR TITLE
Add a management command that will send an email to check deliverability

### DIFF
--- a/bedrock/base/management/commands/check_email_deliverability.py
+++ b/bedrock/base/management/commands/check_email_deliverability.py
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import sys
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now as tz_now
+
+from bedrock.base.config_manager import config
+
+
+class Command(BaseCommand):
+    help = """Sends an email to our monitoring service to check email deliverability.
+    Sends an email to the address specified in the EMAIL_DELIVERABILITY_TEST_ADDRESS environment variable.
+    Should be run as a cron job at least every 6 hours."""
+
+    def add_arguments(self, parser):
+        default_email = config(
+            "EMAIL_DELIVERABILITY_TEST_ADDRESS",
+            default="",
+            parser=str,
+        )
+
+        parser.add_argument(
+            "-e",
+            "--email",
+            action="store",
+            dest="email",
+            default=default_email,
+            help="The email address to send the test message to. Defaults to EMAIL_DELIVERABILITY_TEST_ADDRESS from the environment.",
+            required=False,
+            type=str,
+        )
+
+    def handle(self, *args, **kwargs):
+        email = kwargs.get("email")
+        if not email:
+            self.stdout.write(self.style.WARNING("Unable to send test email: no destination address available"))
+            sys.exit(1)
+
+        subject = "Test email to confirm email deliverability"
+        message = f"Timestamp of email sent: {tz_now()}"
+
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[email],
+            fail_silently=False,
+        )
+        self.stdout.write(self.style.SUCCESS(f"Test email sent successfully to {email}"))

--- a/bedrock/base/management/commands/check_email_deliverability.py
+++ b/bedrock/base/management/commands/check_email_deliverability.py
@@ -36,9 +36,13 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
+        if not all([settings.EMAIL_HOST_USER, settings.EMAIL_HOST_PASSWORD]):
+            self.stdout.write("Email not configured for sending. Exiting")
+            sys.exit(0)
+
         email = kwargs.get("email")
         if not email:
-            self.stdout.write(self.style.WARNING("Unable to send test email: no destination address available"))
+            self.stdout.write("Unable to send test email: no destination address available")
             sys.exit(1)
 
         subject = "Test email to confirm email deliverability"
@@ -51,4 +55,4 @@ class Command(BaseCommand):
             recipient_list=[email],
             fail_silently=False,
         )
-        self.stdout.write(self.style.SUCCESS(f"Test email sent successfully to {email}"))
+        self.stdout.write(f"Test email sent successfully to {email}")

--- a/bedrock/base/tests/test_commands.py
+++ b/bedrock/base/tests/test_commands.py
@@ -6,26 +6,33 @@ from unittest.mock import patch
 
 from django.core import mail
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 class CheckEmailDeliverabilityTestCase(TestCase):
-    # Color markers for console output
-    warning_marker = "\x1b[33;1m"
-    success_marker = "\x1b[32;1m"
-    end_marker = "\x1b[0m\n"
+    @override_settings(EMAIL_HOST_USER="", EMAIL_HOST_PASSWORD="")
+    @patch("sys.stdout")
+    def test_no_email_config_at_all(self, mock_stdout):
+        with self.assertRaises(SystemExit) as cm:
+            call_command("check_email_deliverability")
+        self.assertEqual(cm.exception.code, 0)
 
+        mock_stdout.write.assert_called_once_with("Email not configured for sending. Exiting\n")
+
+    @override_settings(EMAIL_HOST_USER="user", EMAIL_HOST_PASSWORD="pass")
     @patch("sys.stdout")
     def test_no_email_address_at_all(self, mock_stdout):
         with self.assertRaises(SystemExit) as cm:
             call_command("check_email_deliverability")
         self.assertEqual(cm.exception.code, 1)
 
-        mock_stdout.write.assert_called_once_with(
-            f"{self.warning_marker}Unable to send test email: no destination address available{self.end_marker}"
-        )
+        mock_stdout.write.assert_called_once_with("Unable to send test email: no destination address available\n")
 
-    @patch.dict("os.environ", {"EMAIL_DELIVERABILITY_TEST_ADDRESS": "envtest@example.com"})
+    @override_settings(EMAIL_HOST_USER="user", EMAIL_HOST_PASSWORD="pass")
+    @patch.dict(
+        "os.environ",
+        {"EMAIL_DELIVERABILITY_TEST_ADDRESS": "envtest@example.com"},
+    )
     @patch("sys.stdout")
     def test_send_test_email_with_env_var_email(self, mock_stdout):
         email_address = "envtest@example.com"
@@ -33,8 +40,9 @@ class CheckEmailDeliverabilityTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Test email to confirm email deliverability")
         self.assertEqual(mail.outbox[0].to, [email_address])
-        mock_stdout.write.assert_called_once_with(f"{self.success_marker}Test email sent successfully to {email_address}{self.end_marker}")
+        mock_stdout.write.assert_called_once_with(f"Test email sent successfully to {email_address}\n")
 
+    @override_settings(EMAIL_HOST_USER="user", EMAIL_HOST_PASSWORD="pass")
     @patch("sys.stdout")
     def test_send_test_email_with_cli_email_argument(self, mock_stdout):
         email_address = "test@example.com"
@@ -42,4 +50,4 @@ class CheckEmailDeliverabilityTestCase(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Test email to confirm email deliverability")
         self.assertEqual(mail.outbox[0].to, [email_address])
-        mock_stdout.write.assert_called_once_with(f"{self.success_marker}Test email sent successfully to {email_address}{self.end_marker}")
+        mock_stdout.write.assert_called_once_with(f"Test email sent successfully to {email_address}\n")

--- a/bedrock/base/tests/test_commands.py
+++ b/bedrock/base/tests/test_commands.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest.mock import patch
+
+from django.core import mail
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class CheckEmailDeliverabilityTestCase(TestCase):
+    # Color markers for console output
+    warning_marker = "\x1b[33;1m"
+    success_marker = "\x1b[32;1m"
+    end_marker = "\x1b[0m\n"
+
+    @patch("sys.stdout")
+    def test_no_email_address_at_all(self, mock_stdout):
+        with self.assertRaises(SystemExit) as cm:
+            call_command("check_email_deliverability")
+        self.assertEqual(cm.exception.code, 1)
+
+        mock_stdout.write.assert_called_once_with(
+            f"{self.warning_marker}Unable to send test email: no destination address available{self.end_marker}"
+        )
+
+    @patch.dict("os.environ", {"EMAIL_DELIVERABILITY_TEST_ADDRESS": "envtest@example.com"})
+    @patch("sys.stdout")
+    def test_send_test_email_with_env_var_email(self, mock_stdout):
+        email_address = "envtest@example.com"
+        call_command("check_email_deliverability", email=email_address)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Test email to confirm email deliverability")
+        self.assertEqual(mail.outbox[0].to, [email_address])
+        mock_stdout.write.assert_called_once_with(f"{self.success_marker}Test email sent successfully to {email_address}{self.end_marker}")
+
+    @patch("sys.stdout")
+    def test_send_test_email_with_cli_email_argument(self, mock_stdout):
+        email_address = "test@example.com"
+        call_command("check_email_deliverability", email=email_address)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Test email to confirm email deliverability")
+        self.assertEqual(mail.outbox[0].to, [email_address])
+        mock_stdout.write.assert_called_once_with(f"{self.success_marker}Test email sent successfully to {email_address}{self.end_marker}")

--- a/bedrock/legal/views.py
+++ b/bedrock/legal/views.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.conf import settings
 from django.core.mail import EmailMessage
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
@@ -11,7 +12,7 @@ from bedrock.base.urlresolvers import reverse
 from bedrock.legal.forms import FraudReportForm
 from lib import l10n_utils
 
-FRAUD_REPORT_EMAIL_FROM = "Mozilla.com <noreply@mozilla.com>"
+FRAUD_REPORT_EMAIL_FROM = settings.DEFAULT_FROM_EMAIL
 FRAUD_REPORT_EMAIL_SUBJECT = "New trademark infringement report: %s; %s"
 FRAUD_REPORT_EMAIL_TO = ["trademarks@mozilla.com"]
 

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -199,7 +199,7 @@ class WebvisionDocView(RequireSafeMixin, TemplateView):
 
 
 MIECO_EMAIL_SUBJECT = {"mieco": "MIECO Interest Form", "innovations": "Innovations Interest Form"}
-MIECO_EMAIL_SENDER = "Mozilla.com <noreply@mozilla.com>"
+MIECO_EMAIL_SENDER = settings.DEFAULT_FROM_EMAIL
 MIECO_EMAIL_TO = {
     "mieco": ["mieco@mozilla.com"],
     "innovations": ["innovations@mozilla.com"],

--- a/bedrock/press/views.py
+++ b/bedrock/press/views.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.conf import settings
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
@@ -15,7 +16,7 @@ from .forms import PressInquiryForm, SpeakerRequestForm
 
 PRESS_INQUIRY_EMAIL_SUBJECT = "New Press Inquiry"
 PRESS_INQUIRY_EMAIL_TO = ["press@mozilla.com"]
-SPEAKER_REQUEST_EMAIL_FROM = PRESS_INQUIRY_EMAIL_FROM = "Mozilla.com <noreply@mozilla.com>"
+SPEAKER_REQUEST_EMAIL_FROM = PRESS_INQUIRY_EMAIL_FROM = settings.DEFAULT_FROM_EMAIL
 SPEAKER_REQUEST_EMAIL_SUBJECT = "New speaker request form submission"
 SPEAKER_REQUEST_EMAIL_TO = ["press@mozilla.com"]
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -862,6 +862,8 @@ MESSAGE_STORAGE = "django.contrib.messages.storage.cookie.CookieStorage"
 
 default_email_backend = "django.core.mail.backends.console.EmailBackend" if DEBUG else "django.core.mail.backends.smtp.EmailBackend"
 
+DEFAULT_FROM_EMAIL = "Mozilla.com <noreply@mozilla.com>"
+
 EMAIL_BACKEND = config("EMAIL_BACKEND", default=default_email_backend)
 EMAIL_HOST = config("EMAIL_HOST", default="localhost")
 EMAIL_PORT = config("EMAIL_PORT", default="25", parser=int)


### PR DESCRIPTION
If we set an env var `EMAIL_DELIVERABILITY_TEST_ADDRESS` to be the address of a dedicated snitch in Dead Man's Snitch (https://deadmanssnitch.com/snitches/2995da2cd9/setup) and then run this management command via a k8s cron job, in production only, we will be able to be alerted if email deliverability is affected.

There will be a corresponding infra PR that uses this management command.

It was kept out of cron.py for simplicity in controlling exactly where it is triggered.

- [X] I used an AI to write some of this code.

I used Copilot to generate the base of the tests, but then tuned them by hand (to make them appropriate, not just to make them work)

## Issue / Bugzilla link

Resolves #14566 

Related PR in infra that needs to be merged **after** this https://github.com/mozilla-it/webservices-infra/pull/2062

## Testing

Locally, with `DEBUG=True` try:
* `EMAIL_HOST_USER="fake" EMAIL_HOST_PASSWORD="pass" EMAIL_DELIVERABILITY_TEST_ADDRESS=foo@example.com ./manage.py check_email_deliverability`
* `EMAIL_HOST_USER="fake" EMAIL_HOST_PASSWORD="pass" ./manage.py check_email_deliverability --email=foo@example.com`
* `EMAIL_HOST_USER="fake" EMAIL_HOST_PASSWORD="pass" ./manage.py check_email_deliverability -e foo@example.com`
* `EMAIL_HOST_USER="fake" EMAIL_HOST_PASSWORD="pass" ./manage.py check_email_deliverability --help`
* `EMAIL_HOST_USER="fake" EMAIL_HOST_PASSWORD="pass" ./manage.py check_email_deliverability`



