### PR TITLE
Update Nightly firstrun "Start Testing" link

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -61,7 +61,7 @@
           base_el='li'
         ) %}
           <p>{{ ftl('nightly-firstrun-find-and-file-bugs') }}</p>
-          <a href="https://quality.mozilla.org/get-involved/" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start testing">{{ ftl('nightly-firstrun-start-testing') }}</a>
+          <a href="https://wiki.mozilla.org/Nightly#Filing_Bugs" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start testing">{{ ftl('nightly-firstrun-start-testing') }}</a>
         {% endcall %}
 
         {% call picto(


### PR DESCRIPTION
## One-line summary

Points the Nightly firstrun CTA for QA contributions to wiki instead of QMO site.

## Significant changes and points to review

## Issue / Bugzilla link

Resolves #14991

## Testing

http://localhost:8000/en-US/firefox/nightly/firstrun/