### PR TITLE
Add m24-logo sizing also to protocol-firefox

### DIFF
--- a/media/css/protocol/protocol-firefox.scss
+++ b/media/css/protocol/protocol-firefox.scss
@@ -86,6 +86,15 @@ template {
     background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
 }
 
+// temporary branding refresh tweaks
+.c-navigation-logo .c-navigation-logo-image.m24-logo {
+    @media #{$mq-md} {
+        height: 21px;
+        position: relative;
+        top: 1px;
+    }
+}
+
 .mzp-c-footer-primary-logo.m24-logo a {
     background-image: url('/media/img/logos/m24/lockup-white.svg');
     height: 27px;


### PR DESCRIPTION
## One-line summary

Fixes the m24-logo jumping around based on what bundle is loaded.

## Significant changes and points to review

When navigating between pages using protocol-mozilla and protocol-firefox, the m24-logo in old nav shifts — unless the positioning matches between the styles, so this adds the -mozilla treatment to -firefox base too.

## Issue / Bugzilla link

Resolves #15207

## Testing

Set up .env just for the brand refresh:

```python
SWITCH_M24_ABOUT=False
SWITCH_M24_GLOBAL_STYLES=False
SWITCH_M24_HOME=False
SWITCH_M24_LOGO=True
SWITCH_M24_NAVIGATION_AND_FOOTER=False
```