### PR TITLE
Add helper to get only the hostname out of MEDIA_URL

### DIFF
--- a/bedrock/base/tests/test_settings.py
+++ b/bedrock/base/tests/test_settings.py
@@ -7,6 +7,10 @@
 from django.conf import settings
 from django.test import override_settings
 
+import pytest
+
+from bedrock.settings.base import _get_media_cdn_hostname_for_storage_backend
+
 
 @override_settings(DEV=False, PROD_LANGUAGES=("de", "fr", "nb-NO", "ja", "ja-JP-mac", "en-US", "en-GB"))
 def test_lang_groups():
@@ -15,3 +19,17 @@ def test_lang_groups():
         "ja": ["ja-JP-mac", "ja"],
         "en": ["en-US", "en-GB"],
     }
+
+
+@pytest.mark.parametrize(
+    "media_url, expected_hostname",
+    (
+        ("https://www-dev.allizom.org/media/cms/", "https://www-dev.allizom.org"),
+        ("https://www-dev.allizom.org/some/future/assets/path/", "https://www-dev.allizom.org"),
+        ("https://www.allizom.org/media/cms/", "https://www.allizom.org"),
+        ("https://www.mozilla.org/media/cms/", "https://www.mozilla.org"),
+        ("/custom-media/", "/custom-media/"),  # this one is the default, used in local dev
+    ),
+)
+def test_get_media_cdn_hostname(media_url, expected_hostname):
+    assert _get_media_cdn_hostname_for_storage_backend(media_url) == expected_hostname


### PR DESCRIPTION
TLDR: We just need the root URL of the CDN, from `settings.MEDIA_URL`.

Longer form: 

`settings.MEDIA_URL` is a custom route on our CDN that points to a cloud bucket, which we use for uploaded media from the CMS.

Specifically, due to infra constraints, it has to point to a _sub-path_ in the bucket, not the top/root of it. 

It also needs to be distinct from the CDN route that points to our collected static assets (which are at `https://<CDN_HOSTNAME>/media/` - that is `settings.STATIC_URL` in production)

With all this in mind, `settings.MEDIA_URL`, when set, points to `https://<CDN_HOSTNAME>/media/cms/` 

However, when `django-storages` computes the URL for a object in that CMS bucket, it wants just the hostname of the bucket, not the full CDN/proxy path to the subdir in the bucket, because it opinionatedly concatenates it with `settings.GS_LOCATION` (which is needed to ensure the files are uploaded to the sub-path mentioned above).

- [X] I used an AI to write some of this code: I thought I'd try Copilot to extract the root URL. Ironically then spent as much time sense-checking it as writing it myself. I did learn about `ParseResult.hostname` being a lowercased `ParseResult.netloc`, so I emerged more intelligent, at least


## Testing

* there are unit tests and I've test-driven this locally. Also, when this gets merged only the CMS deployment in Dev has credentials available that will trigger this code path