### PR TITLE
Update l10n automation tags and wording

### DIFF
--- a/.github/workflows/routine_l10n_obsolete.yml
+++ b/.github/workflows/routine_l10n_obsolete.yml
@@ -36,7 +36,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: "[bot] Remove obsolete l10n strings and ftl files"
           ASSIGNEES:
-          LABELS: L10N
+          LABELS: L10N,Frontend
           BODY: |
             ### Remove obsolete strings
 
@@ -44,7 +44,7 @@ jobs:
             If you find strings that have no date, either find the date by looking at git history
             or add an expiry date and leave it to be removed in 2 months.
 
-            - [ ] Remove old obsolete strings
+            - [ ] Remove old obsolete strings and their fallback usage
 
             ### Remove obsolete ftl files
 


### PR DESCRIPTION
## One-line summary

Updates the l10n cron to add "Frontend" label as well (+unrelated wording update)

## Significant changes and points to review

ATTN: For the current issue to get closed, it needs to have the "Frontend" tag added too, manually now, as this action uses the tag definition both to open new, but also list the old issue for closing. So for it to work on the currently opened issue ~2months from now, it will only close it if it has both of the labels at that point.

## Issue / Bugzilla link

#14571

## Testing

[runs/9927407215/job/27422314530#step:2:1](https://github.com/janbrasna/gha-cli-cron-test/actions/runs/9927407215/job/27422314530#step:2:1)