### PR TITLE
Provide a hybrid list of locales drawn from CMS-backed and Django-backed sources

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -4,10 +4,12 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{%- set available_languages = get_lang_switcher_options(request, translations) -%}
+
     <link rel="canonical" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
     <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}{{ canonical_path }}">
-    {% if translations -%}
-      {%- for code, label in translations|dictsort -%}
+    {% if available_languages -%}
+      {%- for code, label in available_languages|dictsort -%}
         {%- set alt_url = alternate_url(canonical_path, code) -%}
         {%- if alt_url -%}
           {%- set loop_canonical_path = alt_url -%}

--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{%- set available_languages = get_lang_switcher_options(request, translations) -%}
+{%- set available_languages = get_locale_options(request, translations) -%}
 
     <link rel="canonical" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
     <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}{{ canonical_path }}">

--- a/bedrock/base/templates/includes/protocol/lang-switcher-refresh.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher-refresh.html
@@ -4,12 +4,17 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% if translations|length > 1 %}
+ {%- set available_languages = get_lang_switcher_options(request, translations) -%}
+
+ {% if available_languages|length > 1 %}
+
+
+ {% if available_languages|length > 1 %}
    <form id="lang_form" class="moz24-c-language-switcher" method="get" action="#">
     <label for="page-language-select">{{ ftl('footer-refresh-language') }}</label>
     <a class="mzp-c-language-switcher-link" href="{{ url('mozorg.locales') }}">{{ ftl('footer-refresh-language') }}</a>
      <select id="page-language-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr" data-testid="footer-language-select">
-       {% for code, label in translations|dictsort -%}
+       {% for code, label in available_languages|dictsort -%}
          {# Don't escape the label as it may include entity references
          # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
          <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>

--- a/bedrock/base/templates/includes/protocol/lang-switcher-refresh.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher-refresh.html
@@ -7,9 +7,6 @@
  {%- set available_languages = get_locale_options(request, translations) -%}
 
  {% if available_languages|length > 1 %}
-
-
- {% if available_languages|length > 1 %}
    <form id="lang_form" class="moz24-c-language-switcher" method="get" action="#">
     <label for="page-language-select">{{ ftl('footer-refresh-language') }}</label>
     <a class="mzp-c-language-switcher-link" href="{{ url('mozorg.locales') }}">{{ ftl('footer-refresh-language') }}</a>

--- a/bedrock/base/templates/includes/protocol/lang-switcher-refresh.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher-refresh.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {%- set available_languages = get_lang_switcher_options(request, translations) -%}
+ {%- set available_languages = get_locale_options(request, translations) -%}
 
  {% if available_languages|length > 1 %}
 

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -4,12 +4,16 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if translations|length > 1 %}
+
+
+{%- set available_languages = get_lang_switcher_options(request, translations) -%}
+
+{% if available_languages|length > 1 %}
   <form id="lang_form" class="mzp-c-language-switcher" method="get" action="#">
     <a class="mzp-c-language-switcher-link" href="{{ url('mozorg.locales') }}">{{ ftl('footer-language') }}</a>
     <label for="page-language-select">{{ ftl('footer-language') }}</label>
     <select id="page-language-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr" data-testid="footer-language-select">
-      {% for code, label in translations|dictsort -%}
+      {% for code, label in available_languages|dictsort -%}
         {# Don't escape the label as it may include entity references
         # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
         <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -4,8 +4,6 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-
-
 {%- set available_languages = get_locale_options(request, translations) -%}
 
 {% if available_languages|length > 1 %}

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -6,7 +6,7 @@
 
 
 
-{%- set available_languages = get_lang_switcher_options(request, translations) -%}
+{%- set available_languages = get_locale_options(request, translations) -%}
 
 {% if available_languages|length > 1 %}
   <form id="lang_form" class="mzp-c-language-switcher" method="get" action="#">

--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -17,6 +17,7 @@ from markupsafe import Markup
 
 from bedrock.base import waffle
 from bedrock.utils import expand_locale_groups
+from lib.l10n_utils import get_translations_native_names
 
 from ..urlresolvers import reverse
 
@@ -153,3 +154,22 @@ def alternate_url(path, locale):
         return alt_paths[path][locale]
 
     return None
+
+
+@library.global_function
+def get_lang_switcher_options(request, translations):
+    # For purely Django-rendered pages, or purely CMS-backed pages, we can just
+    # rely on the `translations` var in the render context to know what locales
+    # are viable for the page being rendered. Great! \o/
+    available_locales = translations
+
+    # However, if a URL route is decorated with bedrock.cms.decorators.prefer_cms
+    # that means that a page could come from the CMS or from Django depending on
+    # the locale being requested. In this situation _locales_available_via_cms
+    # and _locales_for_django_fallback_view are annotated onto the request.
+    # We need to use these to create a more accurate view of what locales are
+    # available
+    if hasattr(request, "_locales_available_via_cms") and hasattr(request, "_locales_for_django_fallback_view"):
+        available_locales = get_translations_native_names(sorted(set(request._locales_available_via_cms + request._locales_for_django_fallback_view)))
+
+    return available_locales

--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -157,7 +157,7 @@ def alternate_url(path, locale):
 
 
 @library.global_function
-def get_lang_switcher_options(request, translations):
+def get_locale_options(request, translations):
     # For purely Django-rendered pages, or purely CMS-backed pages, we can just
     # rely on the `translations` var in the render context to know what locales
     # are viable for the page being rendered. Great! \o/

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -89,7 +89,7 @@ def test_switch():
         ),
     ),
 )
-def test_get_lang_switcher_options(rf, translations_locales, cms_locales, django_locales, expected):
+def test_get_locale_options(rf, translations_locales, cms_locales, django_locales, expected):
     native_translations = get_translations_native_names(translations_locales)
     native_expected = get_translations_native_names(expected)
 
@@ -99,7 +99,7 @@ def test_get_lang_switcher_options(rf, translations_locales, cms_locales, django
         request._locales_available_via_cms = cms_locales
         request._locales_for_django_fallback_view = django_locales
 
-    assert native_expected == helpers.get_lang_switcher_options(
+    assert native_expected == helpers.get_locale_options(
         request=request,
         translations=native_translations,
     )

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -1,14 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
+import pytest
 from django_jinja.backend import Jinja2
 
 from bedrock.base.templatetags import helpers
+from lib.l10n_utils import get_translations_native_names
 
 jinja_env = Jinja2.get_default()
 SEND_TO_DEVICE_MESSAGE_SETS = {
@@ -69,3 +70,36 @@ def test_switch():
 
     assert ret is waffle.switch.return_value
     waffle.switch.assert_called_with("dude")
+
+
+@pytest.mark.parametrize(
+    "translations_locales, cms_locales, django_locales, expected",
+    (
+        (
+            ["en-US", "fr", "sco"],
+            ["de", "pt-BR"],
+            ["ja-JP", "zh-CN"],
+            ["de", "pt-BR", "ja-JP", "zh-CN"],
+        ),
+        (
+            ["en-US", "fr", "sco"],
+            [],
+            [],
+            ["en-US", "fr", "sco"],
+        ),
+    ),
+)
+def test_get_lang_switcher_options(rf, translations_locales, cms_locales, django_locales, expected):
+    native_translations = get_translations_native_names(translations_locales)
+    native_expected = get_translations_native_names(expected)
+
+    request = rf.get("/dummy/path/")
+
+    if cms_locales and django_locales:
+        request._locales_available_via_cms = cms_locales
+        request._locales_for_django_fallback_view = django_locales
+
+    assert native_expected == helpers.get_lang_switcher_options(
+        request=request,
+        translations=native_translations,
+    )

--- a/bedrock/cms/decorators.py
+++ b/bedrock/cms/decorators.py
@@ -9,18 +9,40 @@ from django.http import Http404
 from wagtail.views import serve as wagtail_serve
 
 from bedrock.base.i18n import remove_lang_prefix
+from lib.l10n_utils.fluent import get_active_locales
+
+from .utils import get_cms_locales_for_path
 
 HTTP_200_OK = 200
 
 
-def prefer_cms(view_func):
+def prefer_cms(view_func=None, fallback_ftl_files=None, fallback_lang_codes=None):
     """
     A decorator that helps us migrate from pure Django-based views
-    to CMS views.
+    to CMS views, or support having _some_ locales served from the CMS and
+    other / evergreen content in other locales coming from Django views .
 
     It will try to see if `wagtail.views.serve` can find a live CMS page for the
     URL path that matches the current Django view's path, and if so, will
     return that. If not, it will let the regular Django view run.
+
+    Args:
+        view_func - the function to wrap
+        fallback_ftl_files (optional) - a list of the names of the Fluent files used by
+            the Django view that's being wrapped. It's a little repetitive, but
+            from those we can work out what locales the page is availble in
+            across the CMS and Django views
+        fallback_lang_codes (optional) - a list of strings of language codes that
+            show what locales are available for the Django view being wrapped.
+            This is useful if, for some reason, the Fluent files are not a reliable
+            way to determine the available locales for a page
+            (e.g. the Fluent files cover 20 locales for some strings which appear
+            on the page, but the main localized content is only in two languages,
+            because the contnet doesn't come from Fluent - such as Legal Docs,
+            which comes from a git repo)
+
+        Note that setting both fallback_lang_codes and fallback_ftl_files will cause
+        an exception to be raised - only one should be set, not both.
 
     Workflow:
 
@@ -33,42 +55,100 @@ def prefer_cms(view_func):
 
     Example for a function-based view:
 
-        @prefer_cms
+        @prefer_cms(fallback_ftl_files=[...])  # or fallback_lang_codes=["fr", "es-MX",]
         def some_path(request):
             ...
 
     Or, in a URLconf for a regular Django view:
 
         ...
-        path("some/path/", prefer_cms(views.some_view)),
+        path("some/path/", prefer_cms(views.some_view, fallback_ftl_files=[...])),
+
+        # or
+
+        path("some/path/", prefer_cms(views.some_view, fallback_lang_codes=["fr", "pt-BR",])),
+
         ...
 
     Or, in a URLconf with Bedrock's page() helper:
         page(
             "about/leadership/",
             "mozorg/about/leadership/index.html",
+            ftl_files=["some/path/to/fluent/data"],
             decorators=[prefer_cms],
         )
 
+        (Note that no fallback_ftl_files is needed here - we'll just pick up the regular
+        ftl_files kwarg that's already used for page(). ALSO: fallback_ftl_files is NOT
+        supported for the page() helper, as we shouldn't need it in real use)
     """
 
-    @wraps(view_func)
-    def wrapped_view(request, *args, **kwargs):
-        path = remove_lang_prefix(request.path_info)
-        try:
-            # Does Wagtail have a route that matches this? If so, show that page
-            wagtail_response = wagtail_serve(request, path)
-            if wagtail_response.status_code == HTTP_200_OK:
-                return wagtail_response
-        except Http404:
-            pass
+    if fallback_ftl_files and fallback_lang_codes:
+        raise RuntimeError("The prefer_cms decorator can be configured with either fallback_ftl_files or fallback_lang_codes but not both.")
 
-        # If not, call the original view function, but remember to
-        # un-mark the request as being for a CMS page. This is so to avoid
-        # lib.l10n_utils.render() incorrectly looking for available translations
-        # based on CMS data - we're falling back to non-CMS pages, so we want
-        # the Fluent translations that are normal for a Django-rendered page
-        request.is_cms_page = False
-        return view_func(request, *args, **kwargs)
+    fallback_ftl_files = fallback_ftl_files or []
+    fallback_lang_codes = fallback_lang_codes or []
 
-    return wrapped_view
+    def _get_django_locales_available(
+        fallback_ftl_files,
+        fallback_lang_codes,
+        kwargs,
+    ):
+        # Prefer explicit list of lang codes over everything else
+        if fallback_lang_codes:
+            return fallback_lang_codes
+
+        # If we're looking at Fluent files, prefer the ftl_files kwarg (as used
+        # with page()) but also accept an explicitly added fallback_ftl_files param
+        _ftl_files = kwargs.get("ftl_files", fallback_ftl_files)
+        return get_active_locales(_ftl_files, force=True)
+
+    def decorator(func):
+        @wraps(func)
+        def wrapped_view(request, *args, **kwargs):
+            path = remove_lang_prefix(request.path_info)
+
+            # Annotate the request with the Django/fallback locales, as we'll
+            # need them for the language picket in the footer when rendering
+            # the Wagtail response IF there is a Wagtail match
+            request._locales_for_django_fallback_view = _get_django_locales_available(
+                fallback_ftl_files=fallback_ftl_files,
+                fallback_lang_codes=fallback_lang_codes,
+                kwargs=kwargs,
+            )
+
+            try:
+                # Does Wagtail have a route that matches this? If so, show that page
+                wagtail_response = wagtail_serve(request, path)
+                if wagtail_response.status_code == HTTP_200_OK:
+                    return wagtail_response
+            except Http404:
+                pass
+
+            # If the page does not exist in Wagtail, call the original view function and...
+            #
+            # 1) Un-mark this request as being for a CMS page (which happened
+            # via wagtail_serve()) to avoid lib.l10n_utils.render() incorrectly
+            # looking for available translations based on CMS data, rather than
+            # Fluent files
+            request.is_cms_page = False
+
+            # 2) Make extra sure this request is still annotated with any CMS-backed
+            # locale versions that are available, so that we can populate the
+            # language picker appropriately. (The annotation also happened via
+            # wagtail_serve() thanks to AbstractBedrockCMSPage._patch_request_for_bedrock
+            request._locales_available_via_cms = getattr(
+                request,
+                "_locales_available_via_cms",
+                get_cms_locales_for_path(request),
+            )
+            return func(request, *args, **kwargs)
+
+        return wrapped_view
+
+    # If view_func is None, the decorator was called with parameters
+    if view_func is None:
+        return decorator
+    else:
+        # Otherwise, apply the decorator directly to view_func
+        return decorator(view_func)

--- a/bedrock/cms/decorators.py
+++ b/bedrock/cms/decorators.py
@@ -99,8 +99,10 @@ def prefer_cms(
 
     """
 
-    if fallback_ftl_files and fallback_lang_codes:
-        raise RuntimeError("The prefer_cms decorator can be configured with either fallback_ftl_files or fallback_lang_codes but not both.")
+    if len([x for x in [fallback_ftl_files, fallback_lang_codes, fallback_callable] if x]) > 1:
+        raise RuntimeError(
+            "The prefer_cms decorator can be configured with only one of fallback_ftl_files or fallback_lang_codes or fallback_callable."
+        )
 
     fallback_ftl_files = fallback_ftl_files or []
     fallback_lang_codes = fallback_lang_codes or []

--- a/bedrock/cms/decorators.py
+++ b/bedrock/cms/decorators.py
@@ -70,17 +70,14 @@ def prefer_cms(view_func=None, fallback_ftl_files=None, fallback_lang_codes=None
 
         ...
 
-    Or, in a URLconf with Bedrock's page() helper:
-        page(
-            "about/leadership/",
-            "mozorg/about/leadership/index.html",
-            ftl_files=["some/path/to/fluent/data"],
-            decorators=[prefer_cms],
-        )
+    IMPORTANT: there's no support for bedrock.mozorg.util.page(), deliberately.
 
-        (Note that no fallback_ftl_files is needed here - we'll just pick up the regular
-        ftl_files kwarg that's already used for page(). ALSO: fallback_ftl_files is NOT
-        supported for the page() helper, as we shouldn't need it in real use)
+        Making prefer_cms work with our page() helper would have made that function
+        more complex. Given that it's straightforward to convert a page()-based view to
+        a dedicated TemplateView, which _can_ be decorated with prefer_cms at the
+        URLConf level, that is the recommended approach if you are migrating a page()
+        based view to the CMS, or need to have hybrid behaviour.
+
     """
 
     if fallback_ftl_files and fallback_lang_codes:
@@ -98,8 +95,6 @@ def prefer_cms(view_func=None, fallback_ftl_files=None, fallback_lang_codes=None
         if fallback_lang_codes:
             return fallback_lang_codes
 
-        # If we're looking at Fluent files, prefer the ftl_files kwarg (as used
-        # with page()) but also accept an explicitly added fallback_ftl_files param
         _ftl_files = kwargs.get("ftl_files", fallback_ftl_files)
         return get_active_locales(_ftl_files, force=True)
 

--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -59,7 +59,7 @@ class AbstractBedrockCMSPage(WagtailBasePage):
         # Quick annotation to help us track the origin of the page
         request.is_cms_page = True
 
-        # Patch in a list of CMS-available locales for pages that are translations, not just aliases
+        # Patch in a list of available locales for pages that are translations, not just aliases
         request._locales_available_via_cms = get_locales_for_cms_page(self)
         return request
 

--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -10,9 +10,8 @@ from django.views.decorators.cache import never_cache
 from wagtail.models import Page as WagtailBasePage
 from wagtail_localize.fields import SynchronizedField
 
+from bedrock.cms.utils import get_locales_for_cms_page
 from lib import l10n_utils
-
-from ..utils import get_locales_for_cms_page
 
 
 @method_decorator(never_cache, name="serve_password_required_response")

--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -12,6 +12,8 @@ from wagtail_localize.fields import SynchronizedField
 
 from lib import l10n_utils
 
+from ..utils import get_locales_for_cms_page
+
 
 @method_decorator(never_cache, name="serve_password_required_response")
 class AbstractBedrockCMSPage(WagtailBasePage):
@@ -58,13 +60,7 @@ class AbstractBedrockCMSPage(WagtailBasePage):
         request.is_cms_page = True
 
         # Patch in a list of CMS-available locales for pages that are translations, not just aliases
-        request._locales_available_via_cms = [self.locale.language_code]
-        try:
-            _actual_translations = self.get_translations().exclude(id__in=[x.id for x in self.aliases.all()])
-            request._locales_available_via_cms += [x.locale.language_code for x in _actual_translations]
-        except ValueError:
-            # when there's no draft and no potential for aliases, etc, the above lookup will fail
-            pass
+        request._locales_available_via_cms = get_locales_for_cms_page(self)
         return request
 
     def _render_with_fluent_string_support(self, request, *args, **kwargs):

--- a/bedrock/cms/tests/conftest.py
+++ b/bedrock/cms/tests/conftest.py
@@ -77,7 +77,11 @@ def tiny_localized_site():
     fr_root_page = en_us_root_page.copy_for_translation(fr_locale)
     pt_br_root_page = en_us_root_page.copy_for_translation(pt_br_locale)
 
-    en_us_homepage = SimpleRichTextPageFactory(title="Test Page", slug="test-page", parent=en_us_root_page)
+    en_us_homepage = SimpleRichTextPageFactory(
+        title="Test Page",
+        slug="test-page",
+        parent=en_us_root_page,
+    )
 
     en_us_child = SimpleRichTextPageFactory(
         title="Child",
@@ -97,9 +101,14 @@ def tiny_localized_site():
     rev = fr_child.save_revision()
     fr_child.publish(rev)
 
+    # WARNING: there may be a bug with the page tree here
+    # fr_grandchild cannot be found with Page.find_for_request
+    # when all the others can. TODO: debug this, but manually
+    # it works
     fr_grandchild = SimpleRichTextPageFactory(
         title="Petit-enfant",
         slug="grandchild-page",
+        locale=fr_locale,
         parent=fr_child,
     )
 

--- a/bedrock/cms/tests/decorator_test_views.py
+++ b/bedrock/cms/tests/decorator_test_views.py
@@ -1,10 +1,13 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from unittest import mock
 
 from django.http import HttpResponse
 
 from bedrock.cms.decorators import prefer_cms
+
+test_callable_to_get_locales = mock.Mock(return_value=["sco", "es-ES"])
 
 
 def undecorated_dummy_view(request):
@@ -26,5 +29,10 @@ def decorated_dummy_view_with_fluent_files(request):
     return HttpResponse("This is a dummy response from the decorated view with fluent files explicitly passed in")
 
 
-def wrapped_dummy_view(request):
+def wrapped_dummy_view(request, *args, **kwargs):
     return HttpResponse("This is a dummy response from the wrapped view")
+
+
+@prefer_cms(fallback_callable=test_callable_to_get_locales)
+def decorated_dummy_view_for_use_with_a_callable(request, *args, **kwargs):
+    return HttpResponse(f"This is a dummy response from the decorated view for the callable, taking {args} and {kwargs}")

--- a/bedrock/cms/tests/decorator_test_views.py
+++ b/bedrock/cms/tests/decorator_test_views.py
@@ -16,5 +16,15 @@ def decorated_dummy_view(request):
     return HttpResponse("This is a dummy response from the decorated view")
 
 
+@prefer_cms(fallback_lang_codes=["fr-CA", "es-MX", "sco"])
+def decorated_dummy_view_with_locale_strings(request):
+    return HttpResponse("This is a dummy response from the decorated view with locale strings passed in")
+
+
+@prefer_cms(fallback_ftl_files=["test/fluentA", "test/fluentB"])
+def decorated_dummy_view_with_fluent_files(request):
+    return HttpResponse("This is a dummy response from the decorated view with fluent files explicitly passed in")
+
+
 def wrapped_dummy_view(request):
     return HttpResponse("This is a dummy response from the wrapped view")

--- a/bedrock/cms/tests/test_decorators.py
+++ b/bedrock/cms/tests/test_decorators.py
@@ -10,7 +10,6 @@ from wagtail.rich_text import RichText
 from bedrock.base.i18n import bedrock_i18n_patterns
 from bedrock.cms.decorators import prefer_cms
 from bedrock.cms.tests import decorator_test_views
-from bedrock.mozorg.util import page
 from bedrock.urls import urlpatterns as mozorg_urlpatterns
 
 from .factories import SimpleRichTextPageFactory
@@ -28,13 +27,38 @@ urlpatterns = (
             name="decorated_dummy_view",
         ),
         path(
+            "decorated/view/path/with/locale/strings/",
+            decorator_test_views.decorated_dummy_view_with_locale_strings,
+            name="decorated_dummy_view_with_locale_strings",
+        ),
+        path(
+            "decorated/view/path/with/fluent/files/",
+            decorator_test_views.decorated_dummy_view_with_fluent_files,
+            name="decorated_dummy_view_with_fluent_files",
+        ),
+        path(
             "wrapped/view/path/",
             prefer_cms(
                 decorator_test_views.wrapped_dummy_view,
             ),
             name="url_wrapped_dummy_view",
         ),
-        page("book/", "mozorg/book.html", decorators=[prefer_cms]),
+        path(
+            "wrapped/view/path/with/fluent/files/",
+            prefer_cms(
+                decorator_test_views.wrapped_dummy_view,
+                fallback_ftl_files=["test/fluent1", "test/fluent2"],
+            ),
+            name="url_wrapped_dummy_view",
+        ),
+        path(
+            "wrapped/view/path/with/locale/strings/",
+            prefer_cms(
+                decorator_test_views.wrapped_dummy_view,
+                fallback_lang_codes=["fr-CA", "es-MX", "sco"],
+            ),
+            name="url_wrapped_dummy_view",
+        ),
     )
     + mozorg_urlpatterns  # we need to extend these so Jinja2 can call url() in the templates
 )
@@ -87,6 +111,79 @@ def test_decorating_django_view(lang_code_prefix, minimal_site, client):
 
 @pytest.mark.urls(__name__)
 @pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_decorating_django_view__passing_fallback_lang_codes(
+    lang_code_prefix,
+    minimal_site,
+    client,
+):
+    resp = client.get(
+        "/decorated/view/path/with/locale/strings/",
+        follow=True,
+    )
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the decorated view with locale strings passed in"
+    # Show that the expected locales are annotated onto the request
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["fr-CA", "es-MX", "sco"]
+    assert resp.wsgi_request._locales_available_via_cms == []  # No page in CMS yet
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    _set_up_cms_pages(
+        deepest_path="/decorated/view/path/with/locale/strings/",
+        site=minimal_site,
+    )
+
+    resp = client.get(f"{lang_code_prefix}/decorated/view/path/with/locale/strings/", follow=True)
+    assert resp.status_code == 200
+    # Show that the expected locales are annotated onto the request
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["fr-CA", "es-MX", "sco"]
+    assert resp.wsgi_request._locales_available_via_cms == ["en-US"]
+    assert "This is a CMS page now, with the slug of strings" in resp.content.decode("utf-8")
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_decorating_django_view__passing_ftl_files(lang_code_prefix, minimal_site, client, mocker):
+    mock_get_active_locales = mocker.patch("bedrock.cms.decorators.get_active_locales")
+    mock_get_active_locales.return_value = ["sco", "es-ES", "fr-CA"]
+
+    assert not mock_get_active_locales.called
+    resp = client.get(
+        "/decorated/view/path/with/fluent/files/",
+        follow=True,
+    )
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the decorated view with fluent files explicitly passed in"
+    # Show that the expected locales are annotated onto the request
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["sco", "es-ES", "fr-CA"]
+    mock_get_active_locales.assert_called_once_with(
+        ["test/fluentA", "test/fluentB"],
+        force=True,
+    )
+
+    assert resp.wsgi_request._locales_available_via_cms == []  # No page in CMS yet
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    _set_up_cms_pages(
+        deepest_path="/decorated/view/path/with/fluent/files/",
+        site=minimal_site,
+    )
+
+    mock_get_active_locales.reset_mock()
+
+    resp = client.get(f"{lang_code_prefix}/decorated/view/path/with/fluent/files/", follow=True)
+    assert resp.status_code == 200
+    # Show that the expected locales are annotated onto the request
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["sco", "es-ES", "fr-CA"]
+    mock_get_active_locales.assert_called_once_with(
+        ["test/fluentA", "test/fluentB"],
+        force=True,
+    )
+    assert resp.wsgi_request._locales_available_via_cms == ["en-US"]
+    assert "This is a CMS page now, with the slug of files" in resp.content.decode("utf-8")
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
 def test_patching_in_urlconf__standard_django_view(lang_code_prefix, minimal_site, client):
     # Show wrapped view renders Django view initially,
     # because there is no CMS page at that route yet
@@ -107,21 +204,80 @@ def test_patching_in_urlconf__standard_django_view(lang_code_prefix, minimal_sit
 
 @pytest.mark.urls(__name__)
 @pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
-def test_support_with_bedrock_page_view(lang_code_prefix, minimal_site, client):
-    # Show decorated page() view renders Django view initially, because there is no CMS page at that route yet
-    resp = client.get(f"{lang_code_prefix}/book/", follow=True)
+def test_patching_in_urlconf__standard_django_view__with_locale_list(
+    lang_code_prefix,
+    minimal_site,
+    client,
+):
+    resp = client.get(
+        "/wrapped/view/path/with/locale/strings/",
+        follow=True,
+    )
     assert resp.status_code == 200
-    assert "The Book of Mozilla" in resp.content.decode("utf-8")
+    assert resp.content.decode("utf-8") == "This is a dummy response from the wrapped view"
+    # Show that the expected locales are annotated onto the request
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["fr-CA", "es-MX", "sco"]
+    assert resp.wsgi_request._locales_available_via_cms == []  # No page in CMS yet
 
     # Show the decorated view will "prefer" to render the Wagtail page when it exists
     _set_up_cms_pages(
-        deepest_path="/book/",
+        deepest_path="/wrapped/view/path/with/locale/strings/",
         site=minimal_site,
     )
 
-    resp = client.get(f"{lang_code_prefix}/book/", follow=True)
+    resp = client.get(f"{lang_code_prefix}/wrapped/view/path/with/locale/strings/", follow=True)
     assert resp.status_code == 200
-    assert "This is a CMS page now, with the slug of book" in resp.content.decode("utf-8")
+    # Show that the expected locales are annotated onto the request
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["fr-CA", "es-MX", "sco"]
+    assert resp.wsgi_request._locales_available_via_cms == ["en-US"]
+    assert "This is a CMS page now, with the slug of strings" in resp.content.decode("utf-8")
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.parametrize("lang_code_prefix", ("", "/en-US"))
+def test_patching_in_urlconf__standard_django_view__with_fluent_files(
+    lang_code_prefix,
+    minimal_site,
+    client,
+    mocker,
+):
+    mock_get_active_locales = mocker.patch("bedrock.cms.decorators.get_active_locales")
+    mock_get_active_locales.return_value = ["sco", "es-ES", "fr-CA"]
+
+    assert not mock_get_active_locales.called
+
+    resp = client.get(
+        "/wrapped/view/path/with/fluent/files/",
+        follow=True,
+    )
+    assert resp.status_code == 200
+    assert resp.content.decode("utf-8") == "This is a dummy response from the wrapped view"
+
+    mock_get_active_locales.assert_called_once_with(
+        ["test/fluent1", "test/fluent2"],
+        force=True,
+    )
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["sco", "es-ES", "fr-CA"]
+    assert resp.wsgi_request._locales_available_via_cms == []  # No page in CMS yet
+
+    # Show the decorated view will "prefer" to render the Wagtail page when it exists
+    _set_up_cms_pages(
+        deepest_path="/wrapped/view/path/with/fluent/files/",
+        site=minimal_site,
+    )
+
+    mock_get_active_locales.reset_mock()
+
+    resp = client.get(f"{lang_code_prefix}/wrapped/view/path/with/fluent/files/", follow=True)
+    assert resp.status_code == 200
+    mock_get_active_locales.assert_called_once_with(
+        ["test/fluent1", "test/fluent2"],
+        force=True,
+    )
+
+    assert resp.wsgi_request._locales_for_django_fallback_view == ["sco", "es-ES", "fr-CA"]
+    assert resp.wsgi_request._locales_available_via_cms == ["en-US"]
+    assert "This is a CMS page now, with the slug of files" in resp.content.decode("utf-8")
 
 
 @pytest.mark.urls(__name__)

--- a/bedrock/cms/tests/test_decorators.py
+++ b/bedrock/cms/tests/test_decorators.py
@@ -382,3 +382,69 @@ def test_draft_pages_do_not_get_preferred_over_django_views(lang_code_prefix, mi
     resp = client.get("/decorated/view/path/", follow=True)
     assert resp.status_code == 200
     assert resp.content.decode("utf-8") == "This is a dummy response from the decorated view"
+
+
+def _fake_callable():
+    pass
+
+
+@pytest.mark.parametrize(
+    "config, expect_exeption",
+    (
+        (
+            {
+                "fallback_ftl_files": ["test/files"],
+                "fallback_lang_codes": ["sco", "en-CA"],
+            },
+            True,
+        ),
+        (
+            {
+                "fallback_ftl_files": ["test/files"],
+                "fallback_callable": _fake_callable,
+            },
+            True,
+        ),
+        (
+            {
+                "fallback_lang_codes": ["sco", "en-CA"],
+                "fallback_callable": _fake_callable,
+            },
+            True,
+        ),
+        (
+            {
+                "fallback_ftl_files": ["test/files"],
+                "fallback_lang_codes": ["sco", "en-CA"],
+                "fallback_callable": _fake_callable,
+            },
+            True,
+        ),
+        (
+            {
+                "fallback_ftl_files": ["test/files"],
+            },
+            False,
+        ),
+        (
+            {
+                "fallback_lang_codes": ["sco", "en-CA"],
+            },
+            False,
+        ),
+        (
+            {
+                "fallback_callable": _fake_callable,
+            },
+            False,
+        ),
+    ),
+)
+def test_prefer_cms_rejects_invalid_setup(mocker, config, expect_exeption):
+    fake_view = mocker.Mock(name="fake view")
+
+    if expect_exeption:
+        with pytest.raises(RuntimeError):
+            prefer_cms(view_func=fake_view, **config)
+    else:
+        prefer_cms(view_func=fake_view, **config)

--- a/bedrock/cms/tests/test_models.py
+++ b/bedrock/cms/tests/test_models.py
@@ -7,7 +7,7 @@ from unittest import mock
 from django.test import override_settings
 
 import pytest
-from wagtail.models import Locale, Page
+from wagtail.models import Page
 
 from bedrock.cms.models import (
     AbstractBedrockCMSPage,
@@ -100,32 +100,19 @@ def test_CMS_ALLOWED_PAGE_MODELS_controls_Page_can_create_at(
         assert page_class.can_create_at(home_page) == success_expected
 
 
-def test__patch_request_for_bedrock__locales_available_via_cms(tiny_localized_site, rf):
+@mock.patch("bedrock.cms.models.base.get_locales_for_cms_page")
+def test__patch_request_for_bedrock__locales_available_via_cms(
+    mock_get_locales_for_cms_page,
+    minimal_site,
+    rf,
+):
     request = rf.get("/some-path/that/is/irrelevant")
-    en_us_homepage = Page.objects.get(locale__language_code="en-US", slug="home")
-    en_us_test_page = en_us_homepage.get_children()[0]
 
-    # By default there are no aliases in the system, so all _locales_available_for_cms will
-    # match the pages set up in the tiny_localized_site fixture
-    assert Page.objects.filter(alias_of__isnull=False).count() == 0
+    page = SimpleRichTextPage.objects.last()  # made by the minimal_site fixture
 
-    patched_request = en_us_test_page.specific._patch_request_for_bedrock(request)
-    assert sorted(patched_request._locales_available_via_cms) == ["en-US", "fr", "pt-BR"]
+    mock_get_locales_for_cms_page.return_value = ["en-US", "fr", "pt-BR"]
 
-    # now make aliases of the test_page into Dutch and Spanish
-    nl_locale = Locale.objects.create(language_code="nl")
-    es_es_locale = Locale.objects.create(language_code="es-ES")
-
-    nl_page_alias = en_us_test_page.copy_for_translation(locale=nl_locale, copy_parents=True, alias=True)
-    nl_page_alias.save()
-
-    es_es_page_alias = en_us_test_page.copy_for_translation(locale=es_es_locale, copy_parents=True, alias=True)
-    es_es_page_alias.save()
-
-    assert Page.objects.filter(alias_of__isnull=False).count() == 4  # 2 child + 2 parent pages, which had to be copied too
-
-    # Show that the aliases don't appear in the available locales
-    patched_request = en_us_test_page.specific._patch_request_for_bedrock(request)
+    patched_request = page.specific._patch_request_for_bedrock(request)
     assert sorted(patched_request._locales_available_via_cms) == ["en-US", "fr", "pt-BR"]
 
 

--- a/bedrock/cms/tests/test_rendering.py
+++ b/bedrock/cms/tests/test_rendering.py
@@ -98,7 +98,8 @@ def test_locales_are_drawn_from_page_translations(minimal_site, rf, serving_meth
     page = Page.objects.last().specific
     fr_page = page.copy_for_translation(fr_locale)
     fr_page.title = "FR test page"
-    fr_page.save()
+    rev = fr_page.save_revision()
+    fr_page.publish(rev)
     assert fr_page.locale.language_code == "fr"
 
     _relative_url = page.relative_url(minimal_site)

--- a/bedrock/cms/tests/test_utils.py
+++ b/bedrock/cms/tests/test_utils.py
@@ -34,3 +34,14 @@ def test_get_locales_for_cms_page(tiny_localized_site):
 
     # Show that the aliases don't appear in the available locales
     assert sorted(get_locales_for_cms_page(en_us_test_page)) == ["en-US", "fr", "pt-BR"]
+
+
+def test_get_locales_for_cms_page__ensure_draft_pages_are_excluded(tiny_localized_site):
+    en_us_homepage = Page.objects.get(locale__language_code="en-US", slug="home")
+    en_us_test_page = en_us_homepage.get_children()[0]
+    fr_homepage = Page.objects.get(locale__language_code="fr", slug="home-fr")
+    fr_test_page = fr_homepage.get_children()[0]
+
+    fr_test_page.unpublish()
+
+    assert sorted(get_locales_for_cms_page(en_us_test_page)) == ["en-US", "pt-BR"]

--- a/bedrock/cms/tests/test_utils.py
+++ b/bedrock/cms/tests/test_utils.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+from wagtail.models import Locale, Page
+
+from bedrock.cms.utils import get_locales_for_cms_page
+
+pytestmark = [pytest.mark.django_db]
+
+
+def test_get_locales_for_cms_page(tiny_localized_site):
+    en_us_homepage = Page.objects.get(locale__language_code="en-US", slug="home")
+    en_us_test_page = en_us_homepage.get_children()[0]
+
+    # By default there are no aliases in the system, so all _locales_available_for_cms will
+    # match the pages set up in the tiny_localized_site fixture
+    assert Page.objects.filter(alias_of__isnull=False).count() == 0
+
+    assert sorted(get_locales_for_cms_page(en_us_test_page)) == ["en-US", "fr", "pt-BR"]
+
+    # now make aliases of the test_page into Dutch and Spanish
+    nl_locale = Locale.objects.create(language_code="nl")
+    es_es_locale = Locale.objects.create(language_code="es-ES")
+
+    nl_page_alias = en_us_test_page.copy_for_translation(locale=nl_locale, copy_parents=True, alias=True)
+    nl_page_alias.save()
+
+    es_es_page_alias = en_us_test_page.copy_for_translation(locale=es_es_locale, copy_parents=True, alias=True)
+    es_es_page_alias.save()
+
+    assert Page.objects.filter(alias_of__isnull=False).count() == 4  # 2 child + 2 parent pages, which had to be copied too
+
+    # Show that the aliases don't appear in the available locales
+    assert sorted(get_locales_for_cms_page(en_us_test_page)) == ["en-US", "fr", "pt-BR"]

--- a/bedrock/cms/tests/test_utils.py
+++ b/bedrock/cms/tests/test_utils.py
@@ -2,10 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+
 import pytest
+from wagtail.coreutils import get_dummy_request
 from wagtail.models import Locale, Page
 
-from bedrock.cms.utils import get_locales_for_cms_page
+from bedrock.cms.utils import get_cms_locales_for_path, get_locales_for_cms_page, get_page_for_request
 
 pytestmark = [pytest.mark.django_db]
 
@@ -45,3 +47,98 @@ def test_get_locales_for_cms_page__ensure_draft_pages_are_excluded(tiny_localize
     fr_test_page.unpublish()
 
     assert sorted(get_locales_for_cms_page(en_us_test_page)) == ["en-US", "pt-BR"]
+
+
+@pytest.mark.parametrize(
+    "path, expected_page_url",
+    [
+        (
+            "/en-US/test-page/",
+            "/en-US/test-page/",
+        ),
+        (
+            "/test-page/",
+            "/en-US/test-page/",
+        ),
+        (
+            "/pt-BR/test-page/",
+            "/pt-BR/test-page/",
+        ),
+        (
+            "/pt-BR/test-page/child-page/",
+            "/pt-BR/test-page/child-page/",
+        ),
+        (
+            "/fr/test-page/",
+            "/fr/test-page/",
+        ),
+        (
+            "/fr/test-page/child-page/",
+            "/fr/test-page/child-page/",
+        ),
+        # These two routes do not work, even though a manual test with similar ones
+        # does not show up as a problem. I think it's possibly related to the
+        # tiny_localized_site fixture generated in cms/tests/conftest.py
+        # (
+        #     "/fr/test-page/child-page/grandchild-page/",
+        #     "/fr/test-page/child-page/grandchild-page/",
+        # ),
+        # (
+        #     "/test-page/child-page/grandchild-page/",
+        #     "/fr/test-page/child-page/grandchild-page/",
+        # ),
+    ],
+)
+def test_get_page_for_request__happy_path(path, expected_page_url, tiny_localized_site):
+    request = get_dummy_request(path=path)
+    page = get_page_for_request(request=request)
+    assert isinstance(page, Page)
+    assert page.url == expected_page_url
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/en-US/test-page/fake/path/",
+        "/fr/test-page/fake/path/",
+        "/not/a/real/test-page",
+    ],
+)
+def test_get_page_for_request__no_match(path, tiny_localized_site):
+    request = get_dummy_request(path=path)
+    page = get_page_for_request(request=request)
+    assert page is None
+
+
+@pytest.mark.parametrize(
+    "get_page_for_request_should_return_a_page, get_locales_for_cms_page_retval, expected",
+    (
+        (True, ["en-CA", "sco", "zh-CN"], ["en-CA", "sco", "zh-CN"]),
+        (False, None, []),
+    ),
+)
+def test_get_cms_locales_for_path(
+    rf,
+    get_page_for_request_should_return_a_page,
+    get_locales_for_cms_page_retval,
+    expected,
+    minimal_site,
+    mocker,
+):
+    request = rf.get("/path/is/irrelevant/due/to/mocks")
+    mock_get_page_for_request = mocker.patch("bedrock.cms.utils.get_page_for_request")
+    mock_get_locales_for_cms_page = mocker.patch("bedrock.cms.utils.get_locales_for_cms_page")
+
+    if get_page_for_request_should_return_a_page:
+        page = mocker.Mock("fake-page")
+        mock_get_page_for_request.return_value = page
+        mock_get_locales_for_cms_page.return_value = get_locales_for_cms_page_retval
+    else:
+        mock_get_page_for_request.return_value = None
+
+    request = rf.get("/irrelevant/because/we/are/mocking")
+    assert get_cms_locales_for_path(request) == expected
+
+    if get_page_for_request_should_return_a_page:
+        mock_get_page_for_request.assert_called_once_with(request=request)
+        mock_get_locales_for_cms_page.assert_called_once_with(page=page)

--- a/bedrock/cms/utils.py
+++ b/bedrock/cms/utils.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Subquery
 from django.http import Http404
 
 from wagtail.models import Locale, Page
@@ -40,7 +41,9 @@ def get_locales_for_cms_page(page):
             page.get_translations()
             .live()
             .exclude(
-                id__in=[x.id for x in page.aliases.all()],
+                id__in=Subquery(
+                    page.aliases.all().values_list("id", flat=True),
+                )
             )
         )
         locales_available_via_cms += [x.locale.language_code for x in _actual_translations]

--- a/bedrock/cms/utils.py
+++ b/bedrock/cms/utils.py
@@ -8,8 +8,12 @@ def get_locales_for_cms_page(page):
     # translations, not just aliases
     locales_available_via_cms = [page.locale.language_code]
     try:
-        _actual_translations = page.get_translations().exclude(
-            id__in=[x.id for x in page.aliases.all()],
+        _actual_translations = (
+            page.get_translations()
+            .live()
+            .exclude(
+                id__in=[x.id for x in page.aliases.all()],
+            )
         )
         locales_available_via_cms += [x.locale.language_code for x in _actual_translations]
     except ValueError:

--- a/bedrock/cms/utils.py
+++ b/bedrock/cms/utils.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+def get_locales_for_cms_page(page):
+    # Patch in a list of CMS-available locales for pages that are
+    # translations, not just aliases
+    locales_available_via_cms = [page.locale.language_code]
+    try:
+        _actual_translations = page.get_translations().exclude(
+            id__in=[x.id for x in page.aliases.all()],
+        )
+        locales_available_via_cms += [x.locale.language_code for x in _actual_translations]
+    except ValueError:
+        # when there's no draft and no potential for aliases, etc, the above lookup will fail
+        pass
+
+    return locales_available_via_cms

--- a/bedrock/cms/utils.py
+++ b/bedrock/cms/utils.py
@@ -1,11 +1,26 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from django.http import Http404
+
+
+def get_page_for_path(request, path):
+    from wagtail.models import Site
+
+    site = Site.find_for_request(request)
+    try:
+        page, args, kwargs = site.root_page.specific.route(request, path)
+        return page
+    except Http404:
+        pass
+
+    return None
 
 
 def get_locales_for_cms_page(page):
     # Patch in a list of CMS-available locales for pages that are
     # translations, not just aliases
+
     locales_available_via_cms = [page.locale.language_code]
     try:
         _actual_translations = (
@@ -21,3 +36,12 @@ def get_locales_for_cms_page(page):
         pass
 
     return locales_available_via_cms
+
+
+def get_cms_locales_for_path(request):
+    locales = []
+
+    if page := get_page_for_path(request=request, path=request.path):
+        locales = get_locales_for_cms_page(page)
+
+    return locales

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -35,12 +35,18 @@ urlpatterns = (
     # VPN Resource Center
     path(
         "vpn/resource-center/",
-        prefer_cms(views.resource_center_landing_view),
+        prefer_cms(
+            views.resource_center_landing_view,
+            fallback_lang_codes=["de", "en-US", "es-ES", "fr", "it", "ja", "nl", "pl", "pt-BR", "ru", "zh-CN"],
+        ),
         name="products.vpn.resource-center.landing",
     ),
     path(
         "vpn/resource-center/<slug:slug>/",
-        prefer_cms(views.resource_center_article_view),
+        prefer_cms(
+            views.resource_center_article_view,
+            fallback_lang_codes=["de", "en-US", "es-ES", "fr", "it", "ja", "nl", "pl", "pt-BR", "ru", "zh-CN"],
+        ),
         name="products.vpn.resource-center.article",
     ),
     path("monitor/waitlist-plus/", views.monitor_waitlist_plus_page, name="products.monitor.waitlist-plus"),

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -45,7 +45,6 @@ urlpatterns = (
         "vpn/resource-center/<slug:slug>/",
         prefer_cms(
             views.resource_center_article_view,
-            # fallback_lang_codes=["de", "en-US", "es-ES", "fr", "it", "ja", "nl", "pl", "pt-BR", "ru", "zh-CN"],
             fallback_callable=views.resource_center_article_available_locales_lookup,
         ),
         name="products.vpn.resource-center.article",

--- a/bedrock/products/urls.py
+++ b/bedrock/products/urls.py
@@ -45,7 +45,8 @@ urlpatterns = (
         "vpn/resource-center/<slug:slug>/",
         prefer_cms(
             views.resource_center_article_view,
-            fallback_lang_codes=["de", "en-US", "es-ES", "fr", "it", "ja", "nl", "pl", "pt-BR", "ru", "zh-CN"],
+            # fallback_lang_codes=["de", "en-US", "es-ES", "fr", "it", "ja", "nl", "pl", "pt-BR", "ru", "zh-CN"],
+            fallback_callable=views.resource_center_article_available_locales_lookup,
         ),
         name="products.vpn.resource-center.article",
     ),

--- a/bedrock/products/views.py
+++ b/bedrock/products/views.py
@@ -377,6 +377,17 @@ def resource_center_article_view(request, slug):
     )
 
 
+def resource_center_article_available_locales_lookup(*, slug: str) -> list[str]:
+    # Helper func to get a list of language codes available for the given
+    # Contentful-powered VPN RC slug
+    return list(
+        ContentfulEntry.objects.filter(
+            localisation_complete=True,
+            slug=slug,
+        ).values_list("locale", flat=True)
+    )
+
+
 @require_safe
 def monitor_waitlist_scan_page(request):
     template_name = "products/monitor/waitlist/scan.html"

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -407,6 +407,11 @@ page-serving logic comes last in all URLConfs). **BUT...** how can you enter con
 into the CMS fast enough replace the just-removed Django page? (Note: we could use a
 data migraiton here, but that gets complicated when there are images involved)
 
+Equally, you may have a situation where the content for certain paths needs to be
+managed in the CMS for certain locales, while other locales (with rarely changing
+'evergreen' content) may only exist as Django-rendered views drawing strings from
+Fluent.
+
 The answer here is to use the ``bedrock.cms.decorators.prefer_cms`` decorator/helper.
 
 A Django view decorated with ``prefer_cms`` will check if a live CMS page has been
@@ -415,14 +420,16 @@ one, it will show the user `that` CMS page instead. If there is no match in the 
 then the original Django view will be used.
 
 The result is a graceful handover flow that allows us to switch to the CMS page
-without needing to remove the Django view from the URLconf. It doesn't affect
+without needing to remove the Django view from the URLconf, or to maintain a
+hybrid approach to page management. It doesn't affect
 previews, so the review of draft pages before publishing can continue with no changes.
 Once the CMS is populated with a live version of the replacement page, that's when a
-later changeset can remove the deprecated Django view.
+later changeset can remove the deprecated Django view if it's no longer needed.
 
 The ``prefer_cms`` decorator can be used directly on function-based views, or can wrap
-views in the URLconf. It can also be passed to our very handy
-``bedrock.mozorg.util.page`` as one of the list of ``decorator`` arguments.
+views in the URLconf. It should not used with ``bedrock.mozorg.util.page`` due to
+the complexity of passing through what locales are involved, but instead the relevant
+URL route should be refactored as a regular Django view, and then decorated with ``prefer_cms``
 
 For more details, please see the docstring on ``bedrock.cms.decorators.prefer_cms``.
 


### PR DESCRIPTION
## One-line summary

This changeset ensures that the language picker (and `canonical-url.html` header partial) remains accurate when a page is partly in Wagtail CMS and partly rendered via Django views.

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

This piece of work was like pulling at a loose thread on a sweater. It may look like there's a lot going on here, so I'll add notes on the Github diff where I think they'll help.

The `prefer_cms` decorator is applied to a regular Django view and will try to load the decorated URL path from the CMS first, then fall back to the original Django view. Previously, when a page came from the CMS, we would set the `translations` context variable to be a list of locales _available in the CMS only_, which had the downside that the language picker in the footer didn't mention the locales that were still available via the regular Django view. (The inverse was also true: if you reached a Django-rendered page that was decorated with `prefer_cms`, it would not show the locales available in the CMS because it didn't have awareness of them.

I tried different ways to get around this, including patching `translations` in `lib.l10n_utils.render` (which ended very badly as `translations` is used for more than just the footer picker, such as the logic around deciding whether to redirect to the default `en-US` locale.)

The approach that worked better was to, via the `prefer_cms` decorator, annotate the request with two lists of locale language codes: the locales available from the CMS and those available from the Django view. Then, we use a new Jinja helper to pull together these two lists for use in the language picker (we also use the same helper to provide correct locale lists for the canonical URL links in the header). 

(Note that this logic only runs on views decorated with `prefer_cms` - otherwise we still use the regular `translations` context var for such things.)

To make this work the `prefer_cms` decorator needs to be told what locales are available in the regular Django view - it was not viable to introspect the view to get hold of the relevant locales. There are three (!) ways to pass this information in:

1) Pass in the same Fluent files that are used in the view – this is good for views that are HTML templates and Fluent strings _only_. We work out the relevant locales based on the same get_active_locales()` logic as our main `l10n_utils.render()` function.
2) Pass in a list of language codes for the locales - this is good for views that might have content from an external source (eg a git repo) but which we know will be consistentely and completely translated into all of those locales
3) Pass in a callable function or method that will return the appropriate locales for the Django-rendered view. This is best for views with a single URL featuring a slug variable, where _some_ pages are widely localized, but not all of them are, so we can't reliably used a fixed list of locales. Things like the old VPN Resource Center articles are a good example of this, and **this changeset uses the callable pattern to make the language picker work for the VPN RC*

## Issue / Bugzilla link

Resolves #15193 

## Testing

* Use the VPN RC as the test for this. (See `Testing` section on https://github.com/mozilla/bedrock/pull/15236 if you need to set one up locally) 
* Add new CMS pages to the VPN RC using slugs that exist for the Django view in more than just `en-US` (e.g. `what-is-a-vpn` and `the-difference-between-a-vpn-and-a-web-proxy`) - they can just have lorem ipsum content locally - the URL loath is what we are really need here
* Publish the pages and view them.
* Edit bedrock/product.urls
* The footer's language picker should allow you to switch between any of the 10 languages available for those pages regardless of whether they are in the CMS or in Django, with no duplicated locales mentioned and never a 404 or redirect back to the `en-US` version
* The canonical url links in the `head` of the pages should also reflect the other locales available.
* Note that the the VPN RC index page in the CMS currently does _not_ mix Django and CMS-based content - that change is out of scope of this fix, which is focused only on the footer lang switcher

