### PR TITLE
Refresh: Tweaks from design QA

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
@@ -6,7 +6,7 @@
 
 {% from "macros-m24.html" import gallery_tile with context %}
 
-<section class="m24-section-ai m24-t-dark m24-t-transition-01 m24-t-transition-next">
+<section class="m24-section-ai m24-t-dark">
   <div class="m24-c-content">
     <header class="m24-c-intro">
       <h2 class="m24-c-intro-title">Join the movement: <br>AI for the people</h2>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/hero.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/hero.html
@@ -12,7 +12,7 @@
     <div class="m24-c-flag-text">
       <h1 class="m24-c-flag-title">Welcome to Mozilla</h1>
       <p class="m24-c-flag-subtitle">From trustworthy tech to policies that defend your digital rights, we put you first — always.</p>
-      <p class="m24-c-flag-cta"><a href="{{ url('mozorg.about.index') }}" class="m24-c-cta m24-t-sm" data-cta-text="Learn about us">Learn about us</a></p>
+      <p class="m24-c-flag-cta"><a href="{{ url('mozorg.about.index') }}" class="m24-c-cta m24-t-lg" data-cta-text="Learn about us">Learn about us</a></p>
     </div>
   </section>
 </div>

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -87,7 +87,7 @@ a:link {
     color: $m24-color-black;
     display: inline-block;
     font-family: var(--title-font-family);
-    font-size: $text-button-lg;
+    font-size: $text-button-xl;
     font-weight: 600;
 
     &:hover {
@@ -100,6 +100,15 @@ a:link {
 
     &:active {
         color: $m24-color-black;
+    }
+
+    &.m24-t-lg {
+        font-size: $text-button-lg;
+    }
+
+    &.m24-t-md {
+        font-family: var(--body-font-family);
+        font-size: $text-button-md;
     }
 
     &.m24-t-sm {

--- a/media/css/m24/careers.scss
+++ b/media/css/m24/careers.scss
@@ -37,7 +37,7 @@
 }
 
 .m24-consider-cta-info {
-    font-size: $text-title-md;
+    font-size: $text-body-lg;
 }
 
 .m24-c-careers-cta {

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -27,6 +27,7 @@ $max-footer-content-width: $content-max;
 .moz24-footer-content {
     @include container;
     margin: 0 auto;
+    padding-bottom: $container-padding
 }
 
 // primary nav
@@ -87,7 +88,7 @@ $max-footer-content-width: $content-max;
     font-family: $primary-font;
     color: $m24-color-black;
     margin: 0;
-    font-size: $text-title-sm;
+    font-size: $text-body-sm;
     font-weight: 400;
 
     @media(min-width: $screen-md) {
@@ -184,8 +185,8 @@ $max-footer-content-width: $content-max;
 .moz24-footer-label {
     color: $m24-color-functional-gray;
     font-weight: 400;
-    font-size: $text-title-sm;
-    font-family: $secondary-font;
+    font-size: $text-body-sm;
+    font-family: $primary-font;
 }
 
 .moz24-footer-primary-list {
@@ -253,7 +254,6 @@ $max-footer-content-width: $content-max;
 .moz24-footer-donate {
     position: relative;
     border-radius: 0;
-    font-family: $secondary-font;
     font-weight: 500;
     background-color: transparent;
     color: $m24-color-black;
@@ -403,12 +403,12 @@ $max-footer-content-width: $content-max;
     display: flex;
     flex-direction: column;
     color: $m24-color-black;
-    font-weight: 600;
-    font-size: $text-body-sm;
+    font-size: 12px;
 
     @media(min-width: $screen-lg) {
         flex-direction: row;
         justify-content: space-between;
+        font-size: 14px;
     }
 }
 

--- a/media/css/m24/donate.scss
+++ b/media/css/m24/donate.scss
@@ -25,7 +25,7 @@
 
 .m24-c-donate-info {
     padding-top: $spacer-xl;
-    font-size: $text-title-sm;
+    font-size: $text-body-md;
 }
 
 .m24-c-donate-cta {

--- a/media/css/m24/flag.scss
+++ b/media/css/m24/flag.scss
@@ -69,6 +69,12 @@
     }
 }
 
+@media #{$mq-max} {
+    .m24-c-flag-text {
+        grid-column: 1/9;
+    }
+}
+
 // temporary until transition can be refactored
 .m24-c-products {
     background-color: $m24-color-white;

--- a/media/css/m24/intro.scss
+++ b/media/css/m24/intro.scss
@@ -28,7 +28,7 @@
     text-wrap-style: balance;
 
     &.m24-t-md {
-        font-size: 32px; // "subheading" size
+        font-size: $text-title-md;
     }
 
     &.m24-t-lg {

--- a/media/css/m24/launchpad.scss
+++ b/media/css/m24/launchpad.scss
@@ -5,7 +5,8 @@
 @use 'vars/lib' as *;
 
 $launchpad-logo-width: 32px;
-$launchpad-logo-spacing: calc($launchpad-logo-width + #{$grid-gutter});
+$launchpad-logo-padding: 16px;
+$launchpad-logo-spacing: $launchpad-logo-width + $launchpad-logo-padding;
 
 .m24-c-launchpad {
     margin: $spacer-xl 0;
@@ -114,7 +115,7 @@ $launchpad-logo-spacing: calc($launchpad-logo-width + #{$grid-gutter});
     ));
     color: $m24-color-black;
     display: inline-block;
-    font-size: $text-title-md;
+    font-size: $text-body-lg;
     font-weight: 600;
     grid-column: 1 / span 10;
     line-height: 1;
@@ -125,6 +126,7 @@ $launchpad-logo-spacing: calc($launchpad-logo-width + #{$grid-gutter});
     font-size: 12px; // custom mobile size
     grid-column: 1 / span 11;
     padding-left: $launchpad-logo-spacing;
+    padding-right: $launchpad-logo-padding; // give the arrow as much space from the text as the logo gets
 }
 
 @media #{$mq-md} {
@@ -142,6 +144,7 @@ $launchpad-logo-spacing: calc($launchpad-logo-width + #{$grid-gutter});
     .m24-c-launchpad-info {
         grid-column: 4 / 12;
         padding-left: 0;
+        padding-right: 0;
         align-content: end;
     }
 }

--- a/media/css/m24/root.scss
+++ b/media/css/m24/root.scss
@@ -60,9 +60,13 @@
     --text-body-sm: 12px;
 
     // buttons
-    --text-button-lg: 32px;
-    --text-button-md: 24px;
-    --text-button-sm: 18px;
+    --text-button-xl: 24px;
+    --text-button-lg: 18px;
+    --text-button-md: 16px;
+    --text-button-sm: 12px;
+
+    // labels
+    --text-label: 12px;
 }
 
 @media #{$mq-md} {
@@ -85,11 +89,11 @@
         --container-padding: 24px;
 
         // title
-        --text-title-2xl: 64px;
+        --text-title-2xl: 80px;
         --text-title-xl: 48px;
         --text-title-lg: 32px;
         --text-title-md: 24px;
-        --text-title-sm: 16px;
+        --text-title-sm: 18px;
 
         // body
         --text-body-lg: 18px;
@@ -97,8 +101,13 @@
         --text-body-sm: 14px;
 
         // buttons
-        --text-button-lg: 32px;
-        --text-button-sm: 18px;
+        --text-button-xl: 32px;
+        --text-button-lg: 24px;
+        --text-button-md: 18px;
+        --text-button-sm: 16px;
+
+        // labels
+        --text-label: 14px;
     }
 }
 
@@ -125,8 +134,8 @@
         --text-title-2xl: 128px;
         --text-title-xl: 80px;
         --text-title-lg: 48px;
-        --text-title-md: 24px;
-        --text-title-sm: 18px;
+        --text-title-md: 32px;
+        --text-title-sm: 24px;
 
         // body
         --text-body-lg: 24px;
@@ -134,8 +143,13 @@
         --text-body-sm: 16px;
 
         // buttons
-        --text-button-lg: 48px;
+        --text-button-xl: 48px;
+        --text-button-lg: 32px;
+        --text-button-md: 24px;
         --text-button-sm: 18px;
+
+        // labels
+        --text-label: 16px;
     }
 }
 

--- a/media/css/m24/vars/_lib.scss
+++ b/media/css/m24/vars/_lib.scss
@@ -9,3 +9,6 @@
 @forward 'grid';
 @forward 'spacing';
 @forward 'text';
+
+
+$mq-max: '(min-width: 1440px)';

--- a/media/css/m24/vars/_text.scss
+++ b/media/css/m24/vars/_text.scss
@@ -16,6 +16,10 @@ $text-body-md: var(--text-body-md);
 $text-body-sm: var(--text-body-sm);
 
 // buttons
+$text-button-xl: var(--text-button-xl);
 $text-button-lg: var(--text-button-lg);
 $text-button-md: var(--text-button-md);
 $text-button-sm: var(--text-button-sm);
+
+// label
+$text-label: var(--text-label);


### PR DESCRIPTION
## One-line summary

Refresh: Tweaks from design QA

## Significant changes and points to review

- font scale changes and some corresponding size changes
- footer: use UI font for headings (they're too small for heading font)
- footer: add bottom padding until Mozilla logo
- product launchpad: add space between logos & arrows and text in
- homepage hero: left align text when screen is wider than 1440px

## Issue / Bugzilla link

#14826 

## Testing
