### PR TITLE
Fix media path for bluesky image

### DIFF
--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -38,7 +38,7 @@ $image-path: '/media/protocol/img';
             }
 
             &.bluesky {
-                background-image: url('media/img/icons/social/bluesky/white.svg');
+                background-image: url('/media/img/icons/social/bluesky/white.svg');
             }
 
             &.instagram {


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


Fix CI error

> #47 4.534 ValueError: The file ‘css/media/img/icons/social/bluesky/white.svg’ could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x7fb246ba63c0>.

Fails to resolve image in old footer without slash
<img width="264" alt="Screenshot 2025-02-11 at 4 31 05 PM" src="https://github.com/user-attachments/assets/549dc5c5-fc1e-4e39-84dc-286f293c6bc1" />


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
http://localhost:8000/en-US/ with M24_WEBSITE_REFRESH: off
<img width="1309" alt="Screenshot 2025-02-11 at 4 30 52 PM" src="https://github.com/user-attachments/assets/c69b1562-fcac-47f3-9bc0-52974b0becad" />

