### PR TITLE
Add a call to a DMS when the DB export script completes

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -312,3 +312,9 @@ echo "Restored original DATABASE_URL to $DATABASE_URL"
 check_status_and_handle_failure "Checking all_well at the end of the run"
 
 echo "Export to $output_db successful"
+
+# If all is well, ping DMS to avoid an alert being raised.
+if [[ -n "${DB_EXPORT_SCRIPT_DMS_URL}" ]]; then
+    curl "${DB_EXPORT_SCRIPT_DMS_URL}"
+    echo "Pinged snitch"
+fi

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -315,6 +315,6 @@ echo "Export to $output_db successful"
 
 # If all is well, ping DMS to avoid an alert being raised.
 if [[ -n "${DB_EXPORT_SCRIPT_DMS_URL}" ]]; then
-    curl "${DB_EXPORT_SCRIPT_DMS_URL}"
+    curl -m 10 --retry 5 "${DB_EXPORT_SCRIPT_DMS_URL}"
     echo "Pinged snitch"
 fi


### PR DESCRIPTION
## One-line summary

The DB export script is seeming pretty stable now, but never say never, so we should have a Dead Man's Snitch set up to alert us if the export starts to fail, as that has knock-on effects with sitemap generation and site-scanning, as well as local dev.

There's a complementary infra PR that can be merged before or after - the code will only run if the snitch URL is avaiable in the env

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Resolves #15221 
