### PR TITLE
Streamline fx mobile grid with one column hidden

### DIFF
--- a/media/css/firefox/browsers/mobile.scss
+++ b/media/css/firefox/browsers/mobile.scss
@@ -161,7 +161,11 @@ $image-path: '/media/protocol/img';
     // and avoid the noodles background where the form was
     @media #{$mq-lg} {
         .c-page-header .mzp-c-split-body {
-            width: 65%;
+            width: 60%;
+        }
+
+        .mobile-android .c-page-header::before {
+            background-position: right 55% top;
         }
     }
 }

--- a/media/css/firefox/browsers/mobile.scss
+++ b/media/css/firefox/browsers/mobile.scss
@@ -149,6 +149,21 @@ $image-path: '/media/protocol/img';
     .header-product-ctas {
         display: none;
     }
+
+    // and also revert the grid to 1col
+    @media #{$mq-md} {
+        .c-page-header .mzp-c-split-container {
+            display: revert;
+            grid: revert;
+        }
+    }
+
+    // and avoid the noodles background where the form was
+    @media #{$mq-lg} {
+        .c-page-header .mzp-c-split-body {
+            width: 65%;
+        }
+    }
 }
 
 // hide download links for one platform from the other

--- a/media/css/firefox/browsers/mobile.scss
+++ b/media/css/firefox/browsers/mobile.scss
@@ -161,11 +161,11 @@ $image-path: '/media/protocol/img';
     // and avoid the noodles background where the form was
     @media #{$mq-lg} {
         .c-page-header .mzp-c-split-body {
-            width: 60%;
+            width: 75%;
         }
 
-        .mobile-android .c-page-header::before {
-            background-position: right 55% top;
+        .c-page-header::before {
+            left: 15%;
         }
     }
 }


### PR DESCRIPTION
## One-line summary

When on `.ios` or `.android` the send-to-device form is hidden, making the 2col split with just empty space in 50% of the screen feel like a bug. This overrides the split to a single column to make better use of the space (esp. on mobile).

## Significant changes and points to review

For cases when the form is hidden (making the second column empty), this additionally:
1. resets the grid/display for MD+ breakpoints
2. and also constraints the width in LG+ to be able to keep the noodle graphics but not overflow into it (too much).

## Issue / Bugzilla link

Resolves #15648

## Testing

http://localhost:8000/hi-IN/firefox/browsers/mobile/focus/
http://localhost:8000/ar/firefox/browsers/mobile/android/
http://localhost:8000/el/firefox/browsers/mobile/ios/

(compare desktop vs. mobile device or spoof the uastring to include "android" and "mobile", portrait vs. landscape mode and several breakpoints…)

- - - - -

After:  ×  Before:

<img width="992" alt="Screenshot 2024-12-04 at 1 28 16" src="https://github.com/user-attachments/assets/0d894f3e-d18d-4d8a-a595-a3310b735c92">
<img width="1143" alt="Screenshot 2024-12-04 at 1 33 52" src="https://github.com/user-attachments/assets/380ed5b1-fb98-48bf-b690-20cc325db4b4">
<img width="1440" alt="Screenshot 2024-12-05 at 13 45 19" src="https://github.com/user-attachments/assets/1ac54119-4fa6-4df2-b553-7a0bcf2fd5c4">