### PR TITLE
Run JS tests in CI using ubuntu-latest

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -7,16 +7,12 @@ on:
 
 jobs:
   test-js:
-    runs-on: ubuntu-20.04
-    # NB: this workflow fails on Ubuntu 22.04 (AKA ubuntu-latest) because the
-    # browsers are installed from Ubuntu Snaps, and on 22.04 there's currently
-    # an issue where FF lacks access to auto-create a profile, so it hangs.
-    # However, 20.04 is long-term support (LTS) until 2025: https://wiki.ubuntu.com/Releases
+    runs-on: ubuntu-latest
     steps:
-      - name: "Install framebuffer (xvfb), Firefox and Chromium"
+      - name: "Install framebuffer (xvfb) and Chromium"
         run: |
           sudo apt-get update
-          sudo apt-get install chromium-browser firefox xvfb
+          sudo apt-get install chromium-browser xvfb
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## One-line summary

Turns out Firefox is already preinstalled on the `ubuntu-latest` image, so no need to download the snap version

## Issue / Bugzilla link

N/A

## Testing

- [ ] Tests should pass in CI below