### PR TITLE
Add a11y test job running against key pages (#14773)

### DIFF
--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -1,0 +1,74 @@
+# Workflow that runs accessibility tests once per day against dev infra.
+
+name: Accessibility Tests
+run-name: Accessibility Tests for ${{ github.sha }}
+env:
+  SLACK_CHANNEL_ID: CBX0KH5GA # #www-notify in MoCo Slack
+  SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN_FOR_MEAO_NOTIFICATIONS_APP}}
+on:
+  schedule:
+    - cron: "0 15 * * *" # 3pm daily
+  workflow_dispatch:
+    inputs:
+      mozorg_service_hostname:
+        description: The root URL to run tests against. eg "https://www.mozilla.org/"
+        required: true
+
+jobs:
+  notify-of-test-run-start:
+    if: github.repository == 'mozilla/bedrock'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify via Slack that tests are starting
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "Accessibility Tests [${{ github.sha }}]"
+          status: info
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ github.sha }}
+          message: "Accessibility Tests started"
+
+  accessibility-tests:
+    runs-on: ubuntu-latest
+    needs: notify-of-test-run-start
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ github.event.inputs.mozorg_service_hostname || 'https://dev.bedrock.nonprod.webservices.mozgcp.net' }}
+      CI: true
+      CI_JOB_ID: ${{ github.run_id }}
+      DRIVER: ""
+      LABEL: accessibility-tests
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Install dependencies
+      run: cd tests/playwright && npm ci && npm run install-deps
+    - name: Run accessibility tests
+      run: npm run a11y-tests
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: test-results-a11y-${{ github.sha }}
+        path: test-results-a11y/
+        retention-days: 30
+
+  notify-of-test-run-completion:
+    if: github.repository == 'mozilla/bedrock' && always()
+    runs-on: ubuntu-latest
+    needs: [notify-of-test-run-start, accessibility-tests]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify via Slack of test-run outcome
+        uses: ./.github/actions/slack
+        with:
+          env_name: test
+          label: "Accessibility tests [${{ github.sha }}]"
+          status: ${{ needs.accessibility-tests.result }}
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          ref: ${{ github.sha }}
+          message: "Accessibility tests completed. Status: ${{ needs.accessibility-tests.result }}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Install dependencies
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run Playwright tests
-      run: cd tests/playwright && npx playwright test
+      run: cd tests/playwright && npm run integration-tests
 
   notify-of-test-run-completion:
     if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ tests/functional/results.html
 tests/unit/coverage
 tests/unit/dist/
 tests/playwright/test-results/
+tests/playwright/test-results-a11y/
 Thumbs.db
 tmp/*
 venv

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -181,7 +181,7 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title is-summary">
+      <h2 class="c-sub-navigation-title is-summary" data-testid="sub-navigation-title">
         {% if title.href %}
           <a href="{{ title.href }}" data-link-type="nav" data-link-position="subnav" data-link-text="{{ title.cta_name }}">
             {% if title.icon %}<img class="c-sub-navigation-icon" src="{{ title.icon }}" width="24" height="24" alt="">{% endif %}
@@ -192,7 +192,7 @@
           {{ title.text }}
         {% endif %}
       </h2>
-      <ul class="c-sub-navigation-list is-details is-closed">
+      <ul class="c-sub-navigation-list is-details is-closed" data-testid="sub-navigation-menu">
         {% for link in links %}
         <li class="c-sub-navigation-item">
           <a

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -18,6 +18,11 @@ correctly and that new changes don't break existing functionality.
   environment. These tests are run automatically as part of our CI deployment process against
   dev, stage, and prod. Playwright tests are run against Firefox, Chromium, and Webkit headless
   browsers for cross-engine coverage.
+- `Axe`_ tests are used to test for accessibility issues on key pages. These tests are not
+  run as part of our CI deployment process as they can contain a lot of information, but instead
+  run once per day via a GitHub action against dev. Axe tests are run via Playwright as a subset
+  of tests using the ``@a11y`` tag. Accessibility issues are reported in the GitHub action output,
+  which can be downloaded and reviewed.
 - `Selenium`_ tests are bedrock's older, legacy integration test suite, which will eventually be
   replaced by Playwright. These tests are run against Firefox, Chrome, and Internet Explorer
   (via a mix of both a local Selenium Grid and Sauce Labs) as part of our CI pipeline, and
@@ -33,6 +38,7 @@ The test specs for all of the above suites can be found in the root ``./tests`` 
 
 * ``./tests/unit/`` for Jasmine tests.
 * ``./tests/playwright/`` Playwright tests.
+* ``./tests/playwright/specs/a11y/`` Axe tests.
 * ``./tests/functional/`` for Selenium tests.
 
 Automating the browser
@@ -162,7 +168,7 @@ To run the full suite of tests (from the ``/tests/playwright/`` directory):
 
 .. code-block:: bash
 
-    $ npx playwright test
+    $ npm run integration-tests
 
 This will run all tests against three different headless browser engines (Firefox,
 Chromium, WebKit).
@@ -255,6 +261,30 @@ load a different override instead of using ``openPage``:
 
         await page.goto(url + '?automation=true');
     });
+
+Accessibility testing (Axe)
+===========================
+
+Axe tests are run as a subset of Playwright tests using the ``@a11y`` tag. These
+tests are run against the dev environment once per day via a GitHub action. The
+axe spec files can be found in the ``./tests/playwright/specs/a11y/`` directory.
+
+To run the Axe tests locally, you can use the following command from the
+``./tests/playwright/`` directory:
+
+.. code-block:: bash
+
+    $ npm run a11y-tests
+
+The Axe tests consist of two different test types. One that scans an entire page
+for accessibility issues, and another that scans a specific element for issues
+(such as the main navigation and footer). These tests can also be run at both
+desktop and mobile viewport sizes.
+
+Test results are output to the console, and any issues found will be created as
+HTML report files in the ``./tests/playwright/test-results-a11y/`` directory. When
+run via the GitHub action, the reports are also output to the annotation logs for
+each test job.
 
 Running Selenium tests
 ======================
@@ -509,3 +539,4 @@ via product details are well formed and return valid 200 responses.
 .. _Playwright CLI docs: https://playwright.dev/docs/test-cli
 .. _how to write tests: https://playwright.dev/docs/writing-tests
 .. _locator strategy: https://playwright.dev/docs/locators#locate-by-test-id
+.. _Axe: https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/README.md

--- a/tests/playwright/global-setup.js
+++ b/tests/playwright/global-setup.js
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Clean up /test-results-a11y/ directory before running tests.
+ */
+function cleanA11yReportDir() {
+    const dir = 'test-results-a11y/';
+    if (fs.existsSync(dir)) {
+        fs.rmdirSync(dir, {
+            recursive: true
+        });
+    }
+
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+    }
+}
+
+function globalSetup() {
+    cleanA11yReportDir();
+}
+
+module.exports = globalSetup;

--- a/tests/playwright/package-lock.json
+++ b/tests/playwright/package-lock.json
@@ -9,8 +9,29 @@
       "version": "0.1.0",
       "license": "MPL",
       "dependencies": {
+        "@axe-core/playwright": "^4.9.1",
         "@playwright/test": "^1.45.3",
+        "axe-html-reporter": "^2.2.5",
         "dotenv": "^16.4.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.9.1.tgz",
+      "integrity": "sha512-8m4WZbZq7/aq7ZY5IG8GqV+ZdvtGn/iJdom+wBg+iv/3BAOBIfNQtIu697a41438DzEEyptXWmC3Xl5Kx/o9/g==",
+      "dependencies": {
+        "axe-core": "~4.9.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@playwright/test": {
@@ -27,6 +48,49 @@
         "node": ">=18"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-html-reporter": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.5.tgz",
+      "integrity": "sha512-3+w+R7gjTLLtBn8wFPIkSb4VBV/CuMkk4F9+0/Iza7KBK6nxWFQ05LYY39pUf43OxORVhlf6wWT3YXdkLBrFxQ==",
+      "dependencies": {
+        "mustache": "^4.0.1",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "peerDependencies": {
+        "axe-core": ">=3"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
     "node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -37,6 +101,11 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -49,6 +118,76 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/playwright": {
@@ -78,6 +217,26 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     }
   }
 }

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -4,7 +4,9 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
+    "@axe-core/playwright": "^4.9.1",
     "@playwright/test": "^1.45.3",
+    "axe-html-reporter": "^2.2.5",
     "dotenv": "^16.4.1"
   },
   "repository": {
@@ -17,6 +19,8 @@
     "url": "https://bugzilla.mozilla.org/"
   },
   "scripts": {
-    "install-deps": "npx playwright install --with-deps"
+    "install-deps": "npx playwright install --with-deps",
+    "integration-tests": "npx playwright test --grep-invert @a11y",
+    "a11y-tests": "npx playwright test --grep @a11y --project=chromium"
   }
 }

--- a/tests/playwright/playwright.config.js
+++ b/tests/playwright/playwright.config.js
@@ -23,6 +23,8 @@ const desktopViewportSize = {
  * @see https://playwright.dev/docs/test-configuration
  */
 module.exports = defineConfig({
+    /* Global setup file to prepare the environment for the test run. */
+    globalSetup: require.resolve('./global-setup'),
     testDir: './specs',
     /* Run tests in files in parallel */
     fullyParallel: true,
@@ -39,7 +41,7 @@ module.exports = defineConfig({
         /* Base URL to use in actions like `await page.goto('/')`. */
         baseURL: process.env.PLAYWRIGHT_BASE_URL
             ? process.env.PLAYWRIGHT_BASE_URL
-            : 'http://localhost:8000/',
+            : 'http://localhost:8000',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry'

--- a/tests/playwright/specs/a11y/components.spec.js
+++ b/tests/playwright/specs/a11y/components.spec.js
@@ -1,0 +1,177 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const openPage = require('../../scripts/open-page');
+const { createReport, scanPageElement } = require('./includes/helpers');
+const {
+    navigationLocator,
+    footerLocator,
+    subNavigationLocator
+} = require('./includes/locators');
+const { test, expect } = require('@playwright/test');
+
+const testURL = '/en-US/firefox/new/';
+
+test.describe(
+    'Navigation (desktop)',
+    {
+        tag: '@a11y'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(testURL, page, browserName);
+        });
+
+        test('should not have any detectable a11y issues', async ({ page }) => {
+            const firefoxLink = page.getByTestId('navigation-link-firefox');
+            const firefoxMenu = page.getByTestId('navigation-menu-firefox');
+
+            // Hover over Firefox link to open menu
+            await expect(firefoxMenu).not.toBeVisible();
+            await firefoxLink.hover();
+            await expect(firefoxMenu).toBeVisible();
+
+            const results = await scanPageElement(page, navigationLocator);
+            createReport('component', 'navigation-desktop', results);
+            expect(results.violations.length).toEqual(0);
+        });
+    }
+);
+
+test.describe(
+    'Navigation (mobile)',
+    {
+        tag: '@a11y'
+    },
+    () => {
+        test.use({ viewport: { width: 360, height: 780 } });
+
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(testURL, page, browserName);
+        });
+
+        test('should not have any detectable a11y issues', async ({ page }) => {
+            const navigationMenuButton = page.getByTestId(
+                'navigation-menu-button'
+            );
+            const navigationMenuItems = page.getByTestId(
+                'navigation-menu-items'
+            );
+            const firefoxLink = page.getByTestId('navigation-link-firefox');
+            const firefoxMenu = page.getByTestId('navigation-menu-firefox');
+
+            // Open navigation menu
+            await expect(navigationMenuItems).not.toBeVisible();
+            await navigationMenuButton.click();
+            await expect(navigationMenuItems).toBeVisible();
+
+            // Open Firefox menu
+            await expect(firefoxMenu).not.toBeVisible();
+            await firefoxLink.click();
+            await expect(firefoxMenu).toBeVisible();
+
+            const results = await scanPageElement(page, navigationLocator);
+            createReport('component', 'navigation-mobile', results);
+            expect(results.violations.length).toEqual(0);
+        });
+    }
+);
+
+test.describe(
+    'Sub-navigation (desktop)',
+    {
+        tag: '@a11y'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(testURL, page, browserName);
+        });
+
+        test('should not have any detectable a11y issues', async ({ page }) => {
+            const results = await scanPageElement(page, subNavigationLocator);
+            createReport('component', 'sub-navigation-mobile', results);
+            expect(results.violations.length).toEqual(0);
+        });
+    }
+);
+
+test.describe(
+    'Sub-navigation (mobile)',
+    {
+        tag: '@a11y'
+    },
+    () => {
+        test.use({ viewport: { width: 360, height: 780 } });
+
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(testURL, page, browserName);
+        });
+
+        test('should not have any detectable a11y issues', async ({ page }) => {
+            const subNavigationTitle = page.getByTestId('sub-navigation-title');
+            const subNavigationMenu = page.getByTestId('sub-navigation-menu');
+
+            // Open sub-navigation menu
+            await expect(subNavigationMenu).not.toBeVisible();
+            await subNavigationTitle.click();
+            await expect(subNavigationMenu).toBeVisible();
+
+            const results = await scanPageElement(page, subNavigationLocator);
+            createReport('component', 'sub-navigation-mobile', results);
+            expect(results.violations.length).toEqual(0);
+        });
+    }
+);
+
+test.describe(
+    'Footer (desktop)',
+    {
+        tag: '@a11y'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(testURL, page, browserName);
+        });
+
+        test('should not have any detectable a11y issues', async ({ page }) => {
+            const results = await scanPageElement(page, footerLocator);
+            createReport('component', 'footer-desktop', results);
+            expect(results.violations.length).toEqual(0);
+        });
+    }
+);
+
+test.describe(
+    'Footer (mobile)',
+    {
+        tag: '@a11y'
+    },
+    () => {
+        test.use({ viewport: { width: 360, height: 780 } });
+
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(testURL, page, browserName);
+        });
+
+        test('should not have any detectable a11y issues', async ({ page }) => {
+            const footerHeadingCompany = page.getByTestId(
+                'footer-heading-company'
+            );
+            const footerListCompany = page.getByTestId('footer-list-company');
+
+            // Open Company section
+            await expect(footerListCompany).not.toBeVisible();
+            await footerHeadingCompany.click();
+            await expect(footerListCompany).toBeVisible();
+
+            const results = await scanPageElement(page, footerLocator);
+            createReport('component', 'footer-mobile', results);
+            expect(results.violations.length).toEqual(0);
+        });
+    }
+);

--- a/tests/playwright/specs/a11y/includes/helpers.js
+++ b/tests/playwright/specs/a11y/includes/helpers.js
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const { AxeBuilder } = require('@axe-core/playwright');
+const { createHtmlReport } = require('axe-html-reporter');
+const {
+    navigationLocator,
+    footerLocator,
+    subNavigationLocator
+} = require('./locators');
+
+/**
+ * Create an a11y report file.
+ * Report will be saved in `./tests/playwright/test-results-a11y/`.
+ * @param {string} slug
+ * @param {string} type
+ * @param {Object} results JSON object
+ */
+function createReport(slug, type, results) {
+    // Only create a report if there were violations.
+    if (results.violations.length === 0) {
+        return;
+    }
+
+    const fileName = `results-${slug.replaceAll('/', '-').toLowerCase()}-${type}.html`;
+    const reportHTML = createHtmlReport({
+        results: results,
+        options: {
+            projectKey: `${slug} (${type})`,
+            doNotCreateReportFile: true
+        }
+    });
+
+    fs.writeFileSync(`test-results-a11y/${fileName}`, reportHTML);
+}
+
+/**
+ * Scan a whole page for a11y issues.
+ * Exclude global elements such as navigation and footer.
+ * @param {Object} page
+ * @returns {Promise} results
+ */
+async function scanPage(page) {
+    return await new AxeBuilder({ page })
+        .exclude(navigationLocator)
+        .exclude(footerLocator)
+        .exclude(subNavigationLocator)
+        .analyze();
+}
+
+/**
+ * Scan a specific element on the page for a11y issues.
+ * @param {Object} page
+ * @returns {Promise} results
+ */
+async function scanPageElement(page, locator) {
+    return new AxeBuilder({ page }).include(locator).analyze();
+}
+
+module.exports = { createReport, scanPage, scanPageElement };

--- a/tests/playwright/specs/a11y/includes/locators.js
+++ b/tests/playwright/specs/a11y/includes/locators.js
@@ -1,0 +1,17 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * CSS selectors of common elements for
+ * inclusion / exclusion in a11y scans.
+ */
+const footerLocator = '.mzp-c-footer';
+const navigationLocator = '.c-navigation';
+const subNavigationLocator = '.c-sub-navigation';
+
+module.exports = { navigationLocator, footerLocator, subNavigationLocator };

--- a/tests/playwright/specs/a11y/includes/urls.js
+++ b/tests/playwright/specs/a11y/includes/urls.js
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+/**
+ * URL paths for inclusion in page-level a11y scans.
+ * Pages will be scanned at both desktop and mobile resolutions.
+ */
+const pageTestURLs = [
+    '/en-US/',
+    '/en-US/about/',
+    '/en-US/firefox/',
+    '/en-US/firefox/all/',
+    '/en-US/firefox/channel/desktop/',
+    '/en-US/firefox/new/',
+    '/en-US/products/',
+    '/en-US/products/vpn/'
+];
+
+module.exports = { pageTestURLs };

--- a/tests/playwright/specs/a11y/pages.spec.js
+++ b/tests/playwright/specs/a11y/pages.spec.js
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const openPage = require('../../scripts/open-page');
+const { createReport, scanPage } = require('./includes/helpers');
+const { pageTestURLs } = require('./includes/urls');
+const { test, expect } = require('@playwright/test');
+
+for (const url of pageTestURLs) {
+    test.describe(
+        `${url} page (desktop)`,
+        {
+            tag: '@a11y'
+        },
+        () => {
+            test.beforeEach(async ({ page, browserName }) => {
+                await openPage(url, page, browserName);
+            });
+
+            test('should not have any detectable a11y issues', async ({
+                page
+            }) => {
+                const results = await scanPage(page);
+                createReport(url, 'desktop', results);
+                expect(results.violations.length).toEqual(0);
+            });
+        }
+    );
+}
+
+for (const url of pageTestURLs) {
+    test.describe(
+        `${url} page (mobile)`,
+        {
+            tag: '@a11y'
+        },
+        () => {
+            test.use({ viewport: { width: 360, height: 780 } });
+
+            test.beforeEach(async ({ page, browserName }) => {
+                await openPage(url, page, browserName);
+            });
+
+            test('should not have any detectable a11y issues', async ({
+                page
+            }) => {
+                const results = await scanPage(page);
+                createReport(url, 'mobile', results);
+                expect(results.violations.length).toEqual(0);
+            });
+        }
+    );
+}


### PR DESCRIPTION
## One-line summary

Adds a new Playwright a11y test suite, powered via [Axe Core](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/README.md).

## Significant changes and points to review

These initial tests are against a small-ish set of our key, most high-traffic pages. The test runs will fail for now and that's fine. They will not block deployments, and will instead run once per-day against www-dev and report via Slack. We can expand the number of pages this test suite covers as we work through issues it identifies.

## Issue / Bugzilla link

#14773

## Testing

- `cd tests/playwright && npm ci && npm run install-deps`
- `npm run a11y-tests`

Once the test run completes, it should fail (which is expected).

The resulting failures will be captured as HTML reports and saved in `./tests/playwright/test-reports-a11y/`. You can open these files in your browser and read more information about each issue.