### PR TITLE
Fix disappearing reader mode icon on WNP 129 (Fixes #14975)

### DIFF
--- a/media/js/firefox/whatsnew/whatsnew-129-na.js
+++ b/media/js/firefox/whatsnew/whatsnew-129-na.js
@@ -52,6 +52,18 @@ function init() {
     });
 
     Mozilla.UITour.forceShowReaderIcon();
+
+    // show reader mode icon again on visibility change
+    // see https://github.com/mozilla/bedrock/issues/14975
+    document.addEventListener(
+        'visibilitychange',
+        () => {
+            if (!document.hidden) {
+                Mozilla.UITour.forceShowReaderIcon();
+            }
+        },
+        false
+    );
 }
 
 if (


### PR DESCRIPTION
## One-line summary

Same fix as we did for WNP 116: https://github.com/mozilla/bedrock/issues/13484

## Significant changes and points to review

Note: this is a pesky bug as it's not reproducible on localhost. I pushed it to a demo below where the fix can be tested.

Make sure you have UITour enabled for demo1: https://bedrock.readthedocs.io/en/latest/uitour.html#local-development

## Issue / Bugzilla link

#14975

## Testing

https://www-demo1.allizom.org/en-US/firefox/129.0/whatsnew/