### PR TITLE
Ensure CMS StructuralPage pages don't appear in the sitemap

### DIFF
--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -193,9 +193,18 @@ def get_wagtail_urls():
 
     # Get all live, non-private Wagtail pages
     for cms_page in Page.objects.live().public().order_by("path"):
-        # We don't want the Wagtail structural Root page, nor the
-        # site root page, because that isn't surfaced from the CMS (yet)
-        if cms_page.is_root() or cms_page.is_site_root():
+        # We don't want the Wagtail core Root page, nor the site root page,
+        # because that isn't surfaced from the CMS (yet) and we don't want our
+        # StructuralPage type either, which has a handy annotation to identify
+        # it (If you don't know what 'specific' refers to, see
+        # https://docs.wagtail.org/en/v6.2.1/reference/pages/model_reference.html#wagtail.models.Page.specific)
+        if (
+            cms_page.is_root()
+            or cms_page.is_site_root()
+            # not all pages have the is_structural_page attribute, so default those to False
+            or getattr(cms_page.specific, "is_structural_page", False) is True
+        ):
+            # Don't include these pages in the sitemap
             continue
 
         _url = cms_page.get_url()


### PR DESCRIPTION
(...unless they are also parents of real pages)

In the CMS we use a `StructuralPage` page type to create branches/folders in the page tree.

These `StructuralPage`s do not have content, but allow us to structure URL paths as we need, including matching some routes that already exist in the page tree as static/Django-only paths.

However, we've spotted a bug: prior to this changeset, if there's a static path for `foo/` and a `StructuralPage` for `foo/`, the static paths for `foo/` are dropped from the sitemap in favour of those from the CMS _even if the CMS has fewer locales set up than the static route_. This can be seen here where `/about/` was in the CMS as `StructuralPage` only in `en-US`, but in lots of locales as a static page: https://github.com/mozmeao/www-sitemap-generator/commit/bdd1cc0fcb0d62ada6866479aea88018041f9ec4

This changeset fixes things by ensuring we ignore `StructuralPage`s when building page URLs from the CMS, unless they are parents of non-`StructuralPage`s. The tests show an example of both of these.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Resolves #15134

## Testing

Testing locally is tricky as I can't get the `update_sitemaps` to run locally, but hopefully the tests are enough