### PR TITLE
update EN Firefox Share LP copy

### DIFF
--- a/bedrock/firefox/templates/firefox/share.html
+++ b/bedrock/firefox/templates/firefox/share.html
@@ -41,7 +41,7 @@
   {% set main_title = "Invite your friends to <br> <strong>Team Firefox</strong>"|safe %}
   {% set page_description = "As a good friend, we think you should invite your buds to the sunny side of the internet. We have a little something prepared." %}
   {% set main_tagline = "We’ve prepared a little message that you can share with your loved ones so you don't have to think of something yourself. Nobody will notice – promise!" %}
-  {% set share_message = "Experience the internet the way you want — without the data tradeoffs. Have you heard of Firefox? It’s a private, reliable and fast browser with hands-down the best logo. Here’s a link if you want to check it out. <a href='https://mzl.la/us-raf'>mzl.la/us-raf</a>."|safe%}
+  {% set share_message = "Experience the internet the way you want. Have you heard of Firefox? It’s a private, reliable and fast browser with hands-down the best logo. Here’s a link if you want to check it out. <a href='https://mzl.la/us-raf'>mzl.la/us-raf</a>."|safe%}
   {% set share_cta = "Copy and share" %}
   {% set text_copied = "Text copied!" %}
   {% set sign_off = "<strong>Powered by Mozilla.</strong> <br> Putting people before profits since 1998."|safe %}


### PR DESCRIPTION
## One-line summary

This PR updates the copy of the EN version Firefox share landing page.

## Significant changes and points to review

Copy change

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15861

## Testing

http://localhost:8000/en-US/firefox/share/
http://localhost:8000/en-CA/firefox/share/