### PR TITLE
vertically center pencil banner close button (fix #15674)

### DIFF
--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -35,7 +35,8 @@
         height: 24px;
         padding: var(--spacer-xs);
         position: absolute;
-        top: $spacer-sm;
+        top: 50%;
+        margin-top: -12px;
         transition: border-color $fast $bezier;
         width: 24px;
 


### PR DESCRIPTION
## One-line summary

This PR vertically centers the pencil banner close button.

## Significant changes and points to review

Pencil banner close button on various screen sizes, rtl reading direction

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15674

## Testing

http://localhost:8000/en-US/firefox/new/