### PR TITLE
Bugfix: ensure correct list of available translations for a CMS-backed page

### DIFF
--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -52,9 +52,14 @@ class AbstractBedrockCMSPage(WagtailBasePage):
         return False
 
     def _patch_request_for_bedrock(self, request):
-        # Add hints that help us integrate CMS pages with core Bedrock logic
+        "Add hints that help us integrate CMS pages with core Bedrock logic"
+
+        # Quick annotation to help us track the origin of the page
         request.is_cms_page = True
-        request._locales_available_via_cms = [self.locale.language_code] + [x.locale.language_code for x in self.get_translations()]
+
+        # Patch in a list of CMS-available locales for pages that are translations, not just aliases
+        _actual_translations = self.get_translations().exclude(id__in=[x.id for x in self.aliases.all()])
+        request._locales_available_via_cms = [self.locale.language_code] + [x.locale.language_code for x in _actual_translations]
         return request
 
     def _render_with_fluent_string_support(self, request, *args, **kwargs):

--- a/bedrock/cms/tests/conftest.py
+++ b/bedrock/cms/tests/conftest.py
@@ -4,7 +4,7 @@
 
 import pytest
 import wagtail_factories
-from wagtail.models import Site
+from wagtail.models import Locale, Site
 
 from bedrock.cms.tests.factories import LocaleFactory, SimpleRichTextPageFactory
 
@@ -43,3 +43,99 @@ def minimal_site(
     )
 
     return site
+
+
+@pytest.fixture
+def tiny_localized_site():
+    """
+    Generates a small site tree with some pages in other languages:
+
+    en-US:
+        / [Page]
+            /test-page [SimpleRichTextPage]
+                /child-page [SimpleRichTextPage]
+    fr:
+        / [Page]
+            /test-page [SimpleRichTextPage]
+                /child-page [SimpleRichTextPage]
+                    /grandchild-page [SimpleRichTextPage] <- no parallel page
+    pt-BR:
+        / [Page]
+            /test-page [SimpleRichTextPage]
+                /child-page [SimpleRichTextPage]
+
+    Note: no aliases exist
+    """
+
+    en_us_locale = Locale.objects.get(language_code="en-US")
+    fr_locale = LocaleFactory(language_code="fr")
+    pt_br_locale = LocaleFactory(language_code="pt-BR")
+
+    site = Site.objects.get(is_default_site=True)
+
+    en_us_root_page = site.root_page
+    fr_root_page = en_us_root_page.copy_for_translation(fr_locale)
+    pt_br_root_page = en_us_root_page.copy_for_translation(pt_br_locale)
+
+    en_us_homepage = SimpleRichTextPageFactory(title="Test Page", slug="test-page", parent=en_us_root_page)
+
+    en_us_child = SimpleRichTextPageFactory(
+        title="Child",
+        slug="child-page",
+        parent=en_us_homepage,
+    )
+
+    fr_homepage = en_us_homepage.copy_for_translation(fr_locale)
+    fr_homepage.title = "Page de Test"
+    fr_homepage.save()
+    rev = fr_homepage.save_revision()
+    fr_homepage.publish(rev)
+
+    fr_child = en_us_child.copy_for_translation(fr_locale)
+    fr_child.title = "Enfant"
+    fr_child.save()
+    rev = fr_child.save_revision()
+    fr_child.publish(rev)
+
+    fr_grandchild = SimpleRichTextPageFactory(
+        title="Petit-enfant",
+        slug="grandchild-page",
+        parent=fr_child,
+    )
+
+    pt_br_homepage = en_us_homepage.copy_for_translation(pt_br_locale)
+    pt_br_homepage.title = "Página de Teste"
+    pt_br_homepage.save()
+    rev = pt_br_homepage.save_revision()
+    pt_br_homepage.publish(rev)
+
+    pt_br_child = fr_child.copy_for_translation(pt_br_locale)
+    pt_br_child.title = "Página Filho"
+    pt_br_child.save()
+    rev = pt_br_child.save_revision()
+    pt_br_child.publish(rev)
+
+    assert en_us_root_page.locale == en_us_locale
+    assert pt_br_root_page.locale == pt_br_locale
+    assert fr_root_page.locale == fr_locale
+
+    assert en_us_homepage.locale == en_us_locale
+    assert en_us_child.locale == en_us_locale
+
+    assert fr_homepage.locale == fr_locale
+    assert fr_child.locale == fr_locale
+    assert fr_grandchild.locale == fr_locale
+
+    assert pt_br_homepage.locale == pt_br_locale
+    assert pt_br_child.locale == pt_br_locale
+
+    for page in (en_us_homepage, en_us_child, pt_br_homepage, pt_br_child, fr_homepage, fr_child, fr_grandchild):
+        page.refresh_from_db()
+
+    assert en_us_homepage.live is True
+    assert en_us_child.live is True
+    assert pt_br_homepage.live is True
+    assert pt_br_child.live is True
+    assert fr_homepage.live is True
+    assert fr_child.live is True
+    assert fr_grandchild.live is True

--- a/bedrock/cms/tests/test_models.py
+++ b/bedrock/cms/tests/test_models.py
@@ -7,6 +7,7 @@ from unittest import mock
 from django.test import override_settings
 
 import pytest
+from wagtail.models import Locale, Page
 
 from bedrock.cms.models import (
     AbstractBedrockCMSPage,
@@ -97,3 +98,42 @@ def test_CMS_ALLOWED_PAGE_MODELS_controls_Page_can_create_at(
     home_page = SimpleRichTextPage.objects.last()
     with override_settings(Dev=False, CMS_ALLOWED_PAGE_MODELS=config.split(",")):
         assert page_class.can_create_at(home_page) == success_expected
+
+
+def test__patch_request_for_bedrock__locales_available_via_cms(tiny_localized_site, rf):
+    request = rf.get("/some-path/that/is/irrelevant")
+    en_us_homepage = Page.objects.get(locale__language_code="en-US", slug="home")
+    en_us_test_page = en_us_homepage.get_children()[0]
+
+    # By default there are no aliases in the system, so all _locales_available_for_cms will
+    # match the pages set up in the tiny_localized_site fixture
+    assert Page.objects.filter(alias_of__isnull=False).count() == 0
+
+    patched_request = en_us_test_page.specific._patch_request_for_bedrock(request)
+    assert sorted(patched_request._locales_available_via_cms) == ["en-US", "fr", "pt-BR"]
+
+    # now make aliases of the test_page into Dutch and Spanish
+    nl_locale = Locale.objects.create(language_code="nl")
+    es_es_locale = Locale.objects.create(language_code="es-ES")
+
+    nl_page_alias = en_us_test_page.copy_for_translation(locale=nl_locale, copy_parents=True, alias=True)
+    nl_page_alias.save()
+
+    es_es_page_alias = en_us_test_page.copy_for_translation(locale=es_es_locale, copy_parents=True, alias=True)
+    es_es_page_alias.save()
+
+    assert Page.objects.filter(alias_of__isnull=False).count() == 4  # 2 child + 2 parent pages, which had to be copied too
+
+    # Show that the aliases don't appear in the available locales
+    patched_request = en_us_test_page.specific._patch_request_for_bedrock(request)
+    assert sorted(patched_request._locales_available_via_cms) == ["en-US", "fr", "pt-BR"]
+
+
+def test__patch_request_for_bedrock_annotates_is_cms_page(tiny_localized_site, rf):
+    request = rf.get("/some-path/that/is/irrelevant")
+    en_us_homepage = Page.objects.get(locale__language_code="en-US", slug="home")
+    en_us_test_page = en_us_homepage.get_children()[0]
+    assert en_us_test_page.specific.__class__ == SimpleRichTextPage
+
+    patched_request = en_us_test_page.specific._patch_request_for_bedrock(request)
+    assert patched_request.is_cms_page is True


### PR DESCRIPTION
By default, when a page is added, wagtail-localize will add an Alias per locale for each available locale, unless an actual translation of that page exists. This meant that, prior to this changeset, the languge selector in the footer was including languages which only had an Alias of a page available - and an Alias just links to the en-US content, but with a path of, say /fr/... which is misleading.

There'll be separate work to stop the auto-generation of Alias pages by default but as an extra safeguard, this changeset deliberately ignores Alias pages when computing the list of actual locales available for a CMS-backed page.


## Issue / Bugzilla link

Resolves #15037 

## Testing

Unit tests passing is probably ok for now, but if you have a local setup going with other pages in your DB (@alexgibson) feel free to switch to this branch and check the footer lang-selector on some CMS pages