### PR TITLE
Update contribute, MDN, wiki redirects

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -374,8 +374,6 @@ redirectpatterns = (
     # Bug 1255882
     redirect(r"^firefox/about/?$", "mozorg.about.index"),
     # bug 453506, 1255882
-    redirect(r"^editor/editor-embedding\.html$", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla/Embedding_the_editor"),
-    redirect(r"^editor/midasdemo/securityprefs\.html$", "https://developer.mozilla.org/docs/Mozilla/Projects/Midas/Security_preferences"),
     redirect(r"^editor/(?P<page>.*)$", "http://www-archive.mozilla.org/editor/{page}"),
     # Bug 453876, 840416
     redirect(r"^add-ons/kodak", "https://addons.mozilla.org/en-US/firefox/addon/4441"),

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -285,7 +285,7 @@ redirectpatterns = (
     redirect(r"contact/spaces/(?:auckland|tokyo|taipei|london|mountain-view|vancouver|portland)/?$", "/contact/spaces/"),
     redirect("^contribute/buttons/", "https://affiliates.mozilla.org/"),
     # bug 875052
-    redirect(r"^about/get-involved", "/contribute/"),
+    redirect(r"^about/get-involved", "mozorg.contribute"),
     # bug 878926
     redirect(r"^firefoxflicks/?(?P<p>.*)$", "https://firefoxflicks.mozilla.org/{locale}{p}"),
     # bug 849426
@@ -304,13 +304,13 @@ redirectpatterns = (
     redirect(r"^rhino/shell\.html$", "https://developer.mozilla.org/docs/Mozilla/Projects/Rhino/Shell"),
     redirect(r"^rhino/?", "https://developer.mozilla.org/docs/Mozilla/Projects/Rhino"),
     # bug 846362
-    redirect(r"^community/(index(\.(de|fr|hr|sq))?\.html)?$", "/contribute/"),
+    redirect(r"^community/(index(\.(de|fr|hr|sq))?\.html)?$", "mozorg.contribute"),
     # bug 860532 - Reidrects for governance pages
     redirect(r"^about/governance\.html$", "/about/governance/"),
     redirect(r"^about/roles\.html$", "/about/governance/roles/"),
     redirect(r"^about/organizations\.html$", "/about/governance/organizations/"),
     # bug 876233
-    redirect(r"^about/participate/?$", "/contribute/"),
+    redirect(r"^about/participate/?$", "mozorg.contribute"),
     # bug 790784
     # NB: The /foundation/privacy-policy.html redirect must appear before the
     # foundation redirects added with bug 724633. Otherwise, the address will first
@@ -387,7 +387,7 @@ redirectpatterns = (
     redirect(r"^hacking/?$", "https://firefox-source-docs.mozilla.org/"),
     # Issue 10736
     redirect(r"^jobs/?$", "careers.home"),
-    redirect(r"^join/?$", "https://foundation.mozilla.org/donate/"),
+    redirect(r"^join/?$", "careers.home"),
     # Bug 1262593
     redirect(r"^unix/remote\.html$", "http://www-archive.mozilla.org/unix/remote.html"),
     # Bug 1313023
@@ -399,10 +399,10 @@ redirectpatterns = (
     ),
     # Bug 936362
     # only upper-case for XBL. /xbl is a namespace URL for the standard.
-    redirect(r"^XBL/?$", "https://developer.mozilla.org/docs/XBL"),
-    redirect(r"^RDF/?$", "https://developer.mozilla.org/docs/RDF", re_flags="i"),
-    # Bug 1332008
-    redirect(r"^protocol/?$", "https://blog.mozilla.org/opendesign/"),
+    redirect(r"^XBL/?$", "https://www.w3.org/TR/xbl/"),
+    redirect(r"^RDF/?$", "https://www.w3.org/RDF/", re_flags="i"),
+    # Bug 1332008, 1525853
+    redirect(r"^protocol/?$", "https://protocol.mozilla.org"),
     # Bug 1322959 - vanity URL, Issue 8375
     redirect(r"^onlineprivacy/?$", "https://foundation.mozilla.org/internet-health/"),
     # Bug 1335569 - vanity URL, Issue 8375
@@ -412,9 +412,9 @@ redirectpatterns = (
     # Bug 1333146
     redirect(r"^internet-?health-?report/?$", "https://internethealthreport.org/"),
     # Bug 1335040
-    redirect(r"^gigabit(/.*)?", "https://learning.mozilla.org/gigabit/"),
+    redirect(r"^gigabit(/.*)?", "https://wiki.mozilla.org/Gigabit"),
     # Bug 1324504, issue 6994
-    redirect(r"^/contribute/studentambassadors(/.*)?", "https://campus.mozilla.community/"),
+    redirect(r"^/contribute/studentambassadors(/.*)?", "mozorg.contribute"),
     # Bug 1340600, Issue 7840 - vanity URL
     redirect(
         r"^css-?grid/?$",
@@ -430,8 +430,8 @@ redirectpatterns = (
     # Bug 1384370, Issue 7840
     redirect(r"^developers/?$", "https://developer.mozilla.com/"),
     # Bug 1438464
-    redirect(r"^collusion/?$", "https://addons.mozilla.org/firefox/addon/lightbeam/"),
-    redirect(r"^lightbeam(/.*)?", "https://addons.mozilla.org/firefox/addon/lightbeam/"),
+    redirect(r"^collusion/?$", "https://github.com/mozilla/lightbeam-we"),
+    redirect(r"^lightbeam(/.*)?", "https://github.com/mozilla/lightbeam-we"),
     # Bug 1428150
     gone(r"^tabzilla/transbar\.jsonp$"),
     gone(r"^tabzilla/tabzilla\.js$"),
@@ -453,10 +453,10 @@ redirectpatterns = (
     # Issue 6756 - vanity URL, Issue 8375
     redirect(r"^decentralization/?$", "https://foundation.mozilla.org/internet-health/"),
     # issue 6971
-    redirect(r"^gear/?$", "https://mozillagear.corpmerchandise.com/"),
+    redirect(r"^gear/?$", "https://wiki.mozilla.org/SwagStore"),
     # issue 6994
-    redirect(r"^contribute/signup/?$", "https://activate.mozilla.community/"),
-    redirect(r"^/contribute/task(/.*)?", "https://activate.mozilla.community/"),
+    redirect(r"^contribute/signup/?$", "mozorg.contribute"),
+    redirect(r"^/contribute/task(/.*)?", "mozorg.contribute"),
     redirect(r"^contribute/friends/?$", "mozorg.contribute"),
     redirect(r"^contribute/stories(/.*)?$", "mozorg.contribute"),
     # Issue 6461
@@ -477,15 +477,7 @@ redirectpatterns = (
     redirect(r"^styleguide/identity/mozilla(.+)", "https://mozilla.design/mozilla/"),
     redirect(r"^styleguide(/.*)?", "https://mozilla.design/"),
     # Issue 8644, 8932
-    redirect(
-        r"^builders/?$",
-        "https://builders.mozilla.community/",
-        query={
-            "utm_source": "www.mozilla.org",
-            "utm_medium": "referral",
-            "utm_campaign": "builders-redirect",
-        },
-    ),
+    redirect(r"^builders/?$", "https://future.mozilla.org/builders/"),
     # Issue 6824, 14364
     redirect(r"^technology/?$", "https://future.mozilla.org/"),
     # Issue 8668

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -882,7 +882,7 @@ URLS = flatten(
         url_test("/hacking", "https://firefox-source-docs.mozilla.org/"),
         # issue 10736
         url_test("/jobs", "/careers/"),
-        url_test("/join", "https://foundation.mozilla.org/donate/"),
+        url_test("/join", "/careers/"),
         # Bug 1293539
         url_test("/firefox/{48.0,48.0.1,49.0a1,49.0a2}/tour", "https://support.mozilla.org/kb/get-started-firefox-overview-main-features"),
         url_test("/firefox/tour", "https://support.mozilla.org/kb/get-started-firefox-overview-main-features"),
@@ -915,12 +915,12 @@ URLS = flatten(
         ),
         # Bug 936362
         # only upper-case for XBL. /xbl is a namespace URL for the standard.
-        url_test("/XBL", "https://developer.mozilla.org/docs/XBL"),
+        url_test("/XBL", "https://www.w3.org/TR/xbl/"),
         url_test("/xbl", status_code=200),
-        url_test("/RDF", "https://developer.mozilla.org/docs/RDF"),
-        url_test("/rdf", "https://developer.mozilla.org/docs/RDF"),
-        # Bug 1332008
-        url_test("{/en-US,}/protocol/", "https://blog.mozilla.org/opendesign/"),
+        url_test("/RDF", "https://www.w3.org/RDF/"),
+        url_test("/rdf", "https://www.w3.org/RDF/"),
+        # Bug 1332008, 1525853
+        url_test("{/en-US,}/protocol/", "https://protocol.mozilla.org"),
         # Bug 1322959, issue 8375
         url_test("/onlineprivacy", "https://foundation.mozilla.org/internet-health/"),
         # Bug 1335569, issue 8375
@@ -931,11 +931,11 @@ URLS = flatten(
         # Bug 1335569, issue 8375
         url_test("/open-innovation", "https://foundation.mozilla.org/internet-health/"),
         # Bug 1335040
-        url_test("/gigabit/{,apply/}", "https://learning.mozilla.org/gigabit/"),
+        url_test("/gigabit/{,apply/}", "https://wiki.mozilla.org/Gigabit"),
         # Bug 1329931
         url_test("/firefox/os/{,devices/}", "https://support.mozilla.org/products/firefox-os"),
         # Bug 1324504
-        url_test("/contribute/studentambassadors/{,join/,thanks/}", "https://campus.mozilla.community/"),
+        url_test("/contribute/studentambassadors/{,join/,thanks/}", "/contribute/"),
         # Bug 1340600, Issue 7840
         url_test(
             "/css-grid",
@@ -994,8 +994,8 @@ URLS = flatten(
         # bug 1419244
         url_test("/firefox/mobile-download/{,desktop/}", "/firefox/browsers/mobile/"),
         # Bug 1438464
-        url_test("/collusion/", "https://addons.mozilla.org/firefox/addon/lightbeam/"),
-        url_test("/lightbeam/{,about/}?", "https://addons.mozilla.org/firefox/addon/lightbeam/"),
+        url_test("/collusion/", "https://github.com/mozilla/lightbeam-we"),
+        url_test("/lightbeam/{,about/}?", "https://github.com/mozilla/lightbeam-we"),
         # Bug 1428150
         url_test("/tabzilla/media/css/tabzilla.css", "https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css"),
         # bug 960651, 1436973
@@ -1030,8 +1030,8 @@ URLS = flatten(
         # Issue 6979
         url_test("/firefoxfightsforyou/", "/firefox/"),
         # Issue 6994
-        url_test("/contribute/signup/", "https://activate.mozilla.community/"),
-        url_test("/contribute/task/{,devtools-challenger/, firefox-mobile/}", "https://activate.mozilla.community/"),
+        url_test("/contribute/signup/", "/contribute/"),
+        url_test("/contribute/task/{,devtools-challenger/, firefox-mobile/}", "/contribute/"),
         url_test("/contribute/friends/", "/contribute/"),
         # Issue 7287
         url_test("/accounts/", "/account/"),
@@ -1087,15 +1087,7 @@ URLS = flatten(
         # Issue 8418
         url_test("/styleguide/", "https://mozilla.design/"),
         # Issue 8644, 8932
-        url_test(
-            "/builders{,/}",
-            "https://builders.mozilla.community/",
-            query={
-                "utm_source": "www.mozilla.org",
-                "utm_medium": "referral",
-                "utm_campaign": "builders-redirect",
-            },
-        ),
+        url_test("/builders{,/}", "https://future.mozilla.org/builders/"),
         # Issue 6824, 14364
         url_test("/technology/", "https://future.mozilla.org/"),
         # Issue 8419

--- a/tests/redirects/map_htaccess.py
+++ b/tests/redirects/map_htaccess.py
@@ -102,8 +102,6 @@ URLS = flatten(
         # bug 1300373
         url_test("/%2fgoogle.com//", "/google.com/"),
         # bug 453506, 1255882
-        url_test("/editor/editor-embedding.html", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla/Embedding_the_editor"),
-        url_test("/editor/midasdemo/securityprefs.html", "https://developer.mozilla.org/docs/Mozilla/Projects/Midas/Security_preferences"),
         url_test("/editor/random/page.html", "http://www-archive.mozilla.org/editor/random/page.html"),
         # bug 726217, 1255882
         url_test("/projects/bonecho/anti-phishing/", "https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work"),


### PR DESCRIPTION
## One-line summary

Removes broken redirects, updates bunch of others.

## Significant changes and points to review

1. Removes specific redirects leading to MDN 404s and leaves that all to more generic archived content. (Some would still 404 even in the archive (correct url, probably bug in archiving), but less rules here anyways.)
2. Updates more broken MDN links to W3C instead 
3. Redirects archived extensions to gh repo
4. Updates redirects to dead hosts

## Issue / Bugzilla link

🚫🐞

## Testing

http://localhost:8000/editor/midasdemo/securityprefs.html
http://localhost:8000/editor/midasdemo/securityprefs.html%3C/span%3E%3C/a%3E%C2%A0 (this one is in a test;))
http://localhost:8000/about/get-involved
http://localhost:8000/about/participate
http://localhost:8000/community/index.sq.html
http://localhost:8000/join
http://localhost:8000/XBL
http://localhost:8000/xbl
http://localhost:8000/RDF
http://localhost:8000/rdf
http://localhost:8000/protocol
http://localhost:8000/gigabit/abides
http://localhost:8000/collusion
http://localhost:8000/lightbeam
http://localhost:8000/contribute/studentambassadors/dude
http://localhost:8000/contribute/task/abides
http://localhost:8000/contribute/signup/
http://localhost:8000/builders
http://localhost:8000/gear