### PR TITLE
Add ability to override CSP based on path prefix

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -5,6 +5,8 @@
 import logging.config
 import sys
 
+from csp.constants import SELF, UNSAFE_EVAL, UNSAFE_INLINE
+
 from .base import *  # noqa: F403, F405
 
 # This file:
@@ -17,11 +19,6 @@ from .base import *  # noqa: F403, F405
 # Which site do we want Bedrock to serve?
 
 # IS_POCKET_MODE and IS_MOZORG_MODE are set in settings.base
-
-# Some CSP constants to ease the quoting of common values.
-SELF = "'self'"
-UNSAFE_EVAL = "'unsafe-eval'"
-UNSAFE_INLINE = "'unsafe-inline'"
 
 if IS_POCKET_MODE:
     ROOT_URLCONF = "bedrock.urls.pocket_mode"
@@ -268,6 +265,8 @@ CONTENT_SECURITY_POLICY = {
     },
 }
 
+# Mainly for overriding CSP settings for CMS admin.
+# Works in conjunction with the `bedrock.base.middleware.CSPMiddlewareByPathPrefix` middleware.
 CSP_PATH_OVERRIDES = {}
 
 

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -265,8 +265,10 @@ CONTENT_SECURITY_POLICY = {
         # support older browsers (mainly Safari)
         "frame-src": _csp_child_src,
         "report-uri": config("CSP_REPORT_URI", default="") or None,
-    }
+    },
 }
+
+CSP_PATH_OVERRIDES = {}
 
 
 # 4. SETTINGS WHICH APPLY REGARDLESS OF SITE MODE

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -658,7 +658,7 @@ MIDDLEWARE = [
 
 ENABLE_CSP_MIDDLEWARE = config("ENABLE_CSP_MIDDLEWARE", default="true", parser=bool)
 if ENABLE_CSP_MIDDLEWARE:
-    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+    MIDDLEWARE.append("bedrock.base.middleware.CSPMiddlewareByPathPrefix")
 
 INSTALLED_APPS = [
     # Django contrib apps

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -690,6 +690,7 @@ INSTALLED_APPS = [
     "wagtail",
     "modelcluster",
     "taggit",
+    "csp",
     # Local apps
     "bedrock.base",
     "bedrock.cms",  # Wagtail-based CMS bases

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -492,8 +492,8 @@ django-crum==0.7.9 \
     --hash=sha256:037cc8b822975bb1d41cd24269b59a512cc77448fadc3f34ab9a17b229b4b471 \
     --hash=sha256:65e9bc0f070a663fafc4d9e357f45fd4e6f01838b20a9e2fb7670f5706754288
     # via -r requirements/prod.txt
-django-csp @ https://github.com/mozilla/django-csp/archive/3413de318a8a56725d5b68faecd2fc9c0d162097.zip \
-    --hash=sha256:f74d22200d3cb1b921022c23ccaf2cfff055966d382b068c7b5834e31b448f1c
+django-csp @ https://github.com/mozilla/django-csp/archive/9b2cee0866e47f5beb8f21f7375c2b721333efab.zip \
+    --hash=sha256:ffa20676c0d8a10fa107d1c1eb9466e7e8029bbc60b44d402f71c0e66832e2b3
     # via -r requirements/prod.txt
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -492,9 +492,8 @@ django-crum==0.7.9 \
     --hash=sha256:037cc8b822975bb1d41cd24269b59a512cc77448fadc3f34ab9a17b229b4b471 \
     --hash=sha256:65e9bc0f070a663fafc4d9e357f45fd4e6f01838b20a9e2fb7670f5706754288
     # via -r requirements/prod.txt
-django-csp==3.8 \
-    --hash=sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719 \
-    --hash=sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0
+django-csp @ https://github.com/mozilla/django-csp/archive/3413de318a8a56725d5b68faecd2fc9c0d162097.zip \
+    --hash=sha256:f74d22200d3cb1b921022c23ccaf2cfff055966d382b068c7b5834e31b448f1c
     # via -r requirements/prod.txt
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -14,7 +14,7 @@ django-allow-cidr==0.7.1
 django-cors-headers==4.3.1
 django-crum==0.7.9
 # django-csp momentarily pinned to a commit that refactors django-csp prior to 4.0 release.
-https://github.com/mozilla/django-csp/archive/3413de318a8a56725d5b68faecd2fc9c0d162097.zip#egg=django-csp
+https://github.com/mozilla/django-csp/archive/9b2cee0866e47f5beb8f21f7375c2b721333efab.zip#egg=django-csp
 django-extensions==3.2.3
 django-jinja-markdown==1.1
 django-jinja==2.11.0

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -13,7 +13,8 @@ dj-database-url==2.2.0
 django-allow-cidr==0.7.1
 django-cors-headers==4.3.1
 django-crum==0.7.9
-django-csp==3.8
+# django-csp momentarily pinned to a commit that refactors django-csp prior to 4.0 release.
+https://github.com/mozilla/django-csp/archive/3413de318a8a56725d5b68faecd2fc9c0d162097.zip#egg=django-csp
 django-extensions==3.2.3
 django-jinja-markdown==1.1
 django-jinja==2.11.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -339,9 +339,8 @@ django-crum==0.7.9 \
     --hash=sha256:037cc8b822975bb1d41cd24269b59a512cc77448fadc3f34ab9a17b229b4b471 \
     --hash=sha256:65e9bc0f070a663fafc4d9e357f45fd4e6f01838b20a9e2fb7670f5706754288
     # via -r requirements/prod.in
-django-csp==3.8 \
-    --hash=sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719 \
-    --hash=sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0
+django-csp @ https://github.com/mozilla/django-csp/archive/3413de318a8a56725d5b68faecd2fc9c0d162097.zip \
+    --hash=sha256:f74d22200d3cb1b921022c23ccaf2cfff055966d382b068c7b5834e31b448f1c
     # via -r requirements/prod.in
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -339,8 +339,8 @@ django-crum==0.7.9 \
     --hash=sha256:037cc8b822975bb1d41cd24269b59a512cc77448fadc3f34ab9a17b229b4b471 \
     --hash=sha256:65e9bc0f070a663fafc4d9e357f45fd4e6f01838b20a9e2fb7670f5706754288
     # via -r requirements/prod.in
-django-csp @ https://github.com/mozilla/django-csp/archive/3413de318a8a56725d5b68faecd2fc9c0d162097.zip \
-    --hash=sha256:f74d22200d3cb1b921022c23ccaf2cfff055966d382b068c7b5834e31b448f1c
+django-csp @ https://github.com/mozilla/django-csp/archive/9b2cee0866e47f5beb8f21f7375c2b721333efab.zip \
+    --hash=sha256:ffa20676c0d8a10fa107d1c1eb9466e7e8029bbc60b44d402f71c0e66832e2b3
     # via -r requirements/prod.in
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \


### PR DESCRIPTION
Resolves https://github.com/mozilla/bedrock/issues/14576

This shifts our current install of django-csp to the as yet un-released changes on the main branch, which is a big django-csp refactor that required settings changes.

This PR adds a new middleware, `CSPMiddlewareByPathPrefix`, that allows overriding the default CSP if a path prefix matches the current request path.

The setting for this looks like the following:
```python
CSP_PATH_OVERRIDES={
    "/override/path": {
        "DIRECTIVES": {
            # Your custom CSP directives here.
            "default-src": ["override.com"]
        }
    }
}
```