### PR TITLE
Move away from depending on 'py' requirement

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -6,7 +6,6 @@ factory-boy==3.3.0
 freezegun==1.5.1
 markdown-it-py>=2.2.0
 pipdeptree==2.23.0
-py==1.11.0
 Pygments>=2.15.0  # to bring it up to a secure version
 PyPOM==2.2.4
 pyquery==2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1549,10 +1549,6 @@ psycopg-binary==3.1.19 \
     # via
     #   -r requirements/prod.txt
     #   psycopg
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via -r requirements/dev.in
 pyasn1==0.6.0 \
     --hash=sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c \
     --hash=sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473


### PR DESCRIPTION
## One-line summary

The `py` package is explicitly required, but no package directly depends on it.

EDIT: Some `pytest-*` plugins (at least in the versions used here) do require `py.*` imports, but fail to declare `py` as dependency (because `pytest<v7.2.0` did that for them) — they'd need to be updated or removed first.

## Significant changes and points to review

What turned out as a blocker is pytest's removal of py in 7.2.0 and vendoring just the useful bits left its plugins without explicit py dependency but still relying on e.g. py.xml broken from that point on, so only those still maintained and updating/replacing their dependencies will continue working with newer releases _(or will need a py version explicitly required and pinned like here now, until updated)_. But that upgrade is currently blocked: #14013 (also see #14316 for more issues in version compatibility), truth is replacing Selenium with Playwright might happen faster than this.

TODO:

- **pytest-selenium** moved from py.xml to html in 4.0.2 but that has caused some regressions here.
- **pytest-parallel** is unmaintained and may need replacing with pytest-xdist (which is actually not that ideal for selenium fwiw…)

## Issue / Bugzilla link

Resolves #14851

## Testing

`make build` && `make test` && `make run`

Just to verify the legacy entrypoints still work (they are equivalent):
(`docker-compose run test`) `pytest bedrock/firefox`
is the same as
(`docker-compose run test`) `py.test bedrock/firefox`