### PR TITLE
Migrate /newsletter to use Sass @use (#10896)

### DIFF
--- a/media/css/newsletter/newsletter-confirm.scss
+++ b/media/css/newsletter/newsletter-confirm.scss
@@ -2,11 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 // there's not much content on this page, so min-height
 // ensures a bit of breathing space before the footer.

--- a/media/css/newsletter/newsletter-country.scss
+++ b/media/css/newsletter/newsletter-country.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 
 .country-newsletter-form {
     select {

--- a/media/css/newsletter/newsletter-developer.scss
+++ b/media/css/newsletter/newsletter-developer.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .section-intro {
     background:

--- a/media/css/newsletter/newsletter-family.scss
+++ b/media/css/newsletter/newsletter-family.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .newsletter-main {
     background-color: $color-violet-60;

--- a/media/css/newsletter/newsletter-firefox-confirm.scss
+++ b/media/css/newsletter/newsletter-firefox-confirm.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
 
 main {
     min-height: 500px;

--- a/media/css/newsletter/newsletter-firefox.scss
+++ b/media/css/newsletter/newsletter-firefox.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .section-intro {
     .intro-image-container {

--- a/media/css/newsletter/newsletter-management.scss
+++ b/media/css/newsletter/newsletter-management.scss
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 // * -------------------------------------------------------------------------- */
 // Base styles.

--- a/media/css/newsletter/newsletter-management.scss
+++ b/media/css/newsletter/newsletter-management.scss
@@ -26,7 +26,7 @@ main {
     }
 
     .mzp-c-field {
-        padding-bottom: $label-v-spacing;
+        padding-bottom: form.$label-v-spacing;
     }
 }
 

--- a/media/css/newsletter/newsletter-monitor-waitlist.scss
+++ b/media/css/newsletter/newsletter-monitor-waitlist.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .section-subscribe {
     .mzp-l-content:first-child {

--- a/media/css/newsletter/newsletter-mozilla.scss
+++ b/media/css/newsletter/newsletter-mozilla.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .section-intro {
     background:

--- a/media/css/newsletter/newsletter-online-harassment.scss
+++ b/media/css/newsletter/newsletter-online-harassment.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .section-subscribe {
     .mzp-l-content:first-child {

--- a/media/css/newsletter/newsletter-opt-out-confirmation.scss
+++ b/media/css/newsletter/newsletter-opt-out-confirmation.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 /* -------------------------------------------------------------------------- */
 // Common elements

--- a/media/css/newsletter/newsletter-recovery.scss
+++ b/media/css/newsletter/newsletter-recovery.scss
@@ -3,10 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 @use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 /* stylelint-disable declaration-no-important */
 

--- a/media/css/newsletter/newsletter-recovery.scss
+++ b/media/css/newsletter/newsletter-recovery.scss
@@ -12,7 +12,7 @@
 
 .newsletter-recovery-form {
     .mzp-c-field {
-        padding-bottom: $label-v-spacing;
+        padding-bottom: form.$label-v-spacing;
     }
 
     .mzp-c-form-errors {

--- a/media/css/newsletter/newsletter-security-privacy-news.scss
+++ b/media/css/newsletter/newsletter-security-privacy-news.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .section-subscribe {
     .mzp-l-content:first-child {

--- a/media/css/newsletter/newsletter-updated.scss
+++ b/media/css/newsletter/newsletter-updated.scss
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
-@import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/components/notification-bar';
 
 // * -------------------------------------------------------------------------- */
 // newsletter/updated custom styles.


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Removes usage of `@import` from /newsletter style sheets.

Sets lib with config values where notification component or references to `$image-path` are needed

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/10896

## Testing (in progress)
http://localhost:8000/en-US/newsletter/security-and-privacy/
http://localhost:8000/en-US/newsletter/security-and-privacy/online-harassment/
http://localhost:8000/en-US/newsletter/confirm/thanks/
http://localhost:8000/en-US/newsletter/updated/
http://localhost:8000/en-US/newsletter/recovery/
http://localhost:8000/en-US/newsletter/opt-out-confirmation/
http://localhost:8000/en-US/newsletter/mozilla/
http://localhost:8000/en-US/newsletter/firefox/
http://localhost:8000/en-US/newsletter/developer/
http://localhost:8000/en-US/newsletter/monitor-waitlist/
http://localhost:8000/en-US/newsletter/family/

nl-token cookie with token value is required for UUID urls (go to https://www.mozilla.org/en-US/newsletter/recovery/ to get access to a token if you do not already have one stored)
http://localhost:8000/en-US/newsletter/firefox/confirm/<uuid:token>/
http://localhost:8000/en-US/newsletter/country/<uuid:token>/
http://localhost:8000/en-US/newsletter/existing/<uuid:token>
