### PR TITLE
Add paths to legacy nav and footer styles [#15120]

### DIFF
--- a/media/css/protocol/navigation-and-footer.scss
+++ b/media/css/protocol/navigation-and-footer.scss
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$font-path: '/media/protocol/fonts';
+$image-path: '/media/protocol/img';
+
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 @import '~@mozilla-protocol/core/protocol/css/components/footer';


### PR DESCRIPTION
## One-line summary
I neglected to define the image path for the footer styles in #15353 and it's throwing build errors. I haven't actually reproduced the error locally so I'm not certain this will fix it, but it also shouldn't hurt. I think it may depend on the order in which Sass files are compiled?

## Testing
CSS should compile with the appropriate file path for images.