### PR TITLE
Add management command to bootstrap admin users on demo servers

### DIFF
--- a/bedrock/cms/management/commands/bootstrap_demo_server_admins.py
+++ b/bedrock/cms/management/commands/bootstrap_demo_server_admins.py
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+import sys
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.db.transaction import atomic
+
+from everett.manager import ListOf
+
+from bedrock.base.config_manager import config
+
+
+class Command(BaseCommand):
+    help = """Creates a number of Django/Wagtail Admin Users based on
+    a comma-separated list of Mozilla email address set as the
+    DEMO_SERVER_ADMIN_USERS environment variable."""
+
+    @atomic
+    def handle(self, *args, **kwargs):
+        _users = config("DEMO_SERVER_ADMIN_USERS", default="", parser=ListOf(str))
+        DEMO_SERVER_ADMIN_USERS = [x.strip() for x in _users if x]
+
+        if not DEMO_SERVER_ADMIN_USERS:
+            sys.stdout.write("Not bootstrapping users: DEMO_SERVER_ADMIN_USERS not set\n")
+            return
+        else:
+            sys.stdout.write(f"Bootstrapping {len(DEMO_SERVER_ADMIN_USERS)} SSO users\n")
+
+        for email in DEMO_SERVER_ADMIN_USERS:
+            user, created = User.objects.get_or_create(email=email)
+            if not created:
+                sys.stdout.write(f"User {email} already exists - not creating\n")
+            else:
+                user.username = email
+                user.is_staff = True
+                user.is_superuser = True
+                user.set_unusable_password()  # They won't need one to use SSO
+                sys.stdout.write(f"Created Admin user {email} for local SSO use\n")
+                user.save()


### PR DESCRIPTION
This command is intended to be called after a Bedrock Demo has been deployed to Cloud Run so that we can bootstrap users who may then log in via SSO. The value of the users list will come from a GCP Secret as a comma-separated list of email addresses.

The relevant change to the GCP Cloud Build trigger that would use this command will follow as a separate change on the relevant repo.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

#15375

## Testing

`DEMO_SERVER_ADMIN_USERS=test@example.com,test2@example.com ./manage.py bootstrap_demo_server_admins`

Also reviewing the unit tests should be enough for now