### PR TITLE
Explore more CSP tightening (report-only)

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -123,6 +123,7 @@ if csp_ro_report_uri:
 
     # CSP directive updates we're testing that we hope to move to the enforced policy.
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["default-src"] = [csp.constants.SELF]
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["object-src"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["frame-ancestors"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)
 

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -28,16 +28,13 @@ _csp_default_src = [
 ]
 _csp_img_src = [
     "data:",
-    "mozilla.org",
     "www.googletagmanager.com",
     "www.google-analytics.com",
     "images.ctfassets.net",
 ]
 _csp_script_src = [
-    # TODO fix things so that we don't need this
+    # TODO change settings so we don't need unsafes even in dev
     csp.constants.UNSAFE_INLINE,
-    # TODO snap.svg.js passes a string to Function() which is
-    # blocked without unsafe-eval. Find a way to remove that.
     csp.constants.UNSAFE_EVAL,
     "www.googletagmanager.com",
     "www.google-analytics.com",
@@ -125,6 +122,7 @@ if csp_ro_report_uri:
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["report-uri"] = csp_ro_report_uri
 
     # CSP directive updates we're testing that we hope to move to the enforced policy.
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["default-src"] = [csp.constants.SELF]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["frame-ancestors"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)
 


### PR DESCRIPTION
## One-line summary

Restricts `default-src` to just self _(as we otherwise append all the moz hostnames to the individual policies)_ and also restricts `object-src` to none. (All in `report-only` definition for now to confirm it's not needed.)

## Significant changes and points to review

Adds `object-src: none` to report-only for helping out surface any hypothetical use.
Defines `default-src: self` in report-only for surfacing any unspecified defaults used in policies.

This doesn't mean everything would have to come from `self` now, the removed hosts are appended to every policy when constructing the settings, so this is only to restrict the defaults, i.e. in case we have not defined the policy (well/correctly/at all).

(This will be redone anyways regarding https://github.com/mozilla/bedrock/issues/11943#issuecomment-2255722632 when every policy gets its own subset of hosts, instead of appending the default wildcards everywhere…)

Also removes some dupes that were added in recent refactors, removes outdated comments referring to libs no longer used etc.

It's written as to not cause conflicts with #14831 — skipping those two rules here, as they have some Webpack (devserver) and Wagtail (cms-admin) impact.

## Issue / Bugzilla link

#14896 (+#11943)

## Testing

`curl -I http://localhost:8000/de/`