### PR TITLE
Add support for controlling which CMS Page types can be used in the site

### DIFF
--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.conf import settings
 from django.utils.cache import add_never_cache_headers
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
@@ -33,6 +34,14 @@ class AbstractBedrockCMSPage(WagtailBasePage):
 
     class Meta:
         abstract = True
+
+    @classmethod
+    def can_create_at(cls, parent):
+        """Only allow users to add new child pages that are permitted by configuration."""
+        page_model_signature = f"{cls._meta.app_label}.{cls._meta.object_name}"
+        if settings.CMS_ALLOWED_PAGE_MODELS == ["__all__"] or page_model_signature in settings.CMS_ALLOWED_PAGE_MODELS:
+            return super().can_create_at(parent)
+        return False
 
     def _patch_request_for_bedrock(self, request):
         # Add hints that help us integrate CMS pages with core Bedrock logic

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2156,6 +2156,6 @@ _allowed_page_models = [
 ]
 
 if DEV is True:
-    CMS_ALLOWED_PAGE_MODELS = "__all__"
+    CMS_ALLOWED_PAGE_MODELS = ["__all__"]
 else:
     CMS_ALLOWED_PAGE_MODELS = _allowed_page_models

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2138,3 +2138,24 @@ WAGTAIL_RICHEXT_FEATURES_FULL = [
 ]
 
 WAGTAILIMAGES_IMAGE_MODEL = "cms.BedrockImage"
+
+# Custom code in bedrock.cms.models.base.AbstractBedrockCMSPage limits what page
+# models can be added as a child page.
+#
+# This means we can control when a page is available for use in the CMS, versus
+# simply being in the codebase. Also, note that removing a particular page class
+# from this allowlist will not break existing pages that are of that class, but
+# will stop anyone adding a _new_ one.
+#
+# NB: EVERY TIME you add a new Wagtail Page subclass to the CMS, you must enable
+# it here if you want it to be selectable as a new child page in Production
+
+_allowed_page_models = [
+    "cms.SimpleRichTextPage",
+    "cms.StructuralPage",
+]
+
+if DEV is True:
+    CMS_ALLOWED_PAGE_MODELS = "__all__"
+else:
+    CMS_ALLOWED_PAGE_MODELS = _allowed_page_models

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -44,7 +44,24 @@ Adding new content surfaces
 
 Official `Editor Guide`_.
 
-Bedrock-specific details to come.
+.. note::
+    This is initial documentation, noting relevant things that exist already, but much fuller recommendations will follow
+
+The ``CMS_ALLOWED_PAGE_MODELS`` setting
+=======================================
+
+When you add a new page to the CMS, it will be available to add as a new child page immediately if ``DEV=True``. This means it'll be on Dev (www-dev), but not in Staging or Prod.
+
+So if you ship a page that needs to be used immediately in Production (which will generally be most cases), you must remember to add it to ``CMS_ALLOWED_PAGE_MODELS`` in Bedrock's settings. If you do not, it will not be selectable as a new Child Page in the CMS.
+
+Why do we have this behaviour?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two reasons:
+
+1. This setting allows us to complete initial/eager work to add a new page type, but stop it being used in Production until we are ready for it (e.g. a special new campaign page type that we wanted to get ready in good time). While there will be guard rails and approval workflows around publishing, without this it could still be possible for part of the org to start using a new page without us realising it was off-limits, and possibly before it is allowed to be released.
+
+2. This approach allows us to gracefully deprecate pages: if a page is removed in ``settings.CMS_ALLOWED_PAGE_MODELS``, that doesn't mean it disappears from Prod or can't be edited - it just stops a NEW one being added in Prod.
 
 
 Migrating Django pages to the CMS


### PR DESCRIPTION
This means we can control when a page is available for use in the CMS, versus simply being in the codebase. Also, note that removing a particular page class from this allowlist will not break existing pages that are of that class, but will stop anyone adding a _new_ one.

NB: EVERY TIME we add a new Wagtail Page subclass to the CMS, we must add to the CMS_ALLOWED_PAGE_MODELS setting if we want it to be selectable as a new child page in Production (or ticket up when we do want to add it to the setting)

- [ ] I used an AI to write some of this code. Nope. This is all me (but I did repurpose what I'd originally added in Birdbox)

## Issue / Bugzilla link

Resolves #14843 

## Testing

Locally:
1. Have some pages in your CMS
2. Edit `bedrock.settings.base._allowed_page_models` to comment out one of the two page types there. 
3. Set `DEV=False` in your .env and ensure runserver has been restarted
4. Confirm you can't add that page type as a child page
5. Set `DEV=True` in your .env and ensure runserver has been restarted
6. Confirm you CAN now add that page type as a child page



