### PR TITLE
Remove UA client ID from stub attribution data (Fixes #14406)

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -49,7 +49,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "client_id": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
@@ -66,7 +65,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "0fadfe08229c0a3563f7fbc3368a9801d259755bf25a1f604abe0fec30c1170a",
+            "8bc0a52a7f6e9ffbe0620969cf0862274c2ece328edb966383ed1001bd471886",
         )
 
     def test_no_valid_param_data(self):
@@ -75,7 +74,6 @@ class TestStubAttributionCode(TestCase):
             "utm_medium": "ae<t>her",
             "experiment": "dfb</p>s",
             "variation": "ef&bvcv",
-            "client_id": "14</p>4538.1610<t>957",
             "client_id_ga4": "14</p>4538.1610<t>957",
             "session_id": "2w</br>123bg<u>957",
             "dlsource": "fs<a>44fn</a>",
@@ -88,7 +86,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "client_id": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
@@ -105,7 +102,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "0fadfe08229c0a3563f7fbc3368a9801d259755bf25a1f604abe0fec30c1170a",
+            "8bc0a52a7f6e9ffbe0620969cf0862274c2ece328edb966383ed1001bd471886",
         )
 
     def test_some_valid_param_data(self):
@@ -118,7 +115,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "client_id": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
@@ -135,7 +131,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "2c936780cada1e1f6c5b900e5fa0659f64d908e2938f7c91be3de593656c6097",
+            "4dcfffdd4e87c175700d04587d5fa42d613d158e967a282f51c4ea1bc0e9050c",
         )
 
     def test_campaign_data_too_long(self):
@@ -148,7 +144,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
-            "client_id": "1456954538.1610960957",
             "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
@@ -159,12 +154,11 @@ class TestStubAttributionCode(TestCase):
             "campaign": "The|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in"
             "|thatThe|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe"
             "|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides"
-            "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides_",
+            "|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know|about|you_",
             "content": "A144_A000_0000000",
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "chrome",
-            "client_id": "1456954538.1610960957",
             "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
@@ -183,7 +177,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "aefd88209faa9cd73964bdcd3720bffea66fa904ae56da0f297a6051fb0fb13f",
+            "6c8179cbe1393961ce310e610f2b49af699f6bc6d2c92d211bdc872a838c5f67",
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -209,7 +203,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "firefox-new",
             "variation": "1",
             "ua": "chrome",
-            "client_id": "1456954538.1610960957",
             "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
@@ -222,7 +215,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "firefox-new",
             "variation": "1",
             "ua": "chrome",
-            "client_id": "1456954538.1610960957",
             "client_id_ga4": "2456954538.1610960957",
             "session_id": "1668161374",
             "dlsource": "mozorg",
@@ -239,7 +231,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "20dfb63379a9ed9ae9f74acf4c6bbc1496597eca7cec4987ad89ad161cbfd810",
+            "960fd9eabdf2890320457f8638062e8918812f896128afce5d50d2ab097270ad",
         )
 
     def test_handles_referrer(self):
@@ -252,7 +244,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "client_id": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
@@ -269,7 +260,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "2c936780cada1e1f6c5b900e5fa0659f64d908e2938f7c91be3de593656c6097",
+            "4dcfffdd4e87c175700d04587d5fa42d613d158e967a282f51c4ea1bc0e9050c",
         )
 
     def test_handles_referrer_no_source(self):
@@ -285,7 +276,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "client_id": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
@@ -302,7 +292,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "8b7a62992b0acd8610df3aed80b504ff78c7f2ed081568ed6d7e91ea62d5b85c",
+            "31ce6969fb8131e2a798d0127c2d44fc0ac2d278a59bc793238df06f1e0ae8f5",
         )
 
     def test_handles_referrer_utf8(self):
@@ -321,7 +311,6 @@ class TestStubAttributionCode(TestCase):
             "experiment": "(not set)",
             "variation": "(not set)",
             "ua": "(not set)",
-            "client_id": "(not set)",
             "client_id_ga4": "(not set)",
             "session_id": "(not set)",
             "dlsource": "mozorg",
@@ -338,7 +327,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data["attribution_sig"],
-            "0fadfe08229c0a3563f7fbc3368a9801d259755bf25a1f604abe0fec30c1170a",
+            "8bc0a52a7f6e9ffbe0620969cf0862274c2ece328edb966383ed1001bd471886",
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -52,7 +52,6 @@ STUB_VALUE_NAMES = [
     ("experiment", "(not set)"),
     ("variation", "(not set)"),
     ("ua", "(not set)"),
-    ("client_id", "(not set)"),
     ("client_id_ga4", "(not set)"),
     ("session_id", "(not set)"),
     ("dlsource", "mozorg"),

--- a/docs/attribution/0002-firefox-desktop.rst
+++ b/docs/attribution/0002-firefox-desktop.rst
@@ -88,7 +88,7 @@ Attribution data
 +------------------+-----------------------------------------------------------------------------------------+----------------------------+
 | ``variation``    | Query param identifying the experiment variation that was seen by the visitor.          |                            |
 +------------------+-----------------------------------------------------------------------------------------+----------------------------+
-| ``client_id``    | Google Analytics Client ID.                                                             | ``1715265578.1681917481``  |
+| ``client_id_ga4``| Google Analytics 4 Client ID.                                                           | ``1715265578.1681917481``  |
 +------------------+-----------------------------------------------------------------------------------------+----------------------------+
 | ``session_id``   | A random 10 digit string identifier used to associate attribution data with GA session. | ``9770365798``             |
 +------------------+-----------------------------------------------------------------------------------------+----------------------------+
@@ -199,8 +199,8 @@ testing guide. This guide assumes demo1, make sure you're testing on the right U
 4. Look for a cookie called `moz-stub-attribution-code` and copy the value (it should be a base64 encoded string).
 5. Decode the base64 string (e.g. using https://base64decode.org) and check that:
     - `dlsource` parameter value is mozorg
-    - `client_id`, `client_id_ga4` and `session_id` parameters exist
-    - `client_id` and `client_id_ga4` should look something like 0700077325.1656063224
+    - `client_id_ga4` and `session_id` parameters exist
+    - `client_id_ga4` should look something like 0700077325.1656063224
       (the numbers will differ but the format with the middle period should look the same).
     - `source` and `campaign` have the values ham and pineapple, respectively.
     - The ua value should be chrome (assuming you tested in Chrome).

--- a/tests/unit/spec/base/stub-attribution/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution/stub-attribution.js
@@ -12,7 +12,6 @@
 /* eslint new-cap: [2, {"capIsNewExceptions": ["Deferred"]}] */
 
 describe('stub-attribution.js', function () {
-    const GA_CLIENT_ID = '1456954538.1610960957';
     const GA4_CLIENT_ID = '4442748357.1686074738';
     const GA_SESSION_ID = '1668161374';
     const STUB_SESSION_ID = '1234567890';
@@ -35,7 +34,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -44,10 +42,6 @@ describe('stub-attribution.js', function () {
             spyOn(Mozilla.StubAttribution, 'updateBouncerLinks');
             spyOn(window.dataLayer, 'push');
 
-            // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
-                GA_CLIENT_ID
-            );
             spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
                 GA4_CLIENT_ID
             );
@@ -109,9 +103,8 @@ describe('stub-attribution.js', function () {
                 Mozilla.StubAttribution.requestAuthentication
             ).toHaveBeenCalledWith(data);
             expect(window.dataLayer.push).toHaveBeenCalledWith({
-                // TODO: add check for GA4 event
-                event: 'stub-session-id',
-                eLabel: STUB_SESSION_ID
+                event: 'stub_session_set',
+                id: STUB_SESSION_ID
             });
             expect(
                 Mozilla.StubAttribution.updateBouncerLinks
@@ -278,7 +271,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -294,7 +286,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -308,7 +299,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta:dUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -322,7 +312,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -336,7 +325,6 @@ describe('stub-attribution.js', function () {
                 utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -352,7 +340,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -366,7 +353,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta:cm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -380,7 +366,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%25253AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: 'https://example.com/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -394,7 +379,6 @@ describe('stub-attribution.js', function () {
                 utm_content: '%72%74%61%3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ',
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -412,7 +396,6 @@ describe('stub-attribution.js', function () {
                 )}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -428,7 +411,6 @@ describe('stub-attribution.js', function () {
                 )}3AdUJsb2NrMEByYXltb25kaGlsbC5uZXQ`,
                 referrer: 'https://addons.mozilla.org/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -444,7 +426,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rta%3Acm9uaW4td2FsbGV0QGF4aWVpbmZpbml0eS5jb20',
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: STUB_SESSION_ID
             };
@@ -520,11 +501,7 @@ describe('stub-attribution.js', function () {
         afterEach(function () {
             jasmine.clock().uninstall();
         });
-        it('should fire a callback when GA client ID and session ID are found', function () {
-            // stub out UA client ID
-            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
-                GA_CLIENT_ID
-            );
+        it('should fire a callback when GA4 client ID and session ID are found', function () {
             // stub out GA4 client ID
             spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
                 GA4_CLIENT_ID
@@ -535,43 +512,7 @@ describe('stub-attribution.js', function () {
             expect(callback).toHaveBeenCalledWith(true);
         });
 
-        it('should fire a callback when UA client ID is found but GA4 client ID is not', function () {
-            // stub out UA client ID
-            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
-                GA_CLIENT_ID
-            );
-            // stub out GA4 client ID
-            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
-                null
-            );
-            const callback = jasmine.createSpy('callback');
-
-            Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
-            jasmine.clock().tick(2100);
-            expect(callback).toHaveBeenCalledWith(true);
-        });
-
-        it('should fire a callback when UA client ID is not found but GA4 client ID is found', function () {
-            // stub out UA client ID
-            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
-                null
-            );
-            // stub out GA4 client ID
-            spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
-                GA4_CLIENT_ID
-            );
-            const callback = jasmine.createSpy('callback');
-
-            Mozilla.StubAttribution.waitForGoogleAnalyticsThen(callback);
-            jasmine.clock().tick(2100);
-            expect(callback).toHaveBeenCalledWith(true);
-        });
-
-        it('should fire a callback when it times out looking for UA and GA4 ids', function () {
-            // stub out UA client ID
-            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
-                null
-            );
+        it('should fire a callback when it times out looking for GA4 ids', function () {
             // stub out GA4 client ID
             spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
                 null
@@ -586,10 +527,6 @@ describe('stub-attribution.js', function () {
 
     describe('getAttributionData', function () {
         beforeEach(function () {
-            // stub out GA client ID
-            spyOn(Mozilla.StubAttribution, 'getUAClientID').and.returnValue(
-                GA_CLIENT_ID
-            );
             spyOn(Mozilla.StubAttribution, 'getGtagClientID').and.returnValue(
                 GA4_CLIENT_ID
             );
@@ -612,7 +549,6 @@ describe('stub-attribution.js', function () {
                 utm_content: 'rel-esr',
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
@@ -641,7 +577,6 @@ describe('stub-attribution.js', function () {
             const data = {
                 referrer: 'https://www.mozilla.org/en-US/',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
@@ -670,7 +605,6 @@ describe('stub-attribution.js', function () {
             const data = {
                 referrer: '',
                 ua: 'chrome',
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
@@ -701,7 +635,6 @@ describe('stub-attribution.js', function () {
                 ua: 'chrome',
                 experiment: 'firefox-new',
                 variation: 1,
-                client_id: GA_CLIENT_ID,
                 client_id_ga4: GA4_CLIENT_ID,
                 session_id: jasmine.any(String),
                 dlsource: DLSOURCE
@@ -1209,39 +1142,6 @@ describe('stub-attribution.js', function () {
         it('should return false if exceeds sample rate', function () {
             spyOn(window.Math, 'random').and.returnValue(0.6);
             expect(Mozilla.StubAttribution.withinAttributionRate()).toBeFalsy();
-        });
-    });
-
-    describe('getUAClientID', function () {
-        it('should return a valid UA client ID', function () {
-            window.ga = sinon.stub();
-            window.ga.getAll = sinon.stub().returns([
-                {
-                    get: () => GA_CLIENT_ID
-                }
-            ]);
-
-            expect(Mozilla.StubAttribution.getUAClientID()).toEqual(
-                GA_CLIENT_ID
-            );
-        });
-
-        it('should return a null if UA client ID is invalid', function () {
-            window.ga = sinon.stub();
-            window.ga.getAll = sinon.stub().returns([
-                {
-                    get: () => ''
-                }
-            ]);
-
-            expect(Mozilla.StubAttribution.getUAClientID()).toBeNull();
-        });
-
-        it('should return a null if accessing ga object throws an error', function () {
-            window.ga = sinon.stub().throws(function () {
-                return new Error();
-            });
-            expect(Mozilla.StubAttribution.getUAClientID()).toBeNull();
         });
     });
 


### PR DESCRIPTION
## One-line summary

Removes `client_id` from stub attribution data since UA is now turned off in production.

## Issue / Bugzilla link

#14406

## Testing

Using a browsers with DNT/GPC disabled:

1. Open https://www-demo3.allizom.org/en-US/firefox/new/?geo=us
2. Open Dev Tools -> Application tab -> Cookies
3. Find www-demo3 and the `moz-stub-attribution-code` cookie.
4. Copy the cookie value to clipboard.
5. Run the following command in your terminal:

```
echo -n 'PASTE_COOKIE_VALUE_HERE' | base64 --decode
```

- [x] Verify the decoded attribution data does NOT contain a `client_id` query parameter.
- [x] Verify the decoded attribution data DOES contain a `client_id_ga4` query parameter.