### PR TITLE
Add metrics to SimpleDictCache

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -282,17 +282,6 @@ if CACHES["default"]["BACKEND"] == "django_pylibmc.memcached.PyLibMCCache":
         "ketama": True,
     }
 
-# cache for lang files
-CACHES["l10n"] = {
-    "BACKEND": "bedrock.base.cache.SimpleDictCache",
-    "LOCATION": "l10n",
-    "TIMEOUT": DOTLANG_CACHE,
-    "OPTIONS": {
-        "MAX_ENTRIES": 5000,
-        "CULL_FREQUENCY": 4,  # 1/4 entries deleted if max reached
-    },
-}
-
 # cache for Fluent files
 CACHES["fluent"] = {
     "BACKEND": "bedrock.base.cache.SimpleDictCache",


### PR DESCRIPTION
This is so we can investigate out-of-memory restarts and possibly tune these caches a bit.

