### PR TITLE
Update Nothing Personal page app store URLs [fix #15274]

### DIFF
--- a/bedrock/firefox/templates/firefox/nothing-personal/index.html
+++ b/bedrock/firefox/templates/firefox/nothing-personal/index.html
@@ -24,8 +24,8 @@
 
 {% block site_header %}{% endblock %}
 
-{% set ios_url = app_store_url('firefox', 'firefox-nothing-personal') %}
-{% set android_url = play_store_url('firefox', 'firefox-nothing-personal') %}
+{% set ios_url = 'https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926?ppid=fb7ff70c-585e-4c32-bd90-f3abb0500d2a&ct=nothing-personal&mt=8' %}
+{% set android_url = 'https://play.google.com/store/apps/details?id=org.mozilla.firefox&listing=nothing-personal&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dnothing-personal' %}
 
 {% block content %}
   <header class="c-page-header">


### PR DESCRIPTION
## One-line summary
Updates the mobile app store URLs for more specific attribution.

## Issue / Bugzilla link
#15274 


## Testing
http://localhost:8000/firefox/nothing-personal/

App store badges are shown in the page header only on mobile.