### PR TITLE
Fix contrast in system-requirements callout

### DIFF
--- a/media/css/firefox/system-requirements.scss
+++ b/media/css/firefox/system-requirements.scss
@@ -115,25 +115,13 @@ $image-path: '/media/protocol/img';
 // * -------------------------------------------------------------------------- */
 // Callout
 
-.mzp-c-callout-compact,
 .all-download {
-    display: none;
-}
+    @include text-body-md;
+    background-color: $color-marketing-gray-20;
+    font-weight: bold;
+    padding: $spacing-sm $layout-2xs;
 
-.is-modern-browser {
-    .mzp-c-callout-compact {
-        display: block;
-    }
-
-    .all-download {
-        @include text-body-md;
-        background-color: $color-marketing-gray-30;
-        display: block;
-        font-weight: bold;
-        padding: $spacing-sm $layout-2xs;
-
-        @media #{$mq-md} {
-            text-align: center;
-        }
+    @media #{$mq-md} {
+        text-align: center;
     }
 }


### PR DESCRIPTION
## One-line summary

Uses the same callout as #15382, changes gray-30 to gray-20 for consistency.

## Significant changes and points to review

Also removes:
- compact callout styling, that got removed with MZP v19 update and never adapted (so it's not used anymore?) see [#14084/files](https://github.com/mozilla/bedrock/pull/14084/files)
- logic to only show "Get the most recent…" on "supported systems" by comparing to `body.is-modern-browser`, as that logic also stopped working with MZP v19 update and has no function anymore.

## Issue / Bugzilla link

Analogous to #15342

## Testing

http://localhost:8000/firefox/123.0/system-requirements/