### PR TITLE
Fix font specificity in CTA and WNP

### DIFF
--- a/media/css/firefox/developer/whatsnew-mdnplus.scss
+++ b/media/css/firefox/developer/whatsnew-mdnplus.scss
@@ -35,15 +35,15 @@ $image-path: '/media/protocol/img';
         grid-row: 1;
         z-index: 2;
         padding-top: 0;
+
+        .c-mdn-header-title {
+            color: $color-light-gray-30;
+            font-weight: bold;
+        }
     }
 
     .mzp-c-notification-bar {
         margin-bottom: $layout-lg;
-    }
-
-    .c-mdn-header-title {
-        color: $color-light-gray-30;
-        font-weight: bold;
     }
 
     .mandala-wrapper {
@@ -257,16 +257,16 @@ $image-path: '/media/protocol/img';
     .c-mdn-feature {
         margin-bottom: $layout-md;
 
+        .c-mdn-feature-pretitle {
+            @include text-body-xs;
+            color: $color-pink-60;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
         @media #{$mq-md} {
             margin: 0;
         }
-    }
-
-    .c-mdn-feature-pretitle {
-        @include text-body-xs;
-        color: $color-pink-60;
-        letter-spacing: 0.1em;
-        text-transform: uppercase;
     }
 }
 

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -55,7 +55,7 @@ a:link:focus {
 
 *:focus,
 *:focus-visible {
-    outline-offset: 6px;
+    outline-offset: $spacer-2xs;
 }
 
 /* ------------------------------------------------------------------------------- */

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -43,19 +43,13 @@ strong {
     font-weight: 900;
 }
 
-a:link {
+a:link,
+a:link:hover,
+a:link:focus {
     color: $m24-color-black;
 
-    &:hover,
-    &:focus {
+    &:visited {
         color: $m24-color-black;
-    }
-
-    &:visited{
-        &:hover,
-        &:focus {
-            color: $m24-color-black;
-        }
     }
 }
 


### PR DESCRIPTION
## One-line summary

Moves around some rules to gain higher specificity to work as intended (or as before).

## Significant changes and points to review

Various updates to the font stack recently left some gaps here and there where the defaults kick in instead, this change won't hopefully create more side effects than what it resolves;) 🤞

## Issue / Bugzilla link

Fixes #15800
Fixes #15801

## Testing

http://localhost:8000/en-US/
http://localhost:8000/en-US/about/
http://localhost:8000/en-US/firefox/111.1a2/whatsnew/