### PR TITLE
Fix navigation heading levels (Fixes #15809)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
@@ -18,35 +18,35 @@
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="{{ url('mozorg.about.index') }}" data-link-text="About Mozilla" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-about-mozilla') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-about-mozilla') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-text="The Mozilla manifesto" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-manifesto-v2', fallback='navigation-refresh-mozilla-manifesto') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-manifesto-v2', fallback='navigation-refresh-mozilla-manifesto') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-text="Get Involved" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-get-involved-v2', fallback='navigation-refresh-get-involved') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-get-involved-v2', fallback='navigation-refresh-get-involved') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="https://future.mozilla.org/?{{ utm_params }}" data-link-text="Innovation Projects" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-innovation-projects-v2', fallback='navigation-refresh-innovation-projects') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-innovation-projects-v2', fallback='navigation-refresh-innovation-projects') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/?{{ utm_params }}" data-link-text="Blog" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-blog') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-blog') }}</h2>
                 </a>
               </section>
             </li>
@@ -58,28 +58,28 @@
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="https://foundation.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Foundation" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-foundation') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-foundation') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="https://www.mozilla.ai/?{{ utm_params }}" data-link-text="Mozilla.ai" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-ai-v3') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-ai-v3') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="https://mozilla.vc/?{{ utm_params }}" data-link-text="Mozilla Ventures" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-ventures-v2') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-ventures-v2') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
                 <a class="m24-c-menu-item-link" href="{{ url('mozorg.advertising.landing') }}" data-link-text="Mozilla Advertising" data-link-position="topnav - about">
-                  <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-advertising') }}</h4>
+                  <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-advertising') }}</h2>
                 </a>
               </section>
             </li>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -20,7 +20,7 @@
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="{{ url('firefox.new') }}" data-link-text="Firefox Desktop Browser" data-link-position="topnav - firefox" data-testid="m24-navigation-menu-link-firefox-desktop">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-desktop') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-desktop') }}</h2>
               </a>
             </section>
           </li>
@@ -28,7 +28,7 @@
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-ios') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-ios') }}</h2>
               </a>
             </section>
           </li>
@@ -36,7 +36,7 @@
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-android') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-android') }}</h2>
               </a>
             </section>
           </li>
@@ -44,7 +44,7 @@
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/focus/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-focus') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-focus') }}</h2>
               </a>
             </section>
           </li>
@@ -52,7 +52,7 @@
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://blog.mozilla.org/firefox/?{{ utm_params }}" data-link-text="Firefox Blog" data-link-position="topnav - firefox">
                 <svg class="m24-c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M21.1 7.5c-.2-.2-.2-.5 0-.7l.5-.5c.8-.8 2.1-.8 2.9 0l1.2 1.2c.8.8.8 2.1 0 2.9l-.5.5c-.2.2-.5.2-.7 0l-3.4-3.4zm2.3 4.5c.2.2.2.5 0 .7L12.7 23.4c-.2.2-.4.3-.6.4l-5.7 2.4c-.3.1-.6 0-.7-.3-.1-.1-.1-.3 0-.4L8.1 20c.1-.2.3-.5.4-.6L19.2 8.6c.2-.2.5-.2.7 0l3.5 3.4zM11.5 22.7l-3.9 1.7 1.7-3.9c0-.1.1-.2.2-.2l2.3 2.3c-.1 0-.2.1-.3.1z"></path></svg>
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-blog') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-blog') }}</h2>
               </a>
             </section>
           </li>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -17,7 +17,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="{{ url('products.vpn.landing') }}" data-link-text="Mozilla VPN" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/mozilla/vpn/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-vpn-v2') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-vpn-v2') }}</h2>
               </a>
             </section>
           </li>
@@ -25,7 +25,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor-v2') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor-v2') }}</h2>
               </a>
             </section>
           </li>
@@ -33,7 +33,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://relay.firefox.com/?{{ utm_params }}" data-link-text="Firefox Relay" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/relay/logo-white.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-relay') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-relay') }}</h2>
               </a>
             </section>
           </li>
@@ -41,7 +41,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?{{ utm_params }}" data-link-text="Pocket" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/pocket/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-pocket') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-pocket') }}</h2>
               </a>
             </section>
           </li>
@@ -49,7 +49,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://developer.mozilla.org/plus?{{ utm_params }}" data-link-text="MDN Plus" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('img/nav/icons/icon-mdn-plus.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mdn-plus') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mdn-plus') }}</h2>
               </a>
             </section>
           </li>
@@ -57,7 +57,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://fakespot.com/?{{ utm_params }}" data-link-text="Fakespot" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('img/logos/fakespot/logo-blue.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-fakespot') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-fakespot') }}</h2>
               </a>
             </section>
           </li>
@@ -65,7 +65,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <section class="m24-c-menu-item mzp-has-icon">
               <a class="m24-c-menu-item-link" href="https://www.thunderbird.net/{{ referrals }}" data-link-text="Thunderbird" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('img/logos/thunderbird/logo-thunderbird.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-thunderbird') }}</h4>
+                <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-thunderbird') }}</h2>
               </a>
             </section>
           </li>


### PR DESCRIPTION
## One-line summary

The headings in the main navigation should be `h2`, since `role="navigation"` is a top level landmark.

## Issue / Bugzilla link

#15809

## Testing

http://localhost:8000/en-US/

- [ ] Running [a11y tests locally](https://bedrock.readthedocs.io/en/latest/testing.html#accessibility-testing-axe) should no longer generate an a11y report file for the navigation component.