### PR TITLE
Remove brand standards link from footer [fix #15647]

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -48,7 +48,6 @@
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-resources">
               <li><a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-refresh-advertise') }}</a></li>
-              <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-position="footer" data-link-text="Brand Standards">{{ ftl('footer-refresh-brand-standards') }}</a></li>
               <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
             </ul>
           </section>

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -52,7 +52,6 @@
             {% if ftl_has_messages('footer-advertise') %}
               <li><a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-advertise') }}</a></li>
             {% endif %}
-            <li><a href="https://mozilla.design/?{{ utm_params }}&utm_content=resources" data-link-position="footer" data-link-text="Brand Standards">{{ ftl('footer-brand-standards') }}</a></li>
           </ul>
         </section>
 


### PR DESCRIPTION
## One-line summary
Removes the brand standards link until we have an adequate replacement. I didn't mark the string as obsolete because I expect we'll be able to replace the link in the near future and it'll be good to keep that string around.

## Issue / Bugzilla link
#15647 

## Testing
http://localhost:8000/#colophon

It may be hard to get to the old footer in dev mode but you can switch off M24_WEBSITE_REFRESH locally to verify.