### PR TITLE
Add cursor: pointer to details summary on /cookie-settings/ page (Fixes #14781)

### DIFF
--- a/media/css/privacy/cookie-settings-form.scss
+++ b/media/css/privacy/cookie-settings-form.scss
@@ -80,6 +80,10 @@ main {
 
     .cookie-summary {
         border-bottom: 1px solid $color-light-gray-40;
+
+        &:hover {
+            cursor: pointer;
+        }
     }
 
     .cookie-summary-title {


### PR DESCRIPTION
## One-line summary

Adds `cursor: pointer;` to `<summary>` elements on cookie settings page

## Issue / Bugzilla link

#14781

## Testing

http://localhost:8000/en-US/privacy/websites/cookie-settings/