### PR TITLE
Fix string ID typo in homepage gallery

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
@@ -131,7 +131,7 @@
         title=ftl('m24-home-can-ai-be'),
         desc=ftl('m24-home-in-a-world'),
         link_url='https://www.youtube.com/watch?v=GOhibTSUTO0',
-        cta_text=ftl('m24-home-trustworthy-watch-now'),
+        cta_text=ftl('m24-home-watch-now'),
         link_attributes='data-cta-text="Watch now (Trustworthy AI)"'
       ) }}
 


### PR DESCRIPTION
## One-line summary

Fix string ID typo in homepage gallery