### PR TITLE
Fix up sqlite DB export

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -242,6 +242,10 @@ do
     echo "Purged now-redundant data from: $table"
 done
 
+# Delete Wagtail Page records that are not marked as Live
+sqlite3 $output_db "DELETE FROM wagtailcore_page WHERE live=0;"
+echo "Purged Page records that are not marked as live any more"
+
 # And to be sure that there are no relations pointing back to non-existent rows
 echo "Preparing statements for nullifying columns in temporary sql file. (Output is hidden because it's captured from stdout)."
 

--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -162,6 +162,9 @@ python manage.py dumpdata \
     mozorg.WebvisionDoc \
     mozorg.LeadershipPage \
     newsletter.Newsletter \
+    products.VPNCallToActionSnippet \
+    products.VPNResourceCenterIndexPage \
+    products.VPNResourceCenterDetailPage \
     externalfiles.ExternalFile \
     security.Product \
     security.SecurityAdvisory \


### PR DESCRIPTION
## One-line summary

This changeset fixes two niggles with the DB exporter which were creating a flawed DB export that is stopping ``www-sitemap-generator`` from working 

* We weren't exporting the VPN-related Wagtail models, only the Page models (which constitute only half the data)
* We were INCLUDING Wagtial core `Page`s which were not live - ideally we should not, because in the future they would potentially contain retired (but non-Draft) content; and before a page is first published and only exists as a Draft, having just the `Page` data but no specific model (eg the VPN detail page model), Wagtail blows up because it doesn't have the full picture.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

Resolves #15378 

## Testing

* If you don't have one already, set up a local postgres DB from which to export:
1. `docker compose up db` will start a postgres DB on your local machine
2. Create a `bedrock` DB in there:
```
docker compose exec db bash
psql -U postgres
create database bedrock;
\q   # to quit psql
exit  # to leave the Docker container
```
3. Fill the postgres DB from the bedrock sqlite DB you already have, using a script that is not in this PR: `DATABASE_URL="postgres://postgres:postgres@127.0.0.1:5432/bedrock" ./bin/fill-empty-postgres-database.sh`
5. In your .env set `DATABASE_URL="postgres://postgres:postgres@127.0.0.1:5432/bedrock"`
6. Restart your runserver and confirm you can still browse the site. 
7. In the CMS: 
* add a Simple RichText Page ("Test 1") and save it as draft – but never publish it.
* add a Simple RichText Page ("Test 2")  and publish it
* add another Simple RichText ("Test 3")  Page and publish it - and then UNpublish it
* add a VPN Resource Center Index page and Detail page with lorem ipsum content
 
* Export the postgres DB to a new sqlite file:
1. DATABASE_URL="postgres://postgres:postgres@127.0.0.1:5432/bedrock" ./bin/export-db-to-sqlite.sh /Users/steve/Code/bedrock/data/exported.db

2. In your .env set `DATABASE_URL="sqlite://bedrock/data/exported.db"`
3. Restart your runserver and log back into the CMS. Test 1 and Test 3 pages will not be present, but Test 2 will be
4. Confirm the VPN pages added are there as you'd expect