### PR TITLE
Refresh: Fix footer licensing link render

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -108,7 +108,7 @@
           {% set moco_link = 'href="%s" data-link-type="footer" data-link-text="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
           {% set mofo_link = 'href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer" rel="external noopener" data-link-type="footer" data-link-text="Mozilla Foundation"'|safe %}
           {{ ftl('footer-refresh-visit-mozilla-corporations', moco_link=moco_link, mofo_link=mofo_link) }}<br>
-          {{ ftl('footer-refresh-portions-of-this-content', href=url('foundation.licensing.website-content'), current_year=current_year|string) }}
+          {{ ftl('footer-refresh-portions-of-this-content', href='href="%s"'|safe|format(url('foundation.licensing.website-content')), current_year=current_year|string) }}
         </p>
         <ul class="moz24-footer-terms">
           <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-text="Privacy">{{ ftl('footer-refresh-websites-privacy-notice') }}</a></li>

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -108,7 +108,7 @@
           {% set moco_link = 'href="%s" data-link-type="footer" data-link-text="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
           {% set mofo_link = 'href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer" rel="external noopener" data-link-type="footer" data-link-text="Mozilla Foundation"'|safe %}
           {{ ftl('footer-refresh-visit-mozilla-corporations', moco_link=moco_link, mofo_link=mofo_link) }}<br>
-          {{ ftl('footer-refresh-portions-of-this-content', url=url('foundation.licensing.website-content'), current_year=current_year|string) }}
+          {{ ftl('footer-refresh-portions-of-this-content', href=url('foundation.licensing.website-content'), current_year=current_year|string) }}
         </p>
         <ul class="moz24-footer-terms">
           <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-text="Privacy">{{ ftl('footer-refresh-websites-privacy-notice') }}</a></li>


### PR DESCRIPTION
## One-line summary

Fixes empty cc href in new footer.

## Significant changes and points to review

The url('foundation.licensing.website-content') needs to be passed in an updated way incl. the attribute etc., and set correctly to the variable actually used in fluent.

## Issue / Bugzilla link

Fixes #15167

## Testing

http://localhost:8000/en-CA/