### PR TITLE
Migrate /press to use Sass @use (#10896)

### DIFF
--- a/media/css/press/press.scss
+++ b/media/css/press/press.scss
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/set';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/set';
 
 .mzp-c-article {
     min-height: $content-sm;


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Remove outdated Sass `@import` syntax

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/10896

## Testing

https://www.mozilla.org/en-US/press/speakerrequest/ 
https://www.mozilla.org/en-US/press/press-inquiry/ 
http://localhost:8000/en-US/press/press-inquiry/?success=True