### PR TITLE
Ignore non-useful JS error in Sentry

### DIFF
--- a/media/js/base/sentry-consent.es6.js
+++ b/media/js/base/sentry-consent.es6.js
@@ -33,7 +33,8 @@ const options = {
         'NS_ERROR_ABORT', // https://mozilla.sentry.io/share/issue/3a480856d1784ecdb3d8bbd647df0a7b/
         'NS_ERROR_FAILURE', // https://mozilla.sentry.io/share/issue/6361b063ea0d4528ac0ef07e181fbb96/
         'NetworkError when attempting to fetch resource',
-        'Non-Error promise rejection captured'
+        'Non-Error promise rejection captured',
+        "Unexpected token '<'"
     ]
 };
 


### PR DESCRIPTION
## One-line summary

Silences https://mozilla.sentry.io/issues/3334536137/?project=6260331

See https://github.com/getsentry/sentry-javascript/issues/6945 for context

## Issue / Bugzilla link

N/A