### PR TITLE
Update healthz-cron page re postgres backend

### DIFF
--- a/bedrock/base/templates/cron-health-check.html
+++ b/bedrock/base/templates/cron-health-check.html
@@ -80,6 +80,8 @@
         <td><a href="https://github.com/mozilla/bedrock/commit/{{ server_info.git_sha }}">{{ server_info.git_sha[:10] }}</a></td>
       </tr>
       {% endif %}
+
+      {% if SQLITE_DB_IN_USE %}
       {% if server_info.db_git_sha %}
       <tr>
         <td>DB Git SHA</td>
@@ -104,6 +106,13 @@
       <tr>
         <td>DB File</td>
         <td><a href="{{ server_info.db_file_url }}">{{ server_info.db_file_name }}</a></td>
+      </tr>
+      {% endif %}
+      {% endif %}
+      {% if most_recent_data_change_ts %}
+      <tr title="Timestamp of the most recent change to a data source">
+        <td>Latest data change</td>
+        <td>{{most_recent_data_change_ts}}</td>
       </tr>
       {% endif %}
       <tr>


### PR DESCRIPTION
Bedrock will continue to operate with sqlite for local dev, demos and bedrock-test, but otherwise will use postgres as its DB backend.

As such, some of the info on the healthz-cron page will be misleading if postgres is in use, because it's focused on sqlite.

This changeset hides the sqlite-specific data if sqlite is not in use. It also adds a new timestamp that shows the most recent timestamp of all data sources that have been pulled in, as a rough way for us to quickly see that the run-db-update job is still working. (There's also a Dead Man's Snitch watching the relevant job, but this adds a convenient quick look)

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Resolves #14734

## Screenshots

With sqlite in use - very similar to current Bedrock
<img width="750" alt="Screenshot 2024-06-25 at 10 48 11" src="https://github.com/mozilla/bedrock/assets/101457/5fe8e803-a824-4153-8e65-d7c7a3d95f4d">


With Postgres in use instead
<img width="616" alt="Screenshot 2024-06-25 at 10 47 43" src="https://github.com/mozilla/bedrock/assets/101457/aa2cd660-ca7c-4920-a804-8897d00b90f8">



