### PR TITLE
Add URL query param to show consent banner in the EU (Fixes #14853)

### DIFF
--- a/docs/attribution/0007-consent-management.rst
+++ b/docs/attribution/0007-consent-management.rst
@@ -23,7 +23,9 @@ a cookie consent banner. These URLs are stored in a strict `allow-list`_. URLs
 that are not in this list will neither show a banner, nor load any non-necessary
 cookies / analytics in the EU/EAA. The intent here is to provide as little
 disruption for our website visitors as possible, whilst still allowing opt-in
-to analytics URLs such as campaign pages.
+to analytics URLs such as campaign pages. It is also possible to force the banner
+to show on any EU page by adding a query parameter `?mozcb=y` (used for specific
+campaign traffic sources such as advertisements).
 
 Visitors in the EU/EAA countries can also send an opt-out signal by enabling
 either `Global Privacy Control`_ (GPC) and `Do Not Track`_ (DNT) in their

--- a/media/js/base/consent/init.es6.js
+++ b/media/js/base/consent/init.es6.js
@@ -12,6 +12,7 @@ import {
     getConsentState,
     gpcEnabled,
     hasConsentCookie,
+    isURLExceptionAllowed,
     isURLPermitted
 } from './utils.es6';
 
@@ -139,6 +140,7 @@ function init() {
         gpcEnabled: gpcEnabled(),
         dntEnabled: dntEnabled(),
         consentRequired: consentRequired(),
+        isURLExceptionAllowed: isURLExceptionAllowed(window.location.search),
         isURLPermitted: isURLPermitted(window.location.pathname)
     });
 

--- a/media/js/base/consent/utils.es6.js
+++ b/media/js/base/consent/utils.es6.js
@@ -129,7 +129,23 @@ function gpcEnabled() {
  * @return {Boolean}.
  */
 function isFirefoxDownloadThanks(location) {
+    if (typeof location !== 'string') {
+        return false;
+    }
     return location.indexOf('/firefox/download/thanks/') > -1;
+}
+
+/**
+ * Determines if the current page URL contains a query string
+ * that allows the consent banner to be displayed.
+ * @param {String} search - The current page URL search string.
+ * @returns {Boolean}
+ */
+function isURLExceptionAllowed(search) {
+    if (typeof search !== 'string') {
+        return false;
+    }
+    return search.indexOf('mozcb=y') > -1;
 }
 
 /**
@@ -183,7 +199,7 @@ function getConsentState(obj) {
      * then show the cookie banner.
      */
     if (obj.consentRequired) {
-        if (obj.isURLPermitted) {
+        if (obj.isURLPermitted || obj.isURLExceptionAllowed) {
             if (obj.hasConsentCookie) {
                 return 'STATE_HAS_CONSENT_COOKIE';
             } else {
@@ -214,6 +230,7 @@ export {
     gpcEnabled,
     hasConsentCookie,
     isFirefoxDownloadThanks,
+    isURLExceptionAllowed,
     isURLPermitted,
     setConsentCookie
 };

--- a/tests/unit/spec/base/consent/consent-utils.js
+++ b/tests/unit/spec/base/consent/consent-utils.js
@@ -11,6 +11,7 @@ import {
     getHostName,
     hasConsentCookie,
     isFirefoxDownloadThanks,
+    isURLExceptionAllowed,
     isURLPermitted,
     setConsentCookie
 } from '../../../../../media/js/base/consent/utils.es6';
@@ -78,6 +79,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: true,
                 dntEnabled: false,
                 consentRequired: false,
+                isURLExceptionAllowed: false,
                 isURLPermitted: false
             });
             expect(stateA).toEqual('STATE_GPC_ENABLED');
@@ -87,6 +89,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: true,
                 dntEnabled: false,
                 consentRequired: true,
+                isURLExceptionAllowed: false,
                 isURLPermitted: true
             });
             expect(stateB).toEqual('STATE_GPC_ENABLED');
@@ -98,6 +101,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: true,
                 consentRequired: false,
+                isURLExceptionAllowed: false,
                 isURLPermitted: false
             });
             expect(stateA).toEqual('STATE_DNT_ENABLED');
@@ -107,6 +111,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: true,
                 consentRequired: true,
+                isURLExceptionAllowed: false,
                 isURLPermitted: true
             });
             expect(stateB).toEqual('STATE_DNT_ENABLED');
@@ -120,6 +125,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: false,
                 consentRequired: false,
+                isURLExceptionAllowed: false,
                 isURLPermitted: false
             });
             expect(state).toEqual('STATE_COOKIES_PERMITTED');
@@ -131,6 +137,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: false,
                 consentRequired: false,
+                isURLExceptionAllowed: false,
                 isURLPermitted: false
             });
             expect(state).toEqual('STATE_HAS_CONSENT_COOKIE');
@@ -144,6 +151,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: false,
                 consentRequired: true,
+                isURLExceptionAllowed: false,
                 isURLPermitted: true
             });
             expect(state).toEqual('STATE_HAS_CONSENT_COOKIE');
@@ -155,6 +163,7 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: false,
                 consentRequired: true,
+                isURLExceptionAllowed: false,
                 isURLPermitted: true
             });
             expect(state).toEqual('STATE_SHOW_COOKIE_BANNER');
@@ -166,9 +175,34 @@ describe('getConsentState()', function () {
                 gpcEnabled: false,
                 dntEnabled: false,
                 consentRequired: true,
+                isURLExceptionAllowed: false,
                 isURLPermitted: false
             });
             expect(state).toEqual('STATE_BANNER_NOT_PERMITTED');
+        });
+
+        it('should return the expected state when URL exception is allowed and consent cookie exists', function () {
+            const state = getConsentState({
+                hasConsentCookie: true,
+                gpcEnabled: false,
+                dntEnabled: false,
+                consentRequired: true,
+                isURLExceptionAllowed: true,
+                isURLPermitted: false
+            });
+            expect(state).toEqual('STATE_HAS_CONSENT_COOKIE');
+        });
+
+        it('should return the expected state when URL exception is allowed and no existing consent cookie', function () {
+            const state = getConsentState({
+                hasConsentCookie: false,
+                gpcEnabled: false,
+                dntEnabled: false,
+                consentRequired: true,
+                isURLExceptionAllowed: true,
+                isURLPermitted: false
+            });
+            expect(state).toEqual('STATE_SHOW_COOKIE_BANNER');
         });
     });
 });
@@ -253,6 +287,30 @@ describe('isFirefoxDownloadThanks()', function () {
         expect(
             isFirefoxDownloadThanks('https://localhost:8000/en-US/firefox/new/')
         ).toBeFalse();
+        expect(isFirefoxDownloadThanks('')).toBeFalse();
+        expect(isFirefoxDownloadThanks(null)).toBeFalse();
+        expect(isFirefoxDownloadThanks(undefined)).toBeFalse();
+        expect(isFirefoxDownloadThanks(true)).toBeFalse();
+    });
+});
+
+describe('isURLExceptionAllowed()', function () {
+    it('should return true for URL exceptions', function () {
+        expect(isURLExceptionAllowed('?mozcb=y')).toBeTrue();
+        expect(isURLExceptionAllowed('?mozcb=y&foo=bar')).toBeTrue();
+        expect(isURLExceptionAllowed('?foo=bar&mozcb=y')).toBeTrue();
+        expect(isURLExceptionAllowed('?foo=bar&mozcb=y&baz=qux')).toBeTrue();
+    });
+
+    it('should return false for URLs without exceptions', function () {
+        expect(isURLExceptionAllowed('?mozcb=n')).toBeFalse();
+        expect(isURLExceptionAllowed('?mozcb=n&foo=bar')).toBeFalse();
+        expect(isURLExceptionAllowed('?foo=bar&mozcb=n')).toBeFalse();
+        expect(isURLExceptionAllowed('?foo=bar&mozcb=n&baz=qux')).toBeFalse();
+        expect(isURLExceptionAllowed('')).toBeFalse();
+        expect(isURLExceptionAllowed(null)).toBeFalse();
+        expect(isURLExceptionAllowed(undefined)).toBeFalse();
+        expect(isURLExceptionAllowed(true)).toBeFalse();
     });
 });
 


### PR DESCRIPTION
## One-line summary

Adds an optional query parameter that can be used to trigger the consent banner on any URL when viewed in the EU.

## Issue / Bugzilla link

#14853

## Testing

> [!NOTE]
> You'll need to test in a browser with DNT / GPC disabled. On localhost, you'll also need to mock being in an EU country via the `geo` param.

http://localhost:8000/en-US/?geo=gb&mozcb=y