### PR TITLE
Remove press_blog_url helper

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -330,43 +330,6 @@ def video(ctx, *args, **kwargs):
 
 @library.global_function
 @jinja2.pass_context
-def press_blog_url(ctx):
-    """Output a link to the press blog taking locales into account.
-
-    Uses the locale from the current request. Checks to see if we have
-    a press blog that matches this locale, returns the localized press blog
-    url or falls back to the US press blog url if not.
-
-    Examples
-    ========
-
-    In Template
-    -----------
-
-        {{ press_blog_url() }}
-
-    For en-US this would output:
-
-        https://blog.mozilla.org/press/
-
-    For en-GB this would output:
-
-        https://blog.mozilla.org/press-uk/
-
-    For de this would output:
-
-        https://blog.mozilla.org/press-de/
-
-    """
-    locale = getattr(ctx["request"], "locale", "en-US")
-    if locale not in settings.PRESS_BLOGS:
-        locale = "en-US"
-
-    return settings.PRESS_BLOG_ROOT + settings.PRESS_BLOGS[locale]
-
-
-@library.global_function
-@jinja2.pass_context
 def donate_url(ctx, location=""):
     """Output a formatted donation link to the donation popup form.
 

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -196,46 +196,6 @@ class TestVideoTag(TestCase):
         assert extensions == [".webm", ".ogv"]
 
 
-class TestPressBlogUrl(TestCase):
-    rf = RequestFactory()
-
-    def _render(self, locale):
-        req = self.rf.get("/")
-        req.locale = locale
-        return render("{{{{ press_blog_url() }}}}".format("/"), {"request": req})  # noqa: F523
-
-    def test_press_blog_url_no_locale(self):
-        """No locale, fallback to default press blog"""
-        assert self._render("") == "https://blog.mozilla.org/press/"
-
-    def test_press_blog_url_english(self):
-        """en-US locale, default press blog"""
-        assert self._render("en-US") == "https://blog.mozilla.org/press/"
-
-    def test_press_blog_url_europe(self):
-        """Major European locales have their own blog"""
-        assert self._render("es-ES") == "https://blog.mozilla.org/press-es/"
-        assert self._render("fr") == "https://blog.mozilla.org/press-fr/"
-        assert self._render("de") == "https://blog.mozilla.org/press-de/"
-        assert self._render("pl") == "https://blog.mozilla.org/press-pl/"
-        assert self._render("it") == "https://blog.mozilla.org/press-it/"
-        assert self._render("en-GB") == "https://blog.mozilla.org/press-uk/"
-
-    def test_press_blog_url_latam(self):
-        """South American Spanishes use the es-ES blog"""
-        assert self._render("es-AR") == "https://blog.mozilla.org/press-es/"
-        assert self._render("es-CL") == "https://blog.mozilla.org/press-es/"
-        assert self._render("es-MX") == "https://blog.mozilla.org/press-es/"
-
-    def test_press_blog_url_brazil(self):
-        """Brazilian Portuguese has its own br blog"""
-        assert self._render("pt-BR") == "https://blog.mozilla.org/press-br/"
-
-    def test_press_blog_url_other_locale(self):
-        """No blog for locale, fallback to default press blog"""
-        assert self._render("oc") == "https://blog.mozilla.org/press/"
-
-
 class TestDonateUrl(TestCase):
     rf = RequestFactory()
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -896,22 +896,6 @@ FXA_NEWSLETTERS = [
 ]
 FXA_NEWSLETTERS_LOCALES = ["en", "de", "fr"]
 
-# Regional press blogs map to locales
-PRESS_BLOG_ROOT = "https://blog.mozilla.org/"
-PRESS_BLOGS = {
-    "de": "press-de/",
-    "en-GB": "press-uk/",
-    "en-US": "press/",
-    "es-AR": "press-es/",
-    "es-CL": "press-es/",
-    "es-ES": "press-es/",
-    "es-MX": "press-es/",
-    "fr": "press-fr/",
-    "it": "press-it/",
-    "pl": "press-pl/",
-    "pt-BR": "press-br/",
-}
-
 DONATE_LINK = "https://foundation.mozilla.org/{location}"
 
 # Official Firefox Twitter accounts


### PR DESCRIPTION
## One-line summary

Not used since #14561 as all footer "Press" links now point to main EN blog only.

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

This doesn't seem to be coming back anytime soon, and if so it can always be exhumed from git history.

## Issue / Bugzilla link

Closes #14550

## Testing

`make test` and coverage seem happy