### PR TITLE
Change custom 403 page to not 500

### DIFF
--- a/bedrock/base/templates/403_csrf.html
+++ b/bedrock/base/templates/403_csrf.html
@@ -17,12 +17,12 @@
     <p>
       Cross-site request forgery (CSRF) mismatch detected.
     </p>
-    {% if request.user.is_staff %}
+    {% if settings.WAGTAIL_ENABLE_ADMIN %}
     <p>
       This is most likely because your SSO session expired or had to be renewed.
     </p>
     <p>
-      It's likely and regrettable that you have lost work since your last save.
+      If you were editing content, it's likely — and regrettable — that you have lost work since your last save.
       <br>
       If this is happening a lot, please <a href="https://github.com/mozilla/bedrock">open a bug report</a>.
     </p>


### PR DESCRIPTION
For the Web deployment, we don't run session or authentication middleware (because it's stateless) so the custom 403 page that alerts to an expired SSO session will blow up (and has done when we've had bots spamming relevant forms)

Next best check is to show the extra message only on the Editing deployment, which is where SSO is used. The settings object is already in the page context via bedrock.base.context_processors.globals

