### PR TITLE
Filter out non-useful events in Sentry (Fixes #14674)

### DIFF
--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -12,6 +12,7 @@ import {
     getCurrentScope,
     globalHandlersIntegration,
     httpContextIntegration,
+    inboundFiltersIntegration,
     makeFetchTransport
 } from '@sentry/browser';
 
@@ -21,6 +22,17 @@ import {
     getConsentCookie,
     gpcEnabled
 } from './consent/utils.es6';
+
+/**
+ * Filter out non-useful / non-actionable errors.
+ */
+const options = {
+    ignoreErrors: [
+        'NetworkError when attempting to fetch resource',
+        'Event `Event` (type=unhandledrejection) captured as promise rejection',
+        'Non-Error promise rejection captured'
+    ]
+};
 
 const SentryConsent = {
     /**
@@ -39,10 +51,11 @@ const SentryConsent = {
             transport: makeFetchTransport,
             stackParser: defaultStackParser,
             integrations: [
+                browserApiErrorsIntegration(),
                 dedupeIntegration(),
                 globalHandlersIntegration(),
                 httpContextIntegration,
-                browserApiErrorsIntegration()
+                inboundFiltersIntegration(options)
             ]
         });
 

--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -28,8 +28,9 @@ import {
  */
 const options = {
     ignoreErrors: [
-        'NetworkError when attempting to fetch resource',
+        '$ is not defined',
         'Event `Event` (type=unhandledrejection) captured as promise rejection',
+        'NetworkError when attempting to fetch resource',
         'Non-Error promise rejection captured'
     ]
 };


### PR DESCRIPTION
## One-line summary

Filters out some non-useful / non-actionable JS errors in Sentry to cut down on noise.

## Issue / Bugzilla link

#14674

## Testing

Set `SENTRY_FRONTEND_DSN=https://c3ab8514873549d5b3785ebc7fb83c80@o1069899.ingest.sentry.io/6260331` in your `.env` to test locally.

Requires a browser with DNT/GPC disabled.

- [ ] http://localhost:8000/en-US/ loads without error in the console.