### PR TITLE
Add cdn videos to report-only CSP media-src

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -123,7 +123,7 @@ if csp_ro_report_uri:
 
     # CSP directive updates we're testing that we hope to move to the enforced policy.
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["default-src"] = [csp.constants.SELF]
-    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["media-src"] = [csp.constants.SELF, "assets.mozilla.net"]
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["media-src"] = [csp.constants.SELF, "assets.mozilla.net", "videos.cdn.mozilla.net"]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["object-src"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["frame-ancestors"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)


### PR DESCRIPTION
## One-line summary

Follows up from #15548 adding another host serving videos to add to media-src policy recently added to take precedence over default-src wildcard fallbacks.

## Significant changes and points to review

This is a new addition, so instead of allowing all the default hosts we're trying to explicitly define the sources (and/or paths if needed) to have an exhaustive list of known media hosts being used around the site.

## Issue / Bugzilla link

#15546

## Testing

curl -I http://localhost:8000/de/