### PR TITLE
Fix untranslated fallback strings

### DIFF
--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -254,7 +254,7 @@ def ftl_has_messages(l10n, *message_ids, require_all=True):
 
 def translate(l10n, message_id, fallback=None, **kwargs):
     # check the `locale` bundle for the message if we have a fallback defined
-    if fallback and not l10n.has_message(message_id):
+    if fallback and l10n.has_message(fallback) and not l10n.has_message(message_id):
         message_id = fallback
 
     return l10n.format_value(message_id, kwargs)


### PR DESCRIPTION
## One-line summary

Only fall back to a fallback string if it's actually translated.

## Significant changes and points to review

When both current and fallback strings are untranslated in given locale, an English/default string gets used — but this should prefer the current default over the fallback default, as both are default English anyways, so having a current English is at least a bit better.

## Issue / Bugzilla link

Fixes #14461 

## Testing

_(compare with current prod:)_
http://localhost:8000/de/firefox/#fxa-email-form (de:v1)
http://localhost:8000/da/firefox/#fxa-email-form  (da:v1)
http://localhost:8000/be/firefox/#fxa-email-form  (en:v2)
http://localhost:8000/nn-NO/firefox/#fxa-email-form (en:v2)
http://localhost:8000/pt-PT/firefox/#fxa-email-form (pt:v2)

but no locale should show v1 string in default en, only v2 en or v1 in the language…