### PR TITLE
Remove old sources from CSP

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -200,8 +200,6 @@ else:
     _csp_child_src = [
         "www.googletagmanager.com",
         "www.google-analytics.com",
-        "trackertest.org",  # mozilla service for tracker detection
-        "www.surveygizmo.com",
         "accounts.firefox.com",
         "www.youtube.com",
         "js.stripe.com",


### PR DESCRIPTION
## One-line summary

This removes a couple old sources from our CSP directives. The `iframe`s were removed in commits in 2019:
* 86fe12e0c10226afeeec5647d5edff7964dfd952
* 7680a3b5cd30ff39e8b602eecb5894b2499eeccc


- [x] I used an RI (Rob Intelligence) to write some of this code.
