### PR TITLE
Set the `form-action` directive in the report-only CSP

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -134,6 +134,8 @@ if csp_ro_report_uri:
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["object-src"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["base-uri"] = [csp.constants.NONE]
+    # For `form-action`, include a trailing slash to avoid CSP's "exact match" path-part rules, unless exact matching is intended.
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["form-action"] = [csp.constants.SELF, f"{BASKET_URL}/news/", FXA_ENDPOINT]
 
 
 # `CSP_PATH_OVERRIDES` and `CSP_PATH_OVERRIDES_REPORT_ONLY` are mainly for overriding CSP settings


### PR DESCRIPTION
### Summary

This PR introduces the `form-action` directive to the report-only Content Security Policy (CSP) header. The goal is to test and evaluate its compatibility before eventually applying it to the enforced CSP header. The `form-action` directive restricts where forms on the site can send their data upon submission, adding an additional layer of security to prevent potential vulnerabilities.

#### Why `form-action` is Important for Security

The `form-action` directive is a key security measure designed to mitigate attacks that exploit form submissions, such as:
- **Phishing and data exfiltration attacks**: Prevents malicious actors from redirecting form submissions to unauthorized or external servers.
- **Clickjacking**: Works in tandem with other CSP directives to ensure that embedded forms are protected.
- **Cross-site scripting (XSS) risks**: Reduces the attack surface by limiting submission endpoints, even if an attacker manages to inject a form.

By specifying trusted domains or paths for form submissions, `form-action` ensures that forms behave only as intended and cannot be abused for unauthorized data capture.

#### **Next Steps**

1. Deploy the change and monitor CSP violation reports for any issues related to `form-action`.
2. Refine the directive based on findings from the report-only stage.
3. Once confident, apply the directive to the enforced CSP header to fully benefit from its security enhancements.

#### **References**

- [MDN Documentation on `form-action`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action)

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

#15553 (from #11943)

## Testing

- Verify the addition of the `form-action` directive in the report-only CSP header locally.
  - To do this we need to set a couple local env vars:
    - `DEBUG=False` - CSP headers aren't added while in DEBUG mode
    - `CSP_RO_REPORT_URI=/csp-violation` - the report-only header will only be added if this is set.

