### PR TITLE
Ensure we only use x-default on appropriate pages

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -7,7 +7,7 @@
 {%- set available_languages = get_locale_options(request, translations) -%}
 
     <link rel="canonical" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
-    <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}{{ canonical_path }}">
+    {% if is_homepage %}<link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}{{ canonical_path }}">{% endif %}
     {% if available_languages -%}
       {%- for code, label in available_languages|dictsort -%}
         {%- set alt_url = alternate_url(canonical_path, code) -%}

--- a/bedrock/mozorg/templates/mozorg/credits-faq.html
+++ b/bedrock/mozorg/templates/mozorg/credits-faq.html
@@ -13,7 +13,6 @@
 
 {% block canonical_urls %}
   <link rel="canonical" href="{{ canonical_url }}">
-  <link rel="alternate" hreflang="x-default" href="{{ canonical_url }}">
 {% endblock %}
 
 {% block page_og_url %}{{ canonical_url }}{% endblock %}

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -133,6 +133,11 @@ class HomeView(L10nTemplateView):
 
     ftl_files_map = {old_template_name: ["mozorg/home"], template_name: ["mozorg/home-new"]}
 
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx.update({"is_homepage": True})
+        return ctx
+
     def get_template_names(self):
         experience = self.request.GET.get("xv", None)
 


### PR DESCRIPTION
## One-line summary

This changeset reduces the number of pages containing a `link`  with `hreflang` of `x-default`. This change will improve/reduce harm to our SEO

## Significant changes and points to review

You can test-drive this code on https://www-demo8.allizom.org/ - though note that all canonical urls there will refer to www.mozilla.org not www-demo8.allizom.org

To check/confirm:

- [ ] 1. `hreflang="x-default"` must be present in the source code of locale-specific homepages - https://www-demo8.allizom.org/en-US/, https://www-demo8.allizom.org/de/ etc
- [ ] 2. `hreflang="x-default"` must be present  on the locale-selection page for bots (Running `curl https://www-demo8.allizom.org/ | grep x-default` will show that `link` tag is present)
- [ ] 3. `hreflang="x-default"` must not be on any other pages
- [ ] 4. `hreflang="x-default"` has been removed from https://www-demo8.allizom.org/credits/faq/


## Issue / Bugzilla link

Resolves #15464 

