### PR TITLE
Update builders.m.o location

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -476,8 +476,8 @@ redirectpatterns = (
     redirect(r"^styleguide/identity/firefox(.+)", "https://mozilla.design/firefox/"),
     redirect(r"^styleguide/identity/mozilla(.+)", "https://mozilla.design/mozilla/"),
     redirect(r"^styleguide(/.*)?", "https://mozilla.design/"),
-    # Issue 8644, 8932
-    redirect(r"^builders/?$", "https://future.mozilla.org/builders/"),
+    # Issue 8644, 8932, 15613
+    redirect(r"^builders/?$", "https://builders.mozilla.org/"),
     # Issue 6824, 14364
     redirect(r"^technology/?$", "https://future.mozilla.org/"),
     # Issue 8668

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
@@ -270,7 +270,7 @@
         tag=ftl('m24-home-tag-program'),
         title=ftl('m24-home-mozilla-builders'),
         desc=ftl('m24-home-builders-helps-independent'),
-        link_url='https://future.mozilla.org/builders/builders_overview/' + utm_params,
+        link_url='https://builders.mozilla.org/' + utm_params,
         cta_text=ftl('m24-home-read-more'),
         link_attributes='data-cta-text="Read more (Builders)"'
       ) }}

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1086,8 +1086,8 @@ URLS = flatten(
         url_test("/styleguide/websites/sandstone/buttons/", "https://mozilla.design/"),
         # Issue 8418
         url_test("/styleguide/", "https://mozilla.design/"),
-        # Issue 8644, 8932
-        url_test("/builders{,/}", "https://future.mozilla.org/builders/"),
+        # Issue 8644, 8932, 15613
+        url_test("/builders{,/}", "https://builders.mozilla.org/"),
         # Issue 6824, 14364
         url_test("/technology/", "https://future.mozilla.org/"),
         # Issue 8419


### PR DESCRIPTION
## One-line summary

Updates future.mozilla.org/builders link and relevant redirects to builders.mozilla.org

## Significant changes and points to review

https://builders.mozilla.org is up now so this is good to go.

## Issue / Bugzilla link

#15613

## Testing

http://localhost:8000/builders/