### PR TITLE
Remove locale from pencil banner donate link (Fixes #15592)

### DIFF
--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -8,7 +8,7 @@
 {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
 <aside class="m24-pencil-banner" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
   <div class="m24-pencil-banner-copy">
-    {% set donate_url = 'href="https://foundation.mozilla.org/en/?form=donate-today" data-cta-type="link" data-cta-text="donate today"' %}
+    {% set donate_url = 'href="https://foundation.mozilla.org/?form=donate-today" data-cta-type="link" data-cta-text="donate today"' %}
     <p>{{ ftl('m24-pencil-banner-support-ethical', donate=donate_url) }}</p>
   </div>
   <button class="m24-pencil-banner-close" type="button">{{ ftl('ui-close') }}</button>


### PR DESCRIPTION
## One-line summary

Removes hard coded locale in donation link

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15592

## Testing

http://localhost:8000/en-US/