### PR TITLE
Developer experience improvements around DB downloads and getting CMS images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ help:
 	@echo "  uninstall-custom-git-hooks     - uninstall custom git hooks"
 	@echo "  clean-local-deps               - remove all local installed Python dependencies"
 	@echo "  preflight                      - refresh installed dependencies and fetch latest DB ahead of local dev"
+	@echo "  preflight -- --retain-DB		- refresh installed dependencies WITHOUT fetching latest DB"
 	@echo "  run-local-task-queue           - run rqworker on your local machine. Requires redis to be running"
 
 .env:

--- a/Makefile
+++ b/Makefile
@@ -169,18 +169,22 @@ check-requirements: .docker-build-pull
 # For use in local-machine development (not in Docker)
 ######################################################
 
+# Trick to avoid treating flags (eg --retain-db) as a make target
+%:
+	@:
+
+preflight:
+	${MAKE} install-local-python-deps
+	@npm install
+	@$(if $(findstring --retain-db,$(MAKECMDGOALS)),bin/sync-all.sh --retain-db,bin/sync-all.sh)
+	@python manage.py bootstrap_local_admin
+
 install-local-python-deps:
 	# Dev requirements are a superset of prod requirements, but we install
 	# them in the same separate steps that we use for our Docker-based build,
 	# so that it mirrors Production and Dev image building
 	pip install -r requirements/prod.txt
 	pip install -r requirements/dev.txt
-
-preflight:
-	${MAKE} install-local-python-deps
-	$ npm install
-	$ bin/sync-all.sh
-	$ python manage.py bootstrap_local_admin
 
 run-local-task-queue:
 	# We temporarily source the .env for the command's duration only

--- a/bedrock/cms/management/commands/bootstrap_local_admin.py
+++ b/bedrock/cms/management/commands/bootstrap_local_admin.py
@@ -24,10 +24,10 @@ class Command(BaseCommand):
         WAGTAIL_ADMIN_PASSWORD = config("WAGTAIL_ADMIN_PASSWORD", default="")
 
         if not WAGTAIL_ADMIN_EMAIL:
-            sys.stdout.write("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL not defined in environment.")
+            sys.stdout.write("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL not defined in environment\n")
             return
         if not WAGTAIL_ADMIN_EMAIL.endswith("@mozilla.com"):
-            sys.stdout.write("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL is not a @mozilla.com email address.")
+            sys.stdout.write("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL is not a @mozilla.com email address\n")
             return
 
         user, created = User.objects.get_or_create(email=WAGTAIL_ADMIN_EMAIL)
@@ -39,8 +39,8 @@ class Command(BaseCommand):
             user.is_superuser = True
             if not WAGTAIL_ADMIN_PASSWORD:
                 user.set_unusable_password()  # They won't need one to use SSO
-                sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} for local SSO use")
+                sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} for local SSO use.\n")
             else:
                 user.set_password(WAGTAIL_ADMIN_PASSWORD)
-                sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} with password '{WAGTAIL_ADMIN_PASSWORD}'")
+                sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} with password '{WAGTAIL_ADMIN_PASSWORD}'\n")
             user.save()

--- a/bedrock/cms/management/commands/bootstrap_local_admin.py
+++ b/bedrock/cms/management/commands/bootstrap_local_admin.py
@@ -32,14 +32,14 @@ class Command(BaseCommand):
 
         user, created = User.objects.get_or_create(email=WAGTAIL_ADMIN_EMAIL)
         if not created:
-            sys.stdout.write(f"Admin user {WAGTAIL_ADMIN_EMAIL} already exists")
+            sys.stdout.write(f"Admin user {WAGTAIL_ADMIN_EMAIL} already exists\n")
         else:
             user.username = WAGTAIL_ADMIN_EMAIL
             user.is_staff = True
             user.is_superuser = True
             if not WAGTAIL_ADMIN_PASSWORD:
                 user.set_unusable_password()  # They won't need one to use SSO
-                sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} for local SSO use.\n")
+                sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} for local SSO use\n")
             else:
                 user.set_password(WAGTAIL_ADMIN_PASSWORD)
                 sys.stdout.write(f"Created Admin user {WAGTAIL_ADMIN_EMAIL} with password '{WAGTAIL_ADMIN_PASSWORD}'\n")

--- a/bedrock/cms/management/commands/download_media_to_local.py
+++ b/bedrock/cms/management/commands/download_media_to_local.py
@@ -41,10 +41,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # If we're not using sqlite, stop, because this tool isn't for that
 
-        storage_client = storage.Client.create_anonymous_client()
-
         if settings.DATABASES["default"]["ENGINE"] != "django.db.backends.sqlite3":
-            self.stderr.write(f"This command only works if you are using sqlite as your local DB. Got {settings.DATABASES['default']['engine']}\n")
+            self.stderr.write(f"This command only works if you are using sqlite as your local DB. Got {settings.DATABASES['default']['ENGINE']}\n")
             sys.exit(1)
 
         try:
@@ -53,6 +51,7 @@ class Command(BaseCommand):
             self.stderr.write(f"Couldn't determine which bucket you wanted. Got {options['environment']}\n")
             sys.exit(1)
 
+        storage_client = storage.Client.create_anonymous_client()
         bucket = storage_client.bucket(bucket_name)
 
         # Get the files, ideally in a way that checks whether we have them already

--- a/bedrock/cms/management/commands/download_media_to_local.py
+++ b/bedrock/cms/management/commands/download_media_to_local.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from google.cloud import storage
+
+from bedrock.cms.models import BedrockImage
+from bedrock.settings.base import path as build_path
+
+BUCKETS = {
+    "dev": "bedrock-nonprod-dev-cms-media",
+    "stage": "bedrock-nonprod-stage-cms-media",
+    "prod": "bedrock-prod-prod-cms-media",
+}
+
+
+class Command(BaseCommand):
+    help = """Downloads public media files from the appropriate cloud bucket
+    so that they match the sqlite database being currently used."""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--environment",
+            default="dev",
+            help="Which Bedrock environment are you downloading from? Values are dev | stage | prod (default is dev)",
+        )
+        parser.add_argument(
+            "--redownload",
+            action="store_true",
+            dest="redownload",
+            default=False,
+            help="If passed, will force re-download of all the assets in the relevant bucket.",
+        )
+
+    def handle(self, *args, **options):
+        # If we're not using sqlite, stop, because this tool isn't for that
+
+        storage_client = storage.Client.create_anonymous_client()
+
+        if settings.DATABASES["default"]["ENGINE"] != "django.db.backends.sqlite3":
+            self.stderr.write(f"This command only works if you are using sqlite as your local DB. Got {settings.DATABASES['default']['engine']}\n")
+            sys.exit(1)
+
+        try:
+            bucket_name = BUCKETS[options["environment"]]
+        except KeyError:
+            self.stderr.write(f"Couldn't determine which bucket you wanted. Got {options['environment']}\n")
+            sys.exit(1)
+
+        bucket = storage_client.bucket(bucket_name)
+
+        # Get the files, ideally in a way that checks whether we have them already
+        # unless the --redownload param is passed
+        redownload = options["redownload"]
+        if redownload:
+            self.stdout.write("Forcing redownload of all files.\n")
+
+        for image in BedrockImage.objects.all():
+            image_key = f"media/cms/{image.file.name}"
+            local_dest = build_path(settings.MEDIA_ROOT, image.file.name)
+
+            if os.path.exists(local_dest) and not redownload:
+                self.stdout.write(f"Skipping: {local_dest} already exists locally.\n")
+            else:
+                blob = bucket.blob(image_key)
+                blob.download_to_filename(local_dest)
+                self.stdout.write(f"Downloaded {image_key} from {bucket_name} to {local_dest}\n")
+
+                image._pre_generate_expected_renditions()
+                self.stdout.write("Triggered local generation of renditions\n")
+
+        self.stdout.write("All done.\n")

--- a/bedrock/cms/models/images.py
+++ b/bedrock/cms/models/images.py
@@ -8,7 +8,18 @@ from wagtail.images.models import AbstractImage, AbstractRendition, Image
 
 from bedrock.base.tasks import defer_task
 
-AUTOMATIC_RENDITION_FILTER_SPECS = [f"width-{size}" for size in range(2400, 0, -200)] + ["width-100"]
+AUTOMATIC_RENDITION_FILTER_SPECS = [
+    # Generate agreed step sizes:
+    f"width-{size}"
+    for size in range(2400, 0, -200)
+] + [
+    # Add agreed smallest size
+    "width-100",
+    # Add the size that the Wagtail Image Library uses for its listing page - we make sure we
+    # regenerate it, if needed, so that the image library is updated locally after
+    # downloading images from Dev, Stage or Prod
+    "max-165x165",
+]
 
 
 class BedrockImage(AbstractImage):

--- a/bedrock/cms/test_image_models.py
+++ b/bedrock/cms/test_image_models.py
@@ -27,6 +27,7 @@ class BedrockImageTestCase(TestCase):
             "width-400",
             "width-200",
             "width-100",
+            "max-165x165",
         ]
 
         with patch.object(image, "get_renditions") as get_renditions_mock:
@@ -50,6 +51,7 @@ class BedrockImageTestCase(TestCase):
             "width-400",
             "width-200",
             "width-100",
+            "max-165x165",
         ]
 
         with patch("bedrock.base.tasks.django_rq") as mock_django_rq:
@@ -80,6 +82,7 @@ class BedrockImageTestCase(TestCase):
             "width-400",
             "width-200",
             "width-100",
+            "max-165x165",
         ]
         with patch("bedrock.cms.models.images.defer_task") as mock_defer_task:
             image._pre_generate_expected_renditions()

--- a/bedrock/cms/tests/test_commands.py
+++ b/bedrock/cms/tests/test_commands.py
@@ -22,7 +22,7 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         self._run_test(
             mock_write=mock_write,
             expected_output=[
-                call("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL not defined in environment."),
+                call("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL not defined in environment\n"),
             ],
         )
 
@@ -31,7 +31,7 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         self._run_test(
             mock_write=mock_write,
             expected_output=[
-                call("Created Admin user test@mozilla.com for local SSO use"),
+                call("Created Admin user test@mozilla.com for local SSO use\n"),
             ],
         )
 
@@ -40,7 +40,7 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         self._run_test(
             mock_write=mock_write,
             expected_output=[
-                call("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL is not a @mozilla.com email address."),
+                call("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL is not a @mozilla.com email address\n"),
             ],
         )
 
@@ -49,7 +49,7 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         self._run_test(
             mock_write=mock_write,
             expected_output=[
-                call("Created Admin user test@mozilla.com with password 'secret'"),
+                call("Created Admin user test@mozilla.com with password 'secret'\n"),
             ],
         )
 
@@ -58,7 +58,7 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         self._run_test(
             mock_write=mock_write,
             expected_output=[
-                call("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL not defined in environment."),
+                call("Not bootstrapping an Admin user: WAGTAIL_ADMIN_EMAIL not defined in environment\n"),
             ],
         )
 
@@ -69,8 +69,8 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         call_command("bootstrap_local_admin", stdout=out)
         output = mock_write.call_args_list
         expected_output = [
-            call("Created Admin user test@mozilla.com for local SSO use"),
-            call("Admin user test@mozilla.com already exists"),
+            call("Created Admin user test@mozilla.com for local SSO use\n"),
+            call("Admin user test@mozilla.com already exists\n"),
         ]
         self.assertEqual(output, expected_output)
 
@@ -81,7 +81,7 @@ class BootstrapLocalAdminTests(TransactionTestCase):
         call_command("bootstrap_local_admin", stdout=out)
         output = mock_write.call_args_list
         expected_output = [
-            call("Created Admin user test@mozilla.com with password 'secret'"),
-            call("Admin user test@mozilla.com already exists"),
+            call("Created Admin user test@mozilla.com with password 'secret'\n"),
+            call("Admin user test@mozilla.com already exists\n"),
         ]
         self.assertEqual(output, expected_output)

--- a/bin/custom-git-hooks/post-merge
+++ b/bin/custom-git-hooks/post-merge
@@ -15,7 +15,7 @@ def check_for_dependency_changes():
             WARNING,
             "Dependency files have changed! Remember to install new dependencies with",
             COMMAND,
-            "make preflight",
+            "make preflight -- --retain-db",
             RESET,
         )
 

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -156,7 +156,6 @@ python manage.py dumpdata \
     cms.StructuralPage \
     cms.SimpleRichTextPage \
     cms.BedrockImage \
-    cms.BedrockRendition \
     legal_docs.LegalDoc \
     mozorg.WebvisionDoc \
     mozorg.LeadershipPage \

--- a/bin/sync-all.sh
+++ b/bin/sync-all.sh
@@ -10,6 +10,20 @@ if [ ! -e ./manage.py ]; then
     cd $script_parent_dir
 fi
 
-./bin/run-db-download.py --force
+# Check whether --retain-db was passed
+DO_DB_DOWNLOAD=true
+for arg in "$@"; do
+  if [ "$arg" == "--retain-db" ]; then
+    DO_DB_DOWNLOAD=false
+    break
+  fi
+done
+
+if [ "$DO_DB_DOWNLOAD" = true ]; then
+    ./bin/run-db-download.py --force
+else
+    echo "Skipping DB download"
+fi
+
 ./manage.py migrate --noinput
 ./manage.py l10n_update

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -33,8 +33,8 @@ Useful resources:
 - `Wagtail Docs`_.
 - `The Ultimate Wagtail Developers Course`_.
 
-Accessing the CMS
-=================
+Accessing the CMS on your local machine
+=======================================
 
 SSO authentication setup
 ------------------------
@@ -52,7 +52,8 @@ SSO authentication setup
 
 #. Run ``make preflight`` to update bedrock with the latest DB version. As part of
    this step, the make file will also create a local admin user for you, using the
-   Mozilla LDAP email address you added in the previous step.
+   Mozilla LDAP email address you added in the previous step. **If you do not want
+   to overwrite your local database, run** ``make preflight -- --retain-db`` **instead.**
 #. Start bedrock running via ``npm start`` (for local dev) or ``make build run``
    (for Docker).
 #. Go to ``http://localhost:8000/cms-admin/`` and you should see a button to login
@@ -63,7 +64,8 @@ Non-SSO authentication
 ----------------------
 
 #. In your ``.env`` file set ``USE_SSO_AUTH=False``, and ``WAGTAIL_ENABLE_ADMIN=TRUE``.
-#. Run ``make preflight`` to update bedrock with the latest DB version.
+#. Run ``make preflight`` to update bedrock with the latest DB version. **If you do not want
+   to overwrite your local database, run** ``make preflight -- --retain-db`` **instead.**
 #. Create a local admin user with ``./manage.py createsuperuser``, setting both the
    username, email and password to whatever you choose (note: these details will only
    be stored locally on your device).
@@ -74,6 +76,40 @@ Non-SSO authentication
    (for Docker).
 #. Go to ``http://localhost:8000/cms-admin/`` and you should see a form for logging in
    with a username and password. Use the details you created in the previous step.
+
+Fetching the latest CMS data for local work
+===========================================
+
+.. note::
+  **TL;DR version:**
+
+  1. Get the DB with ``make preflight``
+  2. If you need the images that the DB expects to exist, use ``python manage.py download_media_to_local``
+
+The CMS content exists in hosted cloud database and a trimmed-down version of this
+data is exported to a sqlite DB for use in local development and other processes.
+The exported database contains all the same content, but deliberately omits
+sensitive info like user accounts, unpublished drafts and outmoded versions of pages.
+
+The DB export is generated twice a day and is put into the same public cloud buckets
+we've used for years. Your local Bedrock install will just download the `bedrock-dev`
+one as part of ``make preflight``.
+
+The DB will contain a table that knows the relative paths of the images uploaded to
+the CMS, but not the actual images. Those are in a cloud storage bucket, and if you want
+your local machine to have them available after you download the DB that expects them
+to be present, you can run ``python manage.py download_media_to_local`` which will
+sync down any images you don't already have.
+
+.. note::
+  By default, ``make preflight`` and ``./bin/run-db-download.py`` will download
+  a database file based on ``bedrock-dev``. If you want to download from stage or
+  prod, which are also available in sanitised form, you need to tell Bedrock which
+  environment you want by prefixing the command with ``AWS_DB_S3_BUCKET=bedrock-db-stage``
+  or ``AWS_DB_S3_BUCKET=bedrock-db-prod``.
+
+  ``AWS_DB_S3_BUCKET=bedrock-db-stage make preflight``
+  ``AWS_DB_S3_BUCKET=bedrock-db-stage python manage.py download_media_to_local``
 
 Adding new content surfaces
 ===========================

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -4,9 +4,9 @@
 
 .. _cms:
 
-====================
-CMS capability (WIP)
-====================
+===
+CMS
+===
 
 From 2024, Bedrock's CMS will be powered by `Wagtail CMS`_.
 
@@ -451,6 +451,32 @@ Instead, we pre-generate those renditions when the image is saved.
 This approach will not be a problem if we stick to image filter-specs from the
 'approved' list. Note that extending the list of filter-specs is possible, if
 we need to.
+
+
+I've downloaded a fresh DB and the images are missing!
+------------------------------------------------------
+
+That's expected: the images don't live in the DB, only references to them live there.
+CMS images are destined for public consumption, and Dev, Stage and Prod all store
+their images in a publicly-accessible cloud bucket.
+
+We have a tool to help you sync down the images from the relevant bucket.
+
+By default, the sqlite DB you can download to run bedrock locally is based on the data in
+Bedrock Dev. To get images from the cloud bucket for dev, run:
+
+.. code-block:: shell
+  ./manage.py download_media_to_local
+
+This will look at your local DB, find the image files that it says should be
+available locally, copy them down to your local machine, then trigger the
+versions/renditions of them that should also exist.
+
+The command will only download images you don't already have locally.
+You can use the ``--redownload`` option to force a redownload of all images.
+
+If you have a DB from Stage you can pass the ``--environment=stage`` option
+to get the images from the Stage bucket instead. Same goes for Production.
 
 L10N and Translation Management
 -------------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -238,7 +238,9 @@ credits, release notes, localizations, legal-docs etc::
     dependencies up to date and also fetches the latest DB containing the latest site
     content. This is a good thing to run after pulling latest changes from the ``main`` branch.
 
-    We also have a git hook that will alert you if ``make preflight`` needs to be run. You can install it with ``make install-custom-git-hooks``
+    IMPORTANT: if you do not want to replace your local DB with a fresher one, use ``make preflight -- --retain-db`` instead.
+
+    We also have a git hook that will alert you if ``make preflight`` needs to be run. You can install that with ``make install-custom-git-hooks``.
 
 .. _run-python-tests:
 


### PR DESCRIPTION
## One-line summary

This changeset adds a few things to make it easier to develop CMS pages locally by getting a stable state


## Significant changes and points to review

* Update "make preflight" command to allow a -- `--retain-db` flag + documentation
* Add `download_media_to_local` management command that copies images from the relevant cloud bucket to your local machine + documentation

- [X] I used an AI to sketch in some of the logic around the `make preflight` and `./bin/sync-all.sh` changes

## Issue / Bugzilla link

Resolves #14659 

## Testing

Note that you may need to set `WAGTAIL_ADMIN_EMAIL` (and maybe `WAGTAIL_ADMIN_PASSWORD`) in your .env to make it easier to retain access to your local CMS admin each time you refresh your DB - https://bedrock.readthedocs.io/en/latest/cms.html#accessing-the-cms has more on this and is worth a read.

#### DB download

1. Run `make preflight -- --retain-db` and confirm you don't get a new DB - the output will show what's happening
2. Run `./bin/sync-all.sh --retain-db` and confirm you don't get a new DB - the output will show what's happening
3. Copy your `data/bedrock.db` to a safe place, then run the above without `--retain-db`. You can copy the bedrock.db back afterward

##### Image download

1. Run `make preflight`  to get a latest DB from dev, which currently contains images
2. In the CMS, to the [Image library](http://localhost:8000/cms-admin/images/) and confirm that there are lots of dead thumbnail images there 
3. As a one-off step to drop data that otherwise blocks regeneration of renditions, please do the following. (This will not t be needed in the future because of [this change](https://github.com/mozilla/bedrock/commit/5fb7b99a3d3ca97c7bbd1965bebba97d90ae5f69) in this PR)
```
$ python manage.py dbshell
sqlite> delete from cms_bedrockrendition;
sqlite> .quit
```
4. Download images with `python manage.py download_media_to_local`
5. Refresh the Image library and you should see the thumbnails are all there now. Click into an image and confirm that the original file (see the filename link) is also there.
5. Run `python manage.py download_media_to_local` again and confirm that those images are NOT redownloaded again
