### PR TITLE
Nothing Personal page, right align window titles [#14824]

### DIFF
--- a/media/css/firefox/nothing-personal/_browser.scss
+++ b/media/css/firefox/nothing-personal/_browser.scss
@@ -24,7 +24,7 @@
             font-weight: 500;
             margin-bottom: 0;
             padding-left: 80px;
-            text-align: start;
+            text-align: end;
             white-space: nowrap;
 
             @media (min-width: $mq-tad-smaller-sm) {


### PR DESCRIPTION
Aligns window titles to the right on mobile.

http://localhost:8000/firefox/nothing-personal/