### PR TITLE
Skip GHA GAR push from forks

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,7 @@ jobs:
   build_and_publish_public_images:
     name: Build public Bedrock images and push to Docker hub
     runs-on: ubuntu-latest
+    if: github.repository == ${{ env.APPLICATION_REPOSITORY }}
     outputs:
       long_sha: ${{ steps.long-sha.outputs.LONG_SHA }}
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,7 +30,7 @@ jobs:
   build_and_publish_public_images:
     name: Build public Bedrock images and push to Docker hub
     runs-on: ubuntu-latest
-    if: github.repository == ${{ env.APPLICATION_REPOSITORY }}
+    if: github.repository == 'mozilla/bedrock'
     outputs:
       long_sha: ${{ steps.long-sha.outputs.LONG_SHA }}
 


### PR DESCRIPTION
## One-line summary

Only run from this repo.

## Significant changes and points to review

While the repo is already set in `env`, the `jobs.[id].if` context doesn't surprisingly have access to it 🤦 so it's hardcoded (again).

## Issue / Bugzilla link

Resolves #15804

## Testing

https://github.com/janbrasna/bedrock/actions/runs/12633383014 (status: skipped)