### PR TITLE
Update ESR link on /welcome/20/ page to link to /firefox/all/desktop-esr/ (Fixes #15501)

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page19.html
+++ b/bedrock/firefox/templates/firefox/welcome/page19.html
@@ -231,7 +231,11 @@
 
     {{ download_firefox_thanks(alt_copy=cta_text, button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ cta_text }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr">
+      <a href="{{ url('firefox.all.platforms', product_slug='desktop-esr') }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">
+        {{ cta_text }}
+      </a>
+    </p>
 
     <small>{{ update_time }}</small>
 
@@ -304,4 +308,3 @@
 {% block js %}
   {{ js_bundle('firefox_welcome_page19_to_24') }}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/welcome/page20.html
+++ b/bedrock/firefox/templates/firefox/welcome/page20.html
@@ -42,7 +42,11 @@
 
     {{ download_firefox_thanks(alt_copy=ftl('welcome-page20-21-update-now-cta'), button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ ftl('welcome-page20-21-update-now-cta') }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr">
+      <a href="{{ url('firefox.all.platforms', product_slug='desktop-esr') }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">
+        {{ ftl('welcome-page20-21-update-now-cta') }}
+      </a>
+    </p>
 
     <small>{{ ftl('welcome-page20-21-usually-takes') }}</small>
 

--- a/bedrock/firefox/templates/firefox/welcome/page21.html
+++ b/bedrock/firefox/templates/firefox/welcome/page21.html
@@ -38,7 +38,11 @@
 
     {{ download_firefox_thanks(alt_copy=ftl('welcome-page20-21-update-now-cta'), button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ ftl('welcome-page20-21-update-now-cta') }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr">
+      <a href="{{ url('firefox.all.platforms', product_slug='desktop-esr') }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">
+        {{ ftl('welcome-page20-21-update-now-cta') }}
+      </a>
+    </p>
 
     <small>{{ ftl('welcome-page20-21-usually-takes') }}</small>
 

--- a/bedrock/firefox/templates/firefox/welcome/page22.html
+++ b/bedrock/firefox/templates/firefox/welcome/page22.html
@@ -42,7 +42,11 @@
 
     {{ download_firefox_thanks(alt_copy=ftl('welcome-page22-update-now-cta'), button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ ftl('welcome-page22-update-now-cta') }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr">
+      <a href="{{ url('firefox.all.platforms', product_slug='desktop-esr') }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">
+        {{ ftl('welcome-page22-update-now-cta') }}
+      </a>
+    </p>
 
     <small>{{ ftl('welcome-page22-usually-takes') }}</small>
 
@@ -63,4 +67,3 @@
 {% block js %}
   {{ js_bundle('firefox_welcome_page19_to_24') }}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/welcome/page23.html
+++ b/bedrock/firefox/templates/firefox/welcome/page23.html
@@ -42,7 +42,11 @@
 
     {{ download_firefox_thanks(alt_copy=ftl('welcome-page23-update-now-cta'), button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ ftl('welcome-page23-update-now-cta') }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr">
+      <a href="{{ url('firefox.all.platforms', product_slug='desktop-esr') }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">
+        {{ ftl('welcome-page23-update-now-cta') }}
+      </a>
+    </p>
 
     <small>{{ ftl('welcome-page23-usually-takes') }}</small>
 
@@ -63,4 +67,3 @@
 {% block js %}
   {{ js_bundle('firefox_welcome_page19_to_24') }}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/welcome/page24.html
+++ b/bedrock/firefox/templates/firefox/welcome/page24.html
@@ -42,7 +42,11 @@
 
     {{ download_firefox_thanks(alt_copy=ftl('welcome-page24-update-now-cta'), button_class='mzp-t-xl', dom_id='update-firefox') }}
 
-    <p class="c-main-cta" id="update-firefox-esr"><a href="{{ url('firefox.enterprise.index') + '#download' }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">{{ ftl('welcome-page24-update-now-cta') }}</a></p>
+    <p class="c-main-cta" id="update-firefox-esr">
+      <a href="{{ url('firefox.all.platforms', product_slug='desktop-esr') }}" class="mzp-c-button mzp-t-product mzp-t-xl" data-cta-text="Update now">
+        {{ ftl('welcome-page24-update-now-cta') }}
+      </a>
+    </p>
 
     <small>{{ ftl('welcome-page24-usually-takes') }}</small>
 
@@ -63,4 +67,3 @@
 {% block js %}
   {{ js_bundle('firefox_welcome_page19_to_24') }}
 {% endblock %}
-


### PR DESCRIPTION
## One-line summary

The folks working on the root-ca-succession project have agreed that this feels like the more appropriate link for ESR users.

## Issue / Bugzilla link

#15501

## Testing

- http://localhost:8000/en-US/firefox/welcome/19/
- http://localhost:8000/en-US/firefox/welcome/20/
- http://localhost:8000/en-US/firefox/welcome/21/
- http://localhost:8000/en-US/firefox/welcome/22/
- http://localhost:8000/en-US/firefox/welcome/23/
- http://localhost:8000/en-US/firefox/welcome/24/