### PR TITLE
Fix Firefox DevTools features duplicate string

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/features.html
@@ -1,4 +1,3 @@
-
 {#
  This Source Code Form is subject to the terms of the Mozilla Public
  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -50,7 +49,7 @@
         }
       ),
     ) %}
-      <p>{{ ftl('firefox-developer-inspect-and-refine') }}</p>
+      <p>{{ ftl('firefox-developer-track-css') }}</p>
       <p>
         <a href="https://firefox-source-docs.mozilla.org/devtools-user/web_console/" class="mzp-c-cta-link" rel="external">
           {{ ftl('firefox-developer-learn-about-web-console') }}


### PR DESCRIPTION
## One-line summary

Fixes fluent string reference for FX Dev page feature description that's repetitive.

## Significant changes and points to review

The intended string was already included, just not linked.

## Issue / Bugzilla link

Fixes #14609 (also closes #14610 as superseded)

## Testing

http://localhost:8000/firefox/developer/#fordevs