### PR TITLE
Remove repeated banner include from legacy home page [fix #14941]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-old.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-old.html
@@ -33,7 +33,6 @@
   {% elif show_firefox_app_store_banner %}
     {% include 'includes/banners/mobile/firefox-app-store.html' %}
   {% endif %}
-  {% include 'includes/banners/fundraiser.html' %}
 {% endblock %}
 
 {% block experiments %}


### PR DESCRIPTION
## One-line summary
Cleans up repeated include outside the switch statement.

## Issue / Bugzilla link
#14941 

## Testing
http://localhost:8000/sco/