### PR TITLE
Fix missing footer styles on /firefox/new/ and /thanks/ (Fixes #15138)

### DIFF
--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -14,7 +14,3 @@
     {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}
 {% endblock %}
-
-{% block site_footer %}
-  {% include 'includes/protocol/footer/footer.html' %}
-{% endblock %}

--- a/bedrock/cms/templates/cms/base-protocol.html
+++ b/bedrock/cms/templates/cms/base-protocol.html
@@ -10,10 +10,8 @@
 {% endblock %}
 
 {% block site_css %}
-
   {{ super() }}
   {{ css_bundle('cms-base') }}
-
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -32,6 +32,9 @@
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
   {{ css_bundle('protocol-firefox') }}
+  {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
+    {{ css_bundle('m24-navigation-and-footer') }}
+  {% endif %}
 
   <!--[if IE]>
     {{ css_bundle('firefox_new_ie') }}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -32,6 +32,9 @@
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
   {{ css_bundle('protocol-firefox') }}
+  {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
+    {{ css_bundle('m24-navigation-and-footer') }}
+  {% endif %}
 {% endblock %}
 
 {% block body_class %}mzp-t-firefox{% endblock %}

--- a/bedrock/products/templates/products/vpn/base.html
+++ b/bedrock/products/templates/products/vpn/base.html
@@ -17,10 +17,6 @@
   {% include 'products/vpn/includes/subnav-refresh.html' %}
 {% endblock %}
 
-{% block site_css %}
-  {{ super() }}
-{% endblock %}
-
 {% block js %}{% endblock %}
 
 {% block third_party_js %}


### PR DESCRIPTION
## One-line summary

The firefox/new page uses `extrahead` instead of `site_css` to serve CSS to older IE browsers.

## Issue / Bugzilla link

#15138

## Testing

- http://localhost:8000/en-US/firefox/new/
- http://localhost:8000/en-US/firefox/new/?xv=basic
- http://localhost:8000/en-US/firefox/download/thanks/
- http://localhost:8000/en-US/firefox/download/thanks/?xv=basic