### PR TITLE
Bump VPN minimum requirements for iOS 15.0 and up (Fixes #15581)

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -123,7 +123,7 @@
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-ios-long-v2', fallback='vpn-download-for-ios') }}</h2>
             <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-version-requirements', version='14.0') }}</p>
+            <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
             <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link">
               <img src="{{ static('img/products/vpn/download/apple-app-store-badge.svg') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
             </a>
@@ -194,7 +194,7 @@
           </div>
           <div class="platform-body">
             <h2>{{ ftl('vpn-download-for-ios') }}</h2>
-            <p>{{ ftl('vpn-download-version-requirements', version='14.0') }}</p>
+            <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
           </div>
           <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link">
             <span class="visually-hidden">{{ ftl('vpn-download-for-ios-long-v2') }}</span>


### PR DESCRIPTION
## One-line summary

Bumps supported version number for VPN on iOS from 14.0 to 15.0

## Issue / Bugzilla link

#15581

## Testing

http://localhost:8000/en-US/products/vpn/download/