### PR TITLE
Add our fork of wagtaildraftsharing to Bedrock

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -756,6 +756,7 @@ INSTALLED_APPS = [
     "wagtail_localize",
     "wagtail_localize.locales",  # This replaces "wagtail.locales"
     "wagtail.search",
+    "wagtaildraftsharing",  # has to come before wagtail.admin due to template overriding; also needs wagtail.snippets
     "wagtail.admin",
     "wagtail",
     "modelcluster",
@@ -2080,6 +2081,7 @@ if WAGTAIL_ENABLE_ADMIN:
             "django-admin",
             "django-rq",
             "oidc",
+            "_internal_draft_preview",
         ]
     )
 
@@ -2153,6 +2155,11 @@ WAGTAIL_LOCALIZE_SMARTLING = {
     },
     "REFORMAT_LANGUAGE_CODES": False,  # don't force language codes into Django's all-lowercase pattern
 }
+
+WAGTAIL_DRAFTSHARING_ADMIN_MENU_POSITION = 9000
+# WAGTAIL_DRAFTSHARING_VERBOSE_NAME = "Internal Share"
+# WAGTAIL_DRAFTSHARING_VERBOSE_NAME_PLURAL = "Internal Shares"
+# WAGTAIL_DRAFTSHARING_MENU_ITEM_LABEL = "Create internal sharing link"
 
 # Custom settings, not a core Wagtail ones, to scope out RichText options
 WAGTAIL_RICHTEXT_FEATURES_FULL = [

--- a/bedrock/urls/mozorg_mode.py
+++ b/bedrock/urls/mozorg_mode.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from django.urls import include, path
 from django.utils.module_loading import import_string
 
+import wagtaildraftsharing.urls as wagtaildraftsharing_urls
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -68,6 +69,7 @@ if settings.WAGTAIL_ENABLE_ADMIN:
         path("cms-admin/", include(wagtailadmin_urls)),
         path("django-admin/", admin.site.urls),  # needed to show django-rq UI
         path("django-rq/", include("django_rq.urls")),  # task queue management
+        path("_internal_draft_preview/", include(wagtaildraftsharing_urls)),  # ONLY available in CMS mode
     )
 
 if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -120,6 +120,7 @@ check_status_and_handle_failure "Dumping wagtailcore.Locale"
 # wagtailcore.PageSubscription  # Excluded: dependent on User model
 # django_rq.Queue               # Excluded: irrelevant to local use and not a real DB table: data lives in Redis
 # django.contrib.admin.LogEntry # Excluded: dependent on User model
+# wagtaildraftsharing.Wagtaildraftsharinglink  # Excluded: sensitive, linked to user, and also irrelevant because the Revisions do not exist
 
 # Deliberate TEMPORARY INCLUSIONS (because without them we cannot load the data) - tables are
 # cleaned at the end, which is why they are in the tables_to_wipe_after_import variable, defined earlier.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2258,6 +2258,7 @@ wagtail==6.1.3 \
     #   wagtail-factories
     #   wagtail-localize
     #   wagtail-localize-smartling
+    #   wagtaildraftsharing
 wagtail-factories==4.2.1 \
     --hash=sha256:7a180fc1b074af7a78648c634740ee89d4dbb45899917744b66431d38155b6ae \
     --hash=sha256:bfe158092982a2b30a3e603c482242905df0b163fc69573fa6f159df482175c5
@@ -2271,6 +2272,9 @@ wagtail-localize==1.10 \
 wagtail-localize-smartling==0.3.0 \
     --hash=sha256:0b09d2986c464e5aaa632b250d4b8a4ac2a130101035106afe8c18030baec82b \
     --hash=sha256:4dc69b6bba8834f0bd3a91a482a8ed7727b6cd0b34aa3107f141d0033c7954a7
+    # via -r requirements/prod.txt
+wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.0.tar.gz#egg=wagtaildraftsharing \
+    --hash=sha256:085b641f63e55a85f38e5a56db943601fdff74cada9a4befc59b69db9c327377
     # via -r requirements/prod.txt
 wcwidth==0.2.13 \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -55,6 +55,7 @@ sentry-processor==0.0.1
 sentry-sdk==2.15.0
 supervisor==4.2.5
 timeago==1.0.16
+https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.0.tar.gz#egg=wagtaildraftsharing
 wagtail-localize-smartling==0.3.0
 wagtail-localize==1.10
 Wagtail==6.1.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1592,6 +1592,7 @@ wagtail==6.1.3 \
     #   -r requirements/prod.in
     #   wagtail-localize
     #   wagtail-localize-smartling
+    #   wagtaildraftsharing
 wagtail-localize==1.10 \
     --hash=sha256:11746223d5f20d898efff36042f730a3d499135b4a92945db01fc9769c47cb28 \
     --hash=sha256:ecde7efd366485ea325904efbbae5e50297f094f4b91ca8ac94aec04dd3b0ded
@@ -1601,6 +1602,9 @@ wagtail-localize==1.10 \
 wagtail-localize-smartling==0.3.0 \
     --hash=sha256:0b09d2986c464e5aaa632b250d4b8a4ac2a130101035106afe8c18030baec82b \
     --hash=sha256:4dc69b6bba8834f0bd3a91a482a8ed7727b6cd0b34aa3107f141d0033c7954a7
+    # via -r requirements/prod.in
+wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.0.tar.gz#egg=wagtaildraftsharing \
+    --hash=sha256:085b641f63e55a85f38e5a56db943601fdff74cada9a4befc59b69db9c327377
     # via -r requirements/prod.in
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \


### PR DESCRIPTION
This branch was originally a test harness for using https://github.com/mozmeao/wagtaildraftsharing/pull/1 in bedrock, but now it's just adding in the completed work from that PR.

In order to test drive this branch (using the steps outlined for reviewing that PR liked above), you need to carry out these steps:

1. Check out this branch by running `git fetch` on whatever your `mozilla` origin is called, then `git switch 15181--wagtail-page-review-without-auth`. 
2. `make install-local-python-deps` to get requirements installed - check that our fork of wagtaildraftsharing is being installed
3. `./manage.py migrate`
4. Start your runserver as usual and then go to https://github.com/mozmeao/wagtaildraftsharing/pull/1 to continue testing

## Related Issues

Resolves #15181