### PR TITLE
Prevent the automatic creation of Wagtail Page Aliases in other locales

### DIFF
--- a/bedrock/cms/apps.py
+++ b/bedrock/cms/apps.py
@@ -2,9 +2,31 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import logging
+
 from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
 
 
 class CmsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "bedrock.cms"
+
+    def ready(self):
+        from wagtail import hooks
+
+        # Find and remove the existing hook function that creates page aliases on synctree.
+
+        # `hooks.get_hooks()`` does a broader search for hooks and updates/fully populates `hooks._hooks``
+        after_create_page_hooks = hooks.get_hooks("after_create_page")
+
+        for hook in after_create_page_hooks:
+            if hook.__module__ == "wagtail_localize.synctree" and hook.__name__ == "after_create_page":
+                logger.info("Patching to remove the 'after_create_page' hook from 'wagtail_localize.synctree'")
+
+                # hookspec below is a tuple of (hook_func, position_int)
+                reduced_hooks = [hookspec for hookspec in hooks._hooks["after_create_page"] if hookspec[0] != hook]
+
+                # Warning: internal attribute, may break in the future (so we have a test that checks this works)
+                hooks._hooks["after_create_page"] = reduced_hooks

--- a/bedrock/cms/test_wagtail_hooks_override.py
+++ b/bedrock/cms/test_wagtail_hooks_override.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from wagtail import hooks
+
+
+def test_after_create_page_is_no_longer_in_wagtail_hooks():
+    # In bedrock.cms.apps we have code that deliberately disables
+    # the `after_create_page` hook added by `wagtail_localize.synctree`
+    #
+    # This test confirms that it's not there. For now we just ensure
+    # there is nothing registered against the `after_create_page`` hook
+    # at all. In the future this test may break if other apps (or our own
+    # code) add a different function to to `after_create_page`` hook.
+    # At that point, this test will need updating to allow for that.
+
+    assert hooks.get_hooks("after_create_page") == []

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -457,6 +457,25 @@ Basically, there is plenty of flexibility. The flipside of that flexibility is w
 
     It's worth investing 15 mins in watching the `Wagtail Localize original demo`_ to get a good feel of how it can work.
 
+Overridden Wagtail Behaviour
+============================
+
+*This section outlines areas of the codebase where we have deliberately disabled or amended default Wagtail behaviour*
+
+.. important::
+  **We have disabled the auto-creation of Alias pages by** ``wagtail-localize`` **when a new page is added.**
+
+  By default, when a page is added, Aliases to it are automatically created for each locale. However, this means that if you add a page intended purely to be available in ``en-US``, you also end up with, say, ``/fr/new-page/`` that is served on that path but contains ``en-US`` content – this is not behaviour we wanted to have.
+
+  Now, with Alias auto-creation disabled, this no longer happens, so in our example ``/en-US/new-page/`` exists, but ``/fr/new-page/`` does not exist as a Page or an Alias, so will 404 - which is what we want.
+
+  Linked, syncable, translated pages can still be deliberately created via the ``Translate this page`` menu item.
+
+  **Warning: it's possible that this change will bite us in some way, but we'll work out a different path if need be.**
+
+  This change was added via the ``CmsConfig.ready`` method in ``bedrock/cms/apps.py``.
+
+
 Localization process
 ====================
 


### PR DESCRIPTION
This changeset deliberately removes the after_create_page hook from wagtail_localize.synctree to avoid the default behaviour where adding a page in a locale creates Aliases in all other locales which then serve the soure locale's content but under a different locale path (eg /en-US/test-page/'s content appears on /fr/test-page/ because of the alias)

See changes to cms.rst in this changeset for more details

- [X] I used an AI to write some of this code: specifically, the approach to patching out the wagtail hook, but it seems to work well and I've added a test to protect against regressions

## Issue / Bugzilla link

Resolves #15063

## Testing

- a[ ] On `main`, create a new page in the CMS, publish it. 
- [ ] Confirm you can see that page also created in all other locales (ping @stevejalim if you don't get this default behaviour). 
- [ ] If you edit one of those versions it will say it's an Alias and needs to be made into a page to edit it.
- [ ] On this branch, create another new page and publish it. 
- [ ] Confirm you no longer have a crop of Aliases made in the other locales.
- [ ] In the kebab/context menu for the page you made, click Translate this page and select one or two locales. Do not click the buttong related to Smartling and then submit/save
- [ ] Confirm you can find versions of the source page in the page tree for the other locales. They will default to the en-US content for now, but you can edit them and publish new "localized" content in them
- [ ] Stretch test: edit the source page again and republish. Use the kebab menu to sync translated content again. This should not error. View a localized version of the page and confirm that the source strings for the page have been synced over, and that a new translation is needed for that updated content.
