### PR TITLE
String fix for adblocker page [#15104]

### DIFF
--- a/l10n/en/firefox/features/adblocker.ftl
+++ b/l10n/en/firefox/features/adblocker.ftl
@@ -27,7 +27,7 @@ features-adblocker-considered-by-many-to-be-the = Considered by many to be the g
 # Variables:
 #   $attrs1 (string) - link to https://addons.mozilla.org/firefox/addon/adguard-adblocker/ with other attributes
 #   $attsr2 (string) - link to https://addons.mozilla.org/firefox/addon/popup-blocker/ with other attributes
-features-adblocker-adguard-adblocker-blunts = <a { $attrs1 }>AdGuard AdBlocker</a> blunts advertising everywhere. It blocks ads on the web, social media, even those annoying pop-ups (however if you’re looking to just suppress pop-ups you can’t go wrong with <a { $attrs2 }>Popup Blocker</a>).
+features-adblocker-adguard-adblocker-blunts = <a { $attrs1 }>AdGuard AdBlocker</a> blunts advertising everywhere. It blocks ads on the web, social media, even those annoying pop-ups (however if you’re looking to just suppress pop-ups, you can’t go wrong with <a { $attrs2 }>Popup Blocker</a>).
 
 # Variables:
 #   $attrs (string) - link to https://addons.mozilla.org/firefox/addon/ghostery/ with other attributes


### PR DESCRIPTION
## One-line summary
Added comma (see https://github.com/mozilla-l10n/www-l10n/pull/432#discussion_r1768876738)

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/432#discussion_r1768876738

## Testing
http://localhost:8000/firefox/features/adblocker/