### PR TITLE
Misc a11y fixes

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -5,7 +5,7 @@
  #}
 
  <div class="m24-c-transition m24-t-black"><hr></div>
- <footer class="moz24-footer" id="colophon">
+ <footer class="moz24-footer" id="colophon" role="contentinfo">
   {% if show_newsletter %}
     {% include 'includes/protocol/footer/footer-newsletter.html' %}
   {% endif %}

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -9,7 +9,7 @@
 {% if switch('m24-navigation-and-footer')  and LANG.startswith('en-') %}
   {% include 'includes/protocol/footer/footer-refresh.html' %}
 {% else %}
-<footer class="mzp-c-footer {% if theme_class %}{{ theme_class }}{% endif %}" id="colophon">
+<footer class="mzp-c-footer {% if theme_class %}{{ theme_class }}{% endif %}" id="colophon" role="contentinfo">
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
       <div class="mzp-c-footer-primary-logo {% if switch('m24-logo') %}m24-logo{% endif %}">
@@ -17,9 +17,9 @@
       </div>
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-company">
+          <h2 class="mzp-c-footer-heading" data-testid="footer-heading-company">
             {{ ftl('footer-company') }}
-          </h5>
+          </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-company">
             <li><a href="{{ url('mozorg.about.manifesto') }}" data-link-type="footer" data-link-text="Mozilla Manifesto">{{ ftl('footer-mozilla-manifesto') }}</a></li>
             <li><a href="https://blog.mozilla.org/category/mozilla/news/?{{ utm_params }}&utm_content=company" data-link-type="footer" data-link-text="Press Center">{{ ftl('footer-press-center') }}</a></li>
@@ -44,9 +44,9 @@
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-resources">
+          <h2 class="mzp-c-footer-heading" data-testid="footer-heading-resources">
             {{ ftl('footer-resources') }}
-          </h5>
+          </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-resources">
             <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-text="Privacy Hub">{{ ftl('footer-privacy-hub', fallback='footer-privacy') }}</a></li>
             <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-type="footer" data-link-text="Brand Standards">{{ ftl('footer-brand-standards') }}</a></li>
@@ -54,9 +54,9 @@
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-support">
+          <h2 class="mzp-c-footer-heading" data-testid="footer-heading-support">
             {{ ftl('footer-support') }}
-          </h5>
+          </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-support">
             <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="Product Help">{{ ftl('footer-product-help', fallback='footer-support') }}</a></li>
             <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-type="footer" data-link-text="File a Bug">{{ ftl('footer-file-a-bug') }}</a></li>
@@ -65,9 +65,9 @@
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading" data-testid="footer-heading-developers">
+          <h2 class="mzp-c-footer-heading" data-testid="footer-heading-developers">
             {{ ftl('footer-developers') }}
-          </h5>
+          </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-developers">
             <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
             <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-type="footer" data-link-text="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
@@ -80,7 +80,7 @@
         </section>
 
         <section class="mzp-c-footer-section">
-          <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-mozilla') }}</h5>
+          <h2 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-mozilla') }}</h2>
           <ul class="mzp-c-footer-links-social">
             <li><a class="twitter" href="{{ mozilla_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@mozilla)">{{ ftl('footer-x-formerly-twitter', fallback='footer-twitter') }}<span> (@mozilla)</span></a></li>
             <li><a class="mastodon" href="https://mozilla.social/@Mozilla" rel="me" data-link-type="footer" data-link-text="Mastodon (@mozilla)">{{ ftl('footer-mastodon') }}<span> (@mozilla)</span></a></li>
@@ -90,7 +90,7 @@
             <li><a class="spotify" href="https://open.spotify.com/show/0vT7LJMeVDxyQ2ZamHKu08?si=_uDRD6bRR_6M5YZyISGXgA" data-link-type="footer" data-link-text="Spotify (@mozilla)">{{ ftl('footer-spotify') }}<span> (@mozilla)</span></a></li>
           </ul>
 
-          <h5 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-firefox') }}</h5>
+          <h2 class="mzp-c-footer-heading-social">{{ ftl('footer-follow-firefox') }}</h2>
           <ul class="mzp-c-footer-links-social">
             <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-text="Twitter (@firefox)">{{ ftl('footer-x-formerly-twitter', fallback='footer-twitter') }}<span> (@firefox)</span></a></li>
             <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-text="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>

--- a/bedrock/firefox/templates/firefox/built-for-you/landing.de.html
+++ b/bedrock/firefox/templates/firefox/built-for-you/landing.de.html
@@ -180,7 +180,6 @@
       </div>
       {{ download_firefox_thanks(download_location='speed-section', locale_in_transition=True) }}
     </div>
-  </div>
   {% endcall %}
 
   <section class="mzp-c-callout section-choose">

--- a/bedrock/mozorg/templates/mozorg/about/index-m24.html
+++ b/bedrock/mozorg/templates/mozorg/about/index-m24.html
@@ -20,11 +20,11 @@
 {% endblock %}
 
 {% block content %}
-
-{% include 'mozorg/about/includes/m24/hero.html'%}
-{% include 'mozorg/about/includes/m24/amplify.html'%}
-{% include 'mozorg/about/includes/m24/idea.html'%}
-{% include 'mozorg/about/includes/m24/careers.html'%}
-{% include 'mozorg/about/includes/m24/leadership.html'%}
-
+<main>
+  {% include 'mozorg/about/includes/m24/hero.html'%}
+  {% include 'mozorg/about/includes/m24/amplify.html'%}
+  {% include 'mozorg/about/includes/m24/idea.html'%}
+  {% include 'mozorg/about/includes/m24/careers.html'%}
+  {% include 'mozorg/about/includes/m24/leadership.html'%}
+</main>
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Fixes a handful of small things the a11y checker turned up.

## Significant changes and points to review

- Adds `role="contentinfo"` to both old and new footer components.
- Fixes heading levels in old footer.
- Removes stray `</div>` from German `/built-for-you/` page.
- Adds `<main>` landmark to new `/about/` page.

## Issue / Bugzilla link

#15004

## Testing

- http://localhost:8000/en-US/about/ (new footer)
- http://localhost:8000/de/about/ (old footer)
- http://localhost:8000/de/firefox/built-for-you/