### PR TITLE
Add vanity URL redirect for Nothing Personal page [fix #14944]

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -598,4 +598,5 @@ redirectpatterns = (
     redirect(r"^firefox/privacy/products/?$", "products.landing"),
     redirect(r"^firefox/privacy/safe-passwords/?$", "firefox.features.password-manager"),
     redirect(r"^firefox/privacy/book/?$", "https://support.mozilla.org/kb/how-stay-safe-web"),
+    redirect(r"^firefox/nothingpersonal/?$", "firefox.nothing-personal.index"),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -567,4 +567,6 @@ redirectpatterns = (
     # redirects that don't need a lang code prefix
     redirect(r"^diversity/?$", "mozorg.diversity.2022.index", locale_prefix=False),
     redirect(r"^webvision/?$", "mozorg.about.webvision.summary", locale_prefix=True, prepend_locale=False),
+    # issue 14944
+    redirect(r"^nothing-?personal/?$", "firefox.nothing-personal.index"),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1301,5 +1301,7 @@ URLS = flatten(
         url_test("/firefox/privacy/products/", "/products/"),
         url_test("/firefox/privacy/safe-passwords/", "/firefox/features/password-manager/"),
         url_test("/firefox/privacy/book/", "https://support.mozilla.org/kb/how-stay-safe-web"),
+        # issue 14944
+        url_test("/{nothing-personal,nothingpersonal}/", "/firefox/nothing-personal/"),
     )
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1303,5 +1303,6 @@ URLS = flatten(
         url_test("/firefox/privacy/book/", "https://support.mozilla.org/kb/how-stay-safe-web"),
         # issue 14944
         url_test("/{nothing-personal,nothingpersonal}/", "/firefox/nothing-personal/"),
+        url_test("/firefox/nothingpersonal/", "/firefox/nothing-personal/"),
     )
 )


### PR DESCRIPTION
## One-line summary
Adds a redirect from /nothingpersonal/ (or /nothing-personal/) to /firefox/nothing-personal/. This makes a URL easier to speak aloud in audio ads.

## Issue / Bugzilla link
#14944 

## Testing
http://localhost:8000/nothingpersonal should redirect to http://localhost:8000/firefox/nothing-personal/
