### PR TITLE
Add spacer to VPN mobile pricing display (#15463)

### DIFF
--- a/media/css/products/vpn/pricing-refresh.scss
+++ b/media/css/products/vpn/pricing-refresh.scss
@@ -399,6 +399,7 @@ html.android {
     .vpn-monthly-price-display span {
         display: inline-block;
         font-weight: normal;
+        @include bidi(((margin-left, 0.2em, margin-right, 0),));
         @include text-body-md;
     }
 }


### PR DESCRIPTION
## One-line summary

Tiny tweak that adjusts spacing directly after the monthly amount for VPN pricing.

Before:

![image](https://github.com/user-attachments/assets/31904256-7b60-4683-8b79-95c593f02e9e)

After:

![image](https://github.com/user-attachments/assets/ad0b150d-b1a0-4a81-bbcc-3cd0c1651f24)

## Issue / Bugzilla link

#15463

## Testing

http://localhost:8000/pt-BR/products/vpn/?geo=BR