### PR TITLE
Temporarily skip nav / footer tests for m24 launch (Issue #15625)

### DIFF
--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -7,6 +7,7 @@ import pytest
 from pages.home import HomePage
 
 
+@pytest.mark.skip(reason="Skipped for m24 website refresh launch")
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_navigation(base_url, selenium):
@@ -27,6 +28,7 @@ def test_navigation(base_url, selenium):
     assert not page.navigation.is_about_menu_displayed
 
 
+@pytest.mark.skip(reason="Skipped for m24 website refresh launch")
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_mobile_navigation(base_url, selenium_mobile):
@@ -45,6 +47,7 @@ def test_mobile_navigation(base_url, selenium_mobile):
     assert page.navigation.is_innovation_menu_displayed
 
 
+@pytest.mark.skip(reason="Skipped for m24 website refresh launch")
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.skip_if_firefox(reason="Firefox download button is shown only to non-Firefox users.")
@@ -54,6 +57,7 @@ def test_navigation_download_firefox_button(base_url, selenium):
     assert page.navigation.is_firefox_download_button_displayed
 
 
+@pytest.mark.skip(reason="Skipped for m24 website refresh launch")
 @pytest.mark.nondestructive
 @pytest.mark.skip_if_not_firefox(reason="Mozilla VPN button is shown only to Firefox users.")
 def test_navigation_mozilla_vpn_button(base_url, selenium):

--- a/tests/playwright/specs/a11y/components/navigation.spec.js
+++ b/tests/playwright/specs/a11y/components/navigation.spec.js
@@ -22,7 +22,9 @@ test.describe(
             await openPage(testURL, page, browserName);
         });
 
-        test('should not have any detectable a11y issues', async ({ page }) => {
+        test.skip('should not have any detectable a11y issues', async ({
+            page
+        }) => {
             const firefoxLink = page.getByTestId('navigation-link-firefox');
             const firefoxMenu = page.getByTestId('navigation-menu-firefox');
 
@@ -50,7 +52,9 @@ test.describe(
             await openPage(testURL, page, browserName);
         });
 
-        test('should not have any detectable a11y issues', async ({ page }) => {
+        test.skip('should not have any detectable a11y issues', async ({
+            page
+        }) => {
             const navigationMenuButton = page.getByTestId(
                 'navigation-menu-button'
             );

--- a/tests/playwright/specs/footer.spec.js
+++ b/tests/playwright/specs/footer.spec.js
@@ -22,7 +22,7 @@ test.describe(
             await openPage(url, page, browserName);
         });
 
-        test('Footer open / close click', async ({ page }) => {
+        test.skip('Footer open / close click', async ({ page }) => {
             const footerHeadingCompany = page.getByTestId(
                 'footer-heading-company'
             );

--- a/tests/playwright/specs/footer.spec.js
+++ b/tests/playwright/specs/footer.spec.js
@@ -8,7 +8,7 @@
 
 const { test, expect } = require('@playwright/test');
 const openPage = require('../scripts/open-page');
-const url = '/de/';
+const url = '/en-US/';
 
 test.describe(
     `${url} footer (mobile)`,
@@ -76,17 +76,19 @@ test.describe(
         test('Footer language change', async ({ page }) => {
             const languageSelect = page.getByTestId('footer-language-select');
 
-            // Assert default language is German
-            await expect(languageSelect).toHaveValue('de');
+            // Assert default language is English
+            await expect(languageSelect).toHaveValue('en-US');
 
-            // Change page language from /de/ to /fr/
-            await languageSelect.selectOption('fr');
+            // Change page language from /en-US/ to /de/
+            await languageSelect.selectOption('de');
             await page.waitForURL('**/de/?automation=true', {
                 waitUntil: 'commit'
             });
 
-            // Assert page language is now French
-            await expect(languageSelect).toHaveValue('fr');
+            // Assert page language is now German
+            await expect(
+                page.getByTestId('footer-language-select')
+            ).toHaveValue('de');
         });
     }
 );

--- a/tests/playwright/specs/navigation.spec.js
+++ b/tests/playwright/specs/navigation.spec.js
@@ -20,7 +20,7 @@ test.describe(
             await openPage(url, page, browserName);
         });
 
-        test('Navigation menu hover', async ({ page }) => {
+        test.skip('Navigation menu hover', async ({ page }) => {
             const firefoxLink = page.getByTestId('navigation-link-firefox');
             const firefoxMenu = page.getByTestId('navigation-menu-firefox');
             const productsLink = page.getByTestId('navigation-link-products');
@@ -54,7 +54,7 @@ test.describe(
             await expect(whoWeAreMenu).not.toBeVisible();
         });
 
-        test('Navigation link click', async ({ page }) => {
+        test.skip('Navigation link click', async ({ page }) => {
             const firefoxLink = page.getByTestId('navigation-link-firefox');
             const firefoxMenu = page.getByTestId('navigation-menu-firefox');
             const firefoxMenuLink = page.getByTestId(
@@ -89,7 +89,7 @@ test.describe(
             await openPage(url, page, browserName);
         });
 
-        test('Navigation open / close click', async ({ page }) => {
+        test.skip('Navigation open / close click', async ({ page }) => {
             const navigationMenuButton = page.getByTestId(
                 'navigation-menu-button'
             );
@@ -142,7 +142,7 @@ test.describe(
             await expect(navigationMenuItems).not.toBeVisible();
         });
 
-        test('Navigation link click', async ({ page }) => {
+        test.skip('Navigation link click', async ({ page }) => {
             const navigationMenuButton = page.getByTestId(
                 'navigation-menu-button'
             );


### PR DESCRIPTION
## One-line summary

This should temporarily skip nav / footer tests until the website refresh has launched in prod. At that point we can update tests for the newly added components.

## Issue / Bugzilla link

#15625