### PR TITLE
Fix new home ftl typo

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -168,25 +168,24 @@
         <a href="{{ url('products.vpn.landing') }}" class="mzp-c-button mzp-t-secondary" id="homepage-get-mozilla-vpn" data-cta-text="Get Mozilla VPN" data-cta-type="link">{{ ftl('home-cta-get-vpn') }}</a>
       {% endcall %}
 
+      <!-- Monitor -->
+      {% call picto(
+        base_el='li',
+        title=ftl('home-product-monitor-protect-your', fallback='home-product-monitor-data'),
+        image=resp_img(
+          url='protocol/img/logos/firefox/monitor/logo.svg',
+          optional_attributes={
+            'class': 'mzp-c-picto-image',
+            'loading': 'lazy',
+            'width': '50',
+            'height': '50'
+          }
+          ),
+          body=True,
+          ) %}
+         <a href="https://monitor.mozilla.org/{{ utm_params }}" rel="external noopener" class="mzp-c-button mzp-t-secondary" id="homepage-get-monitor" data-cta-text="Get Mozilla Monitor" data-cta-type="link">{{ ftl('home-cta-get-monitor')}}</a>
+      {% endcall %}
 
-
-        <!-- Monitor -->
-        {% call picto(
-          base_el='li',
-          title=ftl('home-product-monitor-protect-your', fallback='home-product-monitor-data'),
-          image=resp_img(
-            url='protocol/img/logos/firefox/monitor/logo.svg',
-            optional_attributes={
-              'class': 'mzp-c-picto-image',
-              'loading': 'lazy',
-              'width': '50',
-              'height': '50'
-            }
-            ),
-            body=True,
-            ) %}
-          <a href="https://monitor.mozilla.org/{{ utm_params }}" rel="external noopener" class="mzp-c-button mzp-t-secondary" id="homepage-get-monitor" data-cta-text="Get Mozilla Monitor" data-cta-type="link">{{ ftl('home-cta-get-monitor')}}</a>
-        {% endcall %}
     </ul>
   </section>
 
@@ -226,7 +225,6 @@
     {% endif %}
 
     {% set moz_ventures = 'href="%s" data-cta-type="link" data-cta-text="Mozilla Ventures"'|safe|format(('https://mozilla.vc/'+utm_params)) %}
-
     {% set moz_ai = 'href="%s" data-cta-type="link" data-cta-text="Mozilla AI"'|safe|format(('https://mozilla.ai/'+utm_params)) %}
 
     <!-- Foundation -->

--- a/bedrock/mozorg/templates/mozorg/home/includes/mofo-donate-promo.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/mofo-donate-promo.html
@@ -11,6 +11,6 @@
       <small>{{ ftl('home-mofo-build-our-movement') }}</small>
       <h2>{{ ftl('home-mofo-donate-to-mofo-today') }}</h2>
     </div>
-      <a href="{{donate_url(location='featured-section') }}" class="mzp-c-button" data-cta-text="Donate" data-cta-type="link" data-cta-position="mid-page banner">{{ ftl('home-mofo-donate') }}</a>
+      <a href="{{ donate_url(location='featured-section') }}" class="mzp-c-button" data-cta-text="Donate" data-cta-type="link" data-cta-position="mid-page banner">{{ ftl('home-mofo-donate') }}</a>
   </div>
 </aside>

--- a/l10n/en/mozorg/home-new.ftl
+++ b/l10n/en/mozorg/home-new.ftl
@@ -35,11 +35,10 @@ home-cta-get-vpn = Get { -brand-name-mozilla-vpn }
 # Obsolete string (expires 2024-07-23)
 home-product-monitor-data = Data breach alerts
 
-home-product-monitor-protect-your = Protectr your private info from data brokers
+home-product-monitor-protect-your = Protect your private info from data brokers
 home-cta-get-monitor = Get { -brand-name-monitor }
 home-product-fakespot-detect = Detect fake shopping reviews
 home-cta-get-fakespot = Get { -brand-name-fakespot }
-
 
 home-mozilla-takes-bets = “{ -brand-name-mozilla } is taking bets to show the world there’s a business to be made with trustworthy AI. That includes putting things like human rights, data protection and transparency at the core of how these complex systems work.”
 
@@ -60,7 +59,7 @@ home-so-what-is-mozilla = So, what is { -brand-name-mozilla }?
 
 # Variables
 #   $ventures - link to https://mozilla.vc/
-#   $mozai - link to https://www.mozilla.ai/
+#   $mozai - link to https://mozilla.ai/
 home-at-its-core = At its core, { -brand-name-mozilla } is an activist organization led by the { -brand-name-mozilla-foundation } that makes change in the world through a variety of ventures including { -brand-name-mozilla-corporation }, MZLA, <a {$ventures}>{ -brand-name-mozilla-ventures }</a> and <a {$mozai}>{ -brand-name-mozilla-ai }</a>. How are we different? Because we’re mission-driven, it means we have the freedom to make all of our decisions based on what’s best for the internet and for everyone online, not based on the demands of shareholders — we don’t actually have any of those.
 
 home-learn-about-mofo = Learn about the { -brand-name-mozilla-foundation }
@@ -83,7 +82,6 @@ home-featured-product = Featured product
 
 # HTML for visual formatting. "Blur" here is used as a metaphor for hiding or obscuring something.
 home-feature-blur-your-location = Blur your location & activity using <span>{ -brand-name-mozilla-vpn }</span>
-
 
 # Mozilla Foundation donation promo
 home-mofo-build-our-movement = Build our movement


### PR DESCRIPTION
## One-line summary

Fixes "Protect**~~r~~**" typo that hasn't been published yet (incl. l10n) — the rest is just whitespace/formatting.

> ![Screen Shot 2024-05-25 at 14 52 36](https://github.com/mozilla-l10n/www-l10n/assets/1784648/d0f21ec7-ccf2-4d51-992f-7e621521a9ec)

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

1. The downstream PR raised QA around dashes/typography https://github.com/mozilla-l10n/www-l10n/pull/404#pullrequestreview-2077285981 so I might include any result of the discussions here too.
2. There's also new menu items ftl content not used in the output eventually https://github.com/mozilla-l10n/www-l10n/pull/404#pullrequestreview-2079294790 so this can also get cleaned up here with the rest.

## Issue / Bugzilla link

https://github.com/mozilla-l10n/www-l10n/pull/404#pullrequestreview-2078964607

## Testing

http://localhost:8000/en-US/