### PR TITLE
Fix 404 /impact/ page (Fixes #14971)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/impact-report/index.html
+++ b/bedrock/mozorg/templates/mozorg/impact-report/index.html
@@ -33,26 +33,28 @@
       </div>
     </header>
 
-    <section class="c-report">
-      {% call split(
-        block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed c-foundation',
-        image=resp_img(
-          url='img/mozorg/impact/report-cover.jpg',
-          srcset={
-            'img/mozorg/impact/report-cover-high-res.jpg': '1.5x'
-          },
-          optional_attributes={
-            'class': 'mzp-c-split-media-asset',
-            'loading': 'lazy'
-          }
-        ),
-        media_after=False
-      ) %}
-        <h3>Our 2024 report</h3>
-        <p>This holistic report by the Mozilla Corporation and Mozilla Foundation provides transparency to our employees, customers, and community on the progress of our Sustainability and Diversity, Equity, Inclusion, and Belonging commitments in 2023.</p>
-        <p><a href="https://assets.mozilla.net/pdf/Impact_Report_2024.pdf" class="mzp-c-button">View the report</a></p>
-      {% endcall %}
-    </section>
+    {% if switch('impact-report-active') %}
+      <section class="c-report">
+        {% call split(
+          block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed c-foundation',
+          image=resp_img(
+            url='img/mozorg/impact/report-cover.jpg',
+            srcset={
+              'img/mozorg/impact/report-cover-high-res.jpg': '1.5x'
+            },
+            optional_attributes={
+              'class': 'mzp-c-split-media-asset',
+              'loading': 'lazy'
+            }
+          ),
+          media_after=False
+        ) %}
+          <h3>Our 2024 report</h3>
+          <p>This holistic report by the Mozilla Corporation and Mozilla Foundation provides transparency to our employees, customers, and community on the progress of our Sustainability and Diversity, Equity, Inclusion, and Belonging commitments in 2023.</p>
+          <p><a href="https://assets.mozilla.net/pdf/Impact_Report_2024.pdf" class="mzp-c-button">View the report</a></p>
+        {% endcall %}
+      </section>
+    {% endif %}
 
     <section class="c-cards mzp-l-content">
       <h3>Join us in making an impact!</h3>

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -124,7 +124,7 @@ urlpatterns = [
     page("sustainability/carbon-neutral/", "mozorg/sustainability/carbon-neutral.html"),
     page("sustainability/emissions-data/", "mozorg/sustainability/emissions-data.html"),
     # SEI page
-    path("impact/", views.ImpactPageView.as_view(), name="mozorg.impact-report.index"),
+    page("impact/", "mozorg/impact-report/index.html"),
     # Webvision
     # there's also a redirect in mozorg.nonlocale_urls
     path(

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -17,7 +17,6 @@ from django.views.generic import TemplateView
 from jsonview.decorators import json_view
 from product_details import product_details
 
-from bedrock.base.waffle import switch
 from bedrock.contentful.api import ContentfulPage
 from bedrock.mozorg.credits import CreditsFile
 from bedrock.mozorg.forms import MiecoEmailForm
@@ -192,16 +191,6 @@ class WebvisionDocView(RequireSafeMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         context[self.doc_context_name] = doc.content
         return context
-
-
-class ImpactPageView(TemplateView):
-    def render_to_response(self, context, **response_kwargs):
-        template = "mozorg/impact-report/index.html"
-
-        if not switch("impact-report-active"):
-            raise Http404
-
-        return l10n_utils.render(self.request, template, context, **response_kwargs)
 
 
 MIECO_EMAIL_SUBJECT = {"mieco": "MIECO Interest Form", "innovations": "Innovations Interest Form"}


### PR DESCRIPTION
## One-line summary

Switches the /impact/ page to hide the main CTA behind a switch, rather than make past report links non-discoverable.

## Issue / Bugzilla link

#14971

## Testing

Set `SWITCH_IMPACT_REPORT_ACTIVE=False` in your `.env` to hide the main CTA.

http://localhost:8000/en-US/impact/