### PR TITLE
update footer newsletter signup button color (fix #15666)

### DIFF
--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -257,6 +257,7 @@ $max-footer-content-width: $content-max;
         margin-bottom: 0;
 
         button {
+            background-color: $m24-color-alt-white;
             border: $border-width solid $m24-color-black;
             border-radius: 0;
             position: relative;


### PR DESCRIPTION
## One-line summary

This PR updates the background color of the footer newsletter color to be off-black(#161616).

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15666

## Testing

http://localhost:8000/en-US/