### PR TITLE
Update dependabot.yml to ignore certain front-end deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,14 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+        patterns:
+          - '*'
+        exclude-patterns:
+          - 'eslint'  # The following deps need to be kept in sync with pre-commit-config.yaml.
+          - 'eslint-config-prettier'
+          - 'prettier'
+          - 'stylelint'
+          - 'stylelint-config-standard-scss'
     open-pull-requests-limit: 10
     labels:
       - Frontend


### PR DESCRIPTION
## One-line summary

These dependencies need to be kept up to date manually with pre-commit-config.yaml, so this change tells dependabot to ignore them.

## Issue / Bugzilla link

N/A