### PR TITLE
Prevent aria-hidden elements from receiving keyboard focus (Fixes #15137)

### DIFF
--- a/bedrock/firefox/templates/firefox/challenge-the-default/includes/toggles.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/includes/toggles.html
@@ -9,7 +9,7 @@
     <div class="toggle-grid small">
         {% for element in range(4) %}
           <label class="toggle" for="toggle-top-{{ loop.index }}">
-            <input type="checkbox" name="toggle" id="toggle-top-{{ loop.index }}" class="toggle-input" />
+            <input type="checkbox" name="toggle" id="toggle-top-{{ loop.index }}" class="toggle-input" tabindex="-1" />
             <span class="toggle-display"></span>
           </label>
         {% endfor %}
@@ -19,7 +19,7 @@
         </label>
         {% for element in range(4) %}
           <label class="toggle" for="toggle-bottom-{{ loop.index }}">
-            <input type="checkbox" name="toggle" id="toggle-bottom-{{ loop.index }}" class="toggle-input" />
+            <input type="checkbox" name="toggle" id="toggle-bottom-{{ loop.index }}" class="toggle-input" tabindex="-1" />
             <span class="toggle-display"></span>
           </label>
         {% endfor %}
@@ -27,17 +27,17 @@
     <div class="toggle-grid medium">
       {% for element in range(7) %}
       <label class="toggle" for="toggle-top-{{ loop.index }}">
-        <input type="checkbox" name="toggle" id="toggle-top-{{ loop.index }}" class="toggle-input" />
+        <input type="checkbox" name="toggle" id="toggle-top-{{ loop.index }}" class="toggle-input" tabindex="-1" />
         <span class="toggle-display"></span>
       </label>
       {% endfor %}
       <label class="toggle middle" for="toggle-middle">
-        <input type="checkbox" name="toggle" id="toggle-middle" class="toggle-input" />
+        <input type="checkbox" name="toggle" id="toggle-middle" class="toggle-input" tabindex="-1" />
         <span class="toggle-display"></span>
       </label>
       {% for element in range(7) %}
       <label class="toggle" for="toggle-bottom-{{ loop.index }}">
-        <input type="checkbox" name="toggle" id="toggle-bottom-{{ loop.index }}" class="toggle-input" />
+        <input type="checkbox" name="toggle" id="toggle-bottom-{{ loop.index }}" class="toggle-input" tabindex="-1" />
         <span class="toggle-display"></span>
       </label>
       {% endfor %}
@@ -45,17 +45,17 @@
     <div class="toggle-grid large">
       {% for element in range(10) %}
       <label class="toggle" for="toggle-top-{{ loop.index }}">
-        <input type="checkbox" name="toggle" id="toggle-top-{{ loop.index }}" class="toggle-input" />
+        <input type="checkbox" name="toggle" id="toggle-top-{{ loop.index }}" class="toggle-input" tabindex="-1" />
         <span class="toggle-display"></span>
       </label>
       {% endfor %}
       <label class="toggle middle" for="toggle-middle">
-        <input type="checkbox" name="toggle-middle" id="toggle-middle" class="toggle-input" />
+        <input type="checkbox" name="toggle-middle" id="toggle-middle" class="toggle-input" tabindex="-1" />
         <span class="toggle-display"></span>
       </label>
       {% for element in range(10) %}
       <label class="toggle" for="toggle-bottom-{{ loop.index }}">
-        <input type="checkbox" name="toggle" id="toggle-bottom-{{ loop.index }}" class="toggle-input" />
+        <input type="checkbox" name="toggle" id="toggle-bottom-{{ loop.index }}" class="toggle-input" tabindex="-1" />
         <span class="toggle-display"></span>
       </label>
       {% endfor %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/landing-base.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/landing-base.html
@@ -155,7 +155,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <div class="c-hero-top-controls" aria-hidden="true">
               <span class="hero-control-btn minimize"></span>
               <span class="hero-control-btn expand"></span>
-              <button type="button" class="hero-control-btn close">close</button>
+              <button type="button" class="hero-control-btn close" tabindex="-1">close</button>
           </div>
         </div>
         <div class="hero-content-wrapper">
@@ -318,7 +318,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </tbody>
         </table>
         <section aria-hidden="true">
-          <button type="button" class="kitten-button">=^._.^=</button>
+          <button type="button" class="kitten-button" tabindex="-1">=^._.^=</button>
         </section>
         <div class="comparison-cta">
           <h3>{{ compare_cta }}</h3>


### PR DESCRIPTION
## One-line summary

Prevents elements that are visible on the screen but contain `aria-hidden="true"` from receiving keyboard focus (having elements omitted from reading order but included in keyboard navigation can create a confusing state for screen readers).

## Issue / Bugzilla link

#15137

## Testing

http://localhost:8000/de/firefox/challenge-the-default/

- [ ] Easter egg elements that contain `aria-hidden="true"` should no longer be included in keyboard tab navigation order.