### PR TITLE
Update applicant privacy notice on job postings [fix #14875]

### DIFF
--- a/bedrock/careers/templates/careers/position.html
+++ b/bedrock/careers/templates/careers/position.html
@@ -64,7 +64,7 @@
     </div>
   </div>
 
-  <p><a rel="external" target="_blank" href="https://docs.google.com/document/d/e/2PACX-1vTEeCImDA-kqr0wm3JwfOv_2MS5FZ8oyL2pEWfVsZbeO87E41r2wePoOhppQ4qX6w/pub">Applicant Privacy Notice</a></p>
+  <p><a rel="external noopener noreferrer" target="_blank" href="https://docs.google.com/document/d/e/2PACX-1vTEeCImDA-kqr0wm3JwfOv_2MS5FZ8oyL2pEWfVsZbeO87E41r2wePoOhppQ4qX6w/pub">Applicant Privacy Notice</a></p>
 </section>
 </div>
 

--- a/bedrock/careers/templates/careers/position.html
+++ b/bedrock/careers/templates/careers/position.html
@@ -64,7 +64,7 @@
     </div>
   </div>
 
-  <p><a rel="external" href="https://assets.mozilla.net/pdf/Mozilla_Workforce_Privacy_Notice_21-Mar-2024.pdf">Applicant Privacy Notice</a></p>
+  <p><a rel="external" target="_blank" href="https://docs.google.com/document/d/e/2PACX-1vTEeCImDA-kqr0wm3JwfOv_2MS5FZ8oyL2pEWfVsZbeO87E41r2wePoOhppQ4qX6w/pub">Applicant Privacy Notice</a></p>
 </section>
 </div>
 


### PR DESCRIPTION
## One-line summary
Request from legal. This updates the link to point to a public Google doc rather than a PDF.

## Issue / Bugzilla link
#14875 

## Testing
http://localhost:8000/careers/listings/ and choose any open position (this will depend on your local data so I can't link directly to a job). The Applicant Privacy Notice link is at the bottom of the page under the Apply Now dropdown.