### PR TITLE
create shared and unshared CSS bundles for M24 home and about us pages (fix #15907)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/index-m24.html
+++ b/bedrock/mozorg/templates/mozorg/about/index-m24.html
@@ -18,6 +18,7 @@
 {% block page_css %}
   {{ css_bundle('m24-root') }}
   {{ css_bundle('m24-base') }}
+  {{ css_bundle('m24-about') }}
 {% endblock %}
 
 {% set utm_params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=m24-about' %}

--- a/bedrock/mozorg/templates/mozorg/home/home-m24.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-m24.html
@@ -28,6 +28,7 @@
 {% block page_css %}
   {{ css_bundle('m24-root') }}
   {{ css_bundle('m24-base') }}
+  {{ css_bundle('m24-home') }}
   {% if show_fundraising_banner %}
     {{ css_bundle('fundraising-banner') }}
   {% endif %}

--- a/media/css/m24/about.scss
+++ b/media/css/m24/about.scss
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// variables
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use 'vars/lib' as *;
+
+// components
+@use 'careers';
+@use 'feature';

--- a/media/css/m24/base.scss
+++ b/media/css/m24/base.scss
@@ -8,15 +8,9 @@
 
 // components
 @use 'button';
-@use 'careers';
 @use 'intro';
-@use 'donate';
-@use 'feature';
-@use 'flag';
 @use 'gallery';
 @use 'showcase';
-@use 'launchpad';
-@use 'springboard';
 @use 'theme';
 @use 'transition';
 
@@ -60,11 +54,6 @@ a:visited {
 }
 
 /* ------------------------------------------------------------------------------- */
-
-.m24-c-container {
-    @include container;
-}
-
 .m24-c-content {
     @include container;
     padding-top: $spacer-xl;

--- a/media/css/m24/home.scss
+++ b/media/css/m24/home.scss
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// variables
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use 'vars/lib' as *;
+
+// components
+@use 'donate';
+@use 'flag';
+@use 'launchpad';
+@use 'springboard';

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1175,6 +1175,18 @@
       "name": "m24-base"
     },
     {
+      "files":  [
+        "css/m24/home.scss"
+      ],
+      "name": "m24-home"
+    },
+    {
+      "files":  [
+        "css/m24/about.scss"
+      ],
+      "name": "m24-about"
+    },
+    {
       "files": [
         "css/m24/root.scss",
         "css/protocol/protocol-mozilla-2024.scss"


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR create shared and unshared CSS bundles for M24 home and about us pages.

## Significant changes and points to review

1. `media/css/m24/base.scss` becomes the new shared stylesheet between home and about page
2. `media/css/m24/home.scss` and media/css/m24/about.scss are the unique stylesheet for home and about page respectively 


## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15907

## Testing

1. Check out this PR
2. Compare home and about page with production site