### PR TITLE
Remove internal page UTM params

### DIFF
--- a/bedrock/base/templates/includes/banners/firefox-newsletter.html
+++ b/bedrock/base/templates/includes/banners/firefox-newsletter.html
@@ -15,7 +15,7 @@
     <div class="c-banner-copy">
       <h3 class="c-banner-title">Get the most out of Firefox with how-tos and online security tips.</h3>
       <p class="c-banner-cta">
-        <a class="c-banner-button mzp-c-button mzp-t-lg" href="{{ url('newsletter.firefox') }}?{{ utm_params }}" data-cta-text="Get Firefox news">
+        <a class="c-banner-button mzp-c-button mzp-t-lg" href="{{ url('newsletter.firefox') }}" data-cta-text="Get Firefox news" data-cta-position="banner">
           Get Firefox news
         </a>
       </p>

--- a/bedrock/firefox/templates/firefox/releases/index.html
+++ b/bedrock/firefox/templates/firefox/releases/index.html
@@ -20,8 +20,6 @@
 
 {% block body_class %}{{ super() }} mzp-t-firefox{% endblock %}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-releases' %}
-
 {% block content %}
   <main id="main-content" class="mzp-l-content">
     <a href="{{ url('firefox.new') }}">

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -53,8 +53,6 @@
   {% endif %}
 {% endblock %}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-release-notes' %}
-
 {% set channel_name = '' if release.channel == 'Release' else release.channel %}
 
 {% set download_title = download_title|default('Get the most recent version') %}


### PR DESCRIPTION
SEO issue: this will create multiple versions of the same page with different URLs

_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Rely on analytics events only for internal links. UTM params from:

release index: https://github.com/mozilla/bedrock/pull/15879/files#diff-2d4df3ebb9ddb808d359f7d02159c5f1a31a0af3bdf2c66fb522668140b7ea66R23
release notes: https://github.com/mozilla/bedrock/pull/15879/files#diff-49eefdd97979190284c15980e858f1b1caaf4376eea44474958f7a700d5d11a6R56

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/15960


## Testing
http://localhost:8000/en-US/firefox/releases/
http://localhost:8000/en-US/firefox/135.0/releasenotes/ 

The CTA link should not have any UTM params on the URL
<img width="323" alt="Screenshot 2025-02-03 at 9 22 42 AM" src="https://github.com/user-attachments/assets/b74791d6-1feb-4d3f-a2a5-2c6c2c71b849" />

