### PR TITLE
Support failing over to a different, preferred locale for CMS pages upon 404

### DIFF
--- a/bedrock/cms/cms_only_urls.py
+++ b/bedrock/cms/cms_only_urls.py
@@ -7,8 +7,11 @@
 # They are named so that they can be looked up via our url() jinja
 # helper, even though the actual page exists in the CMS only.
 #
-# These URLs will/must have matching routes set up in the CMS pages
-# else they will lead to a 404 from the CMS.
+# These URLs must have matching routes set up in the CMS pages
+# else they can lead to a 404 from the CMS. If the CMS has a translated
+# version of that page available in a locale that the user prefers
+# (via their Accept-Language header) or in the default
+# settings.LANGUAGE_CODE locale, the user will be redirected to that.
 #
 # Note that all URL routes defined here should point to the
 # dummy_view function, which never gets called because this
@@ -17,13 +20,15 @@
 
 from django.urls import path
 
+from bedrock.base.i18n import bedrock_i18n_patterns
+
 
 def dummy_view(*args, **kwargs):
     # This view will never get called
     pass
 
 
-urlpatterns = (
+urlpatterns = bedrock_i18n_patterns(
     # pattern is:
     # path("url/path/here/", dummy_view, name="route.name.here"),
     path("about/leadership/", dummy_view, name="mozorg.about.leadership.index"),

--- a/bedrock/cms/middleware.py
+++ b/bedrock/cms/middleware.py
@@ -44,7 +44,7 @@ class CMSLocaleFallbackMiddleware:
             # Fluent-based hard-coded pages).
 
             path_ = request.path.lstrip("/")
-            extracted_lang, _, _path = path_.partition("/")
+            extracted_lang, _, _sub_path = path_.partition("/")
 
             # Is the requested path available in other languages, checked in
             # order of user preference?
@@ -68,7 +68,9 @@ class CMSLocaleFallbackMiddleware:
             if settings.LANGUAGE_CODE not in ranked_locales:
                 ranked_locales.append(settings.LANGUAGE_CODE)
 
-            _url_path = f"{_path}"
+            # Make sure the locale-less _url_path we're trying to match starts
+            # with / to avoid partial matches
+            _url_path = f"/{_sub_path.lstrip('/')}"
             if not _url_path.endswith("/"):
                 _url_path += "/"
 

--- a/bedrock/cms/middleware.py
+++ b/bedrock/cms/middleware.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import logging
+from http import HTTPStatus
+
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from django.utils.translation.trans_real import parse_accept_lang_header
+
+from wagtail.models import Page
+
+from bedrock.base.i18n import normalize_language
+
+logger = logging.getLogger(__name__)
+
+
+class CMSLocaleFallbackMiddleware:
+    """Middleware to seek a viable translation in the CMS of a request that
+    404ed, based on the user's Accept-Language headers, ultimately
+    trying settings.LANGAUGE_CODE as the last effort
+
+    This has to exist because Wagtail doesn't fail over to the default/any
+    other locale if a request to /some-locale/some/path/ 404s
+    """
+
+    def __init__(self, get_response):
+        # One-time configuration and initialization.
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            # At this point we have a request that has resulted in a 404,
+            # which means it didn't match any Django URLs, and didn't match
+            # a CMS page for the current locale+path combination in the URL.
+
+            # Let's see if there is an alternative version available in a
+            # different locale that the user would actually like to see.
+            # And failing that, if we have it in the default locale, we can
+            # fall back to that (which is consistent with what we do with
+            # Fluent-based hard-coded pages).
+
+            path_ = request.path.lstrip("/")
+            extracted_lang, _, _path = path_.partition("/")
+
+            # Is the requested path available in other languages, checked in
+            # order of user preference?
+            accept_lang_header = request.headers.get("Accept-Language")
+
+            # We only want the language codes from parse_accept_lang_header,
+            # not their weighting, and we want them to be formatted the way
+            # we expect them to be
+            ranked_locales = [normalize_language(x[0]) for x in parse_accept_lang_header(accept_lang_header)]
+
+            # Ensure the default locale is also included, as a last-ditch option.
+            # NOTE: remove if controversial in terms of user intent but then
+            # we'll have to make sure we pass a locale code into the call to
+            # url() in templates, so that cms_only_urls.py returns a useful
+            # language code
+
+            if settings.LANGUAGE_CODE not in ranked_locales:
+                ranked_locales.append(settings.LANGUAGE_CODE)
+
+            _url_path = f"{_path}"
+            if not _url_path.endswith("/"):
+                _url_path += "/"
+
+            # Now try to get hold of all the pages that exist in the CMS for the extracted path
+            cms_pages = Page.objects.filter(url_path__endswith=_url_path)
+
+            if cms_pages:
+                # OK, we have some candidate pages that desired path
+                # locales. Let's try to send the user to their most preferred one.
+
+                # Note: This is not optimal right now, but we can make it one-DB-hit
+                # once the work to pre-cache the page tree lands
+                for locale_code in ranked_locales:
+                    qs = cms_pages.filter(locale__language_code=locale_code)
+                    if qs.exists():
+                        # There _should_ only be one matching for this locale
+                        if qs.count() > 1:
+                            logger.warning(f"CMS 404-fallback problem: multiple pages with same path found {qs}")
+                        return HttpResponseRedirect(qs.first().url)
+
+                # Fallback: send the user to the first one
+                return HttpResponseRedirect(cms_pages.first().url)
+
+        return response

--- a/bedrock/cms/middleware.py
+++ b/bedrock/cms/middleware.py
@@ -53,7 +53,11 @@ class CMSLocaleFallbackMiddleware:
             # We only want the language codes from parse_accept_lang_header,
             # not their weighting, and we want them to be formatted the way
             # we expect them to be
-            ranked_locales = [normalize_language(x[0]) for x in parse_accept_lang_header(accept_lang_header)]
+
+            if accept_lang_header:
+                ranked_locales = [normalize_language(x[0]) for x in parse_accept_lang_header(accept_lang_header)]
+            else:
+                ranked_locales = []
 
             # Ensure the default locale is also included, as a last-ditch option.
             # NOTE: remove if controversial in terms of user intent but then

--- a/bedrock/cms/middleware.py
+++ b/bedrock/cms/middleware.py
@@ -43,8 +43,8 @@ class CMSLocaleFallbackMiddleware:
             # fall back to that (which is consistent with what we do with
             # Fluent-based hard-coded pages).
 
-            path_ = request.path.lstrip("/")
-            extracted_lang, _, _sub_path = path_.partition("/")
+            _path = request.path.lstrip("/")
+            lang_prefix, _, sub_path = _path.partition("/")
             # (There will be a language-code prefix, thanks to earlier i18n middleware)
 
             # Is the requested path available in other languages, checked in
@@ -69,7 +69,7 @@ class CMSLocaleFallbackMiddleware:
             if settings.LANGUAGE_CODE not in ranked_locales:
                 ranked_locales.append(settings.LANGUAGE_CODE)
 
-            _url_path = _sub_path.lstrip("/")
+            _url_path = sub_path.lstrip("/")
             if not _url_path.endswith("/"):
                 _url_path += "/"
 
@@ -82,18 +82,18 @@ class CMSLocaleFallbackMiddleware:
             # * /home/test-path/to/a/page for en-US
             # * /home-fr/test-path/to/a/page for French
 
-            _possible_url_path_patterns = []
+            possible_url_path_patterns = []
             for locale_code in ranked_locales:
                 if locale_code == settings.LANGUAGE_CODE:
                     root = "/home"
                 else:
                     root = f"/home-{locale_code}"
 
-                _full_url_path = f"{root}/{_url_path}"
-                _possible_url_path_patterns.append(_full_url_path)
+                full_url_path = f"{root}/{_url_path}"
+                possible_url_path_patterns.append(full_url_path)
 
             cms_pages_with_viable_locales = Page.objects.filter(
-                url_path__in=_possible_url_path_patterns,
+                url_path__in=possible_url_path_patterns,
                 # There's no extra value in filtering with locale__language_code__in=ranked_locales
                 # due to the locale code being embedded in the url_path strings
             )

--- a/bedrock/cms/middleware.py
+++ b/bedrock/cms/middleware.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class CMSLocaleFallbackMiddleware:
     """Middleware to seek a viable translation in the CMS of a request that
     404ed, based on the user's Accept-Language headers, ultimately
-    trying settings.LANGAUGE_CODE as the last effort
+    trying settings.LANGUAGE_CODE as the last effort
 
     This has to exist because Wagtail doesn't fail over to the default/any
     other locale if a request to /some-locale/some/path/ 404s
@@ -77,7 +77,7 @@ class CMSLocaleFallbackMiddleware:
             # that are also in a locale that is acceptable to the user or maybe the fallback locale.
 
             # We do this by seeking full url_paths that are prefixed with /home/ (for the
-            # default loacle) or home-<locale_code> - Wagtail sort of 'denorms' the
+            # default locale) or home-<locale_code> - Wagtail sort of 'denorms' the
             # language code into the root of the page tree for each separate locale - eg:
             # * /home/test-path/to/a/page for en-US
             # * /home-fr/test-path/to/a/page for French

--- a/bedrock/cms/tests/test_middleware.py
+++ b/bedrock/cms/tests/test_middleware.py
@@ -1,0 +1,132 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.conf import settings
+from django.http import HttpResponse, HttpResponseNotFound
+
+import pytest
+
+from bedrock.cms.middleware import CMSLocaleFallbackMiddleware
+
+pytestmark = [pytest.mark.django_db]
+
+
+def get_200_response(*args, **kwargs):
+    return HttpResponse()
+
+
+def get_404_response(*args, **kwargs):
+    return HttpResponseNotFound()
+
+
+def test_CMSLocaleFallbackMiddleware_200_response_means_middleware_does_not_fire(
+    rf,
+):
+    request = rf.get("/some/page/path/")
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_200_response)
+    response = middleware(request)
+    assert response.status_code == 200
+
+
+def test_CMSLocaleFallbackMiddleware__no_accept_language_header(
+    rf,
+    tiny_localized_site,
+):
+    request = rf.get("/test-page/child-page/")
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/en-US/test-page/child-page/"
+
+
+def test_CMSLocaleFallbackMiddleware_fallback_to_most_preferred_and_existing_locale(
+    rf,
+    tiny_localized_site,
+):
+    # tiny_localized_site supports en-US, fr and pt-BR, but not de
+    request = rf.get(
+        "/test-page/child-page/",
+        HTTP_ACCEPT_LANGUAGE="de-DE,pt-BR;q=0.8,sco;q=0.6",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/pt-BR/test-page/child-page/"
+
+
+def test_CMSLocaleFallbackMiddleware_en_US_selected_because_is_in_accept_language_headers(
+    rf,
+    tiny_localized_site,
+):
+    # tiny_localized_site supports en-US, fr and pt-BR, but not de, so en-US should get picked
+    request = rf.get(
+        "/test-page/child-page/",
+        HTTP_ACCEPT_LANGUAGE="de-DE,en-US;q=0.9,fr;q=0.8,sco;q=0.6",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/en-US/test-page/child-page/"
+
+
+def test_CMSLocaleFallbackMiddleware_en_US_is_selected_as_fallback_locale(
+    rf,
+    tiny_localized_site,
+):
+    # tiny_localized_site supports en-US, fr and pt-BR, but not de, es-MX or sco
+    # so we should fall back to en-US
+    assert settings.LANGUAGE_CODE == "en-US"
+    request = rf.get(
+        "/test-page/child-page/",
+        HTTP_ACCEPT_LANGUAGE="de-DE,es-MX;q=0.8,sco;q=0.6",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/en-US/test-page/child-page/"
+
+
+def test_CMSLocaleFallbackMiddleware_url_path_without_trailing_slash(
+    rf,
+    tiny_localized_site,
+):
+    # Unlikely that this code path will get triggered in reality, but worth
+    # testing just in case
+
+    # tiny_localized_site supports en-US, fr and pt-BR, but not de
+    request = rf.get(
+        "/test-page/child-page",
+        HTTP_ACCEPT_LANGUAGE="de-DE,fr;q=0.8,sco;q=0.6",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/fr/test-page/child-page/"
+
+
+def test_CMSLocaleFallbackMiddleware_404_when_no_page_exists_in_any_locale(
+    rf,
+    tiny_localized_site,
+):
+    request = rf.get(
+        "/non-existent/page/",
+        HTTP_ACCEPT_LANGUAGE="de-DE,fr;q=0.8,sco;q=0.6",
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 404
+
+
+def test_CMSLocaleFallbackMiddleware_accept_language_header_lang_codes_are_converted(
+    rf,
+    tiny_localized_site,
+):
+    request = rf.get(
+        "/test-page/child-page/",
+        HTTP_ACCEPT_LANGUAGE="de-DE,Pt-bR;q=0.8,sco;q=0.6",  # note misformatted pt-BR
+    )
+    middleware = CMSLocaleFallbackMiddleware(get_response=get_404_response)
+    response = middleware(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/pt-BR/test-page/child-page/"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -713,6 +713,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "bedrock.mozorg.middleware.CacheMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    "bedrock.cms.middleware.CMSLocaleFallbackMiddleware",
 ]
 
 ENABLE_CSP_MIDDLEWARE = config("ENABLE_CSP_MIDDLEWARE", default="true", parser=bool)


### PR DESCRIPTION
This changeset addresses the problem where a request to path in a locale that is not in the CMS does not fall back to a locale variant for that path that _is_ in the CMS.

e.g. if /en-US/about/leadership/ exists in the CMS but /fr/about/leadership does not, typical Bedrock behaviour (for non-CMS pages) would be to redirect to the /en-US/ version as a fallback.

This changeset does more than just punt to en-US, though - it aims to redirect to the best-fit locale available in the CMS based on the user's Accept-Language header, and then will fall back to trying en-US

Fixes #15932

## Testing

* pull latest dev DB with make preflight
* go to http://localhost:8000/de/about/leadership - should 302 to /en-US/about/leadership
* go to http://localhost:8000/de/asdasdasdas - should 404 without redirecting
* set your browser language to something not `en-US` (eg `fr`) and go to http://localhost:8000/about/leadership - should 302 to /fr/about/leadership/ then 302 to /en-US/about/leadership/
* Please be evil and try and break things 
