### PR TITLE
Fix Animation button accessibility issues (fixes #15762, #15763, #15764)

### DIFF
--- a/media/css/m24/flag.scss
+++ b/media/css/m24/flag.scss
@@ -55,6 +55,12 @@
     cursor: pointer;
     transition: background-color $fast;
 
+    // Focused button is always visible: https://bugzilla.mozilla.org/show_bug.cgi?id=1936862
+    &:focus {
+        position: relative;
+        z-index: 1001; // must be above .m24-navigation-refresh.m24-mzp-is-sticky
+    }
+
     &:hover,
     &:focus {
         background-color: $m24-color-black; // inverts to white in dark theme section

--- a/media/css/m24/flag.scss
+++ b/media/css/m24/flag.scss
@@ -85,14 +85,9 @@
     }
 
     .m24-c-flag-button {
-        border-radius: 50%;
         display: block;
         margin-bottom: $spacer-md;
         margin-inline-start: auto;
-    }
-
-    .m24-c-flag-button-text {
-        @include visually-hidden;
     }
 
     .m24-c-flag-media {

--- a/media/css/m24/flag.scss
+++ b/media/css/m24/flag.scss
@@ -44,7 +44,7 @@
 .m24-c-flag-button {
     $font-size: 0.75;
     background-color: $m24-color-dark-mid-gray;
-    border: none;
+    border-color: transparent; // High Contrast Mode support
     box-shadow: none;
     color: $m24-color-white;
     font-family: $primary-font;
@@ -62,6 +62,16 @@
 
     &:active {
         background-color: $m24-color-dark-mid-gray;
+    }
+
+    // High Contrast Mode Support: https://bugzilla.mozilla.org/show_bug.cgi?id=1936865
+    @media (forced-colors) {
+        background-color: ButtonFace;
+        color: ButtonText;
+
+        &:focus {
+            outline-color: CanvasText;
+        }
     }
 }
 


### PR DESCRIPTION
## One-line summary

As discussed with Tess, we'd like to keep the text visible on smaller screens to provide toggle animation button label

The above decision also helps make the label more visible for Windows High Contrast Mode

We also want to ensure the button is not overlapped by the sticky nav when focused

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

Other approaches considered for icon-only toggle animation button label:
- animated text reveal on hover
- custom tooltip
- HTML title attribute

Overall, the visible text label felt simplest and most accessible

Other approaches considered for focused button visibility:
- set custom property with sticky navigation height and use scroll margin to keep focused button below the sticky nav (this did not work when banner was also on page)

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15762
https://github.com/mozilla/bedrock/issues/15763
https://github.com/mozilla/bedrock/issues/15764

## Testing

Go to http://localhost:8000/en-US/ and check animation toggle button in hero section
- [x] Text label is visible when large screen is zoomed to 200%
- [x] Text label is visible when on smaller tablet/mobile screens

- [ ] Test in Windows High Contrast Mode to confirm button focus color is correct and border color is visible

(Polypane testing with forced colors)
Focused & not focused
<img width="210" alt="Screenshot 2024-12-19 at 10 44 35 AM" src="https://github.com/user-attachments/assets/781587f5-fe54-4c1e-b701-fc02394ccca6" />
<img width="214" alt="Screenshot 2024-12-19 at 10 44 43 AM" src="https://github.com/user-attachments/assets/67a48bb8-ee5a-42d5-808b-300867ca9462" />


- [x] With no motion pref, tab past the hero section, then tab back. The animation toggle button should be visible over top of the sticky navigation
- [x] When button is not focused, the sticky nav is on top

Focused button above sticky nav
<img width="967" alt="Screenshot 2024-12-19 at 9 58 45 AM" src="https://github.com/user-attachments/assets/bd683c41-8a34-46bc-abd5-a5a3ebedd68e" />

Not-focused button below sticky nav
<img width="979" alt="Screenshot 2024-12-19 at 10 00 40 AM" src="https://github.com/user-attachments/assets/92758da0-687f-45f3-b1fd-3ed22bef38ee" />
