### PR TITLE
Stop changing VPN nav CTA button color (Fixes #15250)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -130,11 +130,11 @@
   <div class="vpn-nav-cta">
     {% if vpn_available %}
       {% set pricing_url = '#pricing' if request.path.endswith('/products/vpn/') else url('products.vpn.landing') + '#pricing' %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ pricing_url }}" data-cta-text="Get Mozilla VPN" data-cta-position="navigation" data-testid="get-mozilla-vpn-nav-button">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-product mzp-t-md" href="{{ pricing_url }}" data-cta-text="Get Mozilla VPN" data-cta-position="navigation" data-testid="get-mozilla-vpn-nav-button">
         {{ ftl('vpn-shared-subscribe-link') }}
       </a>
     {% else %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.invite') }}" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation" data-testid="join-waitlist-nav-button">
+      <a class="mzp-c-button mzp-t-secondary mzp-t-product mzp-t-md" href="{{ url('products.vpn.invite') }}" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation" data-testid="join-waitlist-nav-button">
         {{ ftl('vpn-shared-waitlist-link') }}
       </a>
     {% endif %}


### PR DESCRIPTION
## One-line summary

Updates the VPN nav button color to blue for consistency elsewhere.

## Issue / Bugzilla link

#15250

## Testing

- [ ] Using a non-Firefox browser open http://localhost:8000/en-US/ and confirm the "Get Mozilla VPN" button is blue.
- [ ] Navigate to http://localhost:8000/en-US/products/vpn/ and confirm the button is still the same blue (which also matches the VPN page CTA color).