### PR TITLE
Order VPN articles by first published date descending (Fixes #15517)

### DIFF
--- a/bedrock/products/models.py
+++ b/bedrock/products/models.py
@@ -71,7 +71,7 @@ class VPNResourceCenterIndexPage(ArticleIndexPageBase):
         context = super().get_context(request)
         vpn_available_in_country = vpn_available(request)
         mobile_sub_only = vpn_available_mobile_sub_only(request)
-        article_data = VPNResourceCenterDetailPage.objects.filter(locale=self.locale).live().public()
+        article_data = VPNResourceCenterDetailPage.objects.filter(locale=self.locale).live().public().order_by("-first_published_at")
 
         first_article_group, second_article_group = (
             article_data[:ARTICLE_GROUP_SIZE],


### PR DESCRIPTION
## One-line summary

Renders VPN RC articles on the index page by `first_published_at` date, descending order. This should ensure that the most newly published articles appear first on the page, with the oldest at the bottom.

## Issue / Bugzilla link

15517

## Testing

1. Log into the CMS: http://localhost:8000/cms-admin/
2. Create a structural page with the slug of `products`.
3. Create a child structural page with the slug of `vpn`.
4. Create a child VPN resource center index page with a slug of `resource-center`.
5. Create a RC child page e.g. "Test page 1" and publish.
6. Create a RC child page e.g. "Test page 2" and publish.
7. Verify that "Test page 2" is rendered first on the index page, and "Test page 1" is last.
8. Bonus points for verifying that draft pages always go to the top of the list when published, irrespective of when they were drafted.