### PR TITLE
Add default WNP fallback variant to WNP 130 URLs (Fixes #15034)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -935,6 +935,15 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ["firefox/whatsnew/whatsnew-fx130.html"]
 
+    @override_settings(DEV=True)
+    def test_fx_130_0_0_en_us_v1(self, render_mock):
+        """Should use default WNP template for en-US locale when v=1"""
+        req = self.rf.get("/firefox/whatsnew/?v=1")
+        req.locale = "en-US"
+        self.view(req, version="130.0")
+        template = render_mock.call_args[0][1]
+        assert template == ["firefox/whatsnew/index.html"]
+
     # end 130.0 whatsnew tests
 
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -581,7 +581,10 @@ class WhatsnewView(L10nTemplateView):
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("130."):
             if locale in ["en-US", "en-GB", "en-CA", "de", "fr", "es-ES", "it", "pl"]:
-                template = "firefox/whatsnew/whatsnew-fx130.html"
+                if variant == "1":
+                    template = "firefox/whatsnew/index.html"
+                else:
+                    template = "firefox/whatsnew/whatsnew-fx130.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("129."):


### PR DESCRIPTION
## One-line summary

Adds a `v=1` param to WNP 130 URLs to allow Nimbus to test against the default WNP template.

## Issue / Bugzilla link

#15034

## Testing

- [ ] http://localhost:8000/en-US/firefox/130.0/whatsnew/ shows WNP 130 template
- [ ] http://localhost:8000/en-US/firefox/130.0/whatsnew/?v=1 shows default WNP template