### PR TITLE
CSP: Remove unsafe-eval & unsafe-inline from script-src

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -129,6 +129,8 @@ if csp_ro_report_uri:
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["upgrade-insecure-requests"] = True
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["base-uri"] = [csp.constants.NONE]
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["script-src"].remove(csp.constants.UNSAFE_EVAL)
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["script-src"].remove(csp.constants.UNSAFE_INLINE)
 
 
 # `CSP_PATH_OVERRIDES` and `CSP_PATH_OVERRIDES_REPORT_ONLY` are mainly for overriding CSP settings
@@ -163,7 +165,11 @@ CSP_PATH_OVERRIDES = {
 
 if csp_ro_report_uri:
     # Path based overrides for report-only CSP.
-    CMS_ADMIN_CSP_RO = _override_csp(CONTENT_SECURITY_POLICY_REPORT_ONLY, replace={"frame-ancestors": [csp.constants.SELF]})
+    CMS_ADMIN_CSP_RO = _override_csp(
+        CONTENT_SECURITY_POLICY_REPORT_ONLY,
+        append={"script-src": [csp.constants.UNSAFE_INLINE]},
+        replace={"frame-ancestors": [csp.constants.SELF]},
+    )
     CMS_ADMIN_IMAGES_CSP_RO = _override_csp(CONTENT_SECURITY_POLICY_REPORT_ONLY, append={"img-src": ["blob:"]})
 
     CSP_PATH_OVERRIDES_REPORT_ONLY = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
         path: path.resolve(__dirname, 'assets/'),
         publicPath: '/media/'
     },
+    devtool: 'source-map',
     optimization: {
         minimizer: [
             new TerserPlugin({


### PR DESCRIPTION
## One-line summary

Remove unsafe-eval & unsafe-inline from script-src

**NOTE** 
This also changes webpack to use `devtool: 'source-map'` which may result in slightly slower build times. This is needed to satisfy the CSP requirements locally (not use `eval`) so devs can spot any breaking CSP being added. On my machine it was a negligible difference but I'd be interested to hear about other experiences.

## Issue / Bugzilla link

#14828 

## Testing

I tested locally by clicking around with the console open looking for CSP violations, including the wagtail admin in my checks.