### PR TITLE
Expand footer lang switch to avoid cutting off long word (fix #15609)

### DIFF
--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -179,10 +179,9 @@ $max-footer-content-width: $content-max;
         select {
             font-family: $primary-font;
             width: 100%;
-            background-image: url('/media/img/icons/m24-small/down-caret-white.svg');
-            background-repeat: no-repeat;
-            background-size: 16px 16px;
             @include bidi(((background-position, right 8px center, 8px center),));
+            background: $m24-color-light-gray url('/media/img/icons/m24-small/down-caret-white.svg') no-repeat;
+            background-size: 16px 16px;
 
             @media #{$mq-lg} {
                 min-width: 100%;
@@ -192,7 +191,10 @@ $max-footer-content-width: $content-max;
             &:focus,
             &:focus-visible,
             &:focus-within {
-                background-image: url('/media/img/icons/m24-small/down-caret.svg');
+                color: $m24-color-alt-white;
+                @include bidi(((background-position, right 8px center, 8px center),));
+                background: $m24-color-alt-black url('/media/img/icons/m24-small/up-caret.svg') no-repeat;
+                background-size: 16px 16px;
             }
         }
     }

--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -193,7 +193,7 @@ $max-footer-content-width: $content-max;
             &:focus-within {
                 color: $m24-color-alt-white;
                 @include bidi(((background-position, right 8px center, 8px center),));
-                background: $m24-color-alt-black url('/media/img/icons/m24-small/up-caret.svg') no-repeat;
+                background: $m24-color-alt-black url('/media/img/icons/m24-small/down-caret.svg') no-repeat;
                 background-size: 16px 16px;
             }
         }

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -83,6 +83,10 @@ $max-footer-content-width: $content-max;
         justify-content: center;
         align-items: flex-start;
     }
+
+    @media #{$mq-lg} {
+        align-items: flex-end;
+    }
 }
 
 

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -281,7 +281,7 @@ $max-footer-content-width: $content-max;
     position: relative;
 
     &::before {
-        @include bidi(((left, 0, 0), (right, 0, 102px)));
+        @include bidi(((left, 0, auto), (right, auto, 0)));
         background: transparent url('/media/img/icons/m24-small/globe-white.svg') center center no-repeat;
         background-size: 18px 18px;
         top: 50%;
@@ -314,7 +314,8 @@ $max-footer-content-width: $content-max;
     }
 
     .mzp-js-language-switcher-select {
-        background: $m24-color-white url('/media/img/icons/m24-small/down-caret-white.svg') calc(100% - 8px) 0.75em no-repeat;
+        background: $m24-color-white url('/media/img/icons/m24-small/down-caret-white.svg') no-repeat;
+        @include bidi(((background-position, calc(100% - 8px) 0.75em, 8px 0.75em),));
         background-size: 16px 16px;
         border-radius: 0;
         border: $border-width solid $m24-color-black;

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -279,7 +279,6 @@ $max-footer-content-width: $content-max;
 
 .moz24-c-language-switcher {
     position: relative;
-    border-color: transparent;
 
     &::before {
         @include bidi(((left, 0, 0), (right, 0, 102px)));
@@ -315,10 +314,10 @@ $max-footer-content-width: $content-max;
     }
 
     .mzp-js-language-switcher-select {
-        background: $m24-color-alt-white url('/media/img/icons/m24-small/down-caret-white.svg') calc(100% - 8px) 0.75em no-repeat;
+        background: $m24-color-white url('/media/img/icons/m24-small/down-caret-white.svg') calc(100% - 8px) 0.75em no-repeat;
         background-size: 16px 16px;
         border-radius: 0;
-        border: $border-width solid transparent;
+        border: $border-width solid $m24-color-black;
         color: $m24-color-black;
         font-weight: 600;
         margin-top: 16px;
@@ -329,7 +328,9 @@ $max-footer-content-width: $content-max;
         &:hover,
         &:focus,
         &:focus-visible {
-            border-color: $m24-color-mid-gray;
+            color: $m24-color-white;
+            background: $m24-color-black url('/media/img/icons/m24-small/up-caret.svg') calc(100% - 8px) 0.75em no-repeat;
+            background-size: 16px 16px;
         }
     }
 }

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -334,7 +334,8 @@ $max-footer-content-width: $content-max;
 
         &:hover,
         &:focus,
-        &:focus-visible {
+        &:focus-visible,
+        &:focus-within {
             color: $m24-color-white;
             background: $m24-color-alt-black url('/media/img/icons/m24-small/up-caret.svg') no-repeat;
             @include bidi(((background-position, right 8px center, 8px center),));

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -315,16 +315,16 @@ $max-footer-content-width: $content-max;
     }
 
     .mzp-js-language-switcher-select {
-        background: $m24-color-alt-white url('/media/img/icons/m24-small/down-caret-white.svg') 95px 0.75em no-repeat;
+        background: $m24-color-alt-white url('/media/img/icons/m24-small/down-caret-white.svg') calc(100% - 8px) 0.75em no-repeat;
         background-size: 16px 16px;
         border-radius: 0;
         border: $border-width solid transparent;
         color: $m24-color-black;
         font-weight: 600;
         margin-top: 16px;
-        min-width: unset;
         padding-left: 36px;
-        width: 136px;
+        max-width: 100%;
+        width: fit-content;
 
         &:hover,
         &:focus,

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -273,20 +273,22 @@ $max-footer-content-width: $content-max;
 
 
 // language form
-.moz24-footer-language {
-    position: relative;
-}
-
 .moz24-c-language-switcher {
     position: relative;
 
+    &:has(.mzp-js-language-switcher-select:hover)::before,
+    &:has(.mzp-js-language-switcher-select:focus)::before,
+    &:has(.mzp-js-language-switcher-select:focus-within)::before {
+        background: $m24-color-alt-black url('/media/img/icons/m24-small/globe.svg') center center no-repeat;
+        background-size: 18px 18px;
+    }
+
     &::before {
-        @include bidi(((left, 0, auto), (right, auto, 0)));
+        @include bidi(((left, 4px, auto), (right, auto, 4px)));
         background: transparent url('/media/img/icons/m24-small/globe-white.svg') center center no-repeat;
         background-size: 18px 18px;
         top: 50%;
         margin-top: -16px;
-        color: $m24-color-white;
         content: "";
         display: block;
         height: 32px;
@@ -314,12 +316,12 @@ $max-footer-content-width: $content-max;
     }
 
     .mzp-js-language-switcher-select {
-        background: $m24-color-white url('/media/img/icons/m24-small/down-caret-white.svg') no-repeat;
-        @include bidi(((background-position, calc(100% - 8px) 0.75em, 8px 0.75em),));
+        @include bidi(((background-position, right 8px center, 8px center),));
+        background: $m24-color-alt-white url('/media/img/icons/m24-small/down-caret-white.svg') no-repeat;
         background-size: 16px 16px;
         border-radius: 0;
-        border: $border-width solid $m24-color-black;
-        color: $m24-color-black;
+        border: $border-width solid $m24-color-alt-black;
+        color: $m24-color-alt-black;
         font-weight: 600;
         margin-top: 16px;
         padding-left: 36px;
@@ -330,7 +332,8 @@ $max-footer-content-width: $content-max;
         &:focus,
         &:focus-visible {
             color: $m24-color-white;
-            background: $m24-color-black url('/media/img/icons/m24-small/up-caret.svg') calc(100% - 8px) 0.75em no-repeat;
+            background: $m24-color-alt-black url('/media/img/icons/m24-small/up-caret.svg') no-repeat;
+            @include bidi(((background-position, right 8px center, 8px center),));
             background-size: 16px 16px;
         }
     }

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -337,7 +337,7 @@ $max-footer-content-width: $content-max;
         &:focus-visible,
         &:focus-within {
             color: $m24-color-white;
-            background: $m24-color-alt-black url('/media/img/icons/m24-small/up-caret.svg') no-repeat;
+            background: $m24-color-alt-black url('/media/img/icons/m24-small/down-caret.svg') no-repeat;
             @include bidi(((background-position, right 8px center, 8px center),));
             background-size: 16px 16px;
         }

--- a/media/img/icons/m24-small/up-caret.svg
+++ b/media/img/icons/m24-small/up-caret.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24" viewBox="0 0 24 24">
-  <path fill="#fff" d="m11.9 6.8 9.3 9.3-2.2 2.1-7.1-7.1-6.9 7-2.2-2.2z"/>
+  <path fill="#010101" d="m11.9 6.8 9.3 9.3-2.2 2.1-7.1-7.1-6.9 7-2.2-2.2z"/>
 </svg>


### PR DESCRIPTION
## One-line summary

This PR expands footer lang switch to avoid cutting off long word.

## Significant changes and points to review

- Footer lang switch shouldn't be cutting off any language

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15609

## Testing

In order to avoid cutting off any language, the select is quite long and it looks kind of broken when no hovered. 
<img width="343" alt="normal" src="https://github.com/user-attachments/assets/133649ad-e7c3-46df-8724-2d3db0bb1a18">
<img width="378" alt="hover" src="https://github.com/user-attachments/assets/7e7943ed-deca-4a03-8ce3-27b20b15ecff">

Same approach worked on the older footer cause the district background color made it clear that the triangle is part of the select dropdown. Might wait when the designer is back for some design tweaks on this.
<img width="272" alt="old" src="https://github.com/user-attachments/assets/9dd58173-7ee0-4c8e-b52b-acb1691b59e2">


Tess's take on this:

- default border for the select
- on hover, inverse the colors: black text on white background
