### PR TITLE
Update a11y-checker to scan redesigned footer

### DIFF
--- a/tests/playwright/specs/a11y/components.spec.js
+++ b/tests/playwright/specs/a11y/components.spec.js
@@ -15,8 +15,8 @@ const {
 } = require('./includes/locators');
 const { test, expect } = require('@playwright/test');
 
-const testURL = '/en-US/firefox/new/';
-const footerTestURL = '/de/firefox/new/';
+const testURL = '/en-US/';
+const subNavURL = '/en-US/firefox/new/';
 
 test.describe(
     'Navigation (desktop)',
@@ -90,7 +90,7 @@ test.describe(
     },
     () => {
         test.beforeEach(async ({ page, browserName }) => {
-            await openPage(testURL, page, browserName);
+            await openPage(subNavURL, page, browserName);
         });
 
         test('should not have any detectable a11y issues', async ({ page }) => {
@@ -110,7 +110,7 @@ test.describe(
         test.use({ viewport: { width: 360, height: 780 } });
 
         test.beforeEach(async ({ page, browserName }) => {
-            await openPage(testURL, page, browserName);
+            await openPage(subNavURL, page, browserName);
         });
 
         test('should not have any detectable a11y issues', async ({ page }) => {
@@ -138,7 +138,7 @@ test.describe(
     },
     () => {
         test.beforeEach(async ({ page, browserName }) => {
-            await openPage(footerTestURL, page, browserName);
+            await openPage(testURL, page, browserName);
         });
 
         test('should not have any detectable a11y issues', async ({ page }) => {
@@ -158,7 +158,7 @@ test.describe(
         test.use({ viewport: { width: 360, height: 780 } });
 
         test.beforeEach(async ({ page, browserName }) => {
-            await openPage(footerTestURL, page, browserName);
+            await openPage(testURL, page, browserName);
         });
 
         test('should not have any detectable a11y issues', async ({ page }) => {

--- a/tests/playwright/specs/a11y/includes/locators.js
+++ b/tests/playwright/specs/a11y/includes/locators.js
@@ -10,7 +10,7 @@
  * CSS selectors of common elements for
  * inclusion / exclusion in a11y scans.
  */
-const footerLocator = '.mzp-c-footer';
+const footerLocator = '#colophon';
 const navigationLocator = '.c-navigation';
 const subNavigationLocator = '.c-sub-navigation';
 


### PR DESCRIPTION
## One-line summary

Updates a11y-checker to scan the redesigned footer instead of the old component.

## Issue / Bugzilla link

N/A

## Testing

- `npm start`
- `cd tests/playwright && npm run a11y-tests`