### PR TITLE
Fix invalid role on /leadership modal links (fixes #15538)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/cms/about/blocks/leadership_block.html
+++ b/bedrock/mozorg/templates/mozorg/cms/about/blocks/leadership_block.html
@@ -4,11 +4,11 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<article {% if value.biography %}id="{{ value.id }}"{% endif %} class="vcard{% if value.biography %} has-bio{% endif %}" itemscope itemtype="http://schema.org/Person">
+<div {% if value.biography %}id="{{ value.id }}" {% endif %} class="vcard{% if value.biography %} has-bio{% endif %}" itemscope itemtype="http://schema.org/Person">
   <figure class="headshot">
     {{ srcset_image(value.headshot.image, "width-{200,400}", class="photo", sizes="160px", alt=value.headshot.image_alt_text) }}
     <figcaption>
-      <h4 class="fn" itemprop="name">{{ value.name }}</h4>
+      <h3 class="fn" itemprop="name">{{ value.name }}</h3>
     </figcaption>
   </figure>
 
@@ -40,4 +40,4 @@
       {{ value.biography|richtext }}
     </div>
   {% endif %}
-</article>
+</div>

--- a/bedrock/mozorg/templates/mozorg/cms/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/cms/about/leadership.html
@@ -46,7 +46,7 @@
           {% for group in section.value.leadership_group %}
             <section>
               {% if group.title %}
-                <h3 class="group-title">{{ group.title }}</h3>
+                <h2 class="group-title">{{ group.title }}</h2>
               {% endif %}
               <div class="gallery mgmt-corp">
                 {% for leader in group.leaders %}
@@ -60,7 +60,7 @@
     </main>
   </div>
 
-  <div class="mzp-u-modal-content"></div>
+  <div id="leadership-modal" class="mzp-u-modal-content"></div>
 {% endblock %}
 
 {% block js %}

--- a/media/js/mozorg/about-leadership.js
+++ b/media/js/mozorg/about-leadership.js
@@ -20,16 +20,29 @@ if (typeof window.Mozilla === 'undefined') {
 
     for (var i = 0; i < bios.length; i++) {
         var bio = bios[i];
+
+        // set aria roles on opening bio link and make focusable.
         bio.setAttribute('role', 'button');
+        bio.setAttribute('aria-controls', 'leadership-modal');
+        bio.setAttribute('aria-expanded', 'false');
         bio.setAttribute('tabindex', '0');
 
         bio.addEventListener('click', function (e) {
             e.preventDefault();
-            var modalContent = this.cloneNode(true);
-            modalContent.removeAttribute('id');
-            modalContent.setAttribute('role', 'article');
+            var openingLink = this;
+            var modalContent = openingLink.cloneNode(true);
 
-            MzpModal.createModal(e.target, content, {
+            // remove superfluous attributes from cloned node when in modal.
+            modalContent.removeAttribute('id');
+            modalContent.removeAttribute('role');
+            modalContent.removeAttribute('aria-controls');
+            modalContent.removeAttribute('aria-expanded');
+            modalContent.removeAttribute('tabindex');
+
+            // set opening button expanded state to true
+            openingLink.setAttribute('aria-expanded', 'true');
+
+            MzpModal.createModal(openingLink, content, {
                 closeText: window.Mozilla.Utils.trans('global-close'),
                 onCreate: function () {
                     content.appendChild(modalContent);
@@ -37,6 +50,7 @@ if (typeof window.Mozilla === 'undefined') {
                 },
                 onDestroy: function () {
                     modalContent.parentNode.removeChild(modalContent);
+                    openingLink.setAttribute('aria-expanded', 'false');
                 }
             });
         });


### PR DESCRIPTION
## One-line summary

- Change `<article>` landmark to a regular `<div>` since `role` is applied.
- Start using `aria-controls` and `aria-expanded`.
- Also fixes a heading level issue.

## Issue / Bugzilla link

#15538

## Testing

I tested this with prod CMS data: https://bedrock.readthedocs.io/en/latest/cms.html#fetching-the-latest-cms-data-for-local-work

http://localhost:8000/en-US/about/leadership/

Running a11y tests should not generate a report for the leadership page after this fix:

- `npm start`
- `cd tests/playwright`
- `npm run a11y-tests`

I also tested this with VoiceOver on macOS to make sure things seemed to make sense.