### PR TITLE
Fix the example of the rendition spec in the CMS docs

### DIFF
--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -471,7 +471,7 @@ mentions by providing a "filter spec" e.g.
 
 .. code-block:: jinja
 
-    {% set the_image=image(page.product_image, "max-1024x1024") %}
+    {% set the_image=image(page.product_image, "width-1200") %}
     <img class="some-class" src="{{ the_image.url }})"/>
 
 (More examples are available in the `Wagtail Images docs`_.)


### PR DESCRIPTION
1024x isn't one of the pregenerated/allowed widths
