### PR TITLE
Make section CTAs smaller

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/hero.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/hero.html
@@ -13,7 +13,7 @@
     <div class="m24-c-flag-text">
       <h1 class="m24-c-flag-title">{{ ftl('m24-home-welcome-to-mozilla') }}</h1>
       <p class="m24-c-flag-subtitle">{{ ftl('m24-home-from-trustworthy-tech') }}</p>
-      <p class="m24-c-flag-cta"><a href="{{ url('mozorg.about.index') }}" class="m24-c-cta m24-t-lg" data-cta-text="Learn about us">{{ ftl('m24-home-learn-about-us') }}</a></p>
+      <p class="m24-c-flag-cta"><a href="{{ url('mozorg.about.index') }}" class="m24-c-cta" data-cta-text="Learn about us">{{ ftl('m24-home-learn-about-us') }}</a></p>
     </div>
     <div class="m24-c-flag-media">
       <svg class="m24-c-flag-media-static" role="img" xmlns="http://www.w3.org/2000/svg" width="216" height="243" fill="none" viewBox="0 0 216 243"><title>{{ ftl('m24-home-alt-flag') }}</title><path d="M93.573 29v20.734h72.565v5.351l-61.196 22.238v18.728l61.196 22.237v5.352H72.172v20.734h115.367v-37.788l-49.826-17.224v-5.349l49.826-17.222V29H93.573ZM29.034 214.6h23.743V29H29.034v185.6ZM72.172 71.136h21.401V49.734H72.172v21.402Z" /></svg>

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -87,7 +87,7 @@ a:link {
     color: $m24-color-black;
     display: inline-block;
     font-family: var(--title-font-family);
-    font-size: $text-button-xl;
+    font-size: $text-button-lg;
     font-weight: 600;
     background-image:
     linear-gradient(to right, $m24-color-black 0, $m24-color-black 33%,transparent 33%, transparent 66%, $m24-color-black 66%, $m24-color-black 100%);
@@ -114,8 +114,8 @@ a:link {
         color: $m24-color-black;
     }
 
-    &.m24-t-lg {
-        font-size: $text-button-lg;
+    &.m24-t-xl {
+        font-size: $text-button-xl;
     }
 
     &.m24-t-md {


### PR DESCRIPTION
## One-line summary

Changes c-cta (text-button) size from XL to LG, adding XL as an available theme variant.

## Significant changes and points to review

This updates all occurrences such as section-cta, donate-cta, flag-cta, careers-cta or feature-cta…

## Issue / Bugzilla link

Resolves #15707

## Testing

http://localhost:8000/en-US/
http://localhost:8000/en-US/about/