### PR TITLE
Remove old pytest `allow_thread_sharing` fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,23 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from django.db.backends.sqlite3.base import BaseDatabaseWrapper as SQLiteWrapper
-
 import pytest
 
 from bedrock.base.config_manager import config
-
-
-# pytest-django is currently broken by attempting to set the read only
-# property ``allow_thread_sharing`` (as of Django 2.2), so work around
-# that.
-def mutable_allow_thread_sharing(self, allow):
-    if allow:
-        if not self.allow_thread_sharing:
-            self.inc_thread_sharing()
-
-
-SQLiteWrapper.allow_thread_sharing = property(SQLiteWrapper.allow_thread_sharing.__get__, mutable_allow_thread_sharing)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This was fixed in pytest 4.5
