### PR TITLE
Ensure pre-commit uses LTS version of node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ exclude: >
     | bedrock/externalfiles/files_cache
     | git-repos
   )
+
+default_language_version:
+  node: lts
+
 repos:
   # Note: hooks that add content must run before ones which check formatting, lint, etc
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Since Node 23 came out, fresh installs or updates to our pre-commit hooks will fail for eslint. This is because pre-commit will pick the very new version of Node, because we haven't told it not to.

This change tells pre-commit to use the LTS version installed on the system, which will match what we use for main Bedrock

- [ ] I used an AI to write some of this code.

## Testing

On `main`: 
```
pre-commit clean
pre-commit install-hooks
```
This will fail for eslint

On this branch - and assuming you have an LTS version of Node installed (eg 20)
```
pre-commit clean
pre-commit install-hooks
```
will now install fine