### PR TITLE
Fixup RTL noodle background for landscape mobile/tablet

### DIFF
--- a/media/css/firefox/browsers/mobile.scss
+++ b/media/css/firefox/browsers/mobile.scss
@@ -161,7 +161,7 @@ $image-path: '/media/protocol/img';
     // and avoid the noodles background where the form was
     @media #{$mq-lg} {
         .c-page-header .mzp-c-split-body {
-            width: 75%;
+            width: 70%;
         }
 
         .c-page-header::before {

--- a/media/css/firefox/browsers/mobile.scss
+++ b/media/css/firefox/browsers/mobile.scss
@@ -167,6 +167,10 @@ $image-path: '/media/protocol/img';
         .c-page-header::before {
             left: 15%;
         }
+
+        :dir(rtl) .c-page-header::before {
+            right: 15%;
+        }
     }
 }
 


### PR DESCRIPTION
## One-line summary

A low effort last-minute addition created a visual regression for RTL languages in a corner case when `bidi()` mixin doesn't cover it; this adds the necessary pseudo manually. (Sorry.)

## Significant changes and points to review

The edge case that tripped me up is reported upstream:
- https://github.com/mozilla/protocol/issues/1008 (not sure if currently actionable given `:dir()` support and different logic per se, but might be worth documenting how it works under the hood perhaps to ack this limitation)

This instead of relying on `html[dir=rtl] *` does `html :dir(rtl) *` picking up _any_ naturally occurring RTL node along the way no matter what the document sets — so while achieving the same it uses completely different logic. Shouldn't cause any extra trouble, but worth noting nonetheless.

(NB: This rule is basically only for landscape tablets, details in https://github.com/mozilla/bedrock/pull/15653#discussion_r1869901238 … I'm reproducing it on iPad mini 6 that's 1133×744px, currently only on [`www-dev`](https://www-dev.allizom.org/he/firefox/browsers/mobile/focus/))

## Issue / Bugzilla link

Fixup #15653

## Testing

http://localhost:8000/skr/firefox/browsers/mobile/ios/
http://localhost:8000/ar/firefox/browsers/mobile/android/
http://localhost:8000/he/firefox/browsers/mobile/focus/

(while triggering `html.ios` or `html.android` classes, from spoofing, simulators etc.)