### PR TITLE
Add ja+ko+zh to translations feature

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -26,6 +26,7 @@
 {% if LANG.startswith('en-') %}
   <li>Bulgarian</li>
   <li>Catalan</li>
+  <li>Chinese (Simplified)</li>
   <li>Croatian</li>
   <li>Czech</li>
   <li>Danish</li>
@@ -39,6 +40,8 @@
   <li>Hungarian</li>
   <li>Indonesian</li>
   <li>Italian</li>
+  <li>Japanese</li>
+  <li>Korean</li>
   <li>Latvian</li>
   <li>Lithuanian</li>
   <li>Polish</li>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -905,6 +905,7 @@ def firefox_features_translate(request):
     translate_langs = [
         "bg",
         "ca",
+        "zh-CN",
         "hr",
         "cs",
         "da",
@@ -918,6 +919,8 @@ def firefox_features_translate(request):
         "hu",
         "id",
         "it",
+        "ja",
+        "ko",
         "lv",
         "lt",
         "pl",


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 🤷 

## One-line summary

CJK languages added with Fx 135 launch.

## Significant changes and points to review

Launches Tue 4th Feb.

NB: The current logic strips any (regional) variants in brackets for the generated native names, so the _Chinese (Simplified)_ is listed as "中文" instead of "中文 (简体)":

> <img width="587" alt="Screenshot 2025-01-31 at 21 26 52" src="https://github.com/user-attachments/assets/99cf7a42-170d-46c1-9ca7-a8a7333b9c7b" />

(In case zh-TW is added to the list at some point, it would get listed as "繁体中文" in comparison. That looks reasonable enough, but doublechecking from a native speaker wouldn't hurt whether that's sufficiently politically correct?)

## Issue / Bugzilla link

Resolves #15954

## Testing

http://localhost:8000/en/firefox/features/translate/
http://localhost:8000/nl/firefox/features/translate/