### PR TITLE
Fix chasing underline under multiple lines (fixes #15683)

### DIFF
--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -86,8 +86,9 @@ a:link {
 
 .m24-c-cta {
     @include bidi(((background-position, left var(--cta-bg-position, 100%) top 100%, right var(--cta-bg-position, 100%) top 100%),));
+    box-decoration-break: clone;
     color: $m24-color-black;
-    display: inline-block;
+    display: inline; // required for box cloning
     font-family: var(--title-font-family);
     font-size: $text-button-lg;
     font-weight: 600;


### PR DESCRIPTION
Box decoration break cloning doesn't work as expected with an inline-block element.

All of our current CTA uses are inside a containing block element, so that container can handle block-level layout and let the CTA be inline display.

## One-line summary

Chasing underline should only be under text, not blank space

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

This is more of a future-proofing fix as the [Smaller CTA PR](https://github.com/mozilla/bedrock/pull/15731) seems to have fixed all the reported issues by keeping the text on a single line

Also still helpful for larger font settings

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/15683


## Testing

note: may need to update l10n `./manage.py l10n_update` locally

Check "Let’s build a fairer future" green section on small mobile screen (320px)
And the below section: "Join us and make a difference"

http://localhost:8000/de/about/
http://localhost:8000/cs/about/

<img width="342" alt="Screenshot 2025-01-09 at 1 19 18 PM" src="https://github.com/user-attachments/assets/e64349d3-d5d5-4cf5-98d1-3fd693a8db99" />
<img width="300" alt="Screenshot 2025-01-09 at 1 21 09 PM" src="https://github.com/user-attachments/assets/cb1a9444-5d13-47d3-8789-833dedb6fd68" />
