### PR TITLE
Stop using @import in m24 Sass styles (Fixes #15545)

### DIFF
--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -2,29 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
 // variables
-@import 'vars/animation';
-@import 'vars/color';
-@import 'vars/fonts';
-@import 'vars/grid';
-@import 'vars/spacing';
-@import 'vars/text';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use 'vars/lib' as *;
 
 // components
-@import 'careers';
-@import 'intro';
-@import 'donate';
-@import 'feature';
-@import 'flag';
-@import 'gallery';
-@import 'showcase';
-@import 'launchpad';
-@import 'springboard';
-@import 'theme';
-@import 'transition';
+@use 'careers';
+@use 'intro';
+@use 'donate';
+@use 'feature';
+@use 'flag';
+@use 'gallery';
+@use 'showcase';
+@use 'launchpad';
+@use 'springboard';
+@use 'theme';
+@use 'transition';
 
 /* Protocol overrides ------------------------------------------------------------ */
 

--- a/media/css/m24/careers.scss
+++ b/media/css/m24/careers.scss
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
 
 .m24-c-careers {
     @include container;

--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '../vars/lib' as *;
+
 $max-footer-content-width: $content-max;
 
 @mixin divider-line {

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '../vars/lib' as *;
+
 $max-footer-content-width: $content-max;
 
 @mixin divider-line {

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '../vars/lib' as *;
+
 $margin-top: 54px; // top margin offset for mobile navigation menu
 
 @keyframes nav-slide-in {

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '../vars/lib' as *;
+
 .m24-pencil-banner {
     background-color: $m24-color-light-green;
     padding: $spacer-sm;

--- a/media/css/m24/donate.scss
+++ b/media/css/m24/donate.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
+
 .m24-c-donate {
     @include container;
     color: $m24-color-black;

--- a/media/css/m24/feature.scss
+++ b/media/css/m24/feature.scss
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
 
 // feature
 .m24-c-feature {

--- a/media/css/m24/flag.scss
+++ b/media/css/m24/flag.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
+
 .m24-c-flag {
     @include container;
     padding-top: $spacer-2xl;

--- a/media/css/m24/gallery.scss
+++ b/media/css/m24/gallery.scss
@@ -2,12 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
-// variables
-@import 'vars/spacing';
-@import 'vars/text';
+@use 'vars/lib' as *;
 
 .m24-c-gallery-container {
     @media #{$mq-md} {

--- a/media/css/m24/intro.scss
+++ b/media/css/m24/intro.scss
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
 
 .m24-c-intro {
     font-weight: 500;

--- a/media/css/m24/launchpad.scss
+++ b/media/css/m24/launchpad.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
+
 $launchpad-logo-width: 32px;
 $launchpad-logo-spacing: calc($launchpad-logo-width + #{$grid-gutter});
 

--- a/media/css/m24/root.scss
+++ b/media/css/m24/root.scss
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import 'vars/color';
+@use 'vars/lib' as *;
 
 :root {
     // black and white

--- a/media/css/m24/showcase.scss
+++ b/media/css/m24/showcase.scss
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
 
 .m24-c-showcase-title {
     font-size: $alias-text-title-h2;

--- a/media/css/m24/springboard.scss
+++ b/media/css/m24/springboard.scss
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
 
 $springboard-thumb-width: 32px;
 

--- a/media/css/m24/theme.scss
+++ b/media/css/m24/theme.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
+
 .m24-t-light-alt {
     background-color: $m24-color-white-alt;
 }

--- a/media/css/m24/transition.scss
+++ b/media/css/m24/transition.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use 'vars/lib' as *;
+
 // Adds a pseudo-element at the top of a section with an SVG mask to produce
 // a decorative transition between sections.
 @mixin m24-transition {

--- a/media/css/m24/vars/_grid.scss
+++ b/media/css/m24/vars/_grid.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use 'spacing' as *;
 
 // grid
 $grid-margin: var(--grid-margin);

--- a/media/css/m24/vars/_lib.scss
+++ b/media/css/m24/vars/_lib.scss
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// global components
-@use 'components/footer-newsletter';
-@use 'components/footer-refresh';
-@use 'components/navigation-refresh';
-@use 'components/pencil-banner';
+@forward  '~@mozilla-protocol/core/protocol/css/includes/lib';
+@forward 'animation';
+@forward 'color';
+@forward 'fonts';
+@forward 'grid';
+@forward 'spacing';
+@forward 'text';


### PR DESCRIPTION
## One-line summary

- Removes use of `@import` in website refresh stylesheets.
- Migrates to using `@use` and `@forward` instead.

## Issue / Bugzilla link

#15545

## Testing

Ensure switch M24_WEBSITE_REFRESH is ON

- [x] `npm start` should compile without error.
- [x] Page styling should look the same:

http://localhost:8000/en-US/
http://localhost:8000/en-US/about/