### PR TITLE
Fixup :visited:focus specificity

### DIFF
--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -44,11 +44,11 @@ strong {
 }
 
 a:link,
-a:link:hover,
-a:link:focus {
+a:visited {
     color: $m24-color-black;
 
-    &:visited {
+    &:hover,
+    &:focus {
         color: $m24-color-black;
     }
 }
@@ -101,11 +101,8 @@ a:link:focus {
         transition: $slow $bezier;
     }
 
+    &:active,
     &:focus-visible {
-        color: $m24-color-black;
-    }
-
-    &:active {
         color: $m24-color-black;
     }
 

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -48,7 +48,8 @@ a:visited {
     color: $m24-color-black;
 
     &:hover,
-    &:focus {
+    &:focus,
+    &:active {
         color: $m24-color-black;
     }
 }


### PR DESCRIPTION
## One-line summary

Follows up from #15802

## Significant changes and points to review

Anchor brand colors are not inverted in `@mixin invert-colors` for dark theme, and the blues and greens end up not readable on dark backgrounds. That is mostly overridden to blacks=whites, but here and there some of the original rules end up being higher specificity (or serving a newer color with css variable, but the older via hardcoded values); so this combination needs a tweak.

Only fixing this for css variables should not be an issue, as the dark theme inversion is also done via css variables — so UAs only using hex colors instead of vars won't use dark theme anyways.

## Issue / Bugzilla link

Fixes #15800

## Testing

http://localhost:8000/
http://localhost:8000/about/

_(doesn't reproduce locally 🤷 so pasted the generated m24-base into www-dev to test there…)_

https://www-demo1.allizom.org/
https://www-demo1.allizom.org/about/