### PR TITLE
Add data attributes to Nothing Personal easter egg URLs

### DIFF
--- a/bedrock/firefox/templates/firefox/nothing-personal/index.html
+++ b/bedrock/firefox/templates/firefox/nothing-personal/index.html
@@ -190,8 +190,8 @@
     </div>
     </section>
     <aside>
-      <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" aria-label="Link to a Youtube video" target="_blank" rel="external noopener"><img src="{{ static('img/firefox/nothing-personal/folder-icon.svg') }}" alt="">Folder <br> <.< </a>
-      <a href="https://open.spotify.com/playlist/0vvXsWCC9xrXsKd4FyS8kM" aria-label="Link to a Spotify playlist" target="_blank" rel="external noopener"><img src="{{ static('img/firefox/nothing-personal/music-icon.svg') }}" alt="">focus <br> playlist</a>
+      <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" aria-label="Link to a Youtube video" target="_blank" rel="external noopener" data-link-text="Folder"><img src="{{ static('img/firefox/nothing-personal/folder-icon.svg') }}" alt="">Folder <br> <.< </a>
+      <a href="https://open.spotify.com/playlist/0vvXsWCC9xrXsKd4FyS8kM" aria-label="Link to a Spotify playlist" target="_blank" rel="external noopener" data-link-text="Focus playlist"><img src="{{ static('img/firefox/nothing-personal/music-icon.svg') }}" alt="">focus <br> playlist</a>
       <div class="c-trash" aria-hidden="true">
         <img src="{{ static('img/firefox/nothing-personal/bin-icon.svg') }}" alt="">
         <span>MyLife</span>


### PR DESCRIPTION
## One-line summary
Forgot to add `data-link-text` attributes to the anchor tags in the desktop icon easter eggs. Fixing that now.

Note that these easter eggs are only available on desktop, not mobile.

## Testing
http://localhost:8000/en-US/firefox/nothing-personal/