### PR TITLE
15330  add animated gif support to cms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 8000
 CMD ["./bin/run.sh"]
 
 COPY docker/bin/apt-install /usr/local/bin/
-RUN apt-install gettext libxslt1.1 git curl sqlite3
+RUN apt-install gettext libxslt1.1 git curl sqlite3 libmagickwand-dev
 
 # copy in Python environment
 COPY --from=python-builder /venv /venv

--- a/bedrock/cms/models/images.py
+++ b/bedrock/cms/models/images.py
@@ -22,6 +22,11 @@ AUTOMATIC_RENDITION_FILTER_SPECS = [
 ]
 
 
+def _make_renditions(image_id, filter_specs):
+    image = BedrockImage.objects.get(id=image_id)
+    image.get_renditions(*filter_specs)
+
+
 class BedrockImage(AbstractImage):
     """
     Custom image model from which we can hang extra methods, such as the one that
@@ -64,9 +69,12 @@ class BedrockImage(AbstractImage):
         # If a background worker queue is available, this call will use it
         # to generate renditions, else it will immediately generate them
         defer_task(
-            self.get_renditions,
+            _make_renditions,
             queue_name="image_renditions",
-            func_args=AUTOMATIC_RENDITION_FILTER_SPECS,
+            func_kwargs={
+                "image_id": self.id,
+                "filter_specs": AUTOMATIC_RENDITION_FILTER_SPECS,
+            },
         )
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2299,6 +2299,10 @@ wagtail-localize-smartling==0.3.0 \
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.1.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:606c45c305dda042f8d058ef49d789cab5cced4c6905adebb82620e8ebbcf1cd
     # via -r requirements/prod.txt
+wand==0.6.13 \
+    --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \
+    --hash=sha256:f5013484eaf7a20eb22d1821aaefe60b50cc329722372b5f8565d46d4aaafcca
+    # via -r requirements/prod.txt
 wcwidth==0.2.13 \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \
     --hash=sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -59,5 +59,6 @@ timeago==1.0.16
 https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.1.tar.gz#egg=wagtaildraftsharing
 wagtail-localize-smartling==0.3.0
 wagtail-localize==1.10
+Wand==0.6.13  # For animated GIF support
 Wagtail==6.1.3
 whitenoise==6.7.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1640,6 +1640,10 @@ wagtail-localize-smartling==0.3.0 \
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.1.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:606c45c305dda042f8d058ef49d789cab5cced4c6905adebb82620e8ebbcf1cd
     # via -r requirements/prod.in
+wand==0.6.13 \
+    --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \
+    --hash=sha256:f5013484eaf7a20eb22d1821aaefe60b50cc329722372b5f8565d46d4aaafcca
+    # via -r requirements/prod.in
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923


### PR DESCRIPTION
## One-line summary

This changeset adds support for generating renditions of animated GIFs, using the Python Wand library (which wraps ImageMagick)

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

This is working locally when I don't have a task queue enabled, but it is blowing up when we do have a task queue enabled. However, that may be just on my local system (and the local system doesn't _need_ the task queue running). So I'm keen to get this onto Dev and see how it goes in the real infra. Worst case, renditions will fail to be generated for animated GIFs and we'll have to do those synchronously on save (which should hopefully be fine as long as the job takes <30 secs to avoid a k8s timeout), and I'll patch that work in immediately if we need it.


## Issue / Bugzilla link

#15330


## Testing

Will be tested manually on Dev as soon as it lands
