### PR TITLE
Update pytest entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test: .docker-build-pull
 	${DC} run --rm test
 
 test-cdn: .docker-build-pull test_infra/fixtures/tls.json
-	${DC} run test py.test --base-url https://${TEST_DOMAIN} test_infra
+	${DC} run test pytest --base-url https://${TEST_DOMAIN} test_infra
 
 test-image: .docker-build
 	${DC} run test-image

--- a/bin/integration_tests/run_integration_tests.sh
+++ b/bin/integration_tests/run_integration_tests.sh
@@ -20,7 +20,7 @@ set -xe
 # Common arguments
 if [ "${DRIVER}" = "SauceLabs" ]; then
   # Temporarily exclude logs for Saucelabs jobs https://github.com/pytest-dev/pytest-selenium/issues/288
-  CMD="SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs py.test"
+  CMD="SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs pytest"
 else
   CMD="pytest"
 fi

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -18,7 +18,7 @@ set -xe
 # Common arguments
 if [ "${DRIVER}" = "SauceLabs" ]; then
   # Temporarily exclude logs for Saucelabs jobs https://github.com/pytest-dev/pytest-selenium/issues/288
-  CMD="SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs py.test"
+  CMD="SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs pytest"
 else
   CMD="pytest"
 fi

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -261,10 +261,10 @@ If you don't have Make you can simply run ``docker-compose run test``.
 If you'd like to run only a subset of the tests or only one of the test commands you can accomplish
 that with a command like the following::
 
-    $ docker-compose run test py.test bedrock/firefox
+    $ docker-compose run test pytest bedrock/firefox
 
 This example will run only the unit tests for the ``firefox`` app in bedrock. You can substitute
-``py.test bedrock/firefox`` with most any shell command you'd like and it will run in the Docker
+``pytest bedrock/firefox`` with most any shell command you'd like and it will run in the Docker
 container and show you the output. You can also just run ``bash`` to get an interactive shell in
 the container which you can then use to run any commands you'd like and inspect the file system::
 
@@ -276,11 +276,11 @@ Local
 From the local install instructions above you should still have your virtualenv
 activated, so running the tests is as simple as::
 
-    $ py.test lib bedrock
+    $ pytest lib bedrock
 
 To test a single app, specify the app by name in the command above. e.g.::
 
-    $ py.test bedrock/firefox
+    $ pytest bedrock/firefox
 
 
 Make it run

--- a/docs/redirects.rst
+++ b/docs/redirects.rst
@@ -188,7 +188,7 @@ of the site (e.g. www.mozilla.org) you can set the ``--base-url`` command line o
 
 .. code-block:: bash
 
-    $ py.test --base-url https://www.mozilla.org tests/redirects/
+    $ pytest --base-url https://www.mozilla.org tests/redirects/
 
 By default, tests will run one at a time. If you intend to run the suite
 against a remote instance of the site (e.g. production) it will run a lot

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -111,7 +111,7 @@ Mozorg mode:
 
 .. code-block:: bash
 
-    $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/
+    $ pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/
 
 This will run all test suites found in the ``tests/functional`` directory and
 assumes you have bedrock running at ``localhost`` on port ``8000``. Results will
@@ -125,7 +125,7 @@ time. You need to define a temporary environment variable (needed by the
 
 .. code-block:: bash
 
-    $ BASE_POCKET_URL=http://localhost:8000 py.test -m pocket_mode --driver Firefox --html tests/functional/results.html tests/functional/
+    $ BASE_POCKET_URL=http://localhost:8000 pytest -m pocket_mode --driver Firefox --html tests/functional/results.html tests/functional/
 
 This will run all test suites found in the ``tests/functional`` directory that have
 the pytest "`mark`" of `pocket_mode` and assumes you have bedrock running *in Pocket mode* at
@@ -151,26 +151,26 @@ processes.
     take a long time to run, especially if they're not running in parallel.
     To skip these tests, add ``-m 'not headless'`` to your command line.
 
-To run a single test file you must tell py.test to execute a specific file
+To run a single test file you must tell pytest to execute a specific file
 e.g. ``tests/functional/test_newsletter.py``:
 
 .. code-block:: bash
 
-    $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/new/test_download.py
+    $ pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/new/test_download.py
 
 To run a single test you can filter using the ``-k`` argument supplied with a keyword
 e.g. ``-k test_download_button_displayed``:
 
 .. code-block:: bash
 
-  $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/new/test_download.py -k test_download_button_displayed
+  $ pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/new/test_download.py -k test_download_button_displayed
 
 You can also easily run the tests against any bedrock environment by specifying the
 ``--base-url`` argument. For example, to run all functional tests against dev:
 
 .. code-block:: bash
 
-    $ py.test --base-url https://www-dev.allizom.org --driver Firefox --html tests/functional/results.html tests/functional/
+    $ pytest --base-url https://www-dev.allizom.org --driver Firefox --html tests/functional/results.html tests/functional/
 
 .. Note::
 
@@ -195,7 +195,7 @@ For example, to run the home page tests using Internet Explorer via Sauce Labs:
 
 .. code-block:: bash
 
-    $ SAUCELABS_USERNAME=thedude SAUCELABS_API_KEY=123456789 SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs py.test --base-url https://www-dev.allizom.org --driver SauceLabs --capability browserName 'internet explorer' --capability platformName 'Windows 10' --html tests/functional/results.html tests/functional/test_home.py
+    $ SAUCELABS_USERNAME=thedude SAUCELABS_API_KEY=123456789 SAUCELABS_W3C=true SELENIUM_EXCLUDE_DEBUG=logs pytest --base-url https://www-dev.allizom.org --driver SauceLabs --capability browserName 'internet explorer' --capability platformName 'Windows 10' --html tests/functional/results.html tests/functional/test_home.py
 
 
 Writing Selenium tests


### PR DESCRIPTION
## One-line summary



## Significant changes and points to review



## Issue / Bugzilla link

#14851

## Testing

(`docker-compose run test`) `pytest bedrock/firefox`
is the same as
(`docker-compose run test`) `py.test bedrock/firefox`

also
```sh
mkdir test_infra
mkdir test_infra/fixtures
make test_infra/fixtures/tls.json
make test-cdn  
```
but I'm prolly missing some secret sauce here to run it successfully…:/