### PR TITLE
add fan art video for Firefox 20th landing page (fix #15383)

### DIFF
--- a/bedrock/firefox/templates/firefox/firefox-20th/index.html
+++ b/bedrock/firefox/templates/firefox/firefox-20th/index.html
@@ -115,12 +115,7 @@
 {% call split(
     block_class='fx20-content-fanart mzp-l-split-center-on-sm-md',
     media_class='mzp-l-split-h-center',
-    image=resp_img(
-          url='img/firefox/firefox-20th/fan-art.png',
-          srcset={
-            'img/firefox/firefox-20th/fan-art-high-res.png': '2x'
-          },
-        ),
+    media_include='firefox/firefox-20th/video-fanart.html',
     media_after=True
   ) %}
     <h2 class="fx20-fanart-title">{{ fan_title }}</h2>

--- a/bedrock/firefox/templates/firefox/firefox-20th/video-fanart.html
+++ b/bedrock/firefox/templates/firefox/firefox-20th/video-fanart.html
@@ -1,0 +1,31 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ #}
+
+{% from "macros.html" import video_inline_embed with context %}
+
+{% if LANG == "fr" %}
+  {% set video_title = 'Firefox a 20 ans - Célébrez avec nous' %}
+{% elif LANG == "de" %}
+  {% set video_title = 'Firefox wird 20 - Feiere mit uns' %}
+{% else %}
+  {% set video_title = 'Firefox Turns 20 - Celebrate with Us' %}
+{% endif %}
+
+{{ video_inline_embed(
+  id='SiLWHYrZyRc',
+  title=video_title,
+  image=resp_img(
+    url='img/firefox/firefox-20th/fan-art.png',
+    srcset={
+      'img/firefox/firefox-20th/fan-art-high-res.png': '2x'
+    },
+    optional_attributes={
+      'width': '800',
+      'height': '450',
+      'alt': '',
+    }
+  ),
+) }}


### PR DESCRIPTION
## One-line summary

This PR updates the Firefox 20th landing page fan art section. Replace the split image with a video.

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15383

## Testing

http://localhost:8000/en-US/firefox/firefox20/
http://localhost:8000/en-CA/firefox/firefox20/
http://localhost:8000/en-GB/firefox/firefox20/
http://localhost:8000/fr/firefox/firefox20/
http://localhost:8000/de/firefox/firefox20/

