### PR TITLE
Ignore <blink> element in navigation a11y scan

### DIFF
--- a/tests/playwright/specs/a11y/components/navigation.spec.js
+++ b/tests/playwright/specs/a11y/components/navigation.spec.js
@@ -11,6 +11,7 @@ const { createReport, scanPageElement } = require('../includes/helpers');
 const { navigationLocator } = require('../includes/locators');
 const { test, expect } = require('@playwright/test');
 const testURL = '/en-US/';
+const disabledRules = ['blink'];
 
 test.describe(
     'Navigation (desktop)',
@@ -31,7 +32,11 @@ test.describe(
             await firefoxLink.hover();
             await expect(firefoxMenu).toBeVisible();
 
-            const results = await scanPageElement(page, navigationLocator);
+            const results = await scanPageElement(
+                page,
+                navigationLocator,
+                disabledRules
+            );
             createReport('component', 'navigation-desktop', results);
             expect(results.violations.length).toEqual(0);
         });
@@ -70,7 +75,11 @@ test.describe(
             await firefoxLink.click();
             await expect(firefoxMenu).toBeVisible();
 
-            const results = await scanPageElement(page, navigationLocator);
+            const results = await scanPageElement(
+                page,
+                navigationLocator,
+                disabledRules
+            );
             createReport('component', 'navigation-mobile', results);
             expect(results.violations.length).toEqual(0);
         });

--- a/tests/playwright/specs/a11y/includes/helpers.js
+++ b/tests/playwright/specs/a11y/includes/helpers.js
@@ -61,7 +61,13 @@ async function scanPage(page) {
  * @param {Object} page
  * @returns {Promise} results
  */
-async function scanPageElement(page, locator) {
+async function scanPageElement(page, locator, disabledRules) {
+    if (disabledRules) {
+        return new AxeBuilder({ page })
+            .include(locator)
+            .disableRules(disabledRules)
+            .analyze();
+    }
     return new AxeBuilder({ page }).include(locator).analyze();
 }
 


### PR DESCRIPTION
## One-line summary

Ignores the `<blink>` element in navigation a11y scan.

## Issue / Bugzilla link

N/A

## Testing

- [x] Running [a11y tests locally](https://bedrock.readthedocs.io/en/latest/testing.html#accessibility-testing-axe) should no longer generate an a11y report file for the navigation component.