### PR TITLE
Prefer supplied CTA content for WNP fundraiser buttons

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/mofo-donate-cta.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/mofo-donate-cta.html
@@ -15,7 +15,7 @@
 {% elif LANG == 'pl' %}
   {% set donate_cta = "Wesprzyj Fundację Mozilli darowizną" %}
 {% else %}
-  {% set donate_cta = "Donate to the Mozilla Foundation" %}
+  {% set donate_cta = ftl('whatsnew-donate-to-mofo') %}
 {% endif %}
 
 <div class="wnp-donate-wrapper mzp-u-centered">
@@ -25,10 +25,6 @@
         <path fill="#ff0000" d="M1.2,2.2c-1.5,1.5-1.5,4.2,0,5.7L8,15c2.3-2.4,4.5-4.7,6.9-7c1.5-1.5,1.5-4.2,0-5.7c-1.5-1.5-4-1.5-5.6,0L8,3.5 L6.7,2.3C5.1,0.6,2.7,0.6,1.2,2.2"/>
       </svg>
     </span>
-    {% if ftl_has_messages('whatsnew-donate-to-mofo') %}
-      {{ ftl('whatsnew-donate-to-mofo') }}
-    {% else %}
-      {{ donate_cta }}
-    {% endif %}
+    {{ donate_cta }}
   </a>
 </div>


### PR DESCRIPTION
## One-line summary

Uses hard-coded donate CTA strings over Fluent content for NA+EU locales targeted by the custom WNPs.

## Significant changes and points to review

This will make any changes the community made in Pontoon for _it, pl, es-ES_ "donate" buttons effectively not display in the current WNP content.

## Issue / Bugzilla link

Resolves #14837

## Testing

http://localhost:8000/it/firefox/128.0/whatsnew/
http://localhost:8000/pt-BR/firefox/88.0/whatsnew/
http://localhost:8000/en-US/firefox/128.0/whatsnew/
http://localhost:8000/en-GB/firefox/128.0/whatsnew/?v=1