### PR TITLE
Update About "Our Products" sidebar link

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about-base.html
+++ b/bedrock/mozorg/templates/mozorg/about-base.html
@@ -27,7 +27,7 @@
   <div class="side-reference">
     <h4 class="side-reference-title">{{ ftl('about-shared-our-products') }}</h4>
     <p>{{ ftl('about-shared-software-innovations') }}</p>
-    <a class="more" href="{{ url('firefox') }}">{{ ftl('ui-learn-more') }}</a>
+    <a class="more" href="{{ url('products.landing') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
   <div class="side-reference">


### PR DESCRIPTION
## One-line summary

Updates the _"Learn more"_ link in _"Our Products"_ sidebar for all _About_ pages to link to the new `products.landing`.

## Significant changes and points to review

This was still the old location before `/firefox/browsers` moved to `/firefox` and the new `/products` was created for listing all of it.

## Issue / Bugzilla link

#14222

## Testing

http://localhost:8000/mission/