### PR TITLE
Fix a11y contrast issue on firefox/releasenotes page

### DIFF
--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -359,7 +359,7 @@ $image-path: '/media/protocol/img';
 // all-download link
 
 .all-download {
-    background-color: $color-marketing-gray-30;
+    background-color: $color-marketing-gray-20;
     font-weight: bold;
     padding: $spacing-sm $layout-2xs;
     @include text-body-md;


### PR DESCRIPTION
Change background colour of `.all-download` link


![Screenshot 2024-10-24 at 17 09 08](https://github.com/user-attachments/assets/7e1b44ed-0b33-4a85-bf0c-b710ca393232)




- [ ] I used an AI to write some of this code.



## Issue / Bugzilla link

Resolves 15342


## Testing
Run a11y tests to confirm firefox/releasenotes doesn't come up in the failures