### PR TITLE
Ensure Docker builds include any CSS needed when the CMS Admin mode is active, too

### DIFF
--- a/docker/bin/build_staticfiles.sh
+++ b/docker/bin/build_staticfiles.sh
@@ -8,9 +8,14 @@ set -exo pipefail
 
 rm -rf ./static
 
+# We need to build statics with Wagtail temporarily enabled, so that we
+# get all the files collected that are needed for the CMS deployment to run.
+# Specificially: django.contrb.admin is added to INSTALLED_APPS in CMS mode
+# which is needed for django-rq's management UI and the main Django Admin
+
 if [[ "$1" == "--nolink" ]]; then
-    python manage.py collectstatic --noinput -v 0
+    WAGTAIL_ENABLE_ADMIN=True python manage.py collectstatic --noinput -v 0
 else
-    python manage.py collectstatic -l --noinput -v 0
+    WAGTAIL_ENABLE_ADMIN=True python manage.py collectstatic -l --noinput -v 0
     docker/bin/softlinkstatic.py
 fi


### PR DESCRIPTION
…
To test this, I did `make build prod` to build a new release image, locally, then shelled in:

```
$ pwd
/app
$ ls static/admin/css
autocomplete.4a81fc4242d0.css  dark_mode.ef27a31af300.css  nav_sidebar.269a1bd44627.css     rtl.css
autocomplete.css               dashboard.css               nav_sidebar.css                  vendor
base.523eb49842a7.css          dashboard.e90f2068217b.css  responsive.css                   widgets.css
base.css                       forms.c14e1cb06392.css      responsive.f6533dab034d.css      widgets.ee33ab26c7c2.css
changelists.9237a1ac391b.css   forms.css                   responsive_rtl.7d1130848605.css
changelists.css                login.586129c60a93.css      responsive_rtl.css
dark_mode.css                  login.css                   rtl.512d4b53fc59.css
```

I also compared this with a release image made yesterday, before this change:

```
$ pwd
/app
$ ls static/admin/
ls: cannot access 'static/admin/': No such file or directory
```



## Issue / Bugzilla link

Resolves #14752 - Django Admin and RQ list fail up in CMS mode on Dev deployment
