### PR TITLE
Shift wagtail menus to require staff

### DIFF
--- a/bedrock/cms/wagtail_hooks.py
+++ b/bedrock/cms/wagtail_hooks.py
@@ -5,12 +5,12 @@
 from django.urls import reverse
 
 from wagtail import hooks
-from wagtail.admin.menu import AdminOnlyMenuItem
+from wagtail.admin.menu import MenuItem
 
 
 @hooks.register("register_admin_menu_item")
 def register_task_queue_link():
-    return AdminOnlyMenuItem(
+    return MenuItem(
         "Task Queue",
         reverse("rq_home"),
         icon_name="tasks",
@@ -20,7 +20,7 @@ def register_task_queue_link():
 
 @hooks.register("register_admin_menu_item")
 def register_django_admin_link():
-    return AdminOnlyMenuItem(
+    return MenuItem(
         "Django Admin",
         reverse("admin:index"),
         icon_name="tasks",


### PR DESCRIPTION
## One-line summary

Shift wagtail menus to require staff, not superuser.

