### PR TITLE
Expose "all locales" link in nonJS

### DIFF
--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -305,16 +305,20 @@ $max-footer-content-width: $content-max;
     }
 
     .mzp-c-language-switcher-link {
-        @include visually-hidden;
+        color: $m24-color-black;
+        position: absolute;
+        top: -1.5em;
+
+        .js & {
+            @include visually-hidden;
+        }
 
         &:focus,
         &:focus-visible {
             clip: auto;
-            color: $m24-color-black;
             height: auto;
             overflow: visible;
             text-indent: 0;
-            top: -1.5em;
             width: auto;
         }
     }


### PR DESCRIPTION
## One-line summary

Reuses normally invisible "All locales" link from a11y progressive enhancement to also serve as a graceful degradation for switching languages.

## Significant changes and points to review

Currently only utilized for keyboard navigation. Repurposing that as a generic nonJS access to locales seems worth it.

While the actual locale overview page is slated for removal at some point (perhaps to be replaced with a flavor of 404-locale view that exists elsewhere), as long as it's available it's a viable nonJS route for changing languages that was already there anyways.

## Issue / Bugzilla link

Improves #15201

## Testing

Disable JS, fail `cutsTheMustard()`, or deny loading `*.js` resources.

<img width="335" alt="Screenshot 2025-01-07 at 0 49 26" src="https://github.com/user-attachments/assets/967da554-5faa-4057-b525-a83515083929" />

(no change for normal, JS-enabled consumption)