### PR TITLE
make footer readable and functional for IE 11 (fix #15536)

### DIFF
--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -106,7 +106,7 @@ $max-footer-content-width: $content-max;
 .moz24-footer-links-social {
     margin: 0 0 0 $spacer-lg;
     display: flex;
-    background-color: #161616;
+    background-color: #161616; // hard-coded value as a fallback for readability on older browsers
 
     @media #{$mq-md} {
         margin: 0;

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -32,7 +32,7 @@ $max-footer-content-width: $content-max;
 
 // primary nav
 .moz24-footer-primary {
-    margin-bottom: $spacer-lg;
+    margin: 32px 0;
 }
 
 .moz24-footer-sections-wrapper {
@@ -76,7 +76,7 @@ $max-footer-content-width: $content-max;
 .moz24-footer-refresh-social-wrapper {
     display: flex;
     align-items: center;
-    margin-bottom: $spacer-lg;
+    margin-bottom: 32px;
 
     @media #{$mq-md} {
         flex-direction: column;
@@ -106,6 +106,7 @@ $max-footer-content-width: $content-max;
 .moz24-footer-links-social {
     margin: 0 0 0 $spacer-lg;
     display: flex;
+    background-color: #161616;
 
     @media #{$mq-md} {
         margin: 0;
@@ -173,6 +174,7 @@ $max-footer-content-width: $content-max;
     font-size: $text-body-sm;
     font-family: $primary-font;
     font-weight: 600;
+    @include bidi(((margin-right, 8px, 0), (margin-left, 0, 8px)));
 }
 
 .moz24-footer-primary-list {


### PR DESCRIPTION
## One-line summary

This PR makes the new footer readable and functional for IE 11.

## Significant changes and points to review

This is what it looks like now in IE 11, Window 10

<img width="1398" alt="ie-footer" src="https://github.com/user-attachments/assets/9b59be6a-6a3d-47fc-b5c6-8680c28a1f26" />

RTL

<img width="1334" alt="rtl" src="https://github.com/user-attachments/assets/cfbe94c0-d221-4bf4-92a5-2904b419a4e2" />


## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15536

## Testing

- Using Broswerstack to test in IE 11, Window 10
- The footer should change at all in newer modern browsers