### PR TITLE
Upgrade to sentry-sdk 2.x

### DIFF
--- a/bin/run-worker.sh
+++ b/bin/run-worker.sh
@@ -5,4 +5,4 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program \
-python manage.py rqworker default image_renditions --max-jobs "${RQ_MAX_JOBS:-5000}"
+python manage.py rqworker default image_renditions --max-jobs "${RQ_MAX_JOBS:-5000}" --sentry-dsn "${SENTRY_DSN}"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -860,10 +860,7 @@ greenlet==3.0.3 \
     --hash=sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf \
     --hash=sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da \
     --hash=sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33
-    # via
-    #   -r requirements/prod.txt
-    #   bpython
-    #   sqlalchemy
+    # via bpython
 h11==0.14.0 \
     --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
     --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
@@ -2036,13 +2033,13 @@ selenium==4.9.1 \
 sentry-processor==0.0.1 \
     --hash=sha256:fd7a30fb57aaf05c01cd04cf7d949c628376b2b55d7a0aaa222efe58a8f122bc
     # via -r requirements/prod.txt
-sentry-sdk==1.44.0 \
-    --hash=sha256:eb65289da013ca92fad2694851ad2f086aa3825e808dc285bd7dcaf63602bb18 \
-    --hash=sha256:f7125a9235795811962d52ff796dc032cd1d0dd98b59beaced8380371cd9c13c
+sentry-sdk==2.7.1 \
+    --hash=sha256:25006c7e68b75aaa5e6b9c6a420ece22e8d7daec4b7a906ffd3a8607b67c037b \
+    --hash=sha256:ef1b3d54eb715825657cd4bb3cb42bb4dc85087bac14c56b0fd8c21abd968c9a
     # via -r requirements/prod.txt
-setuptools==70.2.0 \
-    --hash=sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05 \
-    --hash=sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1
+setuptools==70.1.1 \
+    --hash=sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650 \
+    --hash=sha256:a58a8fde0541dab0419750bcc521fbdf8585f6e5cb41909df3a472ef7b81ca95
     # via
     #   -r requirements/prod.txt
     #   supervisor

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -51,7 +51,7 @@ qrcode==7.4.2
 querystringsafe-base64==1.1.1  # Pinned to maintain stub attribution signatures https://github.com/mozilla/bedrock/issues/11156
 requests>=2.32.3  # min secure version
 rich-text-renderer==0.2.8
-sentry-sdk==1.44.0
+sentry-sdk==2.7.1
 sentry-processor==0.0.1
 supervisor==4.2.5
 timeago==1.0.16

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1538,9 +1538,9 @@ s3transfer==0.10.2 \
 sentry-processor==0.0.1 \
     --hash=sha256:fd7a30fb57aaf05c01cd04cf7d949c628376b2b55d7a0aaa222efe58a8f122bc
     # via -r requirements/prod.in
-sentry-sdk==1.44.0 \
-    --hash=sha256:eb65289da013ca92fad2694851ad2f086aa3825e808dc285bd7dcaf63602bb18 \
-    --hash=sha256:f7125a9235795811962d52ff796dc032cd1d0dd98b59beaced8380371cd9c13c
+sentry-sdk==2.7.1 \
+    --hash=sha256:25006c7e68b75aaa5e6b9c6a420ece22e8d7daec4b7a906ffd3a8607b67c037b \
+    --hash=sha256:ef1b3d54eb715825657cd4bb3cb42bb4dc85087bac14c56b0fd8c21abd968c9a
     # via -r requirements/prod.in
 setuptools==70.1.1 \
     --hash=sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650 \


### PR DESCRIPTION
## One-line summary

Sentry 2.x had some backwards incompatible changes. See the [migration guide](https://docs.sentry.io/platforms/python/migration/1.x-to-2.x)

We didn't end up using anything that changed so there aren't many changes here.

I did notice we need to pass the `--sentry-dsn` to the RQ worker for it to get picked up, so I added that.

- [ ] I used an AI to write some of this code.

