### PR TITLE
Fix icon path in navigation-refresh.scss (Fixes #15283)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -81,14 +81,13 @@
     }
 
     &.mzp-is-active {
-        background-color: $color-marketing-gray-20;
-        background-image: url('#{$image-path}/icons/close.svg');
-    }
+        background: url('/media/protocol/img/icons/close.svg') center center no-repeat;
+        width: 40px;
+        @include image-replaced;
 
-    &:not(.mzp-is-active) {
-        text-indent: unset;
-        background-image: none;
-        width: fit-content;
+        &::after {
+            content: none;
+        }
     }
 
     @media #{$mq-md} {


### PR DESCRIPTION
## One-line summary

The nav menu close icon was broken, due to a missing path

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15283

## Testing

`./manage.py waffle_switch M24_NAVIGATION_AND_FOOTER on`