### PR TITLE
Add new campaign params for experiment [fix #15470]

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -44,6 +44,8 @@ def mobile_app(request, *args, **kwargs):
         "fxshare3",
         "fxshare4",
         "fxshare5",
+        "DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_a",
+        "DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_b",
     ]
 
     for p in product_options:


### PR DESCRIPTION
## One-line summary
Adds two new parameters to the list (not pretty but it's the format they're using in their experiment)
```
        "DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_a",
        "DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_b",
```

## Issue / Bugzilla link
#15470 

