### PR TITLE
Fix RTL pages with firefox-app-store banner

### DIFF
--- a/media/css/base/banners/firefox-app-store.scss
+++ b/media/css/base/banners/firefox-app-store.scss
@@ -9,6 +9,7 @@ $image-path: '/media/protocol/img';
 
 #firefox-app-store-banner {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    overflow: hidden;
     position: relative;
     z-index: 1000; // banner shares same z-index as sticky nav.
 


### PR DESCRIPTION
## One-line summary

Clips any overflow so that page width doesn't change.
(Fixes broken RTL product pages on mobile chromium.)

## Significant changes and points to review

Tried to trace the viewport width to something moving far left, e.g. "image-replaced" or "visually-hidden" -9999px etc. but wasn't able to find the actual culprit (to perhaps change that to bidi or inline-start syntax). This instead makes sure the banner is contained in its box for good measure, which also gets the job done, with not much risk of breaking somewhere.

## Issue / Bugzilla link

Resolves #15715

## Testing

_(webkit+chromium, banner displayed i.e. not dismissed and on detected mobile device etc.)_

http://localhost:8000/ar/firefox/
http://localhost:8000/ar/firefox/mobile
http://localhost:8000/ar/firefox/focus
http://localhost:8000/ar/firefox/android
http://localhost:8000/ar/firefox/ios