### PR TITLE
No longer exclude root page for zh-CN route

### DIFF
--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -150,10 +150,6 @@ def get_static_urls():
 
                 locales = set(render.call_args[0][2]["translations"].keys())
 
-                # zh-CN is a redirect on the homepage
-                if path == "/":
-                    locales -= {"zh-CN"}
-
                 # Firefox Focus has a different URL in German
                 if path == "/privacy/firefox-focus/":
                     locales -= {"de"}


### PR DESCRIPTION
Stop excluding /zh-CN/ route from sitemap because it is no longer redirected

Resolves https://github.com/mozmeao/www-sitemap-generator/issues/10

