### PR TITLE
Fix footer donate visited color

### DIFF
--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -238,7 +238,6 @@ $max-footer-content-width: $content-max;
     border-radius: 0;
     font-weight: 600;
     background-color: $m24-color-alt-white;
-    color: $m24-color-black;
     padding: 6px 24px;
     border: $border-width solid $m24-color-black;
     text-decoration: none;
@@ -248,6 +247,7 @@ $max-footer-content-width: $content-max;
 
     &:link,
     &:visited {
+        color: $m24-color-black;
         text-decoration: none;
     }
 

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -240,7 +240,6 @@ $max-footer-content-width: $content-max;
     background-color: $m24-color-alt-white;
     padding: 6px 24px;
     border: $border-width solid $m24-color-black;
-    text-decoration: none;
     text-align: center;
     max-width: 800px;
     margin-bottom: $spacer-lg;


### PR DESCRIPTION
## One-line summary

Avoids using "visited" purple color for Donate CTA in footer of fx base pages.

## Significant changes and points to review

The color was only set on anchor, not :link — and in m24 base styles the :link generally defines white color — something not present in fx styles, where the visited purple treatment is then applied to this CTA.

Moving the CTA color from anchor to :link/:visited is the easiest fix. I don't see anything that can be negatively impacted by missing the white color on the anchor proper, and just defining it for the pseudos, but felt it's worth noting nonetheless.

## Issue / Bugzilla link

Fixes #15701 

## Testing

http://localhost:8000/en-US/firefox/133.0/whatsnew/#colophon
http://localhost:8000/en-US/firefox/welcome/10/#colophon

(Click the Donate button in the footer so it's marked as visited.)