### PR TITLE
fix SUMO link

### DIFF
--- a/bedrock/firefox/templates/firefox/firefox-20th/index.html
+++ b/bedrock/firefox/templates/firefox/firefox-20th/index.html
@@ -103,7 +103,7 @@
         <div class="fx20-action-container">
           <h2>Cheers to SUMO’s top contributors</h2>
           <p>We’re spotlighting the incredible contributions of our SUMO community, some of whom have been with us since the very beginning.</p>
-          <a class="mzp-c-cta-link" href="https://blog.mozilla.org/sumo/2024/11/06/celebrating-our-top-contributors-on-firefoxs-20th-anniversary/?{{ utm_params }}" data-link-text="View blog Contributors">
+          <a class="mzp-c-cta-link" href="https://blog.mozilla.org/sumo/2024/11/07/celebrating-our-top-contributors-on-firefoxs-20th-anniversary/?{{ utm_params }}" data-link-text="View blog Contributors">
             View blog
           </a>
         </div>


### PR DESCRIPTION
## One-line summary

This PR fixes the SUMO link on Firefox 20th landing page. See details: https://github.com/mozilla/bedrock/pull/15409#issuecomment-2462975026

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15383

## Testing

http://localhost:8000/en-US/firefox/firefox20/ SUMO link should work now