### PR TITLE
Bump Protocol to v19.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.24.6",
         "@babel/preset-env": "^7.24.6",
-        "@mozilla-protocol/core": "^19.1.0",
+        "@mozilla-protocol/core": "^19.2.0",
         "@mozilla/glean": "^5.0.1",
         "@mozmeao/consent-banner": "^1.0.0",
         "@mozmeao/cookie-helper": "^1.1.0",
@@ -2192,9 +2192,9 @@
       "dev": true
     },
     "node_modules/@mozilla-protocol/core": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-19.1.0.tgz",
-      "integrity": "sha512-QFuebX2lr6kqwkLfL4YU5iSP5473BjAGSbtVnOFrJ2GulFxgJFNuKle3DxEcY7FhMVoy/Czo1pfbiFNQ4XhLXA=="
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-19.2.0.tgz",
+      "integrity": "sha512-uXkZHkVe+5MhmhP1wyNelliJ7ih2n9wcMoYYvsSeFqcBbP5EqtM2SC7IVThqsReZedRiN1zh6AXQpLXdNYWF/g=="
     },
     "node_modules/@mozilla/glean": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/core": "^7.24.6",
     "@babel/preset-env": "^7.24.6",
-    "@mozilla-protocol/core": "^19.1.0",
+    "@mozilla-protocol/core": "^19.2.0",
     "@mozilla/glean": "^5.0.1",
     "@mozmeao/consent-banner": "^1.0.0",
     "@mozmeao/cookie-helper": "^1.1.0",


### PR DESCRIPTION
## One-line summary

Bumping Protocol to the latest version: https://github.com/mozilla/protocol/blob/v19.2.0/CHANGELOG.md#1920

## Significant changes and points to review

No significant changes to note. This bump should serve as a helper to get [this PR finalized](https://github.com/mozilla/bedrock/pull/14490).

## Issue / Bugzilla link
n/a


## Testing
- `npm install`
- `npm start`
- Make sure no errors are logged in the web console, and CSS isn't breaking 