### PR TITLE
Reuse pronunciation fakespot-aria-hint element

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus/products.html
@@ -71,7 +71,8 @@
             <section class="c-menu-item mzp-has-icon">
               <a class="c-menu-item-link" href="https://fakespot.com/?{{ utm_params }}" data-link-text="Fakespot" data-link-position="topnav - projects">
                 <img loading="lazy" src="{{ static('img/logos/fakespot/logo-blue.svg') }}" class="c-menu-item-icon" width="32" height="32" alt="">
-                <h4 class="c-menu-item-title">{{ ftl('navigation-v2-fakespot') }}</h4>
+                <h4 class="c-menu-item-title" aria-labelledby="fakespot-aria-hint">{{ ftl('navigation-v2-fakespot') }}</h4>
+                <span id="fakespot-aria-hint" aria-label="fake spot"></span>
               {% if ftl_has_messages('navigation-v2-use-ai-to-detect') %}
                 <p class="c-menu-item-desc">{{ ftl('navigation-v2-use-ai-to-detect') }}</p>
               {% endif %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
@@ -28,7 +28,6 @@
         <a class="m24-c-launchpad-link m24-t-product-fakespot" href="https://www.fakespot.com/{{ utm_params }}" data-cta-text="Fakespot" data-cta-position="product-list" aria-labelledby="fakespot-aria-hint">
           <strong class="m24-c-launchpad-title">{{ ftl('m24-home-fakespot') }}</strong>
           <span class="m24-c-launchpad-info">{{ ftl('m24-home-spot-fake-reviews') }}</span>
-          <span id="fakespot-aria-hint" aria-label="fake spot"></span>
         </a>
       </li>
       <li class="m24-c-launchpad-item">

--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -197,7 +197,7 @@
         }
       ),
     ) %}
-      <h2 class="mzp-c-picto-heading" aria-labelledby="fakespot-aria-hint"><a href="https://www.fakespot.com/{{ referrals }}" data-cta-text="Fakespot" data-cta-position="heading" aria-labelledby="fakespot-aria-hint">{{ ftl('firefox-products-fakespot') }}<span id="fakespot-aria-hint" aria-label="fake spot"></span></a></h2>
+      <h2 class="mzp-c-picto-heading" aria-labelledby="fakespot-aria-hint"><a href="https://www.fakespot.com/{{ referrals }}" data-cta-text="Fakespot" data-cta-position="heading" aria-labelledby="fakespot-aria-hint">{{ ftl('firefox-products-fakespot') }}</a></h2>
       <p>{{ ftl('firefox-products-fakespot-has-your') }}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://www.fakespot.com/analyzer{{ referrals }}" rel="external noopener" data-cta-text="Analyze a url with Fakespot">{{ ftl('firefox-products-analyze') }} {{ icon_external|safe }}</a></p>
     {% endcall %}


### PR DESCRIPTION
## One-line summary

Only keep the ID `fakespot-aria-hint` once, in a nav (both old and new), to be referenced from anywhere else on the page.

## Significant changes and points to review

- keeps the "canonical" ID span in the nav heading for the product, that ends up included in most pages
- adds the same for legacy nav, that may get loaded for some locales
- removes the ID span from includes for home, and from products landing, to not appear twice on the same page with the same ID…
- these other marked up labelledby occurrences rely on the presence of the element through the nav include and reference it.

Caveat: only works on pages with a nav displayed. That currently covers the necessary occurrences.

## Issue / Bugzilla link

#15530
https://github.com/mozilla/bedrock/pull/15847#pullrequestreview-2560984145

## Testing

This doesn't get picked up by TTS so just "speaking the page" won't apply this. You'd have to test with e.g. VoiceOver to get the proper pronunciation.