### PR TITLE
Avoid duplicate dark-mode CSS imports on WNP

### DIFF
--- a/media/css/firefox/whatsnew/includes/_mofo-donate-cta.scss
+++ b/media/css/firefox/whatsnew/includes/_mofo-donate-cta.scss
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import 'dark-mode';
 
 /* stylelint-disable declaration-no-important */
 


### PR DESCRIPTION
## One-line summary

Avoid redundant dark-mode imports on What's New Page (WNP)

- [ ] I used an AI to write some of this code.

## Significant changes and points to review

- Removed the redundant @import 'includes/dark-mode'; from _mofo-donate-cta.scss.
- Dark mode is now explicitly imported in whatsnew-135beta.scss.
- No functionality has been impacted, but testing is critical to confirm no regressions.

## Issue / Bugzilla link

Fixes: https://github.com/mozilla/bedrock/issues/15772

## Testing
