### PR TITLE
Fix heading levels on /products/ page (Fixes #15002)

### DIFF
--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -63,7 +63,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="{{ url('firefox') }}" data-cta-type="link" data-cta-text="Firefox" data-cta-position="heading">{{ ftl('firefox-products-firefox') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="{{ url('firefox') }}" data-cta-type="link" data-cta-text="Firefox" data-cta-position="heading">{{ ftl('firefox-products-firefox') }}</a></h2>
       <p>{{ ftl('firefox-products-get-the-browser-that-blocks') }}</p>
       {% set alt_copy = ftl('download-button-download-firefox') + " " + icon_download|safe %}
       <div class="show-else">{{ download_firefox_thanks(alt_copy=alt_copy, button_class='mzp-t-secondary mzp-t-lg') }}</div>
@@ -84,7 +84,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-cta-type="link" data-cta-text="Focus" data-cta-position="heading">{{ ftl('firefox-products-firefox-focus') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-cta-type="link" data-cta-text="Focus" data-cta-position="heading">{{ ftl('firefox-products-firefox-focus') }}</a></h2>
       <p>{{ ftl('firefox-products-your-dedicated-privacy') }}</p>
       <p>
         <span class="hide-ios">{{ google_play_button(href=fc_android_url, id='playStoreLink-focus') }}</span>
@@ -105,7 +105,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="https://relay.firefox.com/{{ referrals }}" data-cta-type="link" data-cta-text="Relay" data-cta-position="heading">{{ ftl('firefox-products-relay') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="https://relay.firefox.com/{{ referrals }}" data-cta-type="link" data-cta-text="Relay" data-cta-position="heading">{{ ftl('firefox-products-relay') }}</a></h2>
       <p>{{ ftl('firefox-products-protect-your-real') }}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://relay.firefox.com/{{ referrals }}#pricing" rel="external noopener" data-cta-type="link" data-cta-text="Get Relay">{{ ftl('firefox-products-get-relay') }} {{ icon_external|safe }}</a>
     {% endcall %}
@@ -123,7 +123,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
       <p>{% if country_code == 'US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://monitor.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="Check for breaches">{% if LANG == 'en-US' %}Check for breaches now{% else %}{{ ftl('firefox-products-check-for-breaches') }}{% endif %} {{ icon_external|safe }}</a></p>
     {% endcall %}
@@ -141,7 +141,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="VPN" data-cta-position="heading">{{ ftl('firefox-products-mozilla-vpn') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="{{ url('products.vpn.landing') }}" data-cta-type="link" data-cta-text="VPN" data-cta-position="heading">{{ ftl('firefox-products-mozilla-vpn') }}</a></h2>
       <p>{{ ftl('firefox-products-surf-stream-and-get-work-done') }}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="{{ url('products.vpn.landing') + '#pricing' }}" rel="external noopener" data-cta-type="link" data-cta-text="Get VPN">{{ ftl('firefox-products-get-mozilla-vpn') }}</a></p>
     {% endcall %}
@@ -159,7 +159,7 @@
         }
       ),
     ) %}
-    <h3 class="mzp-c-picto-heading"><a href="https://developer.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="MDN Plus" data-cta-position="heading">{{ ftl('firefox-products-mdn-plus') }}</a></h3>
+    <h2 class="mzp-c-picto-heading"><a href="https://developer.mozilla.org/{{ referrals }}" data-cta-type="link" data-cta-text="MDN Plus" data-cta-position="heading">{{ ftl('firefox-products-mdn-plus') }}</a></h2>
       <p>{{ ftl('firefox-products-resources-for-developers') }}</p>
       <p>
         <a href="https://developer.mozilla.org/plus/{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-secondary" data-cta-type="link" data-cta-text="Support MDN">{{ ftl('firefox-products-support-mdn') }} {{ icon_external|safe }}</a>
@@ -179,7 +179,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="https://www.thunderbird.net/{{ referrals }}" data-cta-type="link" data-cta-text="Thunderbird" data-cta-position="heading">{{ ftl('firefox-products-thunderbird') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="https://www.thunderbird.net/{{ referrals }}" data-cta-type="link" data-cta-text="Thunderbird" data-cta-position="heading">{{ ftl('firefox-products-thunderbird') }}</a></h2>
       <p>{{ ftl('firefox-products-access-all') }}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://www.thunderbird.net/download/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Thunderbird Download">{{ ftl('firefox-products-download-thunderbird') }} {{ icon_download|safe }}</a></p>
     {% endcall %}
@@ -197,7 +197,7 @@
         }
       ),
     ) %}
-      <h3 class="mzp-c-picto-heading"><a href="https://www.fakespot.com/{{ referrals }}" data-cta-type="link" data-cta-text="Fakespot" data-cta-position="heading">{{ ftl('firefox-products-fakespot') }}</a></h3>
+      <h2 class="mzp-c-picto-heading"><a href="https://www.fakespot.com/{{ referrals }}" data-cta-type="link" data-cta-text="Fakespot" data-cta-position="heading">{{ ftl('firefox-products-fakespot') }}</a></h2>
       <p>{{ ftl('firefox-products-fakespot-has-your') }}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://www.fakespot.com/analyzer{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Analyze a url with Fakespot">{{ ftl('firefox-products-analyze') }} {{ icon_external|safe }}</a></p>
     {% endcall %}
@@ -215,7 +215,7 @@
         }
       ),
     ) %}
-    <h3 class="mzp-c-picto-heading"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" data-cta-type="link" data-cta-text="Pocket" data-cta-position="heading">{{ ftl('firefox-products-pocket') }}</a></h3>
+    <h2 class="mzp-c-picto-heading"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" data-cta-type="link" data-cta-text="Pocket" data-cta-position="heading">{{ ftl('firefox-products-pocket') }}</a></h2>
       <p>{{ ftl('firefox-products-discover-the-best-content-v2') }}</p>
       <p class="show-else"><a href="https://getpocket.com/signup{{ referrals }}" rel="external noopener" class="mzp-c-button mzp-t-product mzp-t-secondary" data-cta-type="link" data-cta-text="Pocket sign up">{{ ftl('firefox-products-get-pocket') }} {{ icon_external|safe }}</a></p>
       <p class="show-android">{{ google_play_button(href=pocket_android_url, id='playStoreLink-pocket') }}</p>


### PR DESCRIPTION
## One-line summary

Updates product headings to `<h2>`

## Issue / Bugzilla link

#15002

## Testing

http://localhost:8000/en-US/products/