### PR TITLE
M24 remove ctas (fix #15478)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/includes/m24/community.html
+++ b/bedrock/mozorg/templates/mozorg/about/includes/m24/community.html
@@ -32,7 +32,5 @@
           }
       ) }}
     </div>
-
-    <p class="m24-c-section-cta"><a href="{{ url('mozorg.contribute') }}" class="m24-c-cta" data-cta-text="Join the movement">Join the movement</a></p>
   </div>
 </section>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/resources-grid.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/resources-grid.html
@@ -53,6 +53,4 @@
       link_attributes='rel="external" data-link-type="link" data-link-text="Listen"',
     ) }}
   </div>
-
-  <p class="m24-c-section-cta"><a href="#TODO" class="m24-c-cta">Dive deeper</a></p>
 </section>


### PR DESCRIPTION
## One-line summary

This PR removes two CTAs from M24 home and about pages.

## Significant changes and points to review

http://localhost:8000/en-US/
http://localhost:8000/en-US/about/

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15478

## Testing
Turn on switch `M24_WEBSITE_REFRESH`