### PR TITLE
Update URLs to use `uuid` path converter

### DIFF
--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -1,25 +1,17 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-import json
 import uuid
 from unittest.mock import patch
 
-from django.http import HttpResponse
-from django.test.client import RequestFactory
+from django.conf import settings
 
 import basket
 from pyquery import PyQuery as pq
 
 from bedrock.base.urlresolvers import reverse
 from bedrock.mozorg.tests import TestCase
-from bedrock.newsletter.views import (
-    general_error,
-    invalid_email_address,
-    kip_confirm,
-    newsletter_all_json,
-    newsletter_strings_json,
-)
+from bedrock.newsletter.views import general_error, invalid_email_address
 
 
 class TestConfirmView(TestCase):
@@ -27,44 +19,48 @@ class TestConfirmView(TestCase):
         self.token = str(uuid.uuid4())
         self.url = reverse("newsletter.confirm", kwargs={"token": self.token})
 
-    def test_normal(self):
+    @patch("basket.confirm")
+    def test_normal(self, confirm):
         """Confirm works with a valid token"""
-        with patch("basket.confirm") as confirm:
-            confirm.return_value = {"status": "ok"}
-            rsp = self.client.get(self.url)
-            self.assertEqual(302, rsp.status_code)
-            self.assertTrue(rsp["Location"].endswith(f"{reverse('newsletter.existing.token', kwargs={'token': self.token})}?confirm=1"))
+        confirm.return_value = {"status": "ok"}
+        rsp = self.client.get(self.url)
+        self.assertEqual(302, rsp.status_code)
+        self.assertURLEqual(rsp["Location"], f"{reverse('newsletter.existing', kwargs={'token': self.token})}?confirm=1")
 
-    def test_normal_with_query_params(self):
+    @patch("basket.confirm")
+    def test_normal_with_query_params(self, confirm):
         """Confirm works with a valid token"""
-        with patch("basket.confirm") as confirm:
-            confirm.return_value = {"status": "ok"}
-            rsp = self.client.get(self.url + "?utm_tracking=oh+definitely+yes&utm_source=malibu")
-            self.assertEqual(302, rsp.status_code)
-            self.assertTrue(
-                rsp["Location"].endswith(
-                    f"{reverse('newsletter.existing.token', kwargs={'token': self.token})}"
-                    "?confirm=1&utm_tracking=oh+definitely+yes&utm_source=malibu"
-                )
-            )
+        confirm.return_value = {"status": "ok"}
+        rsp = self.client.get(self.url + "?utm_tracking=oh+definitely+yes&utm_source=malibu")
+        self.assertEqual(302, rsp.status_code)
+        self.assertURLEqual(
+            rsp["Location"],
+            f"{reverse('newsletter.existing', kwargs={'token': self.token})}?confirm=1&utm_tracking=oh+definitely+yes&utm_source=malibu",
+        )
 
-    def test_basket_down(self):
+    def test_no_token_404(self):
+        """The confirm view requires a token"""
+        url = self.url.replace(f"{self.token}/", "")
+        rsp = self.client.get(url)
+        self.assertEqual(rsp.status_code, 404)
+
+    @patch("basket.confirm")
+    def test_basket_down(self, confirm):
         """If basket is down, we report the appropriate error"""
-        with patch("basket.confirm") as confirm:
-            confirm.side_effect = basket.BasketException()
-            rsp = self.client.get(self.url)
-            self.assertEqual(302, rsp.status_code)
-            confirm.assert_called_with(self.token)
-            self.assertTrue(rsp["Location"].endswith(f"{reverse('newsletter.confirm.thanks')}?error=1"))
+        confirm.side_effect = basket.BasketException()
+        rsp = self.client.get(self.url)
+        self.assertEqual(302, rsp.status_code)
+        confirm.assert_called_with(self.token)
+        self.assertURLEqual(rsp["Location"], f"{reverse('newsletter.confirm.thanks')}?error=1")
 
-    def test_bad_token(self):
+    @patch("basket.confirm")
+    def test_bad_token(self, confirm):
         """If the token is bad, we report the appropriate error"""
-        with patch("basket.confirm") as confirm:
-            confirm.side_effect = basket.BasketException(status_code=403, code=basket.errors.BASKET_UNKNOWN_TOKEN)
-            rsp = self.client.get(self.url)
-            self.assertEqual(302, rsp.status_code)
-            confirm.assert_called_with(self.token)
-            self.assertTrue(rsp["Location"].endswith(f"{reverse('newsletter.confirm.thanks')}?error=2"))
+        confirm.side_effect = basket.BasketException(status_code=403, code=basket.errors.BASKET_UNKNOWN_TOKEN)
+        rsp = self.client.get(self.url)
+        self.assertEqual(302, rsp.status_code)
+        confirm.assert_called_with(self.token)
+        self.assertURLEqual(rsp["Location"], f"{reverse('newsletter.confirm.thanks')}?error=2")
 
 
 class TestNewsletterSubscribe(TestCase):
@@ -88,7 +84,7 @@ class TestNewsletterSubscribe(TestCase):
             "email": "fred@example.com",
         }
         resp = self.ajax_request(data)
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertFalse(resp_data["success"])
         self.assertEqual(len(resp_data["errors"]), 1)
         self.assertIn("privacy", resp_data["errors"][0])
@@ -107,7 +103,7 @@ class TestNewsletterSubscribe(TestCase):
             "country": '<svg/onload=alert("NEFARIOUSNESS")>',
         }
         resp = self.ajax_request(data)
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertFalse(resp_data["success"])
         self.assertEqual(len(resp_data["errors"]), 1)
         self.assertNotIn(data["country"], resp_data["errors"][0])
@@ -125,7 +121,7 @@ class TestNewsletterSubscribe(TestCase):
         }
         source_url = "https://example.com/bambam"
         resp = self.ajax_request(data, HTTP_REFERER=source_url)
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertDictEqual(resp_data, {"success": True})
         basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", source_url=source_url)
 
@@ -135,7 +131,7 @@ class TestNewsletterSubscribe(TestCase):
         source_url = "https://example.com/bambam"
         data = {"newsletters": ["flintstones"], "email": "fred@example.com", "privacy": True, "source_url": source_url}
         resp = self.ajax_request(data, HTTP_REFERER=source_url + "_WILMA")
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertDictEqual(resp_data, {"success": True})
         basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones", source_url=source_url)
 
@@ -148,7 +144,7 @@ class TestNewsletterSubscribe(TestCase):
             "privacy": True,
         }
         resp = self.ajax_request(data)
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertDictEqual(resp_data, {"success": True})
         basket_mock.subscribe.assert_called_with("fred@example.com", "flintstones")
 
@@ -162,7 +158,7 @@ class TestNewsletterSubscribe(TestCase):
             "privacy": True,
         }
         resp = self.ajax_request(data)
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertFalse(resp_data["success"])
         self.assertEqual(resp_data["errors"][0], str(invalid_email_address))
 
@@ -176,7 +172,7 @@ class TestNewsletterSubscribe(TestCase):
             "privacy": True,
         }
         resp = self.ajax_request(data)
-        resp_data = json.loads(resp.content)
+        resp_data = resp.json()
         self.assertFalse(resp_data["success"])
         self.assertEqual(resp_data["errors"][0], str(general_error))
 
@@ -253,33 +249,84 @@ class TestNewsletterSubscribe(TestCase):
 
 class TestNewsletterAllJson(TestCase):
     def test_newsletter_all_json(self):
-        req = RequestFactory().get("/newsletter/newsletter-all.json")
-        req.locale = "en-US"
-        resp = newsletter_all_json(req)
+        resp = self.client.get(reverse("newsletter.all"))
         self.assertEqual(resp.status_code, 200)
-        data = json.loads(resp.content)
-        self.assertTrue("newsletters" in data)
+        self.assertIn("newsletters", resp.json())
 
 
-@patch("bedrock.newsletter.views.l10n_utils.render", return_value=HttpResponse())
 class TestNewsletterStringsJson(TestCase):
-    def test_newsletter_strings_json(self, render_mock):
-        req = RequestFactory().get("/newsletter/newsletter-strings.json")
-        req.locale = "en-US"
-        newsletter_strings_json(req)
-        template = render_mock.call_args[0][1]
-        self.assertTrue(template == "newsletter/includes/newsletter-strings.json")
+    def test_newsletter_strings_json(self):
+        resp = self.client.get(reverse("newsletter.strings"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, "newsletter/includes/newsletter-strings.json")
 
 
-@patch("bedrock.newsletter.views.l10n_utils.render", return_value=HttpResponse())
+class TestNewsletterExistingPage(TestCase):
+    def setUp(self):
+        self.token = str(uuid.uuid4())
+        self.url = reverse("newsletter.existing", kwargs={"token": self.token})
+        self.url_no_token = reverse("newsletter.existing.no-token")
+
+    def test_with_token(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, "newsletter/management.html")
+
+    def test_template_context(self):
+        resp = self.client.get(self.url)
+        context = resp.context
+        self.assertEqual(context["source_url"], reverse("newsletter.existing.no-token"))
+        self.assertEqual(context["did_confirm"], False)
+
+    def test_no_token_okay(self):
+        resp = self.client.get(self.url_no_token)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, "newsletter/management.html")
+
+
+class TestNewsletterCountryPage(TestCase):
+    def setUp(self):
+        self.token = str(uuid.uuid4())
+        self.url = reverse("newsletter.country", kwargs={"token": self.token})
+        self.url_no_token = reverse("newsletter.country.no-token")
+
+    def test_with_token(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, "newsletter/country.html")
+
+    def test_template_context(self):
+        resp = self.client.get(self.url)
+        context = resp.context
+        self.assertEqual(context["action"], f"{settings.BASKET_URL}/news/user-meta/")
+        self.assertEqual(context["recovery_url"], reverse("newsletter.recovery"))
+
+    def test_no_token_okay(self):
+        resp = self.client.get(self.url_no_token)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, "newsletter/country.html")
+
+    def test_country_form(self):
+        resp = self.client.get(self.url + "?geo=fr")
+        form = resp.context["form"]
+        self.assertEqual(form.initial, {"country": "fr"})
+        country_choices = dict(form.fields["country"].choices)
+        # We always set the locale to 'en-US' in the form, thus why this isn't "États-Unis".
+        self.assertEqual(country_choices["us"], "United States")
+
+
 class TestNewsletterConfirmPage(TestCase):
     def setUp(self):
         self.token = str(uuid.uuid4())
         self.url = reverse("newsletter.knowledge-is-power.confirm", kwargs={"token": self.token})
+        self.url_no_token = reverse("newsletter.knowledge-is-power.confirm.no-token")
 
-    def test_newsletter_knowledge_is_power_confirm(self, render_mock):
-        req = RequestFactory().get(self.url)
-        req.locale = "en-US"
-        kip_confirm(req, self.token)
-        template = render_mock.call_args[0][1]
-        self.assertTrue(template == "newsletter/knowledge-is-power-confirm.html")
+    def test_newsletter_knowledge_is_power_confirm(self):
+        rsp = self.client.get(self.url)
+        self.assertEqual(rsp.status_code, 200)
+        self.assertTemplateUsed(rsp, "newsletter/knowledge-is-power-confirm.html")
+
+    def test_no_token_okay(self):
+        rsp = self.client.get(self.url_no_token)
+        self.assertEqual(rsp.status_code, 200)
+        self.assertTemplateUsed(rsp, "newsletter/knowledge-is-power-confirm.html")

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -1,30 +1,40 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from django.urls import path, re_path
+from django.urls import path
 
 from bedrock.mozorg.util import page
 from bedrock.newsletter import views
 from bedrock.utils.views import VariationTemplateView
 
-# A UUID looks like: f81d4fae-7dec-11d0-a765-00a0c91e6bf6
-# Here's a regex to match a UUID:
-uuid_regex = r"[0-Fa-f]{8}-[0-Fa-f]{4}-[0-Fa-f]{4}-[0-Fa-f]{4}-[0-Fa-f]{12}"
-
+# NOTE:
+# URLs are defined with two variations for token handling. This dual approach allows flexibility in
+# token passing, supporting both URL-based and cookie-based methods.
+#
+# 1. With <uuid:token> in the path:
+#    - Used when the token is explicitly provided in the URL.
+#    - Example: /newsletter/confirm/<uuid:token>/
+#
+# 2. Without <uuid:token> in the path:
+#    - Used when the token is not in the URL.
+#    - In this case, the view will attempt to retrieve the token from a cookie named 'nl-token'.
+#    - Example: /newsletter/confirm/
 
 urlpatterns = (
     # view.existing allows a user who has a link including their token to
     # subscribe, unsubscribe, change their preferences. Each newsletter
     # includes that link for them.
-    re_path("^newsletter/existing/(?P<token>[^/]*)/?$", views.existing, name="newsletter.existing.token"),
+    path("newsletter/existing/<uuid:token>/", views.existing, name="newsletter.existing"),
+    path("newsletter/existing/", views.existing, name="newsletter.existing.no-token"),
     # After submitting on the `existing` page, users end up on the
     # `updated` page.  There are optional query params; see the view.
     path("newsletter/updated/", views.updated, name="newsletter.updated"),
     # Confirm subscriptions
-    re_path("^newsletter/confirm/(?P<token>%s)/$" % uuid_regex, views.confirm, name="newsletter.confirm"),
+    path("newsletter/confirm/<uuid:token>/", views.confirm, name="newsletter.confirm"),
     path("newsletter/confirm/thanks/", views.confirm_thanks, name="newsletter.confirm.thanks"),
     # Update country
-    re_path("^newsletter/country/(?P<token>[^/]*)/?$", views.set_country, name="newsletter.country"),
+    path("newsletter/country/<uuid:token>/", views.set_country, name="newsletter.country"),
+    path("newsletter/country/", views.set_country, name="newsletter.country.no-token"),
     # Request recovery message with link to manage subscriptions
     path("newsletter/recovery/", views.recovery, name="newsletter.recovery"),
     # Receives POSTs from all subscribe forms
@@ -43,7 +53,8 @@ urlpatterns = (
         ),
         name="newsletter.knowledge-is-power",
     ),
-    re_path("^newsletter/knowledge-is-power/confirm/(?P<token>[^/]*)/?$", views.kip_confirm, name="newsletter.knowledge-is-power.confirm"),
+    path("newsletter/knowledge-is-power/confirm/<uuid:token>/", views.kip_confirm, name="newsletter.knowledge-is-power.confirm"),
+    path("newsletter/knowledge-is-power/confirm/", views.kip_confirm, name="newsletter.knowledge-is-power.confirm.no-token"),
     page("newsletter/family/", "newsletter/family.html", ftl_files=["mozorg/newsletters"], active_locales=["en-US"]),
     page("newsletter/security-and-privacy/", "newsletter/security-privacy-news.html", ftl_files=["mozorg/newsletters"]),
     page("newsletter/security-and-privacy/online-harassment/", "newsletter/online-harassment.html"),


### PR DESCRIPTION
## One-line summary

I noticed our UUID regex was inconsistently used, so I decided to update URLs to use `uuid` path converter. Also a few updates around when the token is optional and using `urlparams` for cleaner URL concatenation.
