### PR TITLE
Restrict base-uri in report-only CSP

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -128,6 +128,7 @@ if csp_ro_report_uri:
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["frame-ancestors"] = [csp.constants.NONE]
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["style-src"].remove(csp.constants.UNSAFE_INLINE)
     CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["upgrade-insecure-requests"] = True
+    CONTENT_SECURITY_POLICY_REPORT_ONLY["DIRECTIVES"]["base-uri"] = [csp.constants.NONE]
 
 
 # `CSP_PATH_OVERRIDES` and `CSP_PATH_OVERRIDES_REPORT_ONLY` are mainly for overriding CSP settings


### PR DESCRIPTION
## One-line summary

No `<base href>` is being used around the site, so this makes sure no malicious code can tamper with relative links. (Once moved from report-only; this is to surface any potential issues first.)

## Significant changes and points to review

> "Ensures that all relative URLs resolve to trusted origins, maintaining control over URL resolution behavior. Protects user experience and data by preventing exploitation of relative links."

— _Originally posted by @janbrasna in https://github.com/mozilla/bedrock/issues/15555#issuecomment-2495495198_:

> "There don't seem to be any `<base>` elements set visibly from a quick search, and I also don't recall any env settings to inject it for some deployments (e.g. don't see it being used even in `test.bedrock.nonprod.webservices.*`) so the goal is perhaps to set it to `'none'`, right?
> The public facing site should be fine, question is whether Wagtail doesn't need that for anything, but the only base use I can spot is in targets for opening new windows, so a RO test-drive should surface any violations, but hopefully there would be none."

## Issue / Bugzilla link

#15555

## Testing

This should have no impact on Wagtail previews, but please do test the CMS ~experience is intact,~ usage doesn't trigger any base-uri violations, thanks! 😗

To test this locally a couple of local env vars needs setting:
- `DEBUG=False` — CSP headers aren't added while in DEBUG mode
- `CSP_RO_REPORT_URI=https://httpbin.org/post` — the report-only header is added only with any endpoint set