### PR TITLE
Fix a11y issues on /privacy/ page (Fixes #15343)

### DIFF
--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -41,7 +41,7 @@
 
 {% block content %}
 <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">
-  <article class="mzp-l-main" itemtype="http://schema.org/Article">
+  <main class="mzp-l-main">
     {% block article %}
     <header>
       {% if self.article_header_logo()|trim|length %}
@@ -58,10 +58,10 @@
       </div>
       {% endif %}
     </header>
-    <main class="privacy-body" itemprop="articleBody">
+    <section class="privacy-body" itemprop="articleBody">
       {% block sections %}
       {% endblock %}
-    </main>
+    </section>
     {% if self.footnote()|trim|length %}
     <footer class="privacy-footnote">
       <div>
@@ -70,7 +70,7 @@
     </footer>
     {% endif %}
     {% endblock %}
-  </article>
+  </main>
   <aside class="mzp-l-sidebar">
     {{ sidemenu_lists([navigation_bar], body_id) }}
     {% block side_extra %}{% endblock %}

--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -35,7 +35,7 @@
 {% endblock %}
 {% block footnote %}
   <section id="contact" class="section-content">
-    <h4>{{ ftl('privacy-index-contact-mozilla') }}</h4>
+    <h2>{{ ftl('privacy-index-contact-mozilla') }}</h2>
     <p>{{ ftl('privacy-index-if-you-want-to-make-a-correction') }}</p>
 
     <p lang="en" dir="ltr" itemscope itemtype="http://schema.org/Organization">

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -197,6 +197,10 @@ $border: 2px solid $color-marketing-gray-20;
     margin-top: $spacing-2xl;
     padding: $spacing-2xl 0;
 
+    h2 {
+        @include text-title-sm;
+    }
+
     h3 {
         @include visually-hidden;
     }


### PR DESCRIPTION
## One-line summary

- Fixes heading level in privacy footnote
- Moves `<main>` landmark to be top level.

## Issue / Bugzilla link

#15343

## Testing

http://localhost:8000/en-US/privacy/

- [ ] Running [a11y tests locally](https://bedrock.readthedocs.io/en/latest/testing.html#accessibility-testing-axe) should no longer generate an a11y report file for the privacy page.