### PR TITLE
Fix confusing Jan 14 root cert moments title of Mar 14 page content

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page21.html
+++ b/bedrock/firefox/templates/firefox/welcome/page21.html
@@ -7,7 +7,7 @@
 {% extends "firefox/welcome/base.html" %}
 {% from "macros-protocol.html" import picto with context %}
 
-{% block page_title %}{{ ftl('welcome-page20-21-your-firefox') }}{% endblock %}
+{% block page_title %}{{ ftl('welcome-page20-21-update-your-browser') }}{% endblock %}
 
 {% block body_class %}welcome-page19{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Consistently use the same title as is the main message heading for page21 (that's otherwise the case of page19, page20 & page22), to avoid any ambiguity.

## Significant changes and points to review

While not incorrect per se, the two dates _("… **may** start to have problems Jan…" with "… **won’t work** properly Mar…" kinda complement each other)_ have different reasoning — January being concern only for some super-old Fx that will lose access to remote-settings next week, way before the actual root cert expiration begins, so the issue is those clients won't get any future planned moments rollouts to warn them as March gets closer. That demographic was targeted by page20, not page21 (as confirmed by the OP who got page21 in ESR 115.x, that won't stop connecting to mothership in Jan, so the confusion is justified.)

## Issue / Bugzilla link

Fixes #15818

## Testing

http://localhost:8000/en-US/firefox/welcome/21/

<img width="1400" alt="Screenshot 2025-01-07 at 2 33 12" src="https://github.com/user-attachments/assets/606226af-1d64-4654-95d7-97daed964749" />