### PR TITLE
add alt text for images on leadership page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/boards.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/boards.html
@@ -18,7 +18,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Mitchell Baker, Executive Chair of the Board, Member of the Nominating and Governance Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mitchell Baker</h4></figcaption>
@@ -91,7 +92,7 @@
 
     <article class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" src="{{ static('img/mozorg/about/leadership/laura-chambers.jpg') }}" alt="" itemprop="image" width="160" height="160">
+        <img class="photo" src="{{ static('img/mozorg/about/leadership/laura-chambers.jpg') }}" alt="Laura Chambers, Board Member" itemprop="image" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Laura Chambers</h4></figcaption>
       </figure>
 
@@ -102,7 +103,7 @@
 
     <article id="kerry-cooper" data-id="kerry-cooper" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" src="{{ static('img/mozorg/about/leadership/kerry-cooper.jpg') }}" alt="" itemprop="image" width="160" height="160">
+        <img class="photo" src="{{ static('img/mozorg/about/leadership/kerry-cooper.jpg') }}" alt="Kerry W. Cooper, Member of the Audit Committee, Member of the Compensation Committee" itemprop="image" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Kerry W. Cooper</h4></figcaption>
       </figure>
 
@@ -155,7 +156,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Karim Lakhani, Chair of the Compensation Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Karim Lakhani</h4></figcaption>
@@ -211,7 +213,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Bob Lisbonne, Chair of the Audit Committee, Member of the Nominating and Governance Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Bob Lisbonne, Chair</h4></figcaption>
@@ -248,7 +251,7 @@
 
     <article id="hugh-molotsi" data-id="hugh-molotsi" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" src="{{ static('img/mozorg/about/leadership/hugh-molotsi.jpg') }}" alt="" itemprop="image" width="160" height="160">
+        <img class="photo" src="{{ static('img/mozorg/about/leadership/hugh-molotsi.jpg') }}" alt="Hugh Molotsi, Chair of the Nominating and Governance Committee, Member of the Compensation Committee" itemprop="image" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Hugh Molotsi</h4></figcaption>
       </figure>
 
@@ -300,7 +303,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Kristin Skogen Lund, Member of the Audit Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Kristin Skogen Lund</h4></figcaption>
@@ -345,7 +349,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Mitchell Baker, Chair'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mitchell Baker, Chair</h4></figcaption>
@@ -363,7 +368,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Brian Behlendorf'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Brian Behlendorf</h4></figcaption>
@@ -403,7 +409,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Zain Habboo'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Zain Habboo</h4></figcaption>
@@ -450,7 +457,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Amy Keating'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Amy Keating</h4></figcaption>
@@ -488,7 +496,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Raffi Krikorian'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Raffi Krikorian</h4></figcaption>
@@ -558,7 +567,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Edwin Macharia'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Edwin Macharia</h4></figcaption>
@@ -602,7 +612,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Alondra Nelson'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Alondra Nelson</h4></figcaption>
@@ -649,7 +660,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Mark Surman'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
@@ -667,7 +679,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Helen Turvey'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Helen Turvey</h4></figcaption>
@@ -698,7 +711,7 @@
 
     <article id="nicole-wong" data-id="nicole-wong" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/nicole-wong.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Nicole Wong" src="{{ static('img/mozorg/about/leadership/nicole-wong.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Nicole Wong</h4></figcaption>
       </figure>
 
@@ -739,7 +752,7 @@
   <ul class="gallery">
     <li class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/cathy-davidson.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Cathy Davidson" src="{{ static('img/mozorg/about/leadership/cathy-davidson.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Cathy Davidson</h4></figcaption>
       </figure>
     </li>
@@ -755,7 +768,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Julie Hanna'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Julie Hanna</h4></figcaption>
@@ -764,21 +778,21 @@
 
     <li id="reid-hoffman" class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/reid-hoffman.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Reid Hoffman" src="{{ static('img/mozorg/about/leadership/reid-hoffman.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Reid Hoffman</h4></figcaption>
       </figure>
     </li>
 
     <li id="joi-ito" class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/joi-ito.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Joi Ito" src="{{ static('img/mozorg/about/leadership/joi-ito.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Joi Ito</h4></figcaption>
       </figure>
     </li>
 
     <li id="mitch-kapor" class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/mitch-kapor.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Mitch Kapor" src="{{ static('img/mozorg/about/leadership/mitch-kapor.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Mitch Kapor</h4></figcaption>
       </figure>
     </li>
@@ -794,7 +808,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Navrina Singh'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Navrina Singh</h4></figcaption>
@@ -812,7 +827,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Wambui Kinya'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Wambui Kinya</h4></figcaption>
@@ -830,7 +846,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Ronaldo Lemos'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Ronaldo Lemos</h4></figcaption>
@@ -847,7 +864,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Mohamed Nanabhay'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mohamed Nanabhay</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/boards.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/boards.html
@@ -19,7 +19,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Mitchell Baker, Executive Chair of the Board, Member of the Nominating and Governance Committee'
+            'alt': 'Headshot of Mitchell Baker, Executive Chair of the Board, Member of the Nominating and Governance Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mitchell Baker</h4></figcaption>
@@ -92,7 +92,7 @@
 
     <article class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" src="{{ static('img/mozorg/about/leadership/laura-chambers.jpg') }}" alt="Laura Chambers, Board Member" itemprop="image" width="160" height="160">
+        <img class="photo" src="{{ static('img/mozorg/about/leadership/laura-chambers.jpg') }}" alt="Headshot of Laura Chambers, Board Member" itemprop="image" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Laura Chambers</h4></figcaption>
       </figure>
 
@@ -103,7 +103,7 @@
 
     <article id="kerry-cooper" data-id="kerry-cooper" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" src="{{ static('img/mozorg/about/leadership/kerry-cooper.jpg') }}" alt="Kerry W. Cooper, Member of the Audit Committee, Member of the Compensation Committee" itemprop="image" width="160" height="160">
+        <img class="photo" src="{{ static('img/mozorg/about/leadership/kerry-cooper.jpg') }}" alt="Headshot of Kerry W. Cooper, Member of the Audit Committee, Member of the Compensation Committee" itemprop="image" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Kerry W. Cooper</h4></figcaption>
       </figure>
 
@@ -157,7 +157,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Karim Lakhani, Chair of the Compensation Committee'
+            'alt': 'Headshot of Karim Lakhani, Chair of the Compensation Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Karim Lakhani</h4></figcaption>
@@ -214,7 +214,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Bob Lisbonne, Chair of the Audit Committee, Member of the Nominating and Governance Committee'
+            'alt': 'Headshot of Bob Lisbonne, Chair of the Audit Committee, Member of the Nominating and Governance Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Bob Lisbonne, Chair</h4></figcaption>
@@ -251,7 +251,7 @@
 
     <article id="hugh-molotsi" data-id="hugh-molotsi" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" src="{{ static('img/mozorg/about/leadership/hugh-molotsi.jpg') }}" alt="Hugh Molotsi, Chair of the Nominating and Governance Committee, Member of the Compensation Committee" itemprop="image" width="160" height="160">
+        <img class="photo" src="{{ static('img/mozorg/about/leadership/hugh-molotsi.jpg') }}" alt="Headshot of Hugh Molotsi, Chair of the Nominating and Governance Committee, Member of the Compensation Committee" itemprop="image" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Hugh Molotsi</h4></figcaption>
       </figure>
 
@@ -304,7 +304,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Kristin Skogen Lund, Member of the Audit Committee'
+            'alt': 'Headshot of Kristin Skogen Lund, Member of the Audit Committee'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Kristin Skogen Lund</h4></figcaption>
@@ -350,7 +350,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Mitchell Baker, Chair'
+            'alt': 'Headshot of Mitchell Baker, Chair'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mitchell Baker, Chair</h4></figcaption>
@@ -369,7 +369,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Brian Behlendorf'
+            'alt': 'Headshot of Brian Behlendorf'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Brian Behlendorf</h4></figcaption>
@@ -410,7 +410,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Zain Habboo'
+            'alt': 'Headshot of Zain Habboo'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Zain Habboo</h4></figcaption>
@@ -458,7 +458,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Amy Keating'
+            'alt': 'Headshot of Amy Keating'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Amy Keating</h4></figcaption>
@@ -497,7 +497,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Raffi Krikorian'
+            'alt': 'Headshot of Raffi Krikorian'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Raffi Krikorian</h4></figcaption>
@@ -568,7 +568,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Edwin Macharia'
+            'alt': 'Headshot of Edwin Macharia'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Edwin Macharia</h4></figcaption>
@@ -613,7 +613,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Alondra Nelson'
+            'alt': 'Headshot of Alondra Nelson'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Alondra Nelson</h4></figcaption>
@@ -661,7 +661,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Mark Surman'
+            'alt': 'Headshot of Mark Surman'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
@@ -680,7 +680,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Helen Turvey'
+            'alt': 'Headshot of Helen Turvey'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Helen Turvey</h4></figcaption>
@@ -711,7 +711,7 @@
 
     <article id="nicole-wong" data-id="nicole-wong" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="Nicole Wong" src="{{ static('img/mozorg/about/leadership/nicole-wong.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Headshot of Nicole Wong" src="{{ static('img/mozorg/about/leadership/nicole-wong.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Nicole Wong</h4></figcaption>
       </figure>
 
@@ -752,7 +752,7 @@
   <ul class="gallery">
     <li class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="Cathy Davidson" src="{{ static('img/mozorg/about/leadership/cathy-davidson.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Headshot of Cathy Davidson" src="{{ static('img/mozorg/about/leadership/cathy-davidson.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Cathy Davidson</h4></figcaption>
       </figure>
     </li>
@@ -769,7 +769,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Julie Hanna'
+            'alt': 'Headshot of Julie Hanna'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Julie Hanna</h4></figcaption>
@@ -778,21 +778,21 @@
 
     <li id="reid-hoffman" class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="Reid Hoffman" src="{{ static('img/mozorg/about/leadership/reid-hoffman.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Headshot of Reid Hoffman" src="{{ static('img/mozorg/about/leadership/reid-hoffman.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Reid Hoffman</h4></figcaption>
       </figure>
     </li>
 
     <li id="joi-ito" class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="Joi Ito" src="{{ static('img/mozorg/about/leadership/joi-ito.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Headshot of Joi Ito" src="{{ static('img/mozorg/about/leadership/joi-ito.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Joi Ito</h4></figcaption>
       </figure>
     </li>
 
     <li id="mitch-kapor" class="vcard" itemscope itemtype="http://schema.org/Person">
       <figure class="headshot">
-        <img class="photo" itemprop="image" alt="Mitch Kapor" src="{{ static('img/mozorg/about/leadership/mitch-kapor.jpg') }}" width="160" height="160">
+        <img class="photo" itemprop="image" alt="Headshot of Mitch Kapor" src="{{ static('img/mozorg/about/leadership/mitch-kapor.jpg') }}" width="160" height="160">
         <figcaption><h4 class="fn" itemprop="name">Mitch Kapor</h4></figcaption>
       </figure>
     </li>
@@ -809,7 +809,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Navrina Singh'
+            'alt': 'Headshot of Navrina Singh'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Navrina Singh</h4></figcaption>
@@ -828,7 +828,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Wambui Kinya'
+            'alt': 'Headshot of Wambui Kinya'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Wambui Kinya</h4></figcaption>
@@ -847,7 +847,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Ronaldo Lemos'
+            'alt': 'Headshot of Ronaldo Lemos'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Ronaldo Lemos</h4></figcaption>
@@ -865,7 +865,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Mohamed Nanabhay'
+            'alt': 'Headshot of Mohamed Nanabhay'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mohamed Nanabhay</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
@@ -24,7 +24,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Laura Chambers, Chief Executive Officer'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Laura Chambers</h4></figcaption>
@@ -100,7 +101,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Ian Carmichael, SVP of Firefox'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Ian Carmichael</h4></figcaption>
@@ -149,7 +151,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'width': '160',
         'height': '160',
         'class': 'photo',
-        'itemprop': 'image'
+        'itemprop': 'image',
+        'alt': 'Dani Chehak, Chief People Officer'
         }
         ) }}
         <figcaption>
@@ -174,7 +177,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'width': '160',
         'height': '160',
         'class': 'photo',
-        'itemprop': 'image'
+        'itemprop': 'image',
+        'alt': 'Eric Muhlheim, Chief Financial Officer'
         }
         ) }}
         <figcaption>
@@ -235,7 +239,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'width': '160',
         'height': '160',
         'class': 'photo',
-        'itemprop': 'image'
+        'itemprop': 'image',
+        'alt': 'Lindsey O’Brien, Chief Marketing Officer'
         }
         ) }}
         <figcaption>
@@ -290,7 +295,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'width': '160',
         'height': '160',
         'class': 'photo',
-        'itemprop': 'image'
+        'itemprop': 'image',
+        'alt': 'Steve Teixeira, Chief Product Officer'
         }
         ) }}
         <figcaption>
@@ -354,7 +360,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'width': '160',
         'height': '160',
         'class': 'photo',
-        'itemprop': 'image'
+        'itemprop': 'image',
+        'alt': 'Carlos Torres, Chief Legal Officer'
         }
         ) }}
         <figcaption>
@@ -401,7 +408,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'width': '160',
         'height': '160',
         'class': 'photo',
-        'itemprop': 'image'
+        'itemprop': 'image',
+        'alt': 'Imo Udom, SVP of Innovation Ecosystems'
         }
         ) }}
         <figcaption>
@@ -459,7 +467,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Suba Vasudevan, SVP of Strategy and Operations'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Suba Vasudevan</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/executive.html
@@ -25,7 +25,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Laura Chambers, Chief Executive Officer'
+            'alt': 'Headshot of Laura Chambers, Chief Executive Officer'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Laura Chambers</h4></figcaption>
@@ -102,7 +102,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Ian Carmichael, SVP of Firefox'
+          'alt': 'Headshot of Ian Carmichael, SVP of Firefox'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Ian Carmichael</h4></figcaption>
@@ -152,7 +152,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'height': '160',
         'class': 'photo',
         'itemprop': 'image',
-        'alt': 'Dani Chehak, Chief People Officer'
+        'alt': 'Headshot of Dani Chehak, Chief People Officer'
         }
         ) }}
         <figcaption>
@@ -178,7 +178,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'height': '160',
         'class': 'photo',
         'itemprop': 'image',
-        'alt': 'Eric Muhlheim, Chief Financial Officer'
+        'alt': 'Headshot of Eric Muhlheim, Chief Financial Officer'
         }
         ) }}
         <figcaption>
@@ -240,7 +240,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'height': '160',
         'class': 'photo',
         'itemprop': 'image',
-        'alt': 'Lindsey O’Brien, Chief Marketing Officer'
+        'alt': 'Headshot of Lindsey O’Brien, Chief Marketing Officer'
         }
         ) }}
         <figcaption>
@@ -296,7 +296,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'height': '160',
         'class': 'photo',
         'itemprop': 'image',
-        'alt': 'Steve Teixeira, Chief Product Officer'
+        'alt': 'Headshot of Steve Teixeira, Chief Product Officer'
         }
         ) }}
         <figcaption>
@@ -361,7 +361,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'height': '160',
         'class': 'photo',
         'itemprop': 'image',
-        'alt': 'Carlos Torres, Chief Legal Officer'
+        'alt': 'Headshot of Carlos Torres, Chief Legal Officer'
         }
         ) }}
         <figcaption>
@@ -409,7 +409,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         'height': '160',
         'class': 'photo',
         'itemprop': 'image',
-        'alt': 'Imo Udom, SVP of Innovation Ecosystems'
+        'alt': 'Headshot of Imo Udom, SVP of Innovation Ecosystems'
         }
         ) }}
         <figcaption>
@@ -468,7 +468,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Suba Vasudevan, SVP of Strategy and Operations'
+          'alt': 'Headshot of Suba Vasudevan, SVP of Strategy and Operations'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Suba Vasudevan</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/mofo.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/mofo.html
@@ -19,7 +19,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Mark Surman, President'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
@@ -89,7 +90,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'J. Bob Alotta, Senior Vice President, Global Programs'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">J. Bob Alotta</h4></figcaption>
@@ -147,7 +149,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Ashley Boyd, Senior Vice President of Global Advocacy'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Ashley Boyd</h4></figcaption>
@@ -207,7 +210,8 @@
             'width': '160',
             'height': '160',
             'class': 'photo',
-            'itemprop': 'image'
+            'itemprop': 'image',
+            'alt': 'Angela Plohman, Chief Operating Officer'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Angela Plohman</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/mofo.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/mofo.html
@@ -20,7 +20,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Mark Surman, President'
+            'alt': 'Headshot of Mark Surman, President'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
@@ -91,7 +91,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'J. Bob Alotta, Senior Vice President, Global Programs'
+            'alt': 'Headshot of J. Bob Alotta, Senior Vice President, Global Programs'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">J. Bob Alotta</h4></figcaption>
@@ -150,7 +150,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Ashley Boyd, Senior Vice President of Global Advocacy'
+            'alt': 'Headshot of Ashley Boyd, Senior Vice President of Global Advocacy'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Ashley Boyd</h4></figcaption>
@@ -211,7 +211,7 @@
             'height': '160',
             'class': 'photo',
             'itemprop': 'image',
-            'alt': 'Angela Plohman, Chief Operating Officer'
+            'alt': 'Headshot of Angela Plohman, Chief Operating Officer'
           }
         ) }}
         <figcaption><h4 class="fn" itemprop="name">Angela Plohman</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/senior.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/senior.html
@@ -20,7 +20,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Ramona Blake, VP of Sustainability & Diversity'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Ramona Blake</h4></figcaption>
@@ -62,7 +63,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Brandon Borrman, VP of Communications'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Brandon Borrman</h4></figcaption>
@@ -117,7 +119,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Katherine Bose, VP of Business &amp; Corporate Development'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Katherine Bose</h4></figcaption>
@@ -169,7 +172,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Vicky Chin, VP of Engineering'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Vicky Chin</h4></figcaption>
@@ -216,7 +220,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Nicholas Grammater, VP of Finance'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Nicholas Grammater</h4></figcaption>
@@ -262,7 +267,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Linda Griffin, VP of Global Policy'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Linda Griffin</h4></figcaption>
@@ -311,7 +317,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'John Humphrey, VP of Data Science and Engineering'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">John Humphrey</h4></figcaption>
@@ -356,7 +363,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Robin Karakash, VP of Marketing, Europe'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Robin Karakash</h4></figcaption>
@@ -393,7 +401,7 @@
 
   <article id="christina-lang" data-id="christina-lang" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/christina-lang.jpg') }}" width="160" height="160">
+      <img class="photo" itemprop="image" alt="Christina Lang, VP of Marketing, North America" src="{{ static('img/mozorg/about/leadership/christina-lang.jpg') }}" width="160" height="160">
       <figcaption><h4 class="fn" itemprop="name">Christina Lang</h4></figcaption>
     </figure>
 
@@ -443,7 +451,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Masayo Nobe, VP of Legal'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Masayo Nobe</h4></figcaption>
@@ -494,7 +503,8 @@
           'width': '160',
           'height': '160',
           'class': 'photo',
-          'itemprop': 'image'
+          'itemprop': 'image',
+          'alt': 'Andrew Overholt, VP of Engineering'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Andrew Overholt</h4></figcaption>

--- a/bedrock/mozorg/templates/mozorg/about/leadership/includes/senior.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership/includes/senior.html
@@ -21,7 +21,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Ramona Blake, VP of Sustainability & Diversity'
+          'alt': 'Headshot of Ramona Blake, VP of Sustainability & Diversity'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Ramona Blake</h4></figcaption>
@@ -64,7 +64,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Brandon Borrman, VP of Communications'
+          'alt': 'Headshot of Brandon Borrman, VP of Communications'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Brandon Borrman</h4></figcaption>
@@ -120,7 +120,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Katherine Bose, VP of Business &amp; Corporate Development'
+          'alt': 'Headshot of Katherine Bose, VP of Business &amp; Corporate Development'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Katherine Bose</h4></figcaption>
@@ -173,7 +173,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Vicky Chin, VP of Engineering'
+          'alt': 'Headshot of Vicky Chin, VP of Engineering'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Vicky Chin</h4></figcaption>
@@ -221,7 +221,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Nicholas Grammater, VP of Finance'
+          'alt': 'Headshot of Nicholas Grammater, VP of Finance'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Nicholas Grammater</h4></figcaption>
@@ -268,7 +268,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Linda Griffin, VP of Global Policy'
+          'alt': 'Headshot of Linda Griffin, VP of Global Policy'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Linda Griffin</h4></figcaption>
@@ -318,7 +318,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'John Humphrey, VP of Data Science and Engineering'
+          'alt': 'Headshot of John Humphrey, VP of Data Science and Engineering'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">John Humphrey</h4></figcaption>
@@ -364,7 +364,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Robin Karakash, VP of Marketing, Europe'
+          'alt': 'Headshot of Robin Karakash, VP of Marketing, Europe'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Robin Karakash</h4></figcaption>
@@ -401,7 +401,7 @@
 
   <article id="christina-lang" data-id="christina-lang" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
     <figure class="headshot">
-      <img class="photo" itemprop="image" alt="Christina Lang, VP of Marketing, North America" src="{{ static('img/mozorg/about/leadership/christina-lang.jpg') }}" width="160" height="160">
+      <img class="photo" itemprop="image" alt="Headshot of Christina Lang, VP of Marketing, North America" src="{{ static('img/mozorg/about/leadership/christina-lang.jpg') }}" width="160" height="160">
       <figcaption><h4 class="fn" itemprop="name">Christina Lang</h4></figcaption>
     </figure>
 
@@ -452,7 +452,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Masayo Nobe, VP of Legal'
+          'alt': 'Headshot of Masayo Nobe, VP of Legal'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Masayo Nobe</h4></figcaption>
@@ -504,7 +504,7 @@
           'height': '160',
           'class': 'photo',
           'itemprop': 'image',
-          'alt': 'Andrew Overholt, VP of Engineering'
+          'alt': 'Headshot of Andrew Overholt, VP of Engineering'
         }
       ) }}
       <figcaption><h4 class="fn" itemprop="name">Andrew Overholt</h4></figcaption>


### PR DESCRIPTION
## One-line summary

This PR adds alt text for images on leadership page

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/14671

## Testing
