### PR TITLE
Update a11y for `firefox/all/` page

### DIFF
--- a/bedrock/firefox/templates/firefox/all/download.html
+++ b/bedrock/firefox/templates/firefox/all/download.html
@@ -9,8 +9,7 @@
 {% set icon_download ='<span class="mzp-c-button-icon-end"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 13c.2 0 .4-.1.5-.2l4.4-4.4-1.1-1.1-3.1 3.1V1H7.2v9.4L4.1 7.3l-1 1.1 4.4 4.4c.1.1.3.2.5.2z" /><path d="M13.5 12v2c0 .3-.2.5-.5.5H3c-.3 0-.5-.2-.5-.5v-2H1v2c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2v-2h-1.5z" /></svg></span>' %}
 
 {# Show download #}
-
-<h2 class="c-step-name{% if not (product and platform and locale) %} t-step-disabled{% endif %}">
+<h2 {% if not (product and platform and locale) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
   {{ ftl('firefox-all-download') }}
   {% if product and platform and locale %}
     <img alt="{{ ftl('firefox-all-down-arrow') }}" class="c-step-icon" src="{{ static('protocol/img/icons/arrow-down.svg') }}" width="30" height="30">

--- a/bedrock/firefox/templates/firefox/all/lang.html
+++ b/bedrock/firefox/templates/firefox/all/lang.html
@@ -5,7 +5,7 @@
 #}
 
 {# Choose language #}
-<h2 class="c-step-name {% if not (product and platform) %} t-step-disabled{% endif %}">
+<h2 {% if not (product and platform) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
   {{ ftl('firefox-all-language-v2', fallback='firefox-all-language') }}
   {% if product and platform and locale %}
     <span class="c-step-choice">{{ locale_name }}</span>

--- a/bedrock/firefox/templates/firefox/all/platform.html
+++ b/bedrock/firefox/templates/firefox/all/platform.html
@@ -7,7 +7,7 @@
 
 {# Choose platform #}
 
-<h2 class="c-step-name{% if not product %} t-step-disabled{% endif %}">
+<h2 {% if not product %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
   {{ ftl('firefox-all-platform-v2', fallback='firefox-all-platform') }}
   {% if product and platform %}
     <span class="c-step-choice">{{ platform_name }}</span>

--- a/media/css/firefox/all.scss
+++ b/media/css/firefox/all.scss
@@ -79,7 +79,8 @@ $image-path: '/media/protocol/img';
     }
 
     &.t-step-disabled {
-        opacity: 0.4;
+        cursor: not-allowed;
+        opacity: 0.5;
 
 
     [dir='rtl'] & .c-step-icon {


### PR DESCRIPTION
## One-line summary
Some a11y issues needed to be worked on for the updated `firefox/all/` page

## Significant changes and points to review

- [ ] Slightly increased color contrast on disabled text
- [ ] Added `cursor: not-allowed` for extra visual indicator that text is disabled
- [ ] Added `aria-disabled` attributes to disabled text



## Issue / Bugzilla link
- Fixes #15060 
- Fixes #15065 


## Testing
- http://localhost:8000/en-US/firefox/all/
- [ ] Open screenreader application (i.e. VoiceOver on MacOS)
- [ ] Tab over to the disabled text
- [ ] When screenreader reads text, it should also mention that the text is dimmed/disabled (depending on your OS/screenreader) 
  - [ ] When checking this, the element should have the attribute of `aria-disabled="true"`
- [ ] When text is activated, it shouldn't mention that the text is dimmed/disabled
  - [ ]   When checking this, the element should have the attribute of `aria-disabled="false"`
