### PR TITLE
Update wording in Nothing Personal page's metadata

### DIFF
--- a/bedrock/firefox/templates/firefox/nothing-personal/index.html
+++ b/bedrock/firefox/templates/firefox/nothing-personal/index.html
@@ -15,12 +15,12 @@
   {{ css_bundle('protocol-newsletter') }}
 {% endblock %}
 
-{% block page_title_prefix %}Nothing Personal{% endblock %}
+{% block page_title_prefix %}Firefox - Nothing Personal. Just Browsing.{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 
 {% block page_image %}{{ static('img/firefox/nothing-personal/meta-img.png') }}{% endblock %}
 {% block page_og_title %}Firefox. Nothing personal. Just browsing.{% endblock %}
-{% block page_desc %}Firefox isn’t that interested in your data. No offense.{% endblock %}
+{% block page_desc %}Firefox browser is fast, reliable and private. We really don’t need your personal data to help you get where you need to go online.{% endblock %}
 
 {% block site_header %}{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Updates copy in head elements as per issue.

- [ ] I used an AI to write some of this code.


## Issue / Bugzilla link

Resolves #15355 

## Testing

Go to http://localhost:8000/en-US/firefox/nothing-personal/ and view source, looking for title and meta name="description" tags