### PR TITLE
Update footer newsletter text and signups (fixes #15585)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-newsletter.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-newsletter.html
@@ -8,7 +8,7 @@
   <div class="moz24-newsletter-wrapper">
     <div class="moz24-newsletter-info">
       <img loading="lazy" class="moz24-newsletter-image" src="{{ static('img/logos/m24/symbol-white.svg') }}" alt="" width="40" height="48">
-      <p>{{ ftl('footer-refresh-discover-mozilla-products') }}</p>
+      <p>{{ ftl('footer-refresh-discover-mozilla-products', fallback='newsletter-form-we-will-only-send-v2') }}</p>
     </div>
 
     <div class="moz24-newsletter">

--- a/bedrock/base/templates/includes/protocol/footer/footer-newsletter.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-newsletter.html
@@ -8,12 +8,12 @@
   <div class="moz24-newsletter-wrapper">
     <div class="moz24-newsletter-info">
       <img loading="lazy" class="moz24-newsletter-image" src="{{ static('img/logos/m24/symbol-white.svg') }}" alt="" width="40" height="48">
-      <p>{{ ftl('footer-refresh-get-the-best') }}</p>
+      <p>{{ ftl('footer-refresh-discover-mozilla-products') }}</p>
     </div>
 
     <div class="moz24-newsletter">
       {{ email_newsletter_form(
-        newsletters='mozilla-and-you',
+        newsletters='mozilla-foundation, mozilla-and-you',
         title=None
         )}}
       </div>

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-footer-refresh-get-the-best = Get the best { -brand-name-firefox } tips, tricks and updates. We promise to keep your email private and secure — just the best of { -brand-name-firefox } sent straight to your inbox.
+footer-refresh-discover-mozilla-products =Discover { -brand-name-mozilla } products and initiatives. We promise to keep your email private and secure — no sharing, no selling, just great updates.
 footer-refresh-leadership = Leadership
 footer-refresh-advertise = Advertise with { -brand-name-mozilla }
 footer-refresh-firefox-release-notes = { -brand-name-firefox } Release Notes

--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -195,9 +195,26 @@ $max-footer-content-width: $content-max;
 
         @media #{$mq-lg} {
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            grid-template-rows: 30px 45px 75px;
+            grid-template-columns: [full-width-start] 1fr 1fr [full-width-end];
             column-gap: $spacer-lg;
+
+            > * {
+                grid-column: full-width;
+            }
+
+            // country input
+            label:first-of-type,
+            p:first-of-type {
+                grid-column-start: 1;
+                grid-column-end: 2;
+            }
+
+            // lang input
+            label:nth-of-type(2),
+            p:nth-of-type(2) {
+                grid-column-start: 2;
+                grid-column-end: 3;
+            }
         }
 
         p {
@@ -209,25 +226,10 @@ $max-footer-content-width: $content-max;
 
             @media #{$mq-lg} {
                 display: inline-grid;
-
-                &:first-of-type {
-                    grid-column-start: 1;
-                    grid-column-end: 2;
-                }
-
-                &:nth-of-type(2) {
-                    grid-column-start: 2;
-                    grid-column-end: 3;
-                }
             }
 
             &:has(> label.mzp-u-inline) {
-                margin: $spacer-lg 0 $spacer-md;
-
-                @media #{$mq-lg} {
-                    grid-column-start: 1;
-                    grid-column-end: 3;
-                }
+                margin-bottom: $spacer-lg;
 
                 input {
                     margin: 0;


### PR DESCRIPTION
## One-line summary

Update footer newsletter signup to include foundation newsletter as well

mozilla-and-you and mozilla-foundation

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

Footer newsletter now has two newsletter sign up options

Couple of styling challenges that should be fixed now (and have hopefully not created new issues)

general spacing
<img width="268" alt="Screenshot 2024-12-10 at 1 04 38 PM" src="https://github.com/user-attachments/assets/6aa0eded-61ba-40c5-a245-e9cd2a74961c">

large font
<img width="693" alt="Screenshot 2024-12-10 at 1 09 21 PM" src="https://github.com/user-attachments/assets/4388c3e6-f18d-4eb5-ab94-959dfbf6aa4e">


- removed explicit grid rows in favour of auto row placement (more resilient with large font
- updated p spacing 


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/15585


## Testing

Go to http://localhost:8000/en-US/ and confirm the newsletter expands with 2 newletters checked: firefox & mozilla foundations
<img width="723" alt="Screenshot 2024-12-10 at 1 32 38 PM" src="https://github.com/user-attachments/assets/0a768125-1c4e-425c-80d6-aa633e46e817">

Uncheck both newsletters and confirm you cannot sign up without selecting at least one
<img width="844" alt="Screenshot 2024-12-10 at 2 22 02 PM" src="https://github.com/user-attachments/assets/5dbb67fd-c14e-4e69-9bbf-7667203527de">


Check newsletters and confirm you get thanks message and network tab shows request with expected newsletters
<img width="706" alt="Screenshot 2024-12-10 at 1 32 22 PM" src="https://github.com/user-attachments/assets/c507cefe-7a3d-415e-8ac3-e4c80edd12ad">

<img width="345" alt="Screenshot 2024-12-10 at 2 12 38 PM" src="https://github.com/user-attachments/assets/47a4d266-2c56-4b97-9866-b6937850881b">
