### PR TITLE
update links for Firefox share page de and fr versions (fix #15949)

### DIFF
--- a/bedrock/firefox/templates/firefox/share.html
+++ b/bedrock/firefox/templates/firefox/share.html
@@ -20,7 +20,7 @@
   {% set main_title = "Hol deine Freund*innen ins <br><strong>Team Firefox</strong>"|safe %}
   {% set page_description = "Wir glauben, als gute*r Freund*in solltest du sie auf die sonnige Seite des Internets einladen. Wir haben da mal was vorbereitet." %}
   {% set main_tagline = "Wir haben eine kleine Nachricht vorbereitet, die du mit deinen Liebsten teilen kannst, damit du dir nicht selbst etwas ausdenken musst. Wird keiner merken – versprochen!" %}
-  {% set share_message = "Hey! Ich wollte dir nur sagen, dass du echt schöne Augen hast. Ihre perfekte Form erinnert mich an das Firefox-Logo. Kennst du Firefox? Das ist dieser private, super verlässliche Browser. Eigentlich echt gut, hier ist ein Link, falls du dir den mal angucken willst: <a href='https://mzl.la/ctd-de'>mzl.la/ctd-de</a>. <br><br> Wie gehts dir eigentlich?"|safe%}
+  {% set share_message = "Hey! Ich wollte dir nur sagen, dass du echt schöne Augen hast. Ihre perfekte Form erinnert mich an das Firefox-Logo. Kennst du Firefox? Das ist dieser private, super verlässliche Browser. Eigentlich echt gut, hier ist ein Link, falls du dir den mal angucken willst: <a href='https://mzl.la/de-raf'>mzl.la/de-raf</a>. <br><br> Wie gehts dir eigentlich?"|safe%}
   {% set share_cta = "Kopieren und teilen" %}
   {% set text_copied = "Text kopiert!" %}
   {% set email_subject = "Komm ins Team Firefox!" %}
@@ -30,7 +30,7 @@
   {% set main_title = "Invitez vos amis à rejoindre la <br> <strong>team Firefox</strong>"|safe %}
   {% set page_description = "Nous pensons que, comme un bon ami, il est temps de les inviter à découvrir le bon côté de l'internet. Nous avons donc préparé quelque chose pour vous." %}
   {% set main_tagline = "Nous avons préparé un message personnel pour vos amis, afin que vous n'ayez pas à le faire vous-même. Ils ne se douteront de rien, c'est promis !" %}
-  {% set share_message = "Salut ! Je voulais juste te dire que tu as de beaux yeux. Leur forme parfaite me rappelle le logo de Firefox. Tu connais Firefox ? Ce navigateur privé, super fiable. Il est plutôt pas mal en vrai, voici un lien si tu veux le tester : <a href='https://mzl.la/ctd-fr'>mzl.la/ctd-fr</a>.<br><br> Sinon, comment vas-tu ?"|safe%}
+  {% set share_message = "Salut ! Je voulais juste te dire que tu as de beaux yeux. Leur forme parfaite me rappelle le logo de Firefox. Tu connais Firefox ? Ce navigateur privé, super fiable. Il est plutôt pas mal en vrai, voici un lien si tu veux le tester : <a href='https://mzl.la/fr-raf'>mzl.la/fr-raf</a>.<br><br> Sinon, comment vas-tu ?"|safe%}
   {% set share_cta = "Copier et partager" %}
   {% set text_copied = "Texte copié !" %}
   {% set email_subject = "Rejoins la team Firefox !" %}


### PR DESCRIPTION
## One-line summary

This PR updates links for Firefox share page de and fr versions

## Significant changes and points to review

http://localhost:8000/de/firefox/share/
http://localhost:8000/fr/firefox/share/

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15949

## Testing
