### PR TITLE
Style hr transition in base-navigation-and-footer

### DIFF
--- a/media/css/m24/base-navigation-and-footer.scss
+++ b/media/css/m24/base-navigation-and-footer.scss
@@ -14,5 +14,6 @@
 @import 'vars/text';
 
 // global components
+@import 'transition';
 @import 'components/footer-refresh';
 @import 'components/navigation-refresh';


### PR DESCRIPTION
## One-line summary

In #15125 the hr divider was moved from refreshed pages to the refreshed footer, applied to all pre-existing pages — thus needs the styling applied independently with the footer, too.

## Significant changes and points to review

- This is ugly being duplicated from m24 base (and redundant =dupe once both m24/base and m24/base-nav* get active at the same time), but other than that I can only think of just hiding this hr with lower specificity, and only let the styling kick in once the new base is enabled?
- (@stephaniehobson Or is this something you'd like to address within #15170 reshuffling?)

## Issue / Bugzilla link

Fixes #15152 and #15159

## Testing

http://localhost:8000/en-CA/impact/
http://localhost:8000/en-CA/advertising/
http://localhost:8000/en-GB/firefox/developer/
http://localhost:8000/en-GB/firefox/nightly/firstrun/
http://localhost:8000/en-US/careers/