### PR TITLE
Update mastodon server for FirefoxNightly account

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -72,7 +72,7 @@
 
       <p>{{ ftl('nightly-whatsnew-this-is-a-good') }}</p>
 
-      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v3', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mozilla.social/@FirefoxNightly"') }}</p>
+      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v3', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mastodon.social/@FirefoxNightly"') }}</p>
 
       <p>
           {% set attrs = 'href="#" class="nightly-experiments-link"' %}

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -18,7 +18,7 @@ nightly-whatsnew-this-is-a-good = This is a good time to thank you for helping u
 
 # Variables:
 #   $blog (url) - link to https://blog.nightly.mozilla.org/
-#   $mastodon (url) - link to https://mozilla.social/@FirefoxNightly
+#   $mastodon (url) - link to https://mastodon.social/@FirefoxNightly
 #   $twitter (url) - link to https://twitter.com/FirefoxNightly
 nightly-whatsnew-if-you-want-to-v3 = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a { $blog }>blog</a> and following us on <a { $mastodon }>Mastodon</a> or <a { $twitter }>X</a> are good starting points!
 


### PR DESCRIPTION
## One-line summary
The Firefox Nightly account was migrated to mastodon social.
Update of the link on out Whatsnew page.