### PR TITLE
Fix RTL launchpad & links padding

### DIFF
--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -393,7 +393,7 @@ $max-footer-content-width: $content-max;
 
     li {
         font-family: $primary-font;
-        padding: 0 24px 0 0;
+        padding-inline-end: $spacer-md;
         margin-bottom: $spacer-xs;
 
         @media #{$mq-md} {

--- a/media/css/m24/launchpad.scss
+++ b/media/css/m24/launchpad.scss
@@ -67,7 +67,6 @@ $launchpad-logo-spacing: $launchpad-logo-width + $launchpad-logo-padding;
             (transition-property, right, left),
             (background-image, url('/media/img/icons/m24-small/arrow-right.svg'), url('/media/img/icons/m24-small/arrow-left.svg'))
         ));
-        background-image: url('/media/img/icons/m24-small/arrow-right.svg');
         background-size: 18px auto;
         transition-duration: $fast;
         transition-timing-function: $bezier;
@@ -129,8 +128,10 @@ $launchpad-logo-spacing: $launchpad-logo-width + $launchpad-logo-padding;
     color: $m24-color-dark-gray;
     font-size: $text-body-sm;
     grid-column: 1 / span 11;
-    padding-left: $launchpad-logo-spacing;
-    padding-right: $launchpad-logo-padding; // give the arrow as much space from the text as the logo gets
+    @include bidi((
+        (padding-left, $launchpad-logo-spacing, $launchpad-logo-padding),
+        (padding-right, $launchpad-logo-padding, $launchpad-logo-spacing),
+    ));
 }
 
 @media #{$mq-md} {


### PR DESCRIPTION
## One-line summary

Resolves home launchpad & colophon RTL alignment, most visible on smaller screens.

## Significant changes and points to review

Uses logical/flow values where related to surrounding text, but still keeps mzp bidi in cases where it interacts with different parts of layout on left and right specifically.

## Issue / Bugzilla link

Fixes #15794

## Testing

_(best shown <1024 px)_
http://localhost:8000/en-US/
http://localhost:8000/he/
http://localhost:8000/ar/