### PR TITLE
Fix the language picker issue / inescapable redirect to en-US on the CMS-powered VPN Resource Center index page

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1049,7 +1049,7 @@ CONTENTFUL_HOMEPAGE_LOOKUP = {
 
 CONTENTFUL_LOCALE_SUFFICIENT_CONTENT_PERCENTAGE = config(
     "CONTENTFUL_LOCALE_SUFFICIENT_CONTENT_PERCENTAGE",
-    default="1" if DEV is True else "60",
+    default="1" if DEV is True else "10",
     parser=float,
 )
 


### PR DESCRIPTION
This changeset fixes the problem with the language picker on the CMS-powered VPN RC page, where selecting any language will redirect to en-US. 

It does this by lowering threshold for determining whether there is 'enough' VPN Content to justify an index page

(Settle in with a warm drink. This is a one-character code fix and a zillion characters of explanation.)

Back when the entire VPN RC was powered by Contentful, we added logic that would only allow the index page of the VPN RC to be displayed in a particular locale if there were 'enough' articles translated into that locale.

'Enough' was defined not as a specific threshold but as a percentage of the overall number of documents available in en-US.

Initially, this was fine, but as the number of documents in en-US grew the threshold failed to be reached, meaning the index pages for non-en-US locales would redirect to en-US instead, because they didn't have "enough".

This gotcha will become irrelevant as soon as we start publishing localized versions of the VPN content via the CMS, and then deleting the code for the non-CMS page versions. However, we need a fix now, so that if someone selects a locale from the footer of the en-US VPN RC index page, they don't get redirected back to that same page.

The simplest fix is just to drop the threshold to 10%, down from 60%. This basicallly makes that content redundant, but still supports the idea of hiding the index if there are just one or two articles there (there are 25 in en-US, so 10% would be hit if there are 3 or more available in the other locale -- and _all_ of the other locales seem to have at least 5 articles localized to them, so this is fine as a threshold.)

Resolves #15521

# Testing

* In your `.env` set DEV=False
* Pull down a sanitized copy of the prod DB with `AWS_DB_S3_BUCKET=bedrock-db-prod ./bin/run-db-download.py --force`
* Go to http://localhost:8000/en-US/products/vpn/resource-center/ and play with the language picker (ignore the missing images - or download them if you want them)
* Confirm you can visit the index pages for other locales