### PR TITLE
Ignore NS_ERROR_ABORT No error message alerts in Sentry front-end

### DIFF
--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -30,6 +30,7 @@ const options = {
     ignoreErrors: [
         '$ is not defined',
         'Event `Event` (type=unhandledrejection) captured as promise rejection',
+        'NS_ERROR_ABORT',
         'NetworkError when attempting to fetch resource',
         'Non-Error promise rejection captured'
     ]


### PR DESCRIPTION
## One-line summary

The Glean folks took a look at this in [bug 1907022](https://bugzilla.mozilla.org/show_bug.cgi?id=1907022) and agree it's likely a non-actionable network side effect.

## Issue / Bugzilla link

N/A