### PR TITLE
Add check for Mozilla.Cient in whatsnew-events.js

### DIFF
--- a/media/js/firefox/whatsnew/whatsnew-events.js
+++ b/media/js/firefox/whatsnew/whatsnew-events.js
@@ -4,22 +4,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-// Log account status
-Mozilla.Client.getFxaDetails((details) => {
+// Create namespace
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+function sendEvents() {
     'use strict';
 
-    window.dataLayer.push({
-        event: 'dimension_set',
-        firefox_is_signed_in: details.setup ? true : false
+    // Log account status
+    window.Mozilla.Client.getFxaDetails((details) => {
+        window.dataLayer.push({
+            event: 'dimension_set',
+            firefox_is_signed_in: details.setup ? true : false
+        });
     });
-});
 
-// Log default status
-Mozilla.UITour.getConfiguration('appinfo', (details) => {
-    'use strict';
-
-    window.dataLayer.push({
-        event: 'dimension_set',
-        firefox_is_default: details.defaultBrowser ? true : false
+    // Log default status
+    window.Mozilla.UITour.getConfiguration('appinfo', (details) => {
+        window.dataLayer.push({
+            event: 'dimension_set',
+            firefox_is_default: details.defaultBrowser ? true : false
+        });
     });
-});
+}
+
+if (typeof window.Mozilla.Client !== 'undefined') {
+    sendEvents();
+}


### PR DESCRIPTION
## One-line summary

Adds an extra check to silence a small number of errors we're seeing in Sentry (likely from people on slow / intermittent connections when loading the WNP).

https://mozilla.sentry.io/issues/5349155168/events/?project=6260331

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/firefox/133.0/whatsnew/