### PR TITLE
Identify partner builds as "release" channel in analytics

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -108,21 +108,28 @@ TrackProductDownload.getEventFromUrl = (downloadURL) => {
         stageURL.test(downloadURL) ||
         devURL.test(downloadURL)
     ) {
+        // expect the link to have parameters like: ?product=firefox-beta-latest-ssl&os=osx&lang=en-US
         // extract the values we need from the parameters
         const productParam = params.product;
         const productSplit = productParam.split('-');
+
         // product is first word of product param
         let product = productSplit[0];
-        // partner builds are labelled as ?product=partner-firefox so class these as regular 'firefox' download events.
+        // (except partner builds are labelled as ?product=partner-firefox so class these as regular 'firefox' download events)
         product = product === 'partner' ? 'firefox' : product;
+
+        // platform is `os` param
         let platform = params.os;
         // change platform to macos if it's osx
         platform = platform === 'osx' ? 'macos' : platform;
         // append 'msi' to platform if msi is in the product parameter
         platform =
             productParam.indexOf('msi') !== -1 ? platform + '-msi' : platform;
-        // release channel is second word of product param
+
+        // release channel uses second word of product param
         let release = productSplit[1];
+        // (except partner builds - where 'partner' is the first word)
+        release = productSplit[0] === 'partner' ? 'release' : release;
         // (except for latest, msi, or sub installer - we update those to say release)
         if (release === 'latest' || release === 'stub' || release === 'msi') {
             release = 'release';

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -227,6 +227,12 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         );
         expect(testEvent['release_channel']).toBe('release');
     });
+    it('should identify release_channel for Firefox partner builds', function () {
+        const testEvent = TrackProductDownload.getEventFromUrl(
+            'https://bouncer-bouncer.stage.mozaws.net/?product=partner-firefox-release-smi-smi-001-latest&os=osx&lang=en-GB&_gl=1&234*_ga*ABC'
+        );
+        expect(testEvent['release_channel']).toBe('partner');
+    });
     it('should identify release_channel for Firefox Beta', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
             'https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US'

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -231,7 +231,7 @@ describe('TrackProductDownload.getEventFromUrl', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(
             'https://bouncer-bouncer.stage.mozaws.net/?product=partner-firefox-release-smi-smi-001-latest&os=osx&lang=en-GB&_gl=1&234*_ga*ABC'
         );
-        expect(testEvent['release_channel']).toBe('partner');
+        expect(testEvent['release_channel']).toBe('release');
     });
     it('should identify release_channel for Firefox Beta', function () {
         const testEvent = TrackProductDownload.getEventFromUrl(


### PR DESCRIPTION
## One-line summary

Identify partner builds as "release" channel in analytics 

## Issue / Bugzilla link

#15841  

## Testing

Using the javascript console, click the link and then print the `dataLayer`.