### PR TITLE
Remove overdue obsolete strings

### DIFF
--- a/bedrock/base/templates/includes/banners/consent-banner.html
+++ b/bedrock/base/templates/includes/banners/consent-banner.html
@@ -8,7 +8,7 @@
   <div class="moz-consent-banner-content">
     <h2 class="moz-consent-banner-heading">{{ ftl('consent-banner-heading') }}</h2>
     <div class="moz-consent-banner-copy">
-      <p>{{ ftl('consent-banner-body-v2', fallback='consent-banner-body') }}</p>
+      <p>{{ ftl('consent-banner-body-v2') }}</p>
       <div class="moz-consent-banner-controls">
         <button type="button" id="moz-consent-banner-button-accept" class="moz-consent-banner-button moz-consent-banner-button-accept" data-testid="consent-banner-accept-button">
           {{ ftl('consent-banner-button-accept') }}

--- a/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
@@ -65,7 +65,7 @@
             <section class="c-menu-item mzp-has-icon">
               <a class="c-menu-item-link" href="https://blog.mozilla.org/firefox/?{{ utm_params }}" data-link-text="Firefox Blog" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
-                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-blog', fallback='navigation-firefox-blog') }}</h4>
+                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-blog') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-read-about-new-firefox-features', fallback='navigation-read-about-new-firefox') }}</p>
               </a>
             </section>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -124,7 +124,7 @@
       {% if intro_text %}
         {{ intro_text }}
       {% else %}
-        {{ ftl('fxa-form-enter-your-email-v2', fallback='fxa-form-enter-your-email') }}
+        {{ ftl('fxa-form-enter-your-email-v2') }}
       {% endif %}
       </p>
     </header>

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -374,7 +374,7 @@
     <li>
       <h2 class="c-help-title">{{ ftl('firefox-all-arm64-installers') }}</h2>
       <p class="c-help-desc">
-        {{ ftl('firefox-all-arm64-installers-optimized-v2', fallback='firefox-all-arm64-installers-optimized') }}
+        {{ ftl('firefox-all-arm64-installers-optimized-v2') }}
       </p>
     </li>
   </ul>

--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -29,7 +29,7 @@
   <section class="mzp-l-content mzp-t-content-md t-center">
       <div class="mzp-c-logo mzp-t-logo-xl mzp-t-product-developer mzp-l-logo-center"></div>
       <h1>
-        {{ ftl('firefox-developer-welcome-to-firefox-developer-edition', fallback='firefox-developer-welcome-to-firefox-browser') }}
+        {{ ftl('firefox-developer-welcome-to-firefox-developer-edition') }}
       </h1>
   </section>
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-mdnplus.html
@@ -25,7 +25,7 @@
   <section class="c-mdn-header mzp-t-dark">
     <div class="mzp-l-content mzp-t-content-md c-mdn-header-content">
       <div class="mzp-c-notification-bar mzp-t-success">
-        <p>{{ ftl('developer-mdnplus-congrats-you-now-have-latest-v2', fallback='developer-mdnplus-congrats-you-now-have-latest') }}</p>
+        <p>{{ ftl('developer-mdnplus-congrats-you-now-have-latest-v2') }}</p>
       </div>
 
       <h1 class="c-mdn-header-title">{{ ftl('developer-mdnplus-more-mdn-your-mdn') }}</h1>

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -25,7 +25,7 @@
 <main class="mzp-t-dark">
   <div class="mzp-l-content mzp-t-content-md t-center">
     <div class="mzp-c-logo mzp-t-logo-xl mzp-t-product-developer mzp-l-logo-center"></div>
-    <h1>{{ ftl('firefox-developer-congrats-you-now-have-latest-v2', fallback='firefox-developer-congrats-you-now-have-latest') }}</h1>
+    <h1>{{ ftl('firefox-developer-congrats-you-now-have-latest-v2') }}</h1>
     {% set attrs = 'href="' ~ url('firefox.notes', channel='aurora') ~ '"' %}
     {% if LANG.startswith('en-') %}
       <p>View the <a {{ attrs|safe }}>release notes</a> to see what’s new.</p>

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -46,10 +46,10 @@
 <div class="mzp-l-content">
   <div class="mzp-l-card-half">
     {{ card (
-      title=ftl('features-index-firefox-keeps-getting-faster', fallback='features-index-is-firefox-a-fast-browser'),
+      title=ftl('features-index-firefox-keeps-getting-faster'),
       ga_title="Firefox keeps getting faster",
       aspect_ratio="mzp-has-aspect-16-9",
-      desc=ftl('features-index-the-latest-browser-speed-benchmarks', fallback='features-index-firefox-uses-less-memory-than'),
+      desc=ftl('features-index-the-latest-browser-speed-benchmarks'),
       image=resp_img(
         url="img/firefox/features/fast.png",
         srcset={
@@ -164,7 +164,7 @@
       link=url('firefox.features.translate'),
       title=ftl('features-index-translate-the-web'),
       ga_title="Translate the Web",
-      desc=ftl('features-index-translate-websites-to-your', fallback='features-index-translate-more-than'),
+      desc=ftl('features-index-translate-websites-to-your'),
     ) }}
 
     {{ feature_item(

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -13,7 +13,7 @@
 <p>{{ ftl('password-manager-firefox-securely-stores-your') }}</p>
 
 {% set fxa = 'href="%s"'|safe|format(url('mozorg.account')) %}
-<p>{{ ftl('password-manager-with-a-free-mozilla-account-v2', fallback='password-manager-with-a-free-firefox-account', fxa=fxa) }}</p>
+<p>{{ ftl('password-manager-with-a-free-mozilla-account-v2', fxa=fxa) }}</p>
 
 <h2>{{ ftl('password-manager-password-autofill-for-easy-logins') }}</h2>
 <p>{{ ftl('password-manager-firefox-can-automatically-fill-in') }}</p>

--- a/bedrock/firefox/templates/firefox/features/pdf-editor.html
+++ b/bedrock/firefox/templates/firefox/features/pdf-editor.html
@@ -7,7 +7,7 @@
 {% extends "firefox/features/base-article.html" %}
 
 {% block article_title_short %}{{ ftl('pdf-editor-pdf-editor') }}{% endblock %}
-{% block article_title %}{{ ftl('pdf-editor-add-text-to-pdfs-v2', fallback='pdf-editor-add-text-to-pdfs') }}{% endblock %}
+{% block article_title %}{{ ftl('pdf-editor-add-text-to-pdfs-v2') }}{% endblock %}
 {% block page_desc %}{{ ftl('pdf-editor-view-and-edit-pdf-files-right-in') }}{% endblock %}
 
 {% block article_content %}

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -13,7 +13,7 @@
 <p>{{ ftl('features-private-browsing-if-you-share-a-computer') }}</p>
 
 <h2>{{ ftl('features-private-browsing-what-does-private-browsing-do') }}</h2>
-<p>{{ ftl('features-private-browsing-private-browsing-mode-opens-v2', fallback='features-private-browsing-private-browsing-mode-opens') }}</p>
+<p>{{ ftl('features-private-browsing-private-browsing-mode-opens-v2') }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/bedrock/firefox/templates/firefox/features/sync.html
+++ b/bedrock/firefox/templates/firefox/features/sync.html
@@ -13,7 +13,7 @@
 <p>{{ ftl('features-sync-with-firefox-you-can-pick-up-where') }}</p>
 
 {% set fxa = 'href="%s"'|safe|format(url('mozorg.account')) %}
-<p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account-v3', fallback='features-sync-sign-up-for-a-free-firefox-account', fxa=fxa) }}</p>
+<p>{{ ftl('features-sync-sign-up-for-a-free-mozilla-account-v3', fxa=fxa) }}</p>
 
 <figure class="c-article-figure">
   {{ resp_img(

--- a/bedrock/firefox/templates/firefox/index.html
+++ b/bedrock/firefox/templates/firefox/index.html
@@ -53,11 +53,11 @@
     {% if ftl_has_messages('firefox-browsers-main-heading') %}
       <h1>{{ ftl('firefox-browsers-main-heading') }}</h1>
       <h2 class="mzp-has-zap-11">
-        {{ ftl('firefox-browsers-get-the-browsers-strong-v2', fallback='firefox-browsers-get-the-browsers-strong') }}
+        {{ ftl('firefox-browsers-get-the-browsers-strong-v2') }}
       </h2>
     {% else %}
       <h1 class="mzp-has-zap-11">
-        {{ ftl('firefox-browsers-get-the-browsers-strong-v2', fallback='firefox-browsers-get-the-browsers-strong') }}
+        {{ ftl('firefox-browsers-get-the-browsers-strong-v2') }}
       </h1>
     {% endif %}
   </header>

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -66,7 +66,7 @@
         <img src="{{ static('protocol/img/logos/firefox/browser/logo-word-hor.svg') }}" alt="{{ ftl('installer-help-firefox-release-title') }}" width="347" height="64" class="mzp-c-card-image">
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
-            {{ ftl('installer-help-firefox-release-desc-v2', fallback='installer-help-firefox-release-desc', trackers=2000) }}
+            {{ ftl('installer-help-firefox-release-desc-v2', trackers=2000) }}
           </p>
           {{ download_firefox(platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang, button_class='mzp-t-secondary mzp-t-md', alt_copy=ftl('download-button-download-now')) }}
         </div>

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -531,7 +531,7 @@
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-sync-your-devices') }}</h3>
         {% set available_attrs = fxa_link_fragment(entrypoint='mozilla.org-firefox-desktop') %}
 
-        <p>{{ ftl('firefox-desktop-download-firefox-is-available-v2', fallback='firefox-desktop-download-firefox-is-available', attrs=available_attrs) }}</p>
+        <p>{{ ftl('firefox-desktop-download-firefox-is-available-v2', attrs=available_attrs) }}</p>
       </div>
 
       <div class="mzp-c-card js-animate">

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -61,7 +61,7 @@
 
       <p>{{ ftl('nightly-whatsnew-this-is-a-good') }}</p>
 
-      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v3', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mozilla.social/@FirefoxNightly"', fallback='nightly-whatsnew-if-you-want-to-v2') }}</p>
+      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v3', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mozilla.social/@FirefoxNightly"') }}</p>
 
       <p>
           {% set attrs = 'href="#" class="nightly-experiments-link"' %}

--- a/bedrock/firefox/templates/firefox/set-as-default/thanks.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/thanks.html
@@ -78,9 +78,9 @@
 
       <section class="thanks-extra-links-item join">
         <h2 class="thanks-extra-links-heading">
-          {{ ftl('set-as-default-create-an-account', fallback='set-as-default-thanks-join-firefox') }}
+          {{ ftl('set-as-default-create-an-account') }}
         </h2>
-        <p>{{ ftl('set-as-default-thanks-sign-up-for-a-free-account-v2', fallback='set-as-default-thanks-sign-up-for-a-free-account') }}</p>
+        <p>{{ ftl('set-as-default-thanks-sign-up-for-a-free-account-v2') }}</p>
         <a href="{{ url('mozorg.account') }}">{{ ftl('set-as-default-thanks-get-an-account') }}</a>
       </section>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/includes/release-notes.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/release-notes.html
@@ -7,11 +7,5 @@
 <aside class="mzp-l-content c-utilities">
   {% set releasenotes_url = url('firefox.releases.index') if not version else '/firefox/%s/releasenotes/'|format(version) %}
   {% set releasenotes_link = 'href="%s" target="_blank"'|safe|format(releasenotes_url) %}
-
-  {% if ftl_has_messages('whatsnew-release-notes-v2') %}
-    <p>{{ ftl('whatsnew-release-notes-v2', url=releasenotes_link) }}</p>
-  {% else %}
-    <p>{{ ftl('whatsnew-release-notes', url=releasenotes_url) }}</p>
-  {% endif %}
-
+  <p>{{ ftl('whatsnew-release-notes-v2', url=releasenotes_link) }}</p>
 </aside>

--- a/bedrock/firefox/templates/firefox/whatsnew/index-thanks.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-thanks.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 {% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx125-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx125-eu.html
@@ -7,7 +7,7 @@
 {% from "macros-protocol.html" import split with context %}
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx125-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx125-na.html
@@ -7,7 +7,7 @@
 {% from "macros-protocol.html" import split with context %}
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-eu.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 {% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx126-na.html
@@ -8,7 +8,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx127-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx127-eu.html
@@ -9,7 +9,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 {% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx127-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx127-na.html
@@ -8,7 +8,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx128-eu-addons.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx128-eu-addons.html
@@ -8,7 +8,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx128-eu-donate.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx128-eu-donate.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
@@ -112,4 +112,3 @@
 </section>
 
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx128-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx128-na.html
@@ -9,7 +9,7 @@
 
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
+{% block page_title %}{{ ftl('whatsnew-page-title-v2') }}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -70,7 +70,7 @@
       )}}
       {{ card(
           class='mzp-c-card-medium',
-          title=ftl('about-talking-tech-issues-irl', fallback='about-talking-internet-issues-irl'),
+          title=ftl('about-talking-tech-issues-irl'),
           ga_title='Talking Internet Issues IRL',
           desc=ftl('about-in-mozillas-multi-award-winning', fallback='about-in-mozillas-irl-podcast-host'),
           image=resp_img('img/mozorg/about/irl.png', srcset={"img/mozorg/about/irl-high-res.png": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -72,7 +72,7 @@
           class='mzp-c-card-medium',
           title=ftl('about-talking-tech-issues-irl'),
           ga_title='Talking Internet Issues IRL',
-          desc=ftl('about-in-mozillas-multi-award-winning', fallback='about-in-mozillas-irl-podcast-host'),
+          desc=ftl('about-in-mozillas-multi-award-winning'),
           image=resp_img('img/mozorg/about/irl.png', srcset={"img/mozorg/about/irl-high-res.png": "2x"}, optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
           aspect_ratio='mzp-has-aspect-3-2',
           link_url='https://irlpodcast.org/'

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -78,7 +78,7 @@
     ) %}
       <p>
         <a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-text="X (formerly Twitter)" aria-label="{{ ftl('manifesto-share-on-x-aria-label') }}">
-          {{ ftl('manifesto-share-on-x', fallback='manifesto-share-on-twitter') }}
+          {{ ftl('manifesto-share-on-x') }}
         </a>
       </p>
     {% endcall %}
@@ -131,7 +131,7 @@
           </li>
         </ol>
         <footer class="content principles-foot">
-          <p><a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-text="Twitter" aria-label="{{ ftl('manifesto-share-on-x-aria-label') }}">{{ ftl('manifesto-share-on-x', fallback='manifesto-share-on-twitter') }}</a></p>
+          <p><a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', ftl('manifesto-i-support-the-vision-of')) }}" data-link-type="social share" data-link-text="Twitter" aria-label="{{ ftl('manifesto-share-on-x-aria-label') }}">{{ ftl('manifesto-share-on-x') }}</a></p>
           <p><a class="mzp-c-cta-link" href="{{ url('mozorg.about.manifesto-details') }}">{{ ftl('manifesto-read-the-entire-manifesto') }}</a></p>
         </footer>
       </section>

--- a/bedrock/mozorg/templates/mozorg/account.html
+++ b/bedrock/mozorg/templates/mozorg/account.html
@@ -11,9 +11,9 @@
 {% set _entrypoint = 'mozilla.org-firefox-accounts' %}
 {% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=account' %}
 
-{% block page_title %}{{ ftl('mozilla-accounts-get-a-mozilla-account', fallback='firefox-accounts-get-a-firefox-account') }}{% endblock %}
+{% block page_title %}{{ ftl('mozilla-accounts-get-a-mozilla-account') }}{% endblock %}
 
-{% block page_desc %}{{ ftl('mozilla-accounts-securely-sync-your', fallback='firefox-accounts-securely-sync-your') }}{% endblock %}
+{% block page_desc %}{{ ftl('mozilla-accounts-securely-sync-your') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('protocol-emphasis-box') }}
@@ -53,7 +53,7 @@
         </div>
 
         <div class="c-manage">
-          <p>{{ ftl('mozilla-accounts-already', fallback='firefox-accounts-already') }}</p>
+          <p>{{ ftl('mozilla-accounts-already') }}</p>
           <a href="https://accounts.firefox.com/settings" id="manage" data-testid="manage-account-link">{{ ftl('firefox-accounts-manage') }}</a>
         </div>
       </div>
@@ -61,7 +61,7 @@
     <div class="mzp-c-split-body">
       <h1 class="accounts-header">{{ ftl('mozilla-account-header') }}</h1>
       <div class="accounts-products">
-        <h2>{{ ftl('mozilla-account-sign-in-to', fallback='firefox-accounts-sign-in-to') }}</h2>
+        <h2>{{ ftl('mozilla-account-sign-in-to') }}</h2>
 
         <a href="{{ url('firefox') }}"><h4 class="mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-firefox">{{ ftl('firefox-accounts-firefox-browser') }}</h4></a>
         <ul class="mzp-u-list-styled">

--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -115,7 +115,7 @@
       <blockquote>
         <p>{{ ftl('home-the-health-of') }}
         </p>
-        <cite>{{ ftl('home-mitchell-baker-v2', fallback="home-mitchell-baker") }}</cite>
+        <cite>{{ ftl('home-mitchell-baker-v2') }}</cite>
       </blockquote>
     </div>
   </div>
@@ -182,7 +182,7 @@
       <!-- Relay -->
       {% call picto(
         base_el='li',
-        title=ftl('home-product-relay-hide-your', fallback='home-product-relay-masks'),
+        title=ftl('home-product-relay-hide-your'),
         image=resp_img(
           url='protocol/img/logos/firefox/relay/logo-white.svg',
           optional_attributes={
@@ -218,7 +218,7 @@
       <!-- Monitor -->
       {% call picto(
         base_el='li',
-        title=ftl('home-product-monitor-protect-your', fallback='home-product-monitor-data'),
+        title=ftl('home-product-monitor-protect-your'),
         image=resp_img(
           url='protocol/img/logos/firefox/monitor/logo.svg',
           optional_attributes={
@@ -289,8 +289,8 @@
         ),
         media_after=False
     ) %}
-    <h2>{{ ftl('home-so-what-is-mozilla', fallback='home-is-mozilla-a-corporation')}}</h2>
-    <p>{{ ftl('home-at-its-core', fallback='home-mozilla-consists-of', ventures=moz_ventures, mozai=moz_ai) }}</p>
+    <h2>{{ ftl('home-so-what-is-mozilla') }}</h2>
+    <p>{{ ftl('home-at-its-core', ventures=moz_ventures, mozai=moz_ai) }}</p>
     <a href="https://foundation.mozilla.org/{{ utm_params }}" rel="external noopener" class="mzp-c-button">
       {{ ftl('home-learn-about-mofo') }}
     </a>

--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -110,7 +110,7 @@
   },
   "mozilla-accounts": {
     "description": "{{ ftl('newsletters-get-tips-from-mozilla')|striptags }}",
-    "title": "{{ ftl('newsletters-mozilla-accounts', fallback='newsletters-firefox-accounts')|striptags }}"
+    "title": "{{ ftl('newsletters-mozilla-accounts')|striptags }}"
   },
   "mozilla-and-you": {
     "description": "{{ ftl('newsletters-get-how-tos')|striptags }}",

--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -66,7 +66,7 @@
         <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-type="footer" data-link-text="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
         <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-text="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
         <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-text="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
-        <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@firefox)">{{ ftl('opt-out-confirmation-x-formerly-twitter', fallback='opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>
+        <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@firefox)">{{ ftl('opt-out-confirmation-x-formerly-twitter') }}<span> (@firefox)</span></a></li>
       </ul>
     </aside>
   </div>{#-- /.content --#}

--- a/bedrock/privacy/templates/privacy/cookie-settings.html
+++ b/bedrock/privacy/templates/privacy/cookie-settings.html
@@ -46,7 +46,7 @@
 
       <p>{{ ftl('cookie-settings-explainer') }}</p>
 
-      <p>{{ ftl('cookie-settings-page-intro-v2', fallback='cookie-settings-page-intro') }}</p>
+      <p>{{ ftl('cookie-settings-page-intro-v2') }}</p>
     </header>
 
     <form class="cookie-consent-form">

--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -45,7 +45,7 @@
   <header class="mzp-l-content">
     <h1>{{ ftl('firefox-products-products') }}</h1>
     <p>
-      {{ ftl('firefox-products-firefox-beginning-v2', fallback='firefox-products-firefox-beginning') }}
+      {{ ftl('firefox-products-firefox-beginning-v2') }}
       {{ ftl('firefox-products-mozillas-family-of-products-sentence', fallback='firefox-products-mozillas-family-of-products') }}
     </p>
   </header>
@@ -216,7 +216,7 @@
       ),
     ) %}
     <h3 class="mzp-c-picto-heading"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" data-cta-type="link" data-cta-text="Pocket" data-cta-position="heading">{{ ftl('firefox-products-pocket') }}</a></h3>
-      <p>{{ ftl('firefox-products-discover-the-best-content-v2', fallback='firefox-products-discover-the-best-content') }}</p>
+      <p>{{ ftl('firefox-products-discover-the-best-content-v2') }}</p>
       <p class="show-else"><a href="https://getpocket.com/signup{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-secondary" data-cta-type="link" data-cta-text="Pocket sign up">{{ ftl('firefox-products-get-pocket') }} {{ icon_external|safe }}</a></p>
       <p class="show-android">{{ google_play_button(href=pocket_android_url, id='playStoreLink-pocket') }}</p>
       <p class="show-ios">{{ apple_app_store_button(href=pocket_ios_url, id='appStoreLink-pocket') }}</p>

--- a/bedrock/products/templates/products/vpn/includes/download-faq.html
+++ b/bedrock/products/templates/products/vpn/includes/download-faq.html
@@ -23,13 +23,13 @@
       <summary>
         <h3>{{ ftl('vpn-download-faq-working') }}</h3>
       </summary>
-      <p>{{ ftl('vpn-download-faq-visual-indicators-v2', fallback='vpn-download-faq-visual-indicators', connected='https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected', monitor='https://monitor.mozilla.org/') }}</p>
+      <p>{{ ftl('vpn-download-faq-visual-indicators-v2', connected='https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected', monitor='https://monitor.mozilla.org/') }}</p>
     </details>
     <details>
       <summary>
         <h3>{{ ftl('vpn-download-faq-add-device') }}</h3>
       </summary>
-      <p>{{ ftl('vpn-download-faq-adding-another-v3', fallback='vpn-download-faq-adding-another-v2', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
+      <p>{{ ftl('vpn-download-faq-adding-another-v3', subscription='https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription') }}</p>
     </details>
     <details>
       <summary>

--- a/bedrock/products/templates/products/vpn/more/what-is-a-vpn.html
+++ b/bedrock/products/templates/products/vpn/more/what-is-a-vpn.html
@@ -62,6 +62,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <p>{{ ftl('vpn-what-is-vpns-can-be', mozvpn=url('products.vpn.landing')) }}</p>
 
 <h3>{{ ftl('vpn-what-is-mozilla-vpn-fast') }}</h3>
-<p>{{ ftl('vpn-what-is-mozilla-vpn-is-a-v3', fallback='vpn-what-is-mozilla-vpn-is-a',
+<p>{{ ftl('vpn-what-is-mozilla-vpn-is-a-v3',
   mozvpn=url('products.vpn.landing')) }}</p>
 {% endblock %}

--- a/l10n/en/banners/consent-banner.ftl
+++ b/l10n/en/banners/consent-banner.ftl
@@ -7,9 +7,6 @@
 consent-banner-heading = Help us improve your { -brand-name-mozilla } experience
 consent-banner-body-v2 = In addition to Cookies necessary for this site to function, we’d like your permission to set some additional Cookies to better understand your browsing needs and improve your experience. Rest assured — we value your privacy.
 
-# Obsolete string (expires: 2024-07-22)
-consent-banner-body = In addition to cookies necessary for this site to function, we’d like your permission to set some additional Cookies to better understand your browsing needs and improve your experience. Rest assured — we value your privacy.
-
 consent-banner-button-reject = Reject All Additional Cookies
 consent-banner-button-accept = Accept All Additional Cookies
 consent-banner-settings-link = Cookie settings

--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -58,12 +58,6 @@ download-a-different-build = Download a different build
 
 ## Linux
 
-# Obsolete string
-download-button-linux-32 = Download { -brand-name-linux } 32-bit
-
-# Obsolete string
-download-button-linux-64 = Download { -brand-name-linux } 64-bit
-
 download-button-linux-32-v2 = Download for Linux 32-bit
 download-button-linux-64-v2 = Download for Linux 64-bit
 

--- a/l10n/en/firefox/accounts.ftl
+++ b/l10n/en/firefox/accounts.ftl
@@ -7,21 +7,12 @@
 # HTML page title
 mozilla-accounts-get-a-mozilla-account = Get a { -brand-name-mozilla-account } – Keep your data private, safe and synced
 
-# Obsolete string
-firefox-accounts-get-a-firefox-account = Get a { -brand-name-firefox-account } – Keep your data private, safe and synced
-
-# Obsolete string
-firefox-accounts-securely-sync-your = Securely sync your passwords, bookmarks and tabs across all your devices. Get a { -brand-name-firefox-account } now – One login – Power and privacy everywhere.
-
 # HTML page description
 mozilla-accounts-securely-sync-your = Securely sync your passwords, bookmarks and tabs across all your devices. Get a { -brand-name-mozilla-account } now – One login – Power and privacy everywhere.
 
 firefox-accounts-enter-your-email-address = Enter your email address to get started.
 firefox-accounts-already-have-an-account = Already have an account?
 firefox-accounts-sign-in = Sign In
-
-# Obsolete string
-firefox-accounts-already = You already have a { -brand-name-firefox-account }. Congrats!
 
 mozilla-accounts-already = You already have a { -brand-name-mozilla-account }. Congrats!
 firefox-accounts-manage = Manage your account
@@ -30,12 +21,6 @@ mozilla-account-header = { -brand-name-mozilla-account }
 
 # This is followed by a list of things you can do with your Mozilla account
 mozilla-account-sign-in-to = Sign in to your { -brand-name-mozilla-account } to:
-
-# Obsolete string
-firefox-accounts-sign-in-to = Sign in to your { -brand-name-firefox-account } to:
-
-# Obsolete string
-firefox-accounts-meet-our-family-of = Meet our family of privacy-first products.
 
 # Variables:
 #   $send (url) - link to https://blog.mozilla.org/en/products/firefox/firefox-tips/firefox-secret-tips/#send-tabs

--- a/l10n/en/firefox/all.ftl
+++ b/l10n/en/firefox/all.ftl
@@ -41,9 +41,6 @@ firefox-all-windows-installers-for = Windows installers for corporate IT that si
 firefox-all-arm64-installers = ARM64/AArch64 installers
 firefox-all-arm64-installers-optimized-v2 = ARM64/AArch64 installers optimized for Windows and Linux PCs.
 
-# Obsolete string (expires: 2024-06-04)
-firefox-all-arm64-installers-optimized = ARM64/AArch64 installers optimized for Snapdragon-powered { -brand-name-windows } PCs.
-
 firefox-all-product-send-link = Send a download link to your phone
 
 # Variables:

--- a/l10n/en/firefox/browsers.ftl
+++ b/l10n/en/firefox/browsers.ftl
@@ -12,10 +12,6 @@ firefox-browsers-page-desc = Choose from Desktop, { -brand-name-ios }, { -brand-
 
 firefox-browsers-main-heading = { -brand-name-firefox } Browsers
 
-# Obsolete string
-# The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
-firefox-browsers-get-the-browsers-strong = Get the <strong>browsers</strong> that put your privacy first — and always have
-
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
 firefox-browsers-get-the-browsers-strong-v2 = Get the browser that puts your privacy first — and <strong>always</strong> has
 firefox-browsers-desktop = Desktop

--- a/l10n/en/firefox/browsers/mobile/index.ftl
+++ b/l10n/en/firefox/browsers/mobile/index.ftl
@@ -24,15 +24,9 @@ browsers-mobile-looking-for-a-streamlined = Looking for a streamlined, super fas
 browsers-mobile-compare = Compare
 browsers-mobile-see-how-firefox-for-desktop-stacks-v2 = See how { -brand-name-firefox } for desktop stacks up to other browsers.
 
-# Obsolete string (expires 30 June 2024)
-browsers-mobile-see-how-firefox-for-desktop-stacks = See how { -brand-name-firefox } for desktop stacks up to seven other browsers.
-
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words; please omit the strong tags if they need to be around multiple words in your language.
 browsers-mobile-see-how-firefox-for-desktop-strong-v2 = See how { -brand-name-firefox } for <strong>desktop</strong> stacks up to other browsers.
 
-# Obsolete string (expires 30 June 2024)
-# The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words; please omit the strong tags if they need to be around multiple words in your language.
-browsers-mobile-see-how-firefox-for-desktop-strong = See how { -brand-name-firefox } for <strong>desktop</strong> stacks up to seven other browsers.
 browsers-mobile-download = Download
 browsers-mobile-android = { -brand-name-android }
 browsers-mobile-ios = { -brand-name-ios }

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -10,8 +10,6 @@ firefox-developer-page-title = { -brand-name-firefox-developer-edition }
 firefox-developer-firefox-developer-edition-desc = { -brand-name-firefox-developer-edition } is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging
 firefox-developer-firefox-developer-edition = { -brand-name-firefox-developer-edition }
 
-# Obsolete string (expires: 2024-05-14)
-firefox-developer-firefox-browser = { -brand-name-firefox-browser } { -brand-name-developer-edition }
 firefox-developer-welcome-to-your-new-favorite = Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.
 firefox-developer-speak-up = Speak up
 firefox-developer-feedback-makes-us = Feedback makes us better. Tell us how we can improve the browser and Developer tools.
@@ -76,16 +74,11 @@ firefox-developer-download-the-firefox-browser = Download the { -brand-name-fire
 firefox-developer-firefox-has-been-rebuilt = { -brand-name-firefox } has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.
 firefox-developer-welcome-to-firefox-developer-edition = Welcome to { -brand-name-firefox-developer-edition }
 
-# Obsolete string (expires: 2024-05-14)
-firefox-developer-welcome-to-firefox-browser = Welcome to { -brand-name-firefox-browser } { -brand-name-developer-edition }
 firefox-developer-made-for-developers = The browser made for developers
 firefox-developer-all-the-latest-v2 = All the latest developer tools in beta in addition to features like the Multi-line Console Editor and WebSocket Inspector.
 firefox-developer-a-separate-profile = A <strong>separate profile and path</strong> so you can easily run it alongside Release or { -brand-name-beta } { -brand-name-firefox }.
 firefox-developer-preferences-tailored = Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.
 firefox-developer-congrats-you-now-have-latest-v2 = You now have the latest version of { -brand-name-firefox-developer-edition }.
-
-# Obsolete string (expires: 2024-05-14)
-firefox-developer-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox-browser } { -brand-name-developer-edition }.
 
 # Variables:
 #   $attrs (string) - link to the most recent Firefox Developer Edition release notes

--- a/l10n/en/firefox/features/index-2023.ftl
+++ b/l10n/en/firefox/features/index-2023.ftl
@@ -12,12 +12,6 @@ features-index-firefox-is-the-fast-lightweight = { -brand-name-firefox } is the 
 
 features-index-firefox-keeps-getting-faster = { -brand-name-firefox } keeps getting faster
 features-index-the-latest-browser-speed-benchmarks = The latest browser speed benchmarks prove { -brand-name-firefox } is faster than ever.
-
-# Obsolete string
-features-index-is-firefox-a-fast-browser = Is { -brand-name-firefox } a fast browser?
-
-# Obsolete string
-features-index-firefox-uses-less-memory-than = { -brand-name-firefox } uses less memory than Chrome, so your other programs can keep running at top speed.
 features-index-is-firefox-a-private-browser = Is { -brand-name-firefox } a private browser?
 features-index-were-focused-on-your-right-to = We’re focused on your right to privacy. Your data, your web activity, your life online is protected with { -brand-name-firefox }.
 features-index-free-password-manager = Free password manager
@@ -46,8 +40,5 @@ features-index-firefox-automatically-blocks = { -brand-name-firefox } automatica
 features-index-ditch-the-sticky-ads = Ditch the sticky ads following you around with { -brand-name-firefox}’s built-in fingerprinting blockers.
 features-index-translate-the-web = Translate the web
 features-index-translate-websites-to-your = Translate websites to your language directly in your { -brand-name-firefox } browser – without sharing your data with anyone else.
-
-# Obsolete string
-features-index-translate-more-than = Translate from more than 100 languages to your language directly in your { -brand-name-firefox } browser — easier than ever.
 features-index-picture-in-picture = Picture-in-Picture
 features-index-got-things-to-do = Got things to do and things to watch? Do both using Picture-in-Picture in { -brand-name-firefox }.

--- a/l10n/en/firefox/features/password-manager-2023.ftl
+++ b/l10n/en/firefox/features/password-manager-2023.ftl
@@ -16,16 +16,6 @@ password-manager-firefox-securely-stores-your = { -brand-name-firefox } securely
 #   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
 password-manager-with-a-free-mozilla-account-v2 = With a <a { $fxa }>free { -brand-name-mozilla-account }</a> you can securely sync your passwords across all your devices. You can also access all of { -brand-name-mozilla }’s other privacy-respecting products.
 
-# Obsolete string
-# Variables:
-#   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
-password-manager-with-a-free-mozilla-account = With a <a href="{ $fxa }">free { -brand-name-mozilla-account }</a> you can securely sync your passwords across all your devices.
-
-# Obsolete string
-# Variables:
-#   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
-password-manager-with-a-free-firefox-account = With a <a href="{ $fxa }">free { -brand-name-firefox } account</a> you can securely sync your passwords across all your devices.
-
 password-manager-password-autofill-for-easy-logins = Password autofill for easy logins
 password-manager-firefox-can-automatically-fill-in = { -brand-name-firefox } can automatically fill in your saved username and password. If you have more than one login for a site, you can just select the account you want and we’ll take it from there.
 

--- a/l10n/en/firefox/features/pdf-editor-2023.ftl
+++ b/l10n/en/firefox/features/pdf-editor-2023.ftl
@@ -7,9 +7,6 @@
 # Short title used in the subnav
 pdf-editor-pdf-editor = PDF Editor
 
-# Obsolete string (expires: 2024-06-17)
-pdf-editor-add-text-to-pdfs = Add text to PDFs with { -brand-name-firefox } PDF Editor
-
 # page title
 pdf-editor-add-text-to-pdfs-v2 = Edit PDFs for free with { -brand-name-firefox } PDF Editor
 

--- a/l10n/en/firefox/features/private-browsing-2023.ftl
+++ b/l10n/en/firefox/features/private-browsing-2023.ftl
@@ -15,8 +15,6 @@ features-private-browsing-firefox-protects = { -brand-name-firefox } protects yo
 features-private-browsing-if-you-share-a-computer = If you share a computer with other people or if you want to limit how much data websites can collect about you, you can use private browsing mode in { -brand-name-firefox }. Private browsing erases the digital tracks you leave behind when you browse online — think of them like footprints through the woods.
 features-private-browsing-what-does-private-browsing-do = What does private browsing do?
 features-private-browsing-private-browsing-mode-opens-v2 = Private browsing mode opens a new browser window. When you close the last private browsing window, your browsing history and any tracking cookies from websites you visited will be erased. <strong>{ -brand-name-firefox } Pro Tip:</strong> Don’t forget to close all your private browsing windows when you’re done!
-# Obsolete string (expires: 2024-07-18)
-features-private-browsing-private-browsing-mode-opens = Private browsing mode opens a new browser window. When you close it, your browsing history for that window and any tracking cookies from websites you visited will be erased. <strong>{ -brand-name-firefox } Pro Tip:</strong> Don’t forget to close the private browsing window when you’re done!
 
 # Used as an accessible text alternative for an image
 features-private-browsing-a-firefox-window-in-private = A { -brand-name-firefox } browser window in private browsing mode.

--- a/l10n/en/firefox/features/sync-2023.ftl
+++ b/l10n/en/firefox/features/sync-2023.ftl
@@ -14,9 +14,6 @@ features-sync-with-firefox-you-can-pick-up-where = With { -brand-name-firefox },
 #   $fxa (url) = link to https://www.mozilla.org/firefox/accounts/
 features-sync-sign-up-for-a-free-mozilla-account-v3 = <a { $fxa }>Sign up for a free { -brand-name-mozilla-account }</a> and you’ll be able to sync your data everywhere you use { -brand-name-firefox } and other { -brand-name-mozilla } products.
 
-# Obsolete string
-features-sync-sign-up-for-a-free-firefox-account = <a href="{ $fxa }">Sign up for a free { -brand-name-firefox } account</a> and you’ll be able to sync your data everywhere you use your { -brand-name-firefox } browser.
-
 # Variables:
 #   $privacy (url) = link to https://www.mozilla.org/firefox/privacy/
 features-sync-all-your-data-is-encrypted-on-our = All your data is encrypted on our servers so we can’t read it – only you can access it. We don’t sell your info to advertisers because that would go against our <a href="{ $privacy }">data privacy promise</a>.

--- a/l10n/en/firefox/installer-help.ftl
+++ b/l10n/en/firefox/installer-help.ftl
@@ -19,11 +19,6 @@ installer-help-firefox-release-title = { -brand-name-firefox-browser }
 #   $trackers (number) - number of trackers blocked by Firefox (currently in the thousands)
 installer-help-firefox-release-desc-v2 = Get the latest. Automatic privacy is here. Download { -brand-name-firefox } to block over { $trackers } trackers.
 
-# Obsolete string (expires: 2024-05-14)
-# Variables:
-#   $trackers (number) - number of trackers blocked by Firefox (currently in the thousands)
-installer-help-firefox-release-desc = Get the latest. Automatic privacy is here. Download { -brand-name-firefox-browser } to block over { $trackers } trackers.
-
 installer-help-firefox-beta-title-v2 = { -brand-name-firefox } { -brand-name-beta }
 installer-help-firefox-beta-desc = Test about-to-be released features in the most stable pre-release build.
 installer-help-firefox-developer-title-v2 = { -brand-name-firefox } { -brand-name-developer-edition }

--- a/l10n/en/firefox/more.ftl
+++ b/l10n/en/firefox/more.ftl
@@ -34,9 +34,6 @@ new-school-meets = New school meets old school with the fastest browser yet.
 firefox-for-windows = { -brand-name-firefox } for { -brand-name-windows } 64-bit
 we-worry-about = We worry about your data safety so you don’t have to.
 
-six-of-the-best = Six of the best browsers in direct comparison
-
-comparing-firefox-ie = Comparing { -brand-name-firefox-browser } with { -brand-name-microsoft } { -brand-name-ie }
 old-habits-that = Old habits that die hard but you’ll feel better when they do.
 incognito-browser-what = Incognito browser: What it really means
 firefox-calls-it = { -brand-name-firefox } calls it private browsing, { -brand-name-chrome } calls it incognito mode. Both let you browse the web without saving your browsing history.

--- a/l10n/en/firefox/more.ftl
+++ b/l10n/en/firefox/more.ftl
@@ -34,13 +34,7 @@ new-school-meets = New school meets old school with the fastest browser yet.
 firefox-for-windows = { -brand-name-firefox } for { -brand-name-windows } 64-bit
 we-worry-about = We worry about your data safety so you don’t have to.
 
-# Obsolete string
-seven-of-the = Seven of the best browsers in direct comparison
-
 six-of-the-best = Six of the best browsers in direct comparison
-
-# Obsolete string
-we-compare-firefox = We compare { -brand-name-firefox } with { -brand-name-chrome }, { -brand-name-edge }, { -brand-name-safari }, { -brand-name-opera }, { -brand-name-brave } and { -brand-name-ie } to help you make your decision.
 
 comparing-firefox-ie = Comparing { -brand-name-firefox-browser } with { -brand-name-microsoft } { -brand-name-ie }
 old-habits-that = Old habits that die hard but you’ll feel better when they do.

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -137,11 +137,6 @@ firefox-desktop-download-firefox-was-created = { -brand-name-firefox } was creat
 #   $attrs (attrs) - link to https://www.mozilla.org/firefox/privacy/
 firefox-desktop-download-as-the-internet = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy  — we call it the <a { $attrs }>Personal Data Promise</a>: Take less. Keep it safe. No secrets. Your data, your web activity, your life online is protected with { -brand-name-firefox }.
 
-# Obsolete string
-# Variables:
-#   $attrs (attrs) - link to https://accounts.firefox.com/signin
-firefox-desktop-download-firefox-is-available = { -brand-name-firefox } is available on all your devices; take your tabs, history and bookmarks with you. All you need is a <a { $attrs }>{ -brand-name-firefox } account</a>.
-
 # Variables:
 #   $attrs (attrs) - link to https://accounts.firefox.com/signin
 firefox-desktop-download-firefox-is-available-v2 = { -brand-name-firefox } is available on all your devices; take your tabs, history and bookmarks with you. All you need is a <a { $attrs }>{ -brand-name-mozilla-account }</a> and you’ll get access to syncing and more { -brand-name-mozilla } products.

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -22,13 +22,6 @@ nightly-whatsnew-this-is-a-good = This is a good time to thank you for helping u
 #   $twitter (url) - link to https://twitter.com/FirefoxNightly
 nightly-whatsnew-if-you-want-to-v3 = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a { $blog }>blog</a> and following us on <a { $mastodon }>Mastodon</a> or <a { $twitter }>X</a> are good starting points!
 
-# Obsolete string
-# Variables:
-#   $blog (url) - link to https://blog.nightly.mozilla.org/
-#   $mastodon (url) - link to https://mozilla.social/@FirefoxNightly
-#   $twitter (url) - link to https://twitter.com/FirefoxNightly
-nightly-whatsnew-if-you-want-to-v2 = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a href="{ $blog }">blog</a> and following us on <a href="{ $mastodon }">Mastodon</a> or <a href="{ $twitter }">Twitter</a> are good starting points!
-
 # Variables:
 #   $attrs (string) - link href and additional attributes
 nightly-whatsnew-want-to-know-which-v2 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>Nightly Experiments</a> preferences page.

--- a/l10n/en/firefox/products.ftl
+++ b/l10n/en/firefox/products.ftl
@@ -13,9 +13,6 @@ firefox-products-mozillas-family-of-products = { -brand-name-mozilla }’s famil
 firefox-products-products = Products
 firefox-products-firefox-beginning-v2 = { -brand-name-firefox } is just the beginning.
 
-# Obsolete string (expires: 2024-07-03)
-firefox-products-firefox-beginning = { -brand-name-firefox } is just the beginning
-
 firefox-products-mozillas-family-of-products-sentence = { -brand-name-mozilla }’s family of products are all designed to keep you safer and smarter online.
 
 ## Firefox
@@ -70,6 +67,4 @@ firefox-products-analyze = Analyze a URL
 
 firefox-products-pocket = { -brand-name-pocket }
 firefox-products-discover-the-best-content-v2 = Discover the best content on the web — and consume it wherever and whenever you want. Made by { -brand-name-mozilla }.
-# Obsolete string (expires: 2024-07-08)
-firefox-products-discover-the-best-content = Discover the best content on the web — and consume it wherever and whenever you want.
 firefox-products-get-pocket = Get { -brand-name-pocket }

--- a/l10n/en/firefox/set-as-default/thanks.ftl
+++ b/l10n/en/firefox/set-as-default/thanks.ftl
@@ -28,12 +28,6 @@ set-as-default-thanks-get-firefox-for-mobile = Get { -brand-name-firefox } for m
 set-as-default-thanks-travel-the-internet-with = Travel the internet with protection on all your devices.
 set-as-default-thanks-download-the-app = Download the app
 
-# Obsolete string
-set-as-default-thanks-join-firefox = Join { -brand-name-firefox }
-
-# Obsolete string
-set-as-default-thanks-sign-up-for-a-free-account = Sign up for a free account and sync all your passwords, browsing history, and preferences across your devices.
-
 set-as-default-create-an-account = Create an account
 set-as-default-thanks-sign-up-for-a-free-account-v2 = Sign up for a free { -brand-name-mozilla-account } and sync all your passwords, browsing history, and preferences across your devices.
 

--- a/l10n/en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl
@@ -8,9 +8,6 @@
 developer-mdnplus-page-title = { -brand-name-firefox-developer-edition }
 developer-mdnplus-congrats-you-now-have-latest-v2 = Congrats. You now have the latest version of { -brand-name-firefox-developer-edition }.
 
-# Obsolete string (expires: 2024-05-14)
-developer-mdnplus-congrats-you-now-have-latest = Congrats. You now have the latest version of { -brand-name-firefox-browser } { -brand-name-developer-edition }.
-
 # Main title
 developer-mdnplus-more-mdn-your-mdn = More { -brand-name-mdn }. <em>Your</em> { -brand-name-mdn }.
 developer-mdnplus-mdn-is-an-open-source = { -brand-name-mdn-web-docs } is an open-source, collaborative project documenting Web platform technologies, including CSS, HTML, JavaScript and Web APIs. We also provide an extensive set of learning resources for beginning developers and students.

--- a/l10n/en/firefox/whatsnew/whatsnew.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew.ftl
@@ -5,9 +5,6 @@
 ### URL: https://www-dev.allizom.org/firefox/60.0/whatsnew/
 
 whatsnew-page-title-v2 = What’s new with { -brand-name-firefox }
-
-# Obsolete string
-whatsnew-page-title = What’s new with { -brand-name-firefox } - More privacy, more protections.
 whatsnew-page-description = Take your stand against an industry that’s selling your data to third parties. Stay smart and safe online with technology that fights for you.
 whatsnew-firefox = { -brand-name-firefox }
 
@@ -16,11 +13,6 @@ whatsnew-update-notification = Your { -brand-name-firefox } has been updated.
 # Variables:
 #   $url (url) - link to https://www.mozilla.org/firefox/notes/
 whatsnew-release-notes-v2 = Read the <a { $url }>Release Notes</a> to know more about what’s new in your { -brand-name-firefox } browser.
-
-# Obsolete string
-# Variables:
-#   $url (url) - link to https://www.mozilla.org/firefox/notes/
-whatsnew-release-notes = Read the <a href="{ $url }">Release Notes</a> to know more about what’s new in your { -brand-name-firefox } browser.
 
 whatsnew-signoff = <strong>Powered by { -brand-name-mozilla }.</strong> Putting people before profits since 1998.
 

--- a/l10n/en/footer.ftl
+++ b/l10n/en/footer.ftl
@@ -8,8 +8,6 @@ footer-privacy-hub = Privacy Hub
 footer-privacy = Privacy
 footer-press = Press
 
-# Obsolete string (expires 2024-07-02)
-footer-corporate-blog = Corporate Blog
 footer-mozilla-blog = { -brand-name-mozilla } Blog
 footer-browser-comparison = Browser Comparison
 footer-brand-standards = Brand Standards
@@ -41,9 +39,6 @@ footer-websites-legal = Legal
 footer-language = Language
 footer-go = Go
 footer-donate = Donate
-
-# Obsolete string
-footer-twitter = { -brand-name-twitter }
 
 footer-x = X
 footer-x-formerly-twitter = X (formerly Twitter)

--- a/l10n/en/fxa_form.ftl
+++ b/l10n/en/fxa_form.ftl
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Obsolete string
-fxa-form-enter-your-email = <strong>Enter your email</strong> to access { -brand-name-firefox-accounts }.
-
 fxa-form-enter-your-email-v2 = <strong>Enter your email</strong> to create a  { -brand-name-mozilla-account }.
 
 # Variables:

--- a/l10n/en/mozorg/about.ftl
+++ b/l10n/en/mozorg/about.ftl
@@ -37,7 +37,6 @@ about-with-offices-all-over-the = With <a href="{ $url }">offices all over the w
 about-san-francisco = San Francisco
 about-talking-tech-issues-irl = Talking Tech Issues IRL
 about-in-mozillas-multi-award-winning = In { -brand-name-mozilla }'s multi-award winning podcast, host Bridget Todd talks to the people shaping the future of the internet and AI.
-about-in-mozillas-irl-podcast-host = In { -brand-name-mozilla }’s IRL podcast, host Manoush Zomorodi shares real stories of life online and real talk about the future of the Web.
 
 # The number inside the strong tag will be big, bold, and on its own line. Remove the strong tag if you need to put the number in the middle of the phrase.
 about-2000-non-employee-guests-welcomed = <strong>2000</strong> non-employee guests welcomed each year

--- a/l10n/en/mozorg/about.ftl
+++ b/l10n/en/mozorg/about.ftl
@@ -37,9 +37,6 @@ about-with-offices-all-over-the = With <a href="{ $url }">offices all over the w
 about-san-francisco = San Francisco
 about-talking-tech-issues-irl = Talking Tech Issues IRL
 about-in-mozillas-multi-award-winning = In { -brand-name-mozilla }'s multi-award winning podcast, host Bridget Todd talks to the people shaping the future of the internet and AI.
-
-# Obsolete strings (remove in 1-2 months)
-about-talking-internet-issues-irl = Talking Internet Issues IRL
 about-in-mozillas-irl-podcast-host = In { -brand-name-mozilla }’s IRL podcast, host Manoush Zomorodi shares real stories of life online and real talk about the future of the Web.
 
 # The number inside the strong tag will be big, bold, and on its own line. Remove the strong tag if you need to put the number in the middle of the phrase.

--- a/l10n/en/mozorg/about/manifesto.ftl
+++ b/l10n/en/mozorg/about/manifesto.ftl
@@ -57,9 +57,6 @@ manifesto-show-your-support = Show Your Support
 manifesto-an-internet-with-these = An internet with these qualities will not come to life on its own. Individuals and organizations must embed these aspirations into internet technology and into the human experience with the internet. The { -brand-name-mozilla } Manifesto and Addendum represent { -brand-name-mozilla }’s commitment to advancing these aspirations. We aim to work together with people and organizations everywhere who share these goals to make the internet an even better place for everyone.
 manifesto-i-support-the-vision-of = I support the vision of a better, healthier internet from @mozilla, will you join me?
 
-# Obsolete string
-manifesto-share-on-twitter = Share on { -brand-name-twitter }
-
 manifesto-share-on-x = Share on X
 manifesto-share-on-x-aria-label = Share on X (formerly Twitter)
 manifesto-our-10-principles = <strong>Our 10</strong> Principles

--- a/l10n/en/mozorg/home-new.ftl
+++ b/l10n/en/mozorg/home-new.ftl
@@ -13,9 +13,6 @@ home-were-not-normal = We’re not a normal tech company. The things we create p
 # Quotes around string to represent it being a quote by Mitchell Baker
 home-the-health-of = “The health of the internet and online life is why we exist.”
 
-# Obsolete string
-home-mitchell-baker = Mitchell Baker, { -brand-name-mozilla } CEO
-
 home-mitchell-baker-v2 = Mitchell Baker, Executive Chair of the Board, { -brand-name-mozilla-foundation }
 
 home-mozilla-makes-privacy = { -brand-name-mozilla } makes privacy-respecting products
@@ -24,16 +21,10 @@ home-cta-get-firefox = Get { -brand-name-firefox }
 home-product-pocket-articles = The web’s most intriguing articles
 home-cta-get-pocket = Get { -brand-name-pocket}
 
-# Obsolete string (expires: 2024-07-16)
-home-product-relay-masks = Easy-to-use email & phone masks
-
 home-product-relay-hide-your = Hide your phone number and email from spammers
 home-cta-get-relay = Get { -brand-name-relay }
 home-product-vpn-trust = A VPN you can trust
 home-cta-get-vpn = Get { -brand-name-mozilla-vpn }
-
-# Obsolete string (expires 2024-07-23)
-home-product-monitor-data = Data breach alerts
 
 home-product-monitor-protect-your = Protect your private info from data brokers
 home-cta-get-monitor = Get { -brand-name-monitor }
@@ -48,12 +39,6 @@ home-politico-cite = Politico
 home-join-us-in-shaping = Join us in shaping trustworthy AI
 home-work-on-ai = { -brand-name-mozilla }’s work with AI isn’t just a new thing—we’ve spent years funding, building and advocating for AI that’s open, fair and developed responsibly. Our focus is on creating AI that serves the people, prioritizes transparency and supports the public good, not corporate agendas.
 home-read-more = Read more
-
-# Obsolete string (expires: 2024-07-16)
-home-is-mozilla-a-corporation = Is { -brand-name-mozilla } a corporation or a non-profit? Actually, both.
-
-# Obsolete string (expires: 2024-07-16)
-home-mozilla-consists-of = { -brand-name-mozilla } consists of two organizations. The { -brand-name-mozilla-corporation } is wholly owned by the non-profit 501(c) { -brand-name-mozilla-foundation }. Which means we aren’t beholden to any shareholders — only to our mission.
 
 home-so-what-is-mozilla = So, what is { -brand-name-mozilla }?
 

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -367,9 +367,6 @@ newsletters-special-announcements-helping-you = Special announcements helping yo
 # Name for the newsletter in Newsletter subscription page (Firefox Accounts)
 newsletters-mozilla-accounts = { -brand-name-mozilla-accounts }
 
-# Obsolete string
-newsletters-firefox-accounts = { -brand-name-firefox-accounts }
-
 # Description for the newsletter in Newsletter subscription page (Firefox Accounts)
 newsletters-get-tips-from-mozilla = Get tips from { -brand-name-mozilla } on how to get the most out of your account.
 

--- a/l10n/en/navigation.ftl
+++ b/l10n/en/navigation.ftl
@@ -19,9 +19,6 @@ navigation-watch-videos-and-browse = Watch videos and browse the internet on you
 navigation-firefox-browsers-put = { -brand-name-firefox } browsers put your privacy first — and always have.
 navigation-take-the-passwords-youve = Take the passwords you’ve saved in { -brand-name-firefox } with you everywhere.
 
-# Obsolete string
-navigation-join-firefox = Join { -brand-name-firefox }
-
 navigation-access-all-of-firefox = Access all of { -brand-name-firefox } with a single login — and get more from every product when you do.
 navigation-meet-the-firefox-family = Meet the { -brand-name-firefox } Family
 navigation-firefox-blog = { -brand-name-firefox } Blog

--- a/l10n/en/navigation.ftl
+++ b/l10n/en/navigation.ftl
@@ -19,8 +19,6 @@ navigation-watch-videos-and-browse = Watch videos and browse the internet on you
 navigation-firefox-browsers-put = { -brand-name-firefox } browsers put your privacy first — and always have.
 navigation-take-the-passwords-youve = Take the passwords you’ve saved in { -brand-name-firefox } with you everywhere.
 
-navigation-access-all-of-firefox = Access all of { -brand-name-firefox } with a single login — and get more from every product when you do.
-navigation-meet-the-firefox-family = Meet the { -brand-name-firefox } Family
 navigation-firefox-blog = { -brand-name-firefox } Blog
 navigation-read-about-new-firefox = Read about new { -brand-name-firefox } features, and get tips for staying safer online.
 navigation-the-non-profit-behind = The non-profit behind { -brand-name-firefox } is fighting for a healthy internet for all.

--- a/l10n/en/newsletter/opt-out-confirmation.ftl
+++ b/l10n/en/newsletter/opt-out-confirmation.ftl
@@ -41,6 +41,3 @@ opt-out-confirmation-facebook = { -brand-name-facebook }
 
 # Link to https://twitter.com/firefox
 opt-out-confirmation-x-formerly-twitter = X (formerly Twitter)
-
-# Obsolete string
-opt-out-confirmation-twitter = { -brand-name-twitter }

--- a/l10n/en/privacy/cookie-settings.ftl
+++ b/l10n/en/privacy/cookie-settings.ftl
@@ -10,9 +10,6 @@ cookie-settings-breadcrumb-link = Previous page
 cookie-settings-explainer = Cookies are small files containing pieces of information that are saved to your computer or device when you visit a website. { -brand-name-mozilla } uses Cookies to help make our websites work, as well as to collect information on how you use and interact with our websites, such as the pages you visit.
 cookie-settings-page-intro-v2 = This page describes the different types of Cookies and similar technologies such as pixel tags, web beacons, clear GIFs, JavaScript, and local storage (hereafter, “Cookies”) that { -brand-name-mozilla } may use, and gives you control over which types of data you agree to { -brand-name-mozilla } collecting.
 
-# Obsolete string (expires: 2024-07-01)
-cookie-settings-page-intro = This page describes the different types of Cookies and similar technologies (such as pixel tags, web beacons, clear GIFs, JavaScript, and local storage) (“Cookies”) that { -brand-name-mozilla } may use, and gives you control over which types of data you agree to { -brand-name-mozilla } collecting.
-
 cookie-settings-how-mozilla-heading = How { -brand-name-mozilla } uses Cookies
 cookie-settings-how-does-mozilla-use-subheading = How does { -brand-name-mozilla } use this data?
 cookie-settings-save-changes = Save Changes

--- a/l10n/en/products/vpn/more/what-is-a-vpn.ftl
+++ b/l10n/en/products/vpn/more/what-is-a-vpn.ftl
@@ -62,13 +62,3 @@ vpn-what-is-mozilla-vpn-fast = { -brand-name-mozilla-vpn }: Fast, secure, trustw
 # Variables
 #   $mozvpn (url) - https://www.mozilla.org/products/vpn/
 vpn-what-is-mozilla-vpn-is-a-v3 = <a href="{ $mozvpn }">{ -brand-name-mozilla-vpn }</a> is a service that you can trust to keep your connection to the internet safe on all your devices. We don’t keep your network activity logs, and we don’t partner with third parties who build profiles of what you do online. In a world where unpredictability has become the “new normal,” we know that it’s more important than ever for you to feel safe, and for you to know that what you do online is your own business.
-
-# Obsolete string
-# Variables
-#   $mozvpn (url) - https://www.mozilla.org/products/vpn/
-vpn-what-is-mozilla-vpn-is-a-v2 = <a href="{ $mozvpn }">{ -brand-name-mozilla-vpn }</a> is a service that you can trust to keep your connection to the internet safe on all your devices. We don’t keep your network activity logs, and we don’t partner with third parties who build profiles of what you do online. In a world where unpredictability has become the new normal…
-
-# Obsolete string
-# Variables
-#   $mozvpn (url) - https://www.mozilla.org/products/vpn/
-vpn-what-is-mozilla-vpn-is-a = <a href="{ $mozvpn }">{ -brand-name-mozilla-vpn }</a> is a service that you can trust to keep your connection to the internet safe on all your devices. We don’t keep user data logs, and we don’t partner with third party analytics platforms who want to build a profile of what you do online. In a world where unpredictability has become the “new normal,” we know that it’s more important than ever for you to feel safe, and for you to know that what you do online is your own business.

--- a/l10n/en/products/vpn/platform-post-download.ftl
+++ b/l10n/en/products/vpn/platform-post-download.ftl
@@ -58,22 +58,11 @@ vpn-download-faq-working = How do I know the VPN is working?
 #   $monitor (url) link to https://monitor.mozilla.org/
 vpn-download-faq-visual-indicators-v2 = { -brand-name-mozilla-vpn } displays visual indicators of its current status both in the toolbar and the application’s home screen, making it easy to know whether your online activity is protected or not. These indicators allow you to confirm when your navigation is private and secure. Additionally, while connected, you can visit <a href="{ $monitor }">https://monitor.mozilla.org/</a> to confirm if your IP address is masked. For more details, please see <a href="{ $connected }">How can I tell if { -brand-name-mozilla-vpn } is connected?</a>.
 
-# Obsolete string
-# Variables:
-#   $connected (url) - link to https://support.mozilla.org/kb/how-can-i-tell-if-mozilla-vpn-connected
-#   $monitor (url) link to https://monitor.firefox.com/
-vpn-download-faq-visual-indicators = { -brand-name-mozilla-vpn } displays visual indicators of its current status both in the toolbar and the application’s home screen, making it easy to know whether your online activity is protected or not. These indicators allow you to confirm when your navigation is private and secure. Additionally, while connected, you can visit <a href="{ $monitor }">https://monitor.firefox.com/</a> to confirm if your IP address is masked. For more details, please see <a href="{ $connected }">How can I tell if { -brand-name-mozilla-vpn } is connected?</a>.
-
 vpn-download-faq-add-device = How do I add another device?
 
 # Variables:
 #   $subscription - link to https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription
 vpn-download-faq-adding-another-v3 = Adding another device is as simple as downloading and installing the { -brand-name-mozilla-vpn } software and then signing into your existing { -brand-name-mozilla-account } on the new device. For more details, please see <a href="{ $subscription }">How to add devices to your { -brand-name-mozilla-vpn } subscription</a>.
-
-# Obsolete string
-# Variables:
-#   $subscription - link to https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription
-vpn-download-faq-adding-another-v2 = Adding another device is as simple as downloading and installing the { -brand-name-mozilla-vpn } software and then signing into your existing { -brand-name-firefox-account } on the new device. For more details, please see <a href="{ $subscription }">How to add devices to your { -brand-name-mozilla-vpn } subscription</a>.
 
 vpn-download-faq-best-practices = What are some VPN best practices?
 vpn-download-faq-traffic = If your goal is to protect your internet traffic while keeping a fast speed, then it’s always best to choose a server location that is as close as possible to your physical location. This will increase the reliability and speed of your connection as your internet traffic will not need to take a significant detour before arriving at its intended destination on the web.

--- a/l10n/en/products/vpn/platforms/desktop.ftl
+++ b/l10n/en/products/vpn/platforms/desktop.ftl
@@ -32,9 +32,6 @@ vpn-desktop-servers-headline = Connect to servers all over the world
 #   $servers (number) - number of available servers
 vpn-desktop-servers-copy-updated = Browse from Brazil. Game from Japan. Stream from Mexico. { -brand-name-mozilla-vpn } lets you change your phone or computer’s location to one of { $servers } servers.
 
-# Obsolete string
-vpn-desktop-servers-copy = Browse from Brazil. Game from Japan. Stream from Mexico. { -brand-name-mozilla-vpn } lets you change your phone or computer’s location to one of { $servers }.
-
 # Variables:
 #   $devices (number) - number of available devices
 vpn-desktop-devices-headline = Protect up to { $devices } devices


### PR DESCRIPTION
## One-line summary
Removing overdue obsolete strings from some Fluent files.

>[!NOTE]
> I went ahead and removed an obsolete string expiring on July 22nd 2024, so we can have this PR merge on the 22nd

## Issue
Fixes https://github.com/mozilla/bedrock/issues/14820

## Testing

- [ ] http://localhost:8000/en-US/
- [ ]  http://localhost:8000/en-US/firefox/features/
- [ ] http://localhost:8000/en-US/firefox/features/private/
- [ ] http://localhost:8000/en-US/firefox/features/pdf-editor/
- [ ] http://localhost:8000/en-US/firefox/features/password-manager/
- [ ] http://localhost:8000/en-US/firefox/features/sync/
- [ ] http://localhost:8000/en-US/firefox/developer/
- [ ] http://localhost:8000/en-US/firefox/all/
- [ ] http://localhost:8000/en-US/products/vpn/?geo=de (to view consent banner)
- [ ] http://localhost:8000/en-US/firefox/installer-help/
- [ ] http://localhost:8000/en-US/products/
- [ ] http://localhost:8000/firefox/102.0a2/whatsnew/
- [ ] http://localhost:8000/en-US/privacy/websites/cookie-settings/
- [ ] http://localhost:8000/en-US/account/
- [ ] http://localhost:8000/en-US/firefox/
- [ ] http://localhost:8000/en-US/firefox/new/
- [ ] https://www.mozilla.org/en-US/firefox/119.0a1/whatsnew/
- [ ] http://localhost:8000/en-US/firefox/set-as-default/thanks/
- [ ] http://localhost:8000/en-US/firefox/128.0/whatsnew/ (we forgot to update the title string to the new version for all the current WNPs we have in our codebase, so I went ahead and did that)
- [ ] http://localhost:8000/en-US/about/
- [ ] http://localhost:8000/en-US/newsletter/opt-out-confirmation/
- [ ] http://localhost:8000/en-US/products/vpn/download/
- [ ] http://localhost:8000/en-US/products/vpn/resource-center/what-is-a-vpn/
- [ ] http://localhost:8000/en-US/about/manifesto/