### PR TITLE
Fix a11y issues on /participation/ page (fixes #15758)

### DIFF
--- a/bedrock/base/templates/base-article.html
+++ b/bedrock/base/templates/base-article.html
@@ -21,7 +21,7 @@
   {% block main_feature %}{% endblock %}
   <div id="main-content" class="mzp-l-content{% if self.side_nav()|trim|length or self.side_extra()|trim|length %} mzp-has-sidebar mzp-l-sidebar-left{% endif %}">
     {% block sidebar %}
-      <aside class="mzp-l-sidebar">
+      <aside class="mzp-l-sidebar" aria-label="{{ ftl('ui-menu') }}">
         {% block side_nav %}
         {% endblock %}
         {% block side_extra %}
@@ -37,7 +37,7 @@
   </div>
 
   {% block newsletter %}
-    <aside class="section section-newsletter" id="newsletter-subscribe">
+    <aside class="section section-newsletter" id="newsletter-subscribe" aria-label="{{ ftl('newsletter-form-label') }}">
       <div class="content">
         {% block email_form %}
         {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about-base.html
+++ b/bedrock/mozorg/templates/mozorg/about-base.html
@@ -25,19 +25,19 @@
   {{ sidemenu_lists([navigation_bar], body_id) }}
 
   <div class="side-reference">
-    <h4 class="side-reference-title">{{ ftl('about-shared-our-products') }}</h4>
+    <h2 class="side-reference-title">{{ ftl('about-shared-our-products') }}</h2>
     <p>{{ ftl('about-shared-software-innovations') }}</p>
     <a class="more" href="{{ url('products.landing') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
   <div class="side-reference">
-    <h4 class="side-reference-title">{{ ftl('about-shared-get-involved') }}</h4>
+    <h2 class="side-reference-title">{{ ftl('about-shared-get-involved') }}</h2>
     <p>{{ ftl('about-shared-volunteer') }}</p>
     <a class="more" href="{{ url('mozorg.contribute') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
    <div class="side-reference">
-    <h4 class="side-reference-title">{{ ftl('vision-for-the-web') }}</h4>
+    <h2 class="side-reference-title">{{ ftl('vision-for-the-web') }}</h2>
     <p>{{ ftl('read-about-our-vision') }}</p>
     <a class="more" href="{{ url('mozorg.about.webvision.summary') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
@@ -47,7 +47,7 @@
 
 {% block email_form %}
 <div class="mzp-l-content">
-  <aside class="mzp-c-newsletter t-love">
+  <div class="mzp-c-newsletter t-love">
     <div class="mzp-c-newsletter-image">
       <img src="{{ static('img/newsletter/love-news.svg') }}" alt="" height="172" width="200">
     </div>
@@ -59,6 +59,6 @@
         {{ email_newsletter_form(button_class='button-hollow button-light', spinner_color='#fff') }}
       {% endif %}
     </div>
-  </aside>
+  </div>
 </div>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -11,8 +11,10 @@
 
 
 {% block article %}
-<h1 class="mzp-c-article-title">{{ ftl('participation-mozilla-community') }}</h1>
-<h4>{{ ftl('participation-version-31-updated') }}</h4>
+<header>
+  <h1 class="mzp-c-article-title">{{ ftl('participation-mozilla-community') }}</h1>
+  <p><strong>{{ ftl('participation-version-31-updated') }}</strong></p>
+</header>
 
 <section id="introduction">
   <p>


### PR DESCRIPTION
## One-line summary

- Adds unique `aria-label`s to the two `<aside>` landmarks (fix should apply for all pages that use this base template)
- Fixes heading levels in side menu and main document.
- Removes nested `<aside>` landmark that was inside another `<aside>` landmark in the newsletter section.

## Issue / Bugzilla link

#15758

## Testing

http://localhost:8000/en-US/about/governance/policies/participation/

- [ ] Running [a11y tests locally](https://bedrock.readthedocs.io/en/latest/testing.html#accessibility-testing-axe) should no longer generate an a11y report file for the participation page.