### PR TITLE
[Refresh] Navigation positioning fix

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- <div class="m24-navigation-refresh m24-mzp-is-sticky">
+ <nav class="m24-navigation-refresh m24-mzp-is-sticky" role="navigation">
   <div class="m24-c-navigation-l-content">
     <div class="m24-c-navigation-container">
       <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>
@@ -15,15 +15,15 @@
       </div>
       <div class="m24-c-navigation-items" id="m24-c-navigation-items" data-testid="m24-navigation-menu-items">
         <div class="m24-c-navigation-menu">
-          <nav class="m24-c-menu m24-mzp-is-basic">
+          <div class="m24-c-menu m24-mzp-is-basic">
             <ul class="m24-c-menu-category-list">
               {% include 'includes/protocol/navigation/menus-refresh/firefox.html' %}
               {% include 'includes/protocol/navigation/menus-refresh/products.html' %}
               {% include 'includes/protocol/navigation/menus-refresh/about-us.html' %}
             </ul>
-          </nav>
+          </div>
         </div><!-- close .m24-c-navigation-menu -->
       </div><!-- close .m24-c-navigation-items -->
     </div><!-- close .m24-c-navigation-container -->
   </div><!-- close .m24-c-navigation-l-content -->
-</div>
+</nav>

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -5,9 +5,6 @@
 #}
 
 {% if switch('m24-website-refresh', ['en']) %}
-  <div class="c-banner c-banner-is-visible mzp-u-centered">
-    <h2>This is some kind of promo, hello!</h2>
-  </div>
   {% include 'includes/protocol/navigation/navigation-refresh.html' %}
 {% else %}
   {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -5,6 +5,9 @@
 #}
 
 {% if switch('m24-website-refresh', ['en']) %}
+  <div class="c-banner c-banner-is-visible mzp-u-centered">
+    <h2>This is some kind of promo, hello!</h2>
+  </div>
   {% include 'includes/protocol/navigation/navigation-refresh.html' %}
 {% else %}
   {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -80,11 +80,12 @@
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
+        position: static;
     }
 }
 
 .m24-c-navigation-menu-button {
-    background-color: $m24-color-medium-gray;
+    background-color: inherit;
     margin: 0;
     padding: 0;
     color: $color-black;
@@ -107,7 +108,7 @@
     }
 
     &.mzp-is-active {
-        background: url('/media/protocol/img/icons/close.svg') center center no-repeat;
+        background: transparent url('/media/protocol/img/icons/close.svg') center center no-repeat;
         width: 40px;
         @include image-replaced;
 
@@ -140,7 +141,6 @@
             right: 0;
             width: 100%;
             height: calc(100vh - 48px); // 48px margin top
-            background-color: #fff;
             transition: 0.45s;
             margin-top: 48px;
             padding-top: 0;
@@ -195,17 +195,13 @@
     }
 
     &.mzp-is-selected {
-        position: absolute;
-        top: 0;
-        left: 0;
         z-index: 1000;
         width: calc(100% - 32px);
         border-bottom: transparent;
+        position: static;
 
         @media #{$mq-md} {
-            width: fit-content;
-            position: unset;
-            min-width: unset;
+            width: auto;
         }
 
         &::before {
@@ -220,7 +216,6 @@
             @media #{$mq-md} {
                 color: $m24-color-dark-green;
                 padding: 0;
-                background-color: $m24-color-medium-gray;
             }
 
             &::after {
@@ -232,15 +227,11 @@
 
         .m24-c-menu-panel {
             display: block;
-            position: fixed;
             z-index: 100;
-            top: 0;
-            right: 0;
             width: 100%;
             height: auto;
             background-color: #fff;
             overflow: hidden auto;
-            margin-top: 98px;
             animation: nav-slide-in 0.45s ease;
 
             @media (prefers-reduced-motion: reduce) {
@@ -248,10 +239,14 @@
             }
 
             @media #{$mq-md} {
+                position: absolute;
                 display: block;
-                margin-top: 64px;
                 animation: none;
                 max-height: calc(100vh - 64px);
+                overflow: auto;
+                top: 61px;
+                left: 0;
+                right: 0;
             }
         }
     }
@@ -290,7 +285,7 @@
     position: relative;
 
     @media #{$mq-md} {
-        position: unset;
+        position: static;
         display: flex;
         justify-content: space-between;
         gap: 48px;
@@ -366,7 +361,6 @@
 }
 
 .m24-c-menu-item {
-    min-width: unset;
     max-width: 100%;
     padding: 0;
 
@@ -430,12 +424,6 @@
     svg path {
         fill: $m24-color-dark-green;
     }
-}
-
-.m24-c-menu-item:hover,
-.m24-c-menu-item:focus,
-.m24-c-menu-item:active {
-    background-color: unset;
 }
 
 .m24-c-menu-panel .m24-c-menu-panel-content > .m24-mzp-l-content {
@@ -503,7 +491,6 @@
     .m24-c-menu-item-icon {
         height: 16px;
         width: 16px;
-        position: unset;
         @include bidi(((padding-right, 4px, 0), (padding-left, 0, 4px)));
     }
 }
@@ -559,12 +546,6 @@
         width: 24px;
         top: 15px;
         @include bidi(((right, 15px, left, auto), (left, auto, right, 15px)));
-
-        &:hover,
-        &:focus,
-        &:active {
-            top: 15px;
-        }
     }
 }
 


### PR DESCRIPTION
## One-line summary

- Fixes navigation menu positioning when there's content positioned above the navigation (such as the pencil banner).
- Fixes mobile menu button background color regression.
- Tidies up a few redundant uses of `unset` (from when the new navigation CSS was overriding the old CSS).
- Adds navigation landmark / role.

## Significant changes and points to review

- I inserted a fake bit of content above the navigation in this PR to make testing easier. I need to remove it again before merging!
- Please test both the desktop and mobile menus, as the fix required some updates to both sets of styles.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15315

## Testing

1. Set `M24_WEBSITE_REFRESH` to active in your DB.
2. Open http://localhost:8000/en-US/
3. Hover over the menu items.

- [x] Menu should be positioned directly underneath the navigation.

1. Resize the browser to mobile screen size.
2. Click the menu button to open the navigation.

- [x] Menu items should be positioned correctly underneath the navigation.