### PR TITLE
Remove fixed Fluent linter brand exclusions

### DIFF
--- a/.github/l10n/linter_config.yml
+++ b/.github/l10n/linter_config.yml
@@ -27,6 +27,4 @@ CO01:
     - "{ -brand-name-mozilla } account"
   exclusions:
     files: []
-    messages:
-      # firefox/features/translate.ftl
-      - features-translate-for-everyone
+    messages: []


### PR DESCRIPTION
## One-line summary

The remaining linter exception was removed from strings when translations changed last year.

## Issue / Bugzilla link

Removed in https://github.com/mozilla/bedrock/pull/13644

## Testing

✅ [actions/runs/10517645057/job/29142138942?pr=14996#step:5:1](https://github.com/mozilla/bedrock/actions/runs/10517645057/job/29142138942?pr=14996#step:5:1)