### PR TITLE
Add limited media-src CSP to report-only

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -67,6 +67,10 @@ _csp_connect_src = [
 ]
 _csp_connect_extra_for_dev = []
 _csp_font_src = []
+_csp_media_src = [
+    csp.constants.SELF,
+    "assets.mozilla.net",
+]
 
 # 2. TEST-SPECIFIC SETTINGS
 # TODO: make this selectable by an env var, like the other modes
@@ -106,6 +110,7 @@ CONTENT_SECURITY_POLICY = {
         "script-src": list(set(_csp_default_src + _csp_script_src)),
         "style-src": list(set(_csp_default_src + _csp_style_src)),
         "font-src": list(set(_csp_default_src + _csp_font_src)),
+        "media-src": _csp_media_src,
         "child-src": _csp_child_src,
         "connect-src": list(set(_csp_default_src + _csp_connect_src)),
         # support older browsers (mainly Safari)

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -67,10 +67,6 @@ _csp_connect_src = [
 ]
 _csp_connect_extra_for_dev = []
 _csp_font_src = []
-_csp_media_src = [
-    csp.constants.SELF,
-    "assets.mozilla.net",
-]
 
 # 2. TEST-SPECIFIC SETTINGS
 # TODO: make this selectable by an env var, like the other modes
@@ -110,7 +106,6 @@ CONTENT_SECURITY_POLICY = {
         "script-src": list(set(_csp_default_src + _csp_script_src)),
         "style-src": list(set(_csp_default_src + _csp_style_src)),
         "font-src": list(set(_csp_default_src + _csp_font_src)),
-        "media-src": _csp_media_src,
         "child-src": _csp_child_src,
         "connect-src": list(set(_csp_default_src + _csp_connect_src)),
         # support older browsers (mainly Safari)
@@ -128,6 +123,7 @@ if csp_ro_report_uri:
 
     # CSP directive updates we're testing that we hope to move to the enforced policy.
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["default-src"] = [csp.constants.SELF]
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["media-src"] = [csp.constants.SELF, "assets.mozilla.net"]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["object-src"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["frame-ancestors"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)


### PR DESCRIPTION
## One-line summary

Adds media-src CSP-RO rule to make up for RO-removed default-src wildcards.

## Significant changes and points to review

Restricting defaults in #14897 may trigger some yet undefined policies, this specifically adds self+assets.m.o to media rules, to let it run in report-only for some time to see if that's the only host we need to add.

## Issue / Bugzilla link

#15546

## Testing

`curl -I http://localhost:8000/de/`

http://localhost:8000/de/firefox/built-for-you/?v=2