### PR TITLE
Fix 400 error when editing Leadership page

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2098,6 +2098,12 @@ if WAGTAIL_ENABLE_ADMIN:
         ]
     )
 
+    # Increase the number of form fields allowed to be submitted in one GET/POST,
+    # but only for deployments where the CMS is enabled. This is needed to support
+    # complex pages with lots of (small, but) nested fields.
+    # Resolves https://mozilla.sentry.io/issues/5800147294
+    DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000
+
 
 def lazy_wagtail_langs():
     enabled_wagtail_langs = [


### PR DESCRIPTION
This changset increases the number of form fields allowed to be submitted in one GET/POST, but only for deployments where the CMS is enabled.

This is needed to support complex pages with lots of (small, but) nested fields.

Ref: https://mozilla.sentry.io/issues/5800147294
