### PR TITLE
Use consistent line heights (nav, footer, CTAs, content) in old&new pages

### DIFF
--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -35,8 +35,11 @@ h1, h2, h3, h4, h5 {
     font-family: var(--title-font-family);
     font-variant-ligatures: none;
     font-weight: 600;
-    letter-spacing: -0.01em;
-    line-height: 1.1;
+    line-height: 1;
+    
+    main & {
+        letter-spacing: -0.01em;
+    }
 }
 
 strong {
@@ -91,7 +94,7 @@ a:link {
     font-family: var(--title-font-family);
     font-size: $text-button-lg;
     font-weight: 600;
-    line-height: 1.1;
+    line-height: 1;
     background-image:
         linear-gradient(to right, $m24-color-black 0, $m24-color-black 33%,transparent 33%, transparent 66%, $m24-color-black 66%, $m24-color-black 100%);
     background-repeat: no-repeat;

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -26,8 +26,6 @@ body {
     background-color: $m24-color-white;
     color: $m24-color-black;
     font-family: var(--body-font-family);
-    font-variant-ligatures: none;
-    line-height: 1.2;
 }
 
 h1, h2, h3, h4, h5 {

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -30,8 +30,11 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     background-color: $color-white;
     border-bottom: $border-width solid $m24-color-light-mid-gray;
     display: flex;
-    line-height: 1.1;
     width: 100%;
+
+    * {
+        line-height: 1.1;
+    }
 
     @media #{$mq-md} {
         display: block;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -30,6 +30,7 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     background-color: $color-white;
     border-bottom: $border-width solid $m24-color-light-mid-gray;
     display: flex;
+    line-height: var(--body-line-height);
     width: 100%;
 
     @media #{$mq-md} {

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -30,7 +30,7 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     background-color: $color-white;
     border-bottom: $border-width solid $m24-color-light-mid-gray;
     display: flex;
-    line-height: var(--body-line-height);
+    line-height: 1.1;
     width: 100%;
 
     @media #{$mq-md} {

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -6,6 +6,7 @@
 
 .m24-pencil-banner {
     background-color: $m24-color-light-green;
+    line-height: var(--body-line-height);
     padding: $spacer-sm;
     position: relative;
 

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -6,7 +6,6 @@
 
 .m24-pencil-banner {
     background-color: $m24-color-light-green;
-    line-height: var(--body-line-height);
     padding: $spacer-sm;
     position: relative;
 

--- a/media/css/protocol/components/_sub-navigation.scss
+++ b/media/css/protocol/components/_sub-navigation.scss
@@ -32,7 +32,7 @@
         font-family: var(--body-font-family);
         font-size: var(--text-body-md);
         font-weight: bold;
-        line-height: 1.5;
+        line-height: 1.1;
         margin-bottom: 0;
 
         a:link,

--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -119,27 +119,27 @@ template {
 
     // type scale
     --title-2xl-size: 8rem;
-    --title-2xl-line-height: 1.1;
+    --title-2xl-line-height: 1;
     --title-xl-size: 5rem;
-    --title-xl-line-height: 1.1;
+    --title-xl-line-height: 1;
     --title-lg-size: 3rem;
-    --title-lg-line-height: 1.1;
+    --title-lg-line-height: 1;
     --title-md-size: 2.5rem;
-    --title-md-line-height: 1.1;
+    --title-md-line-height: 1;
     --title-sm-size: 2rem;
-    --title-sm-line-height: 1.1;
+    --title-sm-line-height: 1;
     --title-xs-size: 1.75rem;
-    --title-xs-line-height: 1.1;
+    --title-xs-line-height: 1;
     --title-2xs-size: 1.5rem;
-    --title-2xs-line-height: 1.1;
+    --title-2xs-line-height: 1;
     --title-3xs-size: 1.25rem;
-    --title-3xs-line-height: 1.1;
+    --title-3xs-line-height: 1;
     --body-xl-size: 1.313rem;
     --body-lg-size: 1.125rem;
     --body-md-size: 1rem;
     --body-sm-size: 0.875rem;
     --body-xs-size: 0.75rem;
-    --body-line-height: 1.4;
+    --body-line-height: 1.2;
 }
 
 .mzp-t-dark {


### PR DESCRIPTION
> [!NOTE]
>  **Waiting for Protocol v20 to apply new typography site-wide, to see how much it resolves itself.** 🚧 

## One-line summary

Applies refresh metrics to all the content, no matter if m24-base or non-m24-base.

## Significant changes and points to review

Refreshed pages have different defaults affecting also nav elements, making shifts in layout visible when navigating to older pages. ~This sets the base var explicitly to the header components to not inherit any other value.~ 

~Both the desktop and mobile nav inconsistencies caused by differing line-height as captured in the tracking issue are resolved here by using the "taller" version as that seems to be better aligned in general.~ EDIT: Nav uses yet another line height that defines the menu element height.

## Issue / Bugzilla link

Fixes #15788
Fixes #15803

## Testing

/about/ ⇄ /products/
(+ /firefox/ for submenu impact)