### PR TITLE
Add Firefox campaign URLs to a11y checker

### DIFF
--- a/tests/playwright/specs/a11y/includes/urls.js
+++ b/tests/playwright/specs/a11y/includes/urls.js
@@ -11,12 +11,15 @@
  * Pages will be scanned at both desktop and mobile resolutions.
  */
 const pageTestURLs = [
+    '/de/firefox/built-for-you/',
+    '/de/firefox/challenge-the-default/',
     '/en-US/',
     '/en-US/about/',
     '/en-US/firefox/',
     '/en-US/firefox/all/',
     '/en-US/firefox/channel/desktop/',
     '/en-US/firefox/new/',
+    '/en-US/firefox/nothing-personal/',
     '/en-US/products/',
     '/en-US/products/vpn/'
 ];


### PR DESCRIPTION
## One-line summary

Adds marketing campaign URLs to a11y checker job

## Issue / Bugzilla link

N/A