### PR TITLE
Add fx tiktok link to footer

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -83,6 +83,7 @@
                 <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-position="footer" data-link-text="Twitter (@firefox)">{{ ftl('footer-refresh-x-formerly-twitter', fallback='footer-refresh-twitter') }}<span> (@firefox)</span></a></li>
                 <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-position="footer" data-link-text="Instagram (@firefox)">{{ ftl('footer-refresh-instagram') }}<span> (@firefox)</span></a></li>
                 <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-position="footer" data-link-text="YouTube (@firefoxchannel)">{{ ftl('footer-refresh-youtube') }}<span> (@firefoxchannel)</span></a></li>
+                <li><a class="tiktok" href="https://www.tiktok.com/@firefox" data-link-position="footer" data-link-text="TikTok (@firefox)">{{ ftl('footer-refresh-tiktok') }}<span> (@firefox)</span></a></li>
               </ul>
             </div>
           </section>


### PR DESCRIPTION
## One-line summary

Adds `TikTok (@firefox)` social account to footer.

## Significant changes and points to review

Added it to the last position (to align with its fourth position in `@Mozilla` above) without thinking too much whether it should go before of after YT etc.

## Issue / Bugzilla link

Resolves #15692 

## Testing
