### PR TITLE
Add ./static to ESLint ignore paths

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,11 +84,12 @@ module.exports = [
     eslintConfigPrettier,
     {
         ignores: [
-            'media/js/libs/**/*.js',
-            'media/js/ie/libs/**/*.js',
-            'tests/unit/dist/**/*.js',
             'contentful_migrations/**/*.cjs',
-            'docs/_build/**/*.js'
+            'docs/_build/**/*.js',
+            'media/js/ie/libs/**/*.js',
+            'media/js/libs/**/*.js',
+            'static/**/*.js',
+            'tests/unit/dist/**/*.js'
         ]
     },
     {


### PR DESCRIPTION
## One-line summary

Ignores linting errors created by Wagtail CMS generated code

## Issue / Bugzilla link

N/A

## Testing

`npm run lint`