### PR TITLE
Fix missing for-developers ftl fallback

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -13,7 +13,7 @@
 ) %}
   <h2 class="mzp-u-title-xs">{{ ftl('firefox-developer-firefox-developer-edition') }}</h2>
   <h3 class="mzp-u-title-sm">{{ ftl('firefox-developer-made-for-developers') }}</h3>
-  <p>{{ ftl('firefox-developer-all-the-latest-v2', fallback='firefox-developer-all-the-latest') }}</p>
+  <p>{{ ftl('firefox-developer-all-the-latest-v2') }}</p>
   <p>{{ ftl('firefox-developer-a-separate-profile') }}</p>
   <p>{{ ftl('firefox-developer-preferences-tailored') }}</p>
 {% endcall %}


### PR DESCRIPTION
## One-line summary

Removes nonexistent fallback string id.

## Significant changes and points to review

Obsolete string got removed in [`d08bd22`](https://github.com/mozilla/bedrock/commit/d08bd22c02035bde6328648218b2f9484fb6708d#diff-8f44c0404c88ee1d6aa7167be523aed452b0f7cf2a9c006f99965362d47856a7L81-L84) — but left in the template.

## Issue / Bugzilla link

🚫🐞

## Testing

/en-US/firefox/developer/