### PR TITLE
fix(tests/cdn): Make check case insensitive

### DIFF
--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -125,7 +125,7 @@ def test_cdn_cache(base_url):
 
     # then test that caching is working
     resp = requests.get(full_url, timeout=5)
-    assert "Hit" in resp.headers["x-cache"]
+    assert "hit" in resp.headers["x-cache"].lower()
 
 
 @pytest.mark.cdn


### PR DESCRIPTION
## One-line summary
This was the only failing test when run locally, just a difference in casing in how the CDN presents this information.

The `ssl-labs` tests use an external DNS and so cannot test the changes under question. Once deployed we can verify those tests are the same or make adjustments as needed.



## Testing
Ran the tests locally pointing at a local `/etc/hosts` override to test CDN deployment.
