### PR TITLE
Bump VPN client system requirements for macOS and iOS (Fixes #14727)

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -92,7 +92,7 @@
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-mac-long', fallback='vpn-download-for-mac') }}</h2>
             <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-version-requirements', version='10.15') }}</p>
+            <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
             <a class="mzp-c-button" href="{{ url('products.vpn.mac-download') }}" data-cta-type="button" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-primary-mac">
             {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
             </a>
@@ -120,7 +120,7 @@
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-ios-long-v2', fallback='vpn-download-for-ios') }}</h2>
             <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-version-requirements', version='13.0') }}</p>
+            <p>{{ ftl('vpn-download-version-requirements', version='14.0') }}</p>
             <a href="{{ ios_download_url }}" data-cta-type="button" data-cta-text="VPN Download (iOS)" class="platform-download-link">
               <img src="{{ static('img/products/vpn/download/apple-app-store-badge.svg') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
             </a>
@@ -165,7 +165,7 @@
           </div>
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-mac') }}</h2>
-            <p>{{ ftl('vpn-download-version-requirements', version='10.15') }}</p>
+            <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
           </div>
           <a href="{{ url('products.vpn.mac-download') }}" data-cta-type="button" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-secondary-mac">
             <span class="visually-hidden">{{ ftl('vpn-download-for-mac-long') }}</span>
@@ -191,7 +191,7 @@
           </div>
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-ios') }}</h2>
-            <p>{{ ftl('vpn-download-version-requirements', version='13.0') }}</p>
+            <p>{{ ftl('vpn-download-version-requirements', version='14.0') }}</p>
           </div>
           <a href="{{ ios_download_url }}" data-cta-type="button" data-cta-text="VPN Download (iOS)" class="platform-download-link">
             <span class="visually-hidden">{{ ftl('vpn-download-for-ios-long-v2') }}</span>

--- a/bedrock/products/templates/products/vpn/landing.html
+++ b/bedrock/products/templates/products/vpn/landing.html
@@ -291,13 +291,13 @@
         </li>
         <li>
             {% set mac_url='href="%s"'|safe|format(url('products.vpn.platforms.mac')) %}
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-mac-v4', url=mac_url, minversion='10.15') }}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-mac-v4', url=mac_url, minversion='11.0') }}
         </li>
         <li>
             {{ ftl('vpn-landing-faq-compatibility-question-desc-android-v3', url=url('products.vpn.platforms.android')) }}
         </li>
         <li>
-            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v4', url=url('products.vpn.platforms.ios'), version='13.0') }}
+            {{ ftl('vpn-landing-faq-compatibility-question-desc-ios-v4', url=url('products.vpn.platforms.ios'), version='14.0') }}
         </li>
         <li>
           {{ ftl('vpn-landing-faq-compatibility-question-desc-linux-v4', url=url('products.vpn.platforms.linux')) }}


### PR DESCRIPTION
## One-line summary

Bumps system requirements for Mozilla VPN to iOS 14.0 and macOS 11.0 and up.

## Issue / Bugzilla link

#14727

## Testing

- http://localhost:8000/en-US/products/vpn/download/
- http://localhost:8000/en-US/products/vpn/?xv=legacy (see FAQ at bottom of page)