### PR TITLE
Wagtail/Smartling robustness improvements

### DIFF
--- a/bedrock/cms/management/commands/run_smartling_sync.py
+++ b/bedrock/cms/management/commands/run_smartling_sync.py
@@ -9,6 +9,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
 import requests
+from sentry_sdk import capture_exception
 
 from bedrock.base.config_manager import config
 
@@ -32,3 +33,4 @@ class Command(BaseCommand):
                 sys.stdout.write("Snitch pinged\n")
         except Exception as ex:
             sys.stderr.write(f"\nsync_smartling did not execute successfully: {ex}\n")
+            capture_exception(ex)

--- a/bedrock/cms/tests/test_callbacks.py
+++ b/bedrock/cms/tests/test_callbacks.py
@@ -11,7 +11,7 @@ from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 
 from bedrock.cms.tests.factories import SimpleRichTextPageFactory, WagtailUserFactory
-from bedrock.cms.wagtail_localize_smartling.callbacks import visual_context
+from bedrock.cms.wagtail_localize_smartling.callbacks import _get_html_for_sharing_link, visual_context
 
 
 @pytest.mark.django_db
@@ -55,3 +55,52 @@ def test_visual_context__for_inviable_object(client):
         url, html = visual_context(smartling_job=mock_job)
 
     assert exc.value.args[0] == "Object was not visually previewable (i.e. not a Page)"
+
+
+@pytest.mark.django_db
+@mock.patch("bedrock.cms.wagtail_localize_smartling.callbacks.capture_message")
+def test_visual_context__for_page__with_no_revision(mock_capture_message, client):
+    top_level_page = SimpleRichTextPageFactory()
+
+    page = SimpleRichTextPageFactory(parent=top_level_page, slug="visual-context-text-page")
+    page.save_revision()
+
+    wagtail_factories.SiteFactory(
+        root_page=top_level_page,
+        is_default_site=True,
+        hostname=client._base_environ()["SERVER_NAME"],
+    )
+
+    user = WagtailUserFactory()
+
+    mock_job = mock.Mock()
+    mock_job.translation_source.get_source_instance.return_value = page
+    mock_job.user = user
+
+    page.latest_revision = None
+    page.save()
+    with pytest.raises(IncapableVisualContextCallback) as ctx:
+        visual_context(smartling_job=mock_job)
+
+    assert ctx.value.args[0] == (
+        "Object was not visually previewable because it didn't have a saved revision. Are you a developer with a local export?"
+    )
+    mock_capture_message.assert_called_once_with(f"Unable to get a latest_revision for {page} so unable to send visual context.")
+
+
+# The happy path is implicitly tested in test_visual_context__*, above
+@mock.patch("bedrock.cms.wagtail_localize_smartling.callbacks.capture_exception")
+@mock.patch("bedrock.cms.wagtail_localize_smartling.callbacks.SharingLinkView.as_view")
+def test__get_html_for_sharing_link__unhappy_path(mock_sharing_link_as_view, mock_capture_exception):
+    test_exception = Exception("Boom!")
+    mock_sharing_link_as_view.return_value = mock.Mock(side_effect=test_exception)
+
+    sharing_link = mock.Mock()
+    sharing_link.url = "https://example.com/1231313211/link"
+
+    with pytest.raises(IncapableVisualContextCallback) as ctx:
+        _get_html_for_sharing_link(sharing_link)
+
+    assert ctx.value.args[0] == "Was not able to get a HTML export from the sharing link"
+
+    mock_capture_exception.assert_called_once_with(test_exception)

--- a/bedrock/cms/tests/test_callbacks.py
+++ b/bedrock/cms/tests/test_callbacks.py
@@ -54,4 +54,4 @@ def test_visual_context__for_inviable_object(client):
     with pytest.raises(IncapableVisualContextCallback) as exc:
         url, html = visual_context(smartling_job=mock_job)
 
-    assert exc.value.args[0] == "Object was not visually previewable"
+    assert exc.value.args[0] == "Object was not visually previewable (i.e. not a Page)"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2325,7 +2325,7 @@ WAGTAIL_I18N_ENABLED = True
 WAGTAIL_CONTENT_LANGUAGES = lazy(lazy_wagtail_langs, list)()
 
 # Don't automatically make a page for a non-default locale availble in the default locale
-WAGTAILLOCALIZE_SYNC_LIVE_STATUS_ON_TRANSLATE = False
+WAGTAILLOCALIZE_SYNC_LIVE_STATUS_ON_TRANSLATE = False  # note that WAGTAILLOCALIZE is correct without the _
 
 # Settings for https://github.com/mozilla/wagtail-localize-smartling
 WAGTAIL_LOCALIZE_SMARTLING = {

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2366,16 +2366,14 @@ WAGTAIL_LOCALIZE_SMARTLING = {
     "VISUAL_CONTEXT_CALLBACK": "bedrock.cms.wagtail_localize_smartling.callbacks.visual_context",
 }
 
-WAGTAIL_DRAFTSHARING_ADMIN_MENU_POSITION = 9000
-# WAGTAIL_DRAFTSHARING_VERBOSE_NAME = "Internal Share"
-# WAGTAIL_DRAFTSHARING_VERBOSE_NAME_PLURAL = "Internal Shares"
-# WAGTAIL_DRAFTSHARING_MENU_ITEM_LABEL = "Create internal sharing link"
+WAGTAILDRAFTSHARING = {
+    "ADMIN_MENU_POSITION": 9000,
+    # MAX_TTL: 14 * 24 * 60 * 60
+    # VERBOSE_NAME: "Internal Share"
+    # VERBOSE_NAME_PLURAL: "Internal Shares"
+    # MENU_ITEM_LABEL: "Create internal sharing link"
+}
 
-# At the moment, wagtaildraftsharing's expiry is only set via settings. We're using
-# 21 days here because the links are used to send a preview of the source page to
-# Smartling translators, and we want to give them plenty of time. In the future
-# we can bring this back down to 7 days and set a Smartling-specific one of 21
-WAGTAILDRAFTSHARING_MAX_AGE = 21 * 24 * 60 * 60
 
 # Custom settings, not a core Wagtail ones, to scope out RichText options
 WAGTAIL_RICHTEXT_FEATURES_FULL = [

--- a/docs/cms.rst
+++ b/docs/cms.rst
@@ -109,7 +109,8 @@ sync down any images you don't already have.
   or ``AWS_DB_S3_BUCKET=bedrock-db-prod``.
 
   ``AWS_DB_S3_BUCKET=bedrock-db-stage make preflight``
-  ``AWS_DB_S3_BUCKET=bedrock-db-stage python manage.py download_media_to_local``
+
+  ``python manage.py download_media_to_local --environment=stage``
 
 Adding new content surfaces
 ===========================

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2306,9 +2306,9 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.txt
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.7.0 \
-    --hash=sha256:b9551683f5865dce45576ebfc00b5ad8eba3589afce231f74c4b57d62494be17 \
-    --hash=sha256:d9fe19ae24b025b773a27b6f43ac891b836b3e36e032271f6005c8e580cbfd19
+wagtail-localize-smartling==0.8.0 \
+    --hash=sha256:9a4842e51805614f22a12cb46f2f35379993680c71c66ca391a8068aa17ef210 \
+    --hash=sha256:e6ca356ce2310344a288cc1e85c1a280e696064d9c3a4559f0a2d12704083477
     # via -r requirements/prod.txt
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.2.0.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:7a3399c4d621628e6458f1ee3236b7d1d5fdd9577ee385d52e69edf7379f7562

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2310,8 +2310,8 @@ wagtail-localize-smartling==0.7.0 \
     --hash=sha256:b9551683f5865dce45576ebfc00b5ad8eba3589afce231f74c4b57d62494be17 \
     --hash=sha256:d9fe19ae24b025b773a27b6f43ac891b836b3e36e032271f6005c8e580cbfd19
     # via -r requirements/prod.txt
-wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
-    --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d
+wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.2.0.tar.gz#egg=wagtaildraftsharing \
+    --hash=sha256:7a3399c4d621628e6458f1ee3236b7d1d5fdd9577ee385d52e69edf7379f7562
     # via -r requirements/prod.txt
 wand==0.6.13 \
     --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -56,7 +56,7 @@ sentry-processor==0.0.1
 sentry-sdk==2.18.0
 supervisor==4.2.5
 timeago==1.0.16
-https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing
+https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.2.0.tar.gz#egg=wagtaildraftsharing
 wagtail-localize-smartling==0.7.0
 wagtail-localize==1.10
 Wand==0.6.13  # For animated GIF support

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -57,7 +57,7 @@ sentry-sdk==2.18.0
 supervisor==4.2.5
 timeago==1.0.16
 https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.2.0.tar.gz#egg=wagtaildraftsharing
-wagtail-localize-smartling==0.7.0
+wagtail-localize-smartling==0.8.0
 wagtail-localize==1.10
 Wand==0.6.13  # For animated GIF support
 Wagtail==6.1.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1631,8 +1631,8 @@ wagtail-localize-smartling==0.7.0 \
     --hash=sha256:b9551683f5865dce45576ebfc00b5ad8eba3589afce231f74c4b57d62494be17 \
     --hash=sha256:d9fe19ae24b025b773a27b6f43ac891b836b3e36e032271f6005c8e580cbfd19
     # via -r requirements/prod.in
-wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.1.3.tar.gz#egg=wagtaildraftsharing \
-    --hash=sha256:3ffe076b0c3b99e71bd1f0d9a02831f4413577f60b38fc258633fc3602b8409d
+wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.2.0.tar.gz#egg=wagtaildraftsharing \
+    --hash=sha256:7a3399c4d621628e6458f1ee3236b7d1d5fdd9577ee385d52e69edf7379f7562
     # via -r requirements/prod.in
 wand==0.6.13 \
     --hash=sha256:e5dda0ac2204a40c29ef5c4cb310770c95d3d05c37b1379e69c94ea79d7d19c0 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1627,9 +1627,9 @@ wagtail-localize==1.10 \
     # via
     #   -r requirements/prod.in
     #   wagtail-localize-smartling
-wagtail-localize-smartling==0.7.0 \
-    --hash=sha256:b9551683f5865dce45576ebfc00b5ad8eba3589afce231f74c4b57d62494be17 \
-    --hash=sha256:d9fe19ae24b025b773a27b6f43ac891b836b3e36e032271f6005c8e580cbfd19
+wagtail-localize-smartling==0.8.0 \
+    --hash=sha256:9a4842e51805614f22a12cb46f2f35379993680c71c66ca391a8068aa17ef210 \
+    --hash=sha256:e6ca356ce2310344a288cc1e85c1a280e696064d9c3a4559f0a2d12704083477
     # via -r requirements/prod.in
 wagtaildraftsharing @ https://github.com/mozmeao/wagtaildraftsharing/archive/refs/tags/mozmeao-0.2.0.tar.gz#egg=wagtaildraftsharing \
     --hash=sha256:7a3399c4d621628e6458f1ee3236b7d1d5fdd9577ee385d52e69edf7379f7562


### PR DESCRIPTION
## One-line summary

This changeset makes our Smartling interactions more robust and provides more logging to help us diagnose any further teething troubles with its use in production.

## Significant changes and points to review

* **Update wagtaildraftsharing to 0.2.0**
This remedies an issue where it was possible to ask for a sharing link for a page, only to be given one that has expired (and which then blows up the code that's suppose to provide a HTML dump of the page to Smartling). 
We now use a new method `create_for_revision`, which never gets a duplicate. We also make that sharing link one that never expires, rather than second-guess how long a translator might need to translate a page. (These links can still be deleted, so we could add a cleanup job every few months)

* **Update to wagtail-localize-smartling 0.80**
This remedies the other main error in the export run that failed: we got a `File locked` error from the Smartling API because we were trying to make a call related to a file that hadn't completed processing. The solution to this was to refactor the file-upload part of `wagtail-localize-smartling` to use a "Job Batch", which handles file uploads asynchronously and transparently. I've tested this locally against our Smartling Sandbox and it definitely works.
   
* Extra logging added   
  
## Issue / Bugzilla link

Resolves #15629

## Testing
This is tricky to test without local setup. I've tested it a fair amount myself as part of developing the new release of wagtaildraftsharing and wagtail-localize-smartling, and I'll test-drive it again on Dev before we take it to prod. So, code-level eyes and sense checking would be great, but no need to test drive I think.