### PR TITLE
Reinstate tests for revised MVP migrated pages

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -89,6 +89,26 @@ def pytest_generate_tests(metafunc):
             assert urls
             metafunc.parametrize("download_path", urls)
 
+        elif "download_path_l10n" in metafunc.fixturenames:
+            urls = []
+            doc = get_web_page(f"{base_url}/en-US/firefox/all/")
+            product_urls = [a.attrib["href"] for a in doc("ul.c-product-list a")]
+            # If product url links outside of /firefox/all/ ignore it. (e.g. testflight)
+            product_urls = [url for url in product_urls if url.startswith("/en-US/firefox/all/")]
+            for url in product_urls:
+                doc = get_web_page(f"{base_url}{url}")
+                platform_urls = [a.attrib["href"] for a in doc("ul.c-platform-list a")]
+                for url in platform_urls:
+                    doc = get_web_page(f"{base_url}{url}")
+                    lang_urls = [a.attrib["href"] for a in doc("ul.c-lang-list a")]
+                    for url in lang_urls:
+                        doc = get_web_page(f"{base_url}{url}")
+                        download_urls = [a.attrib["href"] for a in doc("a.download-link")]
+                        for url in download_urls:
+                            urls.append(url)
+            assert urls
+            metafunc.parametrize("download_path_l10n", urls)
+
 
 def get_web_page(url):
     try:

--- a/tests/functional/firefox/channel/__init__.py
+++ b/tests/functional/firefox/channel/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/functional/firefox/channel/test_android.py
+++ b/tests/functional/firefox/channel/test_android.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.channel.android import ChannelAndroidPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_buttons_are_displayed(base_url, selenium):
+    page = ChannelAndroidPage(selenium, base_url).open()
+    assert page.beta_download_button.is_displayed
+    assert page.nightly_download_button.is_displayed

--- a/tests/functional/firefox/channel/test_desktop.py
+++ b/tests/functional/firefox/channel/test_desktop.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.channel.desktop import ChannelDesktopPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_buttons_are_displayed(base_url, selenium):
+    page = ChannelDesktopPage(selenium, base_url).open()
+    assert page.beta_download_button.is_displayed
+    assert page.developer_download_button.is_displayed
+    assert page.nightly_download_button.is_displayed

--- a/tests/functional/firefox/features/__init__.py
+++ b/tests/functional/firefox/features/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/functional/firefox/features/test_features.py
+++ b/tests/functional/firefox/features/test_features.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.features.feature import FeaturePage
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+@pytest.mark.parametrize(
+    "slug",
+    [
+        ("adblocker"),
+        ("add-ons"),
+        ("block-fingerprinting"),
+        ("bookmarks"),
+        ("customize"),
+        ("eyedropper"),
+        ("fast"),
+        ("password-manager"),
+        ("pdf-editor"),
+        ("picture-in-picture"),
+        ("pinned-tabs"),
+        ("private-browsing"),
+        ("private"),
+        ("sync"),
+        ("translate"),
+    ],
+)
+def test_download_button_is_displayed(slug, base_url, selenium):
+    page = FeaturePage(selenium, base_url, slug=slug).open()
+    assert page.download_button.is_displayed

--- a/tests/functional/firefox/set_as_default/__init__.py
+++ b/tests/functional/firefox/set_as_default/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/functional/firefox/set_as_default/test_default_landing.py
+++ b/tests/functional/firefox/set_as_default/test_default_landing.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.set_as_default.landing import DefaultLandingPage
+
+
+@pytest.mark.nondestructive
+def test_set_default_button_is_displayed(base_url, selenium):
+    page = DefaultLandingPage(selenium, base_url).open()
+    assert page.is_set_default_button_displayed

--- a/tests/functional/firefox/set_as_default/test_default_thanks.py
+++ b/tests/functional/firefox/set_as_default/test_default_thanks.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.set_as_default.thanks import DefaultThanksPage
+
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_if_firefox(reason="Download button is only displayed to non-Firefox visitors.")
+def test_download_button_is_displayed(base_url, selenium):
+    page = DefaultThanksPage(selenium, base_url).open()
+    assert page.download_button.is_displayed

--- a/tests/functional/firefox/test_all.py
+++ b/tests/functional/firefox/test_all.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.all import FirefoxAllPage
+
+# help modals
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_open_browser_help_modal(base_url, selenium):
+    slug = ""
+    page = FirefoxAllPage(selenium, base_url, slug=slug).open()
+    modal = page.open_help_modal("icon-browser-help")
+    assert modal.is_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_open_installer_help_modal(base_url, selenium):
+    slug = "desktop-release/"
+    page = FirefoxAllPage(selenium, base_url, slug=slug).open()
+    modal = page.open_help_modal("icon-installer-help")
+    assert modal.is_displayed

--- a/tests/functional/firefox/test_developer.py
+++ b/tests/functional/firefox/test_developer.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.developer import DeveloperPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_buttons_are_displayed(base_url, selenium):
+    page = DeveloperPage(selenium, base_url).open()
+    assert page.primary_download_button.is_displayed
+    assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/test_enterprise.py
+++ b/tests/functional/firefox/test_enterprise.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.enterprise.landing import EnterprisePage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_primary_download_links_are_displayed(base_url, selenium):
+    page = EnterprisePage(selenium, base_url).open()
+    assert page.is_primary_download_button_displayed
+    page.win64_download_list.click()
+    assert page.win64_download_list.list_is_open
+    page.win32_download_list.click()
+    assert page.win32_download_list.list_is_open
+    page.mac_download_list.click()
+    assert page.mac_download_list.list_is_open

--- a/tests/functional/firefox/test_installer_help.py
+++ b/tests/functional/firefox/test_installer_help.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.installer_help import InstallerHelpPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_buttons_displayed(base_url, selenium):
+    page = InstallerHelpPage(selenium, base_url).open()
+    assert page.firefox_download_button.is_displayed
+    assert page.beta_download_button.is_displayed
+    assert page.dev_edition_download_button.is_displayed
+    assert page.nightly_download_button.is_displayed

--- a/tests/functional/firefox/test_releasenotes.py
+++ b/tests/functional/firefox/test_releasenotes.py
@@ -1,0 +1,139 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.releasenotes import FirefoxReleaseNotesPage
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_release_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="75.0").open()
+    assert page.primary_download_button_release.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="77.0beta").open()
+    assert page.primary_download_button_beta.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_aurora_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="34.0a2").open()
+    assert page.primary_download_button_aurora.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_dev_edition_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="54.0a2").open()
+    assert page.primary_download_button_dev_edition.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="68.8.0").open()
+    assert page.primary_download_button_esr.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_esr_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="78.0a1").open()
+    assert page.primary_download_button_nightly.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Play Store button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_android_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="android/68.8.0").open()
+    assert page.is_primary_play_store_button_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Play Store button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_android_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="android/68.7beta").open()
+    assert page.primary_download_button_android_beta.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="Download button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_android_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="android/54.0a2").open()
+    assert page.primary_download_button_android_nightly.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason="App Store button is displayed only to non-Firefox users")
+@pytest.mark.nondestructive
+def test_primary_download_button_ios_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="ios/25.0").open()
+    assert page.is_primary_app_store_button_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_secondary_download_button_release_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="75.0").open()
+    assert page.secondary_download_button_release.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="77.0beta").open()
+    assert page.secondary_download_button_beta.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_aurora_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="34.0a2").open()
+    assert page.secondary_download_button_aurora.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_dev_edition_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="54.0a2").open()
+    assert page.secondary_download_button_dev_edition.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="78.0a1").open()
+    assert page.secondary_download_button_nightly.is_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_secondary_download_button_esr_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="68.8.0").open()
+    assert page.secondary_download_button_esr.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_android_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="android/68.8.0").open()
+    assert page.is_secondary_play_store_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_android_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="android/68.7beta").open()
+    assert page.secondary_download_button_android_beta.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_android_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="android/54.0a2").open()
+    assert page.secondary_download_button_android_nightly.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_ios_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug="ios/25.0").open()
+    assert page.is_secondary_app_store_button_displayed

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -17,3 +17,9 @@ def run_download_link_check(url):
 @pytest.mark.nondestructive
 def test_download_links(download_path):
     run_download_link_check(download_path)
+
+
+@pytest.mark.download
+@pytest.mark.nondestructive
+def test_localized_download_links(download_path_l10n):
+    run_download_link_check(download_path_l10n)

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -4,13 +4,13 @@
 
 import pytest
 
-from pages.firefox.home import FirefoxHomePage
+from pages.home import HomePage
 
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_navigation(base_url, selenium):
-    page = FirefoxHomePage(selenium, base_url, locale="de").open()
+    page = HomePage(selenium, base_url, locale="de").open()
     page.navigation.open_firefox_menu()
     assert page.navigation.is_firefox_menu_displayed
 

--- a/tests/pages/firefox/all.py
+++ b/tests/pages/firefox/all.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.modal import ModalProtocol
+
+
+class FirefoxAllPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/all/{slug}"
+
+    # help modals
+
+    def open_help_modal(self, value):
+        modal = ModalProtocol(self)
+        self.find_element(*(By.ID, value)).click()
+        self.wait.until(lambda s: modal.is_displayed)
+        return modal

--- a/tests/pages/firefox/channel/__init__.py
+++ b/tests/pages/firefox/channel/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/firefox/channel/android.py
+++ b/tests/pages/firefox/channel/android.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class ChannelAndroidPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/channel/android/"
+
+    _beta_download_locator = (By.ID, "android-beta-download")
+    _nightly_download_locator = (By.ID, "android-nightly-download")
+
+    @property
+    def beta_download_button(self):
+        el = self.find_element(*self._beta_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def nightly_download_button(self):
+        el = self.find_element(*self._nightly_download_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/firefox/channel/desktop.py
+++ b/tests/pages/firefox/channel/desktop.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class ChannelDesktopPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/channel/desktop/"
+
+    _beta_download_locator = (By.ID, "desktop-beta-download")
+    _developer_download_locator = (By.ID, "desktop-developer-download")
+    _nightly_download_locator = (By.ID, "desktop-nightly-download")
+
+    @property
+    def beta_download_button(self):
+        el = self.find_element(*self._beta_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def developer_download_button(self):
+        el = self.find_element(*self._developer_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def nightly_download_button(self):
+        el = self.find_element(*self._nightly_download_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/firefox/developer.py
+++ b/tests/pages/firefox/developer.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class DeveloperPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/developer/"
+
+    _primary_download_locator = (By.ID, "intro-download")
+    _secondary_download_locator = (By.ID, "footer-download")
+
+    @property
+    def primary_download_button(self):
+        el = self.find_element(*self._primary_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button(self):
+        el = self.find_element(*self._secondary_download_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/firefox/enterprise/__init__.py
+++ b/tests/pages/firefox/enterprise/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/firefox/enterprise/landing.py
+++ b/tests/pages/firefox/enterprise/landing.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.menu_list import MenuList
+
+
+class EnterprisePage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/enterprise/"
+
+    _primary_download_button_locator = (By.ID, "primary-download-button")
+    _win64_download_list_locator = (By.ID, "win64-download-list")
+    _win32_download_list_locator = (By.ID, "win32-download-list")
+    _mac_download_list_locator = (By.ID, "mac-download-list")
+
+    @property
+    def is_primary_download_button_displayed(self):
+        return self.is_element_displayed(*self._primary_download_button_locator)
+
+    @property
+    def win64_download_list(self):
+        el = self.find_element(*self._win64_download_list_locator)
+        return MenuList(self, root=el)
+
+    @property
+    def win32_download_list(self):
+        el = self.find_element(*self._win32_download_list_locator)
+        return MenuList(self, root=el)
+
+    @property
+    def mac_download_list(self):
+        el = self.find_element(*self._mac_download_list_locator)
+        return MenuList(self, root=el)

--- a/tests/pages/firefox/features/__init__.py
+++ b/tests/pages/firefox/features/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class FeaturePage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/features/{slug}/"
+
+    _download_button_locator = (By.ID, "features-footer-download")
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/firefox/installer_help.py
+++ b/tests/pages/firefox/installer_help.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class InstallerHelpPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/installer-help/"
+
+    _firefox_download_button_locator = (By.ID, "download-button-desktop-release")
+    _beta_download_button_locator = (By.ID, "download-button-desktop-beta")
+    _dev_edition_download_button_locator = (By.ID, "download-button-desktop-alpha")
+    _nightly_download_button_locator = (By.ID, "download-button-desktop-nightly")
+
+    @property
+    def firefox_download_button(self):
+        el = self.find_element(*self._firefox_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def beta_download_button(self):
+        el = self.find_element(*self._beta_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def dev_edition_download_button(self):
+        el = self.find_element(*self._dev_edition_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def nightly_download_button(self):
+        el = self.find_element(*self._nightly_download_button_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -1,0 +1,133 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class FirefoxReleaseNotesPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/{slug}/releasenotes/"
+
+    _primary_download_button_release_locator = (By.ID, "download-release-primary")
+    _secondary_download_button_release_locator = (By.ID, "download-release-secondary")
+    _primary_download_button_beta_locator = (By.ID, "download-beta-primary")
+    _secondary_download_button_beta_locator = (By.ID, "download-beta-secondary")
+    _primary_download_button_aurora_locator = (By.ID, "download-dev-edition-primary")
+    _secondary_download_button_aurora_locator = (By.ID, "download-dev-edition-secondary")
+    _primary_download_button_dev_edition_locator = (By.ID, "download-dev-edition-primary")
+    _secondary_download_button_dev_edition_locator = (By.ID, "download-dev-edition-secondary")
+    _primary_download_button_nightly_locator = (By.ID, "download-nightly-primary")
+    _secondary_download_button_nightly_locator = (By.ID, "download-nightly-secondary")
+    _primary_download_button_esr_locator = (By.ID, "download-esr-primary")
+    _secondary_download_button_esr_locator = (By.ID, "download-esr-secondary")
+    _primary_download_button_android_beta_locator = (By.ID, "download-android-beta-primary")
+    _secondary_download_button_android_beta_locator = (By.ID, "download-android-beta-secondary")
+    _primary_download_button_android_nightly_locator = (By.ID, "download-android-nightly-primary")
+    _secondary_download_button_android_nightly_locator = (By.ID, "download-android-nightly-secondary")
+    _primary_play_store_button_locator = (By.ID, "download-android-primary")
+    _secondary_play_store_button_locator = (By.ID, "download-android-secondary")
+    _primary_app_store_button_locator = (By.ID, "download-ios-primary")
+    _secondary_app_store_button_locator = (By.ID, "download-ios-secondary")
+
+    @property
+    def primary_download_button_release(self):
+        el = self.find_element(*self._primary_download_button_release_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_release(self):
+        el = self.find_element(*self._secondary_download_button_release_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_beta(self):
+        el = self.find_element(*self._primary_download_button_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_beta(self):
+        el = self.find_element(*self._secondary_download_button_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_aurora(self):
+        el = self.find_element(*self._primary_download_button_aurora_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_aurora(self):
+        el = self.find_element(*self._secondary_download_button_aurora_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_dev_edition(self):
+        el = self.find_element(*self._primary_download_button_dev_edition_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_dev_edition(self):
+        el = self.find_element(*self._secondary_download_button_dev_edition_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_nightly(self):
+        el = self.find_element(*self._primary_download_button_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_nightly(self):
+        el = self.find_element(*self._secondary_download_button_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_esr(self):
+        el = self.find_element(*self._primary_download_button_esr_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_esr(self):
+        el = self.find_element(*self._secondary_download_button_esr_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_android_beta(self):
+        el = self.find_element(*self._primary_download_button_android_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_android_beta(self):
+        el = self.find_element(*self._secondary_download_button_android_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_android_nightly(self):
+        el = self.find_element(*self._primary_download_button_android_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_android_nightly(self):
+        el = self.find_element(*self._secondary_download_button_android_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def is_primary_play_store_button_displayed(self):
+        return self.is_element_displayed(*self._primary_play_store_button_locator)
+
+    @property
+    def is_secondary_play_store_button_displayed(self):
+        return self.is_element_displayed(*self._secondary_play_store_button_locator)
+
+    @property
+    def is_primary_app_store_button_displayed(self):
+        return self.is_element_displayed(*self._primary_app_store_button_locator)
+
+    @property
+    def is_secondary_app_store_button_displayed(self):
+        return self.is_element_displayed(*self._secondary_app_store_button_locator)
+
+    @property
+    def is_pre_releases_menu_displayed(self):
+        return self.is_element_displayed(*self._pre_releases_menu_locator)

--- a/tests/pages/firefox/set_as_default/__init__.py
+++ b/tests/pages/firefox/set_as_default/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/tests/pages/firefox/set_as_default/landing.py
+++ b/tests/pages/firefox/set_as_default/landing.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class DefaultLandingPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/set-as-default/"
+
+    _set_default_button_locator = (By.ID, "set-as-default-button")
+
+    @property
+    def is_set_default_button_displayed(self):
+        return self.is_element_displayed(*self._set_default_button_locator)

--- a/tests/pages/firefox/set_as_default/thanks.py
+++ b/tests/pages/firefox/set_as_default/thanks.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class DefaultThanksPage(BasePage):
+    _URL_TEMPLATE = "/{locale}/firefox/set-as-default/thanks/"
+
+    _download_button_locator = (By.ID, "download-button-desktop-release")
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/regions/join_firefox_form.py
+++ b/tests/pages/regions/join_firefox_form.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BaseRegion
+
+
+class JoinFirefoxForm(BaseRegion):
+    _root_locator = (By.ID, "fxa-email-form")
+    _email_locator = (By.ID, "fxa-email-field")
+    _continue_button_locator = (By.ID, "fxa-email-form-submit")
+
+    @property
+    def is_displayed(self):
+        return self.page.is_element_displayed(*self._root_locator)
+
+    @property
+    def is_enabled(self):
+        return self.find_element(*self._continue_button_locator).is_enabled()
+
+    @property
+    def email(self):
+        el = self.find_element(*self._email_locator)
+        return el.get_attribute("value")
+
+    def type_email(self, value):
+        self.find_element(*self._email_locator).send_keys(value)
+
+    def click_continue(self):
+        self.wait.until(lambda s: self.is_enabled)
+        self.find_element(*self._continue_button_locator).click()
+        self.wait.until(lambda s: "?action=email" in s.current_url)

--- a/tests/pages/regions/menu_list.py
+++ b/tests/pages/regions/menu_list.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BaseRegion
+
+
+class MenuList(BaseRegion):
+    _title_button_locator = (By.CSS_SELECTOR, ".mzp-c-menu-list-title > button")
+    _list_locator = (By.CSS_SELECTOR, ".mzp-c-menu-list-list")
+
+    # list is visible
+
+    @property
+    def list_is_open(self):
+        return self.is_element_displayed(*self._list_locator)
+
+    def click(self):
+        self.scroll_element_into_view(*self._title_button_locator).click()

--- a/tests/pages/regions/modal.py
+++ b/tests/pages/regions/modal.py
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+from pages.base import BaseRegion
+
+
+class Modal(BaseRegion):
+    _root_locator = (By.ID, "modal")
+    _close_locator = (By.ID, "modal-close")
+
+    def close(self):
+        modal = self.selenium.find_element(*self._root_locator)
+        self.find_element(*self._close_locator).click()
+        self.wait.until(expected.staleness_of(modal))
+
+    @property
+    def is_displayed(self):
+        return self.page.is_element_displayed(*self._root_locator)
+
+    def displays(self, selector):
+        return self.is_element_displayed(*selector)
+
+
+class ModalProtocol(BaseRegion):
+    _root_locator = (By.CLASS_NAME, "mzp-c-modal")
+    _close_locator = (By.CLASS_NAME, "mzp-c-modal-button-close")
+
+    def close(self):
+        modal = self.selenium.find_element(*self._root_locator)
+        self.find_element(*self._close_locator).click()
+        self.wait.until(expected.staleness_of(modal))
+
+    @property
+    def is_displayed(self):
+        return self.page.is_element_displayed(*self._root_locator)
+
+    def displays(self, selector):
+        return self.is_element_displayed(*selector)

--- a/tests/pages/regions/send_to_device.py
+++ b/tests/pages/regions/send_to_device.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+from pages.base import BaseRegion
+
+
+class SendToDevice(BaseRegion):
+    _root_locator = (By.CSS_SELECTOR, ".send-to-device")
+    _email_locator = (By.CSS_SELECTOR, ".send-to-device-input")
+    _submit_button_locator = (By.CSS_SELECTOR, ".send-to-device .mzp-c-button")
+    _thank_you_locator = (By.CSS_SELECTOR, ".thank-you")
+    _system_error_locator = (By.CLASS_NAME, "error-try-again-later")
+
+    @property
+    def is_form_error_displayed(self):
+        return self.is_element_displayed(*self._system_error_locator)
+
+    def type_email(self, value):
+        self.find_element(*self._email_locator).send_keys(value)
+
+    def click_send(self, expected_result=None):
+        self.scroll_element_into_view(*self._submit_button_locator).click()
+        if expected_result == "error":
+            self.wait.until(expected.visibility_of_element_located(self._system_error_locator))
+        else:
+            self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
+
+    @property
+    def send_successful(self):
+        el = self.selenium.find_element(*self._thank_you_locator)
+        return el.is_displayed()
+
+    @property
+    def is_displayed(self):
+        return self.page.is_element_displayed(*self._root_locator)

--- a/tests/playwright/specs/a11y/includes/urls.js
+++ b/tests/playwright/specs/a11y/includes/urls.js
@@ -10,8 +10,23 @@
  * URL paths for inclusion in page-level a11y scans.
  * Pages will be scanned at both desktop and mobile resolutions.
  */
-const desktopTestURLs = ['/en-US/firefox/', '/en-US/firefox/new/'];
+const desktopTestURLs = [
+    '/en-US/firefox/',
+    '/en-US/firefox/all/',
+    '/en-US/firefox/channel/android/',
+    '/en-US/firefox/channel/desktop/',
+    '/en-US/firefox/developer/',
+    '/en-US/firefox/download/thanks/',
+    '/en-US/firefox/enterprise/',
+    '/en-US/firefox/new/',
+    '/en-US/firefox/releasenotes/',
+    '/en-US/privacy/websites/cookie-settings/'
+];
 
-const mobileTestURLs = ['/en-US/firefox/', '/en-US/firefox/new/'];
+const mobileTestURLs = [
+    '/en-US/firefox/',
+    '/en-US/firefox/channel/android/',
+    '/en-US/firefox/new/'
+];
 
 module.exports = { desktopTestURLs, mobileTestURLs };

--- a/tests/playwright/specs/footer.spec.js
+++ b/tests/playwright/specs/footer.spec.js
@@ -8,7 +8,7 @@
 
 const { test, expect } = require('@playwright/test');
 const openPage = require('../scripts/open-page');
-const url = '/en-US/';
+const url = '/en-US/firefox/';
 
 test.describe(
     `${url} footer (mobile)`,
@@ -22,50 +22,6 @@ test.describe(
             await openPage(url, page, browserName);
         });
 
-        test('Footer newsletter submit success', async ({ page }) => {
-            const form = page.getByTestId('newsletter-form');
-            const emailField = page.getByTestId('newsletter-email-input');
-            const countryField = page.getByTestId('newsletter-country-select');
-            const privacyCheckbox = page.getByTestId(
-                'newsletter-privacy-checkbox'
-            );
-            const submitButton = page.getByTestId('newsletter-submit-button');
-            const thanksMessage = page.getByTestId('newsletter-thanks-message');
-
-            // expand form before running test
-            await submitButton.click();
-
-            await expect(thanksMessage).not.toBeVisible();
-            await emailField.fill('success@example.com');
-            await countryField.selectOption('us');
-            await privacyCheckbox.click();
-            await submitButton.click();
-            await expect(form).not.toBeVisible();
-            await expect(thanksMessage).toBeVisible();
-        });
-
-        test('Footer newsletter submit failure', async ({ page }) => {
-            const emailField = page.getByTestId('newsletter-email-input');
-            const countryField = page.getByTestId('newsletter-country-select');
-            const privacyCheckbox = page.getByTestId(
-                'newsletter-privacy-checkbox'
-            );
-            const submitButton = page.getByTestId('newsletter-submit-button');
-            const thanksMessage = page.getByTestId('newsletter-thanks-message');
-            const errorMessage = page.getByTestId('newsletter-error-message');
-
-            // expand form before running test
-            await page.getByTestId('newsletter-submit-button').click();
-
-            await expect(errorMessage).not.toBeVisible();
-            await emailField.fill('failure@example.com');
-            await countryField.selectOption('us');
-            await privacyCheckbox.click();
-            await submitButton.click();
-            await expect(errorMessage).toBeVisible();
-            await expect(thanksMessage).not.toBeVisible();
-        });
-
         test('Footer language change', async ({ page }) => {
             const languageSelect = page.getByTestId('footer-language-select');
 
@@ -74,7 +30,7 @@ test.describe(
 
             // Change page language from /en-US/ to /de/
             await languageSelect.selectOption('de');
-            await page.waitForURL('**/de/?automation=true', {
+            await page.waitForURL('**/de/firefox/?automation=true', {
                 waitUntil: 'commit'
             });
 

--- a/tests/playwright/specs/navigation.spec.js
+++ b/tests/playwright/specs/navigation.spec.js
@@ -8,7 +8,7 @@
 
 const { test, expect } = require('@playwright/test');
 const openPage = require('../scripts/open-page');
-const url = '/en-US/';
+const url = '/en-US/firefox/';
 
 test.describe(
     `${url} navigation (desktop)`,

--- a/tests/playwright/specs/products/firefox/firefox-channel-android.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-channel-android.spec.js
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/channel/android/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Download Firefox Beta / Nightly (Android)', async ({ page }) => {
+            const androidBetaDownload = page.getByTestId(
+                'android-beta-download-android'
+            );
+            const androidNightlyDownload = page.getByTestId(
+                'android-nightly-download-android'
+            );
+
+            // Assert Android Beta download button is displayed.
+            await expect(androidBetaDownload).toBeVisible();
+            await expect(androidBetaDownload).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.firefox_beta/
+            );
+
+            // Assert Android Nightly download button is displayed.
+            await expect(androidNightlyDownload).toBeVisible();
+            await expect(androidNightlyDownload).toHaveAttribute(
+                'href',
+                /^https:\/\/play.google.com\/store\/apps\/details\?id=org.mozilla.fenix/
+            );
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-channel-desktop.spec.js
@@ -1,0 +1,351 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/channel/desktop/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download Firefox Beta / DevEdition / Nightly (Windows, macOS)', async ({
+            page,
+            browserName
+        }) => {
+            const win64BetaDownload = page.getByTestId(
+                'desktop-beta-download-win64'
+            );
+            const winDevDownload = page.getByTestId(
+                'desktop-developer-download-win'
+            );
+            const winNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-win'
+            );
+            const osxBetaDownload = page.getByTestId(
+                'desktop-beta-download-osx'
+            );
+            const osxDevDownload = page.getByTestId(
+                'desktop-developer-download-osx'
+            );
+            const osxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-osx'
+            );
+
+            await openPage(url, page, browserName);
+
+            if (browserName === 'webkit') {
+                // Assert macOS download buttons are displayed.
+                await expect(osxBetaDownload).toBeVisible();
+                await expect(osxBetaDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-beta-latest-ssl&os=osx/
+                );
+                await expect(osxDevDownload).toBeVisible();
+                await expect(osxDevDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=osx/
+                );
+                await expect(osxNightlyDownload).toBeVisible();
+                await expect(osxNightlyDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-nightly-latest-ssl&os=osx/
+                );
+
+                // Assert Windows download buttons are not displayed.
+                await expect(win64BetaDownload).not.toBeVisible();
+                await expect(winDevDownload).not.toBeVisible();
+                await expect(winNightlyDownload).not.toBeVisible();
+            } else {
+                /**
+                 * Assert Windows download buttons are displayed.
+                 * Note: we serve the full installer for Firefox Beta on Windows.
+                 * See https://github.com/mozilla/bedrock/issues/9836
+                 * and https://github.com/mozilla/bedrock/issues/10194
+                 */
+                await expect(win64BetaDownload).toBeVisible();
+                await expect(win64BetaDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-beta-latest-ssl&os=win64/
+                );
+                await expect(winDevDownload).toBeVisible();
+                await expect(winDevDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-stub&os=win/
+                );
+                await expect(winNightlyDownload).toBeVisible();
+                await expect(winNightlyDownload).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-nightly-stub&os=win/
+                );
+
+                // Assert macOS download buttons are not displayed.
+                await expect(osxBetaDownload).not.toBeVisible();
+                await expect(osxDevDownload).not.toBeVisible();
+                await expect(osxNightlyDownload).not.toBeVisible();
+            }
+        });
+
+        test('Download Firefox Beta / DevEdition / Nightly (Linux)', async ({
+            page,
+            browserName
+        }) => {
+            const linuxBetaDownload = page.getByTestId(
+                'desktop-beta-download-linux'
+            );
+            const linux64BetaDownload = page.getByTestId(
+                'desktop-beta-download-linux64'
+            );
+            const linuxDevDownload = page.getByTestId(
+                'desktop-developer-download-linux'
+            );
+            const linux64DevDownload = page.getByTestId(
+                'desktop-developer-download-linux64'
+            );
+            const linuxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-linux'
+            );
+            const linux64NightlyDownload = page.getByTestId(
+                'desktop-nightly-download-linux64'
+            );
+
+            const win64BetaDownload = page.getByTestId(
+                'desktop-beta-download-win64'
+            );
+            const winDevDownload = page.getByTestId(
+                'desktop-developer-download-win'
+            );
+            const winNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-win'
+            );
+            const osxBetaDownload = page.getByTestId(
+                'desktop-beta-download-osx'
+            );
+            const osxDevDownload = page.getByTestId(
+                'desktop-developer-download-osx'
+            );
+            const osxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-osx'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Linux'
+            );
+
+            // Set Linux UA strings.
+            await page.addInitScript({
+                path: `./scripts/useragent/linux/${browserName}.js`
+            });
+            await page.goto(url + '?automation=true');
+
+            // Assert Linux download buttons are displayed.
+            await expect(linuxBetaDownload).toBeVisible();
+            await expect(linuxBetaDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=linux/
+            );
+            await expect(linux64BetaDownload).toBeVisible();
+            await expect(linux64BetaDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=linux64/
+            );
+            await expect(linuxDevDownload).toBeVisible();
+            await expect(linuxDevDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux/
+            );
+            await expect(linux64DevDownload).toBeVisible();
+            await expect(linux64DevDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64/
+            );
+            await expect(linuxNightlyDownload).toBeVisible();
+            await expect(linuxNightlyDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-ssl&os=linux/
+            );
+            await expect(linux64NightlyDownload).toBeVisible();
+            await expect(linux64NightlyDownload).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-ssl&os=linux64/
+            );
+
+            // Assert Windows / macOS download buttons are not displayed.
+            await expect(win64BetaDownload).not.toBeVisible();
+            await expect(winDevDownload).not.toBeVisible();
+            await expect(winNightlyDownload).not.toBeVisible();
+            await expect(osxBetaDownload).not.toBeVisible();
+            await expect(osxDevDownload).not.toBeVisible();
+            await expect(osxNightlyDownload).not.toBeVisible();
+        });
+
+        test('Firefox unsupported OS version messaging (Win / Mac)', async ({
+            page,
+            browserName
+        }) => {
+            const win64BetaDownload = page.getByTestId(
+                'desktop-beta-download-win64'
+            );
+            const winDevDownload = page.getByTestId(
+                'desktop-developer-download-win'
+            );
+            const winNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-win'
+            );
+            const osxBetaDownload = page.getByTestId(
+                'desktop-beta-download-osx'
+            );
+            const osxDevDownload = page.getByTestId(
+                'desktop-developer-download-osx'
+            );
+            const osxNightlyDownload = page.getByTestId(
+                'desktop-nightly-download-osx'
+            );
+
+            const betaDownloadOsxUnsupported = page.locator(
+                'css=.download-button-beta .fx-unsupported-message.mac .download-link'
+            );
+            const devDownloadOsxUnsupported = page.locator(
+                'css=.download-button-alpha .fx-unsupported-message.mac .download-link'
+            );
+            const nightlyDownloadOsxUnsupported = page.locator(
+                'css=.download-button-nightly .fx-unsupported-message.mac .download-link'
+            );
+            const betaDownloadWinUnsupported = page.locator(
+                'css=.download-button-beta .fx-unsupported-message.win .download-link.os_win64'
+            );
+            const devDownloadWinUnsupported = page.locator(
+                'css=.download-button-alpha .fx-unsupported-message.win .download-link.os_win64'
+            );
+            const nightlyDownloadWinUnsupported = page.locator(
+                'css=.download-button-nightly .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            if (browserName === 'webkit') {
+                // Set macOS 10.14 UA strings.
+                await page.addInitScript({
+                    path: `./scripts/useragent/mac-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR button is displayed instead of Firefox Beta button.
+                await expect(betaDownloadOsxUnsupported).toBeVisible();
+                await expect(betaDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
+                );
+                await expect(osxBetaDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Developer Edition button.
+                await expect(devDownloadOsxUnsupported).toBeVisible();
+                await expect(devDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
+                );
+                await expect(osxDevDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Nightly button.
+                await expect(nightlyDownloadOsxUnsupported).toBeVisible();
+                await expect(nightlyDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
+                );
+                await expect(osxNightlyDownload).not.toBeVisible();
+            } else {
+                // Set Windows 8.1 UA string (64-bit).
+                await page.addInitScript({
+                    path: `./scripts/useragent/win-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR button is displayed instead of Firefox Beta 64-bit button.
+                await expect(betaDownloadWinUnsupported).toBeVisible();
+                await expect(betaDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(win64BetaDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Developer Edition button.
+                await expect(devDownloadWinUnsupported).toBeVisible();
+                await expect(devDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(winDevDownload).not.toBeVisible();
+
+                // Assert ESR button is displayed instead of Firefox Nightly button.
+                await expect(nightlyDownloadWinUnsupported).toBeVisible();
+                await expect(nightlyDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(winNightlyDownload).not.toBeVisible();
+            }
+        });
+
+        test('Newsletter submit success', async ({ page, browserName }) => {
+            const newsletterForm = page.getByTestId('newsletter-form');
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('success@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterForm).not.toBeVisible();
+            await expect(newsletterThanksMessage).toBeVisible();
+        });
+
+        test('Newsletter submit failure', async ({ page, browserName }) => {
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+            const newsletterErrorMessage = page.getByTestId(
+                'newsletter-error-message'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('failure@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterErrorMessage).toBeVisible();
+            await expect(newsletterThanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-developer.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-developer.spec.js
@@ -1,0 +1,249 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/developer/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download DevEdition (Windows, macOS)', async ({
+            page,
+            browserName
+        }) => {
+            const introDownloadWin = page.getByTestId('intro-download-win');
+            const introDownloadOsx = page.getByTestId('intro-download-osx');
+            const footerDownloadWin = page.getByTestId('footer-download-win');
+            const footerDownloadOsx = page.getByTestId('footer-download-osx');
+
+            await openPage(url, page, browserName);
+
+            if (browserName === 'webkit') {
+                // Assert macOS download button is displayed.
+                await expect(introDownloadOsx).toBeVisible();
+                await expect(introDownloadOsx).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=osx/
+                );
+                await expect(footerDownloadOsx).toBeVisible();
+                await expect(footerDownloadOsx).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-latest-ssl&os=osx/
+                );
+
+                // Assert Windows download button is not displayed.
+                await expect(introDownloadWin).not.toBeVisible();
+                await expect(footerDownloadWin).not.toBeVisible();
+            } else {
+                // Assert Windows download button is displayed.
+                await expect(introDownloadWin).toBeVisible();
+                await expect(introDownloadWin).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-stub&os=win/
+                );
+                await expect(footerDownloadWin).toBeVisible();
+                await expect(footerDownloadWin).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-devedition-stub&os=win/
+                );
+
+                // Assert macOS download button is not displayed.
+                await expect(introDownloadOsx).not.toBeVisible();
+                await expect(footerDownloadOsx).not.toBeVisible();
+            }
+        });
+
+        test('Download Firefox (Linux)', async ({ page, browserName }) => {
+            const introDownloadWin = page.getByTestId('intro-download-win');
+            const introDownloadOsx = page.getByTestId('intro-download-osx');
+            const footerDownloadWin = page.getByTestId('footer-download-win');
+            const footerDownloadOsx = page.getByTestId('footer-download-osx');
+            const introDownloadLinux = page.getByTestId('intro-download-linux');
+            const introDownloadLinux64 = page.getByTestId(
+                'intro-download-linux64'
+            );
+            const footerDownloadLinux = page.getByTestId(
+                'footer-download-linux'
+            );
+            const footerDownloadLinux64 = page.getByTestId(
+                'footer-download-linux64'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Linux'
+            );
+
+            // Set Linux UA strings.
+            await page.addInitScript({
+                path: `./scripts/useragent/linux/${browserName}.js`
+            });
+            await page.goto(url + '?automation=true');
+
+            // Assert Linux download buttons are displayed.
+            await expect(introDownloadLinux).toBeVisible();
+            await expect(introDownloadLinux).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux/
+            );
+            await expect(introDownloadLinux64).toBeVisible();
+            await expect(introDownloadLinux64).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64/
+            );
+            await expect(footerDownloadLinux).toBeVisible();
+            await expect(footerDownloadLinux).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux/
+            );
+            await expect(footerDownloadLinux64).toBeVisible();
+            await expect(footerDownloadLinux64).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=linux64/
+            );
+
+            // Assert Windows / macOS download buttons are not displayed.
+            await expect(introDownloadWin).not.toBeVisible();
+            await expect(introDownloadOsx).not.toBeVisible();
+            await expect(footerDownloadWin).not.toBeVisible();
+            await expect(footerDownloadOsx).not.toBeVisible();
+        });
+
+        test('Firefox unsupported OS version messaging (Win / Mac)', async ({
+            page,
+            browserName
+        }) => {
+            const introDownloadWin = page.getByTestId('intro-download-win');
+            const introDownloadOsx = page.getByTestId('intro-download-osx');
+            const footerDownloadWin = page.getByTestId('footer-download-win');
+            const footerDownloadOsx = page.getByTestId('footer-download-osx');
+
+            const introDownloadWinUnsupported = page.locator(
+                'css=#intro-download .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const introDownloadOsxUnsupported = page.locator(
+                'css=#intro-download .fx-unsupported-message.mac .download-link'
+            );
+
+            const footerDownloadWinUnsupported = page.locator(
+                'css=#footer-download .fx-unsupported-message.win .download-link.os_win64'
+            );
+
+            const footerDownloadOsxUnsupported = page.locator(
+                'css=#footer-download .fx-unsupported-message.mac .download-link'
+            );
+
+            if (browserName === 'webkit') {
+                // Set macOS 10.14 UA strings.
+                await page.addInitScript({
+                    path: `./scripts/useragent/mac-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR buttons are displayed instead of Firefox Dev buttons.
+                await expect(introDownloadOsxUnsupported).toBeVisible();
+                await expect(introDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
+                );
+                await expect(footerDownloadOsxUnsupported).toBeVisible();
+                await expect(footerDownloadOsxUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=osx/
+                );
+
+                // Assert regular download buttons are not displayed.
+                await expect(introDownloadOsx).not.toBeVisible();
+                await expect(footerDownloadOsx).not.toBeVisible();
+            } else {
+                // Set Windows 8.1 UA string (64-bit).
+                await page.addInitScript({
+                    path: `./scripts/useragent/win-old/${browserName}.js`
+                });
+                await page.goto(url + '?automation=true');
+
+                // Assert ESR buttons are displayed instead of Firefox Dev buttons.
+                await expect(introDownloadWinUnsupported).toBeVisible();
+                await expect(introDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+                await expect(footerDownloadWinUnsupported).toBeVisible();
+                await expect(footerDownloadWinUnsupported).toHaveAttribute(
+                    'href',
+                    /\?product=firefox-esr115-latest-ssl&os=win64/
+                );
+
+                // Assert regular download buttons are not displayed.
+                await expect(introDownloadWin).not.toBeVisible();
+                await expect(footerDownloadWin).not.toBeVisible();
+            }
+        });
+
+        test('Newsletter submit success', async ({ page, browserName }) => {
+            const newsletterForm = page.getByTestId('newsletter-form');
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('success@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterForm).not.toBeVisible();
+            await expect(newsletterThanksMessage).toBeVisible();
+        });
+
+        test('Newsletter submit failure', async ({ page, browserName }) => {
+            const newsletterThanksMessage = page.getByTestId(
+                'newsletter-thanks-message'
+            );
+            const newsletterErrorMessage = page.getByTestId(
+                'newsletter-error-message'
+            );
+            const newsletterEmailInput = page.getByTestId(
+                'newsletter-email-input'
+            );
+            const newsletterPrivacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const newsletterSubmitButton = page.getByTestId(
+                'newsletter-submit-button'
+            );
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await newsletterSubmitButton.click();
+
+            await newsletterEmailInput.fill('failure@example.com');
+            await newsletterPrivacyCheckbox.click();
+            await newsletterSubmitButton.click();
+            await expect(newsletterErrorMessage).toBeVisible();
+            await expect(newsletterThanksMessage).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-enterprise.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-enterprise.spec.js
@@ -1,0 +1,178 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/enterprise/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Firefox ESR Windows 64bit menu open / close', async ({
+            page
+        }) => {
+            const win64MenuButton = page.getByTestId(
+                'firefox-enterprise-win64-menu-button'
+            );
+            const win64MenuLink = page.getByTestId(
+                'firefox-enterprise-win64-menu-link'
+            );
+            const win64MsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-msi-menu-link'
+            );
+            const win64EsrMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-menu-link'
+            );
+            const win64EsrMsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-msi-menu-link'
+            );
+
+            await expect(win64MenuLink).not.toBeVisible();
+            await expect(win64MsiMenuLink).not.toBeVisible();
+            await expect(win64EsrMenuLink).not.toBeVisible();
+            await expect(win64EsrMsiMenuLink).not.toBeVisible();
+
+            // open menu
+            await win64MenuButton.click();
+
+            // Assert Windows 64-bit menu links are displayed.
+            await expect(win64MenuLink).toBeVisible();
+            await expect(win64MenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win64/
+            );
+            await expect(win64MsiMenuLink).toBeVisible();
+            await expect(win64MsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-msi-latest-ssl&os=win64/
+            );
+            await expect(win64EsrMenuLink).toBeVisible();
+            await expect(win64EsrMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=win64/
+            );
+            await expect(win64EsrMsiMenuLink).toBeVisible();
+            await expect(win64EsrMsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-msi-latest-ssl&os=win64/
+            );
+
+            // close menu
+            await win64MenuButton.click();
+
+            // Assert Windows 64-bit menu links are hidden.
+            await expect(win64MenuLink).not.toBeVisible();
+            await expect(win64MsiMenuLink).not.toBeVisible();
+            await expect(win64EsrMenuLink).not.toBeVisible();
+            await expect(win64EsrMsiMenuLink).not.toBeVisible();
+        });
+
+        test('Firefox ESR macOS menu open / close', async ({ page }) => {
+            const macMenuButton = page.getByTestId(
+                'firefox-enterprise-mac-menu-button'
+            );
+            const macMenuLink = page.getByTestId(
+                'firefox-enterprise-mac-menu-link'
+            );
+            const macEsrMenuLink = page.getByTestId(
+                'firefox-enterprise-mac-esr-menu-link'
+            );
+
+            await expect(macMenuLink).not.toBeVisible();
+            await expect(macEsrMenuLink).not.toBeVisible();
+
+            // open menu
+            await macMenuButton.click();
+
+            // Assert macOS menu links are displayed.
+            await expect(macMenuLink).toBeVisible();
+            await expect(macMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=osx/
+            );
+            await expect(macEsrMenuLink).toBeVisible();
+            await expect(macEsrMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=osx/
+            );
+
+            // close menu
+            await macMenuButton.click();
+
+            // Assert macOS menu links are hidden.
+            await expect(macMenuLink).not.toBeVisible();
+            await expect(macEsrMenuLink).not.toBeVisible();
+        });
+
+        test('Firefox ESR Windows 32bit menu open / close', async ({
+            page
+        }) => {
+            const win32MenuButton = page.getByTestId(
+                'firefox-enterprise-win64-menu-button'
+            );
+            const win32MenuLink = page.getByTestId(
+                'firefox-enterprise-win64-menu-link'
+            );
+            const win32MsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-msi-menu-link'
+            );
+            const win32EsrMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-menu-link'
+            );
+            const win32EsrMsiMenuLink = page.getByTestId(
+                'firefox-enterprise-win64-esr-msi-menu-link'
+            );
+
+            await expect(win32MenuLink).not.toBeVisible();
+            await expect(win32MsiMenuLink).not.toBeVisible();
+            await expect(win32EsrMenuLink).not.toBeVisible();
+            await expect(win32EsrMsiMenuLink).not.toBeVisible();
+
+            // open menu
+            await win32MenuButton.click();
+
+            // Assert Windows 32-bit menu links are displayed.
+            await expect(win32MenuLink).toBeVisible();
+            await expect(win32MenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win64/
+            );
+            await expect(win32MsiMenuLink).toBeVisible();
+            await expect(win32MsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-msi-latest-ssl&os=win64/
+            );
+            await expect(win32EsrMenuLink).toBeVisible();
+            await expect(win32EsrMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-latest-ssl&os=win64/
+            );
+            await expect(win32EsrMsiMenuLink).toBeVisible();
+            await expect(win32EsrMsiMenuLink).toHaveAttribute(
+                'href',
+                /\?product=firefox-esr-msi-latest-ssl&os=win64/
+            );
+
+            // close menu
+            await win32MenuButton.click();
+
+            // Assert Windows 32-bit menu links are hidden.
+            await expect(win32MenuLink).not.toBeVisible();
+            await expect(win32MsiMenuLink).not.toBeVisible();
+            await expect(win32EsrMenuLink).not.toBeVisible();
+            await expect(win32EsrMsiMenuLink).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-installer-help.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-installer-help.spec.js
@@ -1,0 +1,164 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/installer-help/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test('Download Firefox (Windows)', async ({ page, browserName }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=release', page, browserName);
+
+            // Assert Windows release channel download button is displayed.
+            await expect(downloadButtonRelease).toBeVisible();
+            await expect(downloadButtonRelease).toHaveAttribute(
+                'href',
+                /\?product=firefox-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonBeta).not.toBeVisible();
+            await expect(downloadButtonDeveloper).not.toBeVisible();
+            await expect(downloadButtonNightly).not.toBeVisible();
+        });
+
+        test('Download Firefox Beta (Windows)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=beta', page, browserName);
+
+            // Assert Windows beta channel download button is displayed.
+            await expect(downloadButtonBeta).toBeVisible();
+            await expect(downloadButtonBeta).toHaveAttribute(
+                'href',
+                /\?product=firefox-beta-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonRelease).not.toBeVisible();
+            await expect(downloadButtonDeveloper).not.toBeVisible();
+            await expect(downloadButtonNightly).not.toBeVisible();
+        });
+
+        test('Download Firefox Developer (Windows)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=aurora', page, browserName);
+
+            // Assert Windows developer channel download button is displayed.
+            await expect(downloadButtonDeveloper).toBeVisible();
+            await expect(downloadButtonDeveloper).toHaveAttribute(
+                'href',
+                /\?product=firefox-devedition-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonRelease).not.toBeVisible();
+            await expect(downloadButtonBeta).not.toBeVisible();
+            await expect(downloadButtonNightly).not.toBeVisible();
+        });
+
+        test('Download Firefox Nightly (Windows)', async ({
+            page,
+            browserName
+        }) => {
+            const downloadButtonRelease = page.getByTestId(
+                'download-button-desktop-release-win'
+            );
+            const downloadButtonBeta = page.getByTestId(
+                'download-button-desktop-beta-win64'
+            );
+            const downloadButtonDeveloper = page.getByTestId(
+                'download-button-desktop-alpha-win'
+            );
+            const downloadButtonNightly = page.getByTestId(
+                'download-button-desktop-nightly-win'
+            );
+
+            test.skip(
+                browserName === 'webkit',
+                'Safari not available on Windows'
+            );
+
+            await openPage(url + '?channel=nightly', page, browserName);
+
+            // Assert Windows nightly channel download button is displayed.
+            await expect(downloadButtonNightly).toBeVisible();
+            await expect(downloadButtonNightly).toHaveAttribute(
+                'href',
+                /\?product=firefox-nightly-latest-ssl&os=win/
+            );
+
+            // Assert download buttons for other channels are not displayed.
+            await expect(downloadButtonRelease).not.toBeVisible();
+            await expect(downloadButtonBeta).not.toBeVisible();
+            await expect(downloadButtonDeveloper).not.toBeVisible();
+        });
+    }
+);

--- a/tests/playwright/specs/products/firefox/firefox-ios-testflight.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-ios-testflight.spec.js
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../../../scripts/open-page');
+const url = '/en-US/firefox/ios/testflight/';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@firefox'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('Signup success', async ({ page, browserName }) => {
+            const newsletterForm = page.getByTestId('newsletter-form');
+            const emailInput = page.getByTestId('newsletter-email-input');
+            const termsCheckbox = page.getByTestId('newsletter-terms-checkbox');
+            const privacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const submitButton = page.getByTestId('newsletter-submit-button');
+            const thanksMessage = page.getByTestId('newsletter-thanks-message');
+
+            await openPage(url, page, browserName);
+
+            await expect(thanksMessage).not.toBeVisible();
+
+            // expand form before running test
+            await submitButton.click();
+
+            await emailInput.fill('success@example.com');
+            await termsCheckbox.click();
+            await privacyCheckbox.click();
+            await submitButton.click();
+            await expect(newsletterForm).not.toBeVisible();
+            await expect(thanksMessage).toBeVisible();
+        });
+
+        test('Signup failure', async ({ page, browserName }) => {
+            const newsletterErrorMessage = page.getByTestId(
+                'newsletter-error-message'
+            );
+            const emailInput = page.getByTestId('newsletter-email-input');
+            const termsCheckbox = page.getByTestId('newsletter-terms-checkbox');
+            const privacyCheckbox = page.getByTestId(
+                'newsletter-privacy-checkbox'
+            );
+            const submitButton = page.getByTestId('newsletter-submit-button');
+            const thanksMessage = page.getByTestId('newsletter-thanks-message');
+
+            await openPage(url, page, browserName);
+
+            // expand form before running test
+            await submitButton.click();
+
+            await emailInput.fill('failure@example.com');
+            await termsCheckbox.click();
+            await privacyCheckbox.click();
+            await submitButton.click();
+            await expect(newsletterErrorMessage).toBeVisible();
+            await expect(thanksMessage).not.toBeVisible();
+        });
+    }
+);


### PR DESCRIPTION
## One-line summary

This is a partial revert-commit of https://github.com/mozilla/bedrock/pull/15909, based on the updated list of MVP firefox pages we're aiming to migrate.

## Issue / Bugzilla link

N/A

## Testing

Playwright tests should pass locally

- `cd tests/playwright`
- `npm run integration-tests`

Selenium tests should pass locally

`pytest --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/ -m 'not headless'`