### PR TITLE
Ensure test stability regardless of local .env settings for DEV env var

### DIFF
--- a/bedrock/base/tests/test_i18n.py
+++ b/bedrock/base/tests/test_i18n.py
@@ -286,6 +286,7 @@ def test_get_language_from_headers(rf, headers, expected):
     assert get_language_from_headers(request) == expected
 
 
+@override_settings(DEV=False)
 @pytest.mark.parametrize(
     "header, expected",
     (


### PR DESCRIPTION
## One-line summary

Fixes test that can be broken if DEV=True in local env

## Testing

* Try DEV=True and then False in yuor env, running `pytest -k test_i18n.py` each time 