### PR TITLE
Show custom WNP 131 when no experiment params are present

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -950,12 +950,12 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_en_us_no_experiment(self, render_mock):
-        """Should use default WNP template for en-US when no experiment params are present"""
+        """Should use WNP 131 template for en-US when no experiment params are present"""
         req = self.rf.get("/firefox/whatsnew/")
         req.locale = "en-US"
         self.view(req, version="131.0")
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
+        assert template == ["firefox/whatsnew/whatsnew-fx131-na.html"]
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_en_us_v1(self, render_mock):
@@ -977,12 +977,12 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_en_ca_no_experiment(self, render_mock):
-        """Should use default WNP template for en-CA when no experiment params are present"""
+        """Should use WNP 131 template for en-CA when no experiment params are present"""
         req = self.rf.get("/firefox/whatsnew/")
         req.locale = "en-US"
         self.view(req, version="131.0")
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
+        assert template == ["firefox/whatsnew/whatsnew-fx131-na.html"]
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_en_ca_v1(self, render_mock):
@@ -1004,12 +1004,12 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_en_gb_no_experiment(self, render_mock):
-        """Should use default WNP template for en-GB when no experiment params are present"""
+        """Should use WNP 131 template for en-GB when no experiment params are present"""
         req = self.rf.get("/firefox/whatsnew/")
         req.locale = "en-GB"
         self.view(req, version="131.0")
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
+        assert template == ["firefox/whatsnew/whatsnew-fx131-eu.html"]
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_en_gb_v1(self, render_mock):
@@ -1040,12 +1040,12 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_de_no_experiment(self, render_mock):
-        """Should use default WNP template for de when no experiment params are present"""
+        """Should use WNP 131 template for de when no experiment params are present"""
         req = self.rf.get("/firefox/whatsnew/")
         req.locale = "de"
         self.view(req, version="131.0")
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
+        assert template == ["firefox/whatsnew/whatsnew-fx131-eu.html"]
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_de_v1(self, render_mock):
@@ -1076,12 +1076,12 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_fr_no_experiment(self, render_mock):
-        """Should use default WNP template for fr when no experiment params are present"""
+        """Should use WNP 131 template for fr when no experiment params are present"""
         req = self.rf.get("/firefox/whatsnew/")
         req.locale = "fr"
         self.view(req, version="131.0")
         template = render_mock.call_args[0][1]
-        assert template == ["firefox/whatsnew/index.html"]
+        assert template == ["firefox/whatsnew/whatsnew-fx131-eu.html"]
 
     @override_settings(DEV=True)
     def test_fx_131_0_0_fr_v1(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -591,15 +591,16 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("131."):
-            if nimbus_branch == "experiment-wnp-131-tabs":
+            if locale in ["en-US", "en-CA"]:
                 if nimbus_variant == "v1":
                     template = "firefox/whatsnew/index.html"
-                elif locale in ["en-US", "en-CA"] and nimbus_variant == "v2":
-                    template = "firefox/whatsnew/whatsnew-fx131-na.html"
-                elif locale in ["en-GB", "de", "fr"] and nimbus_variant in ["v3", "v4"]:
-                    template = "firefox/whatsnew/whatsnew-fx131-eu.html"
                 else:
+                    template = "firefox/whatsnew/whatsnew-fx131-na.html"
+            elif locale in ["en-GB", "de", "fr"]:
+                if nimbus_variant == "v1":
                     template = "firefox/whatsnew/index.html"
+                else:
+                    template = "firefox/whatsnew/whatsnew-fx131-eu.html"
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("130."):


### PR DESCRIPTION
## One-line summary

NA:

- http://localhost:8000/en-US/firefox/131.0/whatsnew/ (en-US no experiment, cookie protection)
- http://localhost:8000/en-US/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v1 (en-US control)
- http://localhost:8000/en-US/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v2 (en-US cookie protection)
- http://localhost:8000/en-CA/firefox/131.0/whatsnew/ (en-CA no experiment, cookie protection)
- http://localhost:8000/en-CA/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v1 (en-CA control)
- http://localhost:8000/en-CA/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v2 (en-CA cookie protection)

EU:

- http://localhost:8000/en-GB/firefox/131.0/whatsnew/ (en-GB no experiment, cookie protection)
- http://localhost:8000/en-GB/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v1 (en-GB control)
- http://localhost:8000/en-GB/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v3 (en-GB cookie protection)
- http://localhost:8000/en-GB/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v4 (en-GB protections dashboard)
- http://localhost:8000/de/firefox/131.0/whatsnew/ (DE no experiment, cookie protection)
- http://localhost:8000/de/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v1 (DE control)
- http://localhost:8000/de/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v3 (DE cookie protection)
- http://localhost:8000/de/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v4 (DE protections dashboard)
- http://localhost:8000/fr/firefox/131.0/whatsnew/ (FR no experiment, cookie protection)
- http://localhost:8000/fr/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v1 (FR control)
- http://localhost:8000/fr/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v3 (FR cookie protection)
- http://localhost:8000/fr/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v4 (FR protections dashboard)