### PR TITLE
Support sending visual context to Smartling, for its CAT tool

### DIFF
--- a/bedrock/cms/tests/factories.py
+++ b/bedrock/cms/tests/factories.py
@@ -9,6 +9,20 @@ from wagtail import models as wagtail_models
 from bedrock.cms import models
 
 
+class WagtailUserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = "auth.User"  # Equivalent to ``model = myapp.models.User``
+        django_get_or_create = ("username",)
+
+    email = "testuser@example.com"
+    password = factory.PostGenerationMethodCall("set_password", "te5tus3r")
+    username = "testuser"
+
+    is_superuser = False
+    is_staff = True
+    is_active = True
+
+
 class SimpleRichTextPageFactory(wagtail_factories.PageFactory):
     title = "Test SimpleRichTextPage"
     live = True

--- a/bedrock/cms/tests/test_callbacks.py
+++ b/bedrock/cms/tests/test_callbacks.py
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest import mock
+
+import pytest
+import wagtail_factories
+from wagtaildraftsharing.models import WagtaildraftsharingLink
+
+from bedrock.cms.tests.factories import SimpleRichTextPageFactory, WagtailUserFactory
+from bedrock.cms.wagtail_localize_smartling.callbacks import visual_context
+
+
+@pytest.mark.django_db
+def test_visual_context(client):
+    top_level_page = SimpleRichTextPageFactory()
+
+    page = SimpleRichTextPageFactory(parent=top_level_page, slug="visual-context-text-page")
+    page.save_revision()
+
+    wagtail_factories.SiteFactory(
+        root_page=top_level_page,
+        is_default_site=True,
+        hostname=client._base_environ()["SERVER_NAME"],
+    )
+
+    user = WagtailUserFactory()
+
+    mock_job = mock.Mock()
+    mock_job.translation_source.get_source_instance.return_value = page
+    mock_job.user = user
+
+    url, html = visual_context(smartling_job=mock_job)
+
+    # light checks because we're not testing wagtaildraftsharing itself
+    assert "<body" in html
+    assert "Test SimpleRichTextPage" in html
+
+    sharing_link_key = WagtaildraftsharingLink.objects.get().key
+    assert url == f"http://testserver:81/_internal_draft_preview/{sharing_link_key}/"

--- a/bedrock/cms/wagtail_localize_smartling/__init__.py
+++ b/bedrock/cms/wagtail_localize_smartling/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/bedrock/cms/wagtail_localize_smartling/callbacks.py
+++ b/bedrock/cms/wagtail_localize_smartling/callbacks.py
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# This file contains callback functions to be called by
+# github.com/mozilla/wagtail-localize-smartling/ and
+# hooked in via settings.
+#
+# The README.md of that repo covers what inputs are
+# provided and what outputs are needed
+
+from typing import TYPE_CHECKING
+
+from django.test import RequestFactory
+
+if TYPE_CHECKING:
+    from wagtail.models import Page
+    from wagtail_localize_smartling.models import Job
+
+from wagtaildraftsharing.models import WagtaildraftsharingLink
+from wagtaildraftsharing.views import SharingLinkView
+
+
+def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
+    request = RequestFactory().get(sharing_link.url)
+    view_func = SharingLinkView.as_view()
+    resp = view_func(
+        request=request,
+        key=sharing_link.key,
+    )
+    return resp.content.decode("utf-8")
+
+
+def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink, page: "Page") -> str:
+    return f"{page.get_site().root_url}{sharing_link.url}"
+
+
+def visual_context(smartling_job: "Job") -> list[str, str]:
+    # Needs to return two strings:
+    # 1. A URL where the page (possibly a draft) can be viewed without authentication
+    # 2. The HTML of the state of the page at this point in time
+
+    page = smartling_job.translation_source.get_source_instance()
+    revision = page.latest_revision
+
+    sharing_link = WagtaildraftsharingLink.objects.get_or_create_for_revision(
+        revision=revision,
+        user=smartling_job.user,
+    )
+
+    url = _get_full_url_for_sharing_link(sharing_link=sharing_link, page=page)
+    html = _get_html_for_sharing_link(sharing_link=sharing_link)
+
+    return (url, html)

--- a/bedrock/cms/wagtail_localize_smartling/callbacks.py
+++ b/bedrock/cms/wagtail_localize_smartling/callbacks.py
@@ -35,7 +35,7 @@ def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink, page: 
     return f"{page.get_site().root_url}{sharing_link.url}"
 
 
-def visual_context(smartling_job: "Job") -> list[str, str]:
+def visual_context(smartling_job: "Job") -> tuple[str, str]:
     # Needs to return two strings:
     # 1. A URL where the page (possibly a draft) can be viewed without authentication
     # 2. The HTML of the state of the page at this point in time

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2359,6 +2359,7 @@ WAGTAIL_LOCALIZE_SMARTLING = {
         "ru": "ru-RU",
     },
     "REFORMAT_LANGUAGE_CODES": False,  # don't force language codes into Django's all-lowercase pattern
+    "VISUAL_CONTEXT_CALLBACK": "bedrock.cms.wagtail_localize_smartling.callbacks.visual_context",
 }
 
 WAGTAIL_DRAFTSHARING_ADMIN_MENU_POSITION = 9000

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2292,12 +2292,12 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.txt
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.4.0 \
-    --hash=sha256:b6865fd0f759b1b7919835d36114ab89c4e8da049d077dfa362ae37618017352 \
-    --hash=sha256:f5c5c7a1f8877599ce56bf7fa85da1e6519652753f5e74e83976c07341714716
+wagtail-localize-smartling==0.6.0 \
+    --hash=sha256:1d58cc0c036ba0a61476ae4747eb589ab4511b06ae425635f47c8f18788136b9 \
+    --hash=sha256:4647b055b67218af3e841bbc43c6291f931598adedec7554b19e69eb7580c528
     # via -r requirements/prod.txt
-wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.1.tar.gz#egg=wagtaildraftsharing \
-    --hash=sha256:606c45c305dda042f8d058ef49d789cab5cced4c6905adebb82620e8ebbcf1cd
+wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
+    --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d
     # via -r requirements/prod.txt
 wand==0.6.13 \
     --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -56,8 +56,8 @@ sentry-processor==0.0.1
 sentry-sdk==2.17.0
 supervisor==4.2.5
 timeago==1.0.16
-https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.1.tar.gz#egg=wagtaildraftsharing
-wagtail-localize-smartling==0.4.0
+https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing
+wagtail-localize-smartling==0.6.0
 wagtail-localize==1.10
 Wand==0.6.13  # For animated GIF support
 Wagtail==6.1.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1633,12 +1633,12 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.in
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.4.0 \
-    --hash=sha256:b6865fd0f759b1b7919835d36114ab89c4e8da049d077dfa362ae37618017352 \
-    --hash=sha256:f5c5c7a1f8877599ce56bf7fa85da1e6519652753f5e74e83976c07341714716
+wagtail-localize-smartling==0.6.0 \
+    --hash=sha256:1d58cc0c036ba0a61476ae4747eb589ab4511b06ae425635f47c8f18788136b9 \
+    --hash=sha256:4647b055b67218af3e841bbc43c6291f931598adedec7554b19e69eb7580c528
     # via -r requirements/prod.in
-wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.1.tar.gz#egg=wagtaildraftsharing \
-    --hash=sha256:606c45c305dda042f8d058ef49d789cab5cced4c6905adebb82620e8ebbcf1cd
+wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
+    --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d
     # via -r requirements/prod.in
 wand==0.6.13 \
     --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \


### PR DESCRIPTION
## One-line summary

This changset adds support for sending a visual context (a HTML document + relevant URL) to Smartling so that the CAT "live translation preview" tool can be used easily.

## Significant changes and points to review

* Adds a callback for wagtail-localize-smartling to send visual context to Smartling

* Updates our `wagtail-localize-smartling` and `wagtaildraftsharing` dependencies, to enable the callback mentioned above to be used (and also to generate a useful URL with it)

## Issue / Bugzilla link

Resolves #14938 

## Testing

I've tested this with @cocomo over a Zoom call, so code-level review here is enough