### PR TITLE
Fix CMS image download

### DIFF
--- a/bedrock/cms/management/commands/download_media_to_local.py
+++ b/bedrock/cms/management/commands/download_media_to_local.py
@@ -64,6 +64,16 @@ class Command(BaseCommand):
             image_key = f"media/cms/{image.file.name}"
             local_dest = build_path(settings.MEDIA_ROOT, image.file.name)
 
+            expected_output_dirs = [
+                os.path.join(settings.MEDIA_ROOT, "original_images"),
+                os.path.join(settings.MEDIA_ROOT, "images"),
+            ]
+
+            for dir_path in expected_output_dirs:
+                if not os.path.exists(dir_path):
+                    self.stdout.write(f"setting up: {dir_path}\n")
+                    os.makedirs(dir_path)
+
             if os.path.exists(local_dest) and not redownload:
                 self.stdout.write(f"Skipping: {local_dest} already exists locally.\n")
             else:

--- a/bedrock/cms/management/commands/download_media_to_local.py
+++ b/bedrock/cms/management/commands/download_media_to_local.py
@@ -65,10 +65,9 @@ class Command(BaseCommand):
             local_dest = build_path(settings.MEDIA_ROOT, image.file.name)
 
             expected_output_dirs = [
-                os.path.join(settings.MEDIA_ROOT, "original_images"),
-                os.path.join(settings.MEDIA_ROOT, "images"),
+                build_path(settings.MEDIA_ROOT, "original_images"),
+                build_path(settings.MEDIA_ROOT, "images"),
             ]
-
             for dir_path in expected_output_dirs:
                 if not os.path.exists(dir_path):
                     self.stdout.write(f"setting up: {dir_path}\n")

--- a/bedrock/cms/management/commands/download_media_to_local.py
+++ b/bedrock/cms/management/commands/download_media_to_local.py
@@ -79,7 +79,10 @@ class Command(BaseCommand):
                 blob = bucket.blob(image_key)
                 blob.download_to_filename(local_dest)
                 self.stdout.write(f"Downloaded {image_key} from {bucket_name} to {local_dest}\n")
-
+                if redownload:
+                    # The DB will still think it has renditions included, and we want to regenerate those
+                    self.stdout.write(f"Deleting DB records of old renditions for {image_key}\n")
+                    image.renditions.all().delete()
                 image._pre_generate_expected_renditions()
                 self.stdout.write("Triggered local generation of renditions\n")
 


### PR DESCRIPTION
This changeset fixes two issues with the CMS-image downloader:

1) If the output/target dirs did not exist, the downloader errored out (This situation would arise if a developer had not previously uploaded CMS images on their machine, which automatically does create the directories)

2) Ensure that when redownloading images, the DB renditions table is also wiped, else fresh renditions of the images being redownloaded will not be generated -- this could cause confusion if, say, the `original_images` directory is lost and restored with a `--redownload` option (where the renditions might then be stale) or if all of `custom-media` is lost and reinstated via `--redownload` then the renditions wouldn't exist at all, because the DB thinks they already exist.

## Testing

If you want to manually test this, it will require shredding your local CMS media, which you may not want to do - DM @stevejalim for a walkthrough