### PR TITLE
Static nav for reduced motion fixes (#15275)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -153,6 +153,10 @@
             overflow: hidden auto;
             animation: nav-slide-in 0.45s ease;
 
+            @media (prefers-reduced-motion: reduce) {
+                animation: none;
+            }
+
             .m24-c-menu-category-list:has(.m24-c-menu-category.mzp-is-selected) {
                 margin-bottom: 0;
 
@@ -242,6 +246,10 @@
             overflow: hidden auto;
             margin-top: 98px;
             animation: nav-slide-in 0.45s ease;
+
+            @media (prefers-reduced-motion: reduce) {
+                animation: none;
+            }
 
             @media #{$mq-md} {
                 display: block;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -27,6 +27,37 @@
     }
 }
 
+// * -------------------------------------------------------------------------- */
+// Sticky navigation styles
+
+@supports (position: sticky) {
+    html.mzp-has-sticky-navigation {
+        .m24-navigation-refresh.m24-mzp-is-sticky {
+            @media #{$mq-md} {
+                @include transition(transform 300ms ease-in-out);
+                position: sticky;
+                z-index: 1000;
+
+                &.mzp-is-scrolling {
+                    // Shadow colors are equivalent to $color-ink-90, $color-blue-90, $color-ink-90
+                    // We can't use a $box-shadow token here because it needs a different size and offset
+                    box-shadow: 0 0 6px 1px rgba(29, 17, 51, 0.04), 0 0 8px 2px rgba(9, 32, 77, 0.12), 0 0 5px -3px rgba(29, 17, 51, 0.12);
+                }
+
+                &.mzp-is-hidden {
+                    @include transform(translate(0, -110%));
+                }
+            }
+        }
+    }
+
+    .m24-navigation-refresh {
+        @media (prefers-reduced-motion: reduce) and (#{$mq-md}) {
+            position: static;
+        }
+    }
+}
+
 // Common navigation styles
 .m24-c-navigation-l-content {
     position: relative;
@@ -529,31 +560,6 @@
         &:focus,
         &:active {
             top: 15px;
-        }
-    }
-}
-
-// * -------------------------------------------------------------------------- */
-// Sticky navigation styles
-
-@supports (position: sticky) {
-    html.mzp-has-sticky-navigation {
-        .m24-navigation-refresh.m24-mzp-is-sticky {
-            @media #{$mq-md} {
-                @include transition(transform 300ms ease-in-out);
-                position: sticky;
-                z-index: 1000;
-
-                &.mzp-is-scrolling {
-                    // Shadow colors are equivalent to $color-ink-90, $color-blue-90, $color-ink-90
-                    // We can't use a $box-shadow token here because it needs a different size and offset
-                    box-shadow: 0 0 6px 1px rgba(29, 17, 51, 0.04), 0 0 8px 2px rgba(9, 32, 77, 0.12), 0 0 5px -3px rgba(29, 17, 51, 0.12);
-                }
-
-                &.mzp-is-hidden {
-                    @include transform(translate(0, -110%));
-                }
-            }
         }
     }
 }

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -22,6 +22,10 @@
     left: 0;
     box-shadow: none;
 
+    @media (prefers-reduced-motion: reduce) {
+        position: static;
+    }
+
     @media #{$mq-md} {
         display: block;
     }
@@ -29,31 +33,22 @@
 
 // * -------------------------------------------------------------------------- */
 // Sticky navigation styles
-
 @supports (position: sticky) {
     html.mzp-has-sticky-navigation {
         .m24-navigation-refresh.m24-mzp-is-sticky {
-            @media #{$mq-md} {
-                @include transition(transform 300ms ease-in-out);
-                position: sticky;
-                z-index: 1000;
+            @include transition(transform 300ms ease-in-out);
+            position: sticky;
+            z-index: 1000;
 
-                &.mzp-is-scrolling {
-                    // Shadow colors are equivalent to $color-ink-90, $color-blue-90, $color-ink-90
-                    // We can't use a $box-shadow token here because it needs a different size and offset
-                    box-shadow: 0 0 6px 1px rgba(29, 17, 51, 0.04), 0 0 8px 2px rgba(9, 32, 77, 0.12), 0 0 5px -3px rgba(29, 17, 51, 0.12);
-                }
-
-                &.mzp-is-hidden {
-                    @include transform(translate(0, -110%));
-                }
+            &.mzp-is-scrolling {
+                // Shadow colors are equivalent to $color-ink-90, $color-blue-90, $color-ink-90
+                // We can't use a $box-shadow token here because it needs a different size and offset
+                box-shadow: 0 0 6px 1px rgba(29, 17, 51, 0.04), 0 0 8px 2px rgba(9, 32, 77, 0.12), 0 0 5px -3px rgba(29, 17, 51, 0.12);
             }
-        }
-    }
 
-    .m24-navigation-refresh {
-        @media (prefers-reduced-motion: reduce) and (#{$mq-md}) {
-            position: static;
+            &.mzp-is-hidden {
+                @include transform(translate(0, -110%));
+            }
         }
     }
 }


### PR DESCRIPTION
## One-line summary

This PR removes animation/transition for the nav when reduced motion preference has been specified. 

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15275

## Testing

1. Check out this PR
2. Set feature switch `M24_NAVIGATION_AND_FOOTER` to be `on`
3. Enable your device's "Reduced Motion" setting
4. Go to http://localhost:8000/en-US/
5. Scroll down the page, the nav animation shouldn't be visible
6. Resize the screen to mobile size and open menu
7. The menu content slide in animation shouldn't be visible