### PR TITLE
Update footer spacing

### DIFF
--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -68,7 +68,7 @@ $max-footer-content-width: $content-max;
 
     .moz24-newsletter-image {
         width: 40px;
-        @include bidi(((margin-right, $spacer-sm, 0), (margin-left, 0, $spacer-sm)));
+        @include bidi(((margin-right, $spacer-md, 0), (margin-left, 0, $spacer-md)));
         margin-bottom: $spacer-md;
 
         @media #{$mq-lg} {

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -58,6 +58,7 @@ $max-footer-content-width: $content-max;
         display: grid;
         grid-template-rows: 1fr 1fr;
         grid-template-columns: 1fr 1fr;
+        column-gap: $grid-margin;
         place-items: stretch start;
 
         @media #{$mq-lg} {

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -55,11 +55,13 @@ $max-footer-content-width: $content-max;
     }
 
     &.moz24-links-section {
-        display: grid;
-        grid-template-rows: 1fr 1fr;
-        grid-template-columns: 1fr 1fr;
-        column-gap: $grid-margin;
-        place-items: stretch start;
+        @media (min-width: #{$screen-xs * 1.25}) {
+            display: grid;
+            grid-template-rows: 1fr 1fr;
+            grid-template-columns: 1fr 1fr;
+            column-gap: $grid-gutter;
+            place-items: stretch start;
+        }
 
         @media #{$mq-lg} {
             width: grid(8);


### PR DESCRIPTION
## One-line summary

Adds column-gap in footer nav and increases spacing around newsletter logo.

## Significant changes and points to review

The spacing was not sufficient for mobile layouts. This updates the spacing for all breakpoints, as it seems more appropriate to keep the same spacing size variable, and let it adapt according to atmedia calculations/adaptations at root level.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15635#issuecomment-2515236569
Also fixes #15598

## Testing

http://localhost:8000/en-US/#colophon