### PR TITLE
Update to Python 3.12.x

### DIFF
--- a/.github/workflows/fluent_linter.yml
+++ b/.github/workflows/fluent_linter.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install Python dependencies
         run: |
           pip install moz-fluent-linter==0.4.*

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"  # matches current Python in production
+          python-version: "3.12"  # matches current Python in production
       - name: "Run Python tests (on Docker)"
         run: |
             make clean test-image

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ########
 # Python dependencies builder
 #
-FROM python:3.11-slim-bookworm AS python-builder
+FROM python:3.12-slim-bookworm AS python-builder
 
 WORKDIR /app
 ENV LANG=C.UTF-8
@@ -52,7 +52,7 @@ RUN npm run build --verbose
 ########
 # django app container
 #
-FROM python:3.11-slim-bookworm AS app-base
+FROM python:3.12-slim-bookworm AS app-base
 
 # Extra python env
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/bedrock/base/tests/test_views.py
+++ b/bedrock/base/tests/test_views.py
@@ -51,7 +51,7 @@ class TestGeoTemplateView(TestCase):
 @pytest.mark.django_db
 def test_get_contentful_sync_info(mock_timeago_format, mock_tz_now):
     mock_timeago_format.return_value = "mock-formatted-time-delta"
-    _now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+    _now = datetime.datetime.utcnow().replace(tzinfo=datetime.UTC)
     mock_tz_now.return_value = _now
 
     middle = tz_now()

--- a/bedrock/cms/tests/test_rendering.py
+++ b/bedrock/cms/tests/test_rendering.py
@@ -109,5 +109,5 @@ def test_locales_are_drawn_from_page_translations(minimal_site, rf, serving_meth
     page_content = str(resp.content)
     assert "Test Page" in page_content
     assert '<option lang="en-US" value="en-US" selected>English</option>' in page_content
-    assert '<option lang="fr" value="fr">Français</option>'.encode("utf-8") in resp.content
+    assert '<option lang="fr" value="fr">Français</option>'.encode() in resp.content
     assert '<option lang="en-GB" value="en-US">English (British) </option>' not in page_content

--- a/bedrock/mozorg/management/commands/update_root_store_policy_page.py
+++ b/bedrock/mozorg/management/commands/update_root_store_policy_page.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         # Note: we don't want to render the actual template at this stage,
         # we just want to augment what's IN the template with the HTML from
         # the Policy doc, rendered from Markdown
-        with open(WRAPPING_TEMPLATE_PATH, "r") as fp:
+        with open(WRAPPING_TEMPLATE_PATH) as fp:
             template = fp.read()
         wrapped_html = template.replace("__HTML_POLICY_CONTENT_PLACEHOLDER__", html)
         return wrapped_html

--- a/bedrock/pocketfeed/api.py
+++ b/bedrock/pocketfeed/api.py
@@ -35,7 +35,7 @@ def complete_articles_data(articles):
         article["pocket_id"] = article["id"]
 
         # convert time_shared from unix timestamp to datetime
-        article["time_shared"] = make_aware(datetime.datetime.fromtimestamp(int(article["time_shared"])), datetime.timezone.utc)
+        article["time_shared"] = make_aware(datetime.datetime.fromtimestamp(int(article["time_shared"])), datetime.UTC)
 
         # remove data points we don't need
         del article["comment"]

--- a/bedrock/pocketfeed/tests/test_api.py
+++ b/bedrock/pocketfeed/tests/test_api.py
@@ -54,7 +54,7 @@ def test_complete_articles_data(req_mock):
     assert "quote" not in articles[0][1]
 
     # 'time_shared' should be converted to a datetime value
-    assert articles[0][1]["time_shared"] == make_aware(datetime.datetime(2018, 7, 18, 11, 14, 18), datetime.timezone.utc)
+    assert articles[0][1]["time_shared"] == make_aware(datetime.datetime(2018, 7, 18, 11, 14, 18), datetime.UTC)
 
     # should have attempted to GET request against image_src
     req_mock.get.assert_called_once_with("https://www.test.com/test.png")

--- a/bin/check-pinned-requirements.py
+++ b/bin/check-pinned-requirements.py
@@ -11,7 +11,7 @@ import subprocess
 def extract_pinned(requirements_file):
     """Extract pinned dependencies from a requirements file."""
     pinned_deps = {}
-    with open(requirements_file, "r") as file:
+    with open(requirements_file) as file:
         for line in file:
             # Skip comments and empty lines
             if line.strip() and not line.startswith("#"):

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -110,7 +110,7 @@ Local Installation
 These instructions assume you have Python, pip, and NodeJS installed. If you don't have `pip` installed
 (you probably do) you can install it with the instructions in `the pip docs <https://pip.pypa.io/en/stable/installing/>`_.
 
-Bedrock currently uses Python 3.11.x. The recommended way to install and use that version is
+Bedrock currently uses Python 3.12.x. The recommended way to install and use that version is
 with `pyenv <https://github.com/pyenv/pyenv>`_ and to create a virtualenv using
 `pyenv-virtualenv <https://github.com/pyenv/pyenv-virtualenv>`_ that will isolate Bedrock's
 dependencies from other things installed on the system.
@@ -119,7 +119,7 @@ The following assumes you are on MacOS, using ``zsh`` as your shell and `Homebre
 as your package manager. If you are not, there are installation instructions for a variety of
 platforms and shells in the READMEs for the two pyenv projects.
 
-**Install Python 3.11.x with pyenv**
+**Install Python 3.12.x with pyenv**
 
 1. Install ``pyenv`` itself ::
 
@@ -138,23 +138,23 @@ using ``zsh``, the ``pyenv`` docs have other routes ::
 
     $ zsh -l
 
-4. Install the latest Python 3.11.x (e.g. 3.11.8), then test it's there::
+4. Install the latest Python 3.12.x (e.g. 3.12.6), then test it's there::
 
-    $ pyenv install 3.11.8
+    $ pyenv install 3.12.6
 
-   If you'd like to make Python 3.11 your default globally, you can do so with::
+   If you'd like to make Python 3.12 your default globally, you can do so with::
 
-    $ pyenv global 3.11.8
+    $ pyenv global 3.12.6
 
-   If you only want to make Python 3.11 available in the current shell, while you set up the
+   If you only want to make Python 3.12 available in the current shell, while you set up the
    Python virtualenv (below), you can do so with::
 
-    $ pyenv shell 3.11.8
+    $ pyenv shell 3.12.6
 
 5. Verify that you have the correct version of Python installed::
 
     $ python --version
-    Python 3.11.8
+    Python 3.12.6
 
 
 **Install a plugin to manage virtualenvs via pyenv and create a virtualenv for Bedrock's dependencies**
@@ -176,7 +176,7 @@ pyenv-virtualenv installed::
 
 4. Make a virtualenv we can use - in this example we'll call it ``bedrock`` but use whatever you want ::
 
-    $ pyenv virtualenv 3.11.8 bedrock
+    $ pyenv virtualenv 3.12.6 bedrock
 
 **Use the virtualenv**
 
@@ -201,7 +201,7 @@ deactivate it when you exit the directory, you can do so with::
 
     If you are on OSX and some of the compiled dependencies fails to compile, try explicitly setting
     the arch flags and try again. The following are relevant to Intel Macs only. If you're on Apple
-    Silicon, 3.11.8 should 'just work':
+    Silicon, 3.12.6 should 'just work':
 
     .. code-block:: bash
 


### PR DESCRIPTION
## One-line summary

We held off on upgrading to Python 3.12 earlier this year to wait for more releases (stability). We're at 3.12.6 to date so we feel safe to upgrade now.

- [ ] I used an AI to write some of this code.

## Testing

Verify integration tests pass.