### PR TITLE
Remove taskbar pinning message on Windows download page

### DIFF
--- a/bedrock/firefox/templates/firefox/new/basic/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/basic/thanks.html
@@ -57,15 +57,6 @@
     {% endif %}
 
       <div class="c-support-install">
-        {# shown to all Windows users from the release of Firefox 103 onward. #}
-        {% if switch('firefox-103-taskbar-message') and ftl_has_messages('firefox-new-taskbar') %}
-          <p class="show-windows">
-            <a href="https://support.mozilla.org/kb/how-unpin-firefox-taskbar-windows-10{{ referrals }}">
-              {{ ftl('firefox-new-taskbar') }}
-            </a>
-          </p>
-        {% endif %}
-
         <div class="show-linux">
           <div class="c-linux-button-group">
             <a href="{{ settings.BOUNCER_URL }}?product=firefox-latest-ssl&os=linux&lang={{ LANG }}"

--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -63,14 +63,6 @@
   {% endif %}
 
     <div class="c-support-install">
-      {# shown to all Windows users from the release of Firefox 103 onward. #}
-      {% if switch('firefox-103-taskbar-message') and ftl_has_messages('firefox-desktop-download-taskbar') %}
-        <p class="show-windows">
-          <a href="https://support.mozilla.org/kb/how-unpin-firefox-taskbar-windows-10{{ referrals }}">
-            {{ ftl('firefox-desktop-download-taskbar') }}
-          </a>
-        </p>
-      {% endif %}
       <p class="show-mac">
         {% set support_mac_attrs = 'href="https://support.mozilla.org/kb/how-download-and-install-firefox-mac%s" rel="external noopener" data-cta-type="link" data-cta-text="Get help with your installation"'|safe|format(referrals) %}
         {{ ftl('firefox-desktop-download-get-help', attrs=support_mac_attrs) }}

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -202,5 +202,3 @@ firefox-desktop-download-please-follow = Please follow <a href="{ $url }">these 
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/firefox/all/
 firefox-desktop-download-your-system-may-not = Your system may not meet the requirements for { -brand-name-firefox }, but you can try one of <a href="{ $url }">these versions</a>.
-
-firefox-desktop-download-taskbar = { -brand-name-firefox } will be pinned to the { -brand-name-windows } taskbar after installation

--- a/l10n/en/firefox/new/download.ftl
+++ b/l10n/en/firefox/new/download.ftl
@@ -65,4 +65,3 @@ firefox-new-from-mozilla = from { -brand-name-mozilla }
 
 firefox-new-desc = { -brand-name-firefox-browser } is a free web browser with fast page loading, less memory usage, and lots of features - a project of the not-for-profit { -brand-name-mozilla }.
 firefox-new-download-a-different = Download a different platform or language
-firefox-new-taskbar = { -brand-name-firefox } will be pinned to the { -brand-name-windows } taskbar after installation


### PR DESCRIPTION
## One-line summary
It's no longer accurate that Firefox gets pinned on Windows after download, so it's time to remove the mention of it.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/14618


## Testing
https://github.com/mozilla/bedrock/issues/14618 (I used a virtual Windows machine via BrowserStack to test this out)
