### PR TITLE
Fix DB export script

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -50,8 +50,6 @@ tables_to_wipe_after_initial_migrate=(
     "auth_group_permissions"
     "auth_group"
     "auth_permission"
-    "auth_user_groups"
-    "auth_user_user_permissions"
     "product_details_productdetailsfile"
 )
 
@@ -63,6 +61,8 @@ tables_to_wipe_after_initial_migrate=(
 
 tables_to_wipe_after_import=(
     "auth_user"
+    "auth_user_groups"
+    "auth_user_user_permissions"
     "wagtailcore_revision"
 )
 
@@ -231,6 +231,15 @@ check_status_and_handle_failure "Loading data from JSON"
 
 # There are things we can't omit or redact in the steps above, so
 # we need to manually delete them once we've served their purpose
+
+# Delete rows from tables mentioned in tables_to_wipe_after_import
+for table in "${tables_to_wipe_after_import[@]}"
+do
+    sqlite3 $output_db "DELETE FROM $table"
+    echo "Purged now-redundant data from: $table"
+done
+
+# And to be sure that there are no relations pointing back to non-existent rows
 echo "Preparing statements for nullifying columns in temporary sql file. (Output is hidden because it's captured from stdout)."
 
 # Convert the array into a comma-separated string suitable for the SQL IN clause
@@ -277,13 +286,6 @@ check_status_and_handle_failure "Showing temporary SQL file"
 rm -f $nullify_specific_columns_sql || all_well=false
 check_status_and_handle_failure "Removing temporary SQL file"
 echo "Deleted that temporary sql"
-
-# Delete rows from tables mentioned in tables_to_wipe_after_import
-for table in "${tables_to_wipe_after_import[@]}"
-do
-    sqlite3 $output_db "DELETE FROM $table"
-    echo "Purged now-redundant data from: $table"
-done
 
 python manage.py rebuild_references_index
 check_status_and_handle_failure "Running rebuild_references_index"

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -18,7 +18,7 @@
 # cd /path/to/checkout/of/bedrock/
 # DATABASE_URL="postgres://user:pass@host:5432/bedrock" ./bin/export-db-to-sqlite.sh /path/to/output.db
 
-# If you want to run this in debug mode, insert `bash -x` (without quotes) before ./bin/
+# If you want to run this in debug mode, insert `bash -ex` (without quotes) before ./bin/
 
 # Set up variables to point to the new output DB and to a temporary sql script which we'll generate later
 

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -293,6 +293,7 @@ check_status_and_handle_failure "Running wagtail_update_index"
 echo "Rebuilt Wagtail object reference helper and search index"
 
 # Check if tables in tables_to_wipe_after_import are empty
+echo "Checking that the tables we expect to be empty are empty"
 for table in "${tables_to_wipe_after_import[@]}"
 do
     count=$(sqlite3 $output_db "SELECT COUNT(*) FROM $table")
@@ -301,8 +302,6 @@ do
         all_well=false
     fi
 done
-echo "Checked that the tables we expect to be empty are empty"
-
 check_status_and_handle_failure "Seeking expected empty tables"
 
 export DATABASE_URL=$ORIGINAL_DATABASE_URL


### PR DESCRIPTION
## One-line summary

This changeset fixes a blocking error with the DB export script which failed when it came across data linking the users table to a permissions table, which up until now had been empty. (Adding a non-superuser User to the CMS admin created a row in the `auth_user_group` table, which previously had been empty.)


- [ ] I used an AI to write some of this code.

## Significant changes and points to review

This changeset:

* Fixes the blocking error when exporting a source DB where the `auth_user_groups` and/or `auth_user_user_permissions` tables have data

    These two tables have a non-NULL `user_id` column, which means that the script is now failing because it could not nullify rows in those tables. The data for those rows was being pulled over via FK constraints because we exported the `auth.User` model from the source DB.

    The fix was to ensure that we were actually purging those two tables as well as the `auth_user table` (which we were doing already).

    Also, the ordering of operations needed to be addressed: clearing the tables before running the nullifying-relations code, rather than after, to avoid integrity issues because of that un-nullable `auth_user_groups.user_id`.

    I've tested this locally and putting the nulling after the table deletion seems to be fine: nullable columns are nulled and no data appears to cascade-delete when `auth_user`, `auth_user_groups` or `auth_user_user_permission` is dropped. If cascading deletion was going to occur, we would already have seen it with the deletion of auth_user, regardless of when it's called in the export script.

* Update output to make more sense in terms of ordering of messages if we do fail to purge key tables
* Improve comment to help with running it in debug mode

## Issue / Bugzilla link

No ticket/issue - hotfix

## Testing

I've tested this locally and once it hits main i'll re-test on real dev data and pull the DB down to my machine