### PR TITLE
remove duplicate CSS bundle (fix #15972)

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -263,12 +263,6 @@
     },
     {
       "files": [
-        "css/m24/base-navigation-and-footer.scss"
-      ],
-      "name": "m24-navigation-and-footer"
-    },
-    {
-      "files": [
         "css/legal/legal.scss"
       ],
       "name": "legal"


### PR DESCRIPTION

## One-line summary

This PR removes duplicate CSS bundle in `media/static-bundles.json`

## Significant changes and points to review

Test header and footer still functioning as expected.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15972

## Testing

http://localhost:8000/en-US/