### PR TITLE
Update @mozmeao/consent-banner to v1.1.0 (Fixes #15839)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-env": "^7.26.0",
         "@mozilla-protocol/core": "^19.2.0",
         "@mozilla/glean": "^5.0.3",
-        "@mozmeao/consent-banner": "^1.0.0",
+        "@mozmeao/consent-banner": "^1.1.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
         "@mozmeao/trafficcop": "^3.0.0",
@@ -2077,9 +2077,9 @@
       }
     },
     "node_modules/@mozmeao/consent-banner": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mozmeao/consent-banner/-/consent-banner-1.0.0.tgz",
-      "integrity": "sha512-O/CJhPTrr2DFGMc07MPeG4C0czFjddjycGvk0E5ZD3sHMVoFDjW+Ym2x2Vznn8ZAF0sHpe5X17NMzPP1uu1hTQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mozmeao/consent-banner/-/consent-banner-1.1.0.tgz",
+      "integrity": "sha512-7p8ripMbe1183oTjuv8rLPVDAAiAfs/Jje8tNRMbI8W/BM1H8xV/K02naJdp2jevtWsIjryWGZf0Bv+3qyYeqw==",
       "peerDependencies": {
         "@mozmeao/cookie-helper": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/preset-env": "^7.26.0",
     "@mozilla-protocol/core": "^19.2.0",
     "@mozilla/glean": "^5.0.3",
-    "@mozmeao/consent-banner": "^1.0.0",
+    "@mozmeao/consent-banner": "^1.1.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
     "@mozmeao/trafficcop": "^3.0.0",


### PR DESCRIPTION
## One-line summary

Bumps consent banner to the latest version. The only notable change is that the font stack was updated to incorporate the new Mozilla brand font (see https://github.com/mozmeao/consent-banner/pull/67)

## Issue / Bugzilla link

#15839

## Testing

Test in a browser with DNT / GPC disabled:

http://localhost:8000/en-US/products/vpn/?geo=de

- [x] Consent banner should display using the new brand font and not Inter.