### PR TITLE
Update Nothing Personal privacy CTA [fix #15090]

### DIFF
--- a/bedrock/firefox/templates/firefox/nothing-personal/index.html
+++ b/bedrock/firefox/templates/firefox/nothing-personal/index.html
@@ -163,7 +163,7 @@
             <p>Hey, you can customize Firefox to be all about you with <a href="{{ url('firefox.features.add-ons') }}" target="_blank" data-link-text="Add-ons">add-ons</a> and <a href="{{ url('firefox.features.customize') }}" target="_blank" data-link-text="Themes">themes</a>. Happy?</p>
 
             <h5>Ok, what’s the privacy-catch?</h5>
-            <p><a href="{{ url('privacy') }}" target="_blank" data-link-text="We don’t keep track of where you go">We don’t keep track of where you go</a> because 1. Yawn, and 2. We really don’t need it.</p>
+            <p><a href="{{ url('privacy.notices.firefox') }}" target="_blank" data-link-text="We don’t keep track of where you go">We don’t keep track of where you go</a> because 1. Yawn, and 2. We really don’t need it.</p>
           </div>
 
           <div class="c-sticky-note c-attached-sticky">


### PR DESCRIPTION
## One-line summary

Changes the link from generic Privacy Hub overview to its Firefox page.

## Significant changes and points to review

After recent fx.privacy.landing removal, all such links now point to privacy root. This was requested to link to the Firefox specific page instead.

## Issue / Bugzilla link

Resolves #15090

## Testing

/en-US/firefox/nothing-personal/