### PR TITLE
Sqlite DB exporter bugfixes

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -113,6 +113,7 @@ check_status_and_handle_failure "Dumping wagtailcore.Locale"
 # wagtailcore.Revision          # Excluded: drafts may leak pre-published content, or stale/dead content
 # wagtailcore.PageViewRestriction  # Excluded: may include passwords
 # wagtailcore.TaskState         # Excluded: comment field may contain sensitive info
+# wagtailcore.WorkflowState     # Excluded: if included, causes integrity errors because it needs TaskState to be present, too
 # wagtailcore.PageLogEntry      # Excluded: may contain sensitive info
 # wagtailcore.Comment           # Excluded: may contain sensitive info
 # wagtailcore.CommentReply      # Excluded: may contain sensitive info
@@ -147,7 +148,6 @@ python manage.py dumpdata \
     wagtailcore.Task \
     wagtailcore.Workflow \
     wagtailcore.GroupApprovalTask \
-    wagtailcore.WorkflowState \
     taggit.Tag \
     taggit.TaggedItem \
     base.ConfigValue \

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -126,6 +126,8 @@ check_status_and_handle_failure "Dumping wagtailcore.Locale"
 # auth.User                     # Will be purged because of  PII
 # wagtailcore.Revision          # Will be purged: drafts may leak pre-published content, or stale/dead content
 
+# MAIN LIST OF MODELS BEING EXPORTED
+
 python manage.py dumpdata \
     auth.Permission \
     auth.Group \
@@ -157,6 +159,7 @@ python manage.py dumpdata \
     cms.BedrockRendition \
     legal_docs.LegalDoc \
     mozorg.WebvisionDoc \
+    mozorg.LeadershipPage \
     newsletter.Newsletter \
     externalfiles.ExternalFile \
     security.Product \

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -151,6 +151,9 @@ Some key things to note here:
   ``mozorg/test_page.html``.
 - If you don't set a custom template name, Wagtail will infer it from the model's
   name: ``<app_label>/<model_name (in snake case)>.html``
+- All new models must be added to the config for the DB exporter script. If you
+  do not, the page will not be correctly exported for local development and will
+  break for anyone using that DB export file. See `Add your new model to the DB export`, below.
 
 Django model migrations
 -----------------------
@@ -301,6 +304,23 @@ give it some data to render:
         page_content = str(resp.content)
         assert "Test Heading" in page_content
         assert "Test Body" in page_content
+
+Add your new model to the DB export
+-----------------------------------
+When you add a new model, you must update the script that generates the sqlite DB
+export of our data, so that the model is included in the export. (It's an allowlist
+pattern, as requested by Mozilla Security).
+
+**If you do not, the page will not be correctly exported for local development and will
+break for anyone using that DB export file.**
+
+(It's down to Wagtail's multi-table inheritance
+pattern: if you don't specify your new model for export, Wagtail's core metadata ``Page`` is exported,
+but not the actual new data model that holds the content that's linked to that ``Page``)
+
+The script is ``bin/export-db-to-sqlite.sh`` and you need to add your new model
+to the list of models being exported. Search for ``MAIN LIST OF MODELS BEING EXPORTED``
+and add your model (in the format ``appname.ModelName``) there.
 
 Editing current content surfaces
 ================================


### PR DESCRIPTION
Two fixes in this changeset for bugs which are only relevant to Dev right now.

1. Resolves #15084
`WorkflowState` references `TaskState`, but the latter is not (and can not be) dumped because it may contain sensitive info. So, let's not dump `WorkflowState`, either, because it's not relevant to loacl development anyway

2. Resolves #15085
Because `mozorg.LeadershipPage` was not specced in the allowlist for the DB export, the "Leadership page" only exists as `wagtailcore.Page` metadata - so it appeared in the tree, but couldn't be rendered or edited because there was no corresponding data in the DB for it. We also improve documentation to help avoid this in the future