### PR TITLE
Add a unit test to detect missing migrations,

### DIFF
--- a/bedrock/base/tests/test_migrations.py
+++ b/bedrock/base/tests/test_migrations.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from django.core.management import call_command
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_no_missing_migrations():
+    "Unit test to confirm that we're not missing any migrations"
+
+    error_message = "We are missing a Django Migration. Please run ./manage.py makemigrations --dry-run to see what is missing"
+
+    try:
+        call_command("makemigrations", "--check")
+    except SystemExit as se:
+        if se.code == 1:
+            pytest.fail(error_message)
+        else:
+            # If something else is up, we don't want to ignore it
+            raise se


### PR DESCRIPTION
...so that we catch them at PR level, before the root-cause changes get merged


- [ ] ~I used an AI to write some of this code.~

## Issue / Bugzilla link

Resolves #14665

## Testing

* [x] Run the test directly, with no missing migrations: `pytest -k test_no_missing_migrations` - it should pass
* [x] Edit a Django model - eg in `bedrock/cms/models/images.py` change `BedrockRendition` to use `on_delete=models.SET_NULL` instead of `on_delete=models.CASCADE` and save the file
* [x] Re-run the test - it should fail now
* Remember to revert/discard your change to the `BedrockRendition` model