### PR TITLE
Add pre-commit hooks to check for untracked, unapplied or absent DB migrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,3 +97,12 @@ repos:
         additional_dependencies:
           - "eslint-config-prettier@9.1.0"
   #       Additional excludes in /.eslintignore file
+  - repo: https://github.com/mozmeao/pre-commit-hooks-django
+    rev: v0.4.1a  # this is OUR micro-bumped release of the fork
+    hooks:
+    -   id: check-untracked-migrations
+        # If specified in args, below, this hook will work only on those
+        # branches, otherwise it will work on all branches
+        # args: ["--branches", "main", "other_branch"]
+    -   id: check-unapplied-migrations
+    -   id: check-absent-migrations


### PR DESCRIPTION
## One-line summary

This changeset adds protection against untracked, unapplied or absent Django Migrations, which could cause us some awkward fixups if a PR lacking the right Migration(s) was merged to main and then its migrations run on the DB.

It uses a mozmeao-homed fork of some third-party pre-commit hooks.

It does add ~2s to the runtime of the pre-commit hooks, but it's worth it, I think.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Solves part of #14859 

## Testing

You can edit a django model (eg change a field) and try to commit it. 

Here's one I made earlier:

<img width="872" alt="Screenshot 2024-07-22 at 21 27 12" src="https://github.com/user-attachments/assets/331dcee5-5b0b-4858-87df-03a5f5a3ab1a">


