### PR TITLE
remove word per stakeholder request fix (#15485, #15486, #15487)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx133-donation.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx133-donation.html
@@ -39,7 +39,7 @@
     {% set main_body_part_two = "Du hast Firefox als deinen Browser gewählt und wir hoffen, dass du jetzt den nächsten Schritt machst, um das Internet zurückzuerobern. Spende heute zum Jahresende an die Mozilla Foundation." %}
     {% set cta_link = "https://foundation.mozilla.org/?form=24-wnp-nov1" %}
   {% else %}
-    {% set main_title = "Spende an die gemeinnützige Mozilla Foundation, die hinter Firefox steht" %}
+    {% set main_title = "Spende an die Mozilla Foundation, die hinter Firefox steht" %}
     {% set main_body_part_one = "Alles, was dir an Firefox gefällt, wird von der Mozilla Foundation ermöglicht – einer globalen Bewegung, die sich gegen verantwortungslose Tech-Unternehmen einsetzt und unsere Privatsphäre online schützt. Es liegt an uns allen, verantwortungslosen Tech-Unternehmen entgegenzutreten und unsere Privatsphäre im Internet zu schützen." %}
     {% set main_body_part_two = "Du hast Firefox als deinen Browser gewählt und wir hoffen, dass du jetzt den nächsten Schritt machst, um das Internet zurückzuerobern. Spende heute zum Jahresende an die Mozilla Foundation." %}
     {% set cta_link = "https://foundation.mozilla.org/?form=24-wnp-nov2" %}


### PR DESCRIPTION
## One-line summary

This PR removes a word per stakeholder request. 

This should have been removed in https://github.com/mozilla/bedrock/pull/15509/commits/482c9fb3d03ef3717609a37fe214d8c9e6d1e5a3. It was missed.

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15487

## Testing

http://localhost:8000/de/firefox/133.0/whatsnew/?v=2&geo=CA