### PR TITLE
Update list of supported languages on translate feature page [fix #14987]

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -25,6 +25,9 @@
 <ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
   <li>Bulgarian</li>
+  <li>Croatian</li>
+  <li>Czech</li>
+  <li>Danish</li>
   <li>Dutch</li>
   <li>English</li>
   <li>Estonian</li>
@@ -33,14 +36,21 @@
   <li>German</li>
   <li>Greek</li>
   <li>Hungarian</li>
+  <li>Indonesian</li>
   <li>Italian</li>
+  <li>Latvian</li>
+  <li>Lithuanian</li>
   <li>Polish</li>
   <li>Portuguese</li>
+  <li>Romanian</li>
   <li>Russian</li>
+  <li>Serbian</li>
+  <li>Slovak</li>
   <li>Slovenian</li>
   <li>Spanish</li>
   <li>Turkish</li>
   <li>Ukrainian</li>
+  <li>Vietnamese</li>
 {% else %}
   {% for lang in context_test -%}
     {% set name = context_test[lang] %}

--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -25,6 +25,7 @@
 <ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
   <li>Bulgarian</li>
+  <li>Catalan</li>
   <li>Croatian</li>
   <li>Czech</li>
   <li>Danish</li>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -814,6 +814,7 @@ def firefox_welcome_page1(request):
 def firefox_features_translate(request):
     translate_langs = [
         "bg",
+        "ca",
         "hr",
         "cs",
         "da",

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -814,6 +814,9 @@ def firefox_welcome_page1(request):
 def firefox_features_translate(request):
     translate_langs = [
         "bg",
+        "hr",
+        "cs",
+        "da",
         "nl",
         "en-US",
         "et",
@@ -822,14 +825,21 @@ def firefox_features_translate(request):
         "de",
         "el",
         "hu",
+        "id",
         "it",
+        "lv",
+        "lt",
         "pl",
         "pt-PT",
+        "ro",
         "ru",
+        "sr",
+        "sk",
         "sl",
         "es-ES",
         "tr",
         "uk",
+        "vi",
     ]
 
     names = get_translations_native_names(sorted(translate_langs))


### PR DESCRIPTION
## One-line summary
Updates the languages on the Firefox Translate feature page.

## Issue / Bugzilla link
#14987 

## Testing
http://localhost:8000/firefox/features/translate/