### PR TITLE
Fix test for welcome 15

### DIFF
--- a/tests/pages/firefox/welcome/page15.py
+++ b/tests/pages/firefox/welcome/page15.py
@@ -10,7 +10,7 @@ from pages.base import BasePage
 class FirefoxWelcomePage15(BasePage):
     _URL_TEMPLATE = "/{locale}/firefox/welcome/15/"
 
-    _try_vpn_button_locator = (By.CSS_SELECTOR, ".c-main .mzp-c-button")
+    _try_vpn_button_locator = (By.CSS_SELECTOR, ".page-body .mzp-c-button")
 
     @property
     def is_try_vpn_button_displayed(self):


### PR DESCRIPTION
## One-line summary
Some elements got changed around in https://github.com/mozilla/bedrock/pull/14964 and the button locator for the test was looking for a class that was no longer there, hence the test was failing because it couldn't find the button. This updates the locator so the test can pass again.

## Testing
http://localhost:8000/firefox/welcome/15/

`pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/welcome/test_welcome_page15.py`