### PR TITLE
Fix a11y issues on firefox/enterprise

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -58,6 +58,7 @@
 
       <ul class="mzp-l-columns mzp-t-columns-three">
         {% call picto(
+          base_el='li',
           title=ftl('firefox-enterprise-your-data-stays-your-business'),
           image=resp_img(
             url='img/firefox/enterprise/icon-data-privacy.svg',
@@ -77,6 +78,7 @@
         {% endcall %}
 
         {% call picto(
+          base_el='li',
           title=ftl('firefox-enterprise-deploy-when-and-how-you-want'),
           image=resp_img(
             url='img/firefox/enterprise/icon-deploy.svg',
@@ -92,6 +94,7 @@
         {% endcall %}
 
         {% call picto(
+          base_el='li',
           title=ftl('firefox-enterprise-choose-your-release-cadence'),
           image=resp_img(
             url='img/firefox/enterprise/icon-release.svg',


### PR DESCRIPTION
## One-line summary

Ensure the three picto components contained within a `<ul>` are `<li>` elements instead of `<div>` elements.

- [ ] I used an AI to write some of this code

## Issue / Bugzilla link

Resolves #15341

## Testing
Run a11y tests to confirm that /firefox/enterprise does not throw up failures.
