### PR TITLE
Refresh: consolidate under a single waffle switch [fix #15289]

### DIFF
--- a/bedrock/base/templates/base-error.html
+++ b/bedrock/base/templates/base-error.html
@@ -16,7 +16,7 @@
   <div class="mzp-l-content">
     <div class="header-image">
       <a class="logo-mozilla" href="{{ url('mozorg.home') }}">
-        {% if switch('m24-logo') %}
+        {% if switch('m24-website-refresh') %}
           <img class="c-navigation-logo-image m24-logo" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('error-page-mozilla') }}"  width="192" height="46">
         {% else %}
           <img class="c-navigation-logo-image" src="{{ static('protocol/img/logos/mozilla/logo-word-hor.svg') }}" alt="{{ ftl('error-page-mozilla') }}"  width="140">

--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -9,13 +9,12 @@
 {% block body_class %}mzp-t-mozilla{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-global-styles') %}
+  {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
+    {% if LANG.startswith('en-') %}
+      {{ css_bundle('m24-navigation-and-footer') }}
+    {% endif %}
   {% else %}
     {{ css_bundle('protocol-mozilla') }}
-  {% endif %}
-  {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
-    {{ css_bundle('m24-root') }}
-    {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -72,14 +72,13 @@
     <!--[if !IE]><!-->
     {# Global styles, hidden from IE9 and lower #}
     {% block site_css %}
-      {% if switch('m24-global-styles') %}
+      {% if switch('m24-website-refresh') %}
         {{ css_bundle('protocol-mozilla-2024') }}
-      {% else %}
+        {% if LANG.startswith('en-') %}
+          {{ css_bundle('m24-navigation-and-footer') }}
+        {% endif %}
+          {% else %}
         {{ css_bundle('protocol-firefox') }}
-      {% endif %}
-      {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
-        {{ css_bundle('m24-root') }}
-        {{ css_bundle('m24-navigation-and-footer') }}
       {% endif %}
     {% endblock %}
 
@@ -141,7 +140,7 @@
         {{ js_bundle('lib') }}
         {{ js_bundle('fxa') }}
         {{ js_bundle('data') }}
-        {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
+        {% if switch('m24-website-refresh', ['en']) %}
           {{ js_bundle('m24-ui') }}
         {% else %}
           {{ js_bundle('ui') }}

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -6,13 +6,13 @@
 
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer' %}
 
-{% if switch('m24-navigation-and-footer')  and LANG.startswith('en-') %}
+{% if switch('m24-website-refresh', ['en']) %}
   {% include 'includes/protocol/footer/footer-refresh.html' %}
 {% else %}
 <footer class="mzp-c-footer {% if theme_class %}{{ theme_class }}{% endif %}" id="colophon" role="contentinfo">
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
-      <div class="mzp-c-footer-primary-logo {% if switch('m24-logo') %}m24-logo{% endif %}">
+      <div class="mzp-c-footer-primary-logo{% if switch('m24-website-refresh') %} m24-logo{% endif %}">
         <a href="{{ url('mozorg.home') }}" data-link-position="footer" data-link-text="Mozilla">{{ ftl('footer-mozilla') }}</a>
       </div>
       <div class="mzp-c-footer-sections">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
+{% if switch('m24-website-refresh', ['en']) %}
   {% include 'includes/protocol/navigation/navigation-refresh.html' %}
 {% else %}
   {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
@@ -22,7 +22,7 @@
         <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items" data-testid="navigation-menu-button">{{ ftl('navigation-v2-menu') }}</button>
         <div class="c-navigation-logo">
           <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
-          {% if switch('m24-logo') %}
+          {% if switch('m24-website-refresh') %}
             <img class="c-navigation-logo-image m24-logo" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ logo_alt }}" width="88" height="21">
           {% else %}
             <img class="c-navigation-logo-image" src="{{ static('protocol/img/logos/mozilla/logo-word-hor.svg') }}" alt="{{ logo_alt }}" width="112" height="32">

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -31,14 +31,13 @@
 
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
-  {% if switch('m24-global-styles') %}
+  {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
+    {% if LANG.startswith('en-') %}
+      {{ css_bundle('m24-navigation-and-footer') }}
+    {% endif %}
   {% else %}
     {{ css_bundle('protocol-firefox') }}
-  {% endif %}
-  {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
-    {{ css_bundle('m24-root') }}
-    {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}
 
   <!--[if IE]>

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -31,14 +31,13 @@
 
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
-  {% if switch('m24-global-styles') %}
+  {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
+    {% if LANG.startswith('en-') %}
+      {{ css_bundle('m24-navigation-and-footer') }}
+    {% endif %}
   {% else %}
     {{ css_bundle('protocol-firefox') }}
-  {% endif %}
-  {% if switch('m24-navigation-and-footer') and LANG.startswith('en-') %}
-    {{ css_bundle('m24-root') }}
-    {{ css_bundle('m24-navigation-and-footer') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -137,7 +137,7 @@ class HomeView(L10nTemplateView):
     def get_template_names(self):
         experience = self.request.GET.get("xv", None)
 
-        if switch("m24-home") and self.request.locale.startswith("en") and experience != "legacy":
+        if switch("m24-website-refresh") and self.request.locale.startswith("en") and experience != "legacy":
             return [self.m24_template_name]
         elif ftl_file_is_active("mozorg/home-new") and experience != "legacy":
             return [self.template_name]
@@ -153,7 +153,7 @@ class AboutView(L10nTemplateView):
     ftl_files_map = {template_name: ["mozorg/about"]}
 
     def get_template_names(self):
-        if switch("m24-about") and self.request.locale.startswith("en"):
+        if switch("m24-website-refresh") and self.request.locale.startswith("en"):
             return [self.m24_template_name]
 
         return [self.template_name]


### PR DESCRIPTION
## One-line summary
Merges all the different website refresh parts to use a single waffle switch.

For now several parts are still English-only (nav and footer globally, the home and about pages) but if we can get them localized for MVP we'll need to modify some logic for the added locales.

## Issue / Bugzilla link
#15289 


## Testing
Add and DEactivate the new switch:
`./manage.py waffle_switch --create M24_WEBSITE_REFRESH off`

The website should have the current branding.

Flip that switch on and the website should have the new branding.

You can then delete the obsolete switches:
```
M24_NAVIGATION_AND_FOOTER
M24_ABOUT
M24_HOME
M24_LOGO
M24_GLOBAL_STYLES
```