### PR TITLE
same space before and after legal section in footer (fix #15659)

### DIFF
--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -350,12 +350,8 @@ $max-footer-content-width: $content-max;
 // secondary nav
 .moz24-footer-secondary {
     position: relative;
-    margin-top: $grid-margin;
+    margin: $spacer-lg 0;
     line-height: 1.5;
-
-    @media #{$mq-md} {
-        padding-top: $grid-margin;
-    }
 }
 
 .moz24-footer-legal {
@@ -379,6 +375,10 @@ $max-footer-content-width: $content-max;
         @include bidi(((margin-right, 10%, 0), (margin-left, 0, 10%)));
     }
 
+    @media #{$mq-lg} {
+        margin-bottom: 0;
+    }
+
     a {
         display: inline-block;
     }
@@ -392,6 +392,8 @@ $max-footer-content-width: $content-max;
 }
 
 .moz24-footer-terms {
+    margin-bottom: 0;
+
     li {
         font-family: $primary-font;
         padding: 0 24px 0 0;
@@ -399,6 +401,10 @@ $max-footer-content-width: $content-max;
 
         @media #{$mq-md} {
             display: inline-block;
+        }
+
+        &:last-of-type {
+            margin-bottom: 0;
         }
     }
 


### PR DESCRIPTION
## One-line summary

This PR updates the footer legal section styles to allow same space before and after legal section.

## Significant changes and points to review

- Footer legal section spaces

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15659

## Testing

http://localhost:8000/en-US/
- Test for various screen sizes