### PR TITLE
Enable dependabot for Playwright dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,16 @@ updates:
     labels:
       - Backend
       - dependencies
+  - package-ecosystem: npm
+    directory: '/tests/playwright'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    labels:
+      - Frontend
+      - dependencies
+    groups:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch


### PR DESCRIPTION
## One-line summary

- Enable dependabot for `/tests/playwright/package.json`.
- Limit to 5 open pull requests per month.
- Group minor/patch updates into a single PR.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups for reference.

Note: I'm adding this as a test before doing it for the main bedrock front-end dependencies.

## Issue / Bugzilla link

N/A