### PR TITLE
Fix navigation menu padding on older browsers (Fixes #15499)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -295,7 +295,6 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
         position: static;
         display: flex;
         justify-content: space-between;
-        gap: 48px;
     }
 }
 
@@ -321,7 +320,7 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
 
     @media #{$mq-md} {
         border-bottom: transparent;
-        padding: 0 0 $spacer-sm;
+        padding: 0 $spacer-md $spacer-sm;
         position: static;
         width: auto;
     }


### PR DESCRIPTION
## One-line summary

Fixes spacing between main navigation menu items in older browsers

## Issue / Bugzilla link

#15499

## Testing

Tested in Chrome 59 on browser stack:

http://localhost:8000/en-US/