### PR TITLE
Amend all usage of docker-compose to be docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DC_CI = "bin/docker-compose.sh"
-DC = $(shell which docker-compose)
+DC = $(shell which docker) compose
 DOCKER = $(shell which docker)
 TEST_DOMAIN = www.mozilla.org
 POCKET_MODE = Pocket
@@ -9,7 +9,7 @@ all: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  build                          - build docker images for dev"
-	@echo "  run                            - docker-compose up the entire system for dev"
+	@echo "  run                            - 'docker compose up' the entire system for dev"
 	@echo "  stop                           - stop all docker containers"
 	@echo "  kill                           - kill all docker containers (more forceful than stop)"
 	@echo "  pull                           - pull the latest production images from Docker Hub"

--- a/bin/docker-compose.sh
+++ b/bin/docker-compose.sh
@@ -6,4 +6,4 @@
 
 source docker/bin/set_git_env_vars.sh
 
-docker-compose "$@"
+docker compose "$@"

--- a/bin/integration_tests/cleanup_after_functional_tests.sh
+++ b/bin/integration_tests/cleanup_after_functional_tests.sh
@@ -18,7 +18,7 @@ docker cp "bedrock-${CI_JOB_ID}:/app/tests/results" "results-${CI_JOB_ID}"
 docker rm "bedrock-${CI_JOB_ID}"
 
 if [ "${DRIVER}" = "Remote" ]; then
-    docker-compose \
+    docker compose \
         -f ./bin/integration_tests/docker_compose_for_integration_tests.yml \
         -p "selenium-hub-${CI_JOB_ID}" \
         down --remove-orphans

--- a/bin/integration_tests/docker_compose_for_integration_tests.yml
+++ b/bin/integration_tests/docker_compose_for_integration_tests.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   selenium-hub:
     image: selenium/hub:3

--- a/bin/integration_tests/functional_tests.sh
+++ b/bin/integration_tests/functional_tests.sh
@@ -18,12 +18,12 @@ then
 fi
 
 if [ "${DRIVER}" = "Remote" ]; then
-    docker-compose \
+    docker compose \
         -f ./bin/integration_tests/docker_compose_for_integration_tests.yml \
         -p "selenium-hub-${CI_JOB_ID}" \
         up -d selenium-hub
 
-    docker-compose \
+    docker compose \
         -f ./bin/integration_tests/docker_compose_for_integration_tests.yml \
         -p "selenium-hub-${CI_JOB_ID}" \
         up -d --scale ${BROWSER_NAME}=${NUM_BROWSER_NODES} ${BROWSER_NAME}

--- a/bin/integration_tests/functional_tests.sh
+++ b/bin/integration_tests/functional_tests.sh
@@ -30,11 +30,11 @@ if [ "${DRIVER}" = "Remote" ]; then
 
     SELENIUM_HOST="grid"
     SELENIUM_PORT=4444
-    DOCKER_LINKS=(--link selenium-hub-${CI_JOB_ID}_selenium-hub_1:grid --net selenium-hub-${CI_JOB_ID}_default)
+    DOCKER_LINKS=(--link selenium-hub-${CI_JOB_ID}-selenium-hub-1:grid --net selenium-hub-${CI_JOB_ID}_default)
 
 
     echo -n "Waiting for Selenium Grid to get ready..."
-    IP=$(docker inspect selenium-hub-${CI_JOB_ID}_selenium-hub_1 | jq -r .[0].NetworkSettings.Networks[].IPAddress)
+    IP=$(docker inspect selenium-hub-${CI_JOB_ID}-selenium-hub-1 | jq -r .[0].NetworkSettings.Networks[].IPAddress)
     set +e
     SELENIUM_READY=$((curl -fs  http://${IP}:4444/wd/hub/status  | jq -es 'if . == [] then null else .[] | .value.ready end' > /dev/null) || echo "false")
     while ! ${SELENIUM_READY}; do

--- a/bin/upload-staticfiles.sh
+++ b/bin/upload-staticfiles.sh
@@ -26,12 +26,12 @@ CONTAINER_NAME="bedrock-${GIT_COMMIT}"
 rm -rf "${TMP_DIR}"
 rm -rf "${TMP_DIR_HASHED}"
 
-# .env file must exist for docker-compose
+# .env file must exist for docker compose
 touch .env
 
 # have to rerun staticfiles without symlinks or we just copy broken symlinks
 docker rm -f "$CONTAINER_NAME" || true
-docker-compose run --name "$CONTAINER_NAME" release docker/bin/build_staticfiles.sh --nolink
+docker compose run --name "$CONTAINER_NAME" release docker/bin/build_staticfiles.sh --nolink
 docker cp "${CONTAINER_NAME}:/app/static" "${TMP_DIR}"
 docker rm -f "$CONTAINER_NAME"
 

--- a/docker/bin/postbuild.sh
+++ b/docker/bin/postbuild.sh
@@ -5,6 +5,6 @@
 
 set -ex
 
-# Docker-Compose does not remove the running database instace. We cannot use docker-compose
+# Docker compose does not remove the running database instace. We cannot use docker compose
 # rm here because we re-tagged the image while uploading to DockerHub.
 docker rm -f `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_db_1

--- a/docker/bin/run_tests.sh
+++ b/docker/bin/run_tests.sh
@@ -10,4 +10,4 @@ set -exo pipefail
 
 source docker/bin/set_git_env_vars.sh
 
-exec docker-compose run test-image
+exec docker compose run test-image

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -63,7 +63,7 @@ If you don't have or want to use Make you can call the docker and compose comman
 
 .. code-block:: bash
 
-    $ docker-compose pull
+    $ docker compose pull
 
 .. code-block:: bash
 
@@ -73,7 +73,7 @@ Then starting it all is simply
 
 .. code-block:: bash
 
-    $ docker-compose up app assets
+    $ docker compose up app assets
 
 All of this is handled by the ``Makefile`` script and called by Make if you follow the above directions.
 You **DO NOT** need to do both.
@@ -101,7 +101,7 @@ If you make a change to ``media/static-bundles.json``, you'll need to restart Do
 
     Sometimes stopping Docker doesn't actually kill the images. To be safe, after stopping docker, run
     ``docker ps`` to ensure the containers were actually stopped. If they have not been stopped, you can force
-    them by running ``docker-compose kill`` to stop all containers, or ``docker kill <container_name>`` to stop
+    them by running ``docker compose kill`` to stop all containers, or ``docker kill <container_name>`` to stop
     a single container, e.g. ``docker kill bedrock_app_1``.
 
 Local Installation
@@ -252,23 +252,23 @@ you've broken something with a change.
 Docker
 ------
 
-We manage our local docker environment with docker-compose and Make. All you need to do here is run::
+We manage our local docker environment with docker compose and Make. All you need to do here is run::
 
     $ make test
 
-If you don't have Make you can simply run ``docker-compose run test``.
+If you don't have Make you can simply run ``docker compose run test``.
 
 If you'd like to run only a subset of the tests or only one of the test commands you can accomplish
 that with a command like the following::
 
-    $ docker-compose run test pytest bedrock/firefox
+    $ docker compose run test pytest bedrock/firefox
 
 This example will run only the unit tests for the ``firefox`` app in bedrock. You can substitute
 ``pytest bedrock/firefox`` with most any shell command you'd like and it will run in the Docker
 container and show you the output. You can also just run ``bash`` to get an interactive shell in
 the container which you can then use to run any commands you'd like and inspect the file system::
 
-    $ docker-compose run test bash
+    $ docker compose run test bash
 
 Local
 -----
@@ -295,9 +295,9 @@ Make it run
 Docker
 ------
 
-You can simply run the ``make run`` script mentioned above, or use docker-compose directly::
+You can simply run the ``make run`` script mentioned above, or use docker compose directly::
 
-    $ docker-compose up app assets
+    $ docker compose up app assets
 
 Local
 -----


### PR DESCRIPTION
This is because the ubuntu-latest GHA image no longer supports the V1 compose API, which was breaking our CI.

https://github.com/actions/runner-images/issues/9692

This is a wholesale change, to ensure consistent use of the v2 syntax



## Testing

I pushed this to `run-integration-tests` and the fact it's running at all shows the change has helped, IMO https://github.com/mozilla/bedrock/actions/runs/10218032453 - please rerun any failed tests on that URL as they should all pass