### PR TITLE
Restore missing VPN shared string (Fixes #15257)

### DIFF
--- a/l10n/en/products/vpn/shared.ftl
+++ b/l10n/en/products/vpn/shared.ftl
@@ -76,6 +76,8 @@ vpn-shared-pricing-total = { $amount } total
 #   $amount (string) - a string containing the total annual subscription price together with the appropriate currency symbol e.g. '35,94 €'
 vpn-shared-pricing-total-plus-tax = { $amount } total + tax
 
+vpn-shared-mozilla-vpn-is-not-yet-available = { -brand-name-mozilla-vpn } is not yet available in your country
+
 # Platform subpage shared strings
 
 vpn-shared-platform-cta-headline = Let’s get started


### PR DESCRIPTION
## One-line summary

Restores a string that was accidentally removed in https://github.com/mozilla/bedrock/pull/15243

## Issue / Bugzilla link

#15257

## Testing

http://localhost:8000/en-US/products/vpn/?geo=cn