### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# See the code-owners Github docs:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Mostly backend-y directories
+/bedrock @mozilla/bedrock-codeowners-backend
+/docker @mozilla/bedrock-codeowners-backend
+/lib @mozilla/bedrock-codeowners-backend
+/requirements @mozilla/bedrock-codeowners-backend
+/wsgi @mozilla/bedrock-codeowners-backend
+*.py @mozilla/bedrock-codeowners-backend
+
+# Mostly frontend-y directories
+/media @mozilla/bedrock-codeowners-frontend
+/package.json @mozilla/bedrock-codeowners-frontend
+*.html @mozilla/bedrock-codeowners-frontend
+*.js @mozilla/bedrock-codeowners-frontend
+*.scss @mozilla/bedrock-codeowners-frontend
+
+# Top-level /tests are mostly frontend-y
+/tests @mozilla/bedrock-codeowners-frontend


### PR DESCRIPTION
## One-line summary

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. The way this is set up here, if someone opens a PR that touches both a python file and a javascript file, both code owners (backend and frontend) will be automatically requested for review.

Note: I haven't yet created the teams. I wanted to get consensus first. Once the teams are created we can add ourselves to them.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners