### PR TITLE
Remove dependabot for Python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: '/requirements'
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 20
-    labels:
-      - Backend
-      - dependencies
   - package-ecosystem: docker
     directory: '/'
     schedule:


### PR DESCRIPTION
## One-line summary

It was discussed in Slack that the we should remove dependabot for Python for the following reasons:
- Too noisy / too many PRs open
- Non actionable via the PR interface due to our tooling
- We frequently update them on our own at a regular weekly-ish cadence
- We will still receive security advisories as an indicator of urgent updates

