### PR TITLE
Add separate string for console in Firefox Developer Edition features section.

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/features.html
@@ -50,7 +50,7 @@
         }
       ),
     ) %}
-      <p>{{ ftl('firefox-developer-inspect-and-refine') }}</p>
+      <p>{{ ftl('firefox-developer-logs-and-javascript') }}</p>
       <p>
         <a href="https://firefox-source-docs.mozilla.org/devtools-user/web_console/" class="mzp-c-cta-link" rel="external">
           {{ ftl('firefox-developer-learn-about-web-console') }}

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -27,6 +27,7 @@ firefox-developer-inspector = Inspector
 firefox-developer-inspect-and-refine = Inspect and refine code to build pixel-perfect layouts.
 firefox-developer-learn-about-page-inspector = Learn more about Page Inspector
 firefox-developer-console = Console
+firefox-developer-logs-and-javascript = View logs and use JavaScript to interact with sites in real time.
 firefox-developer-track-css = Track CSS, JavaScript, security and network issues.
 firefox-developer-learn-about-web-console = Learn more about Web Console
 firefox-developer-debugger = Debugger


### PR DESCRIPTION
## One-line summary

Add separate string for console in Firefox Developer Edition features section.

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

Wording for console section copy.

## Issue / Bugzilla link

#14609

## Testing
http://localhost:8000/en-US/firefox/developer/#:~:text=Build%20and%20Perfect%20your%20sites%0Awith%20Firefox%20DevTools