### PR TITLE
Firefox download to install smoke test (Fixes #14696)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -23,6 +23,12 @@
   {% endif %}
 {% endblock %}
 
+{% block experiments %}
+  {% if switch('experiment-firefox-thanks-smoke-test', ['en-US']) and country_code == "US" %}
+    {{ js_bundle('firefox-thanks-smoke-test') }}
+  {% endif %}
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
   {{ css_bundle('protocol-card') }}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -676,7 +676,7 @@ class NewView(L10nTemplateView):
     ]
 
     # place expected ?v= values in this list
-    variations = []
+    variations = ["1", "2"]
 
     def get(self, *args, **kwargs):
         # Remove legacy query parameters (Bug 1236791)

--- a/media/js/firefox/new/desktop/thanks-smoke-test.es6.js
+++ b/media/js/firefox/new/desktop/thanks-smoke-test.es6.js
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrafficCop from '@mozmeao/trafficcop';
+import { isApprovedToRun } from '../../../base/experiment-utils.es6.js';
+
+const href = window.location.href;
+
+function isEdgeBrowser() {
+    return (
+        navigator.userAgent.indexOf('Edg') !== -1 ||
+        navigator.userAgent.indexOf('Edge') !== -1
+    );
+}
+
+function isWindows10Plus() {
+    const match = navigator.userAgent.match(/Windows NT (\d+\.\d+)/);
+    return match && parseFloat(match[1]) >= 10.0;
+}
+
+const initTrafficCop = () => {
+    if (href.indexOf('v=1') !== -1) {
+        // UA
+        window.dataLayer.push({
+            'data-ex-variant': '1',
+            'data-ex-name': 'firefox-thanks-smoke-test'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: 'firefox-thanks-smoke-test',
+            variant: '1'
+        });
+    } else if (href.indexOf('v=2') !== -1) {
+        // UA
+        window.dataLayer.push({
+            'data-ex-variant': '2',
+            'data-ex-name': 'firefox-thanks-smoke-test'
+        });
+        // GA4
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: 'firefox-thanks-smoke-test',
+            variant: '2'
+        });
+    } else if (TrafficCop) {
+        /**
+         * Experiment is targeted at Windows 10 or greater using Edge browser.
+         */
+        if (isApprovedToRun() && isWindows10Plus() && isEdgeBrowser()) {
+            const cop = new TrafficCop({
+                variations: {
+                    'v=1': 10,
+                    'v=2': 10
+                }
+            });
+            cop.init();
+        }
+    }
+};
+
+initTrafficCop();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1382,6 +1382,12 @@
     },
     {
       "files": [
+        "js/firefox/new/desktop/thanks-smoke-test.es6.js"
+      ],
+      "name": "firefox-thanks-smoke-test"
+    },
+    {
+      "files": [
         "js/base/stub-attribution/stub-attribution.js",
         "js/base/stub-attribution/stub-attribution-init.es6.js"
       ],


### PR DESCRIPTION
## One-line summary

Adds A/A experiment to `/firefox/new/` page for smoke testing.

Targeting:

- `/en-US/` locale only
- US `country_code` only.
- Windows 10 / 11.
- Edge browser.
- 10% of targeted traffic for each variation.

## Issue / Bugzilla link

#14696

## Testing

Test using browser stack running Windows 10/11 using Edge. You might need to refresh a few times before you hit one of the redirects. Both variations are identical (no changes) since this is a smoke test.

https://www-demo1.allizom.org/en-US/firefox/new/?geo=us

- [ ] When hitting one of the variations directly, verify that logging `window.dataLayer` in the web console contains the right GA events for each variation.