### PR TITLE
Bump node Docker image to 20.14.0-slim (Fixes #14705)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --require-hashes --no-cache-dir -r requirements/prod.txt
 ########
 # assets builder and dev server
 #
-FROM node:20.8.0-slim AS assets
+FROM node:20.14.0-slim AS assets
 
 ENV PATH=/app/node_modules/.bin:$PATH
 WORKDIR /app


### PR DESCRIPTION
## One-line summary

Bumps Node to a more recent 20.x image to satisfy some warnings building dependencies.

## Issue / Bugzilla link

#14705

## Testing

- `make build`
- `make run`