### PR TITLE
Make sqlite3 available in the production-grade release Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 8000
 CMD ["./bin/run.sh"]
 
 COPY docker/bin/apt-install /usr/local/bin/
-RUN apt-install gettext libxslt1.1 git curl
+RUN apt-install gettext libxslt1.1 git curl sqlite3
 
 # copy in Python environment
 COPY --from=python-builder /venv /venv
@@ -98,7 +98,7 @@ FROM app-base AS devapp
 
 CMD ["./bin/run-tests.sh"]
 
-RUN apt-install make sqlite3
+RUN apt-install make
 COPY docker/bin/ssllabs-scan /usr/local/bin/ssllabs-scan
 COPY requirements/* ./requirements/
 RUN pip install --require-hashes --no-cache-dir -r requirements/dev.txt


### PR DESCRIPTION
In order to run the postgres-to-sqlite export script in k8s, we need to have sqlite3 available there.

This changeset moves it from the 'devapp' image to the 'app-base' image, making it also available in the 'release' image, which we use in production

## Issue / Bugzilla link

Contributes to https://github.com/mozilla/bedrock/issues/14660 

## Testing

```
make build-prod
docker compose run --rm release bash
```
Then confirm you can run `sqlite3` without complaint