### PR TITLE
Refresh: Update launchpad & submenu Relay logo

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -32,7 +32,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://relay.firefox.com/?{{ utm_params }}" data-link-text="Firefox Relay" data-link-position="topnav - products">
-                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
+                <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-relay') }}</h4>
               </a>
             </section>

--- a/media/css/m24/launchpad.scss
+++ b/media/css/m24/launchpad.scss
@@ -108,7 +108,7 @@ $launchpad-logo-spacing: $launchpad-logo-width + $launchpad-logo-padding;
     }
 
     &.m24-t-product-relay::before {
-        background-image: url('/media/protocol/img/logos/firefox/relay/logo.svg');
+        background-image: url('/media/protocol/img/logos/firefox/relay/logo-white.svg');
     }
 }
 


### PR DESCRIPTION
## One-line summary

Updates old "black hex" Relay logo to currently used "purple hex" in both homepage launchpad and products submenu.

## Significant changes and points to review

The proper fix is upstream in https://github.com/mozilla/protocol-assets/issues/87 — or a local asset can be added here in logos to override it temporarily… but there's a viable asset available already.

This is a rather ugly workaround temporarily using [`logo-white.svg`](https://github.com/mozilla/protocol-assets/blob/a99bd40321cde692479d03dcc619a215ef3890a0/logos/firefox/relay/logo-white.svg) instead of [`logo.svg`](https://github.com/mozilla/protocol-assets/blob/a99bd40321cde692479d03dcc619a215ef3890a0/logos/firefox/relay/logo.svg) that has already been done here before from time to time (I know it's _de iure_ designed to be used on dark backgrounds, but it gets the job done for now…), until resolved properly…

## Issue / Bugzilla link

Fixes #15632

## Testing

http://localhost:8000/