### PR TITLE
VPN download page CTA margin fix (Fixes #15405)

### DIFF
--- a/media/css/products/vpn/download.scss
+++ b/media/css/products/vpn/download.scss
@@ -90,7 +90,6 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
         border-radius: 6px;
         box-shadow: $box-shadow-sm;
         padding: $spacing-xl;
-        height: 315px;
         display: none;
 
         .platform-image {
@@ -101,9 +100,14 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
             color: $color-violet-70;
         }
 
-        &.android {
-            height: 325px;
+        &.android,
+        &.ios {
+            .platform-download-link {
+                display: block;
+            }
+        }
 
+        &.android {
             .platform-download-link {
                 img {
                     width: 220px;


### PR DESCRIPTION
## One-line summary

Fixes a small layout issue on the VPN download page when on mobile.

Screenshot of the bug: 

![image](https://github.com/user-attachments/assets/d41ea21e-4268-46ad-a859-6609b7859e63)

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/VPN-6687

## Testing

1. Open http://localhost:8000/en-US/products/vpn/download/
2. Change the platform class on the `<html>` element from `osx` to `android`.

- [x] The Play Store button should no longer be clipping the container.