### PR TITLE
Update Sentry JS client to v8.8.0

### DIFF
--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -6,12 +6,12 @@
 
 import {
     BrowserClient,
-    Dedupe,
-    GlobalHandlers,
-    HttpContext,
-    TryCatch,
+    browserApiErrorsIntegration,
+    dedupeIntegration,
     defaultStackParser,
-    getCurrentHub,
+    getCurrentScope,
+    globalHandlersIntegration,
+    httpContextIntegration,
     makeFetchTransport
 } from '@sentry/browser';
 
@@ -24,7 +24,8 @@ import {
 
 const SentryConsent = {
     /**
-     * Initialize Sentry JS Client.
+     * Enable tree shaking of unused Sentry JS integrations.
+     * https://docs.sentry.io/platforms/javascript/configuration/tree-shaking/
      */
     initClient: () => {
         // Get Data Source Name (DSN)
@@ -38,14 +39,15 @@ const SentryConsent = {
             transport: makeFetchTransport,
             stackParser: defaultStackParser,
             integrations: [
-                new Dedupe(),
-                new GlobalHandlers(),
-                new HttpContext(),
-                new TryCatch()
+                dedupeIntegration(),
+                globalHandlersIntegration(),
+                httpContextIntegration,
+                browserApiErrorsIntegration()
             ]
         });
 
-        getCurrentHub().bindClient(client);
+        getCurrentScope().setClient(client);
+        client.init();
     },
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^3.0.0",
-        "@sentry/browser": "^7.111.0",
+        "@sentry/browser": "^8.8.0",
         "babel-loader": "^9.1.3",
         "caniuse-lite": "^1.0.30001627",
         "clean-webpack-plugin": "^4.0.0",
@@ -2255,106 +2255,106 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.111.0.tgz",
-      "integrity": "sha512-xaKgPPDEirOan7c9HwzYA1KK87kRp/qfIx9ZKLOEtxwy6nqoMuSByGqSwm1Oqfcjpbd7y6/y+7Bw+69ZKNVLDQ==",
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.8.0.tgz",
+      "integrity": "sha512-yE4khknnGpAxy3TeAD9TU1eUqa0GUJ2xluIAsHKkL+RXg3AgEssMO3DBDUbpHp+QANIjzKmZIXtbdTV+1P26aQ==",
       "dependencies": {
-        "@sentry/core": "7.111.0",
-        "@sentry/types": "7.111.0",
-        "@sentry/utils": "7.111.0"
+        "@sentry/core": "8.8.0",
+        "@sentry/types": "8.8.0",
+        "@sentry/utils": "8.8.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.8.0.tgz",
+      "integrity": "sha512-mybzWx99DuCJxYCVPx12NHVSVbSDF1goEo+rhDGYY8kqyn+snoVBLQtsSdDXYwZyssS1G7Gh6WhX+JVDKcQO9A==",
+      "dependencies": {
+        "@sentry/core": "8.8.0",
+        "@sentry/types": "8.8.0",
+        "@sentry/utils": "8.8.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.8.0.tgz",
+      "integrity": "sha512-gMRWcjpiLJl03JB4rTMN2I4HOOJ6z611kdhUBYc+RRAue13A6uCSIPElgvlCMREkVmr/8eUKrCcIrpqj9PDJ4w==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.8.0",
+        "@sentry/core": "8.8.0",
+        "@sentry/types": "8.8.0",
+        "@sentry/utils": "8.8.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.111.0.tgz",
-      "integrity": "sha512-3KPBIpiegTYmuVw9gA2aKuliAQONS3Ny1kJc9x5kz6XQGuLFxqlh6KzoCVaKfQJeq2WJqRNeR4KFFuNGuB3H8w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.8.0.tgz",
+      "integrity": "sha512-LUoPi38Y8VRnxorIMmKLpfpf+jguhOsovMsZ3ZLc+FvMER62IIvSt4GKK4ARmUBX7+v3r61fdUWqxFs1j3uUTg==",
       "dependencies": {
-        "@sentry/core": "7.111.0",
-        "@sentry/replay": "7.111.0",
-        "@sentry/types": "7.111.0",
-        "@sentry/utils": "7.111.0"
+        "@sentry-internal/replay": "8.8.0",
+        "@sentry/core": "8.8.0",
+        "@sentry/types": "8.8.0",
+        "@sentry/utils": "8.8.0"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.111.0.tgz",
-      "integrity": "sha512-CgXly8rsdu4loWVKi2RqpInH3C2cVBuaYsx4ZP5IJpzSinsUAMyyr3Pc0PZzCyoVpBBXGBGj/4HhFsY3q6Z0Vg==",
-      "dependencies": {
-        "@sentry/core": "7.111.0",
-        "@sentry/types": "7.111.0",
-        "@sentry/utils": "7.111.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.111.0.tgz",
-      "integrity": "sha512-x7S9XoJh+TbMnur4eBhPpCVo+p7udABBV2gQk+Iw6LP9e8EFKmGmNyl76vSsT6GeFJ7mwxDEKfuwbVoLBjIvHw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.8.0.tgz",
+      "integrity": "sha512-TkmbjV9pGpQ+OfUtIE8DaU467w73NqPTX/w/+241VlKpE9HbfranMG0N8Bibgt59GwoNIiC0NhmKaMTZg79elQ==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.111.0",
-        "@sentry-internal/replay-canvas": "7.111.0",
-        "@sentry-internal/tracing": "7.111.0",
-        "@sentry/core": "7.111.0",
-        "@sentry/replay": "7.111.0",
-        "@sentry/types": "7.111.0",
-        "@sentry/utils": "7.111.0"
+        "@sentry-internal/browser-utils": "8.8.0",
+        "@sentry-internal/feedback": "8.8.0",
+        "@sentry-internal/replay": "8.8.0",
+        "@sentry-internal/replay-canvas": "8.8.0",
+        "@sentry/core": "8.8.0",
+        "@sentry/types": "8.8.0",
+        "@sentry/utils": "8.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.111.0.tgz",
-      "integrity": "sha512-/ljeMjZu8CSrLGrseBi/7S2zRIFsqMcvfyG6Nwgfc07J9nbHt8/MqouE1bXZfiaILqDBpK7BK9MLAAph4mkAWg==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.8.0.tgz",
+      "integrity": "sha512-SnQ42rOuUO03WvhS+2aogKhEzCW9cxpnpPzs2obxnS04KoAz7VL3oYyIwiACrRTlKpwdb9y6vuO89fDvgqPQbA==",
       "dependencies": {
-        "@sentry/types": "7.111.0",
-        "@sentry/utils": "7.111.0"
+        "@sentry/types": "8.8.0",
+        "@sentry/utils": "8.8.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/replay": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.111.0.tgz",
-      "integrity": "sha512-cSbI4A4hrO0sZ0ynvLQauPg8YyaDOQkhGkyvbws8W9WgfxR8X827bY9S0f1TPfgaFiVcKb0iRaAwyXHg3pyzOg==",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.111.0",
-        "@sentry/core": "7.111.0",
-        "@sentry/types": "7.111.0",
-        "@sentry/utils": "7.111.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.111.0.tgz",
-      "integrity": "sha512-Oti4pgQ55+FBHKKcHGu51ZUxO1u52G5iVNK4mbtAN+5ArSCy/2s1H8IDJiOMswn3acfUnCR0oB/QsbEgAPZ26g==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.8.0.tgz",
+      "integrity": "sha512-2EOkyHoSOJyCRCsK/O6iA3wyELkRApfY7jNxsC/Amgb5ftuGl/rGO6B4dNKjMJNLNvlkEqZIANoUKOcClBH6yw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.111.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.111.0.tgz",
-      "integrity": "sha512-CB5rz1EgCSwj3xoXogsCZ5pQtfERrURc/ItcCuoaijUhkD0iMq5MCNWMHW3mBsBrqx/Oba+XGvDu0t/5+SWwBg==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.8.0.tgz",
+      "integrity": "sha512-agLqo9KlXacj7NOcdYZUYqTKlFcPXdTzCnC2u9J1LxDjru9cogbiw6yyDtxBg3kpgYZubfOPz/7F2z9wCjK1cw==",
       "dependencies": {
-        "@sentry/types": "7.111.0"
+        "@sentry/types": "8.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^3.0.0",
-    "@sentry/browser": "^7.111.0",
+    "@sentry/browser": "^8.8.0",
     "babel-loader": "^9.1.3",
     "caniuse-lite": "^1.0.30001627",
     "clean-webpack-plugin": "^4.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,9 +131,16 @@ module.exports = {
             ]
         }),
         new Dotenv(),
+        /**
+         * Enable tree shaking of Sentry SDK debug code
+         * https://docs.sentry.io/platforms/javascript/configuration/tree-shaking/
+         */
         new webpack.DefinePlugin({
             __SENTRY_DEBUG__: false,
-            __SENTRY_TRACING__: false
+            __SENTRY_TRACING__: false,
+            __RRWEB_EXCLUDE_IFRAME__: true,
+            __RRWEB_EXCLUDE_SHADOW_DOM__: true,
+            __SENTRY_EXCLUDE_REPLAY_WORKER__: true
         }),
         new MiniCssExtractPlugin({
             filename: ({ chunk }) =>


### PR DESCRIPTION
## One-line summary

Updates Sentry JS client to v8.8.0

## Issue / Bugzilla link

N/A

## Testing

Set `SENTRY_FRONTEND_DSN=https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331` in your `.env` to test locally.

Requires a browser with DNT/GPC disabled.

- [ ] http://localhost:8000/en-US/ loads without error in the console.