### PR TITLE
Add pricing information to VPN mobile subscription CTA (Fixes #15463)

### DIFF
--- a/bedrock/products/templates/products/vpn/includes/mobile-subscribe.html
+++ b/bedrock/products/templates/products/vpn/includes/mobile-subscribe.html
@@ -9,6 +9,7 @@
 {% set android_url = play_store_url('vpn', campaign) %}
 {% set ios_url = app_store_url('vpn', campaign) %}
 {% set redirect_url = 'http://www.mozilla.org/products/vpn/mobile/app/?product=vpn&campaign=' + campaign %}
+{% set local_currency_notice = country_code in ["UG", "SN", "UA", "KE"] and ftl_has_messages('vpn-pricing-transaction-may-be-in') %}
 
 <section class="mzp-c-split vpn-pricing-mobile-subscription mzp-l-split-center-on-sm-md mzp-t-content-xl">
   <div class="mzp-c-split-container">
@@ -16,13 +17,50 @@
       {% if heading %}
         <h2 class="u-title-lg">{{ heading }}</h2>
       {% endif %}
-      <p class="vpn-pricing-desktop-instruction u-body-lg">
-        {% if android_sub_only %}
-          {{ ftl('vpn-pricing-scan-qrcode-to-download-android', fallback='vpn-pricing-scan-qrcode-to-download') }}
-        {% else %}
-          {{ ftl('vpn-pricing-scan-qrcode-to-download') }}
-        {% endif %}
-      </p>
+
+      {% if switch('vpn-wave-vii-pricing') %}
+      <div class="c-pricing-block-mobile-wrapper">
+        <div class="c-pricing-block-mobile">
+          <p class="c-pricing-block-mobile-tag">
+            {{ ftl('vpn-shared-pricing-recommended-offer') }}
+          </p>
+
+          <h2 class="c-pricing-block-mobile-heading">
+            {{ ftl('vpn-pricing-annual') }}
+          </h2>
+
+          <h3 class="c-pricing-block-mobile-sub-heading">
+            {{ vpn_mobile_monthly_price(plan='12-month', country_code=country_code, lang=LANG) }}
+          </h3>
+
+          {% if local_currency_notice %}
+            <p class="c-pricing-block-mobile-currency-info">
+              {{ ftl('vpn-pricing-transaction-may-be-in') }}
+            </p>
+          {% endif %}
+
+          <p class="c-pricing-block-mobile-total">
+            {{ vpn_mobile_total_price(country_code=country_code, lang=LANG) }}
+          </p>
+        </div>
+
+        <div class="c-pricing-block-mobile">
+          <h2 class="c-pricing-block-mobile-heading">
+            {{ ftl('vpn-pricing-monthly') }}
+          </h2>
+
+          <h3 class="c-pricing-block-mobile-sub-heading">
+            {{ vpn_mobile_monthly_price(plan='monthly', country_code=country_code, lang=LANG) }}
+          </h3>
+
+          {% if local_currency_notice %}
+            <p class="c-pricing-block-mobile-currency-info">
+              {{ ftl('vpn-pricing-transaction-may-be-in') }}
+            </p>
+          {% endif %}
+        </div>
+      </div>
+      {% endif %}
 
       <ol class="vpn-pricing-mobile-steps u-body-lg">
         {% if android_sub_only %}
@@ -33,6 +71,14 @@
         <li><span>{{ ftl('vpn-pricing-connect-up-to-platforms', fallback='vpn-pricing-connect-up-to', devices=connect_devices) }}</span></li>
         <li><span>{{ ftl('vpn-pricing-access', servers=connect_servers, countries=connect_countries) }}</span></li>
       </ol>
+
+      <p class="vpn-pricing-desktop-instruction u-body-lg">
+        {% if android_sub_only %}
+          {{ ftl('vpn-pricing-scan-qrcode-to-download-android', fallback='vpn-pricing-scan-qrcode-to-download') }}
+        {% else %}
+          {{ ftl('vpn-pricing-scan-qrcode-to-download') }}
+        {% endif %}
+      </p>
 
       {{ picture(
         url='img/products/vpn/landing-refresh/devices.svg',

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -1231,7 +1231,7 @@ class TestVPNMonthlyPrice(TestCase):
 
     def _render(self, plan, country_code, lang):
         req = self.rf.get("/")
-        req.locale = "en-US"
+        req.locale = lang
         return render(f"{{{{ vpn_monthly_price('{plan}', '{country_code}', '{lang}') }}}}", {"request": req})
 
     def test_vpn_monthly_price_usd_en_us(self):
@@ -1385,6 +1385,315 @@ class TestVPNMonthlyPrice(TestCase):
         self.assertEqual(markup, expected)
 
 
+class TestVPNMobileMonthlyPrice(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, plan, country_code, lang):
+        req = self.rf.get("/")
+        req.locale = "en-US"
+        return render(f"{{{{ vpn_mobile_monthly_price('{plan}', '{country_code}', '{lang}') }}}}", {"request": req})
+
+    def test_vpn_monthly_price_au_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="AU", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">A$14.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_au_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="AU", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">A$7.50<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_bd_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="BD", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">BDT1,200.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_bd_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="BD", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">BDT583.33<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_br_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="BR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">R$56.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_br_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="BR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">R$27.50<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_cl_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="CL", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">CLP9,300<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_cl_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="CL", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">CLP4,582<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_co_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="CO", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">COP41,900.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_co_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="CO", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">COP20,825.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_eg_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="EG", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">EGP479.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_eg_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="EG", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">EGP241.67<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_gr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="GR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">€9.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_gr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="GR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">€4.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_id_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="ID", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">IDR155,000.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_id_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="ID", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">IDR75,000.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_in_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="IN", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">₹839.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_in_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="IN", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">₹416.58<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_ke_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="KE", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$9.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_ke_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="KE", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$5.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_kr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="KR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">₩13,500<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_kr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="KR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">₩6,658<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_ma_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="MA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">MAD99.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_ma_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="MA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">MAD50.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_mx_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="MX", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">MX$189.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_mx_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="MX", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">MX$95.75<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_ng_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="NG", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">NGN15,900.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_ng_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="NG", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">NGN8,325.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_no_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="NO", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">NOK110.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_no_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="NO", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">NOK54.17<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_sa_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="SA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">SAR36.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_sa_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="SA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">SAR18.75<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_sn_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="SN", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$9.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_sn_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="SN", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$4.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_th_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="TH", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">THB330.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_th_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="TH", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">THB165.83<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_tr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="TR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">TRY339.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_tr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="TR", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">TRY166.67<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_tw_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="TW", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">NT$320.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_tw_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="TW", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">NT$158.33<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_ua_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="UA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$9.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_ua_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="UA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$5.00<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_ug_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="UG", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$9.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_ug_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="UG", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$4.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_vn_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="VN", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">₫249,000<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_vn_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="VN", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">₫124,917<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_za_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="ZA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">ZAR169.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_za_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="ZA", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">ZAR83.33<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_monthly_price_unknown_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="monthly", country_code="", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$9.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_price_unknown_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(plan="12-month", country_code="", lang="en-US")
+        expected = '<span class="vpn-monthly-price-display">$4.99<span>/month</span></span>'
+        self.assertEqual(markup, expected)
+
+
 @override_settings(
     VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING,
 )
@@ -1393,7 +1702,7 @@ class TestVPNTotalPrice(TestCase):
 
     def _render(self, country_code, lang):
         req = self.rf.get("/")
-        req.locale = "en-US"
+        req.locale = lang
         return render(f"{{{{ vpn_total_price('{country_code}', '{lang}') }}}}", {"request": req})
 
     def test_vpn_12_month_total_price_usd_en_us(self):
@@ -1481,6 +1790,165 @@ class TestVPNTotalPrice(TestCase):
         self.assertEqual(markup, expected)
 
 
+class TestVPNMobileTotalPrice(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, country_code, lang):
+        req = self.rf.get("/")
+        req.locale = lang
+        return render(f"{{{{ vpn_mobile_total_price('{country_code}', '{lang}') }}}}", {"request": req})
+
+    def test_vpn_12_month_total_price_au_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="AU", lang="en-US")
+        expected = "A$89.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_bd_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="BD", lang="en-US")
+        expected = "BDT7,000.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_br_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="BR", lang="en-US")
+        expected = "R$330.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_cl_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="CL", lang="en-US")
+        expected = "CLP54,990 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_co_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="CO", lang="en-US")
+        expected = "COP249,900.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_eg_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="EG", lang="en-US")
+        expected = "EGP2,899.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_gr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="GR", lang="en-US")
+        expected = "€59.88 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_id_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="ID", lang="en-US")
+        expected = "IDR900,000.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_in_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="IN", lang="en-US")
+        expected = "₹4,999.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_ke_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="KE", lang="en-US")
+        expected = "$59.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_kr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="KR", lang="en-US")
+        expected = "₩79,900 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_ma_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="MA", lang="en-US")
+        expected = "MAD600.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_mx_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="MX", lang="en-US")
+        expected = "MX$1,149.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_ng_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="NG", lang="en-US")
+        expected = "NGN99,900.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_no_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="NO", lang="en-US")
+        expected = "NOK650.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_sa_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="SA", lang="en-US")
+        expected = "SAR224.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_sn_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="SN", lang="en-US")
+        expected = "$59.88 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_th_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="TH", lang="en-US")
+        expected = "THB1,990.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_tr_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="TR", lang="en-US")
+        expected = "TRY1,999.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_tw_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="TW", lang="en-US")
+        expected = "NT$1,900.00 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_ua_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="UA", lang="en-US")
+        expected = "$59.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_ug_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="UG", lang="en-US")
+        expected = "$59.88 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_vn_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="VN", lang="en-US")
+        expected = "₫1,499,000 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_za_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="ZA", lang="en-US")
+        expected = "ZAR999.99 total"
+        self.assertEqual(markup, expected)
+
+    def test_vpn_12_month_total_price_unknown_en_us(self):
+        """Should return expected markup"""
+        markup = self._render(country_code="", lang="en-US")
+        expected = "$59.88 total"
+        self.assertEqual(markup, expected)
+
+
 @override_settings(
     VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING,
 )
@@ -1489,7 +1957,7 @@ class TestVPNSaving(TestCase):
 
     def _render(self, country_code, lang):
         req = self.rf.get("/")
-        req.locale = "en-US"
+        req.locale = lang
         return render(f"{{{{ vpn_saving('{country_code}', '{lang}') }}}}", {"request": req})
 
     def test_vpn_12_month_saving_usd(self):

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1736,6 +1736,286 @@ VPN_VARIABLE_PRICING = {
     },
 }
 
+# Simplified pricing matrix for countries that can
+# only purchase a subscription through the app store.
+VPN_MOBILE_SUB_PRICING = {
+    "AU": {  # Australia
+        "12-month": {
+            "price": "7.5",
+            "total": "89.99",
+            "currency": "AUD",
+        },
+        "monthly": {
+            "price": "14.99",
+            "currency": "AUD",
+        },
+    },
+    "BD": {  # Bangladesh
+        "12-month": {
+            "price": "583.33",
+            "total": "7000",
+            "currency": "BDT",
+        },
+        "monthly": {
+            "price": "1200",
+            "currency": "BDT",
+        },
+    },
+    "BR": {  # Brazil
+        "12-month": {
+            "price": "27.50",
+            "total": "330",
+            "currency": "BRL",
+        },
+        "monthly": {
+            "price": "56",
+            "currency": "BRL",
+        },
+    },
+    "CL": {  # Chile
+        "12-month": {
+            "price": "4582.50",
+            "total": "54990",
+            "currency": "CLP",
+        },
+        "monthly": {
+            "price": "9300",
+            "currency": "CLP",
+        },
+    },
+    "CO": {  # Colombia
+        "12-month": {
+            "price": "20825",
+            "total": "249900",
+            "currency": "COP",
+        },
+        "monthly": {
+            "price": "41900",
+            "currency": "COP",
+        },
+    },
+    "EG": {  # Egypt
+        "12-month": {
+            "price": "241.67",
+            "total": "2899.99",
+            "currency": "EGP",
+        },
+        "monthly": {
+            "price": "479.99",
+            "currency": "EGP",
+        },
+    },
+    "GR": {  # Greece
+        "12-month": {
+            "price": "4.99",
+            "total": "59.88",
+            "currency": "EUR",
+        },
+        "monthly": {
+            "price": "9.99",
+            "currency": "EUR",
+        },
+    },
+    "ID": {  # Indonesia
+        "12-month": {
+            "price": "75000",
+            "total": "900000",
+            "currency": "IDR",
+        },
+        "monthly": {
+            "price": "155000",
+            "currency": "IDR",
+        },
+    },
+    "IN": {  # India
+        "12-month": {
+            "price": "416.58",
+            "total": "4999",
+            "currency": "INR",
+        },
+        "monthly": {
+            "price": "839",
+            "currency": "INR",
+        },
+    },
+    "KE": {  # Kenya
+        "12-month": {
+            "price": "5.00",
+            "total": "59.99",
+            "currency": "USD",
+        },
+        "monthly": {
+            "price": "9.99",
+            "currency": "USD",
+        },
+    },
+    "KR": {  # South Korea
+        "12-month": {
+            "price": "6658.33",
+            "total": "79900",
+            "currency": "KRW",
+        },
+        "monthly": {
+            "price": "13500",
+            "currency": "KRW",
+        },
+    },
+    "MA": {  # Morocco
+        "12-month": {
+            "price": "50",
+            "total": "600",
+            "currency": "MAD",
+        },
+        "monthly": {
+            "price": "99",
+            "currency": "MAD",
+        },
+    },
+    "MX": {  # Mexico
+        "12-month": {
+            "price": "95.75",
+            "total": "1149",
+            "currency": "MXN",
+        },
+        "monthly": {
+            "price": "189",
+            "currency": "MXN",
+        },
+    },
+    "NG": {  # Nigeria
+        "12-month": {
+            "price": "8325",
+            "total": "99900",
+            "currency": "NGN",
+        },
+        "monthly": {
+            "price": "15900",
+            "currency": "NGN",
+        },
+    },
+    "NO": {  # Norway
+        "12-month": {
+            "price": "54.17",
+            "total": "650",
+            "currency": "NOK",
+        },
+        "monthly": {
+            "price": "110",
+            "currency": "NOK",
+        },
+    },
+    "SA": {  # Saudi Arabia
+        "12-month": {
+            "price": "18.75",
+            "total": "224.99",
+            "currency": "SAR",
+        },
+        "monthly": {
+            "price": "36.99",
+            "currency": "SAR",
+        },
+    },
+    "SN": {  # Senegal
+        "12-month": {
+            "price": "4.99",
+            "total": "59.88",
+            "currency": "USD",
+        },
+        "monthly": {
+            "price": "9.99",
+            "currency": "USD",
+        },
+    },
+    "TH": {  # Thailand
+        "12-month": {
+            "price": "165.83",
+            "total": "1990",
+            "currency": "THB",
+        },
+        "monthly": {
+            "price": "330",
+            "currency": "THB",
+        },
+    },
+    "TR": {  # Turkey
+        "12-month": {
+            "price": "166.67",
+            "total": "1999.99",
+            "currency": "TRY",
+        },
+        "monthly": {
+            "price": "339.99",
+            "currency": "TRY",
+        },
+    },
+    "TW": {  # Taiwan
+        "12-month": {
+            "price": "158.33",
+            "total": "1900",
+            "currency": "TWD",
+        },
+        "monthly": {
+            "price": "320",
+            "currency": "TWD",
+        },
+    },
+    "UA": {  # Ukraine
+        "12-month": {
+            "price": "5.00",
+            "total": "59.99",
+            "currency": "USD",
+        },
+        "monthly": {
+            "price": "9.99",
+            "currency": "USD",
+        },
+    },
+    "UG": {  # Uganda
+        "12-month": {
+            "price": "4.99",
+            "total": "59.88",
+            "currency": "USD",
+        },
+        "monthly": {
+            "price": "9.99",
+            "currency": "USD",
+        },
+    },
+    "US": {  # United States (only used as a fallback should a country match not be found).
+        "12-month": {
+            "price": "4.99",
+            "total": "59.88",
+            "currency": "USD",
+        },
+        "monthly": {
+            "price": "9.99",
+            "currency": "USD",
+        },
+    },
+    "VN": {  # Vietnam
+        "12-month": {
+            "price": "124917",
+            "total": "1499000",
+            "currency": "VND",
+        },
+        "monthly": {
+            "price": "249000",
+            "currency": "VND",
+        },
+    },
+    "ZA": {  # South Africa
+        "12-month": {
+            "price": "83.33",
+            "total": "999.99",
+            "currency": "ZAR",
+        },
+        "monthly": {
+            "price": "169.99",
+            "currency": "ZAR",
+        },
+    },
+}
+
 # Mozilla VPN Geo restrictions
 # https://github.com/mozilla-services/guardian-website/blob/master/server/constants.ts
 

--- a/l10n/en/products/vpn/pricing-2023.ftl
+++ b/l10n/en/products/vpn/pricing-2023.ftl
@@ -67,3 +67,4 @@ vpn-pricing-scan-qrcode-to-download-android = To download the app, scan the QR C
 vpn-pricing-sign-up-on-your-mobile-device = Sign up for a { -brand-name-mozilla-vpn } subscription on your mobile device
 vpn-pricing-sign-up-on-your-android-device = Sign up for a { -brand-name-mozilla-vpn } subscription on your Android device
 vpn-pricing-download-the-app = Download the app
+vpn-pricing-transaction-may-be-in = * Transaction may be in local currency equivalent.

--- a/media/css/products/vpn/pricing-refresh.scss
+++ b/media/css/products/vpn/pricing-refresh.scss
@@ -247,7 +247,7 @@ $image-path: '/media/protocol/img';
     }
 
     @media #{$mq-md} {
-        margin: $spacing-2xl 0;
+        margin: $spacing-xl 0 $spacing-2xl;
     }
 }
 
@@ -339,4 +339,77 @@ html.android {
 .vpn-pricing-mobile-unsupported-language {
     padding-top: 0;
     margin-top: -$spacing-2xl;
+}
+
+// Mobile subscription pricing display
+
+.c-pricing-block-mobile-wrapper {
+    margin-top: $spacing-2xl;
+
+    @media #{$mq-xl} {
+        display: grid;
+        grid-gap: $spacing-lg;
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.c-pricing-block-mobile {
+    background: $color-marketing-gray-20;
+    border-radius: $border-radius-md;
+    margin-bottom: $spacing-lg;
+    padding: $spacing-md;
+    position: relative;
+    @include bidi(((text-align, left, right),));
+}
+
+.c-pricing-block-mobile-tag {
+    background: $color-vpn-brand-refresh-purple-20;
+    border-radius: $border-radius-md;
+    color: $color-white;
+    display: inline-block;
+    font-weight: bold;
+    padding: $spacing-xs $spacing-md;
+    @include text-body-sm;
+
+    html[lang^='en'] & {
+        text-transform: uppercase;
+    }
+
+    @media #{$mq-xl} {
+        position: absolute;
+        top: $spacing-md;
+        @include bidi(((left, $spacing-md, right, auto),));
+    }
+}
+
+.c-pricing-block-mobile-heading {
+    border-bottom: 2px solid $color-black;
+    padding-bottom: $spacing-md;
+    @include text-title-xs;
+
+    @media #{$mq-xl} {
+        margin-top: $spacing-2xl;
+    }
+}
+
+.c-pricing-block-mobile-sub-heading {
+    margin-bottom: 0;
+    @include text-title-xs;
+
+    .vpn-monthly-price-display span {
+        display: inline-block;
+        font-weight: normal;
+        @include text-body-md;
+    }
+}
+
+.c-pricing-block-mobile-currency-info {
+    margin: $spacing-lg 0 0;
+    @include text-body-sm;
+}
+
+.c-pricing-block-mobile-total {
+    color: $color-vpn-brand-refresh-gray;
+    font-weight: bold;
+    margin: $spacing-lg 0 0;
 }


### PR DESCRIPTION
## One-line summary

This is a followup to #15262 that adds pricing information for countries where Mozilla VPN must be purchased through a mobile app store.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15463

## Testing

- http://localhost:8000/en-US/products/vpn/?geo=AU
- http://localhost:8000/en-US/products/vpn/?geo=BD
- http://localhost:8000/en-US/products/vpn/?geo=BR
- http://localhost:8000/en-US/products/vpn/?geo=CL
- http://localhost:8000/en-US/products/vpn/?geo=CO
- http://localhost:8000/en-US/products/vpn/?geo=EG
- http://localhost:8000/en-US/products/vpn/?geo=GR
- http://localhost:8000/en-US/products/vpn/?geo=ID
- http://localhost:8000/en-US/products/vpn/?geo=IN
- http://localhost:8000/en-US/products/vpn/?geo=KE
- http://localhost:8000/en-US/products/vpn/?geo=KR
- http://localhost:8000/en-US/products/vpn/?geo=MA
- http://localhost:8000/en-US/products/vpn/?geo=MX
- http://localhost:8000/en-US/products/vpn/?geo=NG
- http://localhost:8000/en-US/products/vpn/?geo=NO
- http://localhost:8000/en-US/products/vpn/?geo=SA
- http://localhost:8000/en-US/products/vpn/?geo=SN
- http://localhost:8000/en-US/products/vpn/?geo=TH
- http://localhost:8000/en-US/products/vpn/?geo=TR
- http://localhost:8000/en-US/products/vpn/?geo=TW
- http://localhost:8000/en-US/products/vpn/?geo=UA
- http://localhost:8000/en-US/products/vpn/?geo=UG
- http://localhost:8000/en-US/products/vpn/?geo=VN
- http://localhost:8000/en-US/products/vpn/?geo=ZA