### PR TITLE
Fix a11y: Change <aside> to <section> for donation promo

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/mofo-donate-promo.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/mofo-donate-promo.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<aside class="mofo-donate-promo mzp-l-content">
+<section class="mofo-donate-promo mzp-l-content">
   <div class="feature-wrapper">
     <img loading="lazy" src="{{ static('img/home/2023/mofo-heart.svg') }}" alt="">
     <div class="feature-info">
@@ -13,4 +13,4 @@
     </div>
     <a href="{{ donate_url(location='featured-section') }}" class="mzp-c-button" data-cta-text="Donate" data-cta-type="link" data-cta-position="mid-page banner">{{ ftl('home-mofo-donate') }}</a>
   </div>
-</aside>
+</section>


### PR DESCRIPTION
## One-line summary

Fix a11y: Change `<aside>` to `<section>` for donation promo

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

Updated the `<aside>` element to `<section>` in the donation promo section on the home page to improve accessibility and adhere to best practices for landmark usage.

## Issue / Bugzilla link

#15078

## Testing

- Verified that the `<aside>` has been correctly changed to `<section>`.
- Checked the home page with a screen reader to confirm that the donation promo section is no longer misinterpreted as a complementary landmark.
- Ensured that the section is now recognized correctly as part of the main content.