### PR TITLE
update top margin for pages with sub nav fixes issue #15214

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -528,22 +528,17 @@
     }
 }
 
-// page content - hide sub nav and page content when nav menu is open
+// page content - hide all content except for the nav when mobile nav menu is open
 // This is not part of Protocol, it is specifc to Bedrock; should be documented in future
 body:has(.c-navigation-items.mzp-is-open) {
-    .c-sub-navigation {
-        display: none;
+    & > .c-sub-navigation,
+    & > .moz-consent-banner.is-visible,
+    & > .c-banner.c-banner-is-visible,
+    & > #outer-wrapper {
+        display: none !important; /* stylelint-disable-line declaration-no-important */
 
         @media #{$mq-md} {
-            display: block;
-        }
-    }
-
-    #outer-wrapper {
-        display: none;
-
-        @media #{$mq-md} {
-            display: block;
+            display: block !important; /* stylelint-disable-line declaration-no-important */
         }
     }
 }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -528,7 +528,7 @@
     }
 }
 
-// page content
+// page content - hide sub nav and page content when nav menu is open
 // This is not part of Protocol, it is specifc to Bedrock; should be documented in future
 body:has(.c-navigation-items.mzp-is-open) {
     .c-sub-navigation {

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -15,7 +15,7 @@
 .moz24-navigation-refresh {
     display: flex;
     width: 100%;
-    position: fixed;
+    position: sticky;
     z-index: 100;
     top: 0;
     left: 0;
@@ -531,41 +531,19 @@
 // page content
 // This is not part of Protocol, it is specifc to Bedrock; should be documented in future
 body:has(.c-navigation-items.mzp-is-open) {
-    #outer-wrapper {
+    .c-sub-navigation {
         display: none;
 
         @media #{$mq-md} {
             display: block;
         }
     }
-}
 
-body:has(.c-sub-navigation) {
-    .c-sub-navigation {
-        margin-top: 48px;
+    #outer-wrapper {
+        display: none;
 
         @media #{$mq-md} {
-            margin-top: 0;
+            display: block;
         }
-    }
-
-    #outer-wrapper {
-        margin-top: 0;
-    }
-}
-
-body:not(:has(.c-sub-navigation)) {
-    nav.c-sub-navigation {
-        margin-top: 0;
-    }
-
-    #outer-wrapper {
-        margin-top: 48px;
-    }
-}
-
-#outer-wrapper {
-    @media #{$mq-md} {
-        margin-top: 0;
     }
 }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -540,9 +540,31 @@ body:has(.c-navigation-items.mzp-is-open) {
     }
 }
 
-#outer-wrapper {
-    margin-top: 48px;
+body:has(.c-sub-navigation) {
+    .c-sub-navigation {
+        margin-top: 48px;
 
+        @media #{$mq-md} {
+            margin-top: 0;
+        }
+    }
+
+    #outer-wrapper {
+        margin-top: 0;
+    }
+}
+
+body:not(:has(.c-sub-navigation)) {
+    nav.c-sub-navigation {
+        margin-top: 0;
+    }
+
+    #outer-wrapper {
+        margin-top: 48px;
+    }
+}
+
+#outer-wrapper {
     @media #{$mq-md} {
         margin-top: 0;
     }


### PR DESCRIPTION
## One-line summary

This PR fixes the margin on mobile pages.

## Significant changes and points to review


## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15214

## Testing
1.Set SWITCH_M24_NAVIGATION_AND_FOOTER to be true in your local env file
2. Go to any page with a sub nav, such as http://localhost:8000/en-US/firefox/new/
3. Resize browser to mobile screen size