### PR TITLE
Fix #14733: Add custom CSP for wagtail image uploads

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -264,7 +264,16 @@ CONTENT_SECURITY_POLICY = {
 
 # Mainly for overriding CSP settings for CMS admin.
 # Works in conjunction with the `bedrock.base.middleware.CSPMiddlewareByPathPrefix` middleware.
-CSP_PATH_OVERRIDES = {}
+
+# /cms-admin/images/ loads just-uploaded images as blobs.
+CMS_ADMIN_IMAGES_CSP = CONTENT_SECURITY_POLICY.copy()
+CMS_ADMIN_IMAGES_CSP["DIRECTIVES"]["img-src"] += ["blob:"]
+
+CSP_PATH_OVERRIDES = {
+    # The first path prefix that matches the request.path.startswith will be used, so order them
+    # from most specific to least.
+    "/cms-admin/images/": CMS_ADMIN_IMAGES_CSP,
+}
 CSP_PATH_OVERRIDES_REPORT_ONLY = {}
 
 


### PR DESCRIPTION
## One-line summary

Wagtail uploaded images show the image preview using a `blob`. This adds a custom CSP just for the wagtail admin to view these.

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

This will need to match the request path that loads the image preview, not the source of the image preview. So this needs testing on our wagtail dev or demo site to ensure the path is correct.

## Issue / Bugzilla link

#14733 

