### PR TITLE
Update bug writing guidelines link on /contact page (Fixes bug 1923262)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -68,7 +68,7 @@
             <li><a href="{{ url('foundation.licensing') }}">Browser distribution &amp; licensing</a></li>
             <li><a href="https://input.mozilla.org/feedback">Firefox feedback</a></li>
             <li><a href="https://support.mozilla.org/kb/websites-look-wrong-or-appear-differently">Report a broken site</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">How to report software issues</a></li>
+            <li><a href="https://bugzilla.mozilla.org/page.cgi?id=bug-writing.html">How to report software issues</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## One-line summary

The MDN redirect is broken for anyone who does not have English as their preferred language.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1923262

## Testing

http://localhost:8000/en-US/contact/