### PR TITLE
Give newsletter landmark a separate aria identifier to the pencil banner (Fixes #15958)

### DIFF
--- a/bedrock/base/templates/includes/banners/base.html
+++ b/bedrock/base/templates/includes/banners/base.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-<aside class="c-banner hide-from-legacy-ie {% block banner_class %}{% endblock %}" id="{% block banner_id %}{% endblock %}" aria-label="{{ ftl('ui-promo-label') }}">
+<aside class="c-banner hide-from-legacy-ie {% block banner_class %}{% endblock %}" id="{% block banner_id %}{% endblock %}" aria-label="{% if aria_label %}{{ aria_label }}{% else %}{{ ftl('ui-promo-label') }}{% endif %}">
   {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
   <div class="c-banner-inner" data-nosnippet="true">
     <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>

--- a/bedrock/base/templates/includes/banners/basic.html
+++ b/bedrock/base/templates/includes/banners/basic.html
@@ -5,7 +5,7 @@
 #}
 
 {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
-<aside class="c-banner hide-from-legacy-ie {% block banner_class %}{% endblock %}" id="{% block banner_id %}{% endblock %}" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
+<aside class="c-banner hide-from-legacy-ie {% block banner_class %}{% endblock %}" id="{% block banner_id %}{% endblock %}" aria-label="{% if aria_label %}{{ aria_label }}{% else %}{{ ftl('ui-promo-label') }}{% endif %}" data-nosnippet="true">
   <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>
   {% block banner_content %}{% endblock%}
 </aside>

--- a/bedrock/firefox/templates/firefox/releases/index.html
+++ b/bedrock/firefox/templates/firefox/releases/index.html
@@ -62,7 +62,10 @@
   </main>
 
   {% if switch('release-notes-newsletter-banner', ['en']) %}
-    {% include 'includes/banners/firefox-newsletter.html' %}
+    {# Give newsletter landmark a separate aria identifier to the pencil banner: https://github.com/mozilla/bedrock/issues/15958 #}
+    {% with aria_label = 'Newsletter' %}
+      {% include 'includes/banners/firefox-newsletter.html' %}
+    {% endwith %}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -394,7 +394,10 @@
 </main>
 
 {% if switch('release-notes-newsletter-banner', ['en']) %}
-  {% include 'includes/banners/firefox-newsletter.html' %}
+  {# Give newsletter landmark a separate aria identifier to the pencil banner: https://github.com/mozilla/bedrock/issues/15958 #}
+  {% with aria_label = 'Newsletter' %}
+    {% include 'includes/banners/firefox-newsletter.html' %}
+  {% endwith %}
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Currently both the pencil banner and the newsletter banner are identified as `Promotion`. This PR adds a unique aria-label of `Newsletter` for the latter, so they can be more easily identified / navigated to.

## Issue / Bugzilla link

#15958

## Testing

http://localhost:8000/en-US/firefox/134.0/releasenotes/

A11y tests should pass:

- `cd tests/playwright`
- `npm run a11y-tests`