### PR TITLE
Fix app store url examples in the docs

### DIFF
--- a/docs/attribution/0003-firefox-mobile.rst
+++ b/docs/attribution/0003-firefox-mobile.rst
@@ -29,8 +29,8 @@ Would render:
 
 .. code-block::
 
-    https://apps.apple.com/us/app/apple-store/id989804926?pt=373246&ct=firefox-home&mt=8
     https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dfirefox-home&hl=en
+    https://apps.apple.com/us/app/apple-store/id989804926?pt=373246&ct=firefox-home&mt=8
 
 For Firefox Focus:
 
@@ -43,8 +43,8 @@ Would render:
 
 .. code-block::
 
-    https://apps.apple.com/us/app/apple-store/id1055677337?pt=373246&ct=firefox-home&mt=8
-    https://play.google.com/store/apps/details?id=org.mozilla.focus&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dfirefox-home&hl=en
+    https://play.google.com/store/apps/details?id=org.mozilla.focus&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dfirefox-browsers-mobile-focus&hl=en
+    https://apps.apple.com/us/app/apple-store/id1055677337?pt=373246&ct=firefox-browsers-mobile-focus&mt=8
 
 App store redirects
 -------------------


### PR DESCRIPTION
## One-line summary

The example URLs in this doc are the wrong way around, and the Focus campaign string was incorrect: https://github.com/mozilla/bedrock/blob/main/docs/attribution/0003-firefox-mobile.rst#app-store-redirects

## Issue / Bugzilla link

N/A

## Testing

- `make livedocs`