### PR TITLE
Disable the Wagtail Userbar extension for jinja

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -802,7 +802,6 @@ TEMPLATES = [
                 "django_jinja.builtins.extensions.DjangoFiltersExtension",
                 "django_jinja_markdown.extensions.MarkdownExtension",
                 "wagtail.jinja2tags.core",
-                "wagtail.admin.jinja2tags.userbar",
                 "wagtail.images.jinja2tags.images",
             ],
         },


### PR DESCRIPTION
Wagtail ships with jinja2 support for the floating context menu on rendered pages, but with the `django_jinja` template engine in use (which is what we have), it appears to not work. Living without it right now is not a big cost, so just tidying up config rather than confuse ourselves
