### PR TITLE
Add KIP newsletter confirmation page (Fixes #14823)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/knowledge-is-power-confirm.html
+++ b/bedrock/newsletter/templates/newsletter/knowledge-is-power-confirm.html
@@ -1,0 +1,47 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends 'base-protocol.html' %}
+
+{% block page_title %}Knowledge is Power Newsletter{% endblock page_title %}
+
+{% block page_css %}
+  {{ css_bundle('newsletter-knowledge-is-power-confirm') }}
+{% endblock %}
+
+{% block content %}
+<main class="mzp-l-content mzp-t-content-lg mzp-u-centered">
+  <header>
+    <h1 class="page-title">Knowledge is Power Newsletter</h1>
+  </header>
+
+  <form id="confirmation-form" class="c-confirmation-form" method="post" action="{{ action }}" data-recovery-url="{{ url('newsletter.recovery') }}">
+    <input type="hidden" name="newsletters" value="{{ newsletters }}">
+    <input type="hidden" name="source_url" value="{{ source_url|absolute_url }}">
+    <p class="c-confirmation-form-tagline">Please click the button below to confirm your subscription.</p>
+    <div class="c-confirm-form-errors mzp-c-form-errors hidden" id="confirm-form-errors">
+      <p class="c-confirm-error-msg error-invalid-token hidden">
+        We are sorry, but could not find your email address in our system.
+      </p>
+      <p class="c-confirm-error-msg error-try-again-later hidden">
+        We are sorry, but there was a problem with our system. Please try again later!
+      </p>
+      <p class="c-confirm-error-msg error-update-browser hidden">
+        Please update your web browser in order to use this page.
+      </p>
+    </div>
+    <button type="submit" class="c-confirm-form-submit mzp-c-button">Subscribe</button>
+  </form>
+  <div class="c-confirmation-form-thanks hidden">
+    <p>Thank you for subscribing!</p>
+    <p>Check your inbox soon for the latest Knowledge is Power newsletter.</p>
+  </div>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('newsletter-knowledge-is-power-confirm') }}
+{% endblock %}

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -16,6 +16,7 @@ from bedrock.mozorg.tests import TestCase
 from bedrock.newsletter.views import (
     general_error,
     invalid_email_address,
+    kip_confirm,
     newsletter_all_json,
     newsletter_strings_json,
 )
@@ -268,3 +269,17 @@ class TestNewsletterStringsJson(TestCase):
         newsletter_strings_json(req)
         template = render_mock.call_args[0][1]
         self.assertTrue(template == "newsletter/includes/newsletter-strings.json")
+
+
+@patch("bedrock.newsletter.views.l10n_utils.render", return_value=HttpResponse())
+class TestNewsletterConfirmPage(TestCase):
+    def setUp(self):
+        self.token = str(uuid.uuid4())
+        self.url = reverse("newsletter.knowledge-is-power.confirm", kwargs={"token": self.token})
+
+    def test_newsletter_knowledge_is_power_confirm(self, render_mock):
+        req = RequestFactory().get(self.url)
+        req.locale = "en-US"
+        kip_confirm(req, self.token)
+        template = render_mock.call_args[0][1]
+        self.assertTrue(template == "newsletter/knowledge-is-power-confirm.html")

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -43,6 +43,7 @@ urlpatterns = (
         ),
         name="newsletter.knowledge-is-power",
     ),
+    re_path("^newsletter/knowledge-is-power/confirm/(?P<token>[^/]*)/?$", views.kip_confirm, name="newsletter.knowledge-is-power.confirm"),
     page("newsletter/family/", "newsletter/family.html", ftl_files=["mozorg/newsletters"], active_locales=["en-US"]),
     page("newsletter/security-and-privacy/", "newsletter/security-privacy-news.html", ftl_files=["mozorg/newsletters"]),
     page("newsletter/security-and-privacy/online-harassment/", "newsletter/online-harassment.html"),

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -284,3 +284,16 @@ def newsletter_subscribe(request):
             return l10n_utils.render(request, "newsletter/index.html", ctx, ftl_files=FTL_FILES)
 
     return l10n_utils.render(request, "newsletter/index.html", ftl_files=FTL_FILES)
+
+
+def kip_confirm(request, token):
+    """Allow a user to confirm their subscription to the knowledge-is-power newsletter"""
+
+    context = {
+        "action": f"{settings.BASKET_URL}/news/subscribe/",
+        "newsletters": "knowledge-is-power",
+        "recovery_url": reverse("newsletter.recovery"),
+        "source_url": reverse("newsletter.knowledge-is-power.confirm", kwargs={"token": ""}),
+    }
+
+    return l10n_utils.render(request, "newsletter/knowledge-is-power-confirm.html", context)

--- a/media/css/newsletter/newsletter-knowledge-is-power-confirm.scss
+++ b/media/css/newsletter/newsletter-knowledge-is-power-confirm.scss
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+
+main {
+    min-height: 500px;
+}
+
+.c-confirmation-form {
+    margin-top: $layout-lg;
+}
+
+.c-confirmation-form-tagline {
+    @include text-body-xl;
+}
+
+.c-confirmation-form-thanks {
+    @include text-body-xl;
+    margin-top: $layout-lg;
+}
+
+.c-confirm-form-errors {
+    max-width: 400px;
+    margin: 0 auto $spacing-xl;
+}
+
+.c-confirm-error-msg {
+    margin-bottom: 0;
+}

--- a/media/js/newsletter/confirm-init.es6.js
+++ b/media/js/newsletter/confirm-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import ConfirmForm from './confirm.es6';
+
+ConfirmForm.init();

--- a/media/js/newsletter/confirm.es6.js
+++ b/media/js/newsletter/confirm.es6.js
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import FormUtils from './form-utils.es6';
+
+let _form;
+
+const ConfirmationForm = {
+    meetsRequirements: () => {
+        return 'Promise' in window;
+    },
+
+    handleFormError: (msg) => {
+        FormUtils.enableFormFields(_form);
+        _form.querySelector('.mzp-c-form-errors').classList.remove('hidden');
+
+        if (msg && msg === FormUtils.errorList.TOKEN_INVALID) {
+            _form
+                .querySelector('.error-invalid-token')
+                .classList.remove('hidden');
+        } else if (msg && msg === FormUtils.errorList.UPDATE_BROWSER) {
+            _form
+                .querySelector('.error-update-browser')
+                .classList.remove('hidden');
+        } else {
+            _form
+                .querySelector('.error-try-again-later')
+                .classList.remove('hidden');
+        }
+    },
+
+    handleFormSuccess: () => {
+        _form.classList.add('hidden');
+        document
+            .querySelector('.c-confirmation-form-thanks')
+            .classList.remove('hidden');
+    },
+
+    redirectToRecoveryPage: () => {
+        const recoveryUrl = _form.getAttribute('data-recovery-url');
+
+        if (FormUtils.isWellFormedURL(recoveryUrl)) {
+            window.location.href = recoveryUrl;
+        } else {
+            ConfirmationForm.handleFormError();
+        }
+    },
+
+    getFormActionURL: () => {
+        return _form.getAttribute('action');
+    },
+
+    serialize: () => {
+        const params = FormUtils.serialize(_form);
+        const token = FormUtils.getUserToken();
+
+        if (params && token) {
+            return `${params}&token=${token}`;
+        }
+
+        return '';
+    },
+
+    subscribe: (e) => {
+        const url = ConfirmationForm.getFormActionURL();
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Disable form fields until POST has completed.
+        FormUtils.disableFormFields(_form);
+
+        // Clear any prior messages that might have been displayed.
+        FormUtils.clearFormErrors(_form);
+
+        const params = ConfirmationForm.serialize();
+
+        FormUtils.postToBasket(
+            null,
+            params,
+            url,
+            ConfirmationForm.handleFormSuccess,
+            ConfirmationForm.handleFormError
+        );
+    },
+
+    init: () => {
+        _form = document.getElementById('confirmation-form');
+
+        if (!ConfirmationForm.meetsRequirements()) {
+            ConfirmationForm.handleFormError('Update your browser');
+            return;
+        }
+
+        _form.addEventListener('submit', ConfirmationForm.subscribe, false);
+
+        // Look for a valid user token before rendering the page.
+        // If not found, redirect to /newsletter/recovery/.
+        return FormUtils.checkForUserToken().catch(
+            ConfirmationForm.redirectToRecoveryPage
+        );
+    }
+};
+
+export default ConfirmationForm;

--- a/media/js/newsletter/form-utils.es6.js
+++ b/media/js/newsletter/form-utils.es6.js
@@ -18,7 +18,9 @@ const errorList = {
     NEWSLETTER_ERROR: 'Newsletter not selected',
     NOT_FOUND: 'Not Found',
     PRIVACY_POLICY_ERROR: 'Privacy policy not checked',
-    REASON_ERROR: 'Reason not selected'
+    REASON_ERROR: 'Reason not selected',
+    TOKEN_INVALID: 'Invalid basket token',
+    UPDATE_BROWSER: 'Update your browser'
 };
 
 const FormUtils = {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -347,6 +347,12 @@
     },
     {
       "files": [
+        "css/newsletter/newsletter-knowledge-is-power-confirm.scss"
+      ],
+      "name": "newsletter-knowledge-is-power-confirm"
+    },
+    {
+      "files": [
         "css/newsletter/newsletter-security-privacy-news.scss"
       ],
       "name": "newsletter-security-privacy-news"
@@ -1332,6 +1338,12 @@
         "js/newsletter/newsletter-init.es6.js"
       ],
       "name": "newsletter"
+    },
+    {
+      "files": [
+        "js/newsletter/confirm-init.es6.js"
+      ],
+      "name": "newsletter-knowledge-is-power-confirm"
     },
     {
       "files": [

--- a/tests/unit/spec/newsletter/confirm.js
+++ b/tests/unit/spec/newsletter/confirm.js
@@ -1,0 +1,206 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import FormUtils from '../../../../media/js/newsletter/form-utils.es6';
+import ConfirmationForm from '../../../../media/js/newsletter/confirm.es6';
+
+const TOKEN_MOCK = 'a1a2a3a4-abc1-12ab-a123-12345a12345b';
+
+describe('ConfirmationForm', function () {
+    beforeEach(async function () {
+        const form = `<div id="confirm-form-container">
+            <form id="confirmation-form" class="c-confirmation-form" action="https://basket.mozilla.org/news/subscribe/" data-recovery-url="https://www.mozilla.org/newsletter/recovery/">
+                <input type="hidden" name="newsletters" value="knowledge-is-power">
+                <input type="hidden" name="source_url" value="https://www.mozilla.org/en-US/newsletter/knowledge-is-power/confirm/">
+                <div class="c-confirm-form-errors mzp-c-form-errors hidden" id="confirm-form-errors">
+                    <p class="c-confirm-error-msg error-invalid-token hidden">
+                        We are sorry, but could not find your email address in our system.
+                    </p>
+                    <p class="c-confirm-error-msg error-try-again-later hidden">
+                        We are sorry, but there was a problem with our system. Please try again later!
+                    </p>
+                    <p class="c-confirm-error-msg error-update-browser hidden">
+                        Please update your web browser in order to use this page.
+                    </p>
+                </div>
+                <button type="submit" class="c-confirm-form-submit mzp-c-button">Subscribe</button>
+            </form>
+            <div class="c-confirmation-form-thanks hidden">
+                <p>Thank you for subscribing!</p>
+            </div>
+        </div>`;
+        document.body.insertAdjacentHTML('beforeend', form);
+    });
+
+    afterEach(function () {
+        const form = document.getElementById('confirm-form-container');
+        form.parentNode.removeChild(form);
+    });
+
+    describe('form submission', function () {
+        let xhr;
+        let xhrRequests = [];
+
+        beforeEach(function () {
+            xhr = sinon.useFakeXMLHttpRequest();
+            xhr.onCreate = (req) => {
+                xhrRequests.push(req);
+            };
+        });
+
+        afterEach(function () {
+            xhr.restore();
+            xhrRequests = [];
+        });
+
+        it('should handle success', function () {
+            spyOn(FormUtils, 'getURLToken').and.returnValue(TOKEN_MOCK);
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
+            spyOn(ConfirmationForm, 'handleFormSuccess').and.callThrough();
+
+            return ConfirmationForm.init().then(() => {
+                document.querySelector('.c-confirm-form-submit').click();
+                xhrRequests[0].respond(
+                    200,
+                    { 'Content-Type': 'application/json' },
+                    '{"status": "ok"}'
+                );
+
+                expect(xhrRequests[0].url).toEqual(
+                    'https://basket.mozilla.org/news/subscribe/'
+                );
+                expect(xhrRequests[0].requestBody).toEqual(
+                    'newsletters=knowledge-is-power&source_url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fnewsletter%2Fknowledge-is-power%2Fconfirm%2F&token=a1a2a3a4-abc1-12ab-a123-12345a12345b'
+                );
+                expect(ConfirmationForm.handleFormSuccess).toHaveBeenCalled();
+                expect(
+                    document
+                        .querySelector('.c-confirmation-form')
+                        .classList.contains('hidden')
+                ).toBeTrue();
+                expect(
+                    document
+                        .querySelector('.c-confirmation-form-thanks')
+                        .classList.contains('hidden')
+                ).toBeFalse();
+            });
+        });
+
+        it('should handle invalid token', function () {
+            spyOn(FormUtils, 'getURLToken').and.returnValue(TOKEN_MOCK);
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
+            spyOn(ConfirmationForm, 'handleFormError').and.callThrough();
+
+            return ConfirmationForm.init()
+                .then()
+                .then(() => {
+                    document.querySelector('.c-confirm-form-submit').click();
+                    xhrRequests[0].respond(
+                        400,
+                        { 'Content-Type': 'application/json' },
+                        '{"status": "error", "desc": "Invalid basket token"}'
+                    );
+
+                    expect(ConfirmationForm.handleFormError).toHaveBeenCalled();
+                    expect(
+                        document
+                            .querySelector('.c-confirm-form-errors')
+                            .classList.contains('hidden')
+                    ).toBeFalse();
+                    expect(
+                        document
+                            .querySelector('.error-invalid-token')
+                            .classList.contains('hidden')
+                    ).toBeFalse();
+                });
+        });
+
+        it('should handle unknown error', function () {
+            spyOn(FormUtils, 'getURLToken').and.returnValue(TOKEN_MOCK);
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
+            spyOn(ConfirmationForm, 'handleFormError').and.callThrough();
+
+            return ConfirmationForm.init().then(() => {
+                document.querySelector('.c-confirm-form-submit').click();
+                xhrRequests[0].respond(
+                    400,
+                    { 'Content-Type': 'application/json' },
+                    '{"status": "error", "desc": "Unknown non-helpful error"}'
+                );
+
+                expect(ConfirmationForm.handleFormError).toHaveBeenCalled();
+                expect(
+                    document
+                        .querySelector('.c-confirm-form-errors')
+                        .classList.contains('hidden')
+                ).toBeFalse();
+                expect(
+                    document
+                        .querySelector('.error-try-again-later')
+                        .classList.contains('hidden')
+                ).toBeFalse();
+            });
+        });
+
+        it('should handle failure', function () {
+            spyOn(FormUtils, 'getURLToken').and.returnValue(TOKEN_MOCK);
+            spyOn(FormUtils, 'getUserToken').and.returnValue(TOKEN_MOCK);
+            spyOn(ConfirmationForm, 'handleFormError').and.callThrough();
+
+            return ConfirmationForm.init().then(() => {
+                document.querySelector('.c-confirm-form-submit').click();
+                xhrRequests[0].respond(
+                    500,
+                    { 'Content-Type': 'application/json' },
+                    null
+                );
+
+                expect(ConfirmationForm.handleFormError).toHaveBeenCalled();
+                expect(
+                    document
+                        .querySelector('.c-confirm-form-errors')
+                        .classList.contains('hidden')
+                ).toBeFalse();
+                expect(
+                    document
+                        .querySelector('.error-try-again-later')
+                        .classList.contains('hidden')
+                ).toBeFalse();
+            });
+        });
+
+        it('should handle an outdated browser', function () {
+            spyOn(ConfirmationForm, 'handleFormError').and.callThrough();
+            spyOn(ConfirmationForm, 'meetsRequirements').and.returnValue(false);
+
+            ConfirmationForm.init();
+
+            expect(ConfirmationForm.handleFormError).toHaveBeenCalled();
+            expect(
+                document
+                    .querySelector('.c-confirm-form-errors')
+                    .classList.contains('hidden')
+            ).toBeFalse();
+            expect(
+                document
+                    .querySelector('.error-update-browser')
+                    .classList.contains('hidden')
+            ).toBeFalse();
+        });
+
+        it('should redirect to /newsletter/recovery/ page if token is missing', function () {
+            spyOn(FormUtils, 'getURLToken').and.returnValue('');
+            spyOn(FormUtils, 'getUserToken').and.returnValue('');
+            spyOn(ConfirmationForm, 'redirectToRecoveryPage');
+
+            return ConfirmationForm.init().then(() => {
+                expect(
+                    ConfirmationForm.redirectToRecoveryPage
+                ).toHaveBeenCalled();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

Adds newsletter confirmation page for Knowledge is Power (KiP).

## Issue / Bugzilla link

#14823

## Testing

First get your newsletter token by following these steps:

1. Open https://www.mozilla.org/en-US/newsletter/recovery/ and enter your email.
2. Find the recovery email, and click the link that opens the email preference center.
3. Open Dev Tools -> Storage -> Cookies and find the cookie called `nl-token`. Copy it's value (which should be a long alpha-numeric string).
4. Whilst you're here, make sure you are *not* subscribed to KiP (unsubscribe if you are).

Next, open the KIP confirmation page using your token in the URL:

1. Open: `http://localhost:8000/en-US/newsletter/knowledge-is-power/confirm/{INSERT_YOUR_TOKEN_HERE}`
2. When the page loads, click "Confirm".

If you see a "thank you" message then you should now be subscribed to KiP.

Finally, confirm the subscription has worked by going back to the newsletter management page, and you should hopefully see KiP is checked in the list.