### PR TITLE
Share Firefox en page (fix #15861)

### DIFF
--- a/bedrock/firefox/templates/firefox/share.html
+++ b/bedrock/firefox/templates/firefox/share.html
@@ -36,6 +36,16 @@
   {% set email_subject = "Rejoins la team Firefox !" %}
   {% set sign_off = "<strong>Conçu par Mozilla.</strong> <br> Pensé pour vous depuis 1998."|safe %}
 
+{% else %}
+
+  {% set main_title = "Invite your friends to <br> <strong>Team Firefox</strong>"|safe %}
+  {% set page_description = "We think, as a good friend, you should invite them to the sunny side of the internet. We have a little something prepared." %}
+  {% set main_tagline = "We have prepared a little message that you can share with your loved ones so that you don't have to think of something yourself. Nobody will notice – promise!" %}
+  {% set share_message = "Experience the internet the way you want — without the data tradeoffs. Have you heard of Firefox? It’s a private, super reliable browser. Actually really good, here's a link if you want to take a look: <a href='https://mzl.la/nothing-personal'>mzl.la/nothing-personal</a>."|safe%}
+  {% set share_cta = "Copy and share" %}
+  {% set text_copied = "Text copied!" %}
+  {% set sign_off = "<strong>Powered by Mozilla.</strong> <br> Putting people before profits since 1998."|safe %}
+
 {% endif %}
 
 {% block content %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -190,7 +190,7 @@ urlpatterns = (
     page("firefox/welcome/24/", "firefox/welcome/page24.html", ftl_files=["firefox/welcome/page24"]),
     page("firefox/switch/", "firefox/switch.html", ftl_files=["firefox/switch"]),
     page("firefox/pocket/", "firefox/pocket.html"),
-    page("firefox/share/", "firefox/share.html", active_locales=["de", "fr"]),
+    page("firefox/share/", "firefox/share.html", active_locales=["de", "fr", "en-US", "en-CA"]),
     page("firefox/nothing-personal/", "firefox/nothing-personal/index.html"),
     # Issue 6604, SEO firefox/new pages
     path("firefox/linux/", views.PlatformViewLinux.as_view(), name="firefox.linux"),


### PR DESCRIPTION
## One-line summary

This PR adds a EN version for the Firefox share page.

## Significant changes and points to review

http://localhost:8000/en-US/firefox/share/
http://localhost:8000/en-CA/firefox/share/

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15861

## Testing
On Demo 3: 
https://www-demo3.allizom.org/en-US/firefox/share/
https://www-demo3.allizom.org/en-CA/firefox/share/