### PR TITLE
Support configurable CSP reporting percentage

### DIFF
--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -24,7 +24,7 @@ from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import trans_real
 
 from commonware.middleware import FrameOptionsHeader as OldFrameOptionsHeader
-from csp.middleware import CSPMiddleware
+from csp.contrib.rate_limiting import RateLimitedCSPMiddleware
 
 from bedrock.base import metrics
 from bedrock.base.i18n import (
@@ -299,7 +299,7 @@ class MetricsViewTimingMiddleware(MiddlewareMixin):
             self._record_timing(request, 500)
 
 
-class CSPMiddlewareByPathPrefix(CSPMiddleware):
+class CSPMiddlewareByPathPrefix(RateLimitedCSPMiddleware):
     """
     A subclass of CSPMiddleware that allows for different CSP policies based path prefix.
 

--- a/bin/qa/check_csp_report.py
+++ b/bin/qa/check_csp_report.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from collections import defaultdict
+
+import click
+import requests
+
+
+@click.command()
+@click.option("-n", type=click.IntRange(0, 100, clamp=True), default=100, help="Number of requests to make")
+@click.argument("url", type=str, required=True)
+def check_for_report_uri(url, n=100):
+    """
+    Check if a URL has a Content-Security-Policy header with a report-uri directive.
+    """
+    print(f"Checking {url}")
+    results = defaultdict(int)
+    for _ in range(n):
+        resp = requests.get(url)
+
+        if "Content-Security-Policy" in resp.headers:
+            header = resp.headers["Content-Security-Policy-Report-Only"]
+            if "report-uri" in header:
+                results["report-uri present"] += 1
+            else:
+                results["report-uri not present"] += 1
+        else:
+            results["No CSP header"] += 1
+
+    print(f"{n} requests made")
+    print(results)
+
+
+if __name__ == "__main__":
+    check_for_report_uri()

--- a/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml
+++ b/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml
@@ -11,7 +11,6 @@ ALLOWED_HOSTS: .allizom.org,.moz.works,.run.app
 CONTENT_CARDS_URL: https://www-dev.allizom.org/media/
 CSP_DEFAULT_SRC: "*.allizom.org"
 CSP_EXTRA_FRAME_SRC: "*.mozaws.net,o1069899.sentry.io"
-CSP_REPORT_ENABLE: "True"
 DB_DOWNLOAD_IGNORE_GIT: "True"
 DEBUG: "False"
 DEV: "True"


### PR DESCRIPTION
## One-line summary

This changeset adds support for including a CSP report-uri in a certain percentage of pages, so that we can get an idea of whether pages have inappropriate CSP set, but without saturating our logging service, Sentry.

NB: the relevant config to enable this on Dev, Stage and Prod will be in a separate PR, and that work needs to be merged to make this changeset do anything.


## Issue / Bugzilla link

Resolve #14451 

## Testing

I've added a script called `./bin/qa/check_csp_report.py` which we can use to check the proportion of headers being set, either locally or on an actual server.

E.g. with `CSP_REPORT_PERCENTAGE=50`
```
$ ./bin/check_csp_report.py -n 100 http://localhost:8000/en-US/firefox/
Checking http://localhost:8000/en-US/firefox/
100 requests made
defaultdict(<class 'int'>, {'report-uri not present': 51, 'report-uri present': 49})
```
