### PR TITLE
Issue #15187 - Nightly update message should refer to Firefox Labs instead of Nightly Experiments

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -65,7 +65,7 @@
 
       <p>
           {% set attrs = 'href="#" class="nightly-experiments-link"' %}
-          {{ ftl('nightly-whatsnew-want-to-know-which-v3', attrs=attrs) }}
+          {{ ftl('nightly-whatsnew-want-to-know-which-v3', fallback='nightly-whatsnew-want-to-know-which-v2', attrs=attrs) }}
         </p>
 
       <p>{{ ftl('nightly-whatsnew-do-you-experience', bugzilla='https://bugzilla.mozilla.org') }}</p>

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -65,7 +65,7 @@
 
       <p>
           {% set attrs = 'href="#" class="nightly-experiments-link"' %}
-          {{ ftl('nightly-whatsnew-want-to-know-which-v2', attrs=attrs) }}
+          {{ ftl('nightly-whatsnew-want-to-know-which-v3', attrs=attrs) }}
         </p>
 
       <p>{{ ftl('nightly-whatsnew-do-you-experience', bugzilla='https://bugzilla.mozilla.org') }}</p>

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -90,6 +90,10 @@
 -brand-name-firefox-private-network = Firefox Private Network
 -brand-name-fpn = FPN
 
+## Firefox projects
+
+-brand-name-firefox-labs = Firefox Labs
+
 ## Pocket
 
 -brand-name-pocket = Pocket

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -25,6 +25,7 @@ nightly-whatsnew-if-you-want-to-v3 = If you want to know what’s happening arou
 # Variables:
 #   $attrs (string) - link href and additional attributes
 nightly-whatsnew-want-to-know-which-v2 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>Nightly Experiments</a> preferences page.
+nightly-whatsnew-want-to-know-which-v3 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>{ -brand-name-firefox-labs }</a> preferences page.
 
 # Variables:
 #   $bugzilla (url) - link to https://bugzilla.mozilla.org/

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -24,7 +24,10 @@ nightly-whatsnew-if-you-want-to-v3 = If you want to know what’s happening arou
 
 # Variables:
 #   $attrs (string) - link href and additional attributes
+# Obsolete string (expires: 2024-11-26)
 nightly-whatsnew-want-to-know-which-v2 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>Nightly Experiments</a> preferences page.
+# Variables:
+#   $attrs (string) - link href and additional attributes
 nightly-whatsnew-want-to-know-which-v3 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>{ -brand-name-firefox-labs }</a> preferences page.
 
 # Variables:


### PR DESCRIPTION

- Created a new string for the page with id `nightly-whatsnew-want-to-know-which-v3`
- Added a new `-brand-name-firefox-labs` string for Firefox Labs in brands.ftl

## Issue / Bugzilla link
issue #15187 


## Testing
- `make test` passed
- I see the new string when running bedrock locally