### PR TITLE
Align CSP override middleware's report-only with django-csp

### DIFF
--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -311,13 +311,16 @@ class CSPMiddlewareByPathPrefix(CSPMiddleware):
     """
 
     def process_response(self, request, response):
-        if hasattr(settings, "CSP_PATH_OVERRIDES"):
-            for prefix, config in settings.CSP_PATH_OVERRIDES.items():
+        if CSP_PATH_OVERRIDES := getattr(settings, "CSP_PATH_OVERRIDES", None):
+            for prefix, config in CSP_PATH_OVERRIDES.items():
                 if request.path.startswith(prefix):
-                    if config.get("REPORT_ONLY", False):
-                        response._csp_config_ro = config.get("DIRECTIVES", {})
-                    else:
-                        response._csp_config = config.get("DIRECTIVES", {})
+                    response._csp_config = config.get("DIRECTIVES", {})
+                    break
+
+        if CSP_PATH_OVERRIDES_RO := getattr(settings, "CSP_PATH_OVERRIDES_REPORT_ONLY", None):
+            for prefix, config in CSP_PATH_OVERRIDES_RO.items():
+                if request.path.startswith(prefix):
+                    response._csp_config_ro = config.get("DIRECTIVES", {})
                     break
 
         return super().process_response(request, response)

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -315,7 +315,8 @@ def test_csp_path_overrides_nullify(csp_middleware):
 
 @override_settings(
     CONTENT_SECURITY_POLICY={"DIRECTIVES": {"default-src": ["default.com"]}},
-    CSP_PATH_OVERRIDES={"/u/thedude": {"REPORT_ONLY": True, "DIRECTIVES": {"default-src": ["override.com"]}}},
+    CONTENT_SECURITY_POLICY_REPORT_ONLY={"DIRECTIVES": {"default-src": ["default.com", "other.com"]}},
+    CSP_PATH_OVERRIDES_REPORT_ONLY={"/u/thedude": {"DIRECTIVES": {"default-src": ["override.com"]}}},
 )
 def test_csp_path_overrides_report_only(csp_middleware):
     rf = RequestFactory()

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -248,7 +248,6 @@ if csp_extra_frame_src:
     _csp_child_src = list(set(_csp_child_src + csp_extra_frame_src))
 
 CONTENT_SECURITY_POLICY = {
-    "REPORT_ONLY": config("CSP_REPORT_ONLY", default="false", parser=bool),
     "DIRECTIVES": {
         "default-src": _csp_default_src,
         "img-src": list(set(_csp_default_src + _csp_img_src)),
@@ -266,6 +265,7 @@ CONTENT_SECURITY_POLICY = {
 # Mainly for overriding CSP settings for CMS admin.
 # Works in conjunction with the `bedrock.base.middleware.CSPMiddlewareByPathPrefix` middleware.
 CSP_PATH_OVERRIDES = {}
+CSP_PATH_OVERRIDES_REPORT_ONLY = {}
 
 
 # 4. SETTINGS WHICH APPLY REGARDLESS OF SITE MODE


### PR DESCRIPTION
## One-line summary

`REPORT_ONLY` no longer lives in the settings dict. This aligns our override middleware with how django-csp works by adding a 2nd override for report-only and updates the middleware to match.


- [ ] I used an AI to write some of this code.

