### PR TITLE
fix the dropdown cutoff issue

### DIFF
--- a/media/css/firefox/browsers/chromebook.scss
+++ b/media/css/firefox/browsers/chromebook.scss
@@ -27,3 +27,7 @@ $image-path: '/media/protocol/img';
 .mzp-c-section-heading + .mzp-c-split {
     padding-top: 0;
 }
+
+.mzp-c-split {
+    overflow-x: unset;
+}


### PR DESCRIPTION
## One-line summary

This PR fixes the issue that the Chromebook dropdown gets cut off.

- [ ] ~I used an AI to write some of this code.~

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/14491


## Testing
1. Checkout this PR
2. Go to http://localhost:8000/en-US//firefox/browsers/chromebook/
3. The dropdown should no long be cut off
4. Review other styles on the page remain the same