### PR TITLE
VPN mobile subscription misc fixes (Fixes #15328)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/mobile-subscribe.html
+++ b/bedrock/products/templates/products/vpn/includes/mobile-subscribe.html
@@ -60,19 +60,16 @@
       </ul>
 
       <p class="vpn-pricing-mobile-button">
-        {# In countries where people can only subscribe using the Google Play Store, we always link to that even for iOS. See #15328. #}
-        {% if android_sub_only %}
-          <a class="ga-product-download mzp-c-button mzp-t-product mzp-t-xl" href="{{ android_url }}" data-cta-text="Play Store" data-cta-type="mozilla_vpn">
-            {{ ftl('vpn-pricing-download-the-app') }}
-          </a>
-        {% else %}
-          <a class="ga-product-download ios-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ ios_url }}" data-cta-text="App Store" data-cta-type="mozilla_vpn">
-            {{ ftl('vpn-pricing-download-the-app') }}
-          </a>
-          <a class="ga-product-download android-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ android_url }}" data-cta-text="Play Store" data-cta-type="mozilla_vpn">
-            {{ ftl('vpn-pricing-download-the-app') }}
-          </a>
+        {# Only show iOS download CTA if Apple App Store subscriptions are available in a person's country. See #15328. #}
+        {% if not android_sub_only %}
+        <a class="ga-product-download ios-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ ios_url }}" data-cta-text="App Store" data-cta-type="mozilla_vpn">
+          {{ ftl('vpn-pricing-download-the-app') }}
+        </a>
         {% endif %}
+
+        <a class="ga-product-download android-cta mzp-c-button mzp-t-product mzp-t-xl" href="{{ android_url }}" data-cta-text="Play Store" data-cta-type="mozilla_vpn">
+          {{ ftl('vpn-pricing-download-the-app') }}
+        </a>
       </p>
     </div>
     <div class="mzp-c-split-media mzp-l-split-h-center">
@@ -88,7 +85,7 @@
           url='img/products/vpn/landing-refresh/qrcode-background.svg',
           sources=[
             {
-              'media': '(max-width: 768px)',
+              'media': '(max-width: 767px)',
               'srcset': {
                 'img/placeholder.png': 'default'
               }


### PR DESCRIPTION
## One-line summary

- Fixes an issue where the QRCode background image is not displayed when the browser window is exactly 768px wide.
- Also hides the blue "Download the app" CTA on iOS when the user is in a country where Apple subscriptions are not supported.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/VPN-6674
#15328

## Testing

1. Open http://localhost:8000/en-US/products/vpn/?geo=br
2. Open dev tools / responsive design mode.
3. Resize the viewport to 768px.

- [x] Verify the QRCode background image is displayed correctly.

Next, change the platform class on the `<html>` element from `osx` to `ios`.

- [x] Verify the blue "Download the app" button is not longer displayed.

Now change the platform class from `ios` to `android`.

- [x] Verify the blue "Download the app" button is displayed, and clicking it goes to the Google Play Store.