### PR TITLE
Enable Tajik localization in prod

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -181,6 +181,7 @@ LOCALES_BY_REGION = {
         "si",
         "ta",
         "te",
+        "tg",
         "th",
         "tl",
         "ur",


### PR DESCRIPTION
## One-line summary

Adds `tg` to allowed locales in settings to stop 404ing in prod.

## Significant changes and points to review

Following up from #15021, this is pending approval from l10ns.

This locale is still listed on the global root home page and offered to crawlers, but returns 404 as it is not explicitly allowed. (The reason is explained in both the previous PR and the linked issue.)

After an inquiry during the previous PR into the commitment of keeping Tajik version of wwwmo up to date, the community got very active the following months, and went from ~20% to currently 60%+ of translated content, with the usual key pages as home, products, browsers, vpn etc. above the threshold for enabling the locale. So the question is, whether also the Tajik locale wouldn't be a worthwhile addition, given its recent activity.

## Issue / Bugzilla link

#15010

## Testing

_(in prod mode, with Debug=False & Dev=False)_
http://localhost:8000/ _(with Accept-Locale unset)_
http://localhost:8000/404-locale/
http://localhost:8000/tg/