### PR TITLE
Fix unmatched closing tag in m24-c-springboard

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/media-springboard.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/media-springboard.html
@@ -11,13 +11,12 @@
   <ul class="m24-c-springboard" id="ai-media">
     <li class="m24-c-springboard-item m24-c-springboard-headings">
       <div class="m24-c-springboard-link">
-        <div class="m24-c-springboard-thumb">
-        </div>
+        <div class="m24-c-springboard-thumb"></div>
         <div class="m24-c-springboard-type">Type</div>
         <div class="m24-c-springboard-author">Author</div>
         <div class="m24-c-springboard-topic">Topic</div>
         <div class="m24-c-springboard-preview">Intro</div>
-      </a>
+      </div>
     </li>
     {{ springboard_item(
       link_url='https://blog.mozilla.org/en/mozilla/mozilla-anonym-raising-the-bar-for-privacy-preserving-digital-advertising/',


### PR DESCRIPTION
## One-line summary

Noticed a validation error in the springboard component due to an unmatched closing tag.

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/