### PR TITLE
Fix m24-logo in 2024 style for old footer

### DIFF
--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -91,6 +91,12 @@ template {
     background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
 }
 
+// temporary logo refresh for old footer
+.mzp-c-footer-primary-logo.m24-logo a {
+    background-image: url('/media/img/logos/m24/lockup-white.svg');
+    height: 27px;
+}
+
 /* ----------------------------------------------------------------------------- */
 // Mozilla 2024 brand theme
 :root {


### PR DESCRIPTION
## One-line summary

Adds support for both old and new branding within the original footer, after switching to the protocol-mozilla-2024 stylesheet.

## Significant changes and points to review

Only en-* locales, or locales with enough translations get the refresh footer and header, even once the -2024 bundle is used; so the old nav and footer still display for various locales even with all the switches flipped — therefore the 2024 bundle also needs to support m24-logo declaration overrides used in old components.

(Another way could be linking the m24 assets right away in all the 2024 styles, as these should be the correct ones come time for this bundle?)

## Issue / Bugzilla link

Resolves #15206

## Testing

http://localhost:8000/cy/
http://localhost:8000/sco/?xv=legacy