### PR TITLE
 Remove obsolete l10n strings (Fix #15496) 

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
@@ -46,8 +46,8 @@
             <section class="c-menu-item mzp-has-icon">
               <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.index') }}" data-link-text="Firefox for Mobile" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-mobile', fallback='navigation-firefox-browser-for-mobile') }}</h4>
-                <p class="c-menu-item-desc">{{ ftl('navigation-v2-take-speed-privacy-and', fallback='navigation-take-speed-privacy-and') }}</p>
+                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-mobile') }}</h4>
+                <p class="c-menu-item-desc">{{ ftl('navigation-v2-take-speed-privacy-and') }}</p>
               </a>
             </section>
           </li>

--- a/bedrock/firefox/templates/firefox/all/base.html
+++ b/bedrock/firefox/templates/firefox/all/base.html
@@ -6,11 +6,11 @@
 {% extends "firefox/base/base-protocol.html" %}
 
 {%- block page_title -%}
-  {{ ftl('firefox-all-download-the-firefox-v2', fallback="firefox-all-download-the-firefox") }}
+  {{ ftl('firefox-all-download-the-firefox-v2') }}
 {%- endblock -%}
 
 {%- block page_desc -%}
-  {{ ftl('firefox-all-everyone-deserves-access-v2', fallback="'firefox-all-everyone-deserves-access") }}
+  {{ ftl('firefox-all-everyone-deserves-access-v2') }}
 {%- endblock -%}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/all/lang.html
+++ b/bedrock/firefox/templates/firefox/all/lang.html
@@ -6,7 +6,7 @@
 
 {# Choose language #}
 <h2 {% if not (product and platform) %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
-  {{ ftl('firefox-all-language-v2', fallback='firefox-all-language') }}
+  {{ ftl('firefox-all-language-v2') }}
   {% if product and platform and locale %}
     <span class="c-step-choice">{{ locale_name }}</span>
     {% if product.slug.startswith('desktop') and platform != "win-store" %}

--- a/bedrock/firefox/templates/firefox/all/platform.html
+++ b/bedrock/firefox/templates/firefox/all/platform.html
@@ -8,7 +8,7 @@
 {# Choose platform #}
 
 <h2 {% if not product %} class="c-step-name t-step-disabled" aria-disabled="true" {% else %} class="c-step-name" aria-disabled="false" {% endif %}>
-  {{ ftl('firefox-all-platform-v2', fallback='firefox-all-platform') }}
+  {{ ftl('firefox-all-platform-v2') }}
   {% if product and platform %}
     <span class="c-step-choice">{{ platform_name }}</span>
     {% if product.slug.startswith('desktop') %}

--- a/bedrock/firefox/templates/firefox/all/product.html
+++ b/bedrock/firefox/templates/firefox/all/product.html
@@ -7,7 +7,7 @@
 {# Choose product #}
 
 <h2 class="c-step-name">
-  {{ ftl('firefox-all-browser-v2', fallback='firefox-all-browser') }}
+  {{ ftl('firefox-all-browser-v2') }}
   {% if product %}
     <span class="c-step-choice">{{ product and product.name }}</span> <a href="{{ url('firefox.all') }}" class="c-step-icon"><img alt="{{ ftl('firefox-all-change-browser') }}" src="{{ static('protocol/img/icons/close.svg') }}" width="30" height="30"></a>
   {% else %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/landing-base.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/landing-base.html
@@ -8,7 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% from "macros-protocol.html" import picto with context %}
 
-{% block page_title %}{{ ftl('firefox-home-firefox-protect-your') }}{% endblock %}
+{% block page_title %}{{ seo_title }}{% endblock %}
 {% block page_title_suffix %} — {{ ftl('firefox-home-mozilla') }}{% endblock %}
 {% block page_desc %}{{ seo_desc }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.de.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.de.html
@@ -8,6 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block page_image %}{{ static('img/firefox/challenge-the-default/ctd-share.png') }}{% endblock %}
 
+{% set seo_title = 'Alle Firefox-Produkte schützen zuallererst deine Privatsphäre online' %}
 {% set seo_desc = 'Du hast eine Wahl, wenn es um Browser geht! Vorinstalliert ist gut, ausgewählt ist besser. Mit Firefox entscheidest du dich gegen den Standard und für konsequenten Datenschutz, mehr Transparenz und eine Non-Profit im Rücken.' %}
 {% set cta_default = 'Firefox als Standardbrowser festlegen' %}
 {% set cta_mobile = 'Firefox fürs Handy entdecken' %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.es-ES.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.es-ES.html
@@ -8,6 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block page_image %}{{ static('img/firefox/challenge-the-default/ctd-share-es.png') }}{% endblock %}
 
+{% set seo_title = 'Firefox - Protege tu vida en línea con productos que priorizan la privacidad' %}
 {% set seo_desc = 'Cuando eliges Firefox, estás tomando una decisión consciente. Mejor protección de datos, más transparencia y una web más sana.' %}
 {% set cta_default = 'Configura Firefox como tu navegador por defecto' %}
 {% set cta_mobile = 'Descubre Firefox para móvil' %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.fr.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.fr.html
@@ -8,6 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block page_image %}{{ static('img/firefox/challenge-the-default/ctd-share-fr.png') }}{% endblock %}
 
+{% set seo_title = 'Firefox – Une gamme de produits qui protègent votre vie privée' %}
 {% set seo_desc = 'Imaginez un navigateur qui ait un intérêt à cœur avant tout : le vôtre. Firefox est rapide, sécurisé, et éthique. Parce que nous n’avons de compte à rendre qu’à vous, nos utilisateurs, pas à des actionnaires ou annonceurs.' %}
 {% set cta_default = 'Choisir Firefox comme navigateur par défaut' %}
 {% set cta_mobile = 'Découvrir Firefox mobile' %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.it.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.it.html
@@ -8,6 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block page_image %}{{ static('img/firefox/challenge-the-default/ctd-share-it.png') }}{% endblock %}
 
+{% set seo_title = 'Firefox: proteggi la tua vita in rete con prodotti che mettono la privacy al primo posto' %}
 {% set seo_desc = 'Quando scegli Firefox, metti te al primo posto. Noi proteggiamo meglio i tuoi dati, tu hai più trasparenza ed entri a far parte del lato più sano di internet.' %}
 {% set cta_default = 'Rendi Firefox il tuo browser predefinito' %}
 {% set cta_mobile = 'Scopri Firefox per il mobile' %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.pl.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/langs/landing.pl.html
@@ -8,6 +8,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block page_image %}{{ static('img/firefox/challenge-the-default/ctd-share-pl.png') }}{% endblock %}
 
+{% set seo_title = 'Firefox — chroń swoje życie w sieci za pomocą produktów zapewniających prywatność' %}
 {% set seo_desc = 'Korzystając z Firefoksa decydujesz się na lepszą ochronę danych, większą transparentość i "zdrowszy" internet. To Twój świadomy wybór.' %}
 {% set cta_default = 'Ustaw Firefoksa jako domyślną przeglądarkę' %}
 {% set cta_mobile = 'Odkryj Firefoksa dla urządzeń mobilnych' %}

--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -19,12 +19,6 @@
 
 <h2>{{ ftl('features-adblocker-find-the-right-ad-blocker') }}</h2>
 
-{% if ftl_has_messages(
-    'features-adblocker-there-are-scores-of-content',
-    'features-adblocker-considered-by-many-to-be-the',
-    'features-adblocker-adguard-adblocker-blunts',
-    'features-adblocker-ghostery-is-another-great',
-    'features-adblocker-these-extensions-work-beautifully') %}
 <p>{{ ftl('features-adblocker-there-are-scores-of-content') }}</p>
 <p>{{ ftl('features-adblocker-considered-by-many-to-be-the', attrs='href="https://addons.mozilla.org/firefox/addon/ublock-origin/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features"|safe') }}</p>
 <p>{{ ftl('features-adblocker-adguard-adblocker-blunts', attrs1='href="https://addons.mozilla.org/firefox/addon/adguard-adblocker/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features"|safe', attrs2='href="https://addons.mozilla.org/firefox/addon/popup-blocker/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features"|safe') }}</p>
@@ -32,11 +26,6 @@
 {% set desktop_link = 'href="%s" data-link-type="link" data-link-text="Firefox for desktop"'|safe|format(url('firefox.new')) %}
 {% set android_link = 'href="%s" data-link-type="link" data-link-text="Firefox for desktop"'|safe|format(url('firefox.browsers.mobile.android')) %}
 <p>{{ ftl('features-adblocker-these-extensions-work-beautifully', attrs1=desktop_link, attrs2=android_link) }}</p>
-{% else %}
-<p>{{ ftl('features-adblocker-theres-adblocker-ultimate', url='https://addons.mozilla.org/firefox/addon/adblocker-ultimate/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7&utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features') }}</p>
-<p>{{ ftl('features-adblocker-popup-ads-are-the-worst', url='https://addons.mozilla.org/firefox/addon/popup-blocker/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7&utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features') }}</p>
-<p>{{ ftl('features-adblocker-one-of-the-most-popular', url='https://addons.mozilla.org/firefox/addon/adblock-for-firefox/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7&utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features') }}</p>
-{% endif %}
 
 <h2>{{ftl('features-adblocker-create-a-tracker-free') }}</h2>
 <p>{{ ftl('features-adblocker-on-firefox-you-can-use', privacy='https://restoreprivacy.com/firefox-privacy/', blocking='https://support.mozilla.org/kb/content-blocking?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-features') }}</p>

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -76,7 +76,7 @@
 
       <p>
           {% set attrs = 'href="#" class="nightly-experiments-link"' %}
-          {{ ftl('nightly-whatsnew-want-to-know-which-v3', fallback='nightly-whatsnew-want-to-know-which-v2', attrs=attrs) }}
+          {{ ftl('nightly-whatsnew-want-to-know-which-v3', attrs=attrs) }}
         </p>
 
       <p>{{ ftl('nightly-whatsnew-do-you-experience', bugzilla='https://bugzilla.mozilla.org') }}</p>

--- a/bedrock/newsletter/templates/newsletter/firefox.html
+++ b/bedrock/newsletter/templates/newsletter/firefox.html
@@ -31,8 +31,8 @@
   {% set page_title_copy = 'Wyciśnij z Firefoksa, ile się da' %}
   {% set page_desc_copy = 'Zarejestruj się, aby co miesiąc otrzymywać nowości od Firefoksa i zawsze wiedzieć, co słychać w internecie.' %}
 {% else %}
-  {% set page_title_copy = ftl('newsletters-make-the-most', fallback='newsletters-put-more-fox-in-your-inbox') %}
-  {% set page_desc_copy = ftl('newsletters-sign-up-to-receive-monthly', fallback='newsletters-see-where-the-web-can-take') %}
+  {% set page_title_copy = ftl('newsletters-make-the-most') %}
+  {% set page_desc_copy = ftl('newsletters-sign-up-to-receive-monthly') %}
 {% endif %}
 
 {% block page_title %}{{ page_title_copy }}{% endblock page_title %}

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -115,9 +115,9 @@
             <span class="mzp-c-fieldnote">
               {# Issue 7460 `mozilla-and-you` is the ID for the Firefox newsletter, because history... #}
               {% if id == 'mozilla-and-you' %}
-                {{ ftl('newsletter-form-we-will-only-send-firefox-v2', fallback='newsletter-form-we-will-only-send-firefox') }}
+                {{ ftl('newsletter-form-we-will-only-send-firefox-v2') }}
               {% else %}
-                {{ ftl('newsletter-form-we-will-only-send-v2', fallback='newsletter-form-we-will-only-send') }}
+                {{ ftl('newsletter-form-we-will-only-send-v2') }}
               {% endif %}
             </span>
         {% endif %}

--- a/l10n/en/firefox/all.ftl
+++ b/l10n/en/firefox/all.ftl
@@ -6,13 +6,10 @@
 
 # HTML page title. Replace "English (US)" with your local language.
 firefox-all-download-the-firefox-v2 = Download { -brand-name-firefox } in English (US) and more than 90 other languages
-# Obsolete string (expires 2024-10-30)
-firefox-all-download-the-firefox = Download the { -brand-name-firefox-browser } in English (US) and more than 90 other languages
+
 
 # HTML page description, also used as the introductory text.
 firefox-all-everyone-deserves-access-v2 = Everyone deserves access to the internet — your language should never be a barrier. That’s why — with the help of dedicated volunteers around the world — we make { -brand-name-firefox } available in more than 90 languages.
-# Obsolete string (expires 2024-10-30)
-firefox-all-everyone-deserves-access = Everyone deserves access to the internet — your language should never be a barrier. That’s why — with the help of dedicated volunteers around the world — we make the { -brand-name-firefox-browser } available in more than 90 languages.
 
 # Variables:
 #   $product_label (string) e.g. Firefox, Firefox Nightly
@@ -29,14 +26,8 @@ firefox-all-down-arrow = Choose from the list below
 
 # Used as an accessible label for a help button. The text is replaced with a "?" icon.
 firefox-all-get-help = Get help
-# Obsolete string (expires 2024-10-30)
-firefox-all-browser = Browser:
 firefox-all-browser-v2 = 1. Browser:
-# Obsolete string (expires 2024-10-30)
-firefox-all-platform = Platform:
 firefox-all-platform-v2 = 2. Platform:
-# Obsolete string (expires 2024-10-30)
-firefox-all-language = Language:
 firefox-all-language-v2 = 3. Language:
 firefox-all-download = 4. Download:
 firefox-all-desktop = Desktop

--- a/l10n/en/firefox/features/adblocker.ftl
+++ b/l10n/en/firefox/features/adblocker.ftl
@@ -38,21 +38,6 @@ features-adblocker-ghostery-is-another-great = <a { $attrs }>Ghostery</a> is ano
 #   $attsr2 (string) - link to /firefox/mobile/android/ with other attributes
 features-adblocker-these-extensions-work-beautifully = These extensions work beautifully on both <a { $attrs1 }>{ -brand-name-firefox } for desktop</a> and <a { $attrs2 }>Android</a>.
 
-# Obsolete string (expires: 2024-11-18)
-# Variables:
-#   $url (url) - link to https://addons.mozilla.org/firefox/addon/adblocker-ultimate/
-features-adblocker-theres-adblocker-ultimate = There’s <a href="{ $url }">AdBlocker Ultimate</a> that gets rid of every single ad, but buyer beware. Some of your favorite newspapers and magazines rely on advertising. Too many people blocking their ads could put them out of business.
-
-# Obsolete string (expires: 2024-11-18)
-# Variables:
-#   $url (url) - link to https://addons.mozilla.org/firefox/addon/popup-blocker/
-features-adblocker-popup-ads-are-the-worst = Popup ads are the worst. Block them with <a href="{ $url }">Popup Blocker</a> and never deal with another annoying popup again.
-
-# Obsolete string (expires: 2024-11-18)
-# Variables:
-#   $url (url) - link to https://addons.mozilla.org/firefox/addon/adblock-for-firefox/
-features-adblocker-one-of-the-most-popular = One of the most popular ad blockers for { -brand-name-chrome }, { -brand-name-safari } and { -brand-name-firefox } is <a href="{ $url }">AdBlock</a>. Use it to block ads on { -brand-name-facebook }, { -brand-name-youtube } and { -brand-name-hulu }.
-
 features-adblocker-create-a-tracker-free = Create a tracker-free zone with Content Blocking
 
 # Variables:

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -24,10 +24,6 @@ nightly-whatsnew-if-you-want-to-v3 = If you want to know what’s happening arou
 
 # Variables:
 #   $attrs (string) - link href and additional attributes
-# Obsolete string (expires: 2024-11-26)
-nightly-whatsnew-want-to-know-which-v2 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>Nightly Experiments</a> preferences page.
-# Variables:
-#   $attrs (string) - link href and additional attributes
 nightly-whatsnew-want-to-know-which-v3 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>{ -brand-name-firefox-labs }</a> preferences page.
 
 # Variables:

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -119,14 +119,8 @@ newsletters-unlock-the-world-of-web = Unlock the world of web development with o
 # Headline for https://www-dev.allizom.org/newsletter/firefox/
 newsletters-make-the-most = Make the most out of { -brand-name-firefox }
 
-# Obsolete string (expires: 2024-11-01)
-newsletters-put-more-fox-in-your-inbox = Put more fox in your inbox.
-
 # Subtitle for https://www-dev.allizom.org/newsletter/firefox/
 newsletters-sign-up-to-receive-monthly = Sign up to receive monthly updates from { -brand-name-firefox } and internet trends that shape your life online.
-
-# Obsolete string (expires: 2024-11-01)
-newsletters-see-where-the-web-can-take = See where the Web can take you with monthly { -brand-name-firefox } tips, tricks and Internet intel.
 
 newsletters-we-are-sorry-but-there = We are sorry, but there was a problem with our system. Please try again later!
 newsletters-thanks-for-updating-your = Thanks for updating your email preferences.

--- a/l10n/en/navigation.ftl
+++ b/l10n/en/navigation.ftl
@@ -2,10 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Obsolete string (expires 2024-12-10)
-navigation-firefox-browser-for-mobile = { -brand-name-firefox-browser } for Mobile
-
-# Obsolete string (expires 2024-12-10)
-navigation-take-speed-privacy-and = Take speed, privacy and peace of mind with you. On { -brand-name-android } and { -brand-name-ios }.
-
 navigation-sign-up = Sign Up

--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -25,13 +25,7 @@ newsletter-form-im-okay-with-mozilla = I’m okay with { -brand-name-mozilla } h
 
 newsletter-form-we-will-only-send-v2 = We will only send you { -brand-name-mozilla }-related information. You can unsubscribe at any time.
 
-# Obsolete string (expires: 2024-11-01)
-newsletter-form-we-will-only-send = We will only send you { -brand-name-mozilla }-related information.
-
 newsletter-form-we-will-only-send-firefox-v2 = We will only send you { -brand-name-firefox }-related information. You can unsubscribe at any time.
-
-# Obsolete string (expires: 2024-11-01)
-newsletter-form-we-will-only-send-firefox = We will only send you { -brand-name-firefox }-related information.
 
 newsletter-form-if-you-havent-previously = If you haven’t previously confirmed a subscription to a { -brand-name-mozilla }-related newsletter, you may have to do so. Please check your inbox or your spam filter for an email from us.
 newsletter-form-firefox-and-you = <span>{ -brand-name-firefox }</span> + You


### PR DESCRIPTION
## One-line summary

L10n maintenance

## Significant changes and points to review

- removed obsolete strings which have expired
- discovered CTD templates were referencing a string ID that had been removed, took the translations off prod and hard coded them like the other strings in the CTD templates

## Issue / Bugzilla link

Fix #15496

## Testing

Do a `make preflight` to make sure you have the most recent translations.

http://localhost:8000/fr/firefox/all/
http://localhost:8000/fr/firefox/features/adblocker/
http://localhost:8000/fr/firefox/135.0a1/whatsnew/
http://localhost:8000/fr/newsletter/firefox/

http://localhost:8000/de/firefox/challenge-the-default/
http://localhost:8000/fr/firefox/challenge-the-default/
http://localhost:8000/es-ES/firefox/challenge-the-default/
http://localhost:8000/it/firefox/challenge-the-default/
http://localhost:8000/pl/firefox/challenge-the-default/
