### PR TITLE
Fix validation errors in navigation

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -8,7 +8,7 @@
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable m24-c-menu-category-has-icon">
   <a class="m24-c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-firefox" data-testid="m24-navigation-link-firefox">
-    <img class="m24-c-menu-title-icon" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="16" height="16" alt="">
+    <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-title-icon" width="16" height="16" alt="">
     {{ ftl('navigation-refresh-firefox-browsers') }}
   </a>
   <div class="m24-c-menu-panel" id="m24-c-menu-panel-firefox">

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -39,7 +39,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-text="Pocket"data-link-position="topnav - products">
+              <a class="m24-c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-text="Pocket" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/pocket/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-pocket') }}</h4>
               </a>


### PR DESCRIPTION
## One-line summary

Fixes a couple of small validation errors I spotted in the new navigation:

1. Removes duplicate `class` attribute on the small Firefox icon in the main menu titles (it looks like `m24-c-menu-item-icon` is not needed here, so safe to remove?)
2. Fixes missing space between attributes on the pocket menu item link.

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/