### PR TITLE
Decouple intro from hero

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/includes/m24/hero.html
+++ b/bedrock/mozorg/templates/mozorg/about/includes/m24/hero.html
@@ -7,8 +7,8 @@
 {% from "macros-protocol.html" import picto with context %}
 
 <section class="m24-c-hero">
-  <div class="m24-c-intro">
-    <div class="m24-c-intro-wrapper">
+  <div class="m24-c-hero-intro">
+    <div class="m24-c-intro">
       <h1 class="m24-c-intro-title m24-t-2xl">Reclaim the internet with us</h1>
       <p>Mozilla is working to put control of the internet back in the hands of the people using it.</p>
     </div>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/hero.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/hero.html
@@ -5,8 +5,8 @@
 #}
 
 <section class="m24-c-hero">
-  <div class="m24-c-intro">
-    <div class="m24-c-intro-wrapper">
+  <div class="m24-c-hero-intro">
+    <div class="m24-c-intro">
       <h1 class="m24-c-intro-title m24-t-2xl">Welcome to Mozilla</h1>
       <p>From ethical tech to policies that defend your digital rights, we put you first—always.</p>
       <p class="m24-c-intro-cta"><a href="{{ url('mozorg.about.index') }}" class="m24-c-cta" data-cta-text="Learn about us">Learn about us</a></p>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/resources-grid.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/resources-grid.html
@@ -7,8 +7,9 @@
 {% from "macros-m24.html" import grid_tile with context %}
 
 <section class="m24-c-content m24-t-transition-next">
-  <h2 class="m24-c-intro-title">Explore issues shaping the future of the internet</h2>
-
+  <header class="m24-c-intro">
+    <h2 class="m24-c-intro-title">Explore issues shaping the future of the internet</h2>
+  </header>
   <div class="m24-c-gallery-container">
     {{ grid_tile(
       class='m24-l-grid-half',

--- a/media/css/m24/donate.scss
+++ b/media/css/m24/donate.scss
@@ -10,7 +10,7 @@
 
 .m24-c-donate-title {
     font-size: $alias-text-title-h2;
-    margin-bottom: $spacer-lg;
+    margin-bottom: $spacer-xl;
     text-wrap-style: balance;
     font-weight: 600;
 }

--- a/media/css/m24/hero.scss
+++ b/media/css/m24/hero.scss
@@ -4,21 +4,15 @@
 
 
 .m24-c-hero {
-    padding-top: $spacer-lg;
-
-    .m24-c-intro {
-        padding: $spacing-2xl $spacer-md;
-        max-width: none;
-
-        .m24-c-intro-wrapper {
-            max-width: $content-max;
-            margin: auto;
-        }
-    }
+    padding-top: $spacer-xl;
 
     .m24-c-hero-title {
         font-size: $text-title-2xl;
     }
+}
+
+.m24-c-hero-intro {
+    @include container;
 }
 
 .m24-c-hero-media {

--- a/media/css/m24/intro.scss
+++ b/media/css/m24/intro.scss
@@ -6,16 +6,20 @@
 .m24-c-intro {
     font-weight: 500;
     font-size: $text-body-xl;
+    margin-bottom: $spacer-xl;
     text-wrap: balance;
     text-wrap-style: balance;
 }
 
 .m24-c-intro-title {
     font-size: $alias-text-title-h2;
-    margin-bottom: 0;
-    padding-bottom: $spacer-sm;
+    margin-bottom: $spacer-sm;
     text-wrap: balance;
     text-wrap-style: balance;
+
+    &.m24-t-lg {
+        font-size: $alias-text-title-h3;
+    }
 
     &.m24-t-2xl {
         font-size: $alias-text-title-h1;
@@ -24,7 +28,7 @@
 
 .m24-c-intro-cta {
     text-align: end;
-    padding-top: $spacer-md;
+    margin-top: $spacer-md;
 }
 
 @media #{$mq-xl} {

--- a/media/css/m24/launchpad.scss
+++ b/media/css/m24/launchpad.scss
@@ -5,8 +5,7 @@
 $logo-spacing: calc(32px + #{$spacer-md});
 
 .m24-c-launchpad {
-    padding: $spacer-xl 0;
-    margin: 0;
+    margin: $spacer-xl 0;
 }
 
 .m24-c-launchpad-item {


### PR DESCRIPTION
## One-line summary

A little refactor to un-tangle the intro from the hero.

## Significant changes and points to review

- c-intro code is all in the intro.scss file
- add code to hero to make the place intro is slotted into what intro expects
- move top padding for hero so it's only on hero component
- continue move from padding to margin as seen in other component refactors

## Issue / Bugzilla link

n/a

## Testing

There shouldn't be too obvious a change anywhere. The text in the hero should now left align with all other intros on the page. We should have a standard spacing between the intro and the next component of `$spacer-xl` but I didn't exit the gallery or showcase since @craigcook is working on them.