### PR TITLE
Close only bot issues from github-actions by l10n cron job

### DIFF
--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -15,6 +15,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --author "github-actions[bot]" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then

--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -1,16 +1,16 @@
-name: Create l10n cleanup task
+name: Bimonthly l10n cleanup reminder
 on:
   schedule:
     - cron: 0 09 14 */2 *
 
 jobs:
   create_issue:
-    name: Create l10n cleanup task
+    name: Create l10n cleanup issue
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - name: Create l10n cleanup task
+      - name: Open new issue (and close old if needed)
         run: |
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
@@ -34,13 +34,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TITLE: Remove obsolete l10n strings and ftl files
+          TITLE: "[bot] Remove obsolete l10n strings and ftl files"
           ASSIGNEES:
           LABELS: L10N
           BODY: |
             ### Remove obsolete strings
 
-            Search the code base for strings marked `obsolete` that are more than 2 months old.
+            Search the code base for [strings marked `obsolete`](https://github.com/search?q=repo%3Amozilla%2Fbedrock+obsolete+language%3AFluent&type=code&l=Fluent) that are more than 2 months old.
             If you find strings that have no date, either find the date by looking at git history
             or add an expiry date and leave it to be removed in 2 months.
 


### PR DESCRIPTION
## One-line summary

Adds `--author` arg to `gh issue list` cli filter to pinpoint only the past l10n cleanup issue generated by the :octocat: **github-actions[bot]** itself.

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

- Adds a link to search results to give an idea how much obsolete ftl strings there are.
- Prefixes the issue title with "[bot] …" for better recognition it's created by automation.
- Improves some of the labels to match other workflows conventions.

## Issue / Bugzilla link

Fix #14571

## Testing

[actions/runs/9263192494/job/25481213414](https://github.com/janbrasna/gha-test-gh-issue-cli-cron/actions/runs/9263192494/job/25481213414) over [these](https://github.com/janbrasna/gha-test-gh-issue-cli-cron/issues)