### PR TITLE
Remove inline styles from job listings

### DIFF
--- a/bedrock/careers/management/commands/sync_greenhouse.py
+++ b/bedrock/careers/management/commands/sync_greenhouse.py
@@ -11,7 +11,6 @@ from django.db import transaction
 
 import bleach
 import requests
-from bleach.css_sanitizer import CSSSanitizer
 from html5lib.filters.base import Filter
 
 from bedrock.careers.models import Position
@@ -57,12 +56,8 @@ ALLOWED_ATTRS = [
     "id",
     "src",
     "srcset",
-    "style",
     "rel",
     "title",
-]
-ALLOWED_STYLES = [
-    "font-weight",
 ]
 
 
@@ -78,7 +73,6 @@ class HeaderConverterFilter(Filter):
 cleaner = bleach.sanitizer.Cleaner(
     tags=ALLOWED_TAGS,
     attributes=ALLOWED_ATTRS,
-    css_sanitizer=CSSSanitizer(allowed_css_properties=ALLOWED_STYLES),
     strip=True,
     filters=[HeaderConverterFilter],
 )


### PR DESCRIPTION
## One-line summary

This bleaches inline styles in Greenhouse API sync, to avoid unsafe-inline style CSP violations (and unblock moving that to enforced policies…)

## Significant changes and points to review

Currently almost all the styles from the original listing data (align, color etc.) are removed already, leaving only either empty `style=""` behind, or a `font-weight: 400` that is the default anyways. So it can be removed completely.

(It will have to go through data sync cron first to update in prod.)

## Issue / Bugzilla link

Resolves #15633 (& refs #14840)

## Testing

`python manage.py sync_greenhouse`

(in my case, in containerized env, it was actually `make clean build run` followed by `make shell` in another session with the management command run from there…)

http://localhost:8000/en-US/careers/position/gh/6135741/
http://localhost:8000/en-US/careers/position/gh/6393976/