### PR TITLE
Fix new logo sizing in base-error

### DIFF
--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -96,7 +96,7 @@ template {
     background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
 }
 
-.c-navigation-logo-image.m24-logo {
+.c-navigation-logo .c-navigation-logo-image.m24-logo {
     @media #{$mq-md} {
         height: 21px;
         position: relative;


### PR DESCRIPTION
## One-line summary

Skips targeting base-error template uses for sizing adjustments of m24-logo.

## Significant changes and points to review

404/500 error pages use `.header-image .logo-mozilla .c-navigation-logo-image` while elsewhere it's `.c-navigation-logo .c-navigation-logo-image` — so this specific selector only targets the old nav, leaving the sizing in base-error header just to the img attrs.

(It could be fine-tuned a bit more though, but that is perhaps to come after cleaning up the outdated variants one day.)

## Issue / Bugzilla link

#15130 followup

## Testing

http://localhost:8000/nl/404
http://localhost:8000/en-US/careers/position/foo/404/ _(with Debug=False)_