### PR TITLE
Refresh: show nav, footer, and banner when translations are available [fix #15570]

### DIFF
--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -11,7 +11,7 @@
 {% block site_css %}
   {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
-    {% if LANG.startswith('en-') %}
+    {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
       {{ css_bundle('m24-navigation-and-footer') }}
     {% else %}
       {{ css_bundle('legacy-navigation-and-footer') }}

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -74,7 +74,7 @@
     {% block site_css %}
       {% if switch('m24-website-refresh') %}
         {{ css_bundle('protocol-mozilla-2024') }}
-        {% if LANG.startswith('en-') %}
+        {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
           {{ css_bundle('m24-navigation-and-footer') }}
         {% else %}
           {{ css_bundle('legacy-navigation-and-footer') }}
@@ -142,7 +142,7 @@
         {{ js_bundle('lib') }}
         {{ js_bundle('fxa') }}
         {{ js_bundle('data') }}
-        {% if switch('m24-website-refresh', ['en']) %}
+        {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
           {{ js_bundle('m24-ui') }}
         {% else %}
           {{ js_bundle('ui') }}

--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if not hide_pencil_banner %}
+{% if not hide_pencil_banner and ftl_file_is_active('m24-pencil-banner') %}
 {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
 <aside class="m24-pencil-banner" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
   <div class="m24-pencil-banner-copy">

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -6,7 +6,7 @@
 
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer' %}
 
-{% if switch('m24-website-refresh') and ftl_file_is_active('footer-refresh') %}
+{% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
   {% include 'includes/protocol/footer/footer-refresh.html' %}
 {% else %}
 <footer class="mzp-c-footer {% if theme_class %}{{ theme_class }}{% endif %}" id="colophon" role="contentinfo">

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -6,7 +6,7 @@
 
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer' %}
 
-{% if switch('m24-website-refresh', ['en']) %}
+{% if switch('m24-website-refresh') and ftl_file_is_active('footer-refresh') %}
   {% include 'includes/protocol/footer/footer-refresh.html' %}
 {% else %}
 <footer class="mzp-c-footer {% if theme_class %}{{ theme_class }}{% endif %}" id="colophon" role="contentinfo">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') %}
+{% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
   {% include 'includes/banners/pencil-banner.html' %}
   {% include 'includes/protocol/navigation/navigation-refresh.html' %}
 {% else %}

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if switch('m24-website-refresh', ['en']) %}
+{% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') %}
   {% include 'includes/banners/pencil-banner.html' %}
   {% include 'includes/protocol/navigation/navigation-refresh.html' %}
 {% else %}

--- a/bedrock/firefox/templates/firefox/new/basic/base.html
+++ b/bedrock/firefox/templates/firefox/new/basic/base.html
@@ -33,7 +33,7 @@
 {% block extrahead %}
   {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
-    {% if LANG.startswith('en-') %}
+    {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
       {{ css_bundle('m24-navigation-and-footer') }}
     {% else %}
       {{ css_bundle('legacy-navigation-and-footer') }}

--- a/bedrock/firefox/templates/firefox/new/desktop/base.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/base.html
@@ -33,7 +33,7 @@
 {% block extrahead %}
   {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
-    {% if LANG.startswith('en-') %}
+    {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
       {{ css_bundle('m24-navigation-and-footer') }}
     {% else %}
       {{ css_bundle('legacy-navigation-and-footer') }}


### PR DESCRIPTION
## One-line summary
Updates the template logic to show global elements when their corresponding Fluent files are active, rather than explicitly for English only.

## Issue / Bugzilla link
#15570 


## Testing
Run `./manage.py l10n_update` to get latest Fluent files, if you haven't lately.
Flip switch `M24_WEBSITE_REFRESH` on

You should see the nav, footer, and pencil banner on localized pages for most tier 1 languages (I've verified de, fr, es-ES, it, and a few others). 

Other locales should fall back to the old content in prod mode (I've been using be and ro to test). In dev mode you'll still see the new elements in English.