### PR TITLE
Fix Andriod link on Nothing Personal page [#15274]

### DIFF
--- a/bedrock/firefox/templates/firefox/nothing-personal/index.html
+++ b/bedrock/firefox/templates/firefox/nothing-personal/index.html
@@ -25,7 +25,7 @@
 {% block site_header %}{% endblock %}
 
 {% set ios_url = 'https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926?ppid=fb7ff70c-585e-4c32-bd90-f3abb0500d2a&ct=nothing-personal&mt=8' %}
-{% set android_url = 'https://play.google.com/store/apps/details?id=org.mozilla.firefox&listing=nothing-personal&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dnothing-personal' %}
+{% set android_url = 'https://play.google.com/store/apps/details?id=org.mozilla.firefox&listing=nothing_personal&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3Dnothing-personal' %}
 
 {% block content %}
   <header class="c-page-header">


### PR DESCRIPTION
## One-line summary
Changes a dash to an underscore in the Play Store URL, which is set up in the Play Store to show a custom "nothing personal" branded page.

## Issue / Bugzilla link
#15274 

## Testing
http://localhost:8000/firefox/nothing-personal/

You'll need to test on an Android device (faked in dev tools, browserstack, or real). Click the Play Store link should load a customized page showing nothing personal branded screenshots.