### PR TITLE
VPN landing pages locale fix

### DIFF
--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -122,7 +122,7 @@ def vpn_landing_page(request):
 
 @require_safe
 def vpn_pricing_page(request):
-    ftl_files = ["products/vpn/landing", "products/vpn/shared", "products/vpn/pricing-2023"]
+    ftl_files = ["products/vpn/pricing-2023", "products/vpn/shared"]
     available_countries = settings.VPN_AVAILABLE_COUNTRIES
     country = get_country_from_request(request)
     vpn_available_in_country = vpn_available(request)

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -83,7 +83,7 @@ def active_locale_available(slug, locale):
 
 @require_safe
 def vpn_landing_page(request):
-    ftl_files = ["products/vpn/landing", "products/vpn/landing-2023", "products/vpn/shared", "products/vpn/pricing-2023"]
+    ftl_files = ["products/vpn/landing-2023", "products/vpn/shared", "products/vpn/pricing-2023"]
     country = get_country_from_request(request)
     vpn_available_in_country = vpn_available(request)
     mobile_sub_only = vpn_available_mobile_sub_only(request)

--- a/l10n/en/products/vpn/landing.ftl
+++ b/l10n/en/products/vpn/landing.ftl
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/products/vpn/invite/
+
+vpn-landing-invite-page-title = Join the Waitlist: { -brand-name-mozilla-vpn }
+
+vpn-landing-invite-page-desc-v2 = Get notified when { -brand-name-mozilla-vpn } is available for your region.
+
+vpn-landing-invite-page-heading = Join the VPN Waitlist
+vpn-landing-invite-email-label = What is your email address?
+vpn-landing-invite-required-label = Required
+
+# Only localize "yourname". Do not change "@example.com".
+vpn-landing-invite-email-placeholder = yourname@example.com
+
+vpn-landing-invite-country-label = What country do you live in?
+vpn-landing-invite-language-label = Select your preferred language.
+
+# Variables:
+#   $privacy (url) - link to https://www.mozilla.org/privacy/subscription-services/
+vpn-landing-invite-privacy-policy = By clicking “Join the waitlist”, you agree to our  <a href="{ $privacy }">Privacy Policy</a>.
+
+vpn-landing-invite-your-information = Your information will only be used to notify you about platform availability.
+vpn-landing-invite-thanks-heading = Thanks! You’re on the list
+vpn-landing-invite-thanks-desc = Once { -brand-name-mozilla-vpn } becomes available for your region, we’ll email you.


### PR DESCRIPTION
## One-line summary

This fixes two issues that came out of https://github.com/mozilla/bedrock/issues/15226

1. VPN landing page should now use `products/vpn/landing-2023.ftl` to figure out which locales were active. It was still looking the old file for reference.
2. Restores some strings that were accidentally removed for the invite page. Thankfully this didn't effect anything in prod, as the old file was still being referenced. I've restored the strings here so we can continue to use them.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15407

## Testing

- [x] When `dev=False`, http://localhost:8000/es-MX/products/vpn/ should redirect to `es-US`
- [x] When `dev=True`, the following URLs should still all show localized strings
  - http://localhost:8000/de/products/vpn/
  - http://localhost:8000/de/products/vpn/pricing/
  - http://localhost:8000/de/products/vpn/invite/