### PR TITLE
Fix: Accessibility issues on contact page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -44,7 +44,7 @@
 
       <div class="contact-sections">
         <div class="contact-section">
-          <h4>Find us online</h4>
+          <h3>Find us online</h3>
           <ul class="mzp-u-list-styled">
             <li><a href="https://facebook.com/mozilla" hreflang="en-US" rel="external">Facebook</a></li>
             <li><a href="{{ mozilla_twitter_url() }}" rel="external">X (formerly Twitter)</a></li>
@@ -53,7 +53,7 @@
         </div>
 
         <div class="contact-section">
-          <h4>Join us</h4>
+          <h3>Join us</h3>
           <ul class="mzp-u-list-styled">
             <li><a href="{{ url('mozorg.contribute') }}">Get involved</a></li>
             <li><a href="{{ url('careers.home') }}">Career opportunities</a></li>
@@ -62,7 +62,7 @@
         </div>
 
         <div class="contact-section">
-          <h4>Questions &amp; feedback</h4>
+          <h3>Questions &amp; feedback</h3>
           <ul class="mzp-u-list-styled">
             <li><a href="https://support.mozilla.org/">Get support</a></li>
             <li><a href="{{ url('foundation.licensing') }}">Browser distribution &amp; licensing</a></li>

--- a/bedrock/mozorg/templates/mozorg/contact/includes/tab-nav.html
+++ b/bedrock/mozorg/templates/mozorg/contact/includes/tab-nav.html
@@ -4,14 +4,16 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<ul class="category-tabs" role="navigation">
-  <li {% if current == 'contact' %}class="current"{% endif %} data-id="contact">
-    <a href="{{ url('mozorg.contact.contact-landing') }}">Contact us</a>
-  </li>
-  <li {% if current == 'spaces' %}class="current"{% endif %} data-id="spaces">
-    <a href="{{ url('mozorg.contact.spaces.spaces-landing') }}">Spaces</a>
-  </li>
-  <li data-id="communities">
-    <a href="https://community.mozilla.org/groups/">Communities</a>
-  </li>
-</ul>
+<nav>
+  <ul class="category-tabs">
+    <li {% if current == 'contact' %}class="current"{% endif %} data-id="contact">
+      <a href="{{ url('mozorg.contact.contact-landing') }}">Contact us</a>
+    </li>
+    <li {% if current == 'spaces' %}class="current"{% endif %} data-id="spaces">
+      <a href="{{ url('mozorg.contact.spaces.spaces-landing') }}">Spaces</a>
+    </li>
+    <li data-id="communities">
+      <a href="https://community.mozilla.org/groups/">Communities</a>
+    </li>
+  </ul>
+</nav>

--- a/bedrock/mozorg/templates/mozorg/contact/includes/tab-nav.html
+++ b/bedrock/mozorg/templates/mozorg/contact/includes/tab-nav.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<nav>
+<nav aria-label="Category">
   <ul class="category-tabs">
     <li {% if current == 'contact' %}class="current"{% endif %} data-id="contact">
       <a href="{{ url('mozorg.contact.contact-landing') }}">Contact us</a>


### PR DESCRIPTION
## One-line summary
This PR addresses the accessibility issues outlined in [Issue #15339](https://github.com/mozilla/bedrock/issues/15339).

- [ ] I used an AI to write some of this code.

## Significant changes and points to review
Axe-core violations and changes:
1. ARIA role should be appropriate for the element: Removed `role="navigation"` from `<ul class="category-tabs" role="navigation">`, since "ARIA role navigation is not allowed for given element."
2. Heading levels should only increase by one: Changed `<h4>` tags to `<h3>`, since last heading level was `<h2>`.
3. `<li>` elements must be contained in a `<ul>` or `<ol>`: Wrapped the `<ul>` in a `<nav>` element to ensure semantic structure and proper roles, since "List item parent element has a role that is not role="list"."

## Issue / Bugzilla link
Fixes [#15339](https://github.com/mozilla/bedrock/issues/15339)

## Testing
Used browser Inspector tools and performed manual testing to verify functionality and accessibility.