### PR TITLE
Prevent showing guarantee copy for VPN mobile subscription countries (Fixes #15262)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/macros.html
+++ b/bedrock/products/templates/products/vpn/includes/macros.html
@@ -73,25 +73,6 @@
 </section>
 {%- endmacro %}
 
-{% macro vpn_conditional_cta(position) -%}
-  {% if vpn_available %}
-    <a class="mzp-c-button mzp-t-xl" href="#pricing" data-cta-text="Scroll to pricing" data-cta-position="{{ position }}" data-testid="get-mozilla-vpn-{{ position }}-button">
-    {{ ftl('vpn-shared-subscribe-link') }}
-    </a>
-    <p class="guarantee-copy">
-      <a href="#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
-    </p>
-  {% else %}
-    <a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-text="Join the VPN Waitlist" data-cta-position="{{ position }}" data-testid="join-waitlist-{{ position }}-button">
-      {{ ftl('vpn-shared-waitlist-link') }}
-    </a>
-
-    <p class="availability-copy">
-      {{ ftl('vpn-shared-available-countries-v6') }}
-    </p>
-  {% endif %}
-{%- endmacro %}
-
 {% macro vpn_conditional_cta_refresh(position) -%}
   <div class="c-aside {{ position }} mzp-l-content mzp-t-content-xl">
     {% if vpn_available %}
@@ -101,27 +82,15 @@
           {{ ftl('vpn-shared-subscribe-link') }}
         </a>
       </p>
-      <p class="c-guarantee">{{ ftl('vpn-shared-features-guarantee') }}</p>
+      {% if not mobile_sub_only %}
+        <p class="c-guarantee">{{ ftl('vpn-shared-features-guarantee') }}</p>
+      {% endif %}
     {% else %}
       <p>
         <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.invite') }}" data-cta-text="Join the VPN Waitlist" data-testid="join-waitlist-{{ position }}-button">
           {{ ftl('vpn-shared-waitlist-link') }}
         </a>
       </p>
-    {% endif %}
-  </div>
-{%- endmacro %}
-
-{% macro vpn_nav_cta(link_text, alt_link_text, download_link_text, utm_source, utm_campaign) -%}
-  <div class="vpn-nav-cta">
-    {% if vpn_available %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="#pricing" data-cta-text="Get Mozilla VPN" data-cta-position="navigation" data-testid="get-mozilla-vpn-nav-button">
-        {{ ftl('vpn-shared-subscribe-link') }}
-      </a>
-    {% else %}
-      <a class="mzp-c-button mzp-t-secondary mzp-t-md" href="{{ url('products.vpn.invite') }}" data-cta-text="Join the VPN Waitlist" data-cta-position="navigation" data-testid="join-waitlist-nav-button">
-        {{ ftl('vpn-shared-waitlist-link') }}
-      </a>
     {% endif %}
   </div>
 {%- endmacro %}
@@ -151,25 +120,6 @@
     </div>
   {% endif %}
 </div>
-{%- endmacro %}
-
-{% macro vpn_content_media(heading, image, class_name=None, has_outline=False) -%}
-  <section class="vpn-content-media {% if has_outline %}has-outline{% endif %} {% if class_name %}{{ class_name }}{% endif %}">
-    <div class="vpn-content-media-image-container">
-      <div class="vpn-content-media-image">
-        {{ image }}
-      </div>
-    </div>
-
-    <div class="vpn-content-media-copy">
-      <div class="vpn-content-media-copy-container">
-        <h2 class="vpn-content-media-heading">{{ heading }}</h2>
-        <div class="vpn-content-media-desc">
-          {{ caller() }}
-        </div>
-      </div>
-    </div>
-  </section>
 {%- endmacro %}
 
 {% macro vpn_nav_platform_cta(alt_link_text) -%}

--- a/bedrock/products/templates/products/vpn/more/base-article.html
+++ b/bedrock/products/templates/products/vpn/more/base-article.html
@@ -22,9 +22,6 @@
     ) %}
     <div class="vpn-hero-cta">
       <p><a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}#pricing">{{ ftl('vpn-shared-subscribe-link') }}</a></p>
-      <p class="guarantee-copy">
-        <a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a>
-      </p>
     </div>
     {% endcall %}
   {% endblock %}
@@ -43,7 +40,6 @@
       <h3 class="vpn-content-well-title">{{ ftl('vpn-shared-subscribe-link') }}</h3>
       <div class="vpn-content-well-desc">
         <p><a class="mzp-c-button mzp-t-xl" href="{{ url('products.vpn.landing') }}#pricing">{{ ftl('vpn-shared-platform-cta-button') }}</a></p>
-        <p class="guarantee-copy"><a href="{{ url('products.vpn.landing') }}#faq-refunds">{{ ftl('vpn-shared-money-back-guarantee') }}</a></p>
       </div>
     {% endcall %}
   </div>

--- a/bedrock/products/templates/products/vpn/platforms/platform-base.html
+++ b/bedrock/products/templates/products/vpn/platforms/platform-base.html
@@ -43,9 +43,6 @@
       )
       ) %}
       <a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.landing') }}">{{ ftl('vpn-shared-subscribe-link')}}</a>
-      <p class="guarantee-copy">
-        {{ ftl('vpn-shared-money-back-guarantee') }}
-      </p>
     {% endcall %}
   {% endblock %}
 
@@ -59,7 +56,6 @@
   <div class="mzp-l-content mzp-t-content-lg c-vpn-platform-footer">
       <div class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-vpn">{{ ftl('vpn-shared-product-name') }}</div>
       <p><a class="mzp-c-button mzp-t-product mzp-t-xl" href="{{ url('products.vpn.landing') }}#pricing">{{ ftl('vpn-shared-subscribe-link') }}</a></p>
-      <p class="guarantee-copy">{{ftl('vpn-shared-money-back-guarantee') }}</p>
   </div>
   </main>
 {% endblock %}

--- a/bedrock/products/templates/products/vpn/resource-center/landing.html
+++ b/bedrock/products/templates/products/vpn/resource-center/landing.html
@@ -61,13 +61,14 @@
   ) %}
     <h1 class="resource-center-wordmark mzp-c-wordmark mzp-t-wordmark-sm mzp-t-product-vpn">{{ ftl('vpn-resource-center-mozilla-vpn') }}</h1>
     <h2 class="mzp-c-callout-title">{{ ftl('vpn-resource-center-start-protecting') }}</h2>
+    {% set link_text = ftl('vpn-shared-subscribe-link') if mobile_sub_only else vpn_saving(country_code=country_code, lang=LANG, ftl_string='vpn-shared-save-percent-on') %}
     {{ vpn_resource_center_cta(
       referral_id='vpn-resource-center',
-      link_text=vpn_saving(country_code=country_code, lang=LANG, ftl_string='vpn-shared-save-percent-on'),
+      link_text=link_text,
       alt_link_text=ftl('vpn-shared-waitlist-link'),
       class_name='mzp-c-button mzp-t-product',
     ) }}
-    {% if vpn_available %}
+    {% if vpn_available and not mobile_sub_only %}
     <p class="resource-center-cta-desc"><em>{{ ftl('vpn-shared-when-you-subscribe') }}</em></p>
     {% endif %}
   {% endcall %}

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -264,6 +264,7 @@ def resource_center_landing_view(request):
     ARTICLE_GROUP_SIZE = 6
     template_name = "products/vpn/resource-center/landing.html"
     vpn_available_in_country = vpn_available(request)
+    mobile_sub_only = vpn_available_mobile_sub_only(request)
     active_locales = locales_with_available_content(
         classification=CONTENT_CLASSIFICATION_VPN,
         content_type=CONTENT_TYPE_PAGE_RESOURCE_CENTER,
@@ -301,6 +302,7 @@ def resource_center_landing_view(request):
     ctx = {
         "active_locales": active_locales,
         "vpn_available": vpn_available_in_country,
+        "mobile_sub_only": mobile_sub_only,
         "category_list": category_list,
         "first_article_group": first_article_group,
         "second_article_group": second_article_group,

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1785,7 +1785,7 @@ VPN_COUNTRY_CODES = [
     "NZ",  # New Zealand
     "SG",  # Singapore
     # United Kingdom + "Territories"
-    "GB",  # United Kingdom of Great Britain and Northern Island
+    "GB",  # United Kingdom of Great Britain and Northern Ireland
     "GG",  # Guernsey (a British Crown dependency)
     "IM",  # Isle of Man (a British Crown dependency)
     "IO",  # British Indian Ocean Territory


### PR DESCRIPTION
## One-line summary

Prevents showing "12 month money back guarantee" copy in countries where subscriptions cannot be purchased directly through the website.

## Significant changes and points to review

- I also removed some old / unused macros
- There are a couple of old (orphaned) SEO pages where i simplified by removing the guarantee copy, rather than replicate all the country detection logic needed.

## Issue / Bugzilla link

#15262

## Testing

- http://localhost:8000/en-US/products/vpn/?geo=au
- http://localhost:8000/en-US/products/vpn/pricing/?geo=au
- http://localhost:8000/en-US/products/vpn/resource-center/?geo=au