### PR TITLE
Hardcode www.mozilla.org links in footer

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -17,16 +17,13 @@
               {{ ftl('footer-refresh-company') }}
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-company">
-              <li><a href="{{ url('mozorg.about.leadership.index') }}" data-link-position="footer" data-link-text="Leadership">{{ ftl('footer-refresh-leadership') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/about/leadership/?{{ utm_params }}" data-link-position="footer" data-link-text="Leadership">{{ ftl('footer-refresh-leadership') }}</a></li>
               <li><a href="https://blog.mozilla.org/category/mozilla/news/?{{ utm_params }}&utm_content=company" data-link-position="footer" data-link-text="Press Center">{{ ftl('footer-refresh-press-center') }}</a></li>
-              <li><a href="{{ url('careers.home') }}" data-link-position="footer" data-link-text="Careers">{{ ftl('footer-refresh-careers') }}</a></li>
-              <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-position="footer" data-link-text="Contact">{{ ftl('footer-refresh-contact') }}</a></li>
-              <li>
-
-              </li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/careers/?{{ utm_params }}" data-link-position="footer" data-link-text="Careers">{{ ftl('footer-refresh-careers') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/contact/?{{ utm_params }}" data-link-position="footer" data-link-text="Contact">{{ ftl('footer-refresh-contact') }}</a></li>
             {% if LANG == "de" %}
               {# Legal requirement in Germany see issue #14240 #}
-              <li><a href="{{ url('legal.impressum') }}" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
+              <li><a href="https://www.mozilla.org/de/about/legal/impressum/?{{ utm_params }}" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
             {% endif %}
             </ul>
           </section>
@@ -47,8 +44,8 @@
               {{ ftl('footer-refresh-resources') }}
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-resources">
-              <li><a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-refresh-advertise') }}</a></li>
-              <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/advertising/?{{ utm_params }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-refresh-advertise') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/{{ latest_firefox_version }}/releasenotes/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
             </ul>
           </section>
 
@@ -57,8 +54,8 @@
               {{ ftl('footer-refresh-developers') }}
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-developers">
-              <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-refresh-developer-edition') }}</a></li>
-              <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-refresh-enterprise') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/developer/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-refresh-developer-edition') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/enterprise/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-refresh-enterprise') }}</a></li>
               <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-refresh-tools') }}</a></li>
               <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn') }}</a></li>
             </ul>
@@ -105,21 +102,23 @@
     <div class="moz24-footer-secondary">
       <div class="moz24-footer-legal">
         <p class="moz24-footer-license" rel="license">
-          {% set moco_link = 'href="%s" data-link-position="footer" data-link-text="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
+          {% set home_href = 'https://www.mozilla.org/' + LANG + '/?' + utm_params %}
+          {% set licensing_href = 'https://www.mozilla.org/' + LANG + '/foundation/licensing/website-content/?' + utm_params %}
+          {% set moco_link = 'href="%s" data-link-position="footer" data-link-text="Mozilla Corporation"'|safe|format(home_href) %}
           {% set mofo_link = 'href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer" rel="external noopener" data-link-position="footer" data-link-text="Mozilla Foundation"'|safe %}
           {{ ftl('footer-refresh-visit-mozilla-corporations', moco_link=moco_link, mofo_link=mofo_link) }}<br>
-          {{ ftl('footer-refresh-portions-of-this-content', href='href="%s"'|safe|format(url('foundation.licensing.website-content')), current_year=current_year|string) }}
+          {{ ftl('footer-refresh-portions-of-this-content', href='href="%s"'|safe|format(licensing_href), current_year=current_year|string) }}
         </p>
         <ul class="moz24-footer-terms">
-          <li><a href="{{ url('privacy.notices.websites') }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-refresh-websites-privacy-notice') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/?{{ utm_params }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-refresh-websites-privacy-notice') }}</a></li>
           <li>
             {# Link to /privacy/websites/cookie-settings/ is a legal requirement and should not be removed. It must be present on every page (Issue 14213). #}
             <a href="{{ url('privacy.cookie-settings') }}" data-link-position="footer" data-link-text="Cookies">{{ ftl('footer-refresh-websites-cookies') }}</a>
           </li>
-          <li><a href="{{ url('legal.index') }}" data-link-position="footer" data-link-text="Legal">{{ ftl('footer-refresh-websites-legal') }}</a></li>
-          <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-refresh-community-participation-guidelines') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/about/legal/?{{ utm_params }}" data-link-position="footer" data-link-text="Legal">{{ ftl('footer-refresh-websites-legal') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/about/governance/policies/participation/?{{ utm_params }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-refresh-community-participation-guidelines') }}</a></li>
           {% if ftl_has_messages('footer-about-this-site') %}
-            <li><a href="{{ url('mozorg.about.this-site') }}" data-link-position="footer" data-link-text="About this site">{{ ftl('footer-refresh-about-this-site') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/about/this-site/?{{ utm_params }}" data-link-position="footer" data-link-text="About this site">{{ ftl('footer-refresh-about-this-site') }}</a></li>
           {% endif %}
         </ul>
       </div>

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=footer' %}
 
 {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
   {% include 'includes/protocol/footer/footer-refresh.html' %}
@@ -13,7 +13,7 @@
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
       <div class="mzp-c-footer-primary-logo{% if switch('m24-website-refresh') %} m24-logo{% endif %}">
-        <a href="{{ url('mozorg.home') }}" data-link-position="footer" data-link-text="Mozilla">{{ ftl('footer-mozilla') }}</a>
+        <a href="https://www.mozilla.org/{{ LANG }}/?{{ utm_params }}" data-link-position="footer" data-link-text="Mozilla">{{ ftl('footer-mozilla') }}</a>
       </div>
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section">
@@ -21,11 +21,11 @@
             {{ ftl('footer-company') }}
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-company">
-            <li><a href="{{ url('mozorg.about.manifesto') }}" data-link-position="footer" data-link-text="Mozilla Manifesto">{{ ftl('footer-mozilla-manifesto') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/about/manifesto/?{{ utm_params }}" data-link-position="footer" data-link-text="Mozilla Manifesto">{{ ftl('footer-mozilla-manifesto') }}</a></li>
             <li><a href="https://blog.mozilla.org/category/mozilla/news/?{{ utm_params }}&utm_content=company" data-link-position="footer" data-link-text="Press Center">{{ ftl('footer-press-center') }}</a></li>
             <li><a href="https://blog.mozilla.org/?{{ utm_params }}&utm_content=company" data-link-position="footer" data-link-text="Mozilla Blog">{{ ftl('footer-mozilla-blog', fallback='footer-corporate-blog') }}</a></li>
-            <li><a href="{{ url('careers.home') }}" data-link-position="footer" data-link-text="Careers">{{ ftl('footer-careers') }}</a></li>
-            <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-position="footer" data-link-text="Contact">{{ ftl('footer-contact') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/careers/?{{ utm_params }}" data-link-position="footer" data-link-text="Careers">{{ ftl('footer-careers') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/contact/?{{ utm_params }}" data-link-position="footer" data-link-text="Contact">{{ ftl('footer-contact') }}</a></li>
             <li>
               <a class="mzp-c-button mzp-t-dark mzp-t-secondary footer-donate" href="{{ donate_url(location='moco-donate-footer') }}" data-link-text="Donate">
                 <span class="mzp-c-button-icon-start">
@@ -38,7 +38,7 @@
             </li>
           {% if LANG == "de" %}
             {# Legal requirement in Germany see issue #14240 #}
-            <li><a href="{{ url('legal.impressum') }}" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
+            <li><a href="https://www.mozilla.org/de/about/legal/impressum/?{{ utm_params }}" data-link-position="footer" data-link-text="Impressum">Impressum</a></li>
           {% endif %}
           </ul>
         </section>
@@ -48,9 +48,9 @@
             {{ ftl('footer-resources') }}
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-resources">
-            <li><a href="{{ url('privacy') }}" data-link-position="footer" data-link-text="Privacy Hub">{{ ftl('footer-privacy-hub', fallback='footer-privacy') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/?{{ utm_params }}" data-link-position="footer" data-link-text="Privacy Hub">{{ ftl('footer-privacy-hub', fallback='footer-privacy') }}</a></li>
             {% if ftl_has_messages('footer-advertise') %}
-              <li><a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-advertise') }}</a></li>
+              <li><a href="https://www.mozilla.org/{{ LANG }}/advertising/?{{ utm_params }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-advertise') }}</a></li>
             {% endif %}
           </ul>
         </section>
@@ -71,12 +71,12 @@
             {{ ftl('footer-developers') }}
           </h2>
           <ul class="mzp-c-footer-list" data-testid="footer-list-developers">
-            <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') }}#beta" data-link-position="footer" data-link-text="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
-            <li><a href="{{ url('firefox.channel.android') }}#beta" data-link-position="footer" data-link-text="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') }}#nightly" data-link-position="footer" data-link-text="Firefox Nightly">{{ ftl('footer-nightly') }}</a></li>
-            <li><a href="{{ url('firefox.channel.android') }}#nightly" data-link-position="footer" data-link-text="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
-            <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-enterprise') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/developer/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/channel/desktop/?{{ utm_params }}#beta" data-link-position="footer" data-link-text="Firefox Beta">{{ ftl('footer-beta') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/channel/android/?{{ utm_params }}#beta" data-link-position="footer" data-link-text="Firefox Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/channel/desktop/?{{ utm_params }}#nightly" data-link-position="footer" data-link-text="Firefox Nightly">{{ ftl('footer-nightly') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/channel/android/?{{ utm_params }}#nightly" data-link-position="footer" data-link-text="Firefox Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/firefox/enterprise/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-enterprise') }}</a></li>
             <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-tools') }}</a></li>
           </ul>
         </section>
@@ -106,22 +106,23 @@
       </div>
       <div class="mzp-c-footer-legal">
         <ul class="mzp-c-footer-terms">
-          <li><a href="{{ url('privacy.notices.websites') }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/privacy/websites/?{{ utm_params }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
           <li>
             {# Link to /privacy/websites/cookie-settings/ is a legal requirement and should not be removed. It must be present on every page (Issue 14213). #}
             <a href="{{ url('privacy.cookie-settings') }}" data-link-position="footer" data-link-text="Cookies">{{ ftl('footer-websites-cookies') }}</a>
           </li>
-          <li><a href="{{ url('legal.index') }}" data-link-position="footer" data-link-text="Legal">{{ ftl('footer-websites-legal') }}</a></li>
-          <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/about/legal/?{{ utm_params }}" data-link-position="footer" data-link-text="Legal">{{ ftl('footer-websites-legal') }}</a></li>
+          <li><a href="https://www.mozilla.org/{{ LANG }}/about/governance/policies/participation/?{{ utm_params }}" data-link-position="footer" data-link-text="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
           {% if ftl_has_messages('footer-about-this-site') %}
-            <li><a href="{{ url('mozorg.about.this-site') }}" data-link-position="footer" data-link-text="About this site">{{ ftl('footer-about-this-site') }}</a></li>
+            <li><a href="https://www.mozilla.org/{{ LANG }}/about/this-site/?{{ utm_params }}" data-link-position="footer" data-link-text="About this site">{{ ftl('footer-about-this-site') }}</a></li>
           {% endif %}
         </ul>
         <p class="mzp-c-footer-license" rel="license">
-          {% set moco_link = 'href="%s" data-link-position="footer" data-link-text="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
+          {% set home_href = 'https://www.mozilla.org/' + LANG + '/?' + utm_params %}
+          {% set moco_link = 'href="%s" data-link-position="footer" data-link-text="Mozilla Corporation"'|safe|format(home_href) %}
           {% set mofo_link = 'href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer" rel="external noopener" data-link-position="footer" data-link-text="Mozilla Foundation"'|safe %}
           {{ ftl('footer-visit-mozilla-corporations', moco_link=moco_link, mofo_link=mofo_link) }}<br>
-          {{ ftl('footer-portions-of-this-content', url=url('foundation.licensing.website-content'), current_year=current_year|string) }}
+          {{ ftl('footer-portions-of-this-content', url='https://www.mozilla.org/' + LANG + '/foundation/licensing/website-content/?' + utm_params, current_year=current_year|string) }}
         </p>
       </div>
     </nav>


### PR DESCRIPTION
## One-line summary

Replaces internal `{{ url() }}` links in the footer with hardcoded links to [www.mozilla.org](http://www.mozilla.org/), with the exception of the `/privacy/cookie-settings/` page.

## Significant changes and points to review

I have also left (for now) calls to the social helper links, such as `mozilla_twitter_url()` and `firefox_twitter_url()`.

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/

Please test both the new and old footer

`./manage.py waffle_switch M24_WEBSITE_REFRESH on`

- [ ] No internal links found other than those mentioned above.
- [ ] No 404 URLs.

`./manage.py waffle_switch M24_WEBSITE_REFRESH off`

- [ ] No internal links found other than those mentioned above.
- [ ] No 404 URLs.