### PR TITLE
Add Playwright test suite (Fixes #14191)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,10 @@ tests/functional/assets
 tests/functional/driver.log
 tests/functional/results.html
 tests/unit/coverage
+tests/unit/dist/
+tests/playwright/test-results/
 Thumbs.db
 tmp/*
 venv
-tests/unit/dist/
 /custom-media
 /local-credentials/*.json

--- a/bedrock/base/templates/includes/banners/consent-banner.html
+++ b/bedrock/base/templates/includes/banners/consent-banner.html
@@ -4,16 +4,16 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<aside class="moz-consent-banner" id="moz-consent-banner" role="region" aria-label="{{ ftl('consent-banner-aria-label') }}" data-nosnippet="true">
+<aside class="moz-consent-banner" id="moz-consent-banner" role="region" aria-label="{{ ftl('consent-banner-aria-label') }}" data-nosnippet="true" data-testid="consent-banner">
   <div class="moz-consent-banner-content">
     <h2 class="moz-consent-banner-heading">{{ ftl('consent-banner-heading') }}</h2>
     <div class="moz-consent-banner-copy">
       <p>{{ ftl('consent-banner-body-v2', fallback='consent-banner-body') }}</p>
       <div class="moz-consent-banner-controls">
-        <button type="button" id="moz-consent-banner-button-accept" class="moz-consent-banner-button moz-consent-banner-button-accept">
+        <button type="button" id="moz-consent-banner-button-accept" class="moz-consent-banner-button moz-consent-banner-button-accept" data-testid="consent-banner-accept-button">
           {{ ftl('consent-banner-button-accept') }}
         </button>
-        <button type="button" id="moz-consent-banner-button-reject" class="moz-consent-banner-button moz-consent-banner-button-reject">
+        <button type="button" id="moz-consent-banner-button-reject" class="moz-consent-banner-button moz-consent-banner-button-reject" data-testid="consent-banner-reject-button">
           {{ ftl('consent-banner-button-reject') }}
         </button>
         <a href="{{ url('privacy.cookie-settings')}}">

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -14,10 +14,10 @@
       </div>
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading">
+          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-company">
             {{ ftl('footer-company') }}
           </h5>
-          <ul class="mzp-c-footer-list">
+          <ul class="mzp-c-footer-list" data-testid="footer-list-company">
             <li><a href="{{ url('mozorg.about.manifesto') }}" data-link-type="footer" data-link-text="Mozilla Manifesto">{{ ftl('footer-mozilla-manifesto') }}</a></li>
             <li><a href="https://blog.mozilla.org/category/mozilla/news/?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-text="Press Center">{{ ftl('footer-press-center') }}</a></li>
             <li><a href="https://blog.mozilla.org/?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-text="Mozilla Blog">{{ ftl('footer-mozilla-blog', fallback='footer-corporate-blog') }}</a></li>
@@ -41,20 +41,20 @@
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading">
+          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-resources">
             {{ ftl('footer-resources') }}
           </h5>
-          <ul class="mzp-c-footer-list">
+          <ul class="mzp-c-footer-list" data-testid="footer-list-resources">
             <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-text="Privacy Hub">{{ ftl('footer-privacy-hub', fallback='footer-privacy') }}</a></li>
             <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-type="footer" data-link-text="Brand Standards">{{ ftl('footer-brand-standards') }}</a></li>
           </ul>
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading">
+          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-support">
             {{ ftl('footer-support') }}
           </h5>
-          <ul class="mzp-c-footer-list">
+          <ul class="mzp-c-footer-list" data-testid="footer-list-support">
             <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="Product Help">{{ ftl('footer-product-help', fallback='footer-support') }}</a></li>
             <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="File a Bug">{{ ftl('footer-file-a-bug') }}</a></li>
             <li><a href="https://pontoon.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="Localise Mozilla">{{ ftl('footer-localize-mozilla') }}</a></li>
@@ -62,10 +62,10 @@
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading">
+          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-developers">
             {{ ftl('footer-developers') }}
           </h5>
-          <ul class="mzp-c-footer-list">
+          <ul class="mzp-c-footer-list" data-testid="footer-list-developers">
             <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
             <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-type="footer" data-link-text="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
             <li><a href="{{ url('firefox.channel.android') }}#beta" data-link-type="footer" data-link-text="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -8,7 +8,7 @@
   <form id="lang_form" class="mzp-c-language-switcher" method="get" action="#">
     <a class="mzp-c-language-switcher-link" href="{{ url('mozorg.locales') }}">{{ ftl('footer-language') }}</a>
     <label for="page-language-select">{{ ftl('footer-language') }}</label>
-    <select id="page-language-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr">
+    <select id="page-language-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr" data-testid="footer-language-select">
       {% for code, label in translations|dictsort -%}
         {# Don't escape the label as it may include entity references
         # like "Português (do&nbsp;Brasil)" (Bug 861149) #}

--- a/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
@@ -7,15 +7,15 @@
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="c-menu-panel-firefox">{{ ftl('navigation-v2-firefox-browsers') }}</a>
+  <a class="c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="c-menu-panel-firefox" data-testid="navigation-link-firefox">{{ ftl('navigation-v2-firefox-browsers') }}</a>
   <div class="c-menu-panel" id="c-menu-panel-firefox">
-    <div class="c-menu-panel-container">
+    <div class="c-menu-panel-container" data-testid="navigation-menu-firefox">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-firefox">{{ ftl('navigation-v2-close-firefox-browsers-menu') }}</button>
       <div class="c-menu-panel-content">
         <ul class="mzp-l-rows-three">
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox" data-testid="navigation-menu-link-firefox-desktop">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-desktop', fallback='navigation-firefox-browser-for-desktop') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-not-for-profit-backed', fallback='navigation-get-the-browser-that-respects') }}</p>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
@@ -7,8 +7,8 @@
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=innovation' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="https://future.mozilla.org/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-innovation">{{ ftl('navigation-v2-innovation') }}</a>
-  <div class="c-menu-panel" id="c-menu-panel-innovation">
+  <a class="c-menu-title" href="https://future.mozilla.org/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-innovation" data-testid="navigation-link-innovation">{{ ftl('navigation-v2-innovation') }}</a>
+  <div class="c-menu-panel" id="c-menu-panel-innovation" data-testid="navigation-menu-innovation">
     <div class="c-menu-panel-container">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-innovation">{{ ftl('navigation-v2-close-innovation-menu') }}</button>
       <div class="c-menu-panel-content">

--- a/bedrock/base/templates/includes/protocol/navigation/menus/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/products.html
@@ -7,8 +7,8 @@
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="{{ url('products.landing') }}" aria-haspopup="true" aria-controls="c-menu-panel-products">{{ ftl('navigation-v2-products') }}</a>
-  <div class="c-menu-panel" id="c-menu-panel-products">
+  <a class="c-menu-title" href="{{ url('products.landing') }}" aria-haspopup="true" aria-controls="c-menu-panel-products" data-testid="navigation-link-products">{{ ftl('navigation-v2-products') }}</a>
+  <div class="c-menu-panel" id="c-menu-panel-products" data-testid="navigation-menu-products">
     <div class="c-menu-panel-container">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-products">{{ ftl('navigation-v2-close-products-menu') }}</button>
       <div class="c-menu-panel-content">

--- a/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
@@ -7,8 +7,8 @@
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=who-we-are' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="c-menu-panel-about">{{ ftl('navigation-v2-who-we-are', fallback='navigation-about') }}</a>
-  <div class="c-menu-panel" id="c-menu-panel-about">
+  <a class="c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="c-menu-panel-about" data-testid="navigation-link-who-we-are">{{ ftl('navigation-v2-who-we-are', fallback='navigation-about') }}</a>
+  <div class="c-menu-panel" id="c-menu-panel-about" data-testid="navigation-menu-who-we-are">
     <div class="c-menu-panel-container">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-about">{{ ftl('navigation-v2-close-who-we-are-menu', fallback='navigation-close-about-menu') }}</button>
       <div class="c-menu-panel-content">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -16,14 +16,14 @@
 <div class="c-navigation top-header-navigation mzp-is-sticky">
   <div class="c-navigation-l-content">
     <div class="c-navigation-container">
-      <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items">{{ ftl('navigation-v2-menu') }}</button>
+      <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items" data-testid="navigation-menu-button">{{ ftl('navigation-v2-menu') }}</button>
       <div class="c-navigation-logo">
         <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-type="nav">
           <img class="c-navigation-logo-image" src="{{ static('protocol/img/logos/mozilla/logo-word-hor.svg') }}" alt="{{ logo_alt }}" width="112" height="32">
         </a>
       </div>
 
-      <div class="c-navigation-items" id="c-navigation-items">
+      <div class="c-navigation-items" id="c-navigation-items" data-testid="navigation-menu-items">
         {% include 'includes/protocol/navigation/nav-cta.html' %}
         <div class="c-navigation-menu">
           <nav class="c-menu mzp-is-basic">

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -68,7 +68,7 @@
 
 {# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#signup-form #}
 {% macro fxa_email_form(entrypoint, entrypoint_experiment, entrypoint_variation, context=None, utm_campaign=None, utm_content=None, utm_term=None, style=None, class_name='fxa-email-form', form_title=None, intro_text=none, button_text=None, button_class='mzp-c-button mzp-t-product') -%}
-  <form action="{{ settings.FXA_ENDPOINT }}" id="fxa-email-form" class="mzp-c-form {{ class_name }}">
+  <form action="{{ settings.FXA_ENDPOINT }}" id="fxa-email-form" class="mzp-c-form {{ class_name }}" data-test-id="fxa-form">
     <input type="hidden" name="action" value="email">
     <input type="hidden" name="entrypoint" value="{{ entrypoint }}" id="fxa-email-form-entrypoint">
     <input type="hidden" name="form_type" value="email">
@@ -125,7 +125,7 @@
     <div class="fxa-email-field-container">
       <div class="mzp-c-field mzp-l-stretch">
         <label class="mzp-c-field-label" for="fxa-email-field">{{ ftl('fxa-form-email-address') }}</label>
-        <input type="email" name="email" id="fxa-email-field" class="mzp-c-field-control" placeholder="user@example.com" required>
+        <input type="email" name="email" id="fxa-email-field" class="mzp-c-field-control" placeholder="user@example.com" required data-testid="fxa-form-email-field">
       </div>
 
       <div class="mzp-c-button-container mzp-l-stretch">
@@ -136,6 +136,7 @@
           data-cta-type="fxa-sync"
           data-cta-text="Register"
           data-cta-position="primary"
+          data-testid="fxa-form-submit-button"
         >
         {% if button_text %}
           {{ button_text }}

--- a/bedrock/base/templates/product-all-unified-macros.html
+++ b/bedrock/base/templates/product-all-unified-macros.html
@@ -5,7 +5,7 @@
 #}
 
 {% macro select_product_list(products, disabled=False) %}
- <select id="select-product" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
+ <select id="select-product" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %} data-testid="firefox-all-product-select">
   {% for p_name, p_label in products %}
     <option value="{{ p_name }}">{{ p_label }}</option>
   {% endfor %}
@@ -15,7 +15,7 @@
 {% macro select_version_list(id, version, disabled=False) %}
   {% set version_select_id = 'select_' ~ id ~ '_version' %}
   <label for="{{ version_select_id }}" class="c-selection-label">{{ ftl('firefox-all-which-version') }}</label>
-  <select id="{{ version_select_id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
+  <select id="{{ version_select_id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %} data-testid="firefox-all-version-select ({{ id }})">
     {# ESR can have two versions available. ESR Latest should always come first in the dropdown. #}
     {% if id == 'desktop_esr_next' %}
       <option value="desktop_esr">{{ desktop_esr_latest_version }}</option>
@@ -48,7 +48,7 @@
   <a href="#installer-help" class="c-button-help icon-installer-help" title="{{ ftl('firefox-all-learn-about-installers')}}">
     {{ ftl('firefox-all-get-help') }}
   </a>
-  <select id="{{ id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
+  <select id="{{ id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %} data-testid="firefox-all-platform-select ({{ id }})">
     {% for p_name, p_label in platforms %}
       <option value="{{ p_name }}">{{ p_label }}</option>
     {% endfor %}
@@ -57,7 +57,7 @@
 
 {% macro select_language_list(id, builds, disabled=False) %}
   <label for="{{ id }}" class="c-selection-label">{{ ftl('firefox-all-select-your-preferred-language') }}</label>
-  <select id="{{ id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
+  <select id="{{ id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %} data-testid="firefox-all-language-select ({{ id }})">
     {% for build in builds %}
       <option value="{{ build.locale }}"{% if build.locale == 'en-US' %} selected{% endif%}>
       {%- if build.name_native and build.name_native != build.name_en -%}

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -154,29 +154,55 @@
             {{ ftl('firefox-all-sorry-we-couldnt-find') }}
           </p>
 
-          <a href="#all-downloads" id="download-button-primary" class="mzp-c-button mzp-t-product c-download-button" data-link-type="download" data-download-location="primary cta">
+          <a href="#all-downloads" id="download-button-primary" class="mzp-c-button mzp-t-product c-download-button" data-link-type="download" data-download-location="primary cta" data-testid="firefox-all-download-button">
             {{ ftl('download-button-download-now') }}
           </a>
 
           <div id="download-android-primary" data-product="android_release" class="c-download-button">
             <ul class="c-download-list">
-              <li>{{ google_play_button(href=android_url, id='playStoreLink-release') }}</li>
+              <li>
+                {{ google_play_button(
+                  href=android_url,
+                  id='playStoreLink-release',
+                  extra_data_attributes={
+                    'testid': 'firefox-all-android-download-button'
+                  }
+                ) }}
+              </li>
               <li><a href="{{ url('firefox.browsers.mobile.get-app') }}" class="c-get-app" data-cta-type="link" data-cta-text="Get It Now" data-cta-position="banner">{{ ftl('firefox-all-product-send-link') }}</a></li>
             </ul>
           </div>
 
           <div id="download-android-beta-primary" data-product="android_beta" class="c-download-button">
-            {{ google_play_button(href=android_beta_url, id='playStoreLink-beta') }}
+            {{ google_play_button(
+              href=android_beta_url,
+              id='playStoreLink-beta',
+              extra_data_attributes={
+                'testid': 'firefox-all-android-beta-download-button'
+              }
+            ) }}
           </div>
 
           <div id="download-android-nightly-primary" data-product="android_nightly" class="c-download-button">
-            {{ google_play_button(href=android_nightly_url, id='playStoreLink-nightly') }}
+            {{ google_play_button(
+              href=android_nightly_url,
+              id='playStoreLink-nightly',
+              extra_data_attributes={
+                'testid': 'firefox-all-android-nightly-download-button'
+              }
+            ) }}
           </div>
 
           <div id="download-ios-primary" data-product="ios_release" class="c-download-button">
             <ul class="c-download-list">
               <li>
-                {{ apple_app_store_button(href=ios_url, id='appStoreLink-ios') }}
+                {{ apple_app_store_button(
+                  href=ios_url,
+                  id='appStoreLink-ios',
+                  extra_data_attributes={
+                    'testid': 'firefox-all-ios-download-button'
+                  }
+                ) }}
               </li>
               <li><a href="{{ url('firefox.browsers.mobile.get-app') }}" class="c-get-app" data-cta-type="link" data-cta-text="Get It Now" data-cta-position="primary">{{ ftl('firefox-all-product-send-link') }}</a></li>
             </ul>

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -135,25 +135,25 @@
           <h3 class="enterprise-download-title">{{ ftl('firefox-enterprise-windows-64-bit') }}</h3>
 
           <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win64-download-list">
-            <h4 class="mzp-c-menu-list-title">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
+            <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-win64-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox" data-testid="firefox-enterprise-win64-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox" data-testid="firefox-enterprise-win64-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser-msi-installer') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64" data-display-name="Firefox Extended Support Release" data-testid="firefox-enterprise-win64-esr-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win64-msi" data-display-name="Firefox Extended Support Release" data-testid="firefox-enterprise-win64-esr-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release-msi') }}
                 </a>
               </li>
@@ -178,15 +178,15 @@
           <h3 class="enterprise-download-title">{{ ftl('firefox-enterprise-macos') }}</h3>
 
           <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="mac-download-list">
-            <h4 class="mzp-c-menu-list-title">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
+            <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-mac-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox" data-testid="firefox-enterprise-mac-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="osx" data-display-name="Firefox Extended Support Release" data-testid="firefox-enterprise-mac-esr-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
@@ -210,25 +210,25 @@
           <h3 class="enterprise-download-title">{{ ftl('firefox-enterprise-windows-32-bit') }}</h3>
 
           <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win32-download-list">
-            <h4 class="mzp-c-menu-list-title">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
+            <h4 class="mzp-c-menu-list-title" data-testid="firefox-enterprise-win32-menu-button">{{ ftl('firefox-enterprise-select-your-download') }}</h4>
             <ul class="mzp-c-menu-list-list download-platform-list">
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox" data-testid="firefox-enterprise-win32-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox" data-testid="firefox-enterprise-win32-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-browser-msi-installer') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win" data-display-name="Firefox Extended Support Release" data-testid="firefox-enterprise-win32-esr-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release') }}
                 </a>
               </li>
               <li class="mzp-c-menu-list-item">
-                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox Extended Support Release">
+                <a class="download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}" data-link-type="download" data-download-os="Desktop" data-download-version="win-msi" data-display-name="Firefox Extended Support Release" data-testid="firefox-enterprise-win32-esr-msi-menu-link">
                   {{ ftl('firefox-enterprise-firefox-extended-support-release-msi') }}
                 </a>
               </li>

--- a/bedrock/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button-thanks.html
@@ -9,6 +9,7 @@
      class="download-link c-button-download-thanks-link mzp-c-button mzp-t-product {% if button_class %}{{ button_class }}{% else %}mzp-t-xl{% endif %}"
      data-direct-link="{{ download_link_direct }}"
      data-link-type="download"
+     data-testid="{{ id }}"
      {% if download_location %}data-download-location="{{ download_location }}"{% endif %}>
     {% if alt_copy %}
       {{ alt_copy }}

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -64,6 +64,7 @@
            data-link-type="download"
            data-display-name="{{ plat.os_arch_pretty or plat.os_pretty }}"
            data-download-version="{{ plat.os }}"
+           data-testid="{{ id }}-{{ plat.os }}"
            {% if plat.os == 'android' %}data-download-os="Android"
            {% elif plat.os == 'ios' %}data-download-os="iOS"
            {% else %}data-download-os="Desktop"{% endif %}

--- a/bedrock/firefox/templates/firefox/includes/send-to-device.html
+++ b/bedrock/firefox/templates/firefox/includes/send-to-device.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<section id="{{ dom_id }}" class="send-to-device {{ class_name }}" data-spinner-color="{{ spinner_color }}">
+<section id="{{ dom_id }}" class="send-to-device {{ class_name }}" data-spinner-color="{{ spinner_color }}" data-testid="send-to-device-form">
   <div class="form-container">
     {% if include_title %}
       <h2 class="form-heading">
@@ -17,7 +17,7 @@
     {% endif %}
     <h2 class="mzp-u-title-xs thank-you hidden">{{ ftl('send-to-device-your-download-link') }}</h2>
     <form class="send-to-device-form" action="{{ basket_url }}" method="post">
-      <div class="mzp-c-form-errors hidden">
+      <div class="mzp-c-form-errors hidden" data-testid="send-to-device-form-error">
         <ul class="mzp-u-list-styled">
           <li class="error-email-invalid hidden">
             {{ ftl('send-to-device-please-enter-an-email') }}
@@ -41,10 +41,10 @@
               {{ ftl('send-to-device-enter-your-email') }}
             {% endif %}
           </label>
-          <input id="{{ dom_id }}-input" class="mzp-c-field-control send-to-device-input" name="email" type="text" required>
+          <input id="{{ dom_id }}-input" class="mzp-c-field-control send-to-device-input" name="email" type="text" required data-testid="send-to-device-form-email-field">
         </div>
         <div class="mzp-c-button-container mzp-l-stretch">
-          <button type="submit" class="button mzp-c-button {% if button_class %} {{ button_class }} {% else %} mzp-t-product {% endif %}">
+          <button type="submit" class="button mzp-c-button {% if button_class %} {{ button_class }} {% else %} mzp-t-product {% endif %}" data-testid="send-to-device-form-submit-button">
             {{ ftl('send-to-device-send') }}
           </button>
         </div>
@@ -57,7 +57,7 @@
           <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
         </p>
       </div>
-      <div class="thank-you hidden">
+      <div class="thank-you hidden" data-testid="send-to-device-form-thanks">
         <p class="email">{{ ftl('send-to-device-check-your-device-email') }}</p>
         <a href="#" role="button" class="more send-another">{{ ftl('send-to-device-send-to-another') }}</a>
       </div>

--- a/bedrock/firefox/templates/firefox/index.html
+++ b/bedrock/firefox/templates/firefox/index.html
@@ -120,7 +120,7 @@
         <![endif]-->
         <!--[if !IE]><!-->
           {# Download link should be locale neutral see issue 7982 #}
-          <a id="qa-desktop-download" class="mzp-c-cta-link cta-download" href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ ftl('firefox-browsers-download-for-desktop') }}</a>
+          <a id="qa-desktop-download" class="mzp-c-cta-link cta-download" href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard" data-testid="firefox-desktop-download">{{ ftl('firefox-browsers-download-for-desktop') }}</a>
         <!--<![endif]-->
       </p>
 
@@ -149,10 +149,10 @@
         {{ apple_app_store_button(href=ios_url, id='appStoreLink') }}
       </div>
       <div id="menu-mobile-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-        <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-browsers-download-for-mobile') }}</h3>
+        <h3 class="mzp-c-menu-list-title" data-testid="firefox-mobile-download-menu-button">{{ ftl('firefox-browsers-download-for-mobile') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-mobile">
-          <li class="mzp-c-menu-list-item"><a href="{{ android_url }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-browsers-android') }}</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ ios_url }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-browsers-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ android_url }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android" data-testid="firefox-android-menu-link">{{ ftl('firefox-browsers-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ ios_url }}" rel="external noopener" class="ga-product-download" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS" data-testid="firefox-ios-menu-link">{{ ftl('firefox-browsers-ios') }}</a></li>
           <li class="mzp-c-menu-list-item t-getapp"><a href="{{ url('firefox.browsers.mobile.get-app') }}" data-cta-type="link" data-cta-text="Get App Mobile">{{ ftl('firefox-browsers-send-me-a-link') }}</a></li>
         </ul>
       </div>

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -73,8 +73,8 @@
       </p>
       <div class="show-linux">
         <div class="c-linux-button-group">
-          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-32-v2') }}</a>
-          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" class="mzp-c-button mzp-t-product">{{ ftl('download-button-linux-64-v2') }}</a>
+          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}" class="mzp-c-button mzp-t-product" data-testid="thanks-download-button-linux-32">{{ ftl('download-button-linux-32-v2') }}</a>
+          <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux64&lang={{ LANG }}" class="mzp-c-button mzp-t-product" data-testid="thanks-download-button-linux-64">{{ ftl('download-button-linux-64-v2') }}</a>
         </div>
         {% set attrs = 'href="https://support.mozilla.org/kb/install-firefox-linux%s#w_install-firefox-deb-package-for-debian-based-distributions" rel="external noopener" data-cta-type="link" data-cta-text="You can set up our APT repository instead"'|safe|format(referrals) %}
         <p class="linux-deb-text">{{ ftl('download-button-using-debian', attrs=attrs) }}</p>

--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -49,7 +49,7 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
       <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
 
       <fieldset class="mzp-c-newsletter-content">
-        <div class="mzp-c-form-errors hidden" id="newsletter-errors">
+        <div class="mzp-c-form-errors hidden" id="newsletter-errors" data-testid="newsletter-error-message">
           <ul class="mzp-u-list-styled">
             <li class="error-email-invalid hidden">
               Please enter a valid email address
@@ -68,13 +68,13 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
 
         <div>
           <label for="id_email">Email</label>
-          <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true">
+          <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" data-testid="newsletter-email-input">
         </div>
 
         <div id="newsletter-details" class="mzp-c-newsletter-details">
           <input type="hidden" name="country" id="id_country"  aria-required="false">
             <label for="id_terms" class="mzp-u-inline">
-              <input id="id_terms" name="terms" required aria-required="true" type="checkbox">
+              <input id="id_terms" name="terms" required aria-required="true" type="checkbox" data-testid="newsletter-terms-checkbox">
               I have read and agree to these
               <a href="#terms-conditions">Terms and Conditions</a>
             </label>
@@ -84,12 +84,12 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
         </div>
 
         <p class="mzp-c-form-submit">
-          <button class="mzp-c-button mzp-t-product" id="newsletter-submit" type="submit">Submit</button>
+          <button class="mzp-c-button mzp-t-product" id="newsletter-submit" type="submit" data-testid="newsletter-submit-button">Submit</button>
         </p>
       </fieldset>
     </form>
 
-    <div id="newsletter-thanks" class="mzp-c-newsletter-thanks hidden">
+    <div id="newsletter-thanks" class="mzp-c-newsletter-thanks hidden" data-testid="newsletter-thanks-message">
       <h3>Congrats!</h3>
       <h4>You have been added to the Firefox for iOS testing program.</h4>
       <p>

--- a/bedrock/mozorg/templates/mozorg/account.html
+++ b/bedrock/mozorg/templates/mozorg/account.html
@@ -61,7 +61,7 @@
 
         <div class="c-manage">
           <p>{{ ftl('mozilla-accounts-already', fallback='firefox-accounts-already') }}</p>
-          <a href="https://accounts.firefox.com/settings" id="manage">{{ ftl('firefox-accounts-manage') }}</a>
+          <a href="https://accounts.firefox.com/settings" id="manage" data-testid="manage-account-link">{{ ftl('firefox-accounts-manage') }}</a>
         </div>
       </div>
     </div>

--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -177,12 +177,12 @@ class NewsletterFooterForm(forms.Form):
         "mozilla-and-you": ftl("multi-newsletter-form-checkboxes-label-firefox"),
     }
 
-    email = forms.EmailField(widget=EmailInput(attrs={"required": "required"}))
+    email = forms.EmailField(widget=EmailInput(attrs={"required": "required", "data-testid": "newsletter-email-input"}))
     # first/last_name not yet included in email_newsletter_form helper
     # currently used on /contribute/friends/ (custom markup)
     first_name = forms.CharField(widget=forms.TextInput, required=False)
     last_name = forms.CharField(widget=forms.TextInput, required=False)
-    privacy = forms.BooleanField(widget=PrivacyWidget)
+    privacy = forms.BooleanField(widget=PrivacyWidget(attrs={"data-testid": "newsletter-privacy-checkbox"}))
     source_url = forms.CharField(required=False)
     newsletters = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple())
 

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -7,7 +7,7 @@
 {% from "newsletter/includes/macros.html" import email_form_thankyou with context %}
 
 {% if not success %}
-  <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post">
+  <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post" data-testid="newsletter-form">
     {% if not is_multi_newsletter_form %}
       <div hidden>
         {{ form.newsletters|safe }}
@@ -33,7 +33,7 @@
     {% endif %}
 
     <fieldset class="mzp-c-newsletter-content">
-      <div class="mzp-c-form-errors {% if not form.errors %}hidden{% endif %}" id="newsletter-errors">
+      <div class="mzp-c-form-errors {% if not form.errors %}hidden{% endif %}" id="newsletter-errors" data-testid="newsletter-error-message">
         {{ form.non_field_errors()|safe }}
         <ul class="mzp-u-list-styled">
           <li class="error-email-invalid {% if not form.email.errors %}hidden{% endif %}">
@@ -93,13 +93,13 @@
 
         <p>
           <label for="privacy" class="mzp-u-inline">
-            <input type="checkbox" id="privacy" name="privacy" required aria-required="true"> {{ ftl('newsletter-form-im-okay-with-mozilla', url=url('privacy.notices.websites')) }}
+            <input type="checkbox" id="privacy" name="privacy" required aria-required="true" data-testid="newsletter-privacy-checkbox"> {{ ftl('newsletter-form-im-okay-with-mozilla', url=url('privacy.notices.websites')) }}
           </label>
         </p>
       </div>
 
       <p class="mzp-c-form-submit">
-        <button type="submit" id="newsletter-submit" class="mzp-c-button {{ button_class }}" data-cta-type="Newsletter-{{ id }}" data-cta-text="Newsletter Sign Up">
+        <button type="submit" id="newsletter-submit" class="mzp-c-button {{ button_class }}" data-cta-type="Newsletter-{{ id }}" data-cta-text="Newsletter Sign Up" data-testid="newsletter-submit-button">
           {% if submit_text %}
             {{ submit_text }}
           {% else %}
@@ -123,7 +123,7 @@
     </fieldset>
   </form>
 
-  <div id="newsletter-thanks" class="mzp-c-newsletter-thanks hidden">
+  <div id="newsletter-thanks" class="mzp-c-newsletter-thanks hidden" data-testid="newsletter-thanks-message">
     {% if thankyou_content %}
       <h3>{{ thankyou_head }}</h3>
       <p>{{ thankyou_content }}</p>

--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -37,7 +37,7 @@
   <section class="vpn-downloads">
       <header class="vpn-download-header">
         {% if block_download %}
-        <div class="mzp-l-content vpn-download-blocked">
+        <div class="mzp-l-content vpn-download-blocked" data-testid="vpn-download-blocked-message">
           <h1>{{ self.page_title_full() }}</h1>
           <p>{{ ftl('vpn-download-not-available-in-country') }}</p>
         </div>
@@ -66,7 +66,7 @@
 
       {% if not block_download %}
 
-      <div class="vpn-download-options mzp-l-content">
+      <div class="vpn-download-options mzp-l-content" data-testid="vpn-download-options">
 
         <!-- Primary list -->
       <div class="vpn-download-primary-platform">
@@ -79,7 +79,7 @@
             <h2>{{ ftl('vpn-download-for-windows-long') }}</h2>
             <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
             <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
-            <a class="mzp-c-button" href="{{ url('products.vpn.windows-download') }}" data-cta-type="button" data-cta-text="VPN Download (Windows)">
+            <a class="mzp-c-button" href="{{ url('products.vpn.windows-download') }}" data-cta-type="button" data-cta-text="VPN Download (Windows)" data-testid="vpn-download-link-primary-windows">
             {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
             </a>
           </div>
@@ -93,7 +93,7 @@
             <h2>{{ ftl('vpn-download-for-mac-long', fallback='vpn-download-for-mac') }}</h2>
             <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
             <p>{{ ftl('vpn-download-version-requirements', version='10.15') }}</p>
-            <a class="mzp-c-button" href="{{ url('products.vpn.mac-download') }}" data-cta-type="button" data-cta-text="VPN Download (macOS)" class="platform-download-link">
+            <a class="mzp-c-button" href="{{ url('products.vpn.mac-download') }}" data-cta-type="button" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-primary-mac">
             {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
             </a>
           </div>
@@ -154,7 +154,7 @@
             <h2>{{ ftl('vpn-download-for-windows-v2') }}</h2>
             <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
           </div>
-          <a href="{{ url('products.vpn.windows-download') }}" data-cta-type="button" data-cta-text="VPN Download (Windows)" class="platform-download-link">
+          <a href="{{ url('products.vpn.windows-download') }}" data-cta-type="button" data-cta-text="VPN Download (Windows)" class="platform-download-link" data-testid="vpn-download-link-secondary-windows">
             <span class="">{{ ftl('vpn-download-for-windows-long') }}</span>
           </a>
         </li>
@@ -167,7 +167,7 @@
             <h2>{{ ftl('vpn-download-for-mac') }}</h2>
             <p>{{ ftl('vpn-download-version-requirements', version='10.15') }}</p>
           </div>
-          <a href="{{ url('products.vpn.mac-download') }}" data-cta-type="button" data-cta-text="VPN Download (macOS)" class="platform-download-link">
+          <a href="{{ url('products.vpn.mac-download') }}" data-cta-type="button" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-secondary-mac">
             <span class="visually-hidden">{{ ftl('vpn-download-for-mac-long') }}</span>
           </a>
         </li>

--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -118,14 +118,14 @@
     {% if vpn_available %}
       <p>
         {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
-        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="{{ position }}">
+        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="{{ position }}" data-testid="get-mozilla-vpn-{{ position }}-button">
           {{ ftl('vpn-shared-subscribe-link') }}
         </a>
       </p>
       <p class="c-guarantee">{{ ftl('vpn-shared-features-guarantee') }}</p>
     {% else %}
       <p>
-        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist">
+        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-testid="join-waitlist-{{ position }}-button">
           {{ ftl('vpn-shared-waitlist-link') }}
         </a>
       </p>
@@ -151,11 +151,11 @@
   <div class="vpn-nav-cta">
     {% if vpn_available %}
       {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="navigation">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ pricing_url }}" data-cta-type="button" data-cta-text="Get Mozilla VPN" data-cta-position="navigation" data-testid="get-mozilla-vpn-nav-button">
         {{ ftl('vpn-shared-subscribe-link') }}
       </a>
     {% else %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation" data-testid="join-waitlist-nav-button">
         {{ ftl('vpn-shared-waitlist-link') }}
       </a>
     {% endif %}

--- a/bedrock/products/templates/products/vpn/includes/pricing-refresh.html
+++ b/bedrock/products/templates/products/vpn/includes/pricing-refresh.html
@@ -51,7 +51,8 @@
             'data-cta-position': 'pricing',
             'data-glean-id': 'subscribe_intent',
             'data-glean-type': 'annual',
-            'data-glean-label': 'vpn'
+            'data-glean-label': 'vpn',
+            'data-testid': 'get-mozilla-vpn-12-month-button'
           })
         }}
         <p class="c-guarantee">{{ ftl('vpn-shared-money-back-guarantee') }}</p>
@@ -86,7 +87,8 @@
             'data-cta-position': 'pricing',
             'data-glean-id': 'subscribe_intent',
             'data-glean-type': 'monthly',
-            'data-glean-label': 'vpn'
+            'data-glean-label': 'vpn',
+            'data-testid': 'get-mozilla-vpn-monthly-button'
           })
         }}
         <p class="c-guarantee">{{ ftl('vpn-shared-money-back-guarantee') }}</p>

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -28,7 +28,7 @@
 
 {% block content %}
 <main class="mzp-l-content mzp-t-content-md">
-  <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post">
+  <form id="newsletter-form" class="mzp-c-newsletter-form" action="{{ action }}" method="post" data-testid="vpn-invite-form">
     <h1 class="mzp-c-form-header">{{ ftl('vpn-landing-invite-page-heading') }}</h1>
     <p class="mzp-c-form-subtitle">{{ ftl('vpn-landing-invite-page-desc-v2') }}</p>
     <div hidden>
@@ -37,7 +37,7 @@
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
 
     <fieldset class="mzp-c-newsletter-content">
-      <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors">
+      <div class="mzp-c-form-errors hide-from-legacy-ie hidden" id="newsletter-errors" data-testid="vpn-invite-error-message">
         <ul class="mzp-u-list-styled">
           <li class="error-email-invalid hidden">{{ ftl('newsletter-form-please-enter-a-valid') }}</li>
           <li class="error-select-country hidden">{{ ftl('newsletter-form-please-select-country') }}</li>
@@ -51,7 +51,7 @@
           {{ ftl('vpn-landing-invite-email-label') }}
           <em class="mzp-c-fieldnote">{{ ftl('vpn-landing-invite-required-label') }}</em>
         </label>
-        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" placeholder="{{ ftl('vpn-landing-invite-email-placeholder') }}">
+        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" placeholder="{{ ftl('vpn-landing-invite-email-placeholder') }}" data-testid="vpn-invite-email-input">
       </div>
 
       <div id="newsletter-details" class="mzp-c-newsletter-details">
@@ -69,7 +69,7 @@
       </div>
 
       <p class="mzp-c-form-submit">
-        <button class="mzp-c-button mzp-t-xl" id="newsletter-submit" type="submit">{{ ftl('vpn-shared-waitlist-link') }}</button>
+        <button class="mzp-c-button mzp-t-xl" id="newsletter-submit" type="submit" data-testid="vpn-invite-submit-button">{{ ftl('vpn-shared-waitlist-link') }}</button>
       </p>
 
       <div class="vpn-invite-privacy">
@@ -81,7 +81,7 @@
 
   </form>
 
-  <div id="newsletter-thanks" class="vpn-invite-success hidden">
+  <div id="newsletter-thanks" class="vpn-invite-success hidden" data-testid="vpn-invite-thanks-message">
     <h3>{{ ftl('vpn-landing-invite-thanks-heading') }}</h3>
     <p>{{ ftl('vpn-landing-invite-thanks-desc') }}</p>
   </div>

--- a/bedrock/products/templates/products/vpn/landing-refresh.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh.html
@@ -103,7 +103,7 @@
 
     {% if vpn_available %}
       <p class="c-main-cta">
-        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="#pricing" data-cta-type="button" data-cta-text="Save on Mozilla VPN" data-cta-position="primary">
+        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="#pricing" data-cta-type="button" data-cta-text="Save on Mozilla VPN" data-cta-position="primary" data-testid="get-mozilla-vpn-hero-button">
           {{ vpn_saving(country_code=country_code, lang=LANG, bundle_relay=False, ftl_string='vpn-shared-save-percent-on') }}
         </a>
         <small>
@@ -112,7 +112,7 @@
       </p>
 
     {% else %}
-      <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="primary">
+      <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-cta-position="primary" data-testid="join-waitlist-hero-button">
         {{ ftl('vpn-shared-waitlist-link') }}
       </a>
     {% endif %}
@@ -169,7 +169,7 @@
       <header class="c-pricing-main-header">
         <h2 class="c-section-title">{{ ftl('vpn-shared-mozilla-vpn-is-not-yet-available') }}</h2>
 
-        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist">
+        <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-type="button" data-cta-text="Join the VPN Waitlist" data-testid="join-waitlist-not-available-button">
           {{ ftl('vpn-shared-waitlist-link') }}
         </a>
       </header>

--- a/bedrock/products/templates/products/vpn/mac-download.html
+++ b/bedrock/products/templates/products/vpn/mac-download.html
@@ -19,7 +19,7 @@
   <div class="vpn-platform-download">
     {% if block_download %}
       <header class="platform-download-header">
-        <div class="mzp-l-content platform-download-blocked">
+        <div class="mzp-l-content platform-download-blocked" data-testid="vpn-download-blocked-message">
           <img src="{{ static('img/products/vpn/download/vpn-unavailable-country.svg') }}" alt="">
           <h1>{{ ftl('vpn-download-unable-to-download') }}</h1>
           <p>{{ ftl('vpn-download-not-in-country') }}</p>
@@ -37,7 +37,7 @@
           <p>{{ ftl('vpn-your-download-should-start', url=mac_download_url, id='vpn-download-link-mac' ) }}</p>
         </div>
       </header>
-      <section class="vpn-download-instructions mzp-l-content">
+      <section class="vpn-download-instructions mzp-l-content" data-testid="vpn-download-instructions">
         <ol class="mzp-l-columns mzp-t-columns-four">
           {% call picto(
             base_el='li',

--- a/bedrock/products/templates/products/vpn/windows-download.html
+++ b/bedrock/products/templates/products/vpn/windows-download.html
@@ -19,7 +19,7 @@
   <div class="vpn-platform-download">
     {% if block_download %}
       <header class="platform-download-header">
-        <div class="mzp-l-content platform-download-blocked">
+        <div class="mzp-l-content platform-download-blocked" data-testid="vpn-download-blocked-message">
         <img src="{{ static('img/products/vpn/download/vpn-unavailable-country.svg') }}" alt="">
         <h1>{{ ftl('vpn-download-unable-to-download') }}</h1>
         <p>{{ ftl('vpn-download-not-in-country') }}</p>
@@ -37,7 +37,7 @@
         <p>{{ ftl('vpn-your-download-should-start', url=windows_download_url, id='vpn-download-link-win') }}</p>
       </div>
     </header>
-    <section class="vpn-download-instructions windows mzp-l-content">
+    <section class="vpn-download-instructions windows mzp-l-content" data-testid="vpn-download-instructions">
       <ol class="mzp-l-columns mzp-t-columns-four">
         {% call picto(
           base_el='li',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -154,6 +154,24 @@ module.exports = [
         }
     },
     {
+        // JS Playwright test files.
+        files: ['tests/playwright/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'script',
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                ...globals.commonjs
+            }
+        },
+        rules: {
+            ...baseRules,
+            ...extendedRules,
+            ...nodeRules
+        }
+    },
+    {
         // JS build files for local dev.
         files: [
             'eslint.config.js',

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -1,0 +1,96 @@
+# Playwright integration tests
+
+See the [Playwright documentation](https://playwright.dev/docs/intro)
+for detailed information on how to write, run and debug tests.
+
+## Installation
+
+Install Playwright and headless browser engines:
+
+```
+npm install && npm run install-deps
+```
+
+## Specifying an environment
+
+By default tests will run against `http://localhost:8000/`.
+You can set `PLAYWRIGHT_BASE_URL` in your `.env` to point to
+a different environment. Remember to have your development
+server running before starting the test suite locally.
+
+## Running the test suite
+
+To run the full suite of tests:
+
+```
+npx playwright test
+```
+
+This will run all tests against three different headless browser
+engines (Firefox, Chromium, WebKit).
+
+### Running specific tests
+
+Tests are grouped using tags, such as `@mozorg`, `@firefox`, `@vpn`.
+To run only one group of tests, instead of the whole suite, you
+can use `--grep`:
+
+```
+npx playwright test --grep @firefox
+```
+
+To run only a specific test file, such as `firefox-new.spec.js`,
+you can pass the filename:
+
+```
+npx playwright test firefox-new
+```
+
+See the [Playwright CLI docs](https://playwright.dev/docs/test-cli)
+for more options when running and debugging tests.
+
+### Writing tests
+
+Test spec files are found in the `./tests/playwright/specs/`
+directory. See the Playwright docs for more examples on [how
+to write tests](https://playwright.dev/docs/writing-tests).
+
+#### Specifying browsers and operating systems.
+
+Tests use User Agent string overrides to mock different browser
+and operating systems combinations. By default tests run with
+User Agent strings configured for Firefox and Chrome running
+on Windows 10, and Safari running on macOS 10.15.7. This is
+accomplished using an `OpenPage()` helper that can be imported
+in each test file:
+
+```javascript
+const openPage = require('../scripts/open-page');
+const url = '/en-US/firefox/new/';
+
+test.beforeEach(async ({ page, browserName }) => {
+    await openPage(url, page, browserName);
+});
+```
+
+To mock a different browser or operating system combination,
+tests can manually load a different override instead of using
+`openPage`:
+
+```javascript
+test.beforeEach(async ({ page, browserName }) => {
+    if (browserName === 'webkit') {
+        // Set macOS 10.14 UA strings.
+        await page.addInitScript({
+            path: `./scripts/useragent/mac-old/${browserName}.js`
+        });
+    } else {
+        // Set Windows 8.1 UA strings (64-bit).
+        await page.addInitScript({
+            path: `./scripts/useragent/win-old/${browserName}.js`
+        });
+    }
+
+    await page.goto(url + '?automation=true');
+});
+```

--- a/tests/playwright/package-lock.json
+++ b/tests/playwright/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.1.0",
       "license": "MPL",
       "dependencies": {
-        "@playwright/test": "^1.44.0",
+        "@playwright/test": "^1.44.1",
         "dotenv": "^16.4.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
       "dependencies": {
-        "playwright": "1.44.0"
+        "playwright": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -52,11 +52,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
       "dependencies": {
-        "playwright-core": "1.44.0"
+        "playwright-core": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/tests/playwright/package-lock.json
+++ b/tests/playwright/package-lock.json
@@ -1,0 +1,83 @@
+{
+  "name": "bedrock",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bedrock",
+      "version": "0.1.0",
+      "license": "MPL",
+      "dependencies": {
+        "@playwright/test": "^1.44.0",
+        "dotenv": "^16.4.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "dependencies": {
+        "playwright": "1.44.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "dependencies": {
+        "playwright-core": "1.44.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bedrock",
+  "version": "0.1.0",
+  "description": "Making mozilla.org awesome, one pebble at a time",
+  "private": true,
+  "dependencies": {
+    "@playwright/test": "^1.44.0",
+    "dotenv": "^16.4.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/bedrock.git"
+  },
+  "author": "Mozilla",
+  "license": "MPL",
+  "bugs": {
+    "url": "https://bugzilla.mozilla.org/"
+  },
+  "scripts": {
+    "install-deps": "npx playwright install --with-deps"
+  }
+}

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.44.1",
     "dotenv": "^16.4.1"
   },
   "repository": {

--- a/tests/playwright/playwright.config.js
+++ b/tests/playwright/playwright.config.js
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { defineConfig, devices } = require('@playwright/test');
+
+// Read environment variables from file.
+require('dotenv').config({
+    path: '../../.env'
+});
+
+// Default desktop viewport size for tests.
+const desktopViewportSize = {
+    width: 1280,
+    height: 720
+};
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+    testDir: './specs',
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 2 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: process.env.CI ? 'github' : 'line',
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        /* Base URL to use in actions like `await page.goto('/')`. */
+        baseURL: process.env.PLAYWRIGHT_BASE_URL
+            ? process.env.PLAYWRIGHT_BASE_URL
+            : 'http://localhost:8000/',
+
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry'
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                ...devices['Desktop Chrome'],
+                viewport: desktopViewportSize
+            }
+        },
+
+        {
+            name: 'firefox',
+            use: {
+                ...devices['Desktop Firefox'],
+                viewport: desktopViewportSize
+            }
+        },
+
+        {
+            name: 'webkit',
+            use: {
+                ...devices['Desktop Safari'],
+                viewport: desktopViewportSize
+            }
+        }
+    ]
+});

--- a/tests/playwright/scripts/open-page.js
+++ b/tests/playwright/scripts/open-page.js
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * Opens a page with a given URL, page, and browser name.
+ * @param {String} url - The URL to open.
+ * @param {Object} page - The Playwright page object.
+ * @param {String} browserName  - The Playwright browser name.
+ */
+const openPage = async (url, page, browserName) => {
+    /**
+     * Add user agent override script based on the browser name.
+     * This enables tests to mock the user agent strings for testing purposes.
+     * @see https://playwright.dev/docs/api/class-page#page-add-init-script
+     */
+    if (browserName === 'webkit') {
+        await page.addInitScript({
+            path: `./scripts/useragent/mac/${browserName}.js`
+        });
+    } else {
+        await page.addInitScript({
+            path: `./scripts/useragent/win/${browserName}.js`
+        });
+    }
+
+    // Add query parameter to the URL to filter out automation traffic.
+    const separator = url.includes('?') ? '&' : '?';
+    await page.goto(url + separator + 'automation=true');
+};
+
+module.exports = openPage;

--- a/tests/playwright/scripts/useragent/linux/chromium.js
+++ b/tests/playwright/scripts/useragent/linux/chromium.js
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for Linux/Chrome/64-bit.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.3',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'userAgentData', {
+    value: {
+        getHighEntropyValues: () => {
+            return Promise.resolve({
+                architecture: 'x64',
+                bitness: '64',
+                platform: 'Linux',
+                platformVersion: ''
+            });
+        }
+    }
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'Linux',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/linux/firefox.js
+++ b/tests/playwright/scripts/useragent/linux/firefox.js
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for Linux/Firefox/64-bit.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (X11; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'Linux',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/mac-old/webkit.js
+++ b/tests/playwright/scripts/useragent/mac-old/webkit.js
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for macOS 10.14/Safari.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'MacIntel',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/mac/webkit.js
+++ b/tests/playwright/scripts/useragent/mac/webkit.js
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for macOS 10.15.7/Safari.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'MacIntel',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/win-old/chromium.js
+++ b/tests/playwright/scripts/useragent/win-old/chromium.js
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for Windows 8.1/Chrome/64-bit.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'userAgentData', {
+    value: {
+        getHighEntropyValues: undefined
+    }
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'Win64',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/win-old/firefox.js
+++ b/tests/playwright/scripts/useragent/win-old/firefox.js
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for Windows 8.1/Firefox/64-bit.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'Win64',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/win/chromium.js
+++ b/tests/playwright/scripts/useragent/win/chromium.js
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for Windows 10/Chrome/64-bit.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'userAgentData', {
+    value: {
+        getHighEntropyValues: () => {
+            return Promise.resolve({
+                architecture: 'x64',
+                bitness: '64',
+                platform: 'Windows',
+                platformVersion: '15.0.0'
+            });
+        }
+    }
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'Win64',
+    configurable: true
+});

--- a/tests/playwright/scripts/useragent/win/firefox.js
+++ b/tests/playwright/scripts/useragent/win/firefox.js
@@ -1,0 +1,20 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * User Agent string override for Windows 10/Firefox/64-bit.
+ */
+Object.defineProperty(navigator, 'userAgent', {
+    value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0',
+    configurable: true
+});
+
+Object.defineProperty(navigator, 'platform', {
+    value: 'Win64',
+    configurable: true
+});

--- a/tests/playwright/specs/account.spec.js
+++ b/tests/playwright/specs/account.spec.js
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/en-US/account/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Account form sign up', async ({ page }) => {
+            const emailQueryString = /&email=success%40example.com/;
+            const emailField = page.getByTestId('fxa-form-email-field');
+            const submitButton = page.getByTestId('fxa-form-submit-button');
+
+            await emailField.fill('success@example.com');
+            await submitButton.click();
+            await page.waitForURL(emailQueryString, {
+                waitUntil: 'commit'
+            });
+            await expect(page).toHaveURL(emailQueryString);
+        });
+    }
+);

--- a/tests/playwright/specs/consent-banner.spec.js
+++ b/tests/playwright/specs/consent-banner.spec.js
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/en-US/products/vpn/?geo=de';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Accept cookies', async ({ page }) => {
+            const banner = page.getByTestId('consent-banner');
+            const acceptButton = page.getByTestId(
+                'consent-banner-accept-button'
+            );
+
+            await expect(banner).toBeVisible();
+            await acceptButton.click();
+            await expect(banner).not.toBeVisible();
+        });
+
+        test('Reject cookies', async ({ page }) => {
+            const banner = page.getByTestId('consent-banner');
+            const acceptButton = page.getByTestId(
+                'consent-banner-reject-button'
+            );
+
+            await expect(banner).toBeVisible();
+            await acceptButton.click();
+            await expect(banner).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/footer.spec.js
+++ b/tests/playwright/specs/footer.spec.js
@@ -1,0 +1,90 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/en-US/';
+
+test.describe(
+    `${url} footer (mobile)`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.use({ viewport: { width: 360, height: 780 } });
+
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Footer open / close click', async ({ page }) => {
+            const footerHeadingCompany = page.getByTestId(
+                'footer-heading-company'
+            );
+            const footerListCompany = page.getByTestId('footer-list-company');
+            const footerHeadingResources = page.getByTestId(
+                'footer-heading-resources'
+            );
+            const footerListResources = page.getByTestId(
+                'footer-list-resources'
+            );
+            const footerHeadingSupport = page.getByTestId(
+                'footer-heading-support'
+            );
+            const footerListSupport = page.getByTestId('footer-list-support');
+            const footerHeadingDevelopers = page.getByTestId(
+                'footer-heading-developers'
+            );
+            const footerListDevelopers = page.getByTestId(
+                'footer-list-developers'
+            );
+
+            // Open and close Company section
+            await expect(footerListCompany).not.toBeVisible();
+            await footerHeadingCompany.click();
+            await expect(footerListCompany).toBeVisible();
+            await footerHeadingCompany.click();
+            await expect(footerListCompany).not.toBeVisible();
+
+            // Open and close Resources section
+            await expect(footerListResources).not.toBeVisible();
+            await footerHeadingResources.click();
+            await expect(footerListResources).toBeVisible();
+            await footerHeadingResources.click();
+            await expect(footerListResources).not.toBeVisible();
+
+            // Open and close Support section
+            await expect(footerListSupport).not.toBeVisible();
+            await footerHeadingSupport.click();
+            await expect(footerListSupport).toBeVisible();
+            await footerHeadingSupport.click();
+            await expect(footerListSupport).not.toBeVisible();
+
+            // Open and close Developers section
+            await expect(footerListDevelopers).not.toBeVisible();
+            await footerHeadingDevelopers.click();
+            await expect(footerListDevelopers).toBeVisible();
+            await footerHeadingDevelopers.click();
+            await expect(footerListDevelopers).not.toBeVisible();
+        });
+
+        test('Footer language change', async ({ page }) => {
+            const languageSelect = page.getByTestId('footer-language-select');
+
+            // Assert default language is English (US)
+            await expect(languageSelect).toHaveValue('en-US');
+
+            // Change page language from /en-US/ to /de/
+            await languageSelect.selectOption('de');
+            await page.waitForURL('**/de/?automation=true');
+
+            // Assert page language is now German
+            await expect(languageSelect).toHaveValue('de');
+        });
+    }
+);

--- a/tests/playwright/specs/home.spec.js
+++ b/tests/playwright/specs/home.spec.js
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/en-US/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Newsletter submit success', async ({ page }) => {
+            const form = page.getByTestId('newsletter-form');
+            const emailField = page.getByTestId('newsletter-email-input');
+            const privacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const submitButton = page.getByTestId('newsletter-submit-button');
+            const thanksMessage = page.getByTestId('newsletter-thanks-message');
+
+            // expand form before running test
+            await submitButton.click();
+
+            await expect(thanksMessage).not.toBeVisible();
+            await emailField.fill('success@example.com');
+            await privacyCheckbox.click();
+            await submitButton.click();
+            await expect(form).not.toBeVisible();
+            await expect(thanksMessage).toBeVisible();
+        });
+
+        test('Newsletter submit failure', async ({ page }) => {
+            const emailField = page.getByTestId('newsletter-email-input');
+            const privacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const submitButton = page.getByTestId('newsletter-submit-button');
+            const thanksMessage = page.getByTestId('newsletter-thanks-message');
+            const errorMessage = page.getByTestId('newsletter-error-message');
+
+            // expand form before running test
+            await page.getByTestId('newsletter-submit-button').click();
+
+            await expect(errorMessage).not.toBeVisible();
+            await emailField.fill('failure@example.com');
+            await privacyCheckbox.click();
+            await submitButton.click();
+            await expect(errorMessage).toBeVisible();
+            await expect(thanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/leadership.spec.js
+++ b/tests/playwright/specs/leadership.spec.js
@@ -1,0 +1,49 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/en-US/about/leadership/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Open / close biography', async ({ page }) => {
+            const leader = page.locator(
+                '#executive .vcard.has-bio:first-child'
+            );
+            const bio = page.locator('.mzp-c-modal .vcard.has-bio .person-bio');
+            const modal = page.locator('.mzp-c-modal');
+            const modalCloseButton = page.locator('.mzp-c-modal-button-close');
+
+            await expect(modal).not.toBeVisible();
+            await expect(bio).not.toBeVisible();
+
+            // Open biography modal
+            await leader.click();
+
+            // Assert modal and bio are visible
+            await expect(modal).toBeVisible();
+            await expect(bio).toBeVisible();
+
+            // Close biography modal
+            await modalCloseButton.click();
+
+            // Assert modal and bio are not visible
+            await expect(modal).not.toBeVisible();
+            await expect(bio).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/navigation.spec.js
+++ b/tests/playwright/specs/navigation.spec.js
@@ -1,0 +1,172 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/en-US/';
+
+test.describe(
+    `${url} navigation (desktop)`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Navigation menu hover', async ({ page }) => {
+            const firefoxLink = page.getByTestId('navigation-link-firefox');
+            const firefoxMenu = page.getByTestId('navigation-menu-firefox');
+            const productsLink = page.getByTestId('navigation-link-products');
+            const productsMenu = page.getByTestId('navigation-menu-products');
+            const whoWeAreLink = page.getByTestId('navigation-link-who-we-are');
+            const whoWeAreMenu = page.getByTestId('navigation-menu-who-we-are');
+            const innovationLink = page.getByTestId(
+                'navigation-link-innovation'
+            );
+            const innovationMenu = page.getByTestId(
+                'navigation-menu-innovation'
+            );
+
+            // Hover over Firefox link
+            await firefoxLink.hover();
+            await expect(firefoxMenu).toBeVisible();
+
+            // Hover over products link
+            await productsLink.hover();
+            await expect(productsMenu).toBeVisible();
+            await expect(firefoxMenu).not.toBeVisible();
+
+            // Hover over who we are link
+            await whoWeAreLink.hover();
+            await expect(whoWeAreMenu).toBeVisible();
+            await expect(productsMenu).not.toBeVisible();
+
+            // Hover over innovation link
+            await innovationLink.hover();
+            await expect(innovationMenu).toBeVisible();
+            await expect(whoWeAreMenu).not.toBeVisible();
+        });
+
+        test('Navigation link click', async ({ page }) => {
+            const firefoxLink = page.getByTestId('navigation-link-firefox');
+            const firefoxMenu = page.getByTestId('navigation-menu-firefox');
+            const firefoxMenuLink = page.getByTestId(
+                'navigation-menu-link-firefox-desktop'
+            );
+
+            // Hover over Firefox link
+            await firefoxLink.hover();
+            await expect(firefoxMenu).toBeVisible();
+
+            // Click Firefox desktop link
+            await firefoxMenuLink.click();
+            await page.waitForURL('**/firefox/new/');
+
+            // Assert Firefox menu is closed after navigation
+            await expect(firefoxMenu).not.toBeVisible();
+        });
+    }
+);
+
+test.describe(
+    `${url} navigation (mobile)`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.use({ viewport: { width: 360, height: 780 } });
+
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Navigation open / close click', async ({ page }) => {
+            const navigationMenuButton = page.getByTestId(
+                'navigation-menu-button'
+            );
+            const navigationMenuItems = page.getByTestId(
+                'navigation-menu-items'
+            );
+            const firefoxLink = page.getByTestId('navigation-link-firefox');
+            const firefoxMenu = page.getByTestId('navigation-menu-firefox');
+            const productsLink = page.getByTestId('navigation-link-products');
+            const productsMenu = page.getByTestId('navigation-menu-products');
+            const whoWeAreLink = page.getByTestId('navigation-link-who-we-are');
+            const whoWeAreMenu = page.getByTestId('navigation-menu-who-we-are');
+            const innovationLink = page.getByTestId(
+                'navigation-link-innovation'
+            );
+            const innovationMenu = page.getByTestId(
+                'navigation-menu-innovation'
+            );
+
+            // Open navigation menu
+            await navigationMenuButton.click();
+            await expect(navigationMenuItems).toBeVisible();
+
+            // Open and close Firefox menu
+            await firefoxLink.click();
+            await expect(firefoxMenu).toBeVisible();
+            await firefoxLink.click();
+            await expect(firefoxMenu).not.toBeVisible();
+
+            // Open and close products menu
+            await productsLink.click();
+            await expect(productsMenu).toBeVisible();
+            await productsLink.click();
+            await expect(productsMenu).not.toBeVisible();
+
+            // Open and close who we are menu
+            await whoWeAreLink.click();
+            await expect(whoWeAreMenu).toBeVisible();
+            await whoWeAreLink.click();
+            await expect(whoWeAreMenu).not.toBeVisible();
+
+            // Open and close innovation menu
+            await innovationLink.click();
+            await expect(innovationMenu).toBeVisible();
+            await innovationLink.click();
+            await expect(innovationMenu).not.toBeVisible();
+
+            // Close navigation menu
+            await navigationMenuButton.click();
+            await expect(navigationMenuItems).not.toBeVisible();
+        });
+
+        test('Navigation link click', async ({ page }) => {
+            const navigationMenuButton = page.getByTestId(
+                'navigation-menu-button'
+            );
+            const navigationMenuItems = page.getByTestId(
+                'navigation-menu-items'
+            );
+            const firefoxLink = page.getByTestId('navigation-link-firefox');
+            const firefoxMenu = page.getByTestId('navigation-menu-firefox');
+            const firefoxMenuLink = page.getByTestId(
+                'navigation-menu-link-firefox-desktop'
+            );
+
+            // Open navigation menu
+            await navigationMenuButton.click();
+            await expect(navigationMenuItems).toBeVisible();
+
+            // Open and Firefox menu
+            await firefoxLink.click();
+            await expect(firefoxMenu).toBeVisible();
+
+            // Click Firefox desktop link
+            await firefoxMenuLink.click();
+            await page.waitForURL('**/firefox/new/');
+
+            // Assert nav menu is closed again after navigation
+            await expect(navigationMenuItems).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-all.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-all.spec.js
@@ -1,0 +1,231 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/all/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Firefox download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+            const platformSelect = page.getByTestId(
+                'firefox-all-platform-select (select_desktop_release_platform)'
+            );
+            const langSelect = page.getByTestId(
+                'firefox-all-language-select (select_desktop_release_language)'
+            );
+
+            await productSelect.selectOption({ label: 'Firefox' });
+            await platformSelect.selectOption({ label: 'Windows 64-bit' });
+            await langSelect.selectOption({ label: 'English (US)' });
+
+            // Assert download button is set to release channel / Windows 64-bit English (US).
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win64&lang=en-US/
+            );
+        });
+
+        test('Firefox Beta download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+            const platformSelect = page.getByTestId(
+                'firefox-all-platform-select (select_desktop_beta_platform)'
+            );
+            const langSelect = page.getByTestId(
+                'firefox-all-language-select (select_desktop_beta_language)'
+            );
+
+            await productSelect.selectOption({ label: 'Firefox Beta' });
+            await platformSelect.selectOption({ label: 'macOS' });
+            await langSelect.selectOption({ label: 'German — Deutsch' });
+
+            // Assert download button is set to release channel / macOS German.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=osx&lang=de/
+            );
+        });
+
+        test('Firefox Developer download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+            const platformSelect = page.getByTestId(
+                'firefox-all-platform-select (select_desktop_developer_platform)'
+            );
+            const langSelect = page.getByTestId(
+                'firefox-all-language-select (select_desktop_developer_language)'
+            );
+
+            await productSelect.selectOption({
+                label: 'Firefox Developer Edition'
+            });
+            await platformSelect.selectOption({ label: 'Linux 64-bit' });
+            await langSelect.selectOption({ label: 'English (US)' });
+
+            // Assert download button is set to Dev Edition / Linux 64-bit English (US).
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64&lang=en-US/
+            );
+        });
+
+        test('Firefox Nightly download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+            const platformSelect = page.getByTestId(
+                'firefox-all-platform-select (select_desktop_nightly_platform)'
+            );
+            const langSelect = page.getByTestId(
+                'firefox-all-language-select (select_desktop_nightly_language)'
+            );
+
+            await productSelect.selectOption({ label: 'Firefox Nightly' });
+            await platformSelect.selectOption({ label: 'Windows 32-bit' });
+            await langSelect.selectOption({ label: 'German — Deutsch' });
+
+            // Assert download button is set to Nightly / Windows 32-bit German.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-l10n-ssl&os=win&lang=de/
+            );
+        });
+
+        test('Firefox ESR download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+            const platformSelect = page.getByTestId(
+                'firefox-all-platform-select (select_desktop_esr_platform)'
+            );
+            const langSelect = page.getByTestId(
+                'firefox-all-language-select (select_desktop_esr_language)'
+            );
+
+            await productSelect.selectOption({
+                label: 'Firefox Extended Support Release'
+            });
+            await platformSelect.selectOption({ label: 'Linux 32-bit' });
+            await langSelect.selectOption({ label: 'English (US)' });
+
+            // Assert download button is set to ESR / Linux 32-bit English (US).
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=linux&lang=en-US/
+            );
+        });
+
+        test('Firefox Android download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-android-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+
+            await productSelect.selectOption({ label: 'Firefox Android' });
+
+            // Assert download button is set to release channel / Android Play Store.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.firefox/
+            );
+        });
+
+        test('Firefox Android Beta download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-android-beta-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+
+            await productSelect.selectOption({ label: 'Firefox Android Beta' });
+
+            // Assert download button is set to Beta channel / Android Play Store.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.firefox_beta/
+            );
+        });
+
+        test('Firefox Android Nightly download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-android-nightly-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+
+            await productSelect.selectOption({
+                label: 'Firefox Android Nightly'
+            });
+
+            // Assert download button is set to Nightly channel / Android Play Store.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.fenix/
+            );
+        });
+
+        test('Firefox iOS download button', async ({ page }) => {
+            const downloadButton = page.getByTestId(
+                'firefox-all-ios-download-button'
+            );
+            const productSelect = page.getByTestId(
+                'firefox-all-product-select'
+            );
+
+            await productSelect.selectOption({ label: 'Firefox iOS' });
+
+            // Assert download button is set to iOS App Store.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadButton).toHaveAttribute(
+                'href',
+                /^https:\/\/apps.apple.com\/app\/apple-store\/id989804926/
+            );
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-all.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-all.spec.js
@@ -10,6 +10,10 @@ const { test, expect } = require('@playwright/test');
 const openPage = require('../../../scripts/open-page');
 const url = '/en-US/firefox/all/';
 
+/**
+ * Temporarily skipping these tests until refactor merges
+ * https://github.com/mozilla/bedrock/pull/14324
+ */
 test.describe(
     `${url} page`,
     {
@@ -20,7 +24,7 @@ test.describe(
             await openPage(url, page, browserName);
         });
 
-        test('Firefox download button', async ({ page }) => {
+        test.skip('Firefox download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-download-button'
             );
@@ -46,7 +50,7 @@ test.describe(
             );
         });
 
-        test('Firefox Beta download button', async ({ page }) => {
+        test.skip('Firefox Beta download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-download-button'
             );
@@ -72,7 +76,7 @@ test.describe(
             );
         });
 
-        test('Firefox Developer download button', async ({ page }) => {
+        test.skip('Firefox Developer download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-download-button'
             );
@@ -100,7 +104,7 @@ test.describe(
             );
         });
 
-        test('Firefox Nightly download button', async ({ page }) => {
+        test.skip('Firefox Nightly download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-download-button'
             );
@@ -126,7 +130,7 @@ test.describe(
             );
         });
 
-        test('Firefox ESR download button', async ({ page }) => {
+        test.skip('Firefox ESR download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-download-button'
             );
@@ -154,7 +158,7 @@ test.describe(
             );
         });
 
-        test('Firefox Android download button', async ({ page }) => {
+        test.skip('Firefox Android download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-android-download-button'
             );
@@ -172,7 +176,7 @@ test.describe(
             );
         });
 
-        test('Firefox Android Beta download button', async ({ page }) => {
+        test.skip('Firefox Android Beta download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-android-beta-download-button'
             );
@@ -190,7 +194,9 @@ test.describe(
             );
         });
 
-        test('Firefox Android Nightly download button', async ({ page }) => {
+        test.skip('Firefox Android Nightly download button', async ({
+            page
+        }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-android-nightly-download-button'
             );
@@ -210,7 +216,7 @@ test.describe(
             );
         });
 
-        test('Firefox iOS download button', async ({ page }) => {
+        test.skip('Firefox iOS download button', async ({ page }) => {
             const downloadButton = page.getByTestId(
                 'firefox-all-ios-download-button'
             );

--- a/tests/playwright/specs/products/firefox/firefox-android.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-android.spec.js
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/browsers/mobile/android/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Send to device form success', async ({ page }) => {
+            const emailField = page.getByTestId(
+                'send-to-device-form-email-field'
+            );
+            const thanksMessage = page.getByTestId(
+                'send-to-device-form-thanks'
+            );
+            const submitButton = page.getByTestId(
+                'send-to-device-form-submit-button'
+            );
+
+            await expect(thanksMessage).not.toBeVisible();
+            await emailField.fill('success@example.com');
+            await submitButton.click();
+            await expect(submitButton).not.toBeVisible();
+            await expect(thanksMessage).toBeVisible();
+        });
+
+        test('Send to device form failure', async ({ page }) => {
+            const emailField = page.getByTestId(
+                'send-to-device-form-email-field'
+            );
+            const errorMessage = page.getByTestId('send-to-device-form-error');
+            const submitButton = page.getByTestId(
+                'send-to-device-form-submit-button'
+            );
+
+            await expect(errorMessage).not.toBeVisible();
+            await emailField.fill('failure@example.com');
+            await submitButton.click();
+            await expect(errorMessage).toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-channel-android.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-channel-android.spec.js
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/channel/android/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Download Firefox Beta / Nightly (Android)', async ({ page }) => {
+            const androidBetaDownload = page.getByTestId(
+                'android-beta-download-android'
+            );
+            const androidNightlyDownload = page.getByTestId(
+                'android-nightly-download-android'
+            );
+
+            // Assert Android Beta download button is displayed.
+            await expect(androidBetaDownload).toBeVisible();
+            await expect(androidBetaDownload).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.firefox_beta/
+            );
+
+            // Assert Android Nightly download button is displayed.
+            await expect(androidNightlyDownload).toBeVisible();
+            await expect(androidNightlyDownload).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.fenix/
+            );
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
@@ -1,0 +1,351 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/channel/desktop/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download Firefox Beta / DevEdition / Nightly (Windows, macOS)', async ({
+            page,
+            browserName
+        }) => {
+            const win64BetaDownload = page.getByTestId(
+                'desktop-beta-download-win64'
+            );
+            const winDevDownload = page.getByTestId(
+                'desktop-developer-download-win'
+            );
+            const winNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-win'
+            );
+            const osxBetaDownload = page.getByTestId(
+                'desktop-beta-download-osx'
+            );
+            const osxDevDownload = page.getByTestId(
+                'desktop-developer-download-osx'
+            );
+            const osxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-osx'
+            );
+
+            await openPage(url, page, browserName);
+
+            if (browserName === 'webkit') {
+                // Assert macOS download buttons are displayed.
+                await expect(osxBetaDownload).toBeVisible();
+                await expect(osxBetaDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-beta-latest-ssl&os=osx/
+                );
+                await expect(osxDevDownload).toBeVisible();
+                await expect(osxDevDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=osx/
+                );
+                await expect(osxNightlyDownload).toBeVisible();
+                await expect(osxNightlyDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-nightly-latest-ssl&os=osx/
+                );
+
+                // Assert Windows download buttons are not displayed.
+                await expect(win64BetaDownload).not.toBeVisible();
+                await expect(winDevDownload).not.toBeVisible();
+                await expect(winNightlyDownload).not.toBeVisible();
+            } else {
+                /**
+                 * Assert Windows download buttons are displayed.
+                 * Note: we serve the full installer for Firefox Beta on Windows.
+                 * See https://github.com/mozilla/bedrock/issues/9836
+                 * and https://github.com/mozilla/bedrock/issues/10194
+                 */
+                await expect(win64BetaDownload).toBeVisible();
+                await expect(win64BetaDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-beta-latest-ssl&os=win64/
+                );
+                await expect(winDevDownload).toBeVisible();
+                await expect(winDevDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-stub&os=win/
+                );
+                await expect(winNightlyDownload).toBeVisible();
+                await expect(winNightlyDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-nightly-stub&os=win/
+                );
+
+                // Assert macOS download buttons are not displayed.
+                await expect(osxBetaDownload).not.toBeVisible();
+                await expect(osxDevDownload).not.toBeVisible();
+                await expect(osxNightlyDownload).not.toBeVisible();
+            }
+        });
+
+        test('Download Firefox Beta / DevEdition / Nightly (Linux)', async ({
+            page,
+            browserName
+        }) => {
+            const linuxBetaDownload = page.getByTestId(
+                'desktop-beta-download-linux'
+            );
+            const linux64BetaDownload = page.getByTestId(
+                'desktop-beta-download-linux64'
+            );
+            const linuxDevDownload = page.getByTestId(
+                'desktop-developer-download-linux'
+            );
+            const linux64DevDownload = page.getByTestId(
+                'desktop-developer-download-linux64'
+            );
+            const linuxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-linux'
+            );
+            const linux64NightlyDownload = page.getByTestId(
+                'desktop-nightly-download-linux64'
+            );
+
+            const win64BetaDownload = page.getByTestId(
+                'desktop-beta-download-win64'
+            );
+            const winDevDownload = page.getByTestId(
+                'desktop-developer-download-win'
+            );
+            const winNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-win'
+            );
+            const osxBetaDownload = page.getByTestId(
+                'desktop-beta-download-osx'
+            );
+            const osxDevDownload = page.getByTestId(
+                'desktop-developer-download-osx'
+            );
+            const osxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-osx'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Linux'
+            );
+
+            // Set Linux UA strings.
+            await page.addInitScript({
+                path: `./scripts/useragent/linux/${browserName}.js`
+            });
+            await page.goto(url + '?automation=true');
+
+            // Assert Linux download buttons are displayed.
+            await expect(linuxBetaDownload).toBeVisible();
+            await expect(linuxBetaDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=linux/
+            );
+            await expect(linux64BetaDownload).toBeVisible();
+            await expect(linux64BetaDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=linux64/
+            );
+            await expect(linuxDevDownload).toBeVisible();
+            await expect(linuxDevDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux/
+            );
+            await expect(linux64DevDownload).toBeVisible();
+            await expect(linux64DevDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64/
+            );
+            await expect(linuxNightlyDownload).toBeVisible();
+            await expect(linuxNightlyDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-ssl&os=linux/
+            );
+            await expect(linux64NightlyDownload).toBeVisible();
+            await expect(linux64NightlyDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-ssl&os=linux64/
+            );
+
+            // Assert Windows / macOS download buttons are not displayed.
+            await expect(win64BetaDownload).not.toBeVisible();
+            await expect(winDevDownload).not.toBeVisible();
+            await expect(winNightlyDownload).not.toBeVisible();
+            await expect(osxBetaDownload).not.toBeVisible();
+            await expect(osxDevDownload).not.toBeVisible();
+            await expect(osxNightlyDownload).not.toBeVisible();
+        });
+
+        test('Firefox unsupported OS version messaging (Win / Mac)', async ({
+            page,
+            browserName
+        }) => {
+            const win64BetaDownload = page.getByTestId(
+                'desktop-beta-download-win64'
+            );
+            const winDevDownload = page.getByTestId(
+                'desktop-developer-download-win'
+            );
+            const winNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-win'
+            );
+            const osxBetaDownload = page.getByTestId(
+                'desktop-beta-download-osx'
+            );
+            const osxDevDownload = page.getByTestId(
+                'desktop-developer-download-osx'
+            );
+            const osxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-osx'
+            );
+
+            const betaDownloadOsxUnsupported = page.locator(
+                'css=.download-button-beta .fx-unsupported-message.mac .download-link'
+            );
+            const devDownloadOsxUnsupported = page.locator(
+                'css=.download-button-alpha .fx-unsupported-message.mac .download-link'
+            );
+            const nightlyDownloadOsxUnsupported = page.locator(
+                'css=.download-button-nightly .fx-unsupported-message.mac .download-link'
+            );
+            const betaDownloadWinUnsupported = page.locator(
+                'css=.download-button-beta .fx-unsupported-message.win .download-link.os_win64'
+            );
+            const devDownloadWinUnsupported = page.locator(
+                'css=.download-button-alpha .fx-unsupported-message.win .download-link.os_win64'
+            );
+            const nightlyDownloadWinUnsupported = page.locator(
+                'css=.download-button-nightly .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            if (browserName === 'webkit') {
+                // Set macOS 10.14 UA strings.
+                await page.addInitScript({
+                    path: `./scripts/useragent/mac-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR button is displayed instead of Firefox Beta button.
+                await expect(betaDownloadOsxUnsupported).toBeVisible();
+                await expect(betaDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+                await expect(osxBetaDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Developer Edition button.
+                await expect(devDownloadOsxUnsupported).toBeVisible();
+                await expect(devDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+                await expect(osxDevDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Nightly button.
+                await expect(nightlyDownloadOsxUnsupported).toBeVisible();
+                await expect(nightlyDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+                await expect(osxNightlyDownload).not.toBeVisible();
+            } else {
+                // Set Windows 8.1 UA string (64-bit).
+                await page.addInitScript({
+                    path: `./scripts/useragent/win-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR button is displayed instead of Firefox Beta 64-bit button.
+                await expect(betaDownloadWinUnsupported).toBeVisible();
+                await expect(betaDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win64/
+                );
+                await expect(win64BetaDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Developer Edition button.
+                await expect(devDownloadWinUnsupported).toBeVisible();
+                await expect(devDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win64/
+                );
+                await expect(winDevDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Nightly button.
+                await expect(nightlyDownloadWinUnsupported).toBeVisible();
+                await expect(nightlyDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win64/
+                );
+                await expect(winNightlyDownload).not.toBeVisible();
+            }
+        });
+
+        test('Newsletter submit success', async ({ page, browserName }) => {
+            const newsletterForm = page.getByTestId('newsletter-form');
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('success@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterForm).not.toBeVisible();
+            await expect(newsletterThanksMessage).toBeVisible();
+        });
+
+        test('Newsletter submit failure', async ({ page, browserName }) => {
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+            const newsletterErrorMessage = page.getByTestId(
+                'newsletter-error-message'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('failure@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterErrorMessage).toBeVisible();
+            await expect(newsletterThanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-developer.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-developer.spec.js
@@ -1,0 +1,249 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/developer/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download DevEdition (Windows, macOS)', async ({
+            page,
+            browserName
+        }) => {
+            const introDownloadWin = page.getByTestId('intro-download-win');
+            const introDownloadOsx = page.getByTestId('intro-download-osx');
+            const footerDownloadWin = page.getByTestId('footer-download-win');
+            const footerDownloadOsx = page.getByTestId('footer-download-osx');
+
+            await openPage(url, page, browserName);
+
+            if (browserName === 'webkit') {
+                // Assert macOS download button is displayed.
+                await expect(introDownloadOsx).toBeVisible();
+                await expect(introDownloadOsx).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=osx/
+                );
+                await expect(footerDownloadOsx).toBeVisible();
+                await expect(footerDownloadOsx).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=osx/
+                );
+
+                // Assert Windows download button is not displayed.
+                await expect(introDownloadWin).not.toBeVisible();
+                await expect(footerDownloadWin).not.toBeVisible();
+            } else {
+                // Assert Windows download button is displayed.
+                await expect(introDownloadWin).toBeVisible();
+                await expect(introDownloadWin).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-stub&os=win/
+                );
+                await expect(footerDownloadWin).toBeVisible();
+                await expect(footerDownloadWin).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-stub&os=win/
+                );
+
+                // Assert macOS download button is not displayed.
+                await expect(introDownloadOsx).not.toBeVisible();
+                await expect(footerDownloadOsx).not.toBeVisible();
+            }
+        });
+
+        test('Download Firefox (Linux)', async ({ page, browserName }) => {
+            const introDownloadWin = page.getByTestId('intro-download-win');
+            const introDownloadOsx = page.getByTestId('intro-download-osx');
+            const footerDownloadWin = page.getByTestId('footer-download-win');
+            const footerDownloadOsx = page.getByTestId('footer-download-osx');
+            const introDownloadLinux = page.getByTestId('intro-download-linux');
+            const introDownloadLinux64 = page.getByTestId(
+                'intro-download-linux64'
+            );
+            const footerDownloadLinux = page.getByTestId(
+                'footer-download-linux'
+            );
+            const footerDownloadLinux64 = page.getByTestId(
+                'footer-download-linux64'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Linux'
+            );
+
+            // Set Linux UA strings.
+            await page.addInitScript({
+                path: `./scripts/useragent/linux/${browserName}.js`
+            });
+            await page.goto(url + '?automation=true');
+
+            // Assert Linux download buttons are displayed.
+            await expect(introDownloadLinux).toBeVisible();
+            await expect(introDownloadLinux).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux/
+            );
+            await expect(introDownloadLinux64).toBeVisible();
+            await expect(introDownloadLinux64).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64/
+            );
+            await expect(footerDownloadLinux).toBeVisible();
+            await expect(footerDownloadLinux).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux/
+            );
+            await expect(footerDownloadLinux64).toBeVisible();
+            await expect(footerDownloadLinux64).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64/
+            );
+
+            // Assert Windows / macOS download buttons are not displayed.
+            await expect(introDownloadWin).not.toBeVisible();
+            await expect(introDownloadOsx).not.toBeVisible();
+            await expect(footerDownloadWin).not.toBeVisible();
+            await expect(footerDownloadOsx).not.toBeVisible();
+        });
+
+        test('Firefox unsupported OS version messaging (Win / Mac)', async ({
+            page,
+            browserName
+        }) => {
+            const introDownloadWin = page.getByTestId('intro-download-win');
+            const introDownloadOsx = page.getByTestId('intro-download-osx');
+            const footerDownloadWin = page.getByTestId('footer-download-win');
+            const footerDownloadOsx = page.getByTestId('footer-download-osx');
+
+            const introDownloadWinUnsupported = page.locator(
+                'css=#intro-download .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const introDownloadOsxUnsupported = page.locator(
+                'css=#intro-download .fx-unsupported-message.mac .download-link'
+            );
+
+            const footerDownloadWinUnsupported = page.locator(
+                'css=#footer-download .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const footerDownloadOsxUnsupported = page.locator(
+                'css=#footer-download .fx-unsupported-message.mac .download-link'
+            );
+
+            if (browserName === 'webkit') {
+                // Set macOS 10.14 UA strings.
+                await page.addInitScript({
+                    path: `./scripts/useragent/mac-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR buttons are displayed instead of Firefox Dev buttons.
+                await expect(introDownloadOsxUnsupported).toBeVisible();
+                await expect(introDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+                await expect(footerDownloadOsxUnsupported).toBeVisible();
+                await expect(footerDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+
+                // Assert regular download buttons are not displayed.
+                await expect(introDownloadOsx).not.toBeVisible();
+                await expect(footerDownloadOsx).not.toBeVisible();
+            } else {
+                // Set Windows 8.1 UA string (64-bit).
+                await page.addInitScript({
+                    path: `./scripts/useragent/win-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR buttons are displayed instead of Firefox Dev buttons.
+                await expect(introDownloadWinUnsupported).toBeVisible();
+                await expect(introDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win64/
+                );
+                await expect(footerDownloadWinUnsupported).toBeVisible();
+                await expect(footerDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win64/
+                );
+
+                // Assert regular download buttons are not displayed.
+                await expect(introDownloadWin).not.toBeVisible();
+                await expect(footerDownloadWin).not.toBeVisible();
+            }
+        });
+
+        test('Newsletter submit success', async ({ page, browserName }) => {
+            const newsletterForm = page.getByTestId('newsletter-form');
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('success@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterForm).not.toBeVisible();
+            await expect(newsletterThanksMessage).toBeVisible();
+        });
+
+        test('Newsletter submit failure', async ({ page, browserName }) => {
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+            const newsletterErrorMessage = page.getByTestId(
+                'newsletter-error-message'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('failure@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterErrorMessage).toBeVisible();
+            await expect(newsletterThanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-enterprise.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-enterprise.spec.js
@@ -1,0 +1,178 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/enterprise/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Firefox ESR Windows 64bit menu open / close', async ({
+            page
+        }) => {
+            const win64MenuButton = page.getByTestId(
+                'firefox-enterprise-win64-menu-button'
+            );
+            const win64MenuLink = page.getByTestId(
+                'firefox-enterprise-win64-menu-link'
+            );
+            const win64MsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-msi-menu-link'
+            );
+            const win64EsrMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-menu-link'
+            );
+            const win64EsrMsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-msi-menu-link'
+            );
+
+            await expect(win64MenuLink).not.toBeVisible();
+            await expect(win64MsiMenuLink).not.toBeVisible();
+            await expect(win64EsrMenuLink).not.toBeVisible();
+            await expect(win64EsrMsiMenuLink).not.toBeVisible();
+
+            // open menu
+            await win64MenuButton.click();
+
+            // Assert Windows 64-bit menu links are displayed.
+            await expect(win64MenuLink).toBeVisible();
+            await expect(win64MenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win64/
+            );
+            await expect(win64MsiMenuLink).toBeVisible();
+            await expect(win64MsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-msi-latest-ssl&os=win64/
+            );
+            await expect(win64EsrMenuLink).toBeVisible();
+            await expect(win64EsrMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=win64/
+            );
+            await expect(win64EsrMsiMenuLink).toBeVisible();
+            await expect(win64EsrMsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-msi-latest-ssl&os=win64/
+            );
+
+            // close menu
+            await win64MenuButton.click();
+
+            // Assert Windows 64-bit menu links are hidden.
+            await expect(win64MenuLink).not.toBeVisible();
+            await expect(win64MsiMenuLink).not.toBeVisible();
+            await expect(win64EsrMenuLink).not.toBeVisible();
+            await expect(win64EsrMsiMenuLink).not.toBeVisible();
+        });
+
+        test('Firefox ESR macOS menu open / close', async ({ page }) => {
+            const macMenuButton = page.getByTestId(
+                'firefox-enterprise-mac-menu-button'
+            );
+            const macMenuLink = page.getByTestId(
+                'firefox-enterprise-mac-menu-link'
+            );
+            const macEsrMenuLink = page.getByTestId(
+                'firefox-enterprise-mac-esr-menu-link'
+            );
+
+            await expect(macMenuLink).not.toBeVisible();
+            await expect(macEsrMenuLink).not.toBeVisible();
+
+            // open menu
+            await macMenuButton.click();
+
+            // Assert macOS menu links are displayed.
+            await expect(macMenuLink).toBeVisible();
+            await expect(macMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=osx/
+            );
+            await expect(macEsrMenuLink).toBeVisible();
+            await expect(macEsrMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=osx/
+            );
+
+            // close menu
+            await macMenuButton.click();
+
+            // Assert macOS menu links are hidden.
+            await expect(macMenuLink).not.toBeVisible();
+            await expect(macEsrMenuLink).not.toBeVisible();
+        });
+
+        test('Firefox ESR Windows 32bit menu open / close', async ({
+            page
+        }) => {
+            const win32MenuButton = page.getByTestId(
+                'firefox-enterprise-win64-menu-button'
+            );
+            const win32MenuLink = page.getByTestId(
+                'firefox-enterprise-win64-menu-link'
+            );
+            const win32MsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-msi-menu-link'
+            );
+            const win32EsrMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-menu-link'
+            );
+            const win32EsrMsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-msi-menu-link'
+            );
+
+            await expect(win32MenuLink).not.toBeVisible();
+            await expect(win32MsiMenuLink).not.toBeVisible();
+            await expect(win32EsrMenuLink).not.toBeVisible();
+            await expect(win32EsrMsiMenuLink).not.toBeVisible();
+
+            // open menu
+            await win32MenuButton.click();
+
+            // Assert Windows 32-bit menu links are displayed.
+            await expect(win32MenuLink).toBeVisible();
+            await expect(win32MenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win64/
+            );
+            await expect(win32MsiMenuLink).toBeVisible();
+            await expect(win32MsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-msi-latest-ssl&os=win64/
+            );
+            await expect(win32EsrMenuLink).toBeVisible();
+            await expect(win32EsrMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=win64/
+            );
+            await expect(win32EsrMsiMenuLink).toBeVisible();
+            await expect(win32EsrMsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-msi-latest-ssl&os=win64/
+            );
+
+            // close menu
+            await win32MenuButton.click();
+
+            // Assert Windows 32-bit menu links are hidden.
+            await expect(win32MenuLink).not.toBeVisible();
+            await expect(win32MsiMenuLink).not.toBeVisible();
+            await expect(win32EsrMenuLink).not.toBeVisible();
+            await expect(win32EsrMsiMenuLink).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-home.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-home.spec.js
@@ -1,0 +1,92 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Download Firefox desktop', async ({ page }) => {
+            // Click download button.
+            const downloadButton = page.getByTestId('firefox-desktop-download');
+            await expect(downloadButton).toBeVisible();
+            await downloadButton.click();
+            await page.waitForURL('**/firefox/download/thanks/');
+
+            // Assert /thanks/ page triggers file download.
+            const download = await page.waitForEvent('download');
+            const downloadURL = download.url();
+
+            expect(downloadURL).toEqual(
+                expect.stringContaining(
+                    'https://download-installer.cdn.mozilla.net/pub/firefox/releases/'
+                )
+            );
+
+            // Cancel download if not finished.
+            await download.cancel();
+        });
+
+        test('Firefox mobile menu open / close', async ({ page }) => {
+            const mobileMenuButton = page.getByTestId(
+                'firefox-mobile-download-menu-button'
+            );
+            const androidMenuLink = page.getByTestId(
+                'firefox-android-menu-link'
+            );
+            const iosMenuLink = page.getByTestId('firefox-ios-menu-link');
+
+            await expect(iosMenuLink).not.toBeVisible();
+            await expect(androidMenuLink).not.toBeVisible();
+
+            // open menu
+            await mobileMenuButton.click();
+
+            // Assert Android and iOS download links are displayed.
+            await expect(androidMenuLink).toBeVisible();
+            await expect(androidMenuLink).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\//
+            );
+            await expect(iosMenuLink).toBeVisible();
+            await expect(iosMenuLink).toHaveAttribute(
+                'href',
+                /^https:\/\/apps.apple.com\/us\/app\/apple-store\//
+            );
+
+            // close menu
+            await mobileMenuButton.click();
+
+            // Assert Android and iOS download links are hidden.
+            await expect(iosMenuLink).not.toBeVisible();
+            await expect(androidMenuLink).not.toBeVisible();
+        });
+
+        test('Account form sign up', async ({ page }) => {
+            const emailQueryString = /&email=success%40example.com/;
+            const accountButton = page.getByTestId('fxa-form-submit-button');
+            const emailField = page.getByTestId('fxa-form-email-field');
+
+            await emailField.fill('success@example.com');
+            await accountButton.click();
+            await page.waitForURL(emailQueryString, {
+                waitUntil: 'commit'
+            });
+            await expect(page).toHaveURL(emailQueryString);
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-installer-help.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-installer-help.spec.js
@@ -1,0 +1,164 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/installer-help/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download Firefox (Windows)', async ({ page, browserName }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=release', page, browserName);
+
+            // Assert Windows release channel download button is displayed.
+            await expect(downloadButtonRelease).toBeVisible();
+            await expect(downloadButtonRelease).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonBeta).not.toBeVisible();
+            await expect(downloadButtonDeveloper).not.toBeVisible();
+            await expect(downloadButtonNightly).not.toBeVisible();
+        });
+
+        test('Download Firefox Beta (Windows)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=beta', page, browserName);
+
+            // Assert Windows beta channel download button is displayed.
+            await expect(downloadButtonBeta).toBeVisible();
+            await expect(downloadButtonBeta).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonRelease).not.toBeVisible();
+            await expect(downloadButtonDeveloper).not.toBeVisible();
+            await expect(downloadButtonNightly).not.toBeVisible();
+        });
+
+        test('Download Firefox Developer (Windows)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=aurora', page, browserName);
+
+            // Assert Windows developer channel download button is displayed.
+            await expect(downloadButtonDeveloper).toBeVisible();
+            await expect(downloadButtonDeveloper).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonRelease).not.toBeVisible();
+            await expect(downloadButtonBeta).not.toBeVisible();
+            await expect(downloadButtonNightly).not.toBeVisible();
+        });
+
+        test('Download Firefox Nightly (Windows)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=nightly', page, browserName);
+
+            // Assert Windows nightly channel download button is displayed.
+            await expect(downloadButtonNightly).toBeVisible();
+            await expect(downloadButtonNightly).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonRelease).not.toBeVisible();
+            await expect(downloadButtonBeta).not.toBeVisible();
+            await expect(downloadButtonDeveloper).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-ios-testflight.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-ios-testflight.spec.js
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/ios/testflight/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Signup success', async ({ page, browserName }) => {
+            const newsletterForm = page.getByTestId('newsletter-form');
+            const emailInput = page.getByTestId('newsletter-email-input');
+            const termsCheckbox = page.getByTestId('newsletter-terms-checkbox');
+            const privacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const submitButton = page.getByTestId('newsletter-submit-button');
+            const thanksMessage = page.getByTestId('newsletter-thanks-message');
+
+            await openPage(url, page, browserName);
+
+            await expect(thanksMessage).not.toBeVisible();
+
+            // expand form before running test
+            await submitButton.click();
+
+            await emailInput.fill('success@example.com');
+            await termsCheckbox.click();
+            await privacyCheckbox.click();
+            await submitButton.click();
+            await expect(newsletterForm).not.toBeVisible();
+            await expect(thanksMessage).toBeVisible();
+        });
+
+        test('Signup failure', async ({ page, browserName }) => {
+            const newsletterErrorMessage = page.getByTestId(
+                'newsletter-error-message'
+            );
+            const emailInput = page.getByTestId('newsletter-email-input');
+            const termsCheckbox = page.getByTestId('newsletter-terms-checkbox');
+            const privacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const submitButton = page.getByTestId('newsletter-submit-button');
+            const thanksMessage = page.getByTestId('newsletter-thanks-message');
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await submitButton.click();
+
+            await emailInput.fill('failure@example.com');
+            await termsCheckbox.click();
+            await privacyCheckbox.click();
+            await submitButton.click();
+            await expect(newsletterErrorMessage).toBeVisible();
+            await expect(thanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-ios.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-ios.spec.js
@@ -1,0 +1,60 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/browsers/mobile/ios/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Send to device form success', async ({ page }) => {
+            const emailField = page.getByTestId(
+                'send-to-device-form-email-field'
+            );
+            const thanksMessage = page.getByTestId(
+                'send-to-device-form-thanks'
+            );
+            const submitButton = page.getByTestId(
+                'send-to-device-form-submit-button'
+            );
+
+            await expect(thanksMessage).not.toBeVisible();
+            await emailField.fill('success@example.com');
+            await submitButton.click();
+            await expect(submitButton).not.toBeVisible();
+            await expect(thanksMessage).toBeVisible();
+        });
+
+        test('Send to device form failure', async ({ page }) => {
+            const emailField = page.getByTestId(
+                'send-to-device-form-email-field'
+            );
+            const thanksMessage = page.getByTestId(
+                'send-to-device-form-thanks'
+            );
+            const submitButton = page.getByTestId(
+                'send-to-device-form-submit-button'
+            );
+            const errorMessage = page.getByTestId('send-to-device-form-error');
+
+            await expect(errorMessage).not.toBeVisible();
+            await emailField.fill('failure@example.com');
+            await submitButton.click();
+            await expect(emailField).toBeVisible();
+            await expect(thanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-new.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-new.spec.js
@@ -1,0 +1,193 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/new/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download Firefox (Windows, macOS)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButton = page.getByTestId('download-button-thanks');
+            const downloadFeaturesButton =
+                page.getByTestId('download-features');
+            const downloadDiscoverButton =
+                page.getByTestId('download-discover');
+
+            await openPage(url, page, browserName);
+
+            // Assert download buttons are visible.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadFeaturesButton).toBeVisible();
+            await expect(downloadDiscoverButton).toBeVisible();
+
+            // Click primary download button.
+            await downloadButton.click();
+            await page.waitForURL('**/firefox/download/thanks/');
+
+            // Assert /thanks/ page triggers file download.
+            const download = await page.waitForEvent('download');
+            const downloadURL = download.url();
+
+            expect(downloadURL).toEqual(
+                expect.stringContaining(
+                    'https://download-installer.cdn.mozilla.net/pub/firefox/releases/'
+                )
+            );
+
+            // Cancel download if not finished.
+            await download.cancel();
+        });
+
+        test('Download Firefox (Linux)', async ({ page, browserName }) => {
+            const downloadButton = page.getByTestId('download-button-thanks');
+            const downloadFeaturesButton =
+                page.getByTestId('download-features');
+            const downloadDiscoverButton =
+                page.getByTestId('download-discover');
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Linux'
+            );
+
+            // Set Linux UA strings.
+            await page.addInitScript({
+                path: `./scripts/useragent/linux/${browserName}.js`
+            });
+            await page.goto(url + '?automation=true');
+
+            // Assert download buttons are visible.
+            await expect(downloadButton).toBeVisible();
+            await expect(downloadFeaturesButton).toBeVisible();
+            await expect(downloadDiscoverButton).toBeVisible();
+
+            // Click primary download button.
+            await downloadButton.click();
+            await page.waitForURL('**/firefox/download/thanks/');
+
+            // Assert Linux 32-bit / 64-bit choices are displayed.
+            const downloadButtonLinux32 = page.getByTestId(
+                'thanks-download-button-linux-32'
+            );
+            const downloadButtonLinux64 = page.getByTestId(
+                'thanks-download-button-linux-64'
+            );
+            await expect(downloadButtonLinux32).toBeVisible();
+            await expect(downloadButtonLinux32).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=linux/
+            );
+            await expect(downloadButtonLinux64).toBeVisible();
+            await expect(downloadButtonLinux64).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=linux64/
+            );
+        });
+
+        test('Firefox unsupported OS version messaging (Win / Mac)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButton = page.getByTestId('download-button-thanks');
+            const downloadFeaturesButton =
+                page.getByTestId('download-features');
+            const downloadDiscoverButton =
+                page.getByTestId('download-discover');
+
+            const downloadOsxUnsupported = page.locator(
+                'css=#download-button-thanks .fx-unsupported-message.mac .download-link'
+            );
+
+            const downloadWinUnsupported = page.locator(
+                'css=#download-button-thanks .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const downloadFeaturesOsxUnsupported = page.locator(
+                'css=#download-features .fx-unsupported-message.mac .download-link'
+            );
+
+            const downloadFeaturesWinUnsupported = page.locator(
+                'css=#download-features .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const downloadDiscoverOsxUnsupported = page.locator(
+                'css=#download-discover .fx-unsupported-message.mac .download-link'
+            );
+
+            const downloadDiscoverWinUnsupported = page.locator(
+                'css=#download-discover .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            if (browserName === 'webkit') {
+                // Set macOS 10.14 UA strings.
+                await page.addInitScript({
+                    path: `./scripts/useragent/mac-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert regular download buttons are not displayed.
+                await expect(downloadButton).not.toBeVisible();
+                await expect(downloadFeaturesButton).not.toBeVisible();
+                await expect(downloadDiscoverButton).not.toBeVisible();
+
+                // Assert Firefox ESR mac download button is displayed.
+                await expect(downloadOsxUnsupported).toBeVisible();
+                await expect(downloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+                await expect(downloadFeaturesOsxUnsupported).toBeVisible();
+                await expect(downloadFeaturesOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+                await expect(downloadDiscoverOsxUnsupported).toBeVisible();
+                await expect(downloadDiscoverOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=osx/
+                );
+            } else {
+                // Set Windows 8.1 UA strings (64-bit).
+                await page.addInitScript({
+                    path: `./scripts/useragent/win-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert regular download buttons are not displayed.
+                await expect(downloadButton).not.toBeVisible();
+                await expect(downloadFeaturesButton).not.toBeVisible();
+                await expect(downloadDiscoverButton).not.toBeVisible();
+
+                // Assert Firefox ESR windows download button is displayed.
+                await expect(downloadWinUnsupported).toBeVisible();
+                await expect(downloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win/
+                );
+                await expect(downloadFeaturesWinUnsupported).toBeVisible();
+                await expect(downloadFeaturesWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win/
+                );
+                await expect(downloadDiscoverWinUnsupported).toBeVisible();
+                await expect(downloadDiscoverWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr-latest-ssl&os=win/
+                );
+            }
+        });
+    }
+);

--- a/tests/playwright/specs/products/vpn/vpn-download-mac.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-download-mac.spec.js
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/products/vpn/download/mac/thanks/';
+const blockedCountries = ['cn'];
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@vpn'
+    },
+    () => {
+        for (const country of blockedCountries) {
+            test.describe('VPN download blocked in country', () => {
+                test.beforeEach(async ({ page, browserName }) => {
+                    await openPage(url + `?geo=${country}`, page, browserName);
+                });
+
+                test(`Country code: ${country}`, async ({ page }) => {
+                    const downloadInstructions = page.getByTestId(
+                        'vpn-download-instructions'
+                    );
+                    const downloadBlockedMessage = page.getByTestId(
+                        'vpn-download-blocked-message'
+                    );
+                    await expect(downloadBlockedMessage).toBeVisible();
+                    await expect(downloadInstructions).not.toBeVisible();
+                });
+            });
+        }
+    }
+);

--- a/tests/playwright/specs/products/vpn/vpn-download-win.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-download-win.spec.js
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/products/vpn/download/windows/thanks/';
+const blockedCountries = ['cn'];
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@vpn'
+    },
+    () => {
+        for (const country of blockedCountries) {
+            test.describe('VPN download blocked in country', () => {
+                test.beforeEach(async ({ page, browserName }) => {
+                    await openPage(url + `?geo=${country}`, page, browserName);
+                });
+
+                test(`Country code: ${country}`, async ({ page }) => {
+                    const downloadInstructions = page.getByTestId(
+                        'vpn-download-instructions'
+                    );
+                    const downloadBlockedMessage = page.getByTestId(
+                        'vpn-download-blocked-message'
+                    );
+                    await expect(downloadBlockedMessage).toBeVisible();
+                    await expect(downloadInstructions).not.toBeVisible();
+                });
+            });
+        }
+    }
+);

--- a/tests/playwright/specs/products/vpn/vpn-download.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-download.spec.js
@@ -1,0 +1,111 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/products/vpn/download/';
+const excludedCountries = ['cn'];
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@vpn'
+    },
+    () => {
+        test.describe('VPN download', () => {
+            test.beforeEach(async ({ page, browserName }) => {
+                await openPage(url + '?geo=us', page, browserName);
+            });
+
+            test('Windows download click', async ({ page, browserName }) => {
+                // Click Windows download link
+                let downloadLink;
+
+                if (browserName === 'webkit') {
+                    downloadLink = page.getByTestId(
+                        'vpn-download-link-secondary-windows'
+                    );
+                } else {
+                    downloadLink = page.getByTestId(
+                        'vpn-download-link-primary-windows'
+                    );
+                }
+
+                await expect(downloadLink).toBeVisible();
+                await downloadLink.click();
+                await page.waitForURL(
+                    '**/products/vpn/download/windows/thanks/'
+                );
+
+                // Assert /thanks/ page triggers file download.
+                const download = await page.waitForEvent('download');
+                const downloadURL = download.url();
+
+                expect(downloadURL).toEqual(
+                    expect.stringContaining(
+                        'https://archive.mozilla.org/pub/vpn/releases/'
+                    )
+                );
+
+                // Cancel download if not finished.
+                await download.cancel();
+            });
+
+            test('Mac download click', async ({ page, browserName }) => {
+                // Click Windows download link
+                let downloadLink;
+
+                if (browserName === 'webkit') {
+                    downloadLink = page.getByTestId(
+                        'vpn-download-link-primary-mac'
+                    );
+                } else {
+                    downloadLink = page.getByTestId(
+                        'vpn-download-link-secondary-mac'
+                    );
+                }
+
+                await expect(downloadLink).toBeVisible();
+                await downloadLink.click();
+                await page.waitForURL('**/products/vpn/download/mac/thanks/');
+
+                // Assert /thanks/ page triggers file download.
+                const download = await page.waitForEvent('download');
+                const downloadURL = download.url();
+
+                expect(downloadURL).toEqual(
+                    expect.stringContaining(
+                        'https://archive.mozilla.org/pub/vpn/releases/'
+                    )
+                );
+
+                // Cancel download if not finished.
+                await download.cancel();
+            });
+        });
+
+        for (const country of excludedCountries) {
+            test.describe('VPN download blocked in country', () => {
+                test.beforeEach(async ({ page, browserName }) => {
+                    await openPage(url + `?geo=${country}`, page, browserName);
+                });
+
+                test(`Country code: ${country}`, async ({ page }) => {
+                    const downloadOptions = page.getByTestId(
+                        'vpn-download-options'
+                    );
+                    const downloadBlockedMessage = page.getByTestId(
+                        'vpn-download-blocked-message'
+                    );
+                    await expect(downloadBlockedMessage).toBeVisible();
+                    await expect(downloadOptions).not.toBeVisible();
+                });
+            });
+        }
+    }
+);

--- a/tests/playwright/specs/products/vpn/vpn-invite.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-invite.spec.js
@@ -1,0 +1,49 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/products/vpn/invite/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@vpn'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Wait list form submit success', async ({ page }) => {
+            const form = page.getByTestId('vpn-invite-form');
+            const emailField = page.getByTestId('vpn-invite-email-input');
+            const submitButton = page.getByTestId('vpn-invite-submit-button');
+            const thanksMessage = page.getByTestId('vpn-invite-thanks-message');
+
+            await expect(thanksMessage).not.toBeVisible();
+            await emailField.fill('success@example.com');
+            await submitButton.click();
+            await expect(form).not.toBeVisible();
+            await expect(thanksMessage).toBeVisible();
+        });
+
+        test('Wait list form submit failure', async ({ page }) => {
+            const emailField = page.getByTestId('vpn-invite-email-input');
+            const submitButton = page.getByTestId('vpn-invite-submit-button');
+            const thanksMessage = page.getByTestId('vpn-invite-thanks-message');
+            const errorMessage = page.getByTestId('vpn-invite-error-message');
+
+            await expect(errorMessage).not.toBeVisible();
+            await emailField.fill('failure@example.com');
+            await submitButton.click();
+            await expect(errorMessage).toBeVisible();
+            await expect(thanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/vpn/vpn-landing.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-landing.spec.js
@@ -1,0 +1,157 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/products/vpn/';
+const availableCountries = ['us', 'ca', 'gb', 'de', 'fr'];
+const unavailableCountries = ['cn'];
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@vpn'
+    },
+    () => {
+        for (const country of availableCountries) {
+            test.describe('VPN available', () => {
+                test.beforeEach(async ({ page, browserName }) => {
+                    await openPage(url + `?geo=${country}`, page, browserName);
+                });
+
+                test(`Country code: ${country}`, async ({ page }) => {
+                    const getVpnNavButton = page.getByTestId(
+                        'get-mozilla-vpn-nav-button'
+                    );
+                    const getVpnHeroButton = page.getByTestId(
+                        'get-mozilla-vpn-hero-button'
+                    );
+                    const getVpnTwelveMonthButton = page.getByTestId(
+                        'get-mozilla-vpn-12-month-button'
+                    );
+                    const getVpnMonthlyButton = page.getByTestId(
+                        'get-mozilla-vpn-monthly-button'
+                    );
+                    const getVpnSecondaryButton = page.getByTestId(
+                        'get-mozilla-vpn-secondary-button'
+                    );
+                    const getVpnTertiaryButton = page.getByTestId(
+                        'get-mozilla-vpn-tertiary-button'
+                    );
+                    const getVpnFooterButton = page.getByTestId(
+                        'get-mozilla-vpn-footer-button'
+                    );
+
+                    const waitlistNavButton = page.getByTestId(
+                        'join-waitlist-nav-button'
+                    );
+                    const waitlistHeroButton = page.getByTestId(
+                        'join-waitlist-hero-button'
+                    );
+                    const waitlistNotAvailableButton = page.getByTestId(
+                        'join-waitlist-not-available-button'
+                    );
+                    const waitlistSecondaryButton = page.getByTestId(
+                        'join-waitlist-secondary-button'
+                    );
+                    const waitlistTertiaryButton = page.getByTestId(
+                        'join-waitlist-tertiary-button'
+                    );
+                    const waitlistFooterButton = page.getByTestId(
+                        'join-waitlist-footer-button'
+                    );
+
+                    // Assert Get Mozilla VPN buttons are displayed.
+                    await expect(getVpnNavButton).toBeVisible();
+                    await expect(getVpnHeroButton).toBeVisible();
+                    await expect(getVpnTwelveMonthButton).toBeVisible();
+                    await expect(getVpnMonthlyButton).toBeVisible();
+                    await expect(getVpnSecondaryButton).toBeVisible();
+                    await expect(getVpnTertiaryButton).toBeVisible();
+                    await expect(getVpnFooterButton).toBeVisible();
+
+                    // Assert Join Waitlist buttons are not displayed.
+                    await expect(waitlistHeroButton).not.toBeVisible();
+                    await expect(waitlistNotAvailableButton).not.toBeVisible();
+                    await expect(waitlistNavButton).not.toBeVisible();
+                    await expect(waitlistSecondaryButton).not.toBeVisible();
+                    await expect(waitlistTertiaryButton).not.toBeVisible();
+                    await expect(waitlistFooterButton).not.toBeVisible();
+                });
+            });
+        }
+
+        for (const country of unavailableCountries) {
+            test.describe('VPN not available', () => {
+                test.beforeEach(async ({ page, browserName }) => {
+                    await openPage(url + `?geo=${country}`, page, browserName);
+                });
+
+                test(`Country code: ${country}`, async ({ page }) => {
+                    const getVpnNavButton = page.getByTestId(
+                        'get-mozilla-vpn-nav-button'
+                    );
+                    const getVpnHeroButton = page.getByTestId(
+                        'get-mozilla-vpn-hero-button'
+                    );
+                    const getVpnTwelveMonthButton = page.getByTestId(
+                        'get-mozilla-vpn-12-month-button'
+                    );
+                    const getVpnMonthlyButton = page.getByTestId(
+                        'get-mozilla-vpn-monthly-button'
+                    );
+                    const getVpnSecondaryButton = page.getByTestId(
+                        'get-mozilla-vpn-secondary-button'
+                    );
+                    const getVpnTertiaryButton = page.getByTestId(
+                        'get-mozilla-vpn-tertiary-button'
+                    );
+                    const getVpnFooterButton = page.getByTestId(
+                        'get-mozilla-vpn-footer-button'
+                    );
+
+                    const waitlistNavButton = page.getByTestId(
+                        'join-waitlist-nav-button'
+                    );
+                    const waitlistHeroButton = page.getByTestId(
+                        'join-waitlist-hero-button'
+                    );
+                    const waitlistNotAvailableButton = page.getByTestId(
+                        'join-waitlist-not-available-button'
+                    );
+                    const waitlistSecondaryButton = page.getByTestId(
+                        'join-waitlist-secondary-button'
+                    );
+                    const waitlistTertiaryButton = page.getByTestId(
+                        'join-waitlist-tertiary-button'
+                    );
+                    const waitlistFooterButton = page.getByTestId(
+                        'join-waitlist-footer-button'
+                    );
+
+                    // Assert Join Waitlist buttons are displayed.
+                    await expect(waitlistNavButton).toBeVisible();
+                    await expect(waitlistHeroButton).toBeVisible();
+                    await expect(waitlistNotAvailableButton).toBeVisible();
+                    await expect(waitlistSecondaryButton).toBeVisible();
+                    await expect(waitlistTertiaryButton).toBeVisible();
+                    await expect(waitlistFooterButton).toBeVisible();
+
+                    // Assert Get Mozilla VPN buttons are not displayed.
+                    await expect(getVpnNavButton).not.toBeVisible();
+                    await expect(getVpnHeroButton).not.toBeVisible();
+                    await expect(getVpnTwelveMonthButton).not.toBeVisible();
+                    await expect(getVpnMonthlyButton).not.toBeVisible();
+                    await expect(getVpnSecondaryButton).not.toBeVisible();
+                    await expect(getVpnTertiaryButton).not.toBeVisible();
+                    await expect(getVpnFooterButton).not.toBeVisible();
+                });
+            });
+        }
+    }
+);


### PR DESCRIPTION
## One-line summary

This PR adds a new suite of integration tests written using https://playwright.dev/. 

## Significant changes and points to review

Right now, this is only run manually and is not (yet) part of our CI deployment process. Once this merges, the next step is to start to run this against a deployment for a while to evaluate it for stability.

Aims of this new test suite:

1. It's written in JavaScript as opposed to Python, so will hopefully be more familiar for front-end developers to maintain.
2. It should be significantly easier to get running locally (everything is managed via an NPM install).
3. It hopefully adds more valuable tests (e.g. asserting auto file downloads, testing older UA strings) compared to the Selenium test suite (which had quite a number of old, superfluous tests for less critical pages).
4. Runs tests in all three major browser engines (Gecko, Chromium, Webkit).

If we like this better than Selenium and it's stable enough, we can look at potentially retiring the old test suite.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/14191

## Testing

1. Start bedrock locally via `npm start`.
2. In a new terminal tab navigate to the playwright directory: `cd tests/playwright/`.
3. Install playwright via `npm install` (I opted for a separate `package.json` as the browser binaries are quite large).
5. Download latest version of browser binaries: `npm run install-deps`.

You should then be able to run Playwright tests (see the `./tests/playwright/README.md` file for instructions).

- [ ] Whole test suite should pass when running`npx playwright test`.