### PR TITLE
Migrate /foundation scss from @import to @use (issue #10896)

### DIFF
--- a/media/css/foundation/annual-report-2011.scss
+++ b/media/css/foundation/annual-report-2011.scss
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/inline-list';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/inline-list';
 
 .section {
     margin-bottom: $layout-lg;

--- a/media/css/foundation/annual-report-2019-2020.scss
+++ b/media/css/foundation/annual-report-2019-2020.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/feature-card';
-@import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '../protocol/components/video';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/feature-card';
+@use '~@mozilla-protocol/core/protocol/css/components/modal';
+@use '../protocol/components/video';
 
 // * -------------------------------------------------------------------------- */
 // Hero image & banner heading

--- a/media/css/foundation/annual-report-2021.scss
+++ b/media/css/foundation/annual-report-2021.scss
@@ -4,11 +4,8 @@
 
 @use 'sass:color';
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/modal';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/modal';
 
 // * -------------------------------------------------------------------------- */
 // Typography

--- a/media/css/foundation/annual-report.scss
+++ b/media/css/foundation/annual-report.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 // * -------------------------------------------------------------------------- */
 // Hero image & banner heading

--- a/media/css/foundation/feed-icon-guidelines.scss
+++ b/media/css/foundation/feed-icon-guidelines.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .para ul {
     @include bidi(((margin-left, $layout-sm, margin-right, 0),));

--- a/media/css/foundation/reimagine-open.scss
+++ b/media/css/foundation/reimagine-open.scss
@@ -4,10 +4,7 @@
 
 @use 'sass:color';
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core//protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .mzp-c-callout.mzp-t-hero {
     background: $color-moz-neon-green url('/media/img/foundation/reimagine-open/bg-header.png') left bottom no-repeat;


### PR DESCRIPTION
## One-line summary

Removes usage of `@import` from /foundation style sheets.

## Issue / Bugzilla link

#10896

## Testing

- http://localhost:8000/en-US/foundation/annualreport/2021/
- http://localhost:8000/en-US/foundation/annualreport/2020/
- http://localhost:8000/en-US/foundation/annualreport/2019/
- http://localhost:8000/en-US/foundation/annualreport/2018/
- http://localhost:8000/en-US/foundation/annualreport/2017/
- http://localhost:8000/en-US/foundation/annualreport/2016/
- http://localhost:8000/en-US/foundation/annualreport/2015/
- http://localhost:8000/en-US/foundation/annualreport/2014/
- http://localhost:8000/en-US/foundation/annualreport/2013/
- http://localhost:8000/en-US/foundation/annualreport/2012/
- http://localhost:8000/en-US/foundation/annualreport/2011/
- http://localhost:8000/en-US/foundation/annualreport/2010/
- http://localhost:8000/en-US/foundation/annualreport/2009/
- http://localhost:8000/en-US/foundation/feed-icon-guidelines/
- http://localhost:8000/en-US/foundation/reimagine-open/