### PR TITLE
Fix WNP 131 CTA for default custom template

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx131-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx131-eu.html
@@ -81,12 +81,12 @@
     <h2 class="wnp-main-title">{{ main_title }}</h2>
     <p class="wnp-main-tagline">{{ main_tagline }}</p>
 
-    {% if nimbus_variant == 'v3' %}
-      <a class="c-banner-button mzp-c-button mzp-t-product mzp-t-xl" href="https://support.mozilla.org/kb/introducing-total-cookie-protection-standard-mode?{{ utm_params }}" data-cta-type="button" data-cta-text="Learn more">
+    {% if nimbus_variant == 'v4' %}
+      <a id="protections-dashboard" class="c-banner-button mzp-c-button mzp-t-product mzp-t-xl" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?{{ utm_params }}" data-cta-type="button" data-cta-text="See my protections dashboard">
         {{ main_cta }}
       </a>
     {% else %}
-      <a id="protections-dashboard" class="c-banner-button mzp-c-button mzp-t-product mzp-t-xl" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?{{ utm_params }}" data-cta-type="button" data-cta-text="See my protections dashboard">
+      <a class="c-banner-button mzp-c-button mzp-t-product mzp-t-xl" href="https://support.mozilla.org/kb/introducing-total-cookie-protection-standard-mode?{{ utm_params }}" data-cta-type="button" data-cta-text="Learn more">
         {{ main_cta }}
       </a>
     {% endif %}


### PR DESCRIPTION
## One-line summary

Switches out the right CTA when the template is viewed without experiment params

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-GB/firefox/131.0/whatsnew/
http://localhost:8000/en-GB/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v4
http://localhost:8000/en-GB/firefox/131.0/whatsnew/?branch=experiment-wnp-131-tabs&variant=v3