### PR TITLE
Pin ESR 115 for unsupported operating systems (Fixes #13753)

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-unsupported.html
+++ b/bedrock/firefox/templates/firefox/includes/download-unsupported.html
@@ -19,12 +19,12 @@
   <p>{{ ftl('download-button-please-download-esr') }}</p>
   <div class="download-platform-list">
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}" data-cta-text="Download Firefox Extended Support Release 64-bit" data-cta-type="firefox">
+      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang={{ LANG }}" data-cta-text="Download Firefox Extended Support Release 64-bit" data-cta-type="firefox">
         {{ ftl('download-firefox-esr-64') }}
       </a>
     </p>
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}" data-cta-text="Download Firefox Extended Support Release 32-bit" data-cta-type="firefox">
+      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win&lang={{ LANG }}" data-cta-text="Download Firefox Extended Support Release 32-bit" data-cta-type="firefox">
         {{ ftl('download-firefox-esr-32') }}
       </a>
     </p>
@@ -42,7 +42,7 @@
   <p>{{ ftl('download-button-please-download-esr') }}</p>
 
   <div class="download-platform-list">
-    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}" data-cta-text="Firefox Extended Support Release MacOS" data-cta-type="firefox">
+    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=osx&lang={{ LANG }}" data-cta-text="Firefox Extended Support Release MacOS" data-cta-type="firefox">
       {{ ftl('download-firefox-esr') }}
     </a>
   </div>

--- a/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
@@ -240,7 +240,7 @@ test.describe(
                 await expect(betaDownloadOsxUnsupported).toBeVisible();
                 await expect(betaDownloadOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
                 await expect(osxBetaDownload).not.toBeVisible();
 
@@ -248,7 +248,7 @@ test.describe(
                 await expect(devDownloadOsxUnsupported).toBeVisible();
                 await expect(devDownloadOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
                 await expect(osxDevDownload).not.toBeVisible();
 
@@ -256,7 +256,7 @@ test.describe(
                 await expect(nightlyDownloadOsxUnsupported).toBeVisible();
                 await expect(nightlyDownloadOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
                 await expect(osxNightlyDownload).not.toBeVisible();
             } else {
@@ -270,7 +270,7 @@ test.describe(
                 await expect(betaDownloadWinUnsupported).toBeVisible();
                 await expect(betaDownloadWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win64/
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
                 );
                 await expect(win64BetaDownload).not.toBeVisible();
 
@@ -278,7 +278,7 @@ test.describe(
                 await expect(devDownloadWinUnsupported).toBeVisible();
                 await expect(devDownloadWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win64/
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
                 );
                 await expect(winDevDownload).not.toBeVisible();
 
@@ -286,7 +286,7 @@ test.describe(
                 await expect(nightlyDownloadWinUnsupported).toBeVisible();
                 await expect(nightlyDownloadWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win64/
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
                 );
                 await expect(winNightlyDownload).not.toBeVisible();
             }

--- a/tests/playwright/specs/products/firefox/firefox-developer.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-developer.spec.js
@@ -154,12 +154,12 @@ test.describe(
                 await expect(introDownloadOsxUnsupported).toBeVisible();
                 await expect(introDownloadOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
                 await expect(footerDownloadOsxUnsupported).toBeVisible();
                 await expect(footerDownloadOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
 
                 // Assert regular download buttons are not displayed.
@@ -176,12 +176,12 @@ test.describe(
                 await expect(introDownloadWinUnsupported).toBeVisible();
                 await expect(introDownloadWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win64/
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
                 );
                 await expect(footerDownloadWinUnsupported).toBeVisible();
                 await expect(footerDownloadWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win64/
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
                 );
 
                 // Assert regular download buttons are not displayed.

--- a/tests/playwright/specs/products/firefox/firefox-new.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-new.spec.js
@@ -151,17 +151,17 @@ test.describe(
                 await expect(downloadOsxUnsupported).toBeVisible();
                 await expect(downloadOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
                 await expect(downloadFeaturesOsxUnsupported).toBeVisible();
                 await expect(downloadFeaturesOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
                 await expect(downloadDiscoverOsxUnsupported).toBeVisible();
                 await expect(downloadDiscoverOsxUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=osx/
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
                 );
             } else {
                 // Set Windows 8.1 UA strings (64-bit).
@@ -179,17 +179,17 @@ test.describe(
                 await expect(downloadWinUnsupported).toBeVisible();
                 await expect(downloadWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win/
+                    /\?product=firefox-esr115-latest-ssl&os=win/
                 );
                 await expect(downloadFeaturesWinUnsupported).toBeVisible();
                 await expect(downloadFeaturesWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win/
+                    /\?product=firefox-esr115-latest-ssl&os=win/
                 );
                 await expect(downloadDiscoverWinUnsupported).toBeVisible();
                 await expect(downloadDiscoverWinUnsupported).toHaveAttribute(
                     'href',
-                    /\?product=firefox-esr-latest-ssl&os=win/
+                    /\?product=firefox-esr115-latest-ssl&os=win/
                 );
             }
         });

--- a/tests/playwright/specs/products/firefox/firefox-new.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-new.spec.js
@@ -115,24 +115,36 @@ test.describe(
                 'css=#download-button-thanks .fx-unsupported-message.mac .download-link'
             );
 
-            const downloadWinUnsupported = page.locator(
+            const downloadWinUnsupported64bit = page.locator(
                 'css=#download-button-thanks .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const downloadWinUnsupported32bit = page.locator(
+                'css=#download-button-thanks .fx-unsupported-message.win .download-link.os_win'
             );
 
             const downloadFeaturesOsxUnsupported = page.locator(
                 'css=#download-features .fx-unsupported-message.mac .download-link'
             );
 
-            const downloadFeaturesWinUnsupported = page.locator(
+            const downloadFeaturesWinUnsupported64bit = page.locator(
                 'css=#download-features .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const downloadFeaturesWinUnsupported32bit = page.locator(
+                'css=#download-features .fx-unsupported-message.win .download-link.os_win'
             );
 
             const downloadDiscoverOsxUnsupported = page.locator(
                 'css=#download-discover .fx-unsupported-message.mac .download-link'
             );
 
-            const downloadDiscoverWinUnsupported = page.locator(
+            const downloadDiscoverWinUnsupported64bit = page.locator(
                 'css=#download-discover .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const downloadDiscoverWinUnsupported32bit = page.locator(
+                'css=#download-discover .fx-unsupported-message.win .download-link.os_win'
             );
 
             if (browserName === 'webkit') {
@@ -176,18 +188,45 @@ test.describe(
                 await expect(downloadDiscoverButton).not.toBeVisible();
 
                 // Assert Firefox ESR windows download button is displayed.
-                await expect(downloadWinUnsupported).toBeVisible();
-                await expect(downloadWinUnsupported).toHaveAttribute(
+                await expect(downloadWinUnsupported64bit).toBeVisible();
+                await expect(downloadWinUnsupported64bit).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(downloadWinUnsupported32bit).not.toBeVisible();
+                await expect(downloadWinUnsupported32bit).toHaveAttribute(
                     'href',
                     /\?product=firefox-esr115-latest-ssl&os=win/
                 );
-                await expect(downloadFeaturesWinUnsupported).toBeVisible();
-                await expect(downloadFeaturesWinUnsupported).toHaveAttribute(
+                await expect(downloadFeaturesWinUnsupported64bit).toBeVisible();
+                await expect(
+                    downloadFeaturesWinUnsupported64bit
+                ).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(
+                    downloadFeaturesWinUnsupported32bit
+                ).not.toBeVisible();
+                await expect(
+                    downloadFeaturesWinUnsupported32bit
+                ).toHaveAttribute(
                     'href',
                     /\?product=firefox-esr115-latest-ssl&os=win/
                 );
-                await expect(downloadDiscoverWinUnsupported).toBeVisible();
-                await expect(downloadDiscoverWinUnsupported).toHaveAttribute(
+                await expect(downloadDiscoverWinUnsupported64bit).toBeVisible();
+                await expect(
+                    downloadDiscoverWinUnsupported64bit
+                ).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(
+                    downloadDiscoverWinUnsupported32bit
+                ).not.toBeVisible();
+                await expect(
+                    downloadDiscoverWinUnsupported32bit
+                ).toHaveAttribute(
                     'href',
                     /\?product=firefox-esr115-latest-ssl&os=win/
                 );

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -263,9 +263,15 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         );
         expect(testEvent['release_channel']).toBe('esr');
     });
-    it('should identify release_channel for Firefox ESR 115', function () {
+    it('should identify release_channel for Firefox ESR 115 64-bit', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang=en-US'
+        );
+        expect(testEvent['release_channel']).toBe('esr115');
+    });
+    it('should identify release_channel for Firefox ESR 115 32-bit', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win&lang=en-US'
         );
         expect(testEvent['release_channel']).toBe('esr115');
     });

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -245,6 +245,12 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         );
         expect(testEvent['release_channel']).toBe('esr');
     });
+    it('should identify release_channel for Firefox ESR 115', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testEvent['release_channel']).toBe('esr115');
+    });
     it('should identify release_channel for Firefox MSI', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang=en-US'
@@ -256,6 +262,12 @@ describe('TrackProductDownload.getEventFromUrl', function () {
             'https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang=en-US'
         );
         expect(testEvent['release_channel']).toBe('esr');
+    });
+    it('should identify release_channel for Firefox ESR 115', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang=en-US'
+        );
+        expect(testEvent['release_channel']).toBe('esr115');
     });
     it('should identify release_channel for Firefox iOS', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(


### PR DESCRIPTION
## One-line summary

We're extending support for Firefox ESR 115 since so many outdated Windows / macOS users rely on it. This PR updates the ESR download buttons shown to unsupported website visitors to always return ESR 115. A special alias has been set up in bouncer here called `firefox-esr115-latest-ssl`

Marking this as a P1 since it needs to go live before the end of September (when `firefox-esr-latest-ssl` starts resolving to ESR 128)

## Issue / Bugzilla link

#13753

## Testing

Successful test run: https://github.com/mozilla/bedrock/actions/runs/10849536114

You can add a class of `windows fx-unsupported` and `osx fx-unsupported` to the `<html>` element to toggle display of the unsupported messaging.

http://localhost:8000/en-US/firefox/new/