### PR TITLE
fix nav position and mobile border issue (fix #15623)

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -5,8 +5,6 @@
 @use '../vars/lib' as *;
 
 $margin-top: 54px; // top margin offset for mobile navigation menu
-$tablet-margin-top: 53px; // top margin offset for tablet navigation menu
-$desktop-margin-top: 56px; // top margin offset for desktop navigation menu
 
 @keyframes nav-slide-in {
     from {
@@ -399,12 +397,8 @@ $desktop-margin-top: 56px; // top margin offset for desktop navigation menu
         padding: 0;
         position: absolute;
         right: auto;
-        top: $tablet-margin-top;
+        top: calc(100% + #{$border-width});
         width: 100%;
-    }
-
-    @media #{$mq-xl} {
-        top: $desktop-margin-top;
     }
 }
 

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -5,6 +5,8 @@
 @use '../vars/lib' as *;
 
 $margin-top: 54px; // top margin offset for mobile navigation menu
+$tablet-margin-top: 53px; // top margin offset for tablet navigation menu
+$desktop-margin-top: 56px; // top margin offset for desktop navigation menu
 
 @keyframes nav-slide-in {
     from {
@@ -198,7 +200,6 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-navigation-menu {
-    border-top: $border-width solid $m24-color-medium-gray;
     margin-bottom: 0;
     width: 100%;
 
@@ -398,8 +399,12 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
         padding: 0;
         position: absolute;
         right: auto;
-        top: 58px;
+        top: $tablet-margin-top;
         width: 100%;
+    }
+
+    @media #{$mq-xl} {
+        top: $desktop-margin-top;
     }
 }
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1638,7 +1638,6 @@
         "js/base/protocol/m24-menu.es6.js",
         "js/base/protocol/m24-navigation.es6.js",
         "js/base/protocol/init-m24-navigation.es6.js"
-
       ],
       "name": "m24-ui"
     },


### PR DESCRIPTION
## One-line summary

This PR fixes styles issue for M24 navigation.

## Significant changes and points to review

- The gap between dropdown menu and nav bar on desktop layout is closed off
- the extra thick border between menu and nav bar on mobile is fixed
<img width="439" alt="before" src="https://github.com/user-attachments/assets/1e4dd0c1-a823-4b2d-8b19-e16e873bbad2">
<img width="439" alt="after" src="https://github.com/user-attachments/assets/879f240b-4cc5-4396-828d-9fce67582574">

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15623

## Testing

http://localhost:8000/en-US/