### PR TITLE
Add prefer_cms decorator to help with migrating pages from hard-coded to CMS

### DIFF
--- a/bedrock/base/i18n.py
+++ b/bedrock/base/i18n.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import re
+
 import django.urls
 from django.conf import settings
 from django.utils.text import capfirst
@@ -163,3 +165,8 @@ def get_best_language(accept_lang):
 
 def check_for_bedrock_language(lang_code):
     return lang_code in [x[0] for x in settings.LANGUAGES]
+
+
+def remove_lang_prefix(url):
+    locale_pattern = r"^/([a-z]{2}(-[a-zA-Z]{2})?)/"  # (e.g., /en-US/ or /en-us/)
+    return re.sub(locale_pattern, "/", url)

--- a/bedrock/cms/decorators.py
+++ b/bedrock/cms/decorators.py
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from functools import wraps
+
+from django.http import Http404
+
+from wagtail.views import serve as wagtail_serve
+
+from bedrock.base.i18n import remove_lang_prefix
+
+HTTP_200_OK = 200
+
+
+def prefer_cms(view_func):
+    """
+    A decorator that helps us migrate from pure Django-based views
+    to CMS views.
+
+    It will try to see if `wagtail.views.serve` can find a live CMS page for the
+    URL path that matches the current Django view's path, and if so, will
+    return that. If not, it will let the regular Django view run.
+
+    Workflow:
+
+    1. This decorator is added to the target view that will be replaced with CMS content
+    2. Code is deployed and initially serves the original Django page
+    3. CMS content is added for /path/to/page/ -- and can be previewed and approved
+       without affecting the existing Django page at all
+    4. CMS Page is published and starts getting served as it is "preferred" over the Django page
+    5. Later, in a second changeset, the Django view and relevant URLconf item can be removed
+
+    Example for a function-based view:
+
+        @prefer_cms
+        def some_path(request):
+            ...
+
+    Or, in a URLconf for a regular Django view:
+
+        ...
+        path("some/path/", prefer_cms(views.some_view)),
+        ...
+
+    Or, in a URLconf with Bedrock's page() helper:
+        page(
+            "about/leadership/",
+            "mozorg/about/leadership/index.html",
+            decorators=[prefer_cms],
+        )
+
+    """
+
+    @wraps(view_func)
+    def wrapped_view(request, *args, **kwargs):
+        path = remove_lang_prefix(request.path_info)
+        try:
+            # Does Wagtail have a route that matches this? If so, show that page
+            wagtail_response = wagtail_serve(request, path)
+            if wagtail_response.status_code == HTTP_200_OK:
+                return wagtail_response
+        except Http404:
+            pass
+
+        # If not, call the original view function
+        return view_func(request, *args, **kwargs)
+
+    return wrapped_view

--- a/bedrock/cms/models/pages.py
+++ b/bedrock/cms/models/pages.py
@@ -45,6 +45,9 @@ class SimpleRichTextPage(AbstractBedrockCMSPage):
 
     Not intended to be commonly used, this is more a very simple reference
     implementation.
+
+    Note that this page is actively used in tests, so removing this will
+    require relevant tests to be refactored, too
     """
 
     # 1. Define model fields

--- a/bedrock/cms/tests/conftest.py
+++ b/bedrock/cms/tests/conftest.py
@@ -4,6 +4,7 @@
 
 import pytest
 import wagtail_factories
+from wagtail.models import Site
 
 from bedrock.cms.tests.factories import LocaleFactory, SimpleRichTextPageFactory
 
@@ -13,17 +14,25 @@ def minimal_site(
     client,
     top_level_page=None,
 ):
-    # Boostraps a minimal site with a root page at / and one child page at /test-page/
+    # Bootstraps a minimal site with a root page at / and one child page at /test-page/
 
     if top_level_page is None:
         top_level_page = SimpleRichTextPageFactory(
             slug="root_page",  # this doesn't get shown
+            live=True,
         )
 
-    site = wagtail_factories.SiteFactory(
-        root_page=top_level_page,
-        hostname=client._base_environ()["SERVER_NAME"],
-    )
+    try:
+        site = Site.objects.get(is_default_site=True)
+        site.root_page = top_level_page
+        site.hostname = client._base_environ()["SERVER_NAME"]
+        site.save()
+    except Site.DoesNotExist:
+        site = wagtail_factories.SiteFactory(
+            root_page=top_level_page,
+            is_default_site=True,
+            hostname=client._base_environ()["SERVER_NAME"],
+        )
 
     LocaleFactory(language_code="fr")
 

--- a/bedrock/cms/tests/decorator_test_views.py
+++ b/bedrock/cms/tests/decorator_test_views.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.http import HttpResponse
+
+from bedrock.cms.decorators import prefer_cms
+
+
+def undecorated_dummy_view(request):
+    return HttpResponse("This is a dummy response from the undecorated view")
+
+
+@prefer_cms
+def decorated_dummy_view(request):
+    return HttpResponse("This is a dummy response from the decorated view")
+
+
+def wrapped_dummy_view(request):
+    return HttpResponse("This is a dummy response from the wrapped view")

--- a/bedrock/cms/tests/test_decorators.py
+++ b/bedrock/cms/tests/test_decorators.py
@@ -1,0 +1,150 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.urls import path
+
+import pytest
+from wagtail.rich_text import RichText
+
+from bedrock.base.i18n import bedrock_i18n_patterns
+from bedrock.cms.decorators import prefer_cms
+from bedrock.cms.tests import decorator_test_views
+from bedrock.mozorg.util import page
+from bedrock.urls.mozorg_mode import urlpatterns as mozorg_urlpatterns
+
+from .factories import SimpleRichTextPageFactory
+
+urlpatterns = (
+    bedrock_i18n_patterns(
+        path(
+            "undecorated/view/path/",
+            decorator_test_views.undecorated_dummy_view,
+            name="undecorated_dummy_view",
+        ),
+        path(
+            "decorated/view/path/",
+            decorator_test_views.decorated_dummy_view,
+            name="decorated_dummy_view",
+        ),
+        path(
+            "wrapped/view/path/",
+            prefer_cms(
+                decorator_test_views.wrapped_dummy_view,
+            ),
+            name="url_wrapped_dummy_view",
+        ),
+        page("book/", "mozorg/book.html", decorators=[prefer_cms]),
+    )
+    + mozorg_urlpatterns  # we need to extend these so Jinja2 can call url() in the templates
+)
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _set_up_cms_pages(deepest_path, site):
+    parent_page = site.root_page
+
+    for slug in deepest_path.lstrip("/").rstrip("/").split("/"):
+        new_page = SimpleRichTextPageFactory(
+            slug=slug,
+            parent=parent_page,
+            content=RichText(f"This is a CMS page now, with the slug of {slug}"),
+        )
+        new_page.save_revision()
+        new_page.publish(new_page.latest_revision)
+
+        parent_page = new_page
+
+    assert new_page.relative_url(site) == f"/en-US{deepest_path}"
+
+    return new_page
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_decorating_django_view(lang_code_prefix, minimal_site, client):
+    # Control case: undecorated view
+    resp = client.get(f"{lang_code_prefix}/undecorated/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the undecorated view"
+
+    # Show decorated view renders Django view initially, because there is no CMS page at that route yet
+    resp = client.get("/decorated/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the decorated view"
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    _set_up_cms_pages(
+        deepest_path="/decorated/view/path/",
+        site=minimal_site,
+    )
+
+    resp = client.get(f"{lang_code_prefix}/decorated/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert "This is a CMS page now, with the slug of path" in resp.content.decode("utf-8")
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_patching_in_urlconf__standard_django_view(lang_code_prefix, minimal_site, client):
+    # Show wrapped view renders Django view initially,
+    # because there is no CMS page at that route yet
+    resp = client.get(f"{lang_code_prefix}/wrapped/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the wrapped view"
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    _set_up_cms_pages(
+        deepest_path="/wrapped/view/path/",
+        site=minimal_site,
+    )
+
+    resp = client.get(f"{lang_code_prefix}/wrapped/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert "This is a CMS page now, with the slug of path" in resp.content.decode("utf-8")
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_support_with_bedrock_page_view(lang_code_prefix, minimal_site, client):
+    # Show decorated page() view renders Django view initially, because there is no CMS page at that route yet
+    resp = client.get(f"{lang_code_prefix}/book/", follow=True)
+    assert resp.status_code == 200
+    assert "The Book of Mozilla" in resp.content.decode("utf-8")
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    _set_up_cms_pages(
+        deepest_path="/book/",
+        site=minimal_site,
+    )
+
+    resp = client.get(f"{lang_code_prefix}/book/", follow=True)
+    assert resp.status_code == 200
+    assert "This is a CMS page now, with the slug of book" in resp.content.decode("utf-8")
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_draft_pages_do_not_get_preferred_over_django_views(lang_code_prefix, minimal_site, client):
+    # Show decorated view renders Django view initially, because there is no CMS page at that route yet
+    resp = client.get("/decorated/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the decorated view"
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    leaf_page = _set_up_cms_pages(
+        deepest_path="/decorated/view/path/",
+        site=minimal_site,
+    )
+    assert leaf_page.live is True
+    resp = client.get(f"{lang_code_prefix}/decorated/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert "This is a CMS page now, with the slug of path" in resp.content.decode("utf-8")
+
+    # Show how unpublishing will give us the Django view's content, because there is no
+    # live CMS page to "prefer"
+    leaf_page.unpublish()
+    resp = client.get("/decorated/view/path/", follow=True)
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the decorated view"

--- a/bedrock/cms/tests/test_models.py
+++ b/bedrock/cms/tests/test_models.py
@@ -63,7 +63,7 @@ def test_StructuralPage_serve_methods(
 
     request = rf.get(_relative_url)
     live_result = sp.serve(request)
-    assert live_result.headers["location"] == root_page.url
+    assert live_result.headers["location"].endswith(root_page.url)
 
     preview_result = sp.serve_preview(request)
-    assert preview_result.headers["location"] == root_page.url
+    assert preview_result.headers["location"].endswith(root_page.url)

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -47,6 +47,30 @@ Official `Editor Guide`_.
 Bedrock-specific details to come.
 
 
+Migrating Django pages to the CMS
+---------------------------------
+
+.. note::
+    This is initial documentation, noting relevant things that exist already, but much fuller recommendations will follow
+
+The ``@prefer_cms`` decorator
+=============================
+
+If you have an existing Django-based page that you want to move to be a CMS-driven page, you are faced with a quandry.
+
+Let's say the page exists at ``/some/path/``;  you can create it in the CMS with a branch of pages that mirror the same slugs (a parent page with a slug of ``some`` and a child page with a slug of ``path``). However, in order for anyone to see the published page, you would have to remove the reference to the Django view from the URLconf, so that Wagtail would get a chance to render it (because Wagtail's page-serving logic comes last in all URLConfs). **BUT...** how can you enter content into the CMS fast enough replace the just-removed Django page? (Note: we could use a data migraiton here, but that gets complicated when there are images involved)
+
+The answer here is to use the ``bedrock.cms.decorators.prefer_cms`` decorator/helper.
+
+A Django view decorated with ``prefer_cms`` will check if a live CMS page has been added that matches the same overall, relative path as the Django view. If it finds one, it will show the user `that` CMS page instead. If there is no match in the CMS, then the original Django view will be used.
+
+
+The result is a graceful handover flow that allows us to switch to the CMS page without needing to remove the Django view from the URLconf. It doesn't affect previews, so the review of draft pages before publishing can continue with no changes. Once the CMS is populated with a live version of the replacement page, that's when a later changeset can remove the deprecated Django view.
+
+The ``prefer_cms`` decorator can be used directly on function-based views, or can wrap views in the URLconf. It can also be passed to our very handy ``bedrock.mozorg.util.page`` as one of the list of ``decorator`` arguments.
+
+For more details, please see the docstring on ``bedrock.cms.decorators.prefer_cms``.
+
 Images
 ------
 


### PR DESCRIPTION
This changeset adds a new decorator (`@prefer_cms`) that we can use to transition from hard-coded Django views to CMS-backed replacement views without having to delete the Django view in order to reveal the CMS page. 

It will try to see if Wagtail can find a live CMS page for the URL path that matches the current Django view's path, and if so, will return that instead. If not, it will let the regular Django view run.

This means that, when someone wants to publish a CMS page to replace a Django view, we don't have to coordinate a code release to remove the Django view and let Wagtail serve the new page instead - it will just hand over gracefully and we can remove the deprecated Django view in a later changeset.

See the updates to `cms.rst` for a fuller explanation

- [X] I used an AI to write some of this code - I used Copilot to generate the skeleton for the decorator, because I always forget the ideal nesting.

## Significant changes and points to review

There's no current use of the new decorator in the codebase, but the tests added here come with fake views and an extended urlconf so we can see them in use. Please review the tests with as much scepticism as you'd use for non-test code.

## Issue / Bugzilla link

Resolves #14829 

## Testing
* CI passing is enough for now