### PR TITLE
Expand a11y test coverage (#14773)

### DIFF
--- a/tests/playwright/specs/a11y/includes/urls.js
+++ b/tests/playwright/specs/a11y/includes/urls.js
@@ -10,18 +10,54 @@
  * URL paths for inclusion in page-level a11y scans.
  * Pages will be scanned at both desktop and mobile resolutions.
  */
-const pageTestURLs = [
+const desktopTestURLs = [
     '/de/firefox/built-for-you/',
     '/de/firefox/challenge-the-default/',
     '/en-US/',
     '/en-US/about/',
+    '/en-US/about/governance/policies/participation/',
+    '/en-US/about/leadership/',
+    '/en-US/about/manifesto/',
+    '/en-US/advertising/',
+    '/en-US/careers/',
+    '/en-US/careers/benefits/',
+    '/en-US/careers/diversity/',
+    '/en-US/careers/listings/',
+    '/en-US/careers/locations/',
+    '/en-US/careers/teams/',
+    '/en-US/contact/',
+    '/en-US/contribute/',
     '/en-US/firefox/',
     '/en-US/firefox/all/',
+    '/en-US/firefox/browsers/mobile/',
+    '/en-US/firefox/browsers/mobile/android/',
+    '/en-US/firefox/browsers/mobile/focus/',
+    '/en-US/firefox/browsers/mobile/ios/',
+    '/en-US/firefox/channel/android/',
     '/en-US/firefox/channel/desktop/',
+    '/en-US/firefox/developer/',
+    '/en-US/firefox/download/thanks/',
+    '/en-US/firefox/enterprise/',
     '/en-US/firefox/new/',
     '/en-US/firefox/nothing-personal/',
+    '/en-US/firefox/releasenotes/',
+    '/en-US/privacy/',
+    '/en-US/privacy/websites/cookie-settings/',
     '/en-US/products/',
-    '/en-US/products/vpn/'
+    '/en-US/products/vpn/',
+    '/en-US/products/vpn/download/',
+    '/en-US/products/vpn/features/',
+    '/en-US/products/vpn/pricing/'
 ];
 
-module.exports = { pageTestURLs };
+const mobileTestURLs = [
+    '/en-US/',
+    '/en-US/firefox/browsers/mobile/',
+    '/en-US/firefox/browsers/mobile/android/',
+    '/en-US/firefox/browsers/mobile/focus/',
+    '/en-US/firefox/browsers/mobile/ios/',
+    '/en-US/firefox/channel/android/',
+    '/en-US/firefox/new/'
+];
+
+module.exports = { desktopTestURLs, mobileTestURLs };

--- a/tests/playwright/specs/a11y/pages.spec.js
+++ b/tests/playwright/specs/a11y/pages.spec.js
@@ -8,10 +8,10 @@
 
 const openPage = require('../../scripts/open-page');
 const { createReport, scanPage } = require('./includes/helpers');
-const { pageTestURLs } = require('./includes/urls');
+const { desktopTestURLs, mobileTestURLs } = require('./includes/urls');
 const { test, expect } = require('@playwright/test');
 
-for (const url of pageTestURLs) {
+for (const url of desktopTestURLs) {
     test.describe(
         `${url} page (desktop)`,
         {
@@ -33,7 +33,7 @@ for (const url of pageTestURLs) {
     );
 }
 
-for (const url of pageTestURLs) {
+for (const url of mobileTestURLs) {
     test.describe(
         `${url} page (mobile)`,
         {


### PR DESCRIPTION
## One-line summary

Expands the a11y checker test job to a much larger set of URLs. Also creates separate URL lists for mobile and desktop scans, as many pages don't really change much when resized.

## Issue / Bugzilla link

#14773

## Testing

- `npm start`
- `cd tests/playwright`
- `npm run a11y-tests`