### PR TITLE
Revert "Add helpful img tag attributes to allow list for release notes"

### DIFF
--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -86,14 +86,10 @@ ALLOWED_TAGS = {
 ALLOWED_ATTRS = [
     "alt",
     "class",
-    "height",
     "href",
     "id",
     "src",
-    "srcset",
-    "rel",
     "title",
-    "width",
 ]
 
 


### PR DESCRIPTION
Reverts mozilla/bedrock#13103