### PR TITLE
Update WNP 130 variant params [#15034]

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -937,8 +937,8 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_130_0_0_en_us_v1(self, render_mock):
-        """Should use default WNP template for en-US locale when v=1"""
-        req = self.rf.get("/firefox/whatsnew/?v=1")
+        """Should use default WNP template for en-US locale when branch=experiment-wnp-130-tabs and variant=v1"""
+        req = self.rf.get("/firefox/whatsnew/?branch=experiment-wnp-130-tabs&variant=v1")
         req.locale = "en-US"
         self.view(req, version="130.0")
         template = render_mock.call_args[0][1]

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -581,8 +581,11 @@ class WhatsnewView(L10nTemplateView):
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("130."):
             if locale in ["en-US", "en-GB", "en-CA", "de", "fr", "es-ES", "it", "pl"]:
-                if variant == "1":
-                    template = "firefox/whatsnew/index.html"
+                if nimbus_branch == "experiment-wnp-130-tabs":
+                    if nimbus_variant == "v1":
+                        template = "firefox/whatsnew/index.html"
+                    else:
+                        template = "firefox/whatsnew/whatsnew-fx130.html"
                 else:
                     template = "firefox/whatsnew/whatsnew-fx130.html"
             else:


### PR DESCRIPTION
## One-line summary
#15035 added a variant param to show the default template, but Nimbus experiments use a different format of `?branch=foo&variant=bar` (I need to document this, right now it's tribal knowledge and that's my bad).

## Issue / Bugzilla link
#15034 

## Testing
fallback template: http://localhost:8000/firefox/130.0/whatsnew/?branch=experiment-wnp-130-tabs&variant=v1 
custom page: http://localhost:8000/firefox/130.0/whatsnew/?branch=experiment-wnp-130-tabs&variant=v2

Should also get the custom page with no params.