### PR TITLE
Refresh: update the font stack and headline weight

### DIFF
--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -40,7 +40,8 @@ h1, h2, h3, h4, h5 {
     color: $m24-color-black;
     font-family: var(--title-font-family);
     font-variant-ligatures: none;
-    font-weight: bold;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     line-height: 1.1;
 }
 

--- a/media/css/m24/root.scss
+++ b/media/css/m24/root.scss
@@ -223,13 +223,3 @@ $m24-font-path: '/media/fonts/m24';
         url('#{$m24-font-path}/mozilla-headline/MozillaHeadline-SemiBold.woff2') format('woff2'),
         url('#{$m24-font-path}/mozilla-headline/MozillaHeadline-SemiBold.woff') format('woff');
 }
-
-@font-face {
-    font-display: swap;
-    font-family: 'Mozilla Headline';
-    font-style: normal;
-    font-weight: bold;
-    src:
-        url('#{$m24-font-path}/mozilla-headline/MozillaHeadline-Bold.woff2') format('woff2'),
-        url('#{$m24-font-path}/mozilla-headline/MozillaHeadline-Bold.woff') format('woff');
-}

--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -90,9 +90,9 @@ template {
 :root {
     // fonts
     /* stylelint-disable value-keyword-case  */
-    --body-font-family: "Mozilla Text", Inter, Arial, X-LocaleSpecific, sans-serif;
-    --button-font-family: "Mozilla Text", Inter, Arial, X-LocaleSpecific, sans-serif;
-    --title-font-family: "Mozilla Headline", Rockwell, "Roboto Slab", X-LocaleSpecific, serif;
+    --body-font-family: 'Mozilla Text', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif;
+    --button-font-family: 'Mozilla Text', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif;
+    --title-font-family: 'Mozilla Headline', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif;
     /* stylelint-enable */
 
     // colors


### PR DESCRIPTION
## One-line summary
After some progress on #15397 we decided to eschew variable fonts for the time being, but we still need to switch to semibold for headlines to match current designs. 

I also updated the font stack; I think sans-serif is a better fallback for the semi-slab Mozilla Headline and couldn't really find a suitable serif system font.