### PR TITLE
Enable dependabot updates for front-end NPM packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,35 @@ updates:
       - Backend
       - dependencies
   - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    groups:
+      frontend:
+        dependency-type: production
+        update-types:
+          - 'minor'
+          - 'patch'
+        patterns:
+          - '*'
+        exclude-patterns:
+          - '@mozilla/glean'  # Glean.js needs to be kept in sync with glean_parser Python dependency
+          - '@mozilla-protocol/*'  # Protocol package updates require individual testing.
+          - '@mozmeao/*'  # Owned NPM package updates require individual testing.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - 'minor'
+          - 'patch'
+    open-pull-requests-limit: 10
+    labels:
+      - Frontend
+      - dependencies
+  - package-ecosystem: npm
     directory: '/tests/playwright'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       playwright:
         update-types:


### PR DESCRIPTION
## One-line summary

- Enables Dependabot for bedrock's main NPM dependencies.
- Groups PRs for minor/patch bumps and dependency type.

## Significant changes and points to review

- Excludes our own self-published NPM packages (such as Protocol), since these are more often than not released intentionally before requiring manual testing in bedrock.

## Issue / Bugzilla link

N/A