### PR TITLE
Disable `upgrade-insecure-requests` for local dev

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -111,7 +111,7 @@ CONTENT_SECURITY_POLICY = {
         # support older browsers (mainly Safari)
         "frame-src": _csp_child_src,
         "frame-ancestors": [csp.constants.NONE],
-        "upgrade-insecure-requests": True,
+        "upgrade-insecure-requests": False if DEBUG else True,
         "report-uri": csp_report_uri,
     },
 }


### PR DESCRIPTION
## One-line summary

This broke local dev on Safari but Firefox ignores it for localhost. So we can just not include this CSP directive when DEBUG=True.

## Issue / Bugzilla link

#15556

## Testing
