### PR TITLE
Increase navigation logo lockup size (Fixes #15477)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
@@ -8,11 +8,9 @@
   <div class="m24-c-navigation-l-content">
     <div class="m24-c-navigation-container">
       <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>
-      <div>
-        <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
-          <img class="m24-c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="88" height="21">
-        </a>
-      </div>
+      <a class="m24-c-navigation-logo-link" href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
+        <img class="m24-c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="101" height="24">
+      </a>
       <div class="m24-c-navigation-items" id="m24-c-navigation-items" data-testid="m24-navigation-menu-items">
         <div class="m24-c-navigation-menu">
           <div class="m24-c-menu m24-mzp-is-basic">

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+$margin-top: 54px; // top margin offset for mobile navigation menu
+
 @keyframes nav-slide-in {
     from {
         transform: translateX(100%);
@@ -84,7 +86,7 @@
     @include clearfix;
 
     @media #{$mq-md} {
-        align-items: center;
+        align-items: start;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -148,7 +150,7 @@
 
     @media #{$mq-md} {
         height: 24px;
-        padding: 0 0 $spacing-sm;
+        padding: 0;
     }
 }
 
@@ -159,8 +161,8 @@
     @media (max-width: $screen-md) {
         &.mzp-is-open {
             display: flex;
-            height: calc(100vh - 45px); // 54px margin top
-            margin-top: 54px;
+            height: calc(100vh - $margin-top);
+            margin-top: $margin-top;
             overflow: hidden auto;
             padding-top: 0;
             position: fixed;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -105,7 +105,7 @@
     font-family: $primary-font;
     font-weight: 600;
     height: 32px;
-    margin: 0;
+    margin: 4px 0 0;
     padding: 0;
     position: relative;
     @include bidi(((float, right, left),));
@@ -137,11 +137,17 @@
     }
 }
 
+.m24-c-navigation-logo-link {
+    display: inline-block;
+}
+
 .m24-c-navigation-logo-image {
-    height: 21px;
+    height: 27px;
+    width: auto;
     padding-top: $spacing-xs;
 
     @media #{$mq-md} {
+        height: 24px;
         padding: 0 0 $spacing-sm;
     }
 }
@@ -153,8 +159,8 @@
     @media (max-width: $screen-md) {
         &.mzp-is-open {
             display: flex;
-            height: calc(100vh - 48px); // 48px margin top
-            margin-top: 48px;
+            height: calc(100vh - 45px); // 54px margin top
+            margin-top: 54px;
             overflow: hidden auto;
             padding-top: 0;
             position: fixed;


### PR DESCRIPTION
## One-line summary

Adjusts the navigation logo size for both desktop and mobile. Also improves focus ring alignment.

## Issue / Bugzilla link

#15477

## Testing

Enable switch `M24_WEBSITE_REFRESH`

http://localhost:8000/en-US/