### PR TITLE
Refresh: update brand fonts globally [fix #15088]

### DIFF
--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -9,7 +9,11 @@
 {% block body_class %}mzp-t-mozilla{% endblock %}
 
 {% block site_css %}
-  {{ css_bundle('protocol-mozilla') }}
+  {% if switch('m24-global-styles') %}
+    {{ css_bundle('protocol-mozilla-2024') }}
+  {% else %}
+    {{ css_bundle('protocol-mozilla') }}
+  {% endif %}
   {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -72,7 +72,11 @@
     <!--[if !IE]><!-->
     {# Global styles, hidden from IE9 and lower #}
     {% block site_css %}
-      {{ css_bundle('protocol-firefox') }}
+      {% if switch('m24-global-styles') %}
+        {{ css_bundle('protocol-mozilla-2024') }}
+      {% else %}
+        {{ css_bundle('protocol-firefox') }}
+      {% endif %}
       {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
         {{ css_bundle('m24-navigation-and-footer') }}
       {% endif %}

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -71,7 +71,7 @@
               {{ ftl('footer-refresh-resources') }}
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-resources">
-              <li><a href="https://www.mozilla.org/advertising/" data-link-type="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-refresh-advertise') }}</a></li>
+              <li><a href="{{ url('mozorg.advertising') }}" data-link-type="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-refresh-advertise') }}</a></li>
               <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-type="footer" data-link-text="Brand Standards">{{ ftl('footer-refresh-brand-standards') }}</a></li>
               <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-type="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
             </ul>

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -31,7 +31,11 @@
 
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
-  {{ css_bundle('protocol-firefox') }}
+  {% if switch('m24-global-styles') %}
+    {{ css_bundle('protocol-mozilla-2024') }}
+  {% else %}
+    {{ css_bundle('protocol-firefox') }}
+  {% endif %}
   {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -31,7 +31,11 @@
 
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
-  {{ css_bundle('protocol-firefox') }}
+  {% if switch('m24-global-styles') %}
+    {{ css_bundle('protocol-mozilla-2024') }}
+  {% else %}
+    {{ css_bundle('protocol-firefox') }}
+  {% endif %}
   {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -137,7 +137,7 @@ class HomeView(L10nTemplateView):
     def get_template_names(self):
         experience = self.request.GET.get("xv", None)
 
-        if switch("m24-home") and self.request.locale.startswith("en"):
+        if switch("m24-home") and self.request.locale.startswith("en") and experience != "legacy":
             return [self.m24_template_name]
         elif ftl_file_is_active("mozorg/home-new") and experience != "legacy":
             return [self.template_name]

--- a/bedrock/newsletter/templates/newsletter/security-privacy-news.html
+++ b/bedrock/newsletter/templates/newsletter/security-privacy-news.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% extends 'base-protocol.html' %}
+{% extends 'base-protocol-mozilla.html' %}
 
 {% block page_title %}{{ ftl('newsletters-subscribe-to-the-newsletter') }}{% endblock page_title %}
 

--- a/media/css/careers/components/diversity.scss
+++ b/media/css/careers/components/diversity.scss
@@ -10,8 +10,8 @@ $image-path: '/media/protocol/img';
 
 .c-careers-diversity-numbers {
     .mzp-c-picto-heading {
-        @include font-base;
         margin-bottom: $spacing-md;
+        font-family: var(--body-font-family);
         font-weight: 400;
     }
 }
@@ -87,8 +87,8 @@ $image-path: '/media/protocol/img';
 
                 p {
                     @include text-body-sm;
-                    @include font-base;
                     color: $color-dark-gray-20;
+                    font-family: var(--body-font-family);
                     font-weight: 700;
                     margin-bottom: 0;
                 }

--- a/media/css/careers/components/locations.scss
+++ b/media/css/careers/components/locations.scss
@@ -18,7 +18,6 @@
 
         a,
         span {
-            @include font-mozilla;
             @include text-body-xl;
             font-weight: bold;
         }

--- a/media/css/careers/components/position.scss
+++ b/media/css/careers/components/position.scss
@@ -40,7 +40,7 @@
     margin-bottom: $spacing-lg;
 
     .mzp-c-menu-list-title {
-        @include font-base;
+        font-family: var(--body-font-family);
     }
 
     ul {

--- a/media/css/careers/components/testimonials.scss
+++ b/media/css/careers/components/testimonials.scss
@@ -87,9 +87,9 @@ $image-path: '/media/protocol/img';
             }
 
             q {
-                @include font-mozilla;
                 @include font-size(28px);
                 color: $color-black;
+                font-family: var(--title-font-family);
                 font-weight: bold;
                 margin-bottom: $spacing-md;
                 position: relative;
@@ -210,8 +210,9 @@ $image-path: '/media/protocol/img';
 
         blockquote {
             @include text-title-2xs;
-            font-weight: 400;
             border: 0;
+            color: $color-black;
+            font-weight: 400;
 
             .c-careers-testimonial-quote {
                 position: relative;
@@ -261,8 +262,8 @@ $image-path: '/media/protocol/img';
 
     p {
         @include text-body-sm;
-        @include font-base;
         color: $color-dark-gray-20;
+        font-family: var(--body-font-family);
         font-weight: 700;
         margin-bottom: 0;
     }

--- a/media/css/firefox/challenge-the-default/_compare-table.scss
+++ b/media/css/firefox/challenge-the-default/_compare-table.scss
@@ -16,14 +16,12 @@
 
 
         h2 {
-            @include font-firefox;
             @include font-size(40px);
             font-weight: 800;
             margin-bottom: $spacing-lg;
         }
 
         p {
-            @include font-firefox;
             color: $color-marketing-gray-70;
             font-weight: 600;
         }
@@ -72,7 +70,6 @@
         }
 
         th {
-            @include font-firefox;
             max-width: 150px;
             border: 2.5px solid $color-black;
             font-size: 14px;

--- a/media/css/firefox/challenge-the-default/_hero.scss
+++ b/media/css/firefox/challenge-the-default/_hero.scss
@@ -41,7 +41,6 @@ $campaign-red: #ff6a75;
 }
 
 .c-ctd-hero {
-    @include font-firefox;
     background: $campaign-red;
     padding: 6px 24px 24px;
     width: 100%;
@@ -214,7 +213,6 @@ $campaign-red: #ff6a75;
         }
 
         h1 {
-            @include font-firefox;
             @include font-size(36px);
             color: $color-black;
             font-weight: 800;

--- a/media/css/firefox/challenge-the-default/index.scss
+++ b/media/css/firefox/challenge-the-default/index.scss
@@ -257,7 +257,6 @@ html:not(.is-firefox) {
     background-color: $color-white;
 
     h2 {
-        @include font-firefox;
         @include font-size(40px);
         font-weight: 800;
         margin-bottom: $spacing-lg;
@@ -265,7 +264,6 @@ html:not(.is-firefox) {
     }
 
     p {
-        @include font-firefox;
         color: $color-marketing-gray-70;
         font-weight: 600;
     }
@@ -359,7 +357,6 @@ html:not(.is-firefox) {
         }
 
         p {
-            @include font-firefox;
             color: $color-marketing-gray-70;
             font-weight: 600;
             margin-top: $spacing-xl;
@@ -422,7 +419,6 @@ html:not(.is-firefox) {
     }
 
     p {
-        @include font-firefox;
         @include font-size(20px);
         font-weight: 600;
         max-width: 475px;

--- a/media/css/firefox/family/components/_hero.scss
+++ b/media/css/firefox/family/components/_hero.scss
@@ -40,7 +40,6 @@ $image-path: '/media/protocol/img';
 
     .c-blurb {
         @include text-body-lg;
-        @include font-firefox;
 
         --shadow-offset: #{$border-radius-md};
         @include f3.card-shadow;

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -913,7 +913,6 @@ button.mzp-c-cta-link {
 
     thead {
         th {
-            @include font-firefox;
             @include text-title-xs;
             border-bottom: 3px solid $color-marketing-gray-20;
             font-weight: bold;

--- a/media/css/firefox/nothing-personal/_browser.scss
+++ b/media/css/firefox/nothing-personal/_browser.scss
@@ -126,10 +126,6 @@
         margin-bottom: $layout-lg;
 
         .c-browser-window-top {
-            h2 {
-                @include text-title-2xl;
-            }
-
             &::after {
                 height: 95px;
                 bottom: 6px;

--- a/media/css/firefox/nothing-personal/styles.scss
+++ b/media/css/firefox/nothing-personal/styles.scss
@@ -86,7 +86,6 @@ $mq-tad-smaller-sm: 455px;
 }
 
 .c-sign-off {
-    @include font-firefox;
     @include text-title-xs;
     margin: $layout-lg 0;
 

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -310,6 +310,11 @@ $image-path: '/media/protocol/img';
 }
 
 // icons
+.c-release-notes .mzp-l-sidebar {
+    display: flex;
+    align-items: flex-start;
+}
+
 .sidebar-icon {
     float: left;
     margin-right: $spacing-sm;

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -172,8 +172,8 @@ $image-path: '/media/protocol/img';
 }
 
 .c-release-version {
-    @include font-base;
     @include text-title-xl;
+    font-family: var(--body-font-family);
     display: block;
 }
 
@@ -184,20 +184,20 @@ $image-path: '/media/protocol/img';
 
 .mzp-l-content {
     .c-release-product {
-        @include font-base;
         @include text-title-2xs;
+        font-family: var(--body-font-family);
         display: block;
     }
 
     .c-release-date {
-        @include font-base;
         @include text-title-2xs;
+        font-family: var(--body-font-family);
     }
 
     .c-release-first-title,
     .c-release-draft-title {
-        @include font-base;
         @include text-title-2xs;
+        font-family: var(--body-font-family);
         font-weight: bold;
 
         // pushes the text down after the big release-version text

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -105,7 +105,7 @@ $image-path: '/media/protocol/img';
 
 .c-share-title {
     @include text-body-lg;
-    @include font-firefox;
+    font-family: var(--body-font-family);
 }
 
 .c-share {

--- a/media/css/foundation/annual-report-2019-2020.scss
+++ b/media/css/foundation/annual-report-2019-2020.scss
@@ -118,9 +118,8 @@ $image-path: '/media/protocol/img';
 // Content sections
 .c-intro-section {
     p {
-        @include font-mozilla;
         @include text-title-sm;
-        font-style: italic;
+        font-family: var(--title-font-family);
         margin-bottom: 0;
     }
 }
@@ -333,8 +332,8 @@ $image-path: '/media/protocol/img';
     }
 
     li {
-        @include font-mozilla;
         @include text-title-sm;
+        font-family: var(--title-font-family);
         margin-left: $spacing-md;
         margin-bottom: $spacing-lg;
         padding-left: $spacing-sm;
@@ -537,8 +536,8 @@ $image-path: '/media/protocol/img';
     }
 
     span {
-        @include font-mozilla;
         @include text-title-xs;
+        font-family: var(--title-font-family);
         font-weight: bold;
         display: block;
         margin-bottom: $spacing-md;
@@ -587,8 +586,8 @@ $image-path: '/media/protocol/img';
     margin-bottom: $spacing-2xl;
 
     .highlight {
-        @include font-mozilla;
         @include text-title-xs;
+        font-family: var(--title-font-family);
         font-weight: bold;
     }
 

--- a/media/css/foundation/annual-report-2021.scss
+++ b/media/css/foundation/annual-report-2021.scss
@@ -56,7 +56,6 @@ main {
     text-align: center;
 
     h1 {
-        @include font-base;
         @include text-title-xl;
         color: $color-white;
         font-weight: normal;
@@ -277,8 +276,8 @@ main {
     }
 
     span {
-        @include font-mozilla;
         @include text-title-xs;
+        font-family: var(--title-font-family);
         display: block;
         font-weight: bold;
         margin-bottom: $spacing-md;

--- a/media/css/foundation/annual-report.scss
+++ b/media/css/foundation/annual-report.scss
@@ -187,9 +187,8 @@ $image-path: '/media/protocol/img';
 
 .c-intro-section {
     p {
-        @include font-mozilla;
         @include text-title-sm;
-        font-style: italic;
+        font-family: var(--title-font-family);
         margin-bottom: 0;
     }
 }

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -28,16 +28,17 @@
 body {
     background-color: $m24-color-white;
     color: $m24-color-black;
-    font-family: 'Mozilla Sans Text', sans-serif;
+    font-family: var(--body-font-family);
     font-variant-ligatures: none;
-    line-height: 1.2;
+    line-height: var(--body-line-height);
 }
 
 h1, h2, h3, h4, h5 {
     color: $m24-color-black;
-    font-family: 'Mozilla SemiSlab', serif;
+    font-family: var(--title-font-family);
     font-variant-ligatures: none;
     font-weight: bold;
+    line-height: 1.1;
 }
 
 strong {
@@ -88,7 +89,7 @@ a:link {
 .m24-c-cta {
     color: $m24-color-black;
     display: inline-block;
-    font-family: 'Mozilla SemiSlab', serif;
+    font-family: var(--title-font-family);
     font-size: $text-button-lg;
 
     &:hover {
@@ -104,7 +105,7 @@ a:link {
     }
 
     &.m24-t-small {
-        font-family: 'Mozilla Sans Text', sans-serif;
+        font-family: var(--body-font-family);
         font-size: $text-button-sm;
     }
 }

--- a/media/css/m24/copy.scss
+++ b/media/css/m24/copy.scss
@@ -10,7 +10,9 @@
     max-width: $content-max;
 
     p {
+        font-weight: 600;
         margin-bottom: 0;
+        text-wrap: balance;
         text-wrap-style: balance;
     }
 }
@@ -19,6 +21,7 @@
     font-size: $alias-text-title-h2;
     margin-bottom: 0;
     padding-bottom: $spacer-sm;
+    text-wrap: balance;
     text-wrap-style: balance;
 
     &.m24-t-2xl {

--- a/media/css/m24/vars/fonts.scss
+++ b/media/css/m24/vars/fonts.scss
@@ -27,6 +27,16 @@ $m24-font-path: '/media/fonts/m24';
 @font-face {
     font-display: swap;
     font-family: 'Mozilla Sans Text';
+    font-style: italic;
+    font-weight: 600;
+    src:
+        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-SemiBoldIt.woff2') format('woff2'),
+        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-SemiBoldIt.woff') format('woff');
+}
+
+@font-face {
+    font-display: swap;
+    font-family: 'Mozilla Sans Text';
     font-style: normal;
     font-weight: bold;
     src:

--- a/media/css/m24/vars/fonts.scss
+++ b/media/css/m24/vars/fonts.scss
@@ -2,13 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$m24-font-path: '/media/fonts/m24/';
+$m24-font-path: '/media/fonts/m24';
 
 @font-face {
     font-display: swap;
     font-family: 'Mozilla Sans Text';
     font-style: normal;
     font-weight: normal;
+    src:
+        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-Regular.woff2') format('woff2'),
+        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-Regular.woff') format('woff');
+}
+
+@font-face {
+    font-display: swap;
+    font-family: 'Mozilla Sans Text';
+    font-style: normal;
+    font-weight: 600;
     src:
         url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-SemiBold.woff2') format('woff2'),
         url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-SemiBold.woff') format('woff');
@@ -30,8 +40,8 @@ $m24-font-path: '/media/fonts/m24/';
     font-style: italic;
     font-weight: normal;
     src:
-        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-SemiBoldIt.woff2') format('woff2'),
-        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-SemiBoldIt.woff') format('woff');
+        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-Italic.woff2') format('woff2'),
+        url('#{$m24-font-path}/mozilla-sans-text/MozillaSansTextBETA-Italic.woff') format('woff');
 }
 
 @font-face {
@@ -50,8 +60,8 @@ $m24-font-path: '/media/fonts/m24/';
     font-style: normal;
     font-weight: normal;
     src:
-        url('#{$m24-font-path}/mozilla-semi-slab/MozillaSemiSlab-SemiBold.woff2') format('woff2'),
-        url('#{$m24-font-path}mozilla-semi-slab/MozillaSemiSlab-SemiBold.woff') format('woff');
+        url('#{$m24-font-path}/mozilla-semi-slab/MozillaSemiSlab-Regular.woff2') format('woff2'),
+        url('#{$m24-font-path}/mozilla-semi-slab/MozillaSemiSlab-Regular.woff') format('woff');
 }
 
 @font-face {
@@ -61,8 +71,10 @@ $m24-font-path: '/media/fonts/m24/';
     font-weight: bold;
     src:
         url('#{$m24-font-path}/mozilla-semi-slab/MozillaSemiSlab-Bold.woff2') format('woff2'),
-        url('#{$m24-font-path}mozilla-semi-slab/MozillaSemiSlab-Bold.woff') format('woff');
+        url('#{$m24-font-path}/mozilla-semi-slab/MozillaSemiSlab-Bold.woff') format('woff');
 }
 
-$primary-font: "Mozilla Sans Text", inter, x-localespecific, sans-serif;
-$secondary-font: "Mozilla SemiSlab", "Zilla Slab", inter, x-localespecific;
+/* stylelint-disable value-keyword-case  */
+$primary-font: "Mozilla Sans Text", Inter, Arial, "X-LocaleSpecific", sans-serif;
+$secondary-font: "Mozilla SemiSlab", Rockwell, "Roboto Slab", "X-LocaleSpecific", serif;
+/* stylelint-enable */

--- a/media/css/mozorg/about-forums.scss
+++ b/media/css/mozorg/about-forums.scss
@@ -66,12 +66,10 @@ $image-path: '/media/protocol/img';
     }
 
     h4 {
-        position: relative;
-        letter-spacing: 0;
-        margin: 0 0.5em 0 0;
-        @include font-base;
         @include text-body-md;
         font-weight: bold;
+        margin: 0 0.5em 0 0;
+        position: relative;
 
         a {
             position: absolute;

--- a/media/css/mozorg/about-patents.scss
+++ b/media/css/mozorg/about-patents.scss
@@ -27,7 +27,8 @@ ol li ol {
 
     h3 {
         @include text-title-xs;
-        @include font-base;
+        font-family: var(--body-font-family);
+        font-weight: 600;
     }
 
     details {

--- a/media/css/mozorg/about.scss
+++ b/media/css/mozorg/about.scss
@@ -143,7 +143,7 @@ $city-image-size: 106px;
 
     strong {
         @include font-size(50px);
-        @include font-mozilla;
+        font-family: var(--title-font-family);
         display: block;
         font-weight: bold;
         margin-bottom: $spacing-sm;

--- a/media/css/mozorg/account.scss
+++ b/media/css/mozorg/account.scss
@@ -60,7 +60,7 @@ $image-path: '/media/protocol/img';
 .accounts-products {
     h2 {
         @include text-title-xs;
-        @include font-base;
+        font-family: var(--body-font-family);
     }
 
     h4 {

--- a/media/css/mozorg/antiharassment-tool.scss
+++ b/media/css/mozorg/antiharassment-tool.scss
@@ -198,8 +198,8 @@ $aht-color-secondary: #FDA1DE;
     }
 
     .mzp-c-picto-heading {
-        @include font-base;
         @include font-size(18px);
+        font-family: var(--body-font-family);
         margin-bottom: $spacing-lg;
     }
 }

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -247,7 +247,6 @@ $image-path: '/media/protocol/img';
     }
 
     .contribute-banner-gethelp-title {
-        @include font-firefox;
         @include font-size(24px);
         color: $title-text-color-inverse;
         position: relative;

--- a/media/css/mozorg/diversity/diversity.scss
+++ b/media/css/mozorg/diversity/diversity.scss
@@ -438,7 +438,6 @@ $image-path: '/media/protocol/img';
             margin-bottom: $layout-lg;
 
             figcaption {
-                @include font-firefox;
                 @include text-body-lg;
                 text-align: center;
                 font-weight: 700;

--- a/media/css/mozorg/home/ctd-promo-de.scss
+++ b/media/css/mozorg/home/ctd-promo-de.scss
@@ -11,10 +11,6 @@ $image-path: '/media/protocol/img';
 .ctd-promo {
     .ctd-promo-non-fx,
     .ctd-promo-fx {
-        h2 {
-            @include font-firefox;
-        }
-
         p {
             @include text-body-lg;
         }

--- a/media/css/mozorg/home/home-new.scss
+++ b/media/css/mozorg/home/home-new.scss
@@ -47,8 +47,8 @@ header {
         }
 
         p {
-            @include font-mozilla;
             @include font-size(18px);
+            font-family: var(--title-font-family);
             margin: 0 auto;
             max-width: 780px;
             line-height: 1.4;
@@ -68,7 +68,6 @@ header {
 
 .c-homepage {
     h2 {
-        @include font-mozilla;
         text-align: center;
 
         @media #{$mq-xs} {
@@ -98,7 +97,7 @@ header {
 
         blockquote,
         cite {
-            @include font-base;
+            font-family: var(--body-font-family);
             text-align: center;
         }
 
@@ -175,9 +174,9 @@ header {
     }
 
     h3 {
-        @include font-base;
         @include text-body-md;
-        font-weight: bold;
+        font-family: var(--body-font-family);
+        font-weight: 600;
         line-height: 1.2;
     }
 

--- a/media/css/mozorg/home/includes/featured-vpn.scss
+++ b/media/css/mozorg/home/includes/featured-vpn.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .vpn-feature {
-    @include font-base;
+    font-family: var(--body-font-family);
     padding-top: 0;
 
     .feature-wrapper {
@@ -38,8 +38,8 @@ $image-path: '/media/protocol/img';
     }
 
     h2 {
-        @include font-base;
         @include text-title-xs;
+        font-family: var(--body-font-family);
         font-weight: bold;
         text-align: center;
         margin: $spacing-lg 0;

--- a/media/css/mozorg/home/includes/mofo-donate-promo.scss
+++ b/media/css/mozorg/home/includes/mofo-donate-promo.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .mofo-donate-promo {
-    @include font-base;
+    font-family: var(--body-font-family);
     padding-top: 0;
 
     .feature-wrapper {
@@ -38,8 +38,8 @@ $image-path: '/media/protocol/img';
     }
 
     h2 {
-        @include font-base;
         @include text-title-xs;
+        font-family: var(--body-font-family);
         font-weight: bold;
         text-align: center;
         margin: $spacing-lg 0;

--- a/media/css/mozorg/home/includes/monitor-banner.scss
+++ b/media/css/mozorg/home/includes/monitor-banner.scss
@@ -31,8 +31,8 @@ rgba(91, 109, 248, 0.15) 100%;
         }
 
         h2 {
-            @include font-base;
             @include font-size(22px);
+            font-family: var(--body-font-family);
             margin: 0 0 $spacing-md;
 
             span {
@@ -106,7 +106,7 @@ rgba(91, 109, 248, 0.15) 100%;
 
 // Mid-page banner
 .monitor-feature {
-    @include font-base;
+    font-family: var(--body-font-family);
     padding-top: 0;
 
     .feature-wrapper {
@@ -123,8 +123,8 @@ rgba(91, 109, 248, 0.15) 100%;
         }
 
         h2 {
-            @include font-base;
             @include font-size(32px);
+            font-family: var(--body-font-family);
             margin: $spacing-lg 0;
             text-align: start;
 

--- a/media/css/mozorg/impact.scss
+++ b/media/css/mozorg/impact.scss
@@ -20,7 +20,6 @@ header {
         align-items: center;
 
         h1 {
-            @include font-base;
             @include text-title-lg;
             color: $color-white;
             font-weight: normal;
@@ -67,9 +66,9 @@ header {
 
         h2 {
             @include text-title-xs;
-            @include font-base;
             color: $color-white;
-            font-weight: 500;
+            font-family: var(--body-font-family);
+            font-weight: 600;
         }
     }
 }

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -23,8 +23,9 @@ $image-path: '/media/protocol/img';
     @include clearfix;
 
     li {
-        @include font-mozilla;
         @include text-title-sm;
+        font-family: var(--title-font-family);
+        font-weight: normal;
         padding-bottom: $spacing-2xl;
         padding-top: $spacing-xl;
         position: relative;
@@ -89,8 +90,8 @@ $image-path: '/media/protocol/img';
 }
 
 .principle-desc {
-    @include font-mozilla;
     @include text-title-sm;
+    font-family: var(--title-font-family);
     margin-bottom: 0;
 }
 

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -23,9 +23,8 @@ $image-path: '/media/protocol/img';
     @include clearfix;
 
     li {
-        @include text-title-sm;
-        font-family: var(--title-font-family);
-        font-weight: normal;
+        @include text-title-xs;
+        font-weight: 600;
         padding-bottom: $spacing-2xl;
         padding-top: $spacing-xl;
         position: relative;
@@ -90,8 +89,7 @@ $image-path: '/media/protocol/img';
 }
 
 .principle-desc {
-    @include text-title-sm;
-    font-family: var(--title-font-family);
+    @include text-title-xs;
     margin-bottom: 0;
 }
 

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -38,9 +38,9 @@ $promo-sm-mq: 400px;
     }
 
     h2 {
-        @include font-base;
         @include font-size(56px);
         @include bidi(((text-align, left, right),));
+        font-family: var(--body-font-family);
         line-height: 1;
         color: $color-white;
         letter-spacing: -2px;
@@ -65,10 +65,10 @@ $promo-sm-mq: 400px;
     }
 
     .accounts-cta-wrapper {
-        @include font-base;
+        align-items: flex-start;
         display: flex;
         flex-direction: column;
-        align-items: flex-start;
+        font-family: var(--body-font-family);
 
         #fxa-email-form {
             color: $color-white;
@@ -110,7 +110,7 @@ $promo-sm-mq: 400px;
         margin-top: $spacing-2xl;
 
         a {
-            @include font-base;
+            font-family: var(--body-font-family);
         }
 
         small {
@@ -211,7 +211,7 @@ $promo-sm-mq: 400px;
             width: 100%;
 
             #fxa-email-form-submit {
-                @include font-base;
+                font-family: var(--body-font-family);
             }
         }
 

--- a/media/css/mozorg/sustainability.scss
+++ b/media/css/mozorg/sustainability.scss
@@ -84,7 +84,8 @@ header {
 
     blockquote {
         @include text-body-lg;
-        @include font-firefox;
+        font-family: var(--body-font-family);
+        font-weight: 600;
 
         cite {
             @include text-body-lg;

--- a/media/css/mozorg/sustainability.scss
+++ b/media/css/mozorg/sustainability.scss
@@ -34,7 +34,6 @@ header {
 
     h2 {
         @include text-title-xs;
-        @include font-mozilla;
         font-weight: 500;
     }
 
@@ -130,9 +129,9 @@ header {
         margin: $spacing-md 0;
 
         figcaption {
-            @include font-base;
             @include text-body-lg;
-            font-weight: 700;
+            font-family: var(--body-font-family);
+            font-weight: 600;
             text-align: center;
         }
 

--- a/media/css/newsletter/newsletter-monitor-waitlist.scss
+++ b/media/css/newsletter/newsletter-monitor-waitlist.scss
@@ -19,10 +19,10 @@ $image-path: '/media/protocol/img';
     }
 
     .section-title {
-        @include font-base;
         @include text-body-xl;
-        text-align: center;
+        font-family: var(--body-font-family);
         font-weight: normal;
+        text-align: center;
     }
 
     .c-not-available {

--- a/media/css/newsletter/newsletter-security-privacy-news.scss
+++ b/media/css/newsletter/newsletter-security-privacy-news.scss
@@ -13,14 +13,12 @@ $image-path: '/media/protocol/img';
     }
 
     .page-title {
-        @include font-mozilla;
         @include text-title-lg;
         text-align: center;
         font-weight: 600;
     }
 
     .section-title {
-        @include font-base;
         @include text-body-xl;
         text-align: center;
         font-weight: normal;

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -67,7 +67,6 @@ $border: 2px solid $color-marketing-gray-20;
 }
 
 .privacy-title {
-    @include font-firefox;
     margin-bottom: $spacing-lg;
 
     @media #{$mq-sm} {

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -14,7 +14,7 @@ $image-path: '/media/protocol/img';
 $border: 2px solid $color-marketing-gray-20;
 
 .mzp-c-sidemenu .mzp-c-sidemenu-title {
-    @include font-base;
+    font-family: var(--body-font-family);
 }
 
 @media #{$mq-md} {
@@ -265,7 +265,6 @@ $border: 2px solid $color-marketing-gray-20;
 #privacy-principles {
     ol {
         @include text-title-md;
-        @include font-mozilla;
         font-weight: bold;
         margin-left: 1.15em;
 
@@ -274,7 +273,6 @@ $border: 2px solid $color-marketing-gray-20;
         }
 
         p {
-            @include font-base;
             @include text-body-md;
             font-weight: normal;
         }

--- a/media/css/products/monitor/waitlist.scss
+++ b/media/css/products/monitor/waitlist.scss
@@ -29,10 +29,10 @@ $image-path: '/media/protocol/img';
     }
 
     .section-title {
-        @include font-base;
         @include text-body-xl;
-        text-align: center;
+        font-family: var(--body-font-family);
         font-weight: normal;
+        text-align: center;
     }
 
     .c-not-available {

--- a/media/css/products/vpn/common-refresh.scss
+++ b/media/css/products/vpn/common-refresh.scss
@@ -10,8 +10,8 @@ $image-path: '/media/protocol/img';
 
 main {
     h1, h2, h3, h4, h5, h6 {
-        @include font-base;
         line-height: $vpn-title-line-height;
+        font-family: var(--body-font-family);
     }
 
     .u-title-xl {
@@ -153,8 +153,8 @@ main {
     padding-bottom: $layout-md;
 
     blockquote {
-        @include font-base;
         border: none;
+        font-family: var(--body-font-family);
         padding: 0;
         margin-bottom: $layout-lg;
 

--- a/media/css/products/vpn/download.scss
+++ b/media/css/products/vpn/download.scss
@@ -54,8 +54,8 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
 .vpn-download-secondary-list {
     .platform-body {
         h2 {
-            @include font-base;
             @include text-body-xl;
+            font-family: var(--body-font-family);
         }
 
         p {

--- a/media/css/products/vpn/invite.scss
+++ b/media/css/products/vpn/invite.scss
@@ -53,8 +53,8 @@ $image-path: '/media/protocol/img';
     }
 
     legend {
-        @include font-base;
         @include text-body-md;
+        font-family: var(--body-font-family);
     }
 }
 

--- a/media/css/products/vpn/resource-center.scss
+++ b/media/css/products/vpn/resource-center.scss
@@ -17,10 +17,6 @@ $image-path: '/media/protocol/img';
     .mzp-l-content {
         max-width: $content-md;
 
-        .mzp-c-callout-title {
-            @include font-firefox;
-        }
-
         .mzp-c-callout-desc {
             font-weight: 700;
             margin-left: auto;

--- a/media/css/products/vpn/resource-center.scss
+++ b/media/css/products/vpn/resource-center.scss
@@ -76,7 +76,7 @@ $image-path: '/media/protocol/img';
 
 .resource-center-cta-desc {
     @include text-body-sm;
-    @include font-base;
+    font-family: var(--body-font-family);
 
     // this color will be added to protocol, this should be updated once its availible as a token
     color: #666;

--- a/media/css/protocol/basic-article.scss
+++ b/media/css/protocol/basic-article.scss
@@ -48,8 +48,8 @@ blockquote.t-small {
 }
 
 .side-reference-title {
-    @include font-base;
     @include text-body-lg;
+    font-family: var(--body-font-family);
 }
 
 .t-love {

--- a/media/css/protocol/components/_menu.scss
+++ b/media/css/protocol/components/_menu.scss
@@ -36,7 +36,7 @@
     h4,
     h5,
     h6 {
-        @include font-base;
+        font-family: var(--body-font-family);
     }
 
     @media #{$mq-md} {
@@ -59,10 +59,10 @@
     position: relative;
 
     .c-menu-title {
-        @include font-base;
         @include text-body-md;
         color: $color-black;
         display: block;
+        font-family: var(--body-font-family);
         font-weight: bold;
         margin-bottom: 0;
         min-height: 32px;

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -32,9 +32,9 @@
     }
 
     .c-sub-navigation-title {
-        @include font-base;
         @include text-body-md;
         display: inline-block;
+        font-family: var(--body-font-family);
         font-weight: bold;
         margin-bottom: 0;
 
@@ -56,8 +56,8 @@
             (float, right, left),
             (margin-right, $spacing-sm, margin-left, $spacing-sm),
         ));
-        @include font-base;
         @include text-body-md;
+        font-family: var(--body-font-family);
         font-weight: bold;
         width: 40%;
 
@@ -136,9 +136,9 @@
 
         a:link,
         a:visited {
-            @include font-base;
             @include text-body-sm;
             color: $color-black;
+            font-family: var(--body-font-family);
             text-decoration: none;
 
             &:hover,

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -32,10 +32,11 @@
     }
 
     .c-sub-navigation-title {
-        @include text-body-md;
         display: inline-block;
         font-family: var(--body-font-family);
+        font-size: var(--text-body-md);
         font-weight: bold;
+        line-height: 1.5;
         margin-bottom: 0;
 
         a:link,

--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -164,6 +164,10 @@ textarea {
     font-family: var(--body-font-family);
 }
 
+.mzp-c-card .mzp-c-card-content .mzp-c-card-tag {
+    font-family: var(--body-font-family);
+}
+
 // Keep the old link colors on Firefox-branded pages
 body.mzp-t-firefox {
     --link-color-hover-inverse: #{$color-blue-05};

--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -1,0 +1,177 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// These are general styles for elements/components that occur on every page.
+// Individual pages may include additional component styles as needed.
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($brand-theme: 'mozilla', $type-scale: 'standard', $font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/themes';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+
+// Base elements - general HTML elements
+@import '~@mozilla-protocol/core/protocol/css/base/elements';
+
+// Base includes - animations
+@import '~@mozilla-protocol/core/protocol/css/base/includes';
+
+// Utility includes
+@import '~@mozilla-protocol/core/protocol/css/base/utilities/backgrounds';
+@import '~@mozilla-protocol/core/protocol/css/base/utilities/titles';
+
+// Global components
+@import '~@mozilla-protocol/core/protocol/css/components/button';
+@import '~@mozilla-protocol/core/protocol/css/components/footer';
+@import '~@mozilla-protocol/core/protocol/css/components/language-switcher';
+@import 'components/download-button';
+
+// Consent banner
+@import '~@mozmeao/consent-banner/styles';
+
+// Custom global components for nav and footer
+// These will later be backported to Protocol
+@import 'components/footer';
+@import 'components/navigation';
+@import 'components/menu';
+@import 'components/menu-item';
+@import 'components/sub-navigation';
+
+// Mozilla 2024 brand variables
+@import '../m24/vars/color';
+@import '../m24/vars/fonts';
+@import '../m24/vars/text';
+
+
+// Temporary styling until the newsletter component is updated in Protocol
+// https://github.com/mozilla/protocol/issues/578
+
+.mzp-c-newsletter-subtitle {
+    @include text-title-xs;
+}
+
+.mzp-c-newsletter-desc {
+    @include text-body-md;
+}
+
+.mzp-c-newsletter-details legend {
+    font-family: var(--body-font-family);
+}
+
+#newsletter-submit + .mzp-c-fieldnote {
+    @include text-body-xs;
+    margin: 0 auto;
+    max-width: 30em;
+}
+
+// style classes automatically added by python to match Protocol form error styles
+.errorlist {
+    @include white-links;
+    background-color: form.$form-red;
+    border-radius: form.$field-border-radius;
+    color: $color-white;
+    padding: $spacing-sm;
+    margin-bottom: $spacing-xl;
+}
+
+.error-msg {
+    @include light-links;
+    background-color: form.$form-red;
+    border-radius: form.$field-border-radius;
+    color: $color-white;
+    padding: $spacing-sm;
+    margin-bottom: $spacing-xl;
+}
+
+// hide <template> elements in the DOM.
+template {
+    display: none !important; /* stylelint-disable-line declaration-no-important */
+}
+
+// temporary override for Mozilla Monitor word mark
+.mzp-c-wordmark.t-product-mozilla-monitor {
+    background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
+}
+
+/* ----------------------------------------------------------------------------- */
+// Mozilla 2024 brand theme
+:root {
+    // fonts
+    /* stylelint-disable value-keyword-case  */
+    --body-font-family: "Mozilla Sans Text", Inter, Arial, X-LocaleSpecific, sans-serif;
+    --button-font-family: "Mozilla Sans Text", Inter, Arial, X-LocaleSpecific, sans-serif;
+    --title-font-family: "Mozilla SemiSlab", Rockwell, "Roboto Slab", X-LocaleSpecific, serif;
+    /* stylelint-enable */
+
+    // colors
+    --background-color-tertiary-inverse: #{$m24-color-dark-gray};
+    --background-color-tertiary: #{$m24-color-light-gray};
+    --background-color-secondary-inverse: #{$m24-color-dark-gray};
+    --background-color-secondary: #{$m24-color-light-gray};
+    --background-color-inverse: #{$m24-color-black};
+    --background-color: #{$m24-color-white};
+    --body-text-color-secondary-inverse: #{$m24-color-light-gray};
+    --body-text-color-secondary: #{$m24-color-dark-gray};
+    --body-text-color-inverse: #{$m24-color-white};
+    --body-text-color: #{$m24-color-black};
+    --link-color-hover-inverse: #{$m24-color-light-green};
+    --link-color-hover: #{$m24-color-dark-green};
+    --link-color-inverse: #{$m24-color-white};
+    --link-color-visited-hover-inverse: #{$m24-color-white};
+    --link-color-visited-hover: #{$m24-color-dark-green};
+    --link-color-visited-inverse: #{$m24-color-light-gray};
+    --link-color-visited: #{$m24-color-dark-gray};
+    --link-color: #{$m24-color-black};
+    --title-text-color-inverse: #{$m24-color-white};
+    --title-text-color: #{$m24-color-black};
+
+    // type scale
+    --title-2xl-size: 8rem;
+    --title-2xl-line-height: 1.1;
+    --title-xl-size: 5rem;
+    --title-xl-line-height: 1.1;
+    --title-lg-size: 3rem;
+    --title-lg-line-height: 1.1;
+    --title-md-size: 2.5rem;
+    --title-md-line-height: 1.1;
+    --title-sm-size: 2rem;
+    --title-sm-line-height: 1.1;
+    --title-xs-size: 1.75rem;
+    --title-xs-line-height: 1.1;
+    --title-2xs-size: 1.5rem;
+    --title-2xs-line-height: 1.1;
+    --title-3xs-size: 1.25rem;
+    --title-3xs-line-height: 1.1;
+    --body-xl-size: 1.313rem;
+    --body-lg-size: 1.125rem;
+    --body-md-size: 1rem;
+    --body-sm-size: 0.875rem;
+    --body-xs-size: 0.75rem;
+    --body-line-height: 1.4;
+}
+
+.mzp-t-dark {
+    color: var(--body-text-color-inverse);
+
+    h1, h2, h3, h4, h5, h6 {
+        color: var(--title-text-color-inverse);
+    }
+}
+
+button,
+input,
+select,
+optgroup,
+textarea {
+    font-family: var(--body-font-family);
+}
+
+// Keep the old link colors on Firefox-branded pages
+body.mzp-t-firefox {
+    --link-color-hover-inverse: #{$color-blue-05};
+    --link-color-hover: #{$color-link-hover};
+    --link-color-inverse: #{$color-blue-10};
+    --link-color-visited-hover-inverse: #{$color-violet-05};
+    --link-color-visited-hover: #{$color-link-hover};
+    --link-color-visited-inverse: #{$color-violet-10};
+    --link-color-visited: #{$color-link-visited};
+    --link-color: #{$color-link};
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1231,6 +1231,12 @@
         "css/m24/base.scss"
       ],
       "name": "m24"
+    },
+    {
+      "files": [
+        "css/protocol/protocol-mozilla-2024.scss"
+      ],
+      "name": "protocol-mozilla-2024"
     }
   ],
   "js": [


### PR DESCRIPTION
## One-line summary
Applies the new brand fonts globally to every page, as well as text and link colors behind the switch `m24-global-styles`

This is, admittedly, quite hacky, but it seems to get the job done until we can do it properly through Protocol.

This also goes all-in on CSS custom properties since it proved basically impossible to override mixins and Sass variables declared in upstream Protocol. That means very old browsers should fall back to system fonts but that seems acceptable. We can solve that when we do a proper Protocol theme, but I've also been thinking for some time we could go all-in on custom properties in Protocol as well. It's time.

## Issue / Bugzilla link
#15088 

## Testing
https://www-demo9.allizom.org/

Main things to be on the lookout for are any spots where foreground/background colors aren't correct (e.g. white text on light background, black text on dark background) or places where the correct font isn't loading (which can be hard to tell sometimes). Also any whole pages I somehow missed.

This is obviously a sweeping change across the entire site so probably needs some careful review, and I fully expect there to be edge cases and oddities we'll discover in the coming weeks.