### PR TITLE
Update Wagtail/ Smartling integration on the Bedrock side

### DIFF
--- a/bedrock/cms/management/commands/run_smartling_sync.py
+++ b/bedrock/cms/management/commands/run_smartling_sync.py
@@ -29,6 +29,6 @@ class Command(BaseCommand):
             )
             if SMARTLING_SYNC_SNITCH_URL:
                 requests.get(SMARTLING_SYNC_SNITCH_URL)
-            sys.stdout.write("Snitch pinged\n")
+                sys.stdout.write("Snitch pinged\n")
         except Exception as ex:
             sys.stderr.write(f"\nsync_smartling did not execute successfully: {ex}\n")

--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -8,6 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 
 from wagtail.models import Page as WagtailBasePage
+from wagtail_localize.fields import SynchronizedField
 
 from lib import l10n_utils
 
@@ -31,6 +32,13 @@ class AbstractBedrockCMSPage(WagtailBasePage):
         2) Apply `never_cache` headers to the `wagtail.Page` class's
         `serve_password_required_response` method, via the @method_decorator above
     """
+
+    # Make the `slug` field 'synchronised', so it automatically gets copied over to
+    # every localized variant of the page and shouldn't get sent for translation.
+    # See https://wagtail-localize.org/stable/how-to/field-configuration/
+    override_translatable_fields = [
+        SynchronizedField("slug"),
+    ]
 
     class Meta:
         abstract = True

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2101,14 +2101,21 @@ if WAGTAIL_ENABLE_ADMIN:
 
 def lazy_wagtail_langs():
     enabled_wagtail_langs = [
-        ("en-US", "English"),
-        # TODO: expand to other locales supported by our translation vendor
-        # ("de", "Deutsch"),
-        ("fr", "Français"),
-        # ("es", "Español"),
-        # ("es", "Español mexicano"),
-        # ("it", "Italiano"),
-        # more to come
+        # Notes:
+        # 1) The labels are only used internally so can be in English
+        # 2) These are the Bedrock-side lang codes. They are mapped to
+        # Smartling-specific ones in the WAGTAIL_LOCALIZE_SMARTLING settings, below
+        ("en-US", "English (US)"),
+        ("de", "German"),
+        ("fr", "French"),
+        ("es-ES", "Spanish (Spain)"),
+        ("it", "Italian"),
+        ("ja", "Japanese"),
+        ("nl", "Dutch (Netherlands)"),
+        ("pl", "Polish"),
+        ("pt-BR", "Portuguese (Brazil)"),
+        ("ru", "Russian"),
+        ("zh-CN", "Chinese (China-Simplified)"),
     ]
     enabled_language_codes = [x[0] for x in LANGUAGES]
     retval = [wagtail_lang for wagtail_lang in enabled_wagtail_langs if wagtail_lang[0] in enabled_language_codes]
@@ -2144,6 +2151,16 @@ WAGTAIL_LOCALIZE_SMARTLING = {
         default="5",
         parser=float,
     ),  # Timeout in seconds for requests to the Smartling API
+    "LOCALE_TO_SMARTLING_LOCALE": {
+        "de": "de-DE",
+        "fr": "fr-FR",
+        "it": "it-IT",
+        "ja": "ja-JP",
+        "nl": "nl-NL",
+        "pl": "pl-PL",
+        "ru": "ru-RU",
+    },
+    "REFORMAT_LANGUAGE_CODES": False,  # don't force language codes into Django's all-lowercase pattern
 }
 
 # Custom settings, not a core Wagtail ones, to scope out RichText options


### PR DESCRIPTION
This changeset tweaks some dials related to the Smartling integration from Wagtail, getting it ready for when we move the VPN Resource Center into Wagtail.

Early review is fine - the only extra commit here will be bumping the version of `wagtail-localize-smartling`

**Done**

* Prevent `slug` field on localized pages from being sent to Smartling, and instead keep it synchronised with the source page's slug
* Configure initial set of language codes that we'll handle in the CMS. (These may change, of course, but they follow what we currently have in used for the VPN Resource Centre, which was localized in Smartling. Hopefully we can leverage Smartling's Translation memory automatically when we move those pages into Wagtail)
* Bump `wagtail-localize-smartling` to latest version (0.2.4 - due as soon as https://github.com/mozilla/wagtail-localize-smartling/pull/16 is updated and merged)


### Testing
Just eyeballing this changeset is fine - i've tested locally and we'll test lots on Dev, Stage and soon Prod