### PR TITLE
Migrate /cms scss from @import to @use (Issue #10896)

### DIFF
--- a/media/css/cms/base.scss
+++ b/media/css/cms/base.scss
@@ -7,10 +7,7 @@
 // mozorg, firefox, etc, and so can use the CSS and JS bundles for those areas
 // of the site.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
-@import './rich-text';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
+@use './rich-text';

--- a/media/css/cms/rich-text.scss
+++ b/media/css/cms/rich-text.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
 .w-rich-text {
     ul {
         @include bidi(((margin-left, $layout-sm, margin-right, 0),));


### PR DESCRIPTION
## One-line summary

Removes usage of `@import` from `/cms` base style sheet.

## Issue / Bugzilla link

#10896

## Testing

http://localhost:8000/cms-admin/

1. Go to the "Hello World" test page.
2. Click the preview button.
3. Confirm the page renders as expected.