### PR TITLE
Avoid unnecessary CMS DB hits for pages that will 404

### DIFF
--- a/bedrock/cms/apps.py
+++ b/bedrock/cms/apps.py
@@ -3,10 +3,24 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from django.apps import AppConfig
-
-from bedrock.cms.signal_handlers import *  # noqa: F403 F406
+from django.db import connection
+from django.db.models.signals import post_migrate
 
 
 class CmsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "bedrock.cms"
+
+    def ready(self):
+        import bedrock.cms.signal_handlers  # noqa: F401
+        from bedrock.cms.utils import warm_page_path_cache
+
+        if "wagtailcore_page" in connection.introspection.table_names():
+            # The route to take if the DB already exists in a viable state
+            warm_page_path_cache()
+        else:
+            # The route to take the DB isn't ready yet (eg tests or an empty DB)
+            post_migrate.connect(
+                bedrock.cms.signal_handlers.trigger_cache_warming,
+                sender=self,
+            )

--- a/bedrock/cms/bedrock_wagtail_urls.py
+++ b/bedrock/cms/bedrock_wagtail_urls.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Custom version of wagtail_urls that wraps the wagtail_serve route
+# with a decorator that does a lookahead to see if Wagtail will 404 or not
+# (based on a precomputed cache of URLs in the CMS)
+
+from django.urls import re_path
+
+from wagtail.urls import urlpatterns as wagtail_urlpatterns
+from wagtail.views import serve as wagtail_serve
+
+from bedrock.cms.decorators import pre_check_for_cms_404
+
+# Modify the wagtail_urlpatterns to replace `wagtail_serve` with a decorated
+# version of the same view, so we can pre-empt Wagtail looking up a page
+# that we know will be a 404
+custom_wagtail_urls = []
+
+for pattern in wagtail_urlpatterns:
+    if hasattr(pattern.callback, "__name__") and pattern.callback.__name__ == "serve":
+        custom_wagtail_urls.append(
+            re_path(
+                # This is a RegexPattern not a RoutePattern, which is why we use re_path not path
+                pattern.pattern,
+                pre_check_for_cms_404(wagtail_serve),
+                name=pattern.name,
+            )
+        )
+    else:
+        custom_wagtail_urls.append(pattern)
+
+# Note: custom_wagtail_urls is imported into the main project urls.py instead of wagtail_urls

--- a/bedrock/cms/signal_handlers.py
+++ b/bedrock/cms/signal_handlers.py
@@ -10,7 +10,10 @@ from django.contrib.auth import get_user_model
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 
+from wagtail.signals import page_published, page_unpublished, post_page_move
 from wagtail_localize_smartling.signals import translation_imported
+
+from bedrock.cms.utils import warm_page_path_cache
 
 if TYPE_CHECKING:
     from wagtail_localize.models import Translation
@@ -71,3 +74,26 @@ def notify_of_imported_translation(
 
 
 translation_imported.connect(notify_of_imported_translation, weak=False)
+
+
+def trigger_cache_warming(sender, **kwargs):
+    # Run after the post-migrate signal is sent for the `cms` app
+    warm_page_path_cache()
+
+
+def rebuild_path_cache_after_page_move(sender, **kwargs):
+    # Check if a page has moved up or down within the tree
+    # (rather than just being reordered). If it has really moved
+    # then we should update the cache
+    if kwargs["url_path_before"] == kwargs["url_path_after"]:
+        # No URLs are changing - nothing to do here!
+        return
+
+    # The page is moving, so we need to rebuild the entire pre-empting-lookup cache
+    warm_page_path_cache()
+
+
+post_page_move.connect(rebuild_path_cache_after_page_move)
+
+page_published.connect(trigger_cache_warming)
+page_unpublished.connect(trigger_cache_warming)

--- a/bedrock/cms/utils.py
+++ b/bedrock/cms/utils.py
@@ -1,13 +1,22 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Subquery
 from django.http import Http404
 
+from wagtail.contrib.redirects.models import Redirect
 from wagtail.models import Locale, Page
 
 from bedrock.base.i18n import split_path_and_normalize_language
+
+logger = logging.getLogger(__name__)
+
+BEDROCK_ALL_CMS_PATHS_CACHE_KEY = "bedrock_cms_all_known_live_page_paths"
 
 
 def get_page_for_request(*, request):
@@ -61,3 +70,54 @@ def get_cms_locales_for_path(request):
         locales = get_locales_for_cms_page(page=page)
 
     return locales
+
+
+def _get_all_cms_paths() -> set:
+    """Fetch all the possible URL paths that are available
+    in Wagtail, in all locales, for LIVE pages only and for
+    all Redirects
+    """
+    pages = set([x.url for x in Page.objects.live() if x.url is not None])
+    redirects = set([x.old_path for x in Redirect.objects.all()])
+
+    return pages.union(redirects)
+
+
+def path_exists_in_cms(path: str) -> bool:
+    """
+    Using the paths cached via warm_page_path_cache, return a boolean
+    simply showing whether or not Wagtail can serve the requested path
+    (whether as a Page or as a Redirect).
+
+    Avoiding Wagtail-raised 404s is the goal of this function.
+    We don't care if there'll be a chain of redirects or a slash being
+    auto-appended - we'll let Django/Wagtail handle that.
+    """
+
+    cms_paths = cache.get(BEDROCK_ALL_CMS_PATHS_CACHE_KEY)
+    if cms_paths is None:
+        cms_paths = warm_page_path_cache()
+    if "?" in path:
+        path = path.partition("?")[0]
+
+    if path in cms_paths:
+        return True
+    elif not path.endswith("/") and f"{path}/" in cms_paths:
+        # pages have trailing slashes in their paths, but we might get asked for one without it
+        return True
+    elif path.endswith("/") and path[:-1] in cms_paths:
+        # redirects have no trailing slashes in their paths, but we might get asked for one with it
+        return True
+    return False
+
+
+def warm_page_path_cache() -> set():
+    paths = _get_all_cms_paths()
+    logger.info(f"Warming the cache '{BEDROCK_ALL_CMS_PATHS_CACHE_KEY}' with {len(paths)} paths ")
+
+    cache.set(
+        BEDROCK_ALL_CMS_PATHS_CACHE_KEY,
+        paths,
+        settings.CACHE_TIME_LONG,
+    )
+    return paths

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2435,6 +2435,8 @@ else:
     CMS_ALLOWED_PAGE_MODELS = _allowed_page_models
 
 
+CMS_DO_PAGE_PATH_PRECHECK = config("CMS_DO_PAGE_PATH_PRECHECK", default="True", parser=bool)
+
 # Our use of django-waffle relies on the following 2 settings to be set this way so that if a switch
 # doesn't exist, we get `None` back from `switch_is_active`.
 WAFFLE_SWITCH_DEFAULT = None

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -8,13 +8,13 @@ from django.urls import include, path
 from django.utils.module_loading import import_string
 
 import wagtaildraftsharing.urls as wagtaildraftsharing_urls
-from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from watchman import views as watchman_views
 
 from bedrock.base import views as base_views
 from bedrock.base.i18n import bedrock_i18n_patterns
+from bedrock.cms.bedrock_wagtail_urls import custom_wagtail_urls
 
 # The default django 404 and 500 handler doesn't run the ContextProcessors,
 # which breaks the base template page. So we replace them with views that do!
@@ -90,7 +90,8 @@ if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage
     # Note that statics are handled via Whitenoise's middleware
 
 # Wagtail is the catch-all route, and it will raise a 404 if needed.
-# Note that we're also using localised URLs here
+# We have customised wagtail_urls in order to decorate wagtail_serve
+# to 'get ahead' of that 404 raising, to avoid hitting the database.
 urlpatterns += bedrock_i18n_patterns(
-    path("", include(wagtail_urls)),
+    path("", include(custom_wagtail_urls)),
 )


### PR DESCRIPTION
This changeset adds a lookahead check before we call `wagtail.views.serve` to know whether it's worth asking the CMS to serve a page. 

The idea is that if the page isn't in the lookahead's data source, we can avoid touching the DB just to ultimately return a 404 earlier. 

This will save us DB load, particularly when we get drive-by scans that pepper the site with irrelevant URLs.

- [X] I used an AI to write some of this code - I bounced some ideas around with ChatGPT, and reworked some of the code suggestions to fit with Bedrock

## Significant changes and points to review

Please be sceptical about this, particularly around cache invalidation/cache updating - e.g. when a page is published, unpublished or moved in the page tree.

## Issue / Bugzilla link

#15505 

## Testing

Details to come
