### PR TITLE
Refresh: Nav - Don't lazy load images in top level of header navigation menu

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -8,7 +8,7 @@
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable m24-c-menu-category-has-icon">
   <a class="m24-c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-firefox" data-testid="m24-navigation-link-firefox">
-    <img class="m24-c-menu-title-icon" loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="16" height="16" alt="">
+    <img class="m24-c-menu-title-icon" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="16" height="16" alt="">
     {{ ftl('navigation-refresh-firefox-browsers') }}
   </a>
   <div class="m24-c-menu-panel" id="m24-c-menu-panel-firefox">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
@@ -10,7 +10,7 @@
       <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>
       <div>
         <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
-          <img loading="lazy" class="m24-c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="88" height="21">
+          <img class="m24-c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="88" height="21">
         </a>
       </div>
       <div class="m24-c-navigation-items" id="m24-c-navigation-items" data-testid="m24-navigation-menu-items">


### PR DESCRIPTION
## One-line summary

Remove lazy loading attributes from images in the navigation menu that appear by default.

## Significant changes and points to review

The wordmark always appears above the fold when a page loads.

I went back and fourth on the Firefox icon since it's hidden on mobile but it's used all over the website so I think this is still the right thing to do.

## Issue / Bugzilla link

n/a

## Testing

Images still load.