### PR TITLE
Show Google Play Store CTA when on an iOS device in Android only country (Fixes #15328)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/mobile-subscribe.html
+++ b/bedrock/products/templates/products/vpn/includes/mobile-subscribe.html
@@ -16,10 +16,20 @@
       {% if heading %}
         <h2 class="u-title-lg">{{ heading }}</h2>
       {% endif %}
-      <p class="vpn-pricing-desktop-instruction u-body-lg">{{ ftl('vpn-pricing-scan-qrcode-to-download') }}</p>
+      <p class="vpn-pricing-desktop-instruction u-body-lg">
+        {% if android_sub_only %}
+          {{ ftl('vpn-pricing-scan-qrcode-to-download-android', fallback='vpn-pricing-scan-qrcode-to-download') }}
+        {% else %}
+          {{ ftl('vpn-pricing-scan-qrcode-to-download') }}
+        {% endif %}
+      </p>
 
       <ol class="vpn-pricing-mobile-steps u-body-lg">
-        <li><span>{{ ftl('vpn-pricing-sign-up-on-your-mobile-device') }}</span></li>
+        {% if android_sub_only %}
+          <li><span>{{ ftl('vpn-pricing-sign-up-on-your-android-device', fallback='vpn-pricing-sign-up-on-your-mobile-device') }}</span></li>
+        {% else %}
+          <li><span>{{ ftl('vpn-pricing-sign-up-on-your-mobile-device') }}</span></li>
+        {% endif %}
         <li><span>{{ ftl('vpn-pricing-connect-up-to-platforms', fallback='vpn-pricing-connect-up-to', devices=connect_devices) }}</span></li>
         <li><span>{{ ftl('vpn-pricing-access', servers=connect_servers, countries=connect_countries) }}</span></li>
       </ol>
@@ -50,12 +60,19 @@
       </ul>
 
       <p class="vpn-pricing-mobile-button">
-        <a class="ga-product-download ios-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ ios_url }}" data-cta-text="Play Store" data-cta-type="mozilla_vpn">
-          {{ ftl('vpn-pricing-download-the-app') }}
-        </a>
-        <a class="ga-product-download android-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ android_url }}" data-cta-text="App Store" data-cta-type="mozilla_vpn">
-          {{ ftl('vpn-pricing-download-the-app') }}
-        </a>
+        {# In countries where people can only subscribe using the Google Play Store, we always link to that even for iOS. See #15328. #}
+        {% if android_sub_only %}
+          <a class="ga-product-download mzp-c-button mzp-t-product mzp-t-xl" href="{{ android_url }}" data-cta-text="Play Store" data-cta-type="mozilla_vpn">
+            {{ ftl('vpn-pricing-download-the-app') }}
+          </a>
+        {% else %}
+          <a class="ga-product-download ios-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ ios_url }}" data-cta-text="App Store" data-cta-type="mozilla_vpn">
+            {{ ftl('vpn-pricing-download-the-app') }}
+          </a>
+          <a class="ga-product-download android-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ android_url }}" data-cta-text="Play Store" data-cta-type="mozilla_vpn">
+            {{ ftl('vpn-pricing-download-the-app') }}
+          </a>
+        {% endif %}
       </p>
     </div>
     <div class="mzp-c-split-media mzp-l-split-h-center">

--- a/l10n/en/products/vpn/pricing-2023.ftl
+++ b/l10n/en/products/vpn/pricing-2023.ftl
@@ -63,5 +63,7 @@ vpn-pricing-if-already-subscribed = If you’re already subscribed to { -brand-n
 ## Mobile only subscription copy
 
 vpn-pricing-scan-qrcode-to-download = To download the app, scan the QR Code with your mobile device or tablet
+vpn-pricing-scan-qrcode-to-download-android = To download the app, scan the QR Code with your Android device or tablet
 vpn-pricing-sign-up-on-your-mobile-device = Sign up for a { -brand-name-mozilla-vpn } subscription on your mobile device
+vpn-pricing-sign-up-on-your-android-device = Sign up for a { -brand-name-mozilla-vpn } subscription on your Android device
 vpn-pricing-download-the-app = Download the app


### PR DESCRIPTION
## One-line summary

Fixes an edge case: In countries where subscriptions are only enabled for the Google Play Store, we always want to link to there even if the visitor is on an iOS device.

## Issue / Bugzilla link

#15328

## Testing

1. Open http://localhost:8000/en-US/products/vpn/?geo=BR
2. Mock iOS by changing the `<html>` class name from `osx` to `ios`.
3. Scroll down to the "One subscription for all your devices" section.

- [ ] Step 1 should say "Sign up for a Mozilla VPN subscription on your Android device"
- [ ] The "Download the app" CTA should link to the Play Store.

![image](https://github.com/user-attachments/assets/db1d4d16-3d9a-40e8-aec1-2cc764b7abe4)
