### PR TITLE
Hardcode www.mozilla.org links in navigation

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/about-us.html
@@ -4,10 +4,10 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=about-us' %}
+ {% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=about-us' %}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
-   <a class="m24-c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-about" data-testid="m24-navigation-link-about-us">{{ ftl('navigation-refresh-about-us') }}</a>
+   <a class="m24-c-menu-title" href="https://www.mozilla.org/{{ LANG }}/about/?{{ utm_params }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-about" data-testid="m24-navigation-link-about-us">{{ ftl('navigation-refresh-about-us') }}</a>
    <div class="m24-c-menu-panel" id="m24-c-menu-panel-about" data-testid="m24-navigation-menu-about-us">
      <div class="m24-c-menu-panel-container">
        <button class="m24-c-menu-button-close" type="button" aria-controls="m24-c-menu-panel-about">{{ ftl('navigation-refresh-close-about-us-menu') }}</button>
@@ -17,21 +17,21 @@
           <ul class="m24-mzp-l-content">
             <li>
               <section class="m24-c-menu-item">
-                <a class="m24-c-menu-item-link" href="{{ url('mozorg.about.index') }}" data-link-text="About Mozilla" data-link-position="topnav - about">
+                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/about/?{{ utm_params }}" data-link-text="About Mozilla" data-link-position="topnav - about">
                   <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-about-mozilla') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
-                <a class="m24-c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-text="The Mozilla manifesto" data-link-position="topnav - about">
+                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/about/manifesto/?{{ utm_params }}" data-link-text="The Mozilla manifesto" data-link-position="topnav - about">
                   <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-manifesto-v2', fallback='navigation-refresh-mozilla-manifesto') }}</h2>
                 </a>
               </section>
             </li>
             <li>
               <section class="m24-c-menu-item">
-                <a class="m24-c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-text="Get Involved" data-link-position="topnav - about">
+                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/contribute/?{{ utm_params }}" data-link-text="Get Involved" data-link-position="topnav - about">
                   <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-get-involved-v2', fallback='navigation-refresh-get-involved') }}</h2>
                 </a>
               </section>
@@ -78,7 +78,7 @@
             </li>
             <li>
               <section class="m24-c-menu-item">
-                <a class="m24-c-menu-item-link" href="{{ url('mozorg.advertising.landing') }}" data-link-text="Mozilla Advertising" data-link-position="topnav - about">
+                <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/advertising/?{{ utm_params }}" data-link-text="Mozilla Advertising" data-link-position="topnav - about">
                   <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-advertising') }}</h2>
                 </a>
               </section>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -4,7 +4,7 @@
   file, You can obtain one at https://mozilla.org/MPL/2.0/.
  #}
 
- {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
+ {% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
 
  <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable m24-c-menu-category-has-icon">
   <a class="m24-c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-firefox" data-testid="m24-navigation-link-firefox">
@@ -26,7 +26,7 @@
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
+              <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/ios/?{{ utm_params }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-ios') }}</h2>
               </a>
@@ -34,7 +34,7 @@
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
+              <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/android/?{{ utm_params }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-for-android') }}</h2>
               </a>
@@ -42,7 +42,7 @@
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
+              <a class="m24-c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/focus/?{{ utm_params }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/focus/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-firefox-focus') }}</h2>
               </a>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -4,7 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
 
 <li class="m24-c-menu-category mzp-has-drop-down mzp-js-expandable">
   <a class="m24-c-menu-title" href="https://www.mozilla.org/{{ LANG }}/products/?{{ utm_params }}" aria-haspopup="true" aria-controls="m24-c-menu-panel-products" data-testid="m24-navigation-link-products">{{ ftl('navigation-refresh-products') }}</a>
@@ -64,7 +64,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="https://www.thunderbird.net/{{ referrals }}" data-link-text="Thunderbird" data-link-position="topnav - products">
+              <a class="m24-c-menu-item-link" href="https://www.thunderbird.net/{{ utm_params }}" data-link-text="Thunderbird" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('img/logos/thunderbird/logo-thunderbird.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-thunderbird') }}</h2>
               </a>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/firefox.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
   <a class="c-menu-title" href="{{ url('firefox') }}" aria-haspopup="true" aria-controls="c-menu-panel-firefox" data-testid="navigation-link-firefox">{{ ftl('navigation-v2-firefox-browsers') }}</a>
@@ -25,7 +25,7 @@
         {% if ftl_has_messages('navigation-v2-firefox-for-ios', 'navigation-v2-firefox-for-android') %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.android') }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/android/?{{ utm_params }}" data-link-text="Firefox for Android" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-android') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-customizable-mobile') }}</p>
@@ -34,7 +34,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.ios') }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/ios/?{{ utm_params }}" data-link-text="Firefox for iOS" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-ios') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-mobile-browser') }}</p>
@@ -44,7 +44,7 @@
         {% else %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.index') }}" data-link-text="Firefox for Mobile" data-link-position="topnav - firefox">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/?{{ utm_params }}" data-link-text="Firefox for Mobile" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-for-mobile') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-take-speed-privacy-and') }}</p>
@@ -54,7 +54,7 @@
         {% endif %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.browsers.mobile.focus') }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/browsers/mobile/focus/?{{ utm_params }}" data-link-text="Firefox Focus" data-link-position="topnav - firefox">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/focus/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-focus') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-simply-private-mobile') }}</p>
@@ -72,7 +72,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-text="Release Notes" data-link-position="topnav - firefox">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/{{ latest_firefox_version }}/releasenotes/?{{ utm_params }}" data-link-text="Release Notes" data-link-position="topnav - firefox">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M2.7 23.6c0 2.4 2 4.4 4.4 4.4h5.6c1.4 0 2.3.5 3.3 1.5 1-1 2-1.5 3.3-1.5h5.6c2.4 0 4.4-2 4.4-4.4V8.4c0-2.4-2-4.4-4.4-4.4h-5.6C18 4 17 4.2 16 5.2c-1-1-2-1.2-3.3-1.2H7.1C4.6 4 2.7 6 2.7 8.4v15.2zm24 0c0 1-.8 1.7-1.7 1.7h-5.6c-1.3 0-2.3.2-3.3 1.2-1-1-2-1.2-3.3-1.2H7.1c-1 0-1.7-.8-1.7-1.7V8.4c0-1 .8-1.7 1.7-1.7h5.6c1.3 0 2.3.5 3.3 1.5 1-1 2-1.5 3.3-1.5h5.6c1 0 1.7.8 1.7 1.7v15.2zM13.3 10.7H8c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7h5.3c.4 0 .7.3.7.7 0 .4-.3.7-.7.7zm-5.3 4h5.3c.4 0 .7-.3.7-.7s-.3-.7-.7-.7H8c-.4 0-.7.3-.7.7s.3.7.7.7zm5.3 4H8c-.4 0-.7-.3-.7-.7s.3-.7.7-.7h5.3c.4 0 .7.3.7.7s-.3.7-.7.7zm-5.3 4h3.4c.4 0 .7-.3.7-.7s-.3-.7-.7-.7H8c-.4 0-.7.3-.7.7s.3.7.7.7z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-release-notes') }}</h4>
               {% if ftl_has_messages('navigation-v2-get-the-details-on-the') %}

--- a/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/innovation.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=innovation' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=innovation' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
   <a class="c-menu-title" href="https://future.mozilla.org/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-innovation" data-testid="navigation-link-innovation">{{ ftl('navigation-v2-innovation') }}</a>
@@ -15,7 +15,7 @@
         <ul class="mzp-l-rows-two">
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.developer.index') }}" data-link-text="Firefox Developer Edition" data-link-position="topnav - innovation">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/developer/?{{ utm_params }}" data-link-text="Firefox Developer Edition" data-link-position="topnav - innovation">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/browser/developer/logo.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-firefox-developer-edition') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-get-the-firefox-browser-built') }}</p>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/products.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=products' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
   <a class="c-menu-title" href="https://www.mozilla.org/{{ LANG }}/products/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-products" data-testid="navigation-link-products">{{ ftl('navigation-v2-products') }}</a>
@@ -24,7 +24,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('firefox.facebookcontainer.index') }}" data-link-text="Facebook Container" data-link-position="topnav - products">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/firefox/facebookcontainer/?{{ utm_params }}" data-link-text="Facebook Container" data-link-position="topnav - products">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#f80073" d="M27 1H5C2.8 1 1 2.8 1 5v22c0 2.2 1.8 4 4 4h22c2.2 0 4-1.8 4-4V5c0-2.2-1.8-4-4-4z"></path><path fill="#fff" d="M26 8.8l-1.4-1.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8h-2.3V8.9L19 7.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8h-2.3V8.9l-1.4-1.4c-.1-.1-.2-.1-.3 0l-1.4 1.4-.1.1v2.8H9.2V8.9L7.8 7.4c-.1-.1-.2-.1-.3 0L6 8.8l-.1.1v15c0 .1.1.2.2.2H9c.1 0 .2-.1.2-.2v-2.8h2.3V24c0 .1.1.2.2.2h2.8c.1 0 .2-.1.2-.2v-2.8H17V24c0 .1.1.2.2.2H20c.1 0 .2-.1.2-.2v-2.8h2.3V24c0 .1.1.2.2.2h2.8c.1 0 .2-.1.2-.2V9c.4-.1.3-.2.3-.2zm-14.7 11H9.2v-6.6h2.3v6.6h-.2zm5.6 0h-2.1v-6.6h2.3v6.6h-.2zm5.7 0h-2.1v-6.6h2.3v6.6h-.2z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-facebook-container') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-help-prevent-facebook-from') }}</p>

--- a/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/whoweare.html
@@ -4,10 +4,10 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=who-we-are' %}
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=who-we-are' %}
 
 <li class="c-menu-category mzp-has-drop-down mzp-js-expandable">
-  <a class="c-menu-title" href="{{ url('mozorg.about.index') }}" aria-haspopup="true" aria-controls="c-menu-panel-about" data-testid="navigation-link-who-we-are">{{ ftl('navigation-v2-who-we-are') }}</a>
+  <a class="c-menu-title" href="https://www.mozilla.org/{{ LANG }}/about/?{{ utm_params }}" aria-haspopup="true" aria-controls="c-menu-panel-about" data-testid="navigation-link-who-we-are">{{ ftl('navigation-v2-who-we-are') }}</a>
   <div class="c-menu-panel" id="c-menu-panel-about" data-testid="navigation-menu-who-we-are">
     <div class="c-menu-panel-container">
       <button class="c-menu-button-close" type="button" aria-controls="c-menu-panel-about">{{ ftl('navigation-v2-close-who-we-are-menu') }}</button>
@@ -15,7 +15,7 @@
         <ul class="mzp-l-rows-four">
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('mozorg.about.manifesto') }}" data-link-text="Mozilla Manifesto" data-link-position="topnav - who-we-are">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/about/manifesto/?{{ utm_params }}" data-link-text="Mozilla Manifesto" data-link-position="topnav - who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M9.5 28.6h13.1c2.6 0 4.6-2.1 4.6-4.6V8.1c0-2.6-2.1-4.6-4.6-4.6H9.5c-2.6 0-4.6 2.1-4.6 4.6V24c-.1 2.5 2 4.6 4.6 4.6zM7.6 8.1c0-1 .8-1.8 1.8-1.8h13.1c1 0 1.8.8 1.8 1.8V24c0 1-.8 1.8-1.8 1.8h-13c-1 0-1.8-.8-1.8-1.8V8.1zm12.6 2.3h-8.4c-.4 0-.7-.3-.7-.7 0-.4.3-.7.7-.7h8.4c.4 0 .7.3.7.7 0 .4-.3.7-.7.7zm-8.4 4.2h8.4c.4 0 .7-.3.7-.7s-.3-.7-.7-.7h-8.4c-.4 0-.7.3-.7.7s.3.7.7.7zm8.4 4.2h-8.4c-.4 0-.7-.3-.7-.7s.3-.7.7-.7h8.4c.4 0 .7.3.7.7s-.3.7-.7.7zM11.8 23h3.6c.4 0 .7-.3.7-.7s-.3-.7-.7-.7h-3.6c-.4 0-.7.3-.7.7s.3.7.7.7z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-mozilla-manifesto') }}</h4>
               {% if ftl_has_messages('navigation-v2-learn-about-the-values') %}
@@ -46,7 +46,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('mozorg.contribute') }}" data-link-text="Get Involved" data-link-position="topnav - who-we-are">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/contribute/?{{ utm_params }}" data-link-text="Get Involved" data-link-position="topnav - who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path fill="#42435a" d="M12 22.7l4-3.9c-.5-.1-.9-.1-1.3-.1C11.1 18.7 4 20.5 4 24v2.7h12l-4-4zm2.7-6.7c2.9 0 5.3-2.4 5.3-5.3s-2.4-5.3-5.3-5.3-5.3 2.4-5.3 5.3c-.1 2.9 2.3 5.3 5.3 5.3z"></path><path fill="#42435a" d="M20.6 27.3L16 22.7l1.9-1.9 2.8 2.8 6.8-6.9 1.9 1.9-8.8 8.7z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-get-involved') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-join-the-fight-for-a') }}</p>
@@ -55,7 +55,7 @@
           </li>
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('careers.home') }}" data-link-text="Careers" data-link-position="topnav - who-we-are">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/careers/?{{ utm_params }}" data-link-text="Careers" data-link-position="topnav - who-we-are">
                 <svg class="c-menu-item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32"><path fill="#42435a" d="M13.3 21.3V20H4v5.3C4 26.8 5.2 28 6.7 28h18.7c1.5 0 2.7-1.2 2.7-2.7V20h-9.3v1.3h-5.5zm13.4-12h-5.3V6.7L18.7 4h-5.3l-2.7 2.7v2.7H5.3c-1.5 0-2.7 1.2-2.7 2.7v4c0 1.5 1.2 2.7 2.7 2.7h8V16h5.3v2.7h8c1.5 0 2.7-1.2 2.7-2.7v-4c0-1.5-1.2-2.7-2.6-2.7zm-8 0h-5.3V6.7h5.3v2.6z"></path></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-careers') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-work-for-a-mission-driven-updated') }}</p>
@@ -76,7 +76,7 @@
         {% if ftl_has_messages('navigation-v2-impact', 'navigation-v2-find-out-how') %}
           <li>
             <section class="c-menu-item mzp-has-icon">
-              <a class="c-menu-item-link" href="{{ url('mozorg.impact-report.index') }}" data-link-text="Impact" data-link-position="topnav - who-we-are">
+              <a class="c-menu-item-link" href="https://www.mozilla.org/{{ LANG }}/impact/?{{ utm_params }}" data-link-text="Impact" data-link-position="topnav - who-we-are">
                   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="c-menu-item-icon"><g transform="translate(4 1)" fill="none"><path d="M.4 14.7 4 12v7l-2.4 1.8A1 1 0 0 1 0 20v-4.5a1 1 0 0 1 .4-.8zM15.6 14.7 12 12v7l2.4 1.8A1 1 0 0 0 16 20v-4.5a1 1 0 0 0-.4-.8z" stroke="#42435a" stroke-width="2"/><path d="M5.137 4.14 7.127.569a1 1 0 0 1 1.747 0l1.989 3.57A9 9 0 0 1 12 8.52V19.02H4V8.52a9 9 0 0 1 1.137-4.38z" stroke="#42435a" stroke-width="2"/><circle cx="8" cy="8" r="1.5" fill="#42435a"/><path d="M7.95 16v6" stroke="#42435a" stroke-linecap="round" stroke-width="2"/></g></svg>
                 <h4 class="c-menu-item-title">{{ ftl('navigation-v2-impact') }}</h4>
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-find-out-how') }}</p>
@@ -86,7 +86,7 @@
         {% endif %}
         </ul>
         <p class="c-menu-category-link">
-          <a href="{{ url('mozorg.about.index') }}" data-link-text="More About Mozilla" data-link-position="topnav - who-we-are">{{ ftl('navigation-v2-more-about-mozilla') }}</a>
+          <a href="https://www.mozilla.org/{{ LANG }}/about/?{{ utm_params }}" data-link-text="More About Mozilla" data-link-position="topnav - who-we-are">{{ ftl('navigation-v2-more-about-mozilla') }}</a>
         </p>
       </div>
     </div><!-- close .c-menu-panel-container -->

--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -4,6 +4,8 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
+{% set utm_params = 'utm_source=www.firefox.com&utm_medium=referral&utm_campaign=nav&utm_content=cta' %}
+
 {% if not hide_nav_cta %}
   <div class="c-navigation-shoulder">
     {% if not custom_nav_cta %}
@@ -22,7 +24,6 @@
         >
           {{ ftl('navigation-v2-get-mozilla-vpn') }}
         </a>
-
       </div>
       {% endif %}
     {% else %}

--- a/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation-refresh.html
@@ -9,7 +9,7 @@
   <div class="m24-c-navigation-l-content">
     <div class="m24-c-navigation-container">
       <button class="m24-c-navigation-menu-button" type="button" aria-controls="m24-c-navigation-items" data-testid="m24-navigation-menu-button">{{ ftl('ui-menu') }}</button>
-      <a class="m24-c-navigation-logo-link" href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
+      <a class="m24-c-navigation-logo-link" href="https://www.mozilla.org/{{ LANG }}/" data-link-text="mozilla home icon" data-link-position="nav">
         <img class="m24-c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('navigation-refresh-mozilla') }}" width="101" height="24">
       </a>
       <div class="m24-c-navigation-items" id="m24-c-navigation-items" data-testid="m24-navigation-menu-items">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -21,7 +21,7 @@
       <div class="c-navigation-container">
         <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items" data-testid="navigation-menu-button">{{ ftl('navigation-v2-menu') }}</button>
         <div class="c-navigation-logo">
-          <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
+          <a href="https://www.mozilla.org/{{ LANG }}/" data-link-text="mozilla home icon" data-link-position="nav">
           {% if switch('m24-website-refresh') %}
             <img class="c-navigation-logo-image m24-logo" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ logo_alt }}" width="88" height="21">
           {% else %}


### PR DESCRIPTION
## One-line summary

Replaces internal `{{ url() }}` links in the navigation with hardcoded links to www.mozilla.org, with the exception of the firefox home page, `/firefox/new/` page, and the `/firefox/download/thanks/` page.

## Issue / Bugzilla link

N/A

## Testing

http://localhost:8000/en-US/

Please test both the new and old navigation

`./manage.py waffle_switch M24_WEBSITE_REFRESH on`

- [ ] No internal links found other than those mentioned above.
- [ ] No 404 URLs.

`./manage.py waffle_switch M24_WEBSITE_REFRESH off`

- [ ] No internal links found other than those mentioned above.
- [ ] No 404 URLs.