### PR TITLE
Simplify nav hovers

### DIFF
--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -4,8 +4,6 @@
 
 @use '../vars/lib' as *;
 
-$max-footer-content-width: $content-max;
-
 @mixin divider-line {
     border-bottom: $border-width solid $m24-color-light-gray;
 }

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -182,16 +182,14 @@
     a:link,
     a:visited {
         text-decoration: none;
-        position: relative;
         color: $m24-color-black;
-        font-weight: 400;
-    }
 
-    a:link:hover,
-    a:visited:hover {
-        text-decoration: underline;
-        text-underline-offset: 0.1em;
-        color: $m24-color-black;
+        &:hover {
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 0.1em;
+            color: $m24-color-black;
+        }
     }
 }
 
@@ -356,15 +354,11 @@
         margin-bottom: 0;
     }
 
-    a {
-        display: inline-block;
-    }
-
-    a,
     a:link,
     a:visited {
         color: $m24-color-black;
         font-weight: 600;
+        display: inline-block;
     }
 }
 
@@ -385,7 +379,6 @@
         }
     }
 
-    a,
     a:link,
     a:visited {
         color: $m24-color-black;

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -4,8 +4,6 @@
 
 @use '../vars/lib' as *;
 
-$max-footer-content-width: $content-max;
-
 @mixin divider-line {
     border-bottom: $border-width solid $m24-color-light-gray;
 }
@@ -127,7 +125,6 @@ $max-footer-content-width: $content-max;
             background-size: 16px 16px;
             background-position: center center;
             opacity: .45;
-            border-bottom: 1px solid rgba(0,0,0,0);
             display: block;
             height: 24px;
             width: 24px;
@@ -139,7 +136,6 @@ $max-footer-content-width: $content-max;
             &:hover,
             &:focus {
                 opacity: 1;
-                border-bottom-color: transparent;
             }
 
             &.linkedin {
@@ -183,7 +179,6 @@ $max-footer-content-width: $content-max;
         padding-bottom: $spacer-xs;
     }
 
-    a,
     a:link,
     a:visited {
         text-decoration: none;
@@ -192,32 +187,11 @@ $max-footer-content-width: $content-max;
         font-weight: 400;
     }
 
-    a:hover,
     a:link:hover,
     a:visited:hover {
+        text-decoration: underline;
+        text-underline-offset: 0.1em;
         color: $m24-color-black;
-
-        &::after {
-            display: block;
-            content: "";
-            position: absolute;
-            width: 100%;
-            height: 1px;
-            left: 0;
-            bottom: 1px;
-            background: $m24-color-black;
-        }
-    }
-
-    a:focus-visible,
-    a:link:focus-visible,
-    a:active,
-    a:link:active {
-        color: $m24-color-black;
-
-        &::after {
-            display: none;
-        }
     }
 }
 

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -115,8 +115,7 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     padding: 0;
     position: relative;
     text-decoration: underline;
-    text-underline-offset: 2px;
-    text-decoration-thickness: 1px;
+    text-underline-offset: 0.1em;
 
     &.mzp-is-active {
         background: transparent url('/media/protocol/img/icons/close.svg') center center no-repeat;
@@ -357,7 +356,6 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     text-decoration: none;
     width: 100%;
 
-    // extra specificity to override link colors on some Firefox pages
     &:link,
     &:visited {
         color: $color-black;
@@ -451,55 +449,30 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
         align-items: center;
         display: flex;
         padding: 8px 0;
-        text-decoration: none;
         width: 100%;
 
         &:link,
         &:visited {
             text-decoration: none;
+
+            svg path {
+                fill: $color-black;
+            }
         }
 
-        .m24-c-menu-item-title {
-            border: none;
-            position: relative;
+        &:link:hover,
+        &:visited:hover {
+            .m24-c-menu-item-title {
+                color: $m24-color-dark-green;
+                text-decoration: underline;
+                text-decoration-thickness: 1px;
+                text-underline-offset: 0.1em;
+            }
+
+            svg path {
+                fill: $m24-color-dark-green;
+            }
         }
-    }
-}
-
-.m24-c-menu-item .m24-c-menu-item-link
-.m24-c-menu-item .m24-c-menu-item-link:link,
-.m24-c-menu-item .m24-c-menu-item-link:visited {
-    text-decoration: none;
-
-    .m24-c-menu-item-title {
-        border: none;
-    }
-
-    svg path {
-        fill: $color-black;
-    }
-}
-
-.m24-c-menu-item .m24-c-menu-item-link:hover,
-.m24-c-menu-item .m24-c-menu-item-link:visited:hover {
-    .m24-c-menu-item-title {
-        color: $m24-color-dark-green;
-        border: none;
-
-        &::after {
-            background: $m24-color-dark-green;
-            bottom: 1px;
-            content: "";
-            display: block;
-            height: 1px;
-            left: 0;
-            position: absolute;
-            width: 100%;
-        }
-    }
-
-    svg path {
-        fill: $m24-color-dark-green;
     }
 }
 
@@ -553,24 +526,17 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
 }
 
 .m24-c-menu-panel .m24-c-menu-category-link {
-    border: none;
     display: flex;
     font-family: $primary-font;
     font-size: $text-body-md;
     justify-content: flex-end;
     margin: $spacer-lg $spacer-lg 0;
-    padding: 0;
 }
 
-.m24-c-menu-panel .m24-c-menu-category-link a,
-.m24-c-menu-panel .m24-c-menu-category-link a:visited,
-.m24-c-menu-panel .m24-c-menu-category-link a:link {
-    border: none;
+.m24-c-menu-panel .m24-c-menu-category-link a:link,
+.m24-c-menu-panel .m24-c-menu-category-link a:visited {
     color: $color-black;
     display: flex;
-    font-family: $primary-font;
-    font-weight: 600;
-    position: relative;
     text-decoration: none;
     width: fit-content;
 
@@ -614,31 +580,6 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     }
 }
 
-.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link,
-.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:link,
-.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:active,
-.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:visited {
-    .m24-c-menu-item-title {
-        border: none;
-        font-weight: 600;
-        position: relative;
-        text-decoration: none;
-    }
-}
-
-.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:hover,
-.mzp-has-icon.m24-c-menu-item .m24-c-menu-item-link:visited:hover {
-    .m24-c-menu-item-title {
-        border: none;
-        text-decoration: none;
-
-        &::after {
-            background: $m24-color-dark-green;
-        }
-    }
-}
-
-// Menu panel close button shown on desktop sized view ports.
 .m24-c-menu-button-close {
     @include bidi(((right, 15px, left, auto), (left, auto, right, 15px)));
     @include image-replaced;

--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -115,6 +115,7 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     padding: 0;
     position: relative;
     text-decoration: underline;
+    text-decoration-thickness: 1px;
     text-underline-offset: 0.1em;
 
     &.mzp-is-active {
@@ -284,10 +285,6 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
                 }
             }
 
-            &::after {
-                background: $m24-color-dark-green;
-            }
-
             .m24-c-menu-panel {
                 @include bidi(((animation, none, none),));
             }
@@ -330,30 +327,18 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
         .m24-c-menu-title-icon {
             @include bidi(((margin, 0 8px 0 0, 0 0 0 8px),));
         }
-
-        .m24-c-menu-title {
-            @media #{$mq-md} {
-                &:hover::after {
-                    bottom: 1px;
-                    width: calc(100% - 24px);
-                    @include bidi(((left, 24px, right, auto),));
-                }
-            }
-        }
     }
 }
 
 .m24-c-menu-title {
     align-items: center;
     border: none;
-    color: $color-black;
     display: flex;
     font-family: $primary-font;
     font-size: $text-body-md;
     font-weight: 600;
     padding: 0;
     position: relative;
-    text-decoration: none;
     width: 100%;
 
     &:link,
@@ -367,15 +352,10 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
     }
 
     @media #{$mq-md} {
-        &:hover::after {
-            background: $color-black;
-            bottom: 1px;
-            content: "";
-            display: block;
-            height: 1px;
-            left: 0;
-            position: absolute;
-            width: 100%;
+        &:hover {
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 0.15em;
         }
     }
 }


### PR DESCRIPTION
👷 _Running into some WebKit bug ignoring thickness on direct flex element. (May need a tweak in actual markup, or just living with it…)_

## One-line summary

Simplifying hover underlines on main menu, dropdowns and footer links: Moving from borders or fills on pseudo elements to native text decoration for better resilience.

## Significant changes and points to review

Accomplishing the same effect while being less fragile.
(Real typographic underline makes descenders more legible by avoiding them instead of crossing.)
Changing to relative distance to adapt better to type scaling.

🚧 WIP 
_(Status: MVP-level, missing some QA and tree shaking, cleanup and tracking down more leftovers no longer needed. TBD next steps about WebKit if no solution deems practical.)_

## Issue / Bugzilla link

Fixes #15850

## Testing

Ready to test, nb: difference in thickness in main nav between Gecko/Blink vs. WebKit…