### PR TITLE
Fix accessibility issues on careers pages

### DIFF
--- a/bedrock/careers/templates/careers/includes/footer.html
+++ b/bedrock/careers/templates/careers/includes/footer.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 {% block careers_bottom %}
-<section class="c-careers-bottom">
+<aside class="c-careers-bottom">
   {% call split(
     block_class='mzp-l-split-center-on-sm-md mzp-l-split-reversed mzp-t-split-nospace',
     media_class='mzp-l-split-h-center mzp-l-split-media-overflow',
@@ -42,5 +42,5 @@
         </li>
     </ul>
   {% endcall %}
-</section>
+</aside>
 {% endblock %}

--- a/bedrock/careers/templates/careers/listings.html
+++ b/bedrock/careers/templates/careers/listings.html
@@ -42,9 +42,9 @@
   <table class="listings-positions" id="listings-positions">
     <thead>
       <tr>
-        <th class="title" scope="col"><h4>Job Title</h4></th>
-        <th class="location" scope="col"><h4>Location</h4></th>
-        <th class="name" scope="col"><h4>Team</h4></th>
+        <th class="title" scope="col"><h3>Job Title</h3></th>
+        <th class="location" scope="col"><h3>Location</h3></th>
+        <th class="name" scope="col"><h3>Team</h3></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## One-line summary

Addresses a11y issues - thanks @alexgibson for the tips!

Moving to a h3 from a h4 on the careers listing page did make the font size slightly larger. It looks fine, but of course I'm happy to try to  match the original h4 size with CSS if reviewers think it's worth it.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Resolves #15338 


## Testing
Run a11y tests - there should now be 14 failures, down from 20, and no failures on the careers pages.