### PR TITLE
Allow Bedrock to boot in prod mode if there is no sqlite DB, but only if DATABASE_URL is defined

### DIFF
--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -6,10 +6,16 @@
 
 # look for the required files and fail quickly if it's not there
 STARTUP_FILES=(
-    "data/bedrock.db"
     "data/last-run-update_locales"
     "data/last-run-download_database"
 )
+# If DATABASE_URL is defined, that means we're using Postgres not sqlite.
+# However, if DATABASE_URL is NOT defined, we need to be sure the sqlite DB file
+# is already present at startup
+if [[ -z "$DATABASE_URL" ]]; then
+    STARTUP_FILES+=("data/bedrock.db")
+fi
+
 for fname in "${STARTUP_FILES[@]}"; do
     if [[ ! -f "$fname" ]]; then
         echo "$fname not found";


### PR DESCRIPTION
Now that Bedrock Dev does not use a sqlite DB because it's on postgres, we're performance tuning and are trying to avoid having a k8s initContainer to copy down the DB before bootup: https://github.com/mozilla-it/webservices-infra/pull/2281 

This also means Bedrock needs to NOT look for that DB file when there's a DATABASE_URL defined