### PR TITLE
Hide releasenotes path comments from subnav output

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -180,13 +180,14 @@
   links
 ) -%}
 {% if 'releasenotes' in request.path %}
-  <!-- remove 'releasenotes' and version number -->
+  {# Map notes permalink to nav items for highlighting as current. #}
+  {# Remove 'releasenotes' and version number: #}
   {% set root_path = ("/").join(request.path.split("/")[0:-3]) %}
-  <!-- Firefox Desktop, Android, and iOS include channel in request path -->
   {% if release.channel == 'Release' %}
+    {# Firefox Desktop, Android, and iOS omit channel in request path: #}
     {% set current_page = ("{}/notes/").format(root_path) %}
   {% else %}
-  <!-- Beta/Developer and Nightly need the channel added -->
+    {# Beta/Developer and Nightly need the channel added: #}
     {% set current_page = ("{}/{}/notes/").format(root_path, release.channel.lower()) %}
   {% endif %}
 {% else %}


### PR DESCRIPTION
## One-line summary

For release notes, the subnav helper has to do some path juggling that's commented with HTML comments instead of Jinja comments. This hides it from resulting HTML.

## Significant changes and points to review

- Turns `<!--` visible comments into `{#` template comments.
- Moves the comments within the conditionals proper.
- Fixes one incorrect wording while at it.

Gets rid of this on output:
> <img width="357" alt="Screenshot 2025-01-13 at 21 17 11" src="https://github.com/user-attachments/assets/2d645d12-83c5-4d07-930a-77afdde8dc2f" />

## Issue / Bugzilla link

🚫🐞

## Testing

http://localhost:8000/en-US/firefox/133.0.3/releasenotes/
http://localhost:8000/en-US/firefox/134.0beta/releasenotes/
http://localhost:8000/en-US/firefox/135.0a1/releasenotes/
http://localhost:8000/en-US/firefox/ios/133.0/releasenotes/
http://localhost:8000/en-US/firefox/android/133.0.3/releasenotes/