### PR TITLE
fix horizontal bar at certain screen size (fix #15596)

### DIFF
--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -108,6 +108,10 @@ $max-footer-content-width: $content-max;
         margin-right: $spacer-2xs;
         display: inline-block;
 
+        &:last-of-type {
+            @include bidi(((margin-right, 0, 0), (margin-left, 0, 0)));
+        }
+
         a {
             @include bidi(((margin-right, 8px, 0), (margin-left, 0, 8px)));
             @include image-replaced;
@@ -118,6 +122,10 @@ $max-footer-content-width: $content-max;
             display: block;
             height: 24px;
             width: 24px;
+
+            &:last-of-type {
+                @include bidi(((margin-right, 0, 0), (margin-left, 0, 0)));
+            }
 
             &:hover,
             &:focus {


### PR DESCRIPTION
## One-line summary

This PR fixes the horizontal bar that are present for certain screen sizes

## Significant changes and points to review

- screen sizes to check: 768 & 1024
- Both `ltr` and `rtl` reading directions

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15596

## Testing

http://localhost:8000/en-US/