### PR TITLE
Update newsletter recovery to use new JSON API

### DIFF
--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -24,6 +24,14 @@
     {% endif %}
 
   <div class="mzp-l-content mzp-t-content-sm">
+
+    {# noscript warning to enable JavaScript #}
+    <noscript>
+      <div class="mzp-c-notification-bar mzp-t-error">
+        <p><strong>{{ ftl('ui-please-turn-on-javascript') }}</strong></p>
+      </div>
+    </noscript>
+
     <h1 class="mzp-u-title-sm">{{ ftl('newsletters-manage-your-newsletter') }}</h1>
 
     <form method="post" action="{{ recovery_url }}" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -23,15 +23,14 @@
       </div>
     {% endif %}
 
-  <div class="mzp-l-content mzp-t-content-sm">
-
     {# noscript warning to enable JavaScript #}
     <noscript>
       <div class="mzp-c-notification-bar mzp-t-error">
-        <p><strong>{{ ftl('ui-please-turn-on-javascript') }}</strong></p>
+        <p>{{ ftl('ui-please-turn-on-javascript') }}</p>
       </div>
     </noscript>
 
+  <div class="mzp-l-content mzp-t-content-sm">
     <h1 class="mzp-u-title-sm">{{ ftl('newsletters-manage-your-newsletter') }}</h1>
 
     <form method="post" action="{{ recovery_url }}" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -197,7 +197,11 @@ def recovery(request):
     form = EmailForm()
     fxa_error = request.GET.get("fxa_error", "0") == "1"
 
-    context = {"form": form, "recovery_url": f"{settings.BASKET_URL}/news/recover/", "fxa_error": fxa_error}
+    context = {
+        "form": form,
+        "recovery_url": f"{settings.BASKET_URL}/api/v1/users/recover/",
+        "fxa_error": fxa_error,
+    }
 
     # This view is shared between two different templates. For context see bug 1442129.
     if "/newsletter/opt-out-confirmation/" in request.get_full_path():

--- a/media/js/newsletter/recovery.es6.js
+++ b/media/js/newsletter/recovery.es6.js
@@ -62,7 +62,7 @@ const RecoveryEmailForm = {
         e.preventDefault();
 
         const email = document.getElementById('id_email').value;
-        const params = 'email=' + encodeURIComponent(email);
+        const params = FormUtils.serializeToJson(_recoveryForm);
         const url = _recoveryForm.getAttribute('action');
 
         // Disable form fields until POST has completed.
@@ -76,7 +76,7 @@ const RecoveryEmailForm = {
             return;
         }
 
-        FormUtils.postToBasket(
+        FormUtils.postJsonToBasket(
             email,
             params,
             url,

--- a/tests/unit/spec/newsletter/form-utils.js
+++ b/tests/unit/spec/newsletter/form-utils.js
@@ -229,6 +229,42 @@ describe('serialize', function () {
     });
 });
 
+describe('serializeToJson', function () {
+    afterEach(function () {
+        const form = document.querySelector('.send-to-device-form');
+        form.parentNode.removeChild(form);
+    });
+
+    it('should return a JSON object as expected', function () {
+        const form = `<form class="send-to-device-form" action="https://basket.mozilla.org/news/subscribe/" method="post">
+            <div class="send-to-device-form-fields">
+                <div class="platform-container">
+                    <input type="hidden" name="newsletters" value="download-firefox-mobile-reco">
+                    <input type="hidden" name="source-url" value="https://www.mozilla.org/en-US/firefox/browsers/mobile/ios/">
+                </div>
+                <div class="mzp-c-field mzp-l-stretch">
+                    <label class="mzp-c-field-label" for="s2d-hero-input">Enter your email</label>
+                    <input id="s2d-hero-input" class="mzp-c-field-control send-to-device-input" name="email" type="text" required="" value="example@example.com">
+                </div>
+                <div class="mzp-c-button-container mzp-l-stretch">
+                    <button type="submit" class="button mzp-c-button  mzp-t-product ">Send</button>
+                </div>
+            </div>
+        </form>`;
+        document.body.insertAdjacentHTML('beforeend', form);
+        expect(
+            FormUtils.serializeToJson(
+                document.querySelector('.send-to-device-form')
+            )
+        ).toEqual({
+            newsletters: 'download-firefox-mobile-reco',
+            'source-url':
+                'https://www.mozilla.org/en-US/firefox/browsers/mobile/ios/',
+            email: 'example@example.com'
+        });
+    });
+});
+
 describe('stripHTML', function () {
     it('should strip HTML tags from strings as expected', function () {
         expect(

--- a/tests/unit/spec/newsletter/recovery.js
+++ b/tests/unit/spec/newsletter/recovery.js
@@ -8,7 +8,7 @@ import RecoveryEmailForm from '../../../../media/js/newsletter/recovery.es6';
 
 describe('RecoveryEmailForm', function () {
     beforeEach(async function () {
-        const form = `<form method="post" action="https://basket.mozilla.org/news/recover/" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">
+        const form = `<form method="post" action="https://basket.mozilla.org/api/v1/users/recover/" id="newsletter-recovery-form" class="newsletter-recovery-form mzp-c-form">
         <header class="mzp-c-newsletter-header">
           <p>Enter your email address and we’ll send you a link to your email preference center.</p>
         </header>


### PR DESCRIPTION
## One-line summary

In basket the `/api/v1/users/recover/` is a new JSON-only API. This updates the newsletter recovery page to switch to this, POSTing a JSON body instead of form-urlencoded.

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

- Added the `postJsonToBasket` function. Future APIs can use this as we add more endpoints
- Added the `serializeToJson` helper, similar to `serialize` but returns a JSON object.

## Issue / Bugzilla link

No issue, but part of https://github.com/mozmeao/basket/issues/1530

## Testing

Verify the recovery form works as before.