### PR TITLE
Remove Moz AI and Moz VC Fluent strings from navigation

### DIFF
--- a/l10n/en/navigation_v2.ftl
+++ b/l10n/en/navigation_v2.ftl
@@ -81,6 +81,3 @@ navigation-v2-webassembly = { -brand-name-webassembly }
 navigation-v2-learn-more-about-the-new = Learn more about the new, low-level, assembly-like language.
 navigation-v2-mozilla-innovation-projects = { -brand-name-mozilla } Innovation Projects
 navigation-v2-discover-ways-to-bring = Discover ways to bring bright ideas to life.
-navigation-v2-mozilla-ai = { -brand-name-mozilla-ai }
-
-navigation-v2-mozilla-ventures = { -brand-name-mozilla-ventures }


### PR DESCRIPTION
## One-line summary
These Fluent strings were leftover from the recent homepage updates, and it was decided that they wouldn't be part of the navigation for now, so we're removing them from the fluent file.

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/404?notification_referrer_id=NT_kwDOAoWVorQxMDc5NzY1Nzg0Mzo0MjMwOTAyNg#discussion_r1614972205


## Testing
http://localhost:8000/en-US/
