### PR TITLE
Update product brand names in nav and on home page (Fixes #15351)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -17,7 +17,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="{{ url('products.vpn.landing') }}" data-link-text="Mozilla VPN" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/mozilla/vpn/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-vpn') }}</h4>
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-vpn-v2') }}</h4>
               </a>
             </section>
           </li>
@@ -25,7 +25,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor') }}</h4>
+                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor-v2') }}</h4>
               </a>
             </section>
           </li>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
@@ -29,14 +29,14 @@
       </a>
     </li>
     <li class="m24-c-spring-item">
-      <a class="m24-c-spring-link m24-t-product-vpn" href="{{ url('products.vpn.landing') }}" data-cta-text="VPN" data-cta-position="product-list">
-        <strong class="m24-c-spring-title">VPN</strong>
+      <a class="m24-c-spring-link m24-t-product-vpn" href="{{ url('products.vpn.landing') }}" data-cta-text="Mozilla VPN" data-cta-position="product-list">
+        <strong class="m24-c-spring-title">Mozilla VPN</strong>
         <span class="m24-c-spring-info">Stay safe on public Wi-Fi, block advertisers, and more.</span>
       </a>
     </li>
     <li class="m24-c-spring-item">
-      <a class="m24-c-spring-link m24-t-product-monitor" href="https://monitor.mozilla.org/{{ utm_params }}" data-cta-text="Monitor" data-cta-position="product-list">
-        <strong class="m24-c-spring-title">Monitor</strong>
+      <a class="m24-c-spring-link m24-t-product-monitor" href="https://monitor.mozilla.org/{{ utm_params }}" data-cta-text="Mozilla Monitor" data-cta-position="product-list">
+        <strong class="m24-c-spring-title">Mozilla Monitor</strong>
         <span class="m24-c-spring-info">Check if your data has been breached then make it private.</span>
       </a>
     </li>

--- a/l10n/en/navigation_refresh.ftl
+++ b/l10n/en/navigation_refresh.ftl
@@ -30,9 +30,9 @@ navigation-refresh-firefox-blog = { -brand-name-firefox } blog
 
 navigation-refresh-products = Products
 navigation-refresh-close-products-menu = Close Products menu
-navigation-refresh-mozilla-monitor = { -brand-name-monitor }
+navigation-refresh-mozilla-monitor-v2 = { -brand-name-mozilla-monitor }
 navigation-refresh-pocket = { -brand-name-pocket }
-navigation-refresh-mozilla-vpn = { -brand-name-vpn }
+navigation-refresh-mozilla-vpn-v2 = { -brand-name-mozilla-vpn }
 navigation-refresh-mdn-plus = { -brand-name-mdn-plus }
 navigation-refresh-fakespot = { -brand-name-fakespot }
 navigation-refresh-thunderbird = { -brand-name-thunderbird }


### PR DESCRIPTION
## One-line summary

Updates both navigation and home page to use full product brand names for Mozilla VPN and Mozilla Monitor.

## Issue / Bugzilla link

#15351

## Testing

Test using `M24_WEBSITE_REFRESH` switch enabled:

http://localhost:8000/en-US/