### PR TITLE
Migrate /privacy to use Sass @use (issue #10896)

### DIFF
--- a/media/css/privacy/cookie-settings-form.scss
+++ b/media/css/privacy/cookie-settings-form.scss
@@ -2,11 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/breadcrumb';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/breadcrumb';
 
 // Temporary fix until https://github.com/mozilla/protocol/issues/933 is resolved
 .mzp-c-breadcrumb {

--- a/media/css/privacy/privacy-email.scss
+++ b/media/css/privacy/privacy-email.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .mzp-c-article-title {
     @include text-title-md;

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -2,14 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
+@use '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
+@use '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
-@import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
-@import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
-
-@import '../protocol/basic-article';
+@use '../protocol/basic-article';
 
 $border: 2px solid $color-marketing-gray-20;
 


### PR DESCRIPTION
## One-line summary

Updates to new Sass `@use` syntax, should be no regression

- [ ] I used an AI to write some of this code.

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10896


## Testing

http://localhost:8000/en-US/privacy/
http://localhost:8000/en-US/privacy/email/
http://localhost:8000/en-US/privacy/websites/cookie-settings/ 

submit form on cookie settings page to see success message
<img width="823" alt="Screenshot 2025-01-14 at 11 47 37 AM" src="https://github.com/user-attachments/assets/48ff1f95-e9a1-40e2-b844-a7d64289ab1e" />
