### PR TITLE
Fix 404 ESR115 download links for /sat/ and /skr/ languages (Fixes #15437)

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-unsupported.html
+++ b/bedrock/firefox/templates/firefox/includes/download-unsupported.html
@@ -14,17 +14,20 @@
   {% set channel_name = 'Firefox' %}
 {% endif %}
 
+{# ESR115 builds do not exist for "sat" ans "skr" languages (see issue #15437). #}
+{% set ESR115_LANG = 'en-US' if LANG in ["sat", "skr"] else LANG %}
+
 <div class="fx-unsupported-message win" data-nosnippet="true">
   <p><strong>{{ ftl('download-button-unsupported-platform', channel_name=channel_name, help_url='https://support.mozilla.org/kb/firefox-users-windows-7-8-and-81-moving-extended-support', os_version='Windows 8.1') }}</strong></p>
   <p>{{ ftl('download-button-please-download-esr') }}</p>
   <div class="download-platform-list">
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang={{ LANG }}" data-download-version="win64" data-cta-text="Download Firefox Extended Support Release 64-bit" data-cta-type="firefox">
+      <a class="mzp-c-button mzp-t-product download-link os_win64 ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win64&lang={{ ESR115_LANG }}" data-download-version="win64" data-cta-text="Download Firefox Extended Support Release 64-bit" data-cta-type="firefox">
         {{ ftl('download-firefox-esr-64') }}
       </a>
     </p>
     <p>
-      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win&lang={{ LANG }}" data-download-version="win" data-cta-text="Download Firefox Extended Support Release 32-bit" data-cta-type="firefox">
+      <a class="mzp-c-button mzp-t-product download-link os_win ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=win&lang={{ ESR115_LANG }}" data-download-version="win" data-cta-text="Download Firefox Extended Support Release 32-bit" data-cta-type="firefox">
         {{ ftl('download-firefox-esr-32') }}
       </a>
     </p>
@@ -42,7 +45,7 @@
   <p>{{ ftl('download-button-please-download-esr') }}</p>
 
   <div class="download-platform-list">
-    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=osx&lang={{ LANG }}" data-download-version="osx" data-cta-text="Firefox Extended Support Release MacOS" data-cta-type="firefox">
+    <a class="mzp-c-button mzp-t-product download-link ga-product-download" href="https://download.mozilla.org/?product=firefox-esr115-latest-ssl&os=osx&lang={{ ESR115_LANG }}" data-download-version="osx" data-cta-text="Firefox Extended Support Release MacOS" data-cta-type="firefox">
       {{ ftl('download-firefox-esr') }}
     </a>
   </div>

--- a/bedrock/firefox/templates/firefox/includes/download-unsupported.html
+++ b/bedrock/firefox/templates/firefox/includes/download-unsupported.html
@@ -14,7 +14,7 @@
   {% set channel_name = 'Firefox' %}
 {% endif %}
 
-{# ESR115 builds do not exist for "sat" ans "skr" languages (see issue #15437). #}
+{# ESR115 builds do not exist for "sat" and "skr" languages (see issue #15437). #}
 {% set ESR115_LANG = 'en-US' if LANG in ["sat", "skr"] else LANG %}
 
 <div class="fx-unsupported-message win" data-nosnippet="true">

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -342,6 +342,9 @@ def firefox_all(request, product_slug=None, platform=None, locale=None):
                 download_esr_115_url = list(filter(lambda b: b["locale"] == locale, firefox_desktop.get_filtered_full_builds("esr115")))[0][
                     "platforms"
                 ][platform]["download_url"]
+                # ESR115 builds do not exist for "sat" ans "skr" languages (see issue #15437).
+                if locale in ["sat", "skr"]:
+                    download_esr_115_url = None
                 context.update(
                     download_esr_115_url=download_esr_115_url,
                 )


### PR DESCRIPTION
## One-line summary

- Hides ESR115 download link on /firefox/all/ if language is not supported.
- Fallback to `en-US` on `/firefox/new/` if language is not supported.

## Issue / Bugzilla link

#15437

## Testing

/firefox/all/

- [ ] ESR115 download link is not shown for the following two languages:

URLs:

- http://localhost:8000/en-US/firefox/all/desktop-esr/win64/sat/
- http://localhost:8000/en-US/firefox/all/desktop-esr/win64/skr/

/firefox/new/

- [ ] ESR115 download link falls back to `en-US` for `/skr/` language:

(Tip: add a class of `fx-unsupported` to the `<html>` element to simulate an unsupported OS)

- http://localhost:8000/skr/firefox/new/