### PR TITLE
Fix issue around partial exclusion of draft pages from DB export

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -243,8 +243,8 @@ do
 done
 
 # Delete Wagtail Page records that are not marked as Live
-sqlite3 $output_db "DELETE FROM wagtailcore_page WHERE live=0;"
-echo "Purged Page records that are not marked as live any more"
+# sqlite3 $output_db "DELETE FROM wagtailcore_page WHERE live=0;"
+# echo "Purged Page records that are not marked as live any more"
 
 # And to be sure that there are no relations pointing back to non-existent rows
 echo "Preparing statements for nullifying columns in temporary sql file. (Output is hidden because it's captured from stdout)."


### PR DESCRIPTION
Until we can find a way to exclude both the wagtailcore_page _and_ the related custom model that references this, the exclusion behaviour creates a DB with a state that fails integrity checks, because the custom model references a wagtailcore_page table row which no longer exists
