### PR TITLE
Fix home SoM image paths [#15727]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som.html
@@ -16,12 +16,12 @@
     <div class="m24-c-showcase">
       <div class="m24-c-showcase-media">
         {{ resp_img(
-          url='img/home/2024//showcase/showcase-som-1440.png',
+          url='img/home/2024/showcase/showcase-som-1440.png',
           srcset={
-            'img/home/2024//showcase/showcase-som-375.png': '375w',
-            'img/home/2024//showcase/showcase-som-686.png': '686w',
-            'img/home/2024//showcase/showcase-som-1440.png': '1440w',
-            'img/home/2024//showcase/showcase-som-2752.png': '2752w',
+            'img/home/2024/showcase/showcase-som-375.png': '375w',
+            'img/home/2024/showcase/showcase-som-686.png': '686w',
+            'img/home/2024/showcase/showcase-som-1440.png': '1440w',
+            'img/home/2024/showcase/showcase-som-2752.png': '2752w',
           },
           sizes={
             'default': '100vw',


### PR DESCRIPTION
## One-line summary

Copypasta error introduced a double slash, which resolved fine on localhost but isn't working elsewhere so we didn't notice until it hit dev/stage/prod.

## Testing
http://localhost:8000/en-US/