### PR TITLE
Add data-cta-name to documentation

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx132-eu.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx132-eu.html
@@ -38,7 +38,7 @@
       <h1 class="wnp-main-title">{{ main_title }}</h1>
       <p class="wnp-main-body">{{ main_body_part_one }}</p>
       <p class="wnp-main-body">{{ main_body_part_two }}</p>
-      <button class="mzp-c-button mzp-t-dark js-new-tab" type="button" data-cta-text="{{ cta }}">{{ cta }}</a>
+      <button class="mzp-c-button mzp-t-dark js-new-tab" type="button" data-cta-text="Try it now" data-cta-name="wnp-fx132-eu-{{LANG}}-try-wallpapers">{{ cta }}</a>
   {% endcall %}
 </section>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx132-na.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx132-na.html
@@ -31,7 +31,7 @@
       <div class="wnp-action-container">
         <h2>Brighten your browser experience</h2>
         <p>Check out our special edition wallpapers — open a new tab and click the gear icon at the top right corner.</p>
-        <button class="c-cta-button js-new-tab" data-cta-text="Try it now">Try it now</button>
+        <button class="c-cta-button js-new-tab" data-cta-text="Try it now" data-cta-name="wnp-fx132-na-{{LANG}}-try-wallpapers">Try it now</button>
         <img class="wnp-sticker-heart" src="{{ static('img/firefox/whatsnew/whatsnew132/sticker-heart.svg') }}" width="92" height="85" alt="">
         <img class="wnp-sticker-fox" src="{{ static('img/firefox/whatsnew/whatsnew132/sticker-fox.svg') }}" width="119" height="96" alt="">
         <img class="wnp-sticker-happy" src="{{ static('img/firefox/whatsnew/whatsnew132/sticker-happy.svg') }}" width="86" height="86" alt="">
@@ -40,7 +40,7 @@
       <div class="wnp-action-container">
         <h2>We’d love to hear your ideas</h2>
         <p>By joining the Mozilla Connect community, you can help build your next favorite Firefox feature.</p>
-        <a class="mzp-c-cta-link" href="https://connect.mozilla.org/?{{ utm_params }}" data-cta-text="Join now">
+        <a class="mzp-c-cta-link" href="https://connect.mozilla.org/?{{ utm_params }}" data-cta-text="Join now" data-cta-name="wnp-fx132-na-{{LANG}}-join-community">
           Join now
         </a>
         <img class="wnp-sticker-chat" src="{{ static('img/firefox/whatsnew/whatsnew132/sticker-chat.svg') }}" width="110" height="105" alt="">

--- a/docs/attribution/0001-analytics.rst
+++ b/docs/attribution/0001-analytics.rst
@@ -114,7 +114,10 @@ The attribute ``data-cta-text`` must be present to trigger the event. All links 
 |                       | - This is to group CTAs by their destination                                     |
 |                       | - Do not use this to identify the element (ie. link, button)                     |
 +-----------------------+----------------------------------------------------------------------------------+
-
+| ``data-cta-name``     | A identifier for this cta that is unique across the entire site. (e.g.           |
+|                       | ``fx20-primarycta``, ``wnp118-sfaq-so-special-features``). This is to help with  |
+|                       | reporting since it is difficult to filter on more than one parameter at a time.  |
++-----------------------+----------------------------------------------------------------------------------+
 
 
 .. code-block:: html


### PR DESCRIPTION
## One-line summary

Add `data-cta-name` as a supported attribute for CTAs, implement on WNP 132

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15391

## Testing

`make livedocs` 

WNP 132 is on [demo2](https://www-demo2.allizom.org/en-US/firefox/132.0/whatsnew/) for testing.