### PR TITLE
Use `frame-ancestors` for clickjacking control

### DIFF
--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -14,7 +14,6 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import TemplateView
 
-from commonware.decorators import xframe_allow
 from jsonview.decorators import json_view
 from product_details import product_details
 
@@ -29,12 +28,6 @@ from lib.l10n_utils import L10nTemplateView, RequireSafeMixin
 from lib.l10n_utils.fluent import ftl_file_is_active
 
 credits_file = CreditsFile("credits")
-TECH_BLOG_SLUGS = ["hacks", "cd", "futurereleases"]
-
-
-@xframe_allow
-def hacks_newsletter(request):
-    return l10n_utils.render(request, "mozorg/newsletter/hacks.mozilla.org.html")
 
 
 @require_safe

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -6,7 +6,7 @@ import logging.config
 import sys
 from copy import deepcopy
 
-from csp.constants import SELF, UNSAFE_EVAL, UNSAFE_INLINE
+import csp.constants
 
 from .base import *  # noqa: F403, F405
 
@@ -117,7 +117,7 @@ if IS_POCKET_MODE:
 
     # CSP settings for POCKET, expanded upon later:
     _csp_default_src = [
-        SELF,
+        csp.constants.SELF,
         "*.getpocket.com",
     ]
     _csp_img_src = [
@@ -129,18 +129,18 @@ if IS_POCKET_MODE:
     ]
     _csp_script_src = [
         # TODO fix use of OptanonWrapper() so that we don't need this
-        UNSAFE_INLINE,
+        csp.constants.UNSAFE_INLINE,
         # TODO onetrust cookie consent breaks
         # blocked without unsafe-eval. Find a way to remove that.
         "www.mozilla.org",
-        UNSAFE_EVAL,
+        csp.constants.UNSAFE_EVAL,
         "www.googletagmanager.com",
         "www.google-analytics.com",
         "cdn.cookielaw.org",
         "assets.getpocket.com",  # allow Pocket Snowplow analytics
     ]
     _csp_style_src = [
-        UNSAFE_INLINE,
+        csp.constants.UNSAFE_INLINE,
         "www.mozilla.org",
     ]
     _csp_child_src = [
@@ -168,7 +168,7 @@ else:
 
     # CSP settings for MOZORG, expanded upon later:
     _csp_default_src = [
-        SELF,
+        csp.constants.SELF,
         "*.mozilla.net",
         "*.mozilla.org",
         "*.mozilla.com",
@@ -183,10 +183,10 @@ else:
     ]
     _csp_script_src = [
         # TODO fix things so that we don't need this
-        UNSAFE_INLINE,
+        csp.constants.UNSAFE_INLINE,
         # TODO snap.svg.js passes a string to Function() which is
         # blocked without unsafe-eval. Find a way to remove that.
-        UNSAFE_EVAL,
+        csp.constants.UNSAFE_EVAL,
         "www.googletagmanager.com",
         "www.google-analytics.com",
         "tagmanager.google.com",
@@ -196,7 +196,7 @@ else:
     ]
     _csp_style_src = [
         # TODO fix things so that we don't need this
-        UNSAFE_INLINE,
+        csp.constants.UNSAFE_INLINE,
     ]
     _csp_child_src = [
         "www.googletagmanager.com",
@@ -259,6 +259,7 @@ CONTENT_SECURITY_POLICY = {
         "connect-src": list(set(_csp_default_src + _csp_connect_src)),
         # support older browsers (mainly Safari)
         "frame-src": _csp_child_src,
+        "frame-ancestors": [csp.constants.NONE],
     },
 }
 


### PR DESCRIPTION
## One-line summary

This sets the CSP directive `frame-ancestors 'none'` which indicates that we do not want any part of our website used in a frame. This takes precedence over the `X-Frame-Options: DENY` header for browsers that support both. For now we are leaving both in for broad browser support.


- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

#14835 

## Testing

It's possible to throw an `iframe` on a page whose `src` is another page in bedrock and verify the browser throws a CSP error.

I put one on the mission page:
```
<iframe src="/en-US/about/manifesto/"></iframe>
```

Which produced this error:
```
Content-Security-Policy: The page’s settings blocked the loading of a resource (frame-ancestors) at http://localhost:8000/en-US/mission/ because it violates the following directive: “frame-ancestors 'none'”
```