### PR TITLE
Fix failing job when syncing with smartling

### DIFF
--- a/bedrock/cms/tests/test_callbacks.py
+++ b/bedrock/cms/tests/test_callbacks.py
@@ -6,6 +6,8 @@ from unittest import mock
 
 import pytest
 import wagtail_factories
+from wagtail.models import Page
+from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 
 from bedrock.cms.tests.factories import SimpleRichTextPageFactory, WagtailUserFactory
@@ -13,7 +15,7 @@ from bedrock.cms.wagtail_localize_smartling.callbacks import visual_context
 
 
 @pytest.mark.django_db
-def test_visual_context(client):
+def test_visual_context__for_page(client):
     top_level_page = SimpleRichTextPageFactory()
 
     page = SimpleRichTextPageFactory(parent=top_level_page, slug="visual-context-text-page")
@@ -39,3 +41,17 @@ def test_visual_context(client):
 
     sharing_link_key = WagtaildraftsharingLink.objects.get().key
     assert url == f"http://testserver:81/_internal_draft_preview/{sharing_link_key}/"
+
+
+def test_visual_context__for_inviable_object(client):
+    inviable_obj = mock.Mock()
+
+    assert not isinstance(inviable_obj, Page)
+
+    mock_job = mock.Mock()
+    mock_job.translation_source.get_source_instance.return_value = inviable_obj
+
+    with pytest.raises(IncapableVisualContextCallback) as exc:
+        url, html = visual_context(smartling_job=mock_job)
+
+    assert exc.value.args[0] == "Object was not visually previewable"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2367,6 +2367,12 @@ WAGTAIL_DRAFTSHARING_ADMIN_MENU_POSITION = 9000
 # WAGTAIL_DRAFTSHARING_VERBOSE_NAME_PLURAL = "Internal Shares"
 # WAGTAIL_DRAFTSHARING_MENU_ITEM_LABEL = "Create internal sharing link"
 
+# At the moment, wagtaildraftsharing's expiry is only set via settings. We're using
+# 21 days here because the links are used to send a preview of the source page to
+# Smartling translators, and we want to give them plenty of time. In the future
+# we can bring this back down to 7 days and set a Smartling-specific one of 21
+WAGTAILDRAFTSHARING_MAX_AGE = 21 * 24 * 60 * 60
+
 # Custom settings, not a core Wagtail ones, to scope out RichText options
 WAGTAIL_RICHTEXT_FEATURES_FULL = [
     # https://docs.wagtail.org/en/stable/advanced_topics/customisation/page_editing_interface.html#limiting-features-in-a-rich-text-field

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2293,9 +2293,9 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.txt
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.6.0 \
-    --hash=sha256:1d58cc0c036ba0a61476ae4747eb589ab4511b06ae425635f47c8f18788136b9 \
-    --hash=sha256:4647b055b67218af3e841bbc43c6291f931598adedec7554b19e69eb7580c528
+wagtail-localize-smartling==0.6.1 \
+    --hash=sha256:292c2d66ac72ea9924a553fad8f57035983437c97d53eb9eb3b8cca17852f54b \
+    --hash=sha256:9373e53328637aaed9cb7f368f892849fa88685f464f192c1e21c8e202da3457
     # via -r requirements/prod.txt
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -57,7 +57,7 @@ sentry-sdk==2.18.0
 supervisor==4.2.5
 timeago==1.0.16
 https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing
-wagtail-localize-smartling==0.6.0
+wagtail-localize-smartling==0.6.1
 wagtail-localize==1.10
 Wand==0.6.13  # For animated GIF support
 Wagtail==6.1.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1614,9 +1614,9 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.in
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.6.0 \
-    --hash=sha256:1d58cc0c036ba0a61476ae4747eb589ab4511b06ae425635f47c8f18788136b9 \
-    --hash=sha256:4647b055b67218af3e841bbc43c6291f931598adedec7554b19e69eb7580c528
+wagtail-localize-smartling==0.6.1 \
+    --hash=sha256:292c2d66ac72ea9924a553fad8f57035983437c97d53eb9eb3b8cca17852f54b \
+    --hash=sha256:9373e53328637aaed9cb7f368f892849fa88685f464f192c1e21c8e202da3457
     # via -r requirements/prod.in
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d


### PR DESCRIPTION
## One-line summary

This changeset updates our `wagtail-localize-smartling` "visual context" callback to fail gracefully (and with the expected custom exception) when it syncs over a content object (e.g. a Snippet) that has no standalone visual context.

Prior to this change, syncing a Snippet would cause the job to fail and create an inconsistent state between Wagtail and Smartling that needed manual cleanup


## Issue / Bugzilla link

https://github.com/mozilla/wagtail-localize-smartling/issues/40

## Testing

I've tested locally - code-eyes are enough right now