### PR TITLE
Add more languages for Giving Tuesday banner (Fixes #15527)

### DIFF
--- a/bedrock/base/templates/includes/banners/fundraiser.html
+++ b/bedrock/base/templates/includes/banners/fundraiser.html
@@ -16,12 +16,36 @@
   {% set banner_button_a = 'Spenden' %}
   {% set banner_button_b = 'Jetzt spenden' %}
   {% set banner_button_c = 'Beitragen' %}
+{% elif LANG.startswith('es-') %}
+  {% set banner_title = 'Dona a Mozilla este Día para Dar' %}
+  {% set banner_tagline = 'Juntos rescatemos Internet de las grandes tecnológicas. Dona.' %}
+  {% set banner_button_a = 'Donar' %}
+  {% set banner_button_b = 'Dar ahora' %}
+  {% set banner_button_c = 'Contribuir' %}
 {% elif LANG == "fr" %}
   {% set banner_title = 'Soutenez Mozilla pour le Giving Tuesday' %}
   {% set banner_tagline = 'Ensemble, nous pouvons empêcher les géants de la tech de s’accaparer Internet.' %}
   {% set banner_button_a = 'Je fais un don' %}
   {% set banner_button_b = 'Je fais un geste' %}
   {% set banner_button_c = 'Je fais une contribution' %}
+{% elif LANG == "it" %}
+  {% set banner_title = 'Festeggia la giornata mondiale del dono con un’offerta a Mozilla.' %}
+  {% set banner_tagline = 'Insieme, liberiamo internet dal controllo di Big Tech. Dona ora.' %}
+  {% set banner_button_a = 'Dona' %}
+  {% set banner_button_b = 'Fai un’offerta' %}
+  {% set banner_button_c = 'Offri il tuo contributo' %}
+{% elif LANG == "pl" %}
+  {% set banner_title = 'Przekaż datek Mozilli na Giving Tuesday' %}
+  {% set banner_tagline = 'Razem możemy odzyskać Internet z rąk gigantów technologicznych. Wpłać teraz.' %}
+  {% set banner_button_a = 'Wpłać datek' %}
+  {% set banner_button_b = 'Wpłać teraz' %}
+  {% set banner_button_c = 'Wspomóż nas' %}
+{% elif LANG == "pt-BR" %}
+  {% set banner_title = 'Doe para a Mozilla no Dia de Doar' %}
+  {% set banner_tagline = 'Juntos, podemos retomar a internet das big techs. Doe hoje mesmo.' %}
+  {% set banner_button_a = 'Doe agora' %}
+  {% set banner_button_b = 'Doe já' %}
+  {% set banner_button_c = 'Contribua' %}
 {% else %}
   {% set banner_title = 'Donate to Mozilla for Giving Tuesday' %}
   {% set banner_tagline = 'Together we can reclaim the internet from Big Tech. Donate now.' %}

--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -22,11 +22,12 @@
 
 {% block page_desc %}{{ ftl('home-did-you-know-mozilla-the-maker') }}{% endblock %}
 
-{% set show_fundraising_banner = switch('fundraising-banner-giving2024') and LANG in ['en-US', 'en-GB', 'en-CA', 'de', 'fr'] %}
+{% set fundraising_banner_langs = ['en-US', 'en-GB', 'en-CA', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'de', 'fr', 'it', 'pl', 'pt-BR'] %}
+{% set show_fundraising_banner = switch('fundraising-banner-giving2024') and LANG in fundraising_banner_langs %}
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 
 {% block experiments %}
-  {% if switch('fundraising-banner-giving2024') %}
+  {% if show_fundraising_banner %}
     {{ js_bundle('fundraising-banner-experiment') }}
   {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-old.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-old.html
@@ -11,6 +11,15 @@
 {% block page_title %}{{ ftl('home-internet-for-people-not-profit') }}{% endblock %}
 {% block page_desc %}{{ ftl('home-did-you-know-mozilla-the-maker') }}{% endblock %}
 
+{% set fundraising_banner_langs = ['en-US', 'en-GB', 'en-CA', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'de', 'fr', 'it', 'pl', 'pt-BR'] %}
+{% set show_fundraising_banner = switch('fundraising-banner-giving2024') and LANG in fundraising_banner_langs %}
+
+{% block experiments %}
+  {% if show_fundraising_banner %}
+    {{ js_bundle('fundraising-banner-experiment') }}
+  {% endif %}
+{% endblock %}
+
 {% set referrals="?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage" %}
 
 {% block page_css %}
@@ -19,13 +28,17 @@
   {{ css_bundle('protocol-newsletter') }}
   {{ css_bundle('home-old') }}
 
-  {% if show_firefox_app_store_banner %}
+  {% if show_fundraising_banner %}
+    {{ css_bundle('fundraising-banner') }}
+  {% elif show_firefox_app_store_banner %}
     {{ css_bundle('firefox-app-store-banner') }}
   {% endif %}
 {% endblock %}
 
 {% block page_banner %}
-  {% if show_firefox_app_store_banner %}
+  {% if show_fundraising_banner %}
+    {% include 'includes/banners/fundraiser.html' %}
+  {% elif show_firefox_app_store_banner %}
     {% include 'includes/banners/mobile/firefox-app-store.html' %}
   {% endif %}
 {% endblock %}
@@ -202,7 +215,9 @@
 {% block js %}
   {{ js_bundle('newsletter') }}
 
-  {% if show_firefox_app_store_banner %}
+  {% if show_fundraising_banner %}
+    {{ js_bundle('fundraising-banner') }}
+  {% elif show_firefox_app_store_banner %}
     {{ js_bundle('firefox-app-store-banner') }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Adds a few more languages to the Giving Tuesday donation banner.

## Issue / Bugzilla link

#15527

## Testing

Disable switch `M24_WEBSITE_REFRESH`

- http://localhost:8000/es-ES/?v=a
- http://localhost:8000/es-ES/?v=b
- http://localhost:8000/es-ES/?v=c
- http://localhost:8000/es-MX/?xv=legacy&v=a
- http://localhost:8000/es-MX/?xv=legacy&v=b
- http://localhost:8000/es-MX/?xv=legacy&v=c
- http://localhost:8000/it/?v=a
- http://localhost:8000/it/?v=b
- http://localhost:8000/it/?v=c
- http://localhost:8000/pl/?xv=legacy?v=a
- http://localhost:8000/pl/?xv=legacy?v=b
- http://localhost:8000/pl/?xv=legacy?v=c
- http://localhost:8000/pt-BR/?v=a
- http://localhost:8000/pt-BR/?v=b
- http://localhost:8000/pt-BR/?v=c