### PR TITLE
Fix error setting httpContextIntegration in Sentry JS

### DIFF
--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -56,7 +56,7 @@ const SentryConsent = {
                 browserApiErrorsIntegration(),
                 dedupeIntegration(),
                 globalHandlersIntegration(),
-                httpContextIntegration,
+                httpContextIntegration(),
                 inboundFiltersIntegration(options)
             ]
         });


### PR DESCRIPTION
## One-line summary

Fixes a regression from https://github.com/mozilla/bedrock/pull/14658 (which I think is why we stopped getting things like browser name and referrer in our front-end errors).

## Issue / Bugzilla link

N/A