### PR TITLE
14650 Add links to move around admins

### DIFF
--- a/bedrock/admin/templates/admin/base_site.html
+++ b/bedrock/admin/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-
+{% comment %} SKIP LICENSE INSERTION {% endcomment %}
 {% comment %}
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,5 +11,8 @@
 {% block branding %}<h1>Bedrock administration</h1>{% endblock %}
 
 {% block userlinks %}
-  <a href="{% url 'rq_home' %}"> View task queue</a> / {{block.super}}
+  <a href="{% url 'wagtailadmin_home' %}"> Go to CMS home</a> /
+  <a href="{% url 'rq_home' %}"> View task queue</a> /
+  <a href="{% url 'admin:logout' %}"> Logout</a>
+  {% include "admin/color_theme_toggle.html" %}
 {% endblock userlinks %}

--- a/bedrock/cms/wagtail_hooks.py
+++ b/bedrock/cms/wagtail_hooks.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.urls import reverse
+
+from wagtail import hooks
+from wagtail.admin.menu import AdminOnlyMenuItem
+
+
+@hooks.register("register_admin_menu_item")
+def register_task_queue_link():
+    return AdminOnlyMenuItem(
+        "Task Queue",
+        reverse("rq_home"),
+        icon_name="tasks",
+        order=80000,
+    )
+
+
+@hooks.register("register_admin_menu_item")
+def register_django_admin_link():
+    return AdminOnlyMenuItem(
+        "Django Admin",
+        reverse("admin:index"),
+        icon_name="tasks",
+        order=80001,
+    )


### PR DESCRIPTION
## One-line summary

Adds links to the Django Admin and Wagtail Admin that make it easier to move between them.

Wagtail menu links are only visible by superusers/admins, which will be the minority of the 

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

Django admin top bar

<img width="622" alt="Screenshot 2024-06-06 at 16 16 04" src="https://github.com/mozilla/bedrock/assets/101457/03fe86d9-13f1-48c0-b611-b640cbb628f1">

-----

Wagtail menu bar (links are only visible to admins/superusers)

<img width="269" alt="Screenshot 2024-06-06 at 16 38 13" src="https://github.com/mozilla/bedrock/assets/101457/6c9f8f0d-f3ff-4473-a9e0-7e913089db53">



## Issue / Bugzilla link

Resolves #14650 

