### PR TITLE
Stop showing mobile store banners for current users

### DIFF
--- a/media/js/base/banners/firefox-app-store-banner.es6.js
+++ b/media/js/base/banners/firefox-app-store-banner.es6.js
@@ -13,6 +13,7 @@ function onLoad() {
 if (
     window.Mozilla.run &&
     window.site &&
+    !window.Mozilla.Client.isFirefox &&
     (window.site.platform === 'android' || window.site.platform === 'ios')
 ) {
     window.Mozilla.run(onLoad);

--- a/media/js/base/banners/firefox-app-store-banner.es6.js
+++ b/media/js/base/banners/firefox-app-store-banner.es6.js
@@ -12,9 +12,9 @@ function onLoad() {
 
 if (
     window.Mozilla.run &&
-    window.site &&
-    !window.Mozilla.Client.isFirefox &&
-    (window.site.platform === 'android' || window.site.platform === 'ios')
+    window.Mozilla.Client &&
+    window.Mozilla.Client.isMobile &&
+    !window.Mozilla.Client.isFirefox
 ) {
     window.Mozilla.run(onLoad);
 }


### PR DESCRIPTION
## One-line summary

Shows mobile store banners only to nonFX users.

_(This picks up and supersedes #13331, updating it to current codebase.)_

## Significant changes and points to review

This was unable to be fixed for a while when FxiOS and Focus stopped identifying themselves beyond generic UIWebView, but the identifiers are back for some time now so they can be told apart from the system engine again.

(At least on phones, or unless asking for "request desktop version" when the UA mimics either desktop Safari or desktop Linux FX, on iPads that's most of the time and even manually requesting mobile site doesn't change it reliably. But that's not issue with this code or changeset just consuming _Mozilla.Client_ and its limitations — the issues are with opinionated choices in the mobile products, as linked e.g. from https://github.com/mozilla/bedrock/issues/6875#issuecomment-2072041531)

Firefox mobile and Focus can't be told apart as they both report alike (FxiOS and Firefox/Mobile on 🤖 respectively), so there is no way to e.g. offer the banner for the second app to user of the first etc., there's no app ID logic involved as it would be with native [smartbanners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) — so it's all or nothing only, with Focus being even more fuzzy about its uastring showing up as various versions of Safari instead;)

This does not add any new logic. Only what `Mozilla.Client.isMobile && !Mozilla.Client.isFirefox` already sniff, know and provide. Better than nothing, but far from perfect when the browsers pretend they're something else completely.

## Issue / Bugzilla link

Resolves #10571

## Testing

| prod fx | PR fx | PR nonfx |
|--------|--------|--------|
| **Focus** iOS:  | (`/firefox`)  |   |
| ![kl1IMG_5490](https://github.com/user-attachments/assets/15b93aa7-09be-4e6c-91c4-ab278a5342f2) | ![kl1IMG_5491](https://github.com/user-attachments/assets/660f746d-96ff-4691-8e4e-5dcf17a3de5c) |        |
|    | (`/firefox/focus`)  | Safari iOS:  |
| ![kl2IMG_5492](https://github.com/user-attachments/assets/626050f1-975a-4b46-8e66-efea19890397) | ![kl2IMG_5493](https://github.com/user-attachments/assets/cf3a98db-9a3b-4a41-b1c9-20c021cdf528) | ![kl2IMG_5501](https://github.com/user-attachments/assets/73396b1d-1176-457b-a92e-c145fe5bf19d) |
|    | (`/`) | Safari iOS: |
| ![kl3IMG_5494](https://github.com/user-attachments/assets/c4c8d6b3-4c75-4766-8f68-f84fd7734c65) | ![kl3IMG_5495](https://github.com/user-attachments/assets/b3f5aa3b-05d7-42ae-adeb-02985facfebb) | ![fx2IMG_5500](https://github.com/user-attachments/assets/9b99ad9a-8629-430b-805f-b57d7c7a136c) | 
| **Firefox** iOS:  | (`/`)  |    |
| ![fx2IMG_5498](https://github.com/user-attachments/assets/47bd7633-b78e-4b4d-9415-54b166b4ca6b) | ![fx2IMG_5499](https://github.com/user-attachments/assets/2e7c4b9f-42b7-4222-8add-5630ed72fd20) |     |
|    | (`/firefox/focus`)  | Safari iOS: |
| ![fx1IMG_5497](https://github.com/user-attachments/assets/0d1db457-15b3-4a98-be47-2c2e694d2112) | ![fx1IMG_5496](https://github.com/user-attachments/assets/336d09bd-138f-442b-82ea-777095dd3de1) | ![kl2IMG_5501](https://github.com/user-attachments/assets/73396b1d-1176-457b-a92e-c145fe5bf19d) |

Other platforms can be spoofed with just uastrings, I've used:
- `Mozilla/5.0 (Android 4.4; Mobile; rv:70.0) Gecko/70.0 Firefox/70.0` (gecko)
- `Mozilla/5.0 (Linux; Android 4.3; Nexus 7 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36` (chromium tablet)
- `Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057` (edge mobile)
- `Opera/12.02 (Android 4.1; Linux; Opera Mobi/ADR-1111101157; U; en-US) Presto/2.9.201 Version/12.02` (opera mobi)
- `Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+` (bb tablet, not treated as `isMobile`)