### PR TITLE
Fix a11y landmark issues on contribute 

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -212,8 +212,8 @@
       <p>{{ ftl('contribute-made-by-desc-cont') }}</p>
     {% endcall %}
 
-  <section class="mzp-l-content">
-    <aside class="mzp-c-newsletter">
+  <aside class="mzp-l-content">
+    <div class="mzp-c-newsletter">
       <div class="mzp-c-newsletter-image">
         {{ resp_img(
           url='img/contribute/newsletter.png',
@@ -232,8 +232,8 @@
           include_language=False)
         }}
       </div>
-    </aside>
-  </section>
+    </div>
+  </aside>
 
   <section class="contribute-banner-wrapper">
     <div class="contribute-banner contribute-banner-gethelp">

--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -192,7 +192,7 @@
             <p>{{ ftl('contribute-opportunities') }}</p>
           </a>
         </li>
-      </div>
+      </ul>
     </div>
   </section>
 


### PR DESCRIPTION
Parts of the page were not contained within landmarks - five of the issues were solved with a fix to invalid html, the last was solved by promoting the newsletter section to become an aside.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Resolves #15340

## Testing

Run a11y tests and confirm that contribute is not included in the list of failures.