### PR TITLE
Support mozorg-specific prefix on Smartling job titles via CMS

### DIFF
--- a/bedrock/cms/templates/cms/email/notifications/translation_imported__body.txt
+++ b/bedrock/cms/templates/cms/email/notifications/translation_imported__body.txt
@@ -9,7 +9,7 @@ You can view the job at {{smartling_cms_dashboard_url}}
 
 From there, for each item listed under "Translations", please open it in a new tab, review and publish it.
 
-Please note that you may need to publish things in a particular order (e.g. Snippet before the Page that uses it; )
+Please note that you may need to publish things in a particular order (e.g. Snippet before the Page that uses it.)
 
 Many thanks
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2358,6 +2358,10 @@ WAGTAIL_LOCALIZE_SMARTLING = {
         "pl": "pl-PL",
         "ru": "ru-RU",
     },
+    "JOB_NAME_PREFIX": config(
+        "WAGTAIL_LOCALIZE_JOB_NAME_PREFIX",
+        default="www.mozilla.org",
+    ),
     "REFORMAT_LANGUAGE_CODES": False,  # don't force language codes into Django's all-lowercase pattern
     "VISUAL_CONTEXT_CALLBACK": "bedrock.cms.wagtail_localize_smartling.callbacks.visual_context",
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2293,9 +2293,9 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.txt
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.6.1 \
-    --hash=sha256:292c2d66ac72ea9924a553fad8f57035983437c97d53eb9eb3b8cca17852f54b \
-    --hash=sha256:9373e53328637aaed9cb7f368f892849fa88685f464f192c1e21c8e202da3457
+wagtail-localize-smartling==0.7.0 \
+    --hash=sha256:b9551683f5865dce45576ebfc00b5ad8eba3589afce231f74c4b57d62494be17 \
+    --hash=sha256:d9fe19ae24b025b773a27b6f43ac891b836b3e36e032271f6005c8e580cbfd19
     # via -r requirements/prod.txt
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -57,7 +57,7 @@ sentry-sdk==2.18.0
 supervisor==4.2.5
 timeago==1.0.16
 https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing
-wagtail-localize-smartling==0.6.1
+wagtail-localize-smartling==0.7.0
 wagtail-localize==1.10
 Wand==0.6.13  # For animated GIF support
 Wagtail==6.1.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1614,9 +1614,9 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.in
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.6.1 \
-    --hash=sha256:292c2d66ac72ea9924a553fad8f57035983437c97d53eb9eb3b8cca17852f54b \
-    --hash=sha256:9373e53328637aaed9cb7f368f892849fa88685f464f192c1e21c8e202da3457
+wagtail-localize-smartling==0.7.0 \
+    --hash=sha256:b9551683f5865dce45576ebfc00b5ad8eba3589afce231f74c4b57d62494be17 \
+    --hash=sha256:d9fe19ae24b025b773a27b6f43ac891b836b3e36e032271f6005c8e580cbfd19
     # via -r requirements/prod.in
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d


### PR DESCRIPTION
## One-line summary

This changeset makes Smartling job titles easier for translation managers to scan by providing a custom prefix (support for which just landed in wagtail-localize-smartling 0.7.0)

It also fixes a typo in the email template that should have been in an earlier PR

## Testing

Tested locally - here's a screenshot from our Smartling sandbox

![Screenshot 2024-11-28 at 17 13 36](https://github.com/user-attachments/assets/0cc388cc-cdd4-48f2-9e93-8463affbad2d)
