### PR TITLE
SOM: Tweak headings in two columns

### DIFF
--- a/media/css/foundation/annual-report-2024.scss
+++ b/media/css/foundation/annual-report-2024.scss
@@ -25,6 +25,8 @@
 .m24-c-ar-intro-title {
     font-size: $text-title-xl;
     margin-bottom: $spacer-sm;
+    text-wrap: balance;
+    text-wrap-style: balance;
 }
 
 .m24-c-ar-intro-body {
@@ -57,6 +59,10 @@
 
         & > .m24-c-content:first-of-type {
             padding-right: 0;
+
+            .m24-c-ar-intro-title {
+                padding-right: $spacer-lg
+            }
         }
 
         & > .m24-c-content:last-of-type {


### PR DESCRIPTION
## One-line summary

Tweak headings in two columns in SoM

## Significant changes and points to review

- added `text-wrap-style: balance`
- added a small gutter on the first column headings to for them to wrap before they get too close to the second column

## Issue / Bugzilla link

n/a

## Testing

The problem is most obvious here: 
http://localhost:8000/en-US/foundation/annualreport/2024/#products