### PR TITLE
Fix a11y issues on /products/vpn/download/ page (fixes #15344)

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -37,216 +37,216 @@
 {% endblock %}
 
 {% block content %}
+<main>
   <section class="vpn-downloads">
-      <header class="vpn-download-header">
-        {% if block_download %}
+    <header class="vpn-download-header">
+      {% if block_download %}
         <div class="mzp-l-content vpn-download-blocked" data-testid="vpn-download-blocked-message">
           <h1>{{ self.page_title_full() }}</h1>
           <p>{{ ftl('vpn-download-not-available-in-country') }}</p>
         </div>
-        {% else %}
-        {% call split(
-          block_class='mzp-l-split-body-wide mzp-l-split-center-on-sm-md',
-          body_class='mzp-l-split-h-start',
-          media_class='mzp-l-split-center-on-sm-md mzp-l-split-h-center',
-          media_after=True,
-          image=resp_img(
-            url='img/products/vpn/landing/vpn-cntwell-04.png',
-            optional_attributes={
-            'class': 'mzp-c-split-media-asset'
-            }
-          )
-        ) %}
+      {% else %}
+      {% call split(
+        block_class='mzp-l-split-body-wide mzp-l-split-center-on-sm-md',
+        body_class='mzp-l-split-h-start',
+        media_class='mzp-l-split-center-on-sm-md mzp-l-split-h-center',
+        media_after=True,
+        image=resp_img(
+          url='img/products/vpn/landing/vpn-cntwell-04.png',
+          optional_attributes={
+          'class': 'mzp-c-split-media-asset'
+          }
+        )
+      ) %}
         <div class="vpn-logo">
           <img src="{{ static('img/logos/vpn/vpn-dark-logo.svg') }}" alt="">
         </div>
         <h1>{{ self.page_title_full() }}</h1>
         <p>{{ ftl('vpn-download-sub-heading', devices=connect_devices) }}</p>
         <p>{{ ftl('vpn-download-mozilla-vpn-offers') }}</p>
-        {% endcall %}
-        {% endif %}
-      </header>
+      {% endcall %}
+      {% endif %}
+    </header>
 
-      {% if not block_download %}
-
+    {% if not block_download %}
       <div class="vpn-download-options mzp-l-content" data-testid="vpn-download-options">
-
         <!-- Primary list -->
-      <div class="vpn-download-primary-platform">
-        <!-- Windows -->
-        <div class="primary-platform windows">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-windows.svg') }}" alt="">
+        <div class="vpn-download-primary-platform">
+          <!-- Windows -->
+          <div class="primary-platform windows">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-windows.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-windows-long') }}</h2>
+              <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
+              <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
+              <a class="mzp-c-button" href="{{ url('products.vpn.windows-download') }}" data-cta-text="VPN Download (Windows)" data-testid="vpn-download-link-primary-windows">
+              {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
+              </a>
+            </div>
           </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-windows-long') }}</h2>
-            <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
-            <a class="mzp-c-button" href="{{ url('products.vpn.windows-download') }}" data-cta-text="VPN Download (Windows)" data-testid="vpn-download-link-primary-windows">
-            {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
-            </a>
+          <!-- Mac OS -->
+          <div class="primary-platform macos">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-mac.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-mac-long', fallback='vpn-download-for-mac') }}</h2>
+              <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
+              <a class="mzp-c-button" href="{{ url('products.vpn.mac-download') }}" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-primary-mac">
+              {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
+              </a>
+            </div>
           </div>
+          <!-- Linux -->
+          <div class="primary-platform linux">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-linux.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-linux-long', fallback='vpn-download-for-linux') }}</h2>
+              <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
+              <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
+              <a class="mzp-c-button" href="{{ linux_download_url }}" data-cta-text="VPN Download (Linux)" class="platform-download-link">
+              {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
+              </a>
+            </div>
+          </div>
+          <!-- iOS -->
+          <div class="primary-platform ios">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-ios.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-ios-long-v2', fallback='vpn-download-for-ios') }}</h2>
+              <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
+              <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link">
+                <img src="{{ static('img/products/vpn/download/apple-app-store-badge.svg') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
+              </a>
+            </div>
+          </div>
+          <!-- Android -->
+          <div class="primary-platform android">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-android.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-android-long', fallback='vpn-download-for-android') }}</h2>
+              <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
+              <a class="platform-download-link" href="{{ android_download_url }}" data-cta-text="VPN Download (Android)" target="_blank" rel="noopener noreferrer">
+                <img src="{{ static('img/products/vpn/download/google-play-badge.png') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
+              </a>
+            </div>
+          </div>
+          <h3>{{ ftl('vpn-download-also-available') }}</h3>
         </div>
-        <!-- Mac OS -->
-        <div class="primary-platform macos">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-mac.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-mac-long', fallback='vpn-download-for-mac') }}</h2>
-            <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
-            <a class="mzp-c-button" href="{{ url('products.vpn.mac-download') }}" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-primary-mac">
-            {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
+
+        <!-- Secondary list -->
+        <ul class="vpn-download-secondary-list">
+          <!-- Windows -->
+          <li class="secondary-platform windows">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-windows.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-windows-v2') }}</h2>
+              <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
+            </div>
+            <a href="{{ url('products.vpn.windows-download') }}" data-cta-text="VPN Download (Windows)" class="platform-download-link" data-testid="vpn-download-link-secondary-windows">
+              <span class="">{{ ftl('vpn-download-for-windows-long') }}</span>
             </a>
-          </div>
-        </div>
-        <!-- Linux -->
-        <div class="primary-platform linux">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-linux.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-linux-long', fallback='vpn-download-for-linux') }}</h2>
-            <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
-            <a class="mzp-c-button" href="{{ linux_download_url }}" data-cta-text="VPN Download (Linux)" class="platform-download-link">
-            {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
+          </li>
+          <!-- Mac OS -->
+          <li class="secondary-platform macos">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-mac.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-mac') }}</h2>
+              <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
+            </div>
+            <a href="{{ url('products.vpn.mac-download') }}" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-secondary-mac">
+              <span class="visually-hidden">{{ ftl('vpn-download-for-mac-long') }}</span>
             </a>
-          </div>
-        </div>
-        <!-- iOS -->
-        <div class="primary-platform ios">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-ios.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-ios-long-v2', fallback='vpn-download-for-ios') }}</h2>
-            <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
+          </li>
+          <!-- Linux -->
+          <li class="secondary-platform linux">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-linux.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-linux') }}</h2>
+              <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
+            </div>
+            <a href="{{ linux_download_url }}" data-cta-text="VPN Download (Linux)" class="platform-download-link">
+              <span class="visually-hidden">{{ ftl('vpn-download-for-linux-long') }}</span>
+            </a>
+          </li>
+          <!-- iOS -->
+          <li class="secondary-platform ios">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-ios.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-ios') }}</h2>
+              <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
+            </div>
             <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link">
-              <img src="{{ static('img/products/vpn/download/apple-app-store-badge.svg') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
+              <span class="visually-hidden">{{ ftl('vpn-download-for-ios-long-v2') }}</span>
             </a>
-          </div>
-        </div>
-        <!-- Android -->
-        <div class="primary-platform android">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-android.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-android-long', fallback='vpn-download-for-android') }}</h2>
-            <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-            <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
-            <a class="platform-download-link" href="{{ android_download_url }}" data-cta-text="VPN Download (Android)" target="_blank" rel="noopener noreferrer">
-              <img src="{{ static('img/products/vpn/download/google-play-badge.png') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
+          </li>
+          <!-- Android -->
+          <li class="secondary-platform android">
+            <div class="platform-image">
+              <img src="{{ static('img/products/vpn/download/platform-android.svg') }}" alt="">
+            </div>
+            <div class="platform-body">
+              <h2>{{ ftl('vpn-download-for-android') }}</h2>
+              <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
+            </div>
+            <a href="{{ android_download_url }}" data-cta-text="VPN Download (Android)" class="platform-download-link">
+              <span class="visually-hidden">{{ ftl('vpn-download-for-android-long') }}</span>
             </a>
-          </div>
+          </li>
+        </ul>
+      </div>
+      {% if ftl_has_messages('vpn-download-previous-versions') %}
+        <div class="vpn-download-previous-versions mzp-l-content ">
+          <p>
+            <a href="https://archive.mozilla.org/pub/vpn/releases/" data-cta-text="VPN Download Previous Versions">{{ ftl('vpn-download-previous-versions') }}</a>
+          </p>
         </div>
-        <h3>{{ ftl('vpn-download-also-available') }}</h3>
-      </div>
-
-      <!-- Secondary list -->
-      <ul class="vpn-download-secondary-list">
-        <!-- Windows -->
-        <li class="secondary-platform windows">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-windows.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-windows-v2') }}</h2>
-            <p>{{ ftl('vpn-download-for-windows-requirements') }}</p>
-          </div>
-          <a href="{{ url('products.vpn.windows-download') }}" data-cta-text="VPN Download (Windows)" class="platform-download-link" data-testid="vpn-download-link-secondary-windows">
-            <span class="">{{ ftl('vpn-download-for-windows-long') }}</span>
-          </a>
-        </li>
-        <!-- Mac OS -->
-        <li class="secondary-platform macos">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-mac.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-mac') }}</h2>
-            <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
-          </div>
-          <a href="{{ url('products.vpn.mac-download') }}" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-secondary-mac">
-            <span class="visually-hidden">{{ ftl('vpn-download-for-mac-long') }}</span>
-          </a>
-        </li>
-        <!-- Linux -->
-        <li class="secondary-platform linux">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-linux.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-linux') }}</h2>
-            <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
-          </div>
-          <a href="{{ linux_download_url }}" data-cta-text="VPN Download (Linux)" class="platform-download-link">
-            <span class="visually-hidden">{{ ftl('vpn-download-for-linux-long') }}</span>
-          </a>
-        </li>
-        <!-- iOS -->
-        <li class="secondary-platform ios">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-ios.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-ios') }}</h2>
-            <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
-          </div>
-          <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link">
-            <span class="visually-hidden">{{ ftl('vpn-download-for-ios-long-v2') }}</span>
-          </a>
-        </li>
-        <!-- Android -->
-        <li class="secondary-platform android">
-          <div class="platform-image">
-            <img src="{{ static('img/products/vpn/download/platform-android.svg') }}" alt="">
-          </div>
-          <div class="platform-body">
-            <h2>{{ ftl('vpn-download-for-android') }}</h2>
-            <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
-          </div>
-          <a href="{{ android_download_url }}" data-cta-text="VPN Download (Android)" class="platform-download-link">
-            <span class="visually-hidden">{{ ftl('vpn-download-for-android-long') }}</span>
-          </a>
-        </li>
-      </ul>
-    </div>
-
-    {% if ftl_has_messages('vpn-download-previous-versions') %}
-      <div class="vpn-download-previous-versions mzp-l-content ">
-        <p>
-          <a href="https://archive.mozilla.org/pub/vpn/releases/" data-cta-text="VPN Download Previous Versions">{{ ftl('vpn-download-previous-versions') }}</a>
-        </p>
-      </div>
-    {% endif %}
-
+      {% endif %}
     {% endif %}
   </section>
-{% if ftl_has_messages('vpn-download-privacy-you-can') %}
-  <section class="vpn-privacy">
-    {% call split(
-      block_class=' mzp-l-split-reversed mzp-l-split-center-on-sm-md',
-      media_class='mzp-l-split-h-center mzp-l-split-center-on-sm-md',
-      media_after=True,
-      image=resp_img(
-      url='img/products/vpn/download/vpn-download-shield.png',
-      optional_attributes={
-      'class': 'mzp-c-split-media-asset'
-      }),
-    ) %}
-    <h2>{{ ftl('vpn-download-privacy-you-can') }}</h2>
-    <p>{{ ftl('vpn-download-from-the-maker', url='https://mullvad.net/help/why-wireguard/', attrs='target="_blank" rel="external noopener noreferrer"') }}</p>
-    <p>{{ ftl('vpn-download-we-never-log') }}</p>
-    {% endcall %}
-  </section>
-{% endif %}
+
+  {% if ftl_has_messages('vpn-download-privacy-you-can') %}
+    <section class="vpn-privacy">
+      {% call split(
+        block_class=' mzp-l-split-reversed mzp-l-split-center-on-sm-md',
+        media_class='mzp-l-split-h-center mzp-l-split-center-on-sm-md',
+        media_after=True,
+        image=resp_img(
+        url='img/products/vpn/download/vpn-download-shield.png',
+        optional_attributes={
+        'class': 'mzp-c-split-media-asset'
+        }),
+      ) %}
+      <h2>{{ ftl('vpn-download-privacy-you-can') }}</h2>
+      <p>{{ ftl('vpn-download-from-the-maker', url='https://mullvad.net/help/why-wireguard/', attrs='target="_blank" rel="external noopener noreferrer"') }}</p>
+      <p>{{ ftl('vpn-download-we-never-log') }}</p>
+      {% endcall %}
+    </section>
+  {% endif %}
+
   <footer class="vpn-footer">
     {% include 'products/vpn/includes/footer-legal.html' %}
   </footer>
+</main>
 {% endblock %}
 
 

--- a/media/css/products/vpn/download.scss
+++ b/media/css/products/vpn/download.scss
@@ -59,7 +59,7 @@ $vpn-download-mq-2xl: '(min-width: 1450px)';
         }
 
         p {
-            color: $color-marketing-gray-60;
+            color: $color-marketing-gray-70;
         }
     }
 }


### PR DESCRIPTION
## One-line summary

- Fixes color contrast issue and landmark issues.
- The indentation in the HTML file was also a little messy, so I tried to tidy up a bit.

## Issue / Bugzilla link

#15344

## Testing

- [ ] Running [a11y tests locally](https://bedrock.readthedocs.io/en/latest/testing.html#accessibility-testing-axe) should no longer generate an a11y report file for the VPN download page.