### PR TITLE
update nav to remove existing nav styles

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -140,7 +140,7 @@
         {{ js_bundle('lib') }}
         {{ js_bundle('fxa') }}
         {{ js_bundle('data') }}
-        {% if switch('m24-navigation-and-footer')and LANG.startswith('en-') %}
+        {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
           {{ js_bundle('m24-ui') }}
         {% else %}
           {{ js_bundle('ui') }}

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -138,9 +138,13 @@
       <!--[if !IE]><!-->
         {# Standard site JS bundles served to all evergreen browsers plus IE 10 and above. #}
         {{ js_bundle('lib') }}
-        {{ js_bundle('ui') }}
         {{ js_bundle('fxa') }}
         {{ js_bundle('data') }}
+        {% if switch('m24-navigation-and-footer')and LANG.startswith('en-') %}
+          {{ js_bundle('m24-ui') }}
+        {% else %}
+          {{ js_bundle('ui') }}
+        {% endif %}
       <!--<![endif]-->
 
       <!--[if IE 9]>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
@@ -4,57 +4,57 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-   <a class="c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="c-menu-panel-about" data-testid="navigation-link-about-us">{{ ftl('navigation-refresh-about-us') }}</a>
-   <div class="c-menu-panel" id="c-menu-panel-about" data-testid="navigation-menu-about-us">
-     <div class="c-menu-panel-container">
-       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-about">{{ ftl('navigation-refresh-close-about-us-menu') }}</button>
-       <div class="c-menu-panel-content">
-         <ul class="mzp-l-content">
+ <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
+   <a class="m24-c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-about" data-testid="navigation-link-about-us">{{ ftl('navigation-refresh-about-us') }}</a>
+   <div class="m24-c-menu-panel" id="m24-c-menu-panel-about" data-testid="navigation-refresh-menu-about-us">
+     <div class="m24-c-menu-panel-container">
+       <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-about">{{ ftl('navigation-refresh-close-about-us-menu') }}</button>
+       <div class="m24-c-menu-panel-content">
+         <ul class="m24-mzp-l-content">
           <li>
-            <section class="c-menu-item">
-              <a class="c-menu-item-link" href="{{ url('mozorg.about.index') }}" data-link-text="About us" data-link-position="topnav - about">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-about-us') }}</h4>
+            <section class="m24-c-menu-item">
+              <a class="m24-c-menu-item-link" href="{{ url('mozorg.about.index') }}" data-link-text="About us" data-link-position="topnav - about">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-about-us') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item">
-              <a class="c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-text="Mozilla manifesto" data-link-position="topnav - about">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-mozilla-manifesto') }}</h4>
+            <section class="m24-c-menu-item">
+              <a class="m24-c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-text="Mozilla manifesto" data-link-position="topnav - about">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-manifesto') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item">
-              <a class="c-menu-item-link" href="https://foundation.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Foundation" data-link-position="topnav - about">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-mozilla-foundation') }}</h4>
+            <section class="m24-c-menu-item">
+              <a class="m24-c-menu-item-link" href="https://foundation.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Foundation" data-link-position="topnav - about">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-foundation') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item">
-              <a class="c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-text="Get Involved" data-link-position="topnav - about">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-get-involved') }}</h4>
+            <section class="m24-c-menu-item">
+              <a class="m24-c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-text="Get Involved" data-link-position="topnav - about">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-get-involved') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item">
-              <a class="c-menu-item-link" href="https://future.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Innovation Projects" data-link-position="topnav - about">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-innovation-projects') }}</h4>
+            <section class="m24-c-menu-item">
+              <a class="m24-c-menu-item-link" href="https://future.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Innovation Projects" data-link-position="topnav - about">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-innovation-projects') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item">
-              <a class="c-menu-item-link" href="https://blog.mozilla.org/?{{ utm_params }}" data-link-text="Blog" data-link-position="topnav - about">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-blog') }}</h4>
+            <section class="m24-c-menu-item">
+              <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/?{{ utm_params }}" data-link-text="Blog" data-link-position="topnav - about">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-blog') }}</h4>
               </a>
             </section>
           </li>
          </ul>
        </div>
-     </div><!-- close .c-menu-panel-container -->
-   </div><!-- close .c-menu-panel -->
+     </div><!-- close .m24-c-menu-panel-container -->
+   </div><!-- close .m24-c-menu-panel -->
  </li><!-- close about us -->

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
@@ -5,8 +5,8 @@
  #}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
-   <a class="m24-c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-about" data-testid="navigation-link-about-us">{{ ftl('navigation-refresh-about-us') }}</a>
-   <div class="m24-c-menu-panel" id="m24-c-menu-panel-about" data-testid="navigation-refresh-menu-about-us">
+   <a class="m24-c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-about" data-testid="m24-navigation-link-about-us">{{ ftl('navigation-refresh-about-us') }}</a>
+   <div class="m24-c-menu-panel" id="m24-c-menu-panel-about" data-testid="m24-navigation-menu-about-us">
      <div class="m24-c-menu-panel-container">
        <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-about">{{ ftl('navigation-refresh-close-about-us-menu') }}</button>
        <div class="m24-c-menu-panel-content">

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -6,58 +6,58 @@
 
  {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
 
- <li class="c-menu-category mzp-has-drop-down mzp-js-expandable c-menu-category-has-icon">
-  <a class="c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="c-menu-panel-firefox" data-testid="navigation-link-firefox">
-    <img class="c-menu-title-icon" loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="16" height="16" alt="">
+ <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable m24-c-menu-category-has-icon">
+  <a class="m24-c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-firefox" data-testid="navigation-refresh-link-firefox">
+    <img class="m24-c-menu-title-icon" loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="16" height="16" alt="">
     {{ ftl('navigation-refresh-firefox-browsers') }}
   </a>
-  <div class="c-menu-panel" id="c-menu-panel-firefox">
-    <div class="c-menu-panel-container" data-testid="navigation-menu-firefox">
-      <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-firefox">{{ ftl('navigation-refresh-close-firefox-browsers-menu') }}</button>
-      <div class="c-menu-panel-content">
-        <ul class="mzp-l-content">
+  <div class="m24-c-menu-panel" id="m24-c-menu-panel-firefox">
+    <div class="m24-c-menu-panel-container" data-testid="navigation-menu-firefox">
+      <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-firefox">{{ ftl('navigation-refresh-close-firefox-browsers-menu') }}</button>
+      <div class="m24-c-menu-panel-content">
+        <ul class="m24-mzp-l-content">
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-position="topnav - firefox" data-testid="navigation-menu-link-firefox-desktop">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-desktop') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-position="topnav - firefox" data-testid="navigation-menu-link-firefox-desktop">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-desktop') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-ios') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-ios') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-android') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-android') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/focus/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-firefox-focus') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/focus/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-focus') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://blog.mozilla.org/firefox/?{{ utm_params }}" data-link-text="Firefox Blog" data-link-position="topnav - firefox">
-                <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-firefox-blog') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/firefox/?{{ utm_params }}" data-link-text="Firefox Blog" data-link-position="topnav - firefox">
+                <svg class="m24-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-blog') }}</h4>
               </a>
             </section>
           </li>
         </ul>
       </div>
-    </div><!-- close .c-menu-panel-container -->
-  </div><!-- close .c-menu-panel -->
+    </div><!-- close .m24-c-menu-panel-container -->
+  </div><!-- close .m24-c-menu-panel -->
 </li><!-- close firefox -->

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -7,18 +7,18 @@
  {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable m24-c-menu-category-has-icon">
-  <a class="m24-c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-firefox" data-testid="navigation-refresh-link-firefox">
+  <a class="m24-c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-firefox" data-testid="m24-navigation-link-firefox">
     <img class="m24-c-menu-title-icon" loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="16" height="16" alt="">
     {{ ftl('navigation-refresh-firefox-browsers') }}
   </a>
   <div class="m24-c-menu-panel" id="m24-c-menu-panel-firefox">
-    <div class="m24-c-menu-panel-container" data-testid="navigation-menu-firefox">
+    <div class="m24-c-menu-panel-container" data-testid="m24-navigation-menu-firefox">
       <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-firefox">{{ ftl('navigation-refresh-close-firefox-browsers-menu') }}</button>
       <div class="m24-c-menu-panel-content">
         <ul class="m24-mzp-l-content">
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-position="topnav - firefox" data-testid="navigation-menu-link-firefox-desktop">
+              <a class="m24-c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-position="topnav - firefox" data-testid="m24-navigation-menu-link-firefox-desktop">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-desktop') }}</h4>
               </a>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -6,77 +6,77 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
 
-<li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="{{ url('products.landing') }}" aria-haspopup="true" aria-controls="c-menu-panel-products" data-testid="navigation-link-products">{{ ftl('navigation-refresh-products') }}</a>
-  <div class="c-menu-panel" id="c-menu-panel-products" data-testid="navigation-menu-products">
-    <div class="c-menu-panel-container">
-      <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-products">{{ ftl('navigation-refresh-close-products-menu') }}</button>
-      <div class="c-menu-panel-content">
-        <ul class="mzp-l-content">
+<li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
+  <a class="m24-c-menu-title" href="{{ url('products.landing') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-products" data-testid="navigation-refresh-link-products">{{ ftl('navigation-refresh-products') }}</a>
+  <div class="m24-c-menu-panel" id="m24-c-menu-panel-products" data-testid="navigation-menu-products">
+    <div class="m24-c-menu-panel-container">
+      <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-products">{{ ftl('navigation-refresh-close-products-menu') }}</button>
+      <div class="m24-c-menu-panel-content">
+        <ul class="m24-mzp-l-content">
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('products.vpn.landing') }}" data-link-text="Mozilla VPN" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('protocol/img/logos/mozilla/vpn/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-mozilla-vpn') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="{{ url('products.vpn.landing') }}" data-link-text="Mozilla VPN" data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('protocol/img/logos/mozilla/vpn/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-vpn') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://relay.firefox.com/?{{ utm_params }}" data-link-text="Firefox Relay" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-firefox-relay') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://relay.firefox.com/?{{ utm_params }}" data-link-text="Firefox Relay" data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-relay') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-text="Pocket" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('protocol/img/logos/pocket/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-pocket') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-text="Pocket"data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('protocol/img/logos/pocket/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-pocket') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://developer.mozilla.org/plus?{{ utm_params }}" data-link-text="MDN Plus" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('img/nav/icons/icon-mdn-plus.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-mdn-plus') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://developer.mozilla.org/plus?{{ utm_params }}" data-link-text="MDN Plus" data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('img/nav/icons/icon-mdn-plus.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mdn-plus') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://fakespot.com/?{{ utm_params }}" data-link-text="Fakespot" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('img/logos/fakespot/logo-blue.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-fakespot') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://fakespot.com/?{{ utm_params }}" data-link-text="Fakespot" data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('img/logos/fakespot/logo-blue.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-fakespot') }}</h4>
               </a>
             </section>
           </li>
           <li>
-            <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="https://www.thunderbird.net/{{ referrals }}" data-link-text="Thunderbird" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('img/logos/thunderbird/logo-thunderbird.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-refresh-thunderbird') }}</h4>
+            <section class="m24-c-menu-item mzp-has-icon">
+              <a class="m24-c-menu-item-link" href="https://www.thunderbird.net/{{ referrals }}" data-link-text="Thunderbird" data-link-position="topnav - products">
+                <img loading="lazy" src="{{ static('img/logos/thunderbird/logo-thunderbird.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-thunderbird') }}</h4>
               </a>
             </section>
           </li>
         </ul>
-        <p class="c-menu-category-link">
+        <p class="m24-c-menu-category-link">
           <a href="{{ url('products.landing') }}" data-link-text="Go to all browsers and products" data-link-position="topnav - products">
             {{ ftl('navigation-refresh-all-products') }}
             <svg fill="none" height="24" width="24" xmlns="http://www.w3.org/2000/svg"><clipPath id="a"><path d="M0 0h24v24H0z"/></clipPath><g clip-path="url(#a)"><path d="M10.45 10.789v1.806H5V10.79zm8.55.903L10.45 4.5v6.289h1.806v-2.41l3.938 3.313-3.938 3.312v-2.409H10.45v6.289z" fill="#fff"/></g></svg>
           </a>
         </p>
       </div>
-    </div><!-- close .c-menu-panel-container -->
-  </div><!-- close .c-menu-panel -->
+    </div><!-- close .m24-c-menu-panel-container -->
+  </div><!-- close .m24-c-menu-panel -->
 </li><!-- close products -->

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -7,8 +7,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
 
 <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="m24-c-menu-title" href="{{ url('products.landing') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-products" data-testid="navigation-refresh-link-products">{{ ftl('navigation-refresh-products') }}</a>
-  <div class="m24-c-menu-panel" id="m24-c-menu-panel-products" data-testid="navigation-menu-products">
+  <a class="m24-c-menu-title" href="{{ url('products.landing') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-products" data-testid="m24-navigation-link-products">{{ ftl('navigation-refresh-products') }}</a>
+  <div class="m24-c-menu-panel" id="m24-c-menu-panel-products" data-testid="m24-navigation-menu-products">
     <div class="m24-c-menu-panel-container">
       <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-products">{{ ftl('navigation-refresh-close-products-menu') }}</button>
       <div class="m24-c-menu-panel-content">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
@@ -4,26 +4,26 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- <div class="c-navigation mzp-is-sticky moz24-navigation-refresh">
-  <div class="c-navigation-l-content">
-    <div class="c-navigation-container">
-      <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items" data-testid="navigation-refresh-menu-button">{{ ftl('ui-menu') }}</button>
-      <div class="c-navigation-logo">
+ <div class="m24-navigation-refresh m24-mzp-is-sticky">
+  <div class="m24-c-navigation-l-content">
+    <div class="m24-c-navigation-container">
+      <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>
+      <div>
         <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
-          <img loading="lazy" class="c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="88" height="21">
+          <img loading="lazy" class="m24-c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="88" height="21">
         </a>
       </div>
-      <div class="c-navigation-items" id="c-navigation-items" data-testid="navigation-menu-items">
-        <div class="c-navigation-menu">
-          <nav class="c-menu mzp-is-basic">
-            <ul class="c-menu-category-list">
+      <div class="m24-c-navigation-items" id="m24-c-navigation-items" data-testid="m24-navigation-menu-items">
+        <div class="m24-c-navigation-menu">
+          <nav class="m24-c-menu m24-mzp-is-basic">
+            <ul class="m24-c-menu-category-list">
               {% include 'includes/protocol/navigation/menus-refresh/firefox.html' %}
               {% include 'includes/protocol/navigation/menus-refresh/products.html' %}
               {% include 'includes/protocol/navigation/menus-refresh/about-us.html' %}
             </ul>
           </nav>
-        </div><!-- close .c-navigation-menu -->
-      </div><!-- close .c-navigation-items -->
-    </div>
-  </div>
+        </div><!-- close .m24-c-navigation-menu -->
+      </div><!-- close .m24-c-navigation-items -->
+    </div><!-- close .m24-c-navigation-container -->
+  </div><!-- close .m24-c-navigation-l-content -->
 </div>

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -12,7 +12,8 @@
     }
 }
 
-.moz24-navigation-refresh {
+.m24-navigation-refresh {
+    background-color: $m24-color-medium-gray;
     display: flex;
     width: 100%;
     position: sticky;
@@ -20,460 +21,337 @@
     top: 0;
     left: 0;
     box-shadow: none;
-    background-color: $m24-color-medium-gray;
 
     @media #{$mq-md} {
-        position: sticky;
         display: block;
     }
+}
 
-    .c-navigation-container {
-        width: 100%;
-        padding: 0;
+// Common navigation styles
+.m24-c-navigation-l-content {
+    position: relative;
+    padding: $spacer-xs $spacer-md;
+    width: 100%;
+    display: flex;
 
-        @media #{$mq-md} {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            align-items: center;
-        }
+    @media #{$mq-md} {
+        padding: $spacer-sm $spacer-md;
+        width: auto;
+        display: block;
+    }
+}
+
+.m24-c-navigation-container {
+    @include clearfix;
+    width: 100%;
+    padding: 0;
+    max-width: $content-max;
+    margin: 0 auto;
+    position: relative;
+
+    @media #{$mq-md} {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
+}
+
+.m24-c-navigation-menu-button {
+    background-color: $m24-color-medium-gray;
+    margin: 0;
+    padding: 0;
+    color: $color-black;
+    position: relative;
+    font-family: $primary-font;
+    font-weight: 600;
+    border: none;
+    height: 32px;
+    @include bidi(((float, right, left),));
+
+    &::after {
+        display: block;
+        background: $color-black;
+        bottom: 4px;
+        content: "";
+        height: 1px;
+        left: 0;
+        position: absolute;
+        width: 100%
     }
 
-    .c-navigation-items {
-        // mobile specfic styles
-        @media (max-width: $screen-md) {
-            display: none;
+    &.mzp-is-active {
+        background-color: $color-marketing-gray-20;
+        background-image: url('#{$image-path}/icons/close.svg');
+    }
 
-            &.mzp-is-open {
-                display: flex;
-                position: fixed;
-                z-index: 100;
-                top: 0;
-                right: 0;
-                width: 100%;
-                height: calc(100vh - 48px); // 48px margin top
-                background-color: #fff;
-                transition: 0.45s;
-                margin-top: 48px;
-                padding-top: 0;
-                overflow: hidden auto;
-                animation: nav-slide-in 0.45s ease;
+    &:not(.mzp-is-active) {
+        text-indent: unset;
+        background-image: none;
+        width: fit-content;
+    }
 
-                .c-menu-category-list:has(.c-menu-category.mzp-is-selected) {
-                    margin-bottom: 0;
+    @media #{$mq-md} {
+        display: none;
+        margin: 24px 0;
+    }
+}
 
-                    .c-menu-category:not(.mzp-is-selected) {
-                        display: none;
-                    }
+.m24-c-navigation-logo-image {
+    height: 21px;
+    padding: 0;
+}
+
+.m24-c-navigation-items {
+    // mobile specfic styles
+    @media (max-width: $screen-md) {
+        display: none;
+
+        &.mzp-is-open {
+            display: flex;
+            position: fixed;
+            z-index: 100;
+            top: 0;
+            right: 0;
+            width: 100%;
+            height: calc(100vh - 48px); // 48px margin top
+            background-color: #fff;
+            transition: 0.45s;
+            margin-top: 48px;
+            padding-top: 0;
+            overflow: hidden auto;
+            animation: nav-slide-in 0.45s ease;
+
+            .m24-c-menu-category-list:has(.m24-c-menu-category.mzp-is-selected) {
+                margin-bottom: 0;
+
+                .m24-c-menu-category:not(.mzp-is-selected) {
+                    display: none;
                 }
             }
         }
     }
+}
 
-    .c-navigation-logo {
+.m24-c-navigation-menu {
+    width: 100%;
+    margin-bottom: 0;
+
+    @media #{$mq-md} {
+        width: auto;
+    }
+}
+
+// Basic hover interactions with JavaScript disabled or not supported.
+.m24-c-menu.m24-mzp-is-basic .m24-c-menu-panel {
+    display: block;
+
+    @media #{$mq-md} {
+        display: none;
+    }
+}
+
+// Enhanced hover interactions with JavaScript enabled.
+.m24-c-menu.m24-mzp-is-enhanced .m24-c-menu-category {
+    border-top: none;
+    border-bottom: 2px solid $token-color-light-gray;
+    padding: 8px 16px;
+    position: relative;
+
+    @media #{$mq-md} {
         padding: 0;
-        margin: 0;
-
-        .c-navigation-logo-image {
-            height: 21px;
-        }
+        border-bottom: transparent;
     }
 
-    .c-navigation-menu {
-        width: 100%;
-        margin-bottom: 0;
+    &.mzp-is-selected {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 1000;
+        width: calc(100% - 32px);
+        border-bottom: transparent;
 
         @media #{$mq-md} {
-            width: auto;
+            width: fit-content;
+            position: unset;
+            min-width: unset;
         }
-    }
-
-    .c-menu-category > .c-menu-title {
-        position: relative;
-        font-family: $primary-font;
-        font-size: $text-button-sm;
-        border-bottom: 2px solid $token-color-light-gray;
-        padding: 0;
 
         &::before {
-            background: url('/media/img/m24/arrow-dark-up.svg') top left repeat;
-            transform: rotate(90deg);
+            left: 0;
+            @include bidi(((left, 8px, right, auto), (right, 8px, left, auto)));
+            transform: rotate(-90deg);
         }
 
-        @media #{$mq-md} {
-            border-bottom: transparent;
+        .m24-c-menu-title {
+            padding: 0 0 0 48px;
+
+            @media #{$mq-md} {
+                color: $m24-color-dark-green;
+                padding: 0;
+                background-color: $m24-color-medium-gray;
+            }
 
             &::after {
-                display: block;
-                background: $color-black;
-                bottom: 7px;
-                content: "";
-                height: 1px;
-                left: 0;
-                position: absolute;
-                width: 100%;
+                @media #{$mq-md} {
+                    background: $m24-color-dark-green;
+                }
             }
         }
 
-        @media #{$mq-lg} {
-            &::after {
-                bottom: 7px;
-                left: 0;
-                width: 100%;
-            }
-        }
-    }
-
-    .c-menu-category-list {
-        padding: 0;
-        position: relative;
-
-        @media #{$mq-md} {
-            position: unset;
-            display: flex;
-            justify-content: space-between;
-            gap: 48px;
-        }
-    }
-
-    // Common navigation styles
-    .c-navigation-l-content {
-        position: relative;
-        padding: $spacer-xs $spacer-md;
-        width: 100%;
-        display: flex;
-
-        @media #{$mq-md} {
-            padding: $spacer-sm $spacer-md;
-            width: auto;
+        .m24-c-menu-panel {
             display: block;
+            position: fixed;
+            z-index: 100;
+            top: 0;
+            right: 0;
+            width: 100%;
+            height: auto;
+            background-color: #fff;
+            overflow: hidden auto;
+            margin-top: 98px;
+            animation: nav-slide-in 0.45s ease;
+
+            @media #{$mq-md} {
+                display: block;
+                margin-top: 64px;
+                animation: none;
+                max-height: calc(100vh - 64px);
+            }
         }
     }
 
-    .c-navigation {
-        background-color: $color-black;
-        color: $color-white;
+    &::before {
+        background: url('/media/img/m24/arrow-dark-up.svg') top left repeat;
+        transform: rotate(90deg);
+        content: '';
+        height: 20px;
+        position: absolute;
+        top: 10px;
+        width: 20px;
+        @include bidi(((right, 8px, left, auto),));
+
+        @media #{$mq-md} {
+            display: none;
+        }
+    }
+}
+
+.m24-c-menu.m24-mzp-is-enhanced .m24-c-menu-category.m24-c-menu-category-has-icon {
+    .m24-c-menu-title-icon {
+        @include bidi(((margin-right, 8px, 0), (margin-left, 0, 8px)));
     }
 
-    button.c-navigation-menu-button {
-        background-color: $m24-color-medium-gray;
-        margin: 0;
-        color: $color-black;
-        position: relative;
-        font-family: $primary-font;
-        font-weight: 600;
+    .m24-c-menu-title::after {
+        bottom: 1px;
+        @include bidi(((left, 24px, right, auto), (right, auto, left, 24px)));
+        width: calc(100% - 24px);
+    }
+}
 
+.m24-c-menu-category-list {
+    padding: 0;
+    margin-bottom: 0;
+    position: relative;
+
+    @media #{$mq-md} {
+        position: unset;
+        display: flex;
+        justify-content: space-between;
+        gap: 48px;
+    }
+}
+
+.m24-c-menu-category.mzp-has-drop-down {
+    .m24-c-menu-panel {
+        background-color: $color-white;
+        color: $color-black;
+        @include border-box;
+        display: none;
+
+        @media #{$mq-md} {
+            left: 0;
+            right: auto;
+            top: 64px;
+            width: 100%;
+            padding: 0;
+            border-bottom: 4px solid $m24-color-medium-gray;
+        }
+    }
+}
+
+.m24-c-menu-category > .m24-c-menu-title {
+    position: relative;
+    font-family: $primary-font;
+    font-size: $text-button-sm;
+    font-weight: 600;
+    padding: 0;
+    color: $color-black;
+    text-decoration: none;
+    border: none;
+    width: 100%;
+    display: block;
+
+    @media #{$mq-md} {
         &::after {
             display: block;
             background: $color-black;
-            bottom: 7px;
-            content: "";
-            height: 1px;
-            left: 0;
-            position: absolute;
-            width: 100%
-        }
-
-        &.mzp-is-active {
-            &::after {
-                display: none;
-            }
-        }
-
-        &:not(.mzp-is-active) {
-            text-indent: unset;
-            background-image: none;
-            width: fit-content;
-        }
-
-        @media #{$mq-md} {
-            margin: 24px 0;
-        }
-    }
-
-    .c-menu-category.mzp-has-drop-down {
-        .c-menu-panel {
-            background-color: $color-white;
-            color: $color-black;
-
-            @media #{$mq-md} {
-                left: 0;
-                right: auto;
-                top: 64px;
-                width: 100%;
-                padding: 0;
-                border-bottom: 4px solid $m24-color-medium-gray;
-            }
-        }
-    }
-
-    .c-menu-panel .c-menu-panel-container {
-        max-width: unset;
-        box-shadow: none;
-
-        @media #{$mq-md} {
-            border-radius: 0;
-            padding: $spacer-lg 0;
-        }
-    }
-
-    .c-menu.mzp-is-enhanced .c-menu-category {
-        position: unset;
-        border: transparent;
-        padding: 8px 16px;
-
-        @media #{$mq-md} {
-            padding: 0;
-        }
-
-        &.mzp-is-selected {
-            position: absolute;
-            top: 0;
-            left: 0;
-            z-index: 1000;
-            min-width: 100%;
-            background-color: $color-white;
-
-            @media #{$mq-md} {
-                position: unset;
-                min-width: unset;
-            }
-
-            .c-menu-title {
-                border-bottom: transparent;
-                padding: 0 0 0 48px;
-
-                @media #{$mq-md} {
-                    color: $m24-color-dark-green;
-                    border-bottom: transparent;
-                    padding: 0;
-                    background-color: $m24-color-medium-gray;
-                }
-
-                &::before {
-                    left: 0;
-                    transform: rotate(-90deg);
-                }
-
-                &::after {
-                    background: $m24-color-dark-green;
-                    height: 1px;
-                    width: 100%;
-                    left: 0;
-                    bottom: 7px;
-                }
-            }
-
-            .c-menu-panel {
-                display: block;
-                position: fixed;
-                z-index: 100;
-                top: 0;
-                right: 0;
-                width: 100%;
-                height: auto;
-                background-color: #fff;
-                overflow: hidden auto;
-                margin-top: 98px;
-                animation: nav-slide-in 0.45s ease;
-
-                @media #{$mq-md} {
-                    margin-top: 64px;
-                    animation: none;
-                    max-height: calc(100vh - 64px);
-                }
-            }
-        }
-    }
-
-    .c-menu-panel {
-        // mobile specfic styles
-        @media (max-width: $screen-md) {
-            display: none;
-        }
-
-        @media #{$mq-md} {
-            padding: 0;
-        }
-    }
-
-    h4.c-menu-item-title {
-        font-size: $text-button-sm;
-        font-family: $primary-font;
-        font-weight: 600;
-        margin-bottom: 0;
-    }
-
-    .mzp-l-content {
-        min-width: unset;
-        padding: $spacer-md 0;
-
-        @media #{$mq-md} {
-            padding: 0;
-        }
-    }
-
-    .c-menu-item {
-        min-width: unset;
-        max-width: 100%;
-        padding: 0;
-
-        @media #{$mq-md} {
-            min-width: 216px;
-            width: auto;
-        }
-
-        .c-menu-item-link {
-            display: flex;
-            align-items: center;
-            padding: 8px 0;
-            width: fit-content;
-
-            h4.c-menu-item-title {
-                border: none;
-
-                &::after {
-                    display: block;
-                    background: $color-black;
-                    bottom: 11px;
-                    content: "";
-                    height: 1px;
-                    left: 0;
-                    position: absolute;
-                    width: 100%;
-                }
-            }
-        }
-    }
-
-    .c-menu-item .c-menu-item-link
-    .c-menu-item .c-menu-item-link:link,
-    .c-menu-item .c-menu-item-link:visited {
-        h4.c-menu-item-title {
-            border: none;
-
-            &::after {
-                display: block;
-                background: $color-black;
-                bottom: 11px;
-                content: "";
-                height: 1px;
-                left: 0;
-                position: absolute;
-                width: 100%;
-            }
-        }
-
-        svg path {
-            fill: $color-black;
-        }
-    }
-
-    .c-menu-item .c-menu-item-link:hover,
-    .c-menu-item .c-menu-item-link:visited:hover {
-        h4.c-menu-item-title {
-            color: $m24-color-dark-green;
-            border: none;
-
-            &::after {
-                background: $m24-color-dark-green;
-            }
-        }
-
-        svg path {
-            fill: $m24-color-dark-green;
-        }
-    }
-
-    .c-menu-item:hover,
-    .c-menu-item:focus,
-    .c-menu-item:active {
-        background-color: unset;
-    }
-
-    .c-menu-panel .c-menu-panel-content > ul.mzp-l-content {
-        display: flex;
-        flex-direction: column;
-        margin: 0 auto;
-        padding: $spacer-md $grid-margin;
-
-        @media #{$mq-md} {
-            padding: 0 $grid-margin;
-        }
-
-        & > li {
-            border-bottom: 2px solid transparent;
-            width: 100%;
-
-            @media #{$mq-md} {
-                border-bottom: 2px solid $token-color-light-gray;
-            }
-
-            .c-menu-item {
-                border-bottom: transparent;
-            }
-        }
-    }
-
-    .c-menu-panel .c-menu-category-link {
-        display: flex;
-        justify-content: flex-end;
-        padding: 0;
-        margin: $spacer-lg $spacer-lg 0;
-        font-family: $primary-font;
-        font-size: $text-button-sm;
-        border: none;
-    }
-
-    .c-menu-panel .c-menu-category-link a,
-    .c-menu-panel .c-menu-category-link a:visited,
-    .c-menu-panel .c-menu-category-link a:link {
-        position: relative;
-        display: flex;
-        width: fit-content;
-        border: none;
-
-        svg path {
-            fill: $color-black;
-        }
-    }
-
-    .c-menu-panel .c-menu-category-link a:hover {
-        color: $m24-color-dark-green;
-
-        .c-menu-item-title::after {
-            display: block;
-            background: $m24-color-dark-green;
-            bottom: -2px;
+            bottom: 1px;
             content: "";
             height: 1px;
             left: 0;
             position: absolute;
             width: 100%;
         }
+    }
+}
 
-        svg path {
-            fill: $m24-color-dark-green;
-        }
+.m24-c-menu-panel {
+    // mobile specfic styles
+    @media (max-width: $screen-md) {
+        display: none;
     }
 
-    .mzp-has-icon .c-menu-item-link {
-        @include bidi(((padding-right, 0, 0), (padding-left, 0, 0)));
+    @media #{$mq-md} {
+        padding: 0;
+    }
+}
 
-        .c-menu-item-icon {
-            height: 16px;
-            width: 16px;
-            position: unset;
-            @include bidi(((padding-right, 4px, 0), (padding-left, 0, 4px)));
-        }
+.m24-c-menu-panel .m24-c-menu-panel-container {
+    @media #{$mq-md} {
+        padding: $spacer-lg 0;
+    }
+}
+
+.m24-c-menu-item-title {
+    font-size: $text-button-sm;
+    font-family: $primary-font;
+    font-weight: 600;
+    margin-bottom: 0;
+}
+
+.m24-c-menu-item {
+    min-width: unset;
+    max-width: 100%;
+    padding: 0;
+
+    @media #{$mq-md} {
+        min-width: 216px;
+        width: auto;
     }
 
-    .mzp-has-icon.c-menu-item .c-menu-item-link,
-    .mzp-has-icon.c-menu-item .c-menu-item-link:link,
-    .mzp-has-icon.c-menu-item .c-menu-item-link:active,
-    .mzp-has-icon.c-menu-item .c-menu-item-link:visited {
-        h4.c-menu-item-title {
-            font-weight: 600;
+    .m24-c-menu-item-link {
+        display: flex;
+        align-items: center;
+        padding: 8px 0;
+        width: 100%;
+        text-decoration: none;
+
+        &:visited {
+            text-decoration: none;
+        }
+
+        .m24-c-menu-item-title {
             border: none;
             position: relative;
 
@@ -489,48 +367,200 @@
             }
         }
     }
+}
 
-    .mzp-has-icon.c-menu-item .c-menu-item-link:hover,
-    .mzp-has-icon.c-menu-item .c-menu-item-link:visited:hover {
-        h4.c-menu-item-title {
-            border: none;
+.m24-c-menu-item .m24-c-menu-item-link
+.m24-c-menu-item .m24-c-menu-item-link:link,
+.m24-c-menu-item .m24-c-menu-item-link:visited {
+    .m24-c-menu-item-title {
+        border: none;
+    }
 
-            &::after {
-                background: $m24-color-dark-green;
-            }
+    svg path {
+        fill: $color-black;
+    }
+}
+
+.m24-c-menu-item .m24-c-menu-item-link:hover,
+.m24-c-menu-item .m24-c-menu-item-link:visited:hover {
+    .m24-c-menu-item-title {
+        color: $m24-color-dark-green;
+        border: none;
+
+        &::after {
+            background: $m24-color-dark-green;
         }
     }
 
-    .c-menu-button-close {
+    svg path {
+        fill: $m24-color-dark-green;
+    }
+}
+
+.m24-c-menu-item:hover,
+.m24-c-menu-item:focus,
+.m24-c-menu-item:active {
+    background-color: unset;
+}
+
+.m24-c-menu-panel .m24-c-menu-panel-content > .m24-mzp-l-content {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    padding: $spacer-md $grid-margin;
+
+    @media #{$mq-md} {
+        padding: 0 $grid-margin;
+    }
+
+    & > li {
+        border-bottom: 2px solid transparent;
+        width: 100%;
+
         @media #{$mq-md} {
-            display: block;
-            top: 15px;
-            @include bidi(((right, 15px, left, auto), (left, auto, right, 15px)));
+            border-bottom: 2px solid $token-color-light-gray;
+        }
 
-            &:hover,
-            &:focus,
-            &:active {
-                top: 15px;
-            }
+        .m24-c-menu-item {
+            border-bottom: transparent;
         }
     }
+}
 
-    .c-menu.mzp-is-enhanced .c-menu-category.c-menu-category-has-icon {
-        .c-menu-title-icon {
-            @include bidi(((margin-right, 8px, 0), (margin-left, 0, 8px)));
+.m24-c-menu-panel .m24-c-menu-category-link {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0;
+    margin: $spacer-lg $spacer-lg 0;
+    font-family: $primary-font;
+    font-size: $text-button-sm;
+    border: none;
+}
+
+.m24-c-menu-panel .m24-c-menu-category-link a,
+.m24-c-menu-panel .m24-c-menu-category-link a:visited,
+.m24-c-menu-panel .m24-c-menu-category-link a:link {
+    position: relative;
+    display: flex;
+    width: fit-content;
+    border: none;
+    text-decoration: none;
+    font-weight: 600;
+    font-family: $primary-font;
+    color: $color-black;
+
+    svg path {
+        fill: $color-black;
+    }
+}
+
+.m24-c-menu-panel .m24-c-menu-category-link a:hover {
+    color: $m24-color-dark-green;
+
+    svg path {
+        fill: $m24-color-dark-green;
+    }
+}
+
+.mzp-has-icon .m24-c-menu-item-link {
+    @include bidi(((padding-right, 0, 0), (padding-left, 0, 0)));
+
+    .m24-c-menu-item-icon {
+        height: 16px;
+        width: 16px;
+        position: unset;
+        @include bidi(((padding-right, 4px, 0), (padding-left, 0, 4px)));
+    }
+}
+
+.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link,
+.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:link,
+.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:active,
+.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:visited {
+    .m24-c-menu-item-title {
+        font-weight: 600;
+        border: none;
+        position: relative;
+
+        &::after {
+            display: block;
+            background: $color-black;
+            bottom: 1px;
+            content: "";
+            height: 1px;
+            left: 0;
+            position: absolute;
+            width: 100%;
         }
+    }
+}
 
-        .c-menu-title::after {
-            bottom: 7px;
-            @include bidi(((left, 24px, right, auto), (right, auto, left, 24px)));
-            width: calc(100% - 24px);
+.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:hover,
+.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:visited:hover {
+    .m24-c-menu-item-title {
+        border: none;
+
+        &::after {
+            background: $m24-color-dark-green;
+        }
+    }
+}
+
+.m24-c-menu-button-close {
+    display: none;
+
+    @media #{$mq-md} {
+        position: absolute;
+        display: block;
+        cursor: pointer;
+        @include image-replaced;
+        background: $color-white url('/media/protocol/img/icons/close.svg') center center no-repeat;
+        @include background-size(20px, 20px);
+        border-radius: $border-radius-sm;
+        border: none;
+        box-shadow: $box-shadow-sm;
+        padding: var(--spacer-xs);
+        height: 24px;
+        width: 24px;
+        top: 15px;
+        @include bidi(((right, 15px, left, auto), (left, auto, right, 15px)));
+
+        &:hover,
+        &:focus,
+        &:active {
+            top: 15px;
+        }
+    }
+}
+
+// * -------------------------------------------------------------------------- */
+// Sticky navigation styles
+
+@supports (position: sticky) {
+    html.mzp-has-sticky-navigation {
+        .m24-navigation-refresh.m24-mzp-is-sticky {
+            @media #{$mq-md} {
+                @include transition(transform 300ms ease-in-out);
+                position: sticky;
+                z-index: 1000;
+
+                &.mzp-is-scrolling {
+                    // Shadow colors are equivalent to $color-ink-90, $color-blue-90, $color-ink-90
+                    // We can't use a $box-shadow token here because it needs a different size and offset
+                    box-shadow: 0 0 6px 1px rgba(29, 17, 51, 0.04), 0 0 8px 2px rgba(9, 32, 77, 0.12), 0 0 5px -3px rgba(29, 17, 51, 0.12);
+                }
+
+                &.mzp-is-hidden {
+                    @include transform(translate(0, -110%));
+                }
+            }
         }
     }
 }
 
 // page content - hide all content except for the nav when mobile nav menu is open
 // This is not part of Protocol, it is specifc to Bedrock; should be documented in future
-body:has(.c-navigation-items.mzp-is-open) {
+body:has(.m24-c-navigation-items.mzp-is-open) {
     & > .c-sub-navigation,
     & > .moz-consent-banner.is-visible,
     & > .c-banner.c-banner-is-visible,

--- a/media/js/base/protocol/init-m24-navigation.js
+++ b/media/js/base/protocol/init-m24-navigation.js
@@ -28,22 +28,6 @@
         }
     }
 
-    function initNavButton() {
-        if (typeof Mozilla.Client === 'undefined') {
-            return false;
-        }
-
-        var nav = document.querySelector('.m24-navigation-refresh');
-
-        // Nav should be present on page.
-        if (nav) {
-            // Add a CSS hook for animating the nav button (issue #9009)
-            nav.classList.add('nav-button-is-ready');
-        }
-    }
-
-    initNavButton();
-
     window.MzpMenu.init({
         onMenuOpen: handleOnMenuOpen
     });

--- a/media/js/base/protocol/init-m24-navigation.js
+++ b/media/js/base/protocol/init-m24-navigation.js
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Initialize Protocol Navigation.
+ */
+(function () {
+    'use strict';
+
+    if (
+        typeof window.MzpMenu === 'undefined' ||
+        typeof window.MzpNavigation === 'undefined'
+    ) {
+        return;
+    }
+
+    var hasMediaQueries = typeof window.matchMedia !== 'undefined';
+
+    function handleOnMenuOpen() {
+        if (
+            !hasMediaQueries ||
+            !window.matchMedia('(min-width: 768px)').matches
+        ) {
+            return;
+        }
+    }
+
+    function initNavButton() {
+        if (typeof Mozilla.Client === 'undefined') {
+            return false;
+        }
+
+        var nav = document.querySelector('.m24-navigation-refresh');
+
+        // Nav should be present on page.
+        if (nav) {
+            // Add a CSS hook for animating the nav button (issue #9009)
+            nav.classList.add('nav-button-is-ready');
+        }
+    }
+
+    initNavButton();
+
+    window.MzpMenu.init({
+        onMenuOpen: handleOnMenuOpen
+    });
+
+    window.MzpNavigation.init();
+})();

--- a/media/js/base/protocol/m24-menu.js
+++ b/media/js/base/protocol/m24-menu.js
@@ -1,0 +1,395 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Copied from Protocol, to be backported along with nav updates.
+
+(function () {
+    'use strict';
+
+    var MzpMenu = {};
+    var _menuOpen = false;
+    var _hoverTimeout;
+    var _hoverTimeoutDelay = 150;
+    var _mqWideNav;
+    var _wideBreakpoint = '768px';
+
+    var _options = {
+        onMenuOpen: null,
+        onMenuClose: null,
+        onMenuButtonClose: null
+    };
+
+    /**
+     * Opens a menu panel.
+     * @param {Object} el - DOM element (`.mzp-c-menu-category.mzp-js-expandable`)
+     * @param {Boolean} animate - show animation when menu panel opens.
+     */
+    MzpMenu.open = function (el, animate) {
+        if (animate) {
+            el.classList.add('mzp-is-animated');
+        }
+
+        el.classList.add('mzp-is-selected');
+
+        _menuOpen = true; // For checking menu state on keyup.
+
+        el.querySelector('.m24-c-menu-title').setAttribute(
+            'aria-expanded',
+            true
+        );
+
+        if (typeof _options.onMenuOpen === 'function') {
+            _options.onMenuOpen(el);
+        }
+    };
+
+    /**
+     * Closes all currently open menu panels.
+     * Note: on small screens more than one menu can be open at the same time.
+     */
+    MzpMenu.close = function () {
+        var current = document.querySelectorAll(
+            '.m24-c-menu-category.mzp-is-selected'
+        );
+
+        for (var i = 0; i < current.length; i++) {
+            // The following classes must be removed in the correct order
+            // to work around a bug in bedrock's classList polyfill for IE9.
+            // https://github.com/mozilla/bedrock/issues/6221 :/
+            current[i].classList.remove('mzp-is-selected');
+            current[i].classList.remove('mzp-is-animated');
+
+            current[i]
+                .querySelector('.m24-c-menu-title')
+                .setAttribute('aria-expanded', false);
+        }
+
+        _menuOpen = false; // For checking menu state on keyup.
+
+        if (typeof _options.onMenuClose === 'function' && current.length > 0) {
+            _options.onMenuClose();
+        }
+
+        return current.length > 0;
+    };
+
+    MzpMenu.onDocumentKeyUp = function (e) {
+        if (e.keyCode === 27 && _menuOpen) {
+            MzpMenu.close();
+        }
+    };
+
+    /**
+     * Menu panel close button `click` event handler.
+     * @param {Object} e - Event object.
+     */
+    MzpMenu.onCloseButtonClick = function (e) {
+        e.preventDefault();
+
+        if (typeof _options.onMenuButtonClose === 'function') {
+            _options.onMenuButtonClose();
+        }
+
+        MzpMenu.close();
+    };
+
+    /**
+     * Toggles the open/closed state of a menu panel.
+     * @param {Object} el - DOM element (`.mzp-c-menu-category.mzp-js-expandable`)
+     */
+    MzpMenu.toggle = function (el) {
+        var state = el.classList.contains('mzp-is-selected') ? true : false;
+
+        if (!state) {
+            MzpMenu.open(el);
+        } else {
+            // The following classes must be removed in the correct order
+            // to work around a bug in bedrock's classList polyfill for IE9.
+            // https://github.com/mozilla/bedrock/issues/6221 :/
+            el.classList.remove('mzp-is-selected');
+            el.classList.remove('mzp-is-animated');
+            el.querySelector('.m24-c-menu-title').setAttribute(
+                'aria-expanded',
+                false
+            );
+
+            if (typeof _options.onMenuClose === 'function') {
+                _options.onMenuClose();
+            }
+        }
+    };
+
+    /**
+     * Menu `mouseenter` event handler.
+     * Opens the menu only when hover intent is shown.
+     * Animates only if a menu panel is not already open.
+     * @param {Object} e - Event object.
+     */
+    MzpMenu.onMouseEnter = function (e) {
+        clearTimeout(_hoverTimeout);
+
+        _hoverTimeout = setTimeout(function () {
+            var current = MzpMenu.close();
+            var animate = current ? false : true;
+
+            MzpMenu.open(e.target, animate);
+        }, _hoverTimeoutDelay);
+    };
+
+    /**
+     * Menu `mouseleave` event handler.
+     * Closes the menu only when hover intent is shown.
+     */
+    MzpMenu.onMouseLeave = function () {
+        clearTimeout(_hoverTimeout);
+
+        _hoverTimeout = setTimeout(function () {
+            MzpMenu.close();
+        }, _hoverTimeoutDelay);
+    };
+
+    /**
+     * Menu `focusout` event handler.
+     * Closes the menu when focus moves to an alement outside of the currently open panel.
+     */
+    MzpMenu.onFocusOut = function () {
+        var self = this;
+
+        /**
+         * After an element loses focus, `document.activeElement` will always be `body` before
+         * moving to the next element. A `setTimeout` of `0` circumvents this issue as it
+         * re-queues the JavaScript to run at the end of the current excecution.
+         */
+        setTimeout(function () {
+            // If the menu is open and the newly focused element is not a child, then call close().
+            if (
+                !self.contains(document.activeElement) &&
+                self.classList.contains('mzp-is-selected')
+            ) {
+                MzpMenu.close();
+            }
+        }, 0);
+    };
+
+    /**
+     * Menu link `click` event handler for wide viewports.
+     * Closes any currently open menu panels before opening the selected one.
+     * @param {Object} e - Event object.
+     */
+    MzpMenu.onClickWide = function (e) {
+        e.preventDefault();
+        MzpMenu.close();
+        MzpMenu.open(e.target.parentNode);
+    };
+
+    /**
+     * Menu link `click` event handler for small viewports.
+     * Toggles the currently selected menu open open/close state.
+     * @param {Object} e - Event object.
+     */
+    MzpMenu.onClickSmall = function (e) {
+        e.preventDefault();
+        MzpMenu.toggle(e.target.parentNode);
+    };
+
+    /**
+     * Convenience function for checking `matchMedia` state.
+     * @return {Boolean}
+     */
+    MzpMenu.isWideViewport = function () {
+        return _mqWideNav.matches;
+    };
+
+    /**
+     * Toggle desktop/mobile navigation using `matchMedia` event handler.
+     */
+    MzpMenu.handleState = function () {
+        _mqWideNav = matchMedia('(min-width: ' + _wideBreakpoint + ')');
+
+        function menuBind(mq) {
+            MzpMenu.close();
+
+            if (mq.matches) {
+                MzpMenu.unbindEventsSmall();
+                MzpMenu.bindEventsWide();
+            } else {
+                MzpMenu.unbindEventsWide();
+                MzpMenu.bindEventsSmall();
+            }
+        }
+
+        if (window.matchMedia('all').addEventListener) {
+            // evergreen
+            _mqWideNav.addEventListener('change', menuBind, false);
+        } else if (window.matchMedia('all').addListener) {
+            // IE fallback
+            _mqWideNav.addListener(menuBind);
+        }
+
+        if (MzpMenu.isWideViewport()) {
+            MzpMenu.bindEventsWide();
+        } else {
+            MzpMenu.bindEventsSmall();
+        }
+    };
+
+    /**
+     * Bind events for wide viewports.
+     */
+    MzpMenu.bindEventsWide = function () {
+        var items = document.querySelectorAll(
+            '.m24-c-menu-category.mzp-js-expandable'
+        );
+        var link;
+        var close;
+
+        for (var i = 0; i < items.length; i++) {
+            items[i].addEventListener(
+                'mouseenter',
+                MzpMenu.onMouseEnter,
+                false
+            );
+            items[i].addEventListener(
+                'mouseleave',
+                MzpMenu.onMouseLeave,
+                false
+            );
+            items[i].addEventListener('focusout', MzpMenu.onFocusOut, false);
+
+            link = items[i].querySelector('.m24-c-menu-title');
+            link.addEventListener('click', MzpMenu.onClickWide, false);
+
+            close = items[i].querySelector('.m24-c-menu-button-close');
+            close.addEventListener('click', MzpMenu.onCloseButtonClick, false);
+        }
+
+        // close with escape key
+        document.addEventListener('keyup', MzpMenu.onDocumentKeyUp, false);
+    };
+
+    /**
+     * Unbind events for wide viewports.
+     */
+    MzpMenu.unbindEventsWide = function () {
+        var items = document.querySelectorAll(
+            '.m24-c-menu-category.mzp-js-expandable'
+        );
+        var link;
+        var close;
+
+        for (var i = 0; i < items.length; i++) {
+            items[i].removeEventListener(
+                'mouseenter',
+                MzpMenu.onMouseEnter,
+                false
+            );
+            items[i].removeEventListener(
+                'mouseleave',
+                MzpMenu.onMouseLeave,
+                false
+            );
+            items[i].removeEventListener('focusout', MzpMenu.onFocusOut, false);
+
+            link = items[i].querySelector('.m24-c-menu-title');
+            link.removeEventListener('click', MzpMenu.onClickWide, false);
+
+            close = items[i].querySelector('.m24-c-menu-button-close');
+            close.removeEventListener(
+                'click',
+                MzpMenu.onCloseButtonClick,
+                false
+            );
+        }
+
+        document.removeEventListener('keyup', MzpMenu.onDocumentKeyUp, false);
+    };
+
+    /**
+     * Bind events for small viewports.
+     */
+    MzpMenu.bindEventsSmall = function () {
+        var items = document.querySelectorAll(
+            '.m24-c-menu-category.mzp-js-expandable .m24-c-menu-title'
+        );
+
+        for (var i = 0; i < items.length; i++) {
+            items[i].addEventListener('click', MzpMenu.onClickSmall, false);
+        }
+    };
+
+    /**
+     * Unbind events for small viewports.
+     */
+    MzpMenu.unbindEventsSmall = function () {
+        var items = document.querySelectorAll(
+            '.m24-c-menu-category.mzp-js-expandable .m24-c-menu-title'
+        );
+
+        for (var i = 0; i < items.length; i++) {
+            items[i].removeEventListener('click', MzpMenu.onClickSmall, false);
+        }
+    };
+
+    /**
+     * Set initial ARIA menu panel states.
+     */
+    MzpMenu.setAria = function () {
+        var items = document.querySelectorAll(
+            '.m24-c-menu-category.mzp-js-expandable .m24-c-menu-title'
+        );
+
+        for (var i = 0; i < items.length; i++) {
+            items[i].setAttribute('aria-expanded', false);
+        }
+    };
+
+    /**
+     * Enhances the menu for 1st class JS support.
+     */
+    MzpMenu.enhanceJS = function () {
+        var menu = document.querySelectorAll('.m24-c-menu');
+
+        for (var i = 0; i < menu.length; i++) {
+            menu[i].classList.remove('m24-mzp-is-basic');
+            menu[i].classList.add('m24-mzp-is-enhanced');
+        }
+    };
+
+    /**
+     * Basic feature detect for 1st class menu JS support.
+     */
+    MzpMenu.isSupported = function () {
+        if (typeof window.MzpSupports !== 'undefined') {
+            return (
+                window.MzpSupports.matchMedia && window.MzpSupports.classList
+            );
+        } else {
+            return false;
+        }
+    };
+
+    /**
+     * Initialize menu.
+     * @param {Object} options - configurable options.
+     */
+    MzpMenu.init = function (options) {
+        if (typeof options === 'object') {
+            for (var i in options) {
+                if (options.hasOwnProperty.call(i)) {
+                    _options[i] = options[i];
+                }
+            }
+        }
+
+        if (MzpMenu.isSupported()) {
+            MzpMenu.handleState();
+            MzpMenu.setAria();
+            MzpMenu.enhanceJS();
+        }
+    };
+
+    window.MzpMenu = MzpMenu;
+})();

--- a/media/js/base/protocol/m24-navigation.js
+++ b/media/js/base/protocol/m24-navigation.js
@@ -1,0 +1,261 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Copied from Protocol, to be back-ported along with nav updates.
+
+(function () {
+    'use strict';
+
+    var MzpNavigation = {};
+    var _navElem;
+    var _navItemsLists;
+    var _options = {
+        onNavOpen: null,
+        onNavClose: null
+    };
+    var _ticking = false;
+    var _lastKnownScrollPosition = 0;
+    var _animationFrameID = null;
+    var _stickyScrollOffset = 300;
+    var _wideBreakpoint = '768px';
+    var _tallBreakpoint = '600px';
+    var _mqLargeNav;
+    var _viewport = document.getElementsByTagName('html')[0];
+
+    /**
+     * Does the viewport meet the minimum width and height
+     * requirements for sticky behavior?
+     * @returns {Boolean}
+     */
+    MzpNavigation.isLargeViewport = function () {
+        return _mqLargeNav.matches;
+    };
+
+    /**
+     * Feature detect for sticky navigation
+     * @returns {Boolean}
+     */
+    MzpNavigation.supportsSticky = function () {
+        if (typeof window.MzpSupports !== 'undefined') {
+            return (
+                window.MzpSupports.matchMedia &&
+                window.MzpSupports.classList &&
+                window.MzpSupports.requestAnimationFrame &&
+                window.MzpSupports.cssFeatureQueries &&
+                CSS.supports('position', 'sticky')
+            );
+        } else {
+            return false;
+        }
+    };
+
+    /**
+     * Scroll event listener. No computationally expensive
+     * operations such as DOM modifications should happen
+     * here. Instead we throttle using `requestAnimationFrame`.
+     */
+    MzpNavigation.onScroll = function () {
+        if (!_ticking) {
+            _animationFrameID = window.requestAnimationFrame(
+                MzpNavigation.checkScrollPosition
+            );
+            _ticking = true;
+        }
+    };
+
+    /**
+     * Create sticky state for the navigation.
+     */
+    MzpNavigation.createSticky = function () {
+        _viewport.classList.add('mzp-has-sticky-navigation');
+        _animationFrameID = window.requestAnimationFrame(
+            MzpNavigation.checkScrollPosition
+        );
+        window.addEventListener('scroll', MzpNavigation.onScroll, false);
+    };
+
+    /**
+     * Destroy sticky state for the navigation.
+     */
+    MzpNavigation.destroySticky = function () {
+        _viewport.classList.remove('mzp-has-sticky-navigation');
+        _navElem.classList.remove('mzp-is-scrolling');
+        _navElem.classList.remove('mzp-is-hidden');
+        _lastKnownScrollPosition = 0;
+
+        if (_animationFrameID) {
+            window.cancelAnimationFrame(_animationFrameID);
+        }
+        window.removeEventListener('scroll', MzpNavigation.onScroll, false);
+    };
+
+    /**
+     * Initialize sticky state for the navigation.
+     * Uses `matchMedia` to determine if conditions
+     * for sticky navigation are satisfied.
+     */
+    MzpNavigation.initSticky = function () {
+        _mqLargeNav = matchMedia(
+            '(min-width: ' +
+                _wideBreakpoint +
+                ') and (min-height: ' +
+                _tallBreakpoint +
+                ')'
+        );
+
+        function makeStickyNav(mq) {
+            if (mq.matches) {
+                MzpNavigation.createSticky();
+            } else {
+                MzpNavigation.destroySticky();
+            }
+        }
+
+        if (window.matchMedia('all').addEventListener) {
+            _mqLargeNav.addEventListener('change', makeStickyNav, false);
+        } else if (window.matchMedia('all').addListener) {
+            _mqLargeNav.addListener(makeStickyNav);
+        }
+
+        if (MzpNavigation.isLargeViewport()) {
+            MzpNavigation.createSticky();
+        }
+    };
+
+    /**
+     * Implements sticky navigation behavior as
+     * user scrolls up and down the viewport.
+     */
+    MzpNavigation.checkScrollPosition = function () {
+        // add styling for when scrolling the viewport
+        if (window.scrollY > 0) {
+            _navElem.classList.add('mzp-is-scrolling');
+        } else {
+            _navElem.classList.remove('mzp-is-scrolling');
+        }
+
+        // scrolling down
+        if (window.scrollY > _lastKnownScrollPosition) {
+            // hide the sticky nav shortly after scrolling down the viewport.
+            if (window.scrollY > _stickyScrollOffset) {
+                // if there's a menu currently open, close it.
+                if (typeof window.MzpMenu !== 'undefined') {
+                    window.MzpMenu.close();
+                }
+
+                _navElem.classList.add('mzp-is-hidden');
+            }
+        }
+        // scrolling up
+        else {
+            _navElem.classList.remove('mzp-is-hidden');
+        }
+
+        _lastKnownScrollPosition = window.scrollY;
+        _ticking = false;
+    };
+
+    /**
+     * Event handler for navigation menu button `click` events.
+     */
+    MzpNavigation.onClick = function (e) {
+        var thisNavItemList = e.target.parentNode.querySelector(
+            '.m24-c-navigation-items'
+        );
+
+        e.preventDefault();
+
+        // Update button state
+        e.target.classList.toggle('mzp-is-active');
+
+        // Update menu state
+        thisNavItemList.classList.toggle('mzp-is-open');
+
+        // Update aria-expended state on menu.
+        var expanded = thisNavItemList.classList.contains('mzp-is-open')
+            ? true
+            : false;
+        thisNavItemList.setAttribute('aria-expanded', expanded);
+
+        if (expanded) {
+            if (typeof _options.onNavOpen === 'function') {
+                _options.onNavOpen(thisNavItemList);
+            }
+        } else {
+            if (typeof _options.onNavClose === 'function') {
+                _options.onNavClose(thisNavItemList);
+            }
+        }
+    };
+
+    /**
+     * Set initial ARIA navigation states.
+     */
+    MzpNavigation.setAria = function () {
+        for (var i = 0; i < _navItemsLists.length; i++) {
+            _navItemsLists[i].setAttribute('aria-expanded', false);
+        }
+    };
+
+    /**
+     * Bind navigation event handlers.
+     */
+    MzpNavigation.bindEvents = function () {
+        _navItemsLists = document.querySelectorAll('.m24-c-navigation-items');
+        if (_navItemsLists.length > 0) {
+            var navButtons = document.querySelectorAll(
+                '.m24-c-navigation-menu-button'
+            );
+            for (var i = 0; i < navButtons.length; i++) {
+                navButtons[i].addEventListener(
+                    'click',
+                    MzpNavigation.onClick,
+                    false
+                );
+            }
+            MzpNavigation.setAria();
+        }
+    };
+
+    /**
+     * Initialize menu.
+     * @param {Object} options - configurable options.
+     */
+    MzpNavigation.init = function (options) {
+        if (typeof options === 'object') {
+            for (var i in options) {
+                if (options.hasOwnProperty.call(i)) {
+                    _options[i] = options[i];
+                }
+            }
+        }
+
+        MzpNavigation.bindEvents();
+
+        /**
+         * Init (optional) sticky navigation.
+         * If there are multiple navigation organisms on a single page,
+         * assume only the first (and hence top-most) instance can and
+         * will be sticky.
+         *
+         * Do not init sticky navigation if user prefers reduced motion
+         */
+
+        _navElem = document.querySelector('.m24-navigation-refresh');
+        var _navIsSticky =
+            _navElem &&
+            _navElem.classList.contains('m24-mzp-is-sticky') &&
+            MzpNavigation.supportsSticky();
+
+        if (_navIsSticky && matchMedia('(prefers-reduced-motion)').matches) {
+            _navElem.classList.remove('m24-mzp-is-sticky');
+        } else if (_navIsSticky) {
+            MzpNavigation.initSticky();
+        }
+    };
+
+    window.MzpNavigation = MzpNavigation;
+})(window.Mzp);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1583,15 +1583,29 @@
     {
       "files": [
         "js/base/protocol/init-details.es6.js",
-        "js/base/protocol/protocol-menu.js",
-        "js/base/protocol/protocol-navigation.js",
-        "js/base/protocol/init-navigation.js",
         "js/base/protocol/init-footer.es6.js",
         "js/base/protocol/init-lang-switcher.es6.js",
         "js/base/protocol/protocol-sub-navigation.js",
-        "js/base/base-page-init.js"
+        "js/base/base-page-init.js",
+        "js/base/protocol/protocol-menu.js",
+        "js/base/protocol/protocol-navigation.js",
+        "js/base/protocol/init-navigation.js"
       ],
       "name": "ui"
+    },
+    {
+      "files": [
+        "js/base/protocol/init-details.es6.js",
+        "js/base/protocol/init-footer.es6.js",
+        "js/base/protocol/init-lang-switcher.es6.js",
+        "js/base/protocol/protocol-sub-navigation.js",
+        "js/base/base-page-init.js",
+        "js/base/protocol/m24-menu.js",
+        "js/base/protocol/m24-navigation.js",
+        "js/base/protocol/init-m24-navigation.js"
+
+      ],
+      "name": "m24-ui"
     },
     {
       "files": [

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1596,7 +1596,6 @@
     {
       "files": [
         "js/base/protocol/init-details.es6.js",
-        "js/base/protocol/init-footer.es6.js",
         "js/base/protocol/init-lang-switcher.es6.js",
         "js/base/protocol/protocol-sub-navigation.js",
         "js/base/base-page-init.js",


### PR DESCRIPTION
## One-line summary

This PR refactors the new navigation to remove old styles from the current nav. This is one of the steps to reduce new base CSS bundle size.

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15120
https://github.com/mozilla/bedrock/issues/15196

## Testing
1. Set `M24_NAVIGATION_AND_FOOTER` switch to be `on`
2. Check out this PR
3. Review navigation styles, it should look and function exactly like before refactoring