### PR TITLE
Update Mozilla account CTA wording

### DIFF
--- a/bedrock/mozorg/templates/mozorg/includes/mozilla-account-cta-promo.html
+++ b/bedrock/mozorg/templates/mozorg/includes/mozilla-account-cta-promo.html
@@ -48,7 +48,7 @@
             {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin') %}
             {% set sign_in_url = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="Accounts Learn More"'|safe %}
             {% set learn_more_url = 'href="'|safe ~ url('mozorg.account') ~ '"'|safe %}
-            {{ ftl('moz-account-already-have', sign_in_url=sign_in_url, learn_more_url=learn_more_url) }}
+            {{ ftl('moz-account-already-have-v2', fallback='moz-account-already-have', sign_in_url=sign_in_url, learn_more_url=learn_more_url) }}
           </small>
         </div>
       </div>

--- a/bedrock/mozorg/templates/mozorg/includes/mozilla-account-form-promo.html
+++ b/bedrock/mozorg/templates/mozorg/includes/mozilla-account-form-promo.html
@@ -49,7 +49,7 @@
         {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin') %}
         {% set sign_in_url = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="Accounts Learn More"'|safe %}
         {% set learn_more_url = 'href="'|safe ~ url('mozorg.account') ~ '"'|safe %}
-        {{ ftl('moz-account-already-have', sign_in_url=sign_in_url, learn_more_url=learn_more_url) }}
+        {{ ftl('moz-account-already-have-v2', fallback='moz-account-already-have', sign_in_url=sign_in_url, learn_more_url=learn_more_url) }}
       </p>
     </div>
 

--- a/l10n/en/mozilla-account-promo.ftl
+++ b/l10n/en/mozilla-account-promo.ftl
@@ -9,7 +9,7 @@ moz-account-promo-title = One login. <br> <span { $class }>Everything</span> { -
 # Variables
 #   $sign_in_url - link to
 #   $learn_more_url - link to https://www.mozilla.org/en-US/firefox/accounts/
-moz-account-already-have-v2 = Already have an account? <a { $sign_in_url }>Sign in</a> or <a { $learn_more_url }>learn more</a> about joining { -brand-name-mozilla }
+moz-account-already-have-v2 = Already have an account? <a { $sign_in_url }>Sign in</a> or <a { $learn_more_url }>learn more</a> about joining { -brand-name-mozilla }.
 
 # Obsolete string (expires: 2024-09-12)
 # Variables

--- a/l10n/en/mozilla-account-promo.ftl
+++ b/l10n/en/mozilla-account-promo.ftl
@@ -9,7 +9,14 @@ moz-account-promo-title = One login. <br> <span { $class }>Everything</span> { -
 # Variables
 #   $sign_in_url - link to
 #   $learn_more_url - link to https://www.mozilla.org/en-US/firefox/accounts/
+moz-account-already-have-v2 = Already have an account? <a { $sign_in_url }>Sign in</a> or <a { $learn_more_url }>learn more</a> about joining { -brand-name-mozilla }
+
+# Obsolete string (expires: 2024-09-12)
+# Variables
+#   $sign_in_url - link to
+#   $learn_more_url - link to https://www.mozilla.org/en-US/firefox/accounts/
 moz-account-already-have = Already have an account? <a { $sign_in_url }>Sign in</a> or <a { $learn_more_url }>learn more</a> about { -brand-name-mozilla }
+
 moz-account-get-a-mozilla-account = Get a { -brand-name-mozilla-account }
 
 moz-account-product-firefox = { -brand-name-firefox }


### PR DESCRIPTION
## One-line summary

Improves a recently added copy with the word _"joining"_ from an older occurence:
> "Already have an account? [Sign in](#) or [learn more](#) about **_joining_** Mozilla"

- [ ] ~I used an AI to write some of this code.~

## Significant changes and points to review

- Makes the call-to-action text consistent with an older occurrence elsewhere.
- (The string in this form is already present and localised, so chances are it would be pulled up from [translation memory](https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/ui.html#machinery).)
- Avoids changing this in `whatsnew/122` that's currently being removed.

## Issue / Bugzilla link

Resolves #14460 

## Testing

/en-US/firefox/browsers/mobile/ (bottom: form)
/en-US/firefox/ (bottom: cta)