### PR TITLE
Fix root global page active locales

### DIFF
--- a/bedrock/base/templates/404-locale.html
+++ b/bedrock/base/templates/404-locale.html
@@ -57,7 +57,7 @@
   <section class="c-block-list">
     <ul>
       {% for locale in available_locales if locale in languages %}
-        <li lang="{{ locale }}"><a href="/{{ locale }}{{ request.path_info }}" title="{{ 'Browse {0} in the {1} language'|f(request.path_info, languages[locale]["native"]) }}">{{ languages[locale]['native'] }}</a></li>
+        <li lang="{{ locale }}"><a href="/{{ locale }}{{ request.path_info }}" title="{{ 'Browse {0} in the {1} language'|f(request.path_info, languages[locale]["English"]) }}">{{ languages[locale]['native'] }}</a></li>
       {% endfor %}
     </ul>
   </section>

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -169,7 +169,9 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
                 translations.update(ftl_active_locales(af))
             translations = sorted(translations)  # `sorted` returns a list.
         elif l10n:
-            translations = l10n.active_locales
+            translations = l10n.active_locales if not is_root_path_with_no_language_clues(request) else l10n.active_home_locales
+            allowed = settings.PROD_LANGUAGES if not settings.DEV else settings.DEV_LANGUAGES
+            translations = set(translations).intersection(allowed)
 
         # if `add_active_locales` is given then add it to the translations for the template
         if "add_active_locales" in context:

--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -85,6 +85,11 @@ class FluentL10n(FluentLocalization):
         return get_active_locales(self.resource_ids[0])
 
     @cached_property
+    def active_home_locales(self):
+        # use mozorg/home to check for activation
+        return get_active_locales("mozorg/home.ftl")
+
+    @cached_property
     def percent_translated(self):
         if not self._message_ids:
             return 0


### PR DESCRIPTION
## One-line summary

Shows only applicable languages for navigating to the home page on global `/` root.

## Significant changes and points to review

1. The current `/` locale choice root lists `active_locales` based either on its own view (404 in fact) language files, or more likely because the metadata checks coincidentally use the first locale file in the folder and the `404.ftl` comes first. But the proper `active_locales` for homepage have to be read from `mozorg/home.ftl` instead.
2. Even with locales populated based on the correct page, there still might be some that are not enabled in settings, so a check to only offer locales that can be navigated to is added.

## Issue / Bugzilla link

Fixes #15010

## Testing

_(in prod mode, with Dev=False for restricted languages & Debug=False as the root is 404)_
http://localhost:8000/ _(with Accept-Locale empty)_