### PR TITLE
Use consistent product name for 'Firefox Translations' in Fluent (Fixes #15442)

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% block page_desc %}{{ ftl('features-translate-firefox-translations-is-a-built-in') }}{% endblock %}
+{% block page_desc %}{{ ftl('features-translate-firefox-translations-is-a-built-in-v2', fallback='features-translate-firefox-translations-is-a-built-in') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/features/translate/og.png') }}{% endblock %}
 
 {% block article_title_short %}{{ ftl('features-translate-translate-the-web') }}{% endblock %}
@@ -14,13 +14,13 @@
 
 {% block article_content %}
 <p>{{ ftl('features-translate-one-of-the-best-things-about') }}</p>
-<p>{{ ftl('features-translate-while-other-browsers-rely-on') }}</p>
+<p>{{ ftl('features-translate-while-other-browsers-rely-on-v2', fallback='features-translate-while-other-browsers-rely-on') }}</p>
 
 <h2>{{ ftl('features-translate-when-you-translate-a-webpage') }}</h2>
 <p>{{ ftl('features-translate-when-your-translations-are') }}</p>
 
 <h2>{{ ftl('features-translate-what-languages-are-currently') }}</h2>
-<p>{{ ftl('features-translate-the-languages-below-are-what') }}</p>
+<p>{{ ftl('features-translate-the-languages-below-are-what-v2', fallback='features-translate-the-languages-below-are-what') }}</p>
 
 <ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
@@ -69,5 +69,9 @@
 <p>{{ ftl('features-translate-and-more-languages-are-in') }}</p>
 
 <h2>{{ ftl('features-translate-firefox-speaks-your-language') }}</h2>
+{% if ftl_has_messages('features-translate-the-firefox-translations-feature-v2') %}
+<p>{{ ftl('features-translate-the-firefox-translations-feature-v2', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox.new'))) }}</p>
+{% else %}
 <p>{{ ftl('features-translate-the-firefox-translations-feature', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox.new'))) }}</p>
+{% endif %}
 {% endblock %}

--- a/l10n/en/firefox/features/translate.ftl
+++ b/l10n/en/firefox/features/translate.ftl
@@ -9,18 +9,26 @@ features-translate-translate-a-webpage-with-firefox = Translate a webpage with {
 features-translate-translate-the-web = Translate the web
 
 # HTML page description
-features-translate-firefox-translations-is-a-built-in = { -brand-name-firefox-translations } is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
+features-translate-firefox-translations-is-a-built-in-v2 = { -brand-name-firefox-translations } is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
+# Obsolete string (expires: 2025-02-17)
+features-translate-firefox-translations-is-a-built-in = { -brand-name-firefox } Translations is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
 features-translate-one-of-the-best-things-about = One of the best things about the internet is that we can access content worldwide. Whether it’s news articles, blogs, or even a review of your latest tech gadget, you can find it all on the seemingly never-ending web. With { -brand-name-firefox }’s latest translation feature, this tool will continuously translate a webpage in real-time.
-features-translate-while-other-browsers-rely-on = While other browsers rely on cloud services, the { -brand-name-firefox-translations } language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
+features-translate-while-other-browsers-rely-on-v2 = While other browsers rely on cloud services, the { -brand-name-firefox-translations } language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
+# Obsolete string (expires: 2025-02-17)
+features-translate-while-other-browsers-rely-on = While other browsers rely on cloud services, the { -brand-name-firefox } Translations language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
 features-translate-when-you-translate-a-webpage = When you translate a webpage, it stays private
 features-translate-when-your-translations-are = When your translations are processed locally, no data from your chosen device leaves your device or relies on cloud services for translation. This means that { -brand-name-mozilla } doesn’t know what web page you translate, and makes our translation feature stand out in comparison to other translation tools.
 features-translate-what-languages-are-currently = What languages are currently supported?
 
 # This is followed by a localized list of supported languages
-features-translate-the-languages-below-are-what = The languages below are currently supported by the { -brand-name-firefox-translations } feature:
+features-translate-the-languages-below-are-what-v2 = The languages below are currently supported by the { -brand-name-firefox-translations } feature:
+# Obsolete string (expires: 2025-02-17)
+features-translate-the-languages-below-are-what = The languages below are currently supported by the { -brand-name-firefox } Translations feature:
 features-translate-and-more-languages-are-in = And more languages are in development!
 features-translate-firefox-speaks-your-language = { -brand-name-firefox } speaks your language
 
 # Variables:
 #   $download (url) = link to https://www.mozilla.org/firefox/new/
-features-translate-the-firefox-translations-feature = The { -brand-name-firefox-translations } feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>
+features-translate-the-firefox-translations-feature-v2 = The { -brand-name-firefox-translations } feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>
+# Obsolete string (expires: 2025-02-17)
+features-translate-the-firefox-translations-feature = The { -brand-name-firefox } Translations feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>

--- a/l10n/en/firefox/features/translate.ftl
+++ b/l10n/en/firefox/features/translate.ftl
@@ -9,18 +9,18 @@ features-translate-translate-a-webpage-with-firefox = Translate a webpage with {
 features-translate-translate-the-web = Translate the web
 
 # HTML page description
-features-translate-firefox-translations-is-a-built-in = { -brand-name-firefox } Translations is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
+features-translate-firefox-translations-is-a-built-in = { -brand-name-firefox-translations } is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
 features-translate-one-of-the-best-things-about = One of the best things about the internet is that we can access content worldwide. Whether it’s news articles, blogs, or even a review of your latest tech gadget, you can find it all on the seemingly never-ending web. With { -brand-name-firefox }’s latest translation feature, this tool will continuously translate a webpage in real-time.
-features-translate-while-other-browsers-rely-on = While other browsers rely on cloud services, the { -brand-name-firefox } Translations language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
+features-translate-while-other-browsers-rely-on = While other browsers rely on cloud services, the { -brand-name-firefox-translations } language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
 features-translate-when-you-translate-a-webpage = When you translate a webpage, it stays private
 features-translate-when-your-translations-are = When your translations are processed locally, no data from your chosen device leaves your device or relies on cloud services for translation. This means that { -brand-name-mozilla } doesn’t know what web page you translate, and makes our translation feature stand out in comparison to other translation tools.
 features-translate-what-languages-are-currently = What languages are currently supported?
 
 # This is followed by a localized list of supported languages
-features-translate-the-languages-below-are-what = The languages below are currently supported by the { -brand-name-firefox } Translations feature:
+features-translate-the-languages-below-are-what = The languages below are currently supported by the { -brand-name-firefox-translations } feature:
 features-translate-and-more-languages-are-in = And more languages are in development!
 features-translate-firefox-speaks-your-language = { -brand-name-firefox } speaks your language
 
 # Variables:
 #   $download (url) = link to https://www.mozilla.org/firefox/new/
-features-translate-the-firefox-translations-feature = The { -brand-name-firefox } Translations feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>
+features-translate-the-firefox-translations-feature = The { -brand-name-firefox-translations } feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>


### PR DESCRIPTION
## One-line summary
Treat "Firefox Translations" as a single product name in Fluent strings.

## Significant changes and points to review

- This is the contents of https://github.com/mozilla/bedrock/pull/15459 with the addition of some versioning
- Updated instances of `{ -brand-name-firefox } Translations` to `{ -brand-name-firefox-translations }` in relevant files.
- Ensured consistency by using the pre-defined `{ -brand-name-firefox-translations }` entry from `brands.ftl` across all strings.
- Verified that the changes align with the Fluent localization standards for product naming.

## Issue / Bugzilla link
Resolves [Issue #15442](https://github.com/mozilla/bedrock/issues/15442)

## Testing
- Manually checked that each modified string renders "Firefox Translations" as a single entity in the UI.
- Confirmed the updated strings in different localization scenarios to ensure they display correctly.