### PR TITLE
wnp 135 beta copy change (fix #15832)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx135beta.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx135beta.html
@@ -30,7 +30,7 @@
 
       <p>The Firefox team has been working on a set of complementary features
         designed to improve the discoverability and security of Firefox’s address
-        bar. With these features now available in Firefox Beta 134, we invite you
+        bar. With these features now available in Firefox Beta 135, we invite you
         to test them out, share your feedback, and play a role in shaping the
         future of Firefox.</p>
 


### PR DESCRIPTION
## One-line summary

This PR updates WNP 135 beta with a copy change.

## Significant changes and points to review

> Copy in body should change from `available in Firefox Beta 134` to `available in Firefox Beta 135`

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15832

## Testing

http://localhost:8000/en-US/firefox/135.0beta/whatsnew/