### PR TITLE
H1 2024 Transparency Report

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,7 @@
 <nav class="prev-reports-nav">
   <h3>Previous Reports</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2023') }}">July-December 2023</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2023') }}">January-June 2023</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2022') }}">July-December 2022</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2022') }}">January-June 2022</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -15,7 +15,7 @@
     </li>
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2023') }}">July-December 2023 Report</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2024') }}">January 1, 2024 to June 30, 2024</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2024.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2024.html
@@ -1,0 +1,362 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}Transparency Report - July-December 2023{% endblock %}
+
+{% block report_title %}
+<h1>Transparency Report <span>Reporting Period: January 1, 2024 to June 30, 2024</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for User Data</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received the following.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Legal Processes</th>
+          <th scope="col">Received</th>
+          <th scope="col">User Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">Search Warrants</a>
+          </th>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">Subpoenas</a>
+          </th>
+          <td>3</td>
+          <td>2</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">Court Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">Wiretap Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">Pen Register Orders</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">Emergency Requests</a>
+          </th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">National Security Requests</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>0-249</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p id="footnote-1">
+        <sup>1</sup> We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for Content Removal</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received no government request for content removal from our services.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Requesting Country</th>
+          <th scope="col">Requests Received</th>
+          <th scope="col">Data Removed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Russia</th>
+          <td>5</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright-trademark-requests" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Copyright and Trademark Requests</h2>
+
+  <h3>Copyright</h3>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 27 Copyright Takedown Notices and 0 Counter Notices(note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>17</td>
+          <td>0</td>
+          <td>14</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>10</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+  <h3>Trademark</h3>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 31 Trademark Takedown Notices and 1 Counter Notice (note that takedown notices can target more than one item).</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+          <th scope="col">
+            Items Removed
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>30</td>
+          <td>1</td>
+          <td>27</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>1</td>
+          <td>0</td>
+          <td>0</td>
+          </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="other-content" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Legal Removal Requests By Companies or Individuals</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 0 private legal removal requests invoking laws other than copyright or trademark (note that takedown notices can target more than one item). Where takedown requests are made pursuant to national laws removal might be limited to the relevant jurisdiction.</p>
+  </div>
+</section>
+
+<section id="personal-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Personal Data Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, we received 7,323 requests.</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Received</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Mozilla</th>
+          <td>6,440</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>817</td>
+        </tr>
+        <tr>
+          <th scope="row">Fakespot</th>
+          <td>66</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="targeted-advertising" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Targeted Advertising Disclosures</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>In the Reporting Period, and during the time we started targeted advertising, we have placed the following targeted advertisements.</p>
+
+    <h3>Mozilla</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li><a href="https://assets.mozilla.net/pdf/transparency-report/h1-2024/firefox-eu-campaign.pdf">Firefox EU Campaign</a></li>
+      <li><a href="https://assets.mozilla.net/pdf/transparency-report/h1-2024/firefox-na-campaign.pdf">Firefox North America Campaign</a></li>
+    </ul>
+  </div>
+</section>
+
+<section id="monthly-active-users" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">EU Monthly Active Users</h2>
+
+  <div data-accordion-role="tabpanel">
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Average MAU in the European Union</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Addons.mozilla.org</th>
+          <td>2,755,114</td>
+        </tr>
+
+        <tr>
+          <th scope="row">MDN</th>
+          <td>2,379,021</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Policy Supplement</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      During the course of this reporting period, Mozilla continued its efforts to protect
+      the security and privacy of our users through public policy.
+    </p>
+    <p>
+      In Europe, we published our <a href="https://blog.mozilla.org/netpolicy/2024/07/17/mozillas-policy-vision-for-the-new-eu-mandate-advancing-openness-privacy-fair-competition-and-choice-for-all/">policy recommendations for the new EU mandate</a> outlining
+      our position on ensuring greater openness, privacy, fair competition, and meaningful choice online.
+      We also <a href="https://blog.mozilla.org/netpolicy/2024/03/27/pathways-to-a-fairer-digital-world-shaping-eu-rules-to-increase-consumer-protection-and-choice-online/">contributed</a> to the EU’s process of evaluating consumer protection rules and emphasized
+      that such rules should unequivocally incentivise the use and uptake of privacy-enhancing
+      technologies to balance personalization and respect for privacy online. At the Computers,
+      Privacy and Data Protection (CPDP) conference, we utilized the conference’s strong focus
+      on privacy to organize a panel on <a href="https://www.cpdpconferences.org/cpdp-panels/lifting-the-hood-on-big-ai-the-future-of-transparency-and-accountability-in-ai">accountability in AI</a>, highlighting the importance of transparency and responsibility in AI development.
+    </p>
+
+    <p>
+      Building on our work in 2023, we continued to engage in a dialogue with the European
+      Commission on the eIDAS legislation published in the official journal. We continued to
+      monitor the implementation of Article 45 to ensure encryption and web security are not weakened
+      by restricting the independence of browser root store programs to apply strict cybersecurity
+      requirements for website authentication.
+    </p>
+
+    <p>
+      In the United States, we engaged in discussions on comprehensive federal privacy proposals, including the <a href="https://blog.mozilla.org/netpolicy/2024/04/26/work-gets-underway-on-a-new-federal-privacy-proposal/">American Privacy Protection Act (APRA)</a>. We <a href="https://blog.mozilla.org/en/mozilla/internet-policy/mozilla-urges-federal-privacy-law-for-ai-development/">testified before Congress</a> on
+      the need for a comprehensive federal privacy law to ensure the responsible development of AI.
+      We also supported state privacy proposals modeled after the <a href="https://blog.mozilla.org/netpolicy/2024/01/11/mozilla-weighs-in-on-state-comprehensive-privacy-proposals/">American Data Privacy Protection Act (ADPPA)</a>
+      to ensure individuals’ security and privacy on the Internet are fundamental and are not
+      treated as optional. Additionally, we co-signed an <a href="https://blog.mozilla.org/netpolicy/2024/03/12/nevada-e2ee-amicus/">amicus brief in the Nevada vs. Meta case</a>, defending end-to-end
+      encryption to affirm our collective commitment to safeguarding encryption, digital privacy
+      and security as fundamental rights. Through our efforts to protect <a href="https://blog.mozilla.org/netpolicy/2024/04/26/net-neutrality-is-back/">net neutrality</a>, we highlighted the privacy implications of weakening
+      net neutrality in <a href="https://www.fcc.gov/ecfs/document/1011790221057/1">January's reply comments</a> to the FCC.
+    </p>
+
+    <p>
+      Globally, through the Global Encryption Coalition Steering Committee, we continue to
+      collectively advocate for the protection of encryption against regulatory efforts that aim
+      to weaken or undermine it. As a part of our collaborative efforts with GEC SC, we contributed
+      to the following activities: We joined allies in signing a <a href="https://www.globalencryption.org/2024/06/joint-statement-urging-australia-to-protect-end-to-end-encryption-in-the-online-safety-act-review/">joint statement</a> urging Australia to protect end-to-end encryption in the Online Safety Act review.
+      We also signed onto a letter outlining GEC’s <a href="https://www.globalencryption.org/2024/04/global-encryption-coalition-gec-sc-contribution-to-the-ongoing-discussions-at-the-uns-global-digital-compact/">concerns</a> about the Belgian Presidency's advocacy to use scanning technologies for
+      encrypted messaging services to prevent CSAM, without addressing the security and fundamental
+      rights concerns raised by experts. This statement was a follow-up of earlier GEC SC <a href="https://www.globalencryption.org/2024/04/statement-of-the-global-encryption-coalitions-steering-committee-on-the-belgian-presidencys-compromise-proposal-on-eu-csam/">comments</a> on the Belgian Presidency’s compromise proposal on EU CSAM.
+      We supported a statement delivered as a part of the open consultations on the zero draft of
+      the Global Digital Compact, <a href="https://www.globalencryption.org/wp-content/uploads/2024/04/Final_GEC-statement-on-the-GDC-Draft-Zero.pdf">articulating</a> the expert insights on protecting
+      and extending the use of strong encryption to protect human rights. We also joined GEC SC in <a href="https://www.globalencryption.org/2024/05/global-encryption-coalition-steering-committee-statement-in-support-of-the-inclusion-of-encryption-as-a-right-for-every-person-in-chile/">supporting</a> the Chilean government’s inclusion of encryption as a
+      right for every person in Chile through its <a href="https://www.bcn.cl/leychile/navegar?idNorma=1202434">Cybersecurity Law</a>. In the UK, GEC SC <a href="https://www.globalencryption.org/2024/02/comments-of-the-global-encryption-coalition-steering-committee-on-ofcoms/">recommended</a> that
+      Ofcom removes E2EE as a risk factor within risk assessments and that the Ofcom guidance be revised.
+      GEC SC also outlined <a href="https://www.globalencryption.org/2024/02/global-encryption-coalition-steering-committee-statement-on-proposed-revisions-to-the-uks-investigatory-powers-act/">concerns</a> on proposed revisions to the UK’s Investigatory Powers Act where the Amendment Bill
+      proposed changes that would interfere with the ability of providers to offer strong encryption in
+      their products, which in turn would harm the security of users not just in the UK, but around the world.
+    </p>
+
+    <p>
+      The policy team played a strong role in supporting product teams to ensure privacy continues
+      to be ingrained in our product offerings. We supported our product teams in testing <a href="https://blog.mozilla.org/netpolicy/2024/08/22/ppa-update/">Privacy-Preserving Attribution (PPA)</a> designed to
+      measure digital ad effectiveness without compromising user privacy. By using advanced
+      cryptographic methods, PPA aggregates data to assess ad impact without tracking individual
+      users, aligning with privacy regulations like GDPR. During the course of this reporting period,
+      Mozilla continued its efforts to protect the security and privacy of our users through public policy.
+    </p>
+
+    <h3>Voluntary Threat Indicators & Data Disclosures</h3>
+
+    <ul class="mzp-u-list-styled">
+      <li>0 Cybersecurity Threat Indicator Disclosures</li>
+      <li>0 Other Specific User Data Disclosures</li>
+    </ul>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -86,6 +86,7 @@ urlpatterns = [
     page("about/policy/transparency/jul-dec-2022/", "mozorg/about/policy/transparency/jul-dec-2022.html"),
     page("about/policy/transparency/jan-jun-2023/", "mozorg/about/policy/transparency/jan-jun-2023.html"),
     page("about/policy/transparency/jul-dec-2023/", "mozorg/about/policy/transparency/jul-dec-2023.html"),
+    page("about/policy/transparency/jan-jun-2024/", "mozorg/about/policy/transparency/jan-jun-2024.html"),
     page("contact/", "mozorg/contact/contact-landing.html"),
     page("contact/spaces/", "mozorg/contact/spaces/spaces-landing.html"),
     page("MPL/", "mozorg/mpl/index.html"),


### PR DESCRIPTION
## One-line summary

Added the new transparency report for January–June 2024

> [!NOTE]
> i messed up the commit message by saying h2 🤦🏼 

## Issue / Bugzilla link
Fixes https://github.com/mozilla/bedrock/issues/15239


## Testing

- [ ] http://localhost:8000/en-US/about/policy/transparency/jan-jun-2024/
- [ ] https://www-demo7.allizom.org/en-US/about/policy/transparency/jan-jun-2024/