### PR TITLE
Refresh: Separate nav and footer styles from protocol base

### DIFF
--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -13,6 +13,8 @@
     {{ css_bundle('protocol-mozilla-2024') }}
     {% if LANG.startswith('en-') %}
       {{ css_bundle('m24-navigation-and-footer') }}
+    {% else %}
+      {{ css_bundle('legacy-navigation-and-footer') }}
     {% endif %}
   {% else %}
     {{ css_bundle('protocol-mozilla') }}

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -76,8 +76,10 @@
         {{ css_bundle('protocol-mozilla-2024') }}
         {% if LANG.startswith('en-') %}
           {{ css_bundle('m24-navigation-and-footer') }}
+        {% else %}
+          {{ css_bundle('legacy-navigation-and-footer') }}
         {% endif %}
-          {% else %}
+      {% else %}
         {{ css_bundle('protocol-firefox') }}
       {% endif %}
     {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -35,6 +35,8 @@
     {{ css_bundle('protocol-mozilla-2024') }}
     {% if LANG.startswith('en-') %}
       {{ css_bundle('m24-navigation-and-footer') }}
+    {% else %}
+      {{ css_bundle('legacy-navigation-and-footer') }}
     {% endif %}
   {% else %}
     {{ css_bundle('protocol-firefox') }}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -35,6 +35,8 @@
     {{ css_bundle('protocol-mozilla-2024') }}
     {% if LANG.startswith('en-') %}
       {{ css_bundle('m24-navigation-and-footer') }}
+    {% else %}
+      {{ css_bundle('legacy-navigation-and-footer') }}
     {% endif %}
   {% else %}
     {{ css_bundle('protocol-firefox') }}

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import 'footer-newsletter';
-
 $max-footer-content-width: $content-max;
 
 @mixin divider-line {

--- a/media/css/m24/navigation-and-footer.scss
+++ b/media/css/m24/navigation-and-footer.scss
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+// variables
+@import 'vars/animation';
+@import 'vars/color';
+@import 'vars/fonts';
+@import 'vars/grid';
+@import 'vars/spacing';
+@import 'vars/text';
+
+// global components
+@import 'components/footer-newsletter';
+@import 'components/footer-refresh';
+@import 'components/navigation-refresh';

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -36,6 +36,14 @@ $image-path: '/media/protocol/img';
             &.twitter {
                 background-image: url('#{$image-path}/icons/social/x/white.svg');
             }
+
+            &.instagram {
+                background-image: url('#{$image-path}/icons/social/instagram/white.svg');
+            }
+
+            &.youtube {
+                background-image: url('#{$image-path}/icons/social/youtube/white.svg');
+            }
         }
     }
 }

--- a/media/css/protocol/navigation-and-footer.scss
+++ b/media/css/protocol/navigation-and-footer.scss
@@ -11,3 +11,17 @@
 @import 'components/navigation';
 @import 'components/menu';
 @import 'components/menu-item';
+
+// temporary branding refresh tweaks
+.c-navigation-logo .c-navigation-logo-image.m24-logo {
+    @media #{$mq-md} {
+        height: 21px;
+        position: relative;
+        top: 1px;
+    }
+}
+
+.mzp-c-footer-primary-logo.m24-logo a {
+    background-image: url('/media/img/logos/m24/lockup-white.svg');
+    height: 27px;
+}

--- a/media/css/protocol/navigation-and-footer.scss
+++ b/media/css/protocol/navigation-and-footer.scss
@@ -2,17 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
-// variables
-@import 'vars/animation';
-@import 'vars/color';
-@import 'vars/fonts';
-@import 'vars/grid';
-@import 'vars/spacing';
-@import 'vars/text';
+@import '~@mozilla-protocol/core/protocol/css/components/footer';
+@import '~@mozilla-protocol/core/protocol/css/components/language-switcher';
 
-// global components
-@import 'components/footer-refresh';
-@import 'components/navigation-refresh';
+@import 'components/footer';
+@import 'components/navigation';
+@import 'components/menu';
+@import 'components/menu-item';

--- a/media/css/protocol/protocol-firefox.scss
+++ b/media/css/protocol/protocol-firefox.scss
@@ -85,17 +85,3 @@ template {
 .mzp-c-wordmark.t-product-mozilla-monitor {
     background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
 }
-
-// temporary branding refresh tweaks
-.c-navigation-logo .c-navigation-logo-image.m24-logo {
-    @media #{$mq-md} {
-        height: 21px;
-        position: relative;
-        top: 1px;
-    }
-}
-
-.mzp-c-footer-primary-logo.m24-logo a {
-    background-image: url('/media/img/logos/m24/lockup-white.svg');
-    height: 27px;
-}

--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -20,8 +20,6 @@
 
 // Global components
 @import '~@mozilla-protocol/core/protocol/css/components/button';
-@import '~@mozilla-protocol/core/protocol/css/components/footer';
-@import '~@mozilla-protocol/core/protocol/css/components/language-switcher';
 @import 'components/download-button';
 
 // Consent banner
@@ -29,10 +27,6 @@
 
 // Custom global components for nav and footer
 // These will later be backported to Protocol
-@import 'components/footer';
-@import 'components/navigation';
-@import 'components/menu';
-@import 'components/menu-item';
 @import 'components/sub-navigation';
 
 // Mozilla 2024 brand variables

--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -85,12 +85,6 @@ template {
     background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
 }
 
-// temporary logo refresh for old footer
-.mzp-c-footer-primary-logo.m24-logo a {
-    background-image: url('/media/img/logos/m24/lockup-white.svg');
-    height: 27px;
-}
-
 /* ----------------------------------------------------------------------------- */
 // Mozilla 2024 brand theme
 :root {

--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -95,16 +95,3 @@ template {
 .mzp-c-wordmark.t-product-mozilla-monitor {
     background-image: url('/media/img/logos/mozilla/monitor/wordmark.svg');
 }
-
-.c-navigation-logo .c-navigation-logo-image.m24-logo {
-    @media #{$mq-md} {
-        height: 21px;
-        position: relative;
-        top: 1px;
-    }
-}
-
-.mzp-c-footer-primary-logo.m24-logo a {
-    background-image: url('/media/img/logos/m24/lockup-white.svg');
-    height: 27px;
-}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -251,12 +251,6 @@
     },
     {
       "files": [
-        "css/m24/base-navigation-and-footer.scss"
-      ],
-      "name": "m24-navigation-and-footer"
-    },
-    {
-      "files": [
         "css/legal/legal.scss"
       ],
       "name": "legal"
@@ -1166,6 +1160,18 @@
         "css/protocol/protocol-mozilla-2024.scss"
       ],
       "name": "protocol-mozilla-2024"
+    },
+    {
+      "files": [
+        "css/m24/navigation-and-footer.scss"
+      ],
+      "name": "m24-navigation-and-footer"
+    },
+    {
+      "files": [
+        "css/protocol/navigation-and-footer.scss"
+      ],
+      "name": "legacy-navigation-and-footer"
     }
   ],
   "js": [


### PR DESCRIPTION
## One-line summary
Removes the nav and footer styles from the refreshed Protocol and sets them up in separate bundles. This lets us load only the styling for the appropriate components based on the page language.

This is based on #15312 but is a simplified approach.

## Issue / Bugzilla link
#15120

## Testing
Test with the `M24_WEBSITE_REFRESH` switch both off and on. When off, the site should be all the legacy Mozilla branding. When on, it gets the refreshed branding.

English pages should get the new nav and footer, non-English pages should get the old nav and footer.
