### PR TITLE
Added ESR link and updated primary link in Moments Page 

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page19.html
+++ b/bedrock/firefox/templates/firefox/welcome/page19.html
@@ -228,8 +228,13 @@
   <div class="mzp-l-content mzp-t-content-md mzp-u-centered">
     <h1 class="c-main-title">{{ main_title }}</h1>
     <p class="c-main-tagline">{{ main_tagline }}</p>
-    <p class="c-main-cta"><a href="{{ url('firefox.new') }}" class="mzp-c-button mzp-t-product mzp-t-xl" rel="external" data-cta-text="Update now">{{ cta_text }}</a></p>
+
+    <p class="c-main-cta" id="update-firefox"><a href="{{ url('firefox.download.thanks') }}" class="mzp-c-button mzp-t-product mzp-t-xl" id="update-client" rel="external" data-cta-text="Update now">{{ cta_text }}</a></p>
+
+    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" rel="external" data-cta-text="Update now">{{ cta_text }}</a></p>
+
     <small>{{ update_time }}</small>
+
   </div>
 </section>
 {% endblock %}
@@ -292,3 +297,8 @@
   </strong>
 </p>
 {% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_welcome_page19') }}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/welcome/page19.html
+++ b/bedrock/firefox/templates/firefox/welcome/page19.html
@@ -229,9 +229,9 @@
     <h1 class="c-main-title">{{ main_title }}</h1>
     <p class="c-main-tagline">{{ main_tagline }}</p>
 
-    <p class="c-main-cta" id="update-firefox"><a href="{{ url('firefox.download.thanks') }}" class="mzp-c-button mzp-t-product mzp-t-xl" id="update-client" rel="external" data-cta-text="Update now">{{ cta_text }}</a></p>
+    {{ download_firefox_thanks(alt_copy=cta_text, button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" rel="external" data-cta-text="Update now">{{ cta_text }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ cta_text }}</a></p>
 
     <small>{{ update_time }}</small>
 

--- a/media/css/firefox/welcome19.scss
+++ b/media/css/firefox/welcome19.scss
@@ -50,6 +50,16 @@ $image-path: '/media/protocol/img';
     text-wrap: balance;
 }
 
+// visible by default and used as a fallback, will be hidden via JS for ESR browsers
+#update-firefox {
+    display: block;
+}
+
+// not displayed by default, will be visible via JS for ESR browsers
+#update-firefox-esr {
+    display: none;
+}
+
 
 .mzp-l-columns {
     padding-top: 0;

--- a/media/js/firefox/welcome/welcome19.js
+++ b/media/js/firefox/welcome/welcome19.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+
+(function () {
+    'use strict';
+
+    const firefoxReleaseCTA = document.getElementById('update-firefox');
+    const firefoxEsrCTA = document.getElementById('update-firefox-esr');
+
+    Mozilla.UITour.getConfiguration('appinfo', function (details) {
+        if (details.defaultUpdateChannel === 'esr') {
+            firefoxEsrCTA.style.display = 'block';
+            firefoxReleaseCTA.style.display = 'none';
+        }
+    });
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1298,6 +1298,12 @@
       ],
       "name": "firefox_welcome_page16"
     },
+        {
+      "files": [
+        "js/firefox/welcome/welcome19.js"
+      ],
+      "name": "firefox_welcome_page19"
+    },
     {
       "files": [
         "js/firefox/new/desktop/download.js"


### PR DESCRIPTION
## One-line summary

The latest change came in to add a new CTA for ESR users + to update the primary CTA to take the user straight to the Download Firefox page.

>[!IMPORTANT]
> Make sure UITour is enabled in your ESR browser to test things. Find the steps here: https://bedrock.readthedocs.io/en/latest/uitour.html#local-development

## Issue / Bugzilla link

Fixes https://github.com/mozilla/bedrock/issues/15162

## Testing

- [ ] http://localhost:8000/en-US/firefox/welcome/19/
- [ ] https://www-demo6.allizom.org/en-US/firefox/welcome/19/
