### PR TITLE
Support bootstrapping demo users in main DB setup script, if appropriate

### DIFF
--- a/bin/sync-all.sh
+++ b/bin/sync-all.sh
@@ -27,3 +27,7 @@ fi
 
 ./manage.py migrate --noinput
 ./manage.py l10n_update
+
+if [[ -n "${DEMO_SERVER_ADMIN_USERS}" ]]; then
+    ./manage.py bootstrap_demo_server_admins
+fi


### PR DESCRIPTION
This is so that we can boostrap SSO users on the demo servers on Cloud Run. 

This approach is a lot simpler, cleaner and more build-time efficient than doing a multi-stage container build in Cloud Build, but it does add to the complexity of that sync-all script...

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

# 15375

## Testing

* `DEMO_SERVER_ADMIN_USERS=test@example.com,test2@example.com ./bin/sync-all.sh` - to see demo users bootstrapped
* `DEMO_SERVER_ADMIN_USERS=test@example.com,test2@example.com ./bin/sync-all.sh` again, to see what happens if they already exist
* `./bin/sync-all.sh` to  confirm demo users are not bootstrapped if the env var isn't there