### PR TITLE
Add `upgrade-insecure-requests` directive to report-only CSP

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -127,6 +127,7 @@ if csp_ro_report_uri:
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["object-src"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["frame-ancestors"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["upgrade-insecure-requests"] = True
 
 
 # `CSP_PATH_OVERRIDES` and `CSP_PATH_OVERRIDES_REPORT_ONLY` are mainly for overriding CSP settings


### PR DESCRIPTION
## One-line summary

This PR adds the `upgrade-insecure-requests` directive to our report-only Content Security Policy (CSP). The `upgrade-insecure-requests` directive automatically upgrades `HTTP` requests to `HTTPS`, helping enforce secure communication for all resources while ensuring compatibility with legacy HTTP links.

- [ ] I used an AI to write some of this code.

## Issue / Bugzilla link

#15556 

## Testing

* Verify the addition of the `upgrade-insecure-requests` directive in the report-only CSP header locally. To do this we need to set a couple local env vars:
  * DEBUG=False - CSP headers aren't added while in DEBUG mode
  * CSP_RO_REPORT_URI=/csp-violation - the report-only header will only be added if this is set.
