### PR TITLE
Add scn (Sicilian) to pontoon.toml [fix #15728]

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -78,6 +78,7 @@ locales = [
     "ro",
     "ru",
     "sco",
+    "scn",
     "si",
     "sk",
     "skr",


### PR DESCRIPTION
## One-line summary
Adds `scn` to Pontoon so the community can start localizing strings. This won't activate the locale in production; that should happen later once it reaches some threshold of completeness.

## Issue / Bugzilla link
#15728 
