### PR TITLE
Prevent JS errors on IE8

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -94,7 +94,9 @@
 
     {% block js_pretrack %}{# include JavaScript that must be run pre GA tracking here #}{% endblock %}
     {% block google_analytics %}
-      {% include 'includes/google-analytics.html' %}
+      <!--[if IE 9]><!-->
+        {% include 'includes/google-analytics.html' %}
+      <!--<![endif]-->
     {% endblock %}
   </head>
 

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -130,6 +130,8 @@
 
 {% block footer_js %}
   {% if show_newsletter %}
-    {{ js_bundle('newsletter') }}
+    <!--[if !IE]><!-->
+      {{ js_bundle('newsletter') }}
+    <!--<![endif]-->
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Prevents 2 JS errors on IE8:
- Loading Google Analytics (which seems unsupported there anyways, it throws an error even when it loads).
- Loading the newsletter JS in the footer on redesigned pages.

## Significant changes and points to review

- Note that we still load GA for IE9, even though it doesn't get regular page specific JS.

## Issue / Bugzilla link

#15867

## Testing

There should be no JS errors when loading the home page on IE8: https://www-demo1.allizom.org/en-US/