### PR TITLE
Add 2024 dsa transparency report

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/2024.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/2024.html
@@ -1,0 +1,39 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}2024 Transparency Reports{% endblock %}
+
+{% block report_title %}
+<h1>2024 Transparency Reports</h1>
+{% endblock %}
+
+{% block report_body %}
+<div class="c-2024-back-link">
+  <img src="{{ static('img/icons/m24-small/left-arrow.svg') }}" alt="">
+  <a href="{{ url('mozorg.about.policy.transparency.index') }}">Mozilla Transparency</a>
+</div>
+<section>
+  <p>Mozilla has traditionally published transparency reports bi-annually. For 2024, in order to comply with the EU Digital Services Act (DSA), Mozilla is including all DSA-required data for the year in a single report. This report will not include information we have traditionally published, such as details about our advertising campaigns and policy advocacy.</p>
+  <p>We made significant improvements to our content moderation systems in 2024, which impacted our data management processes and procedures. In order to ensure the accuracy and completeness of our report, we have omitted certain categories of DSA-related data from the initial version of the report, and made a note of the omitted categories.</p>
+  <p>Mozilla will publish additional information—including the omitted DSA-related data categories and details about our advertising and policy activities, as well as details about requests from and disclosures to governments outside the EU—by March 2025.</p>
+  <ul class="c-2024-reports">
+    <li>
+      <a download class="mzp-c-button" href="https://assets.mozilla.net/pdf/transparency-report/2024-dsa.pdf">2024 DSA Transparency Report <span class="mzp-c-button-icon-end"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <title>Download</title>
+        <path fill="currentColor" d="M19.5 17.31v2.13H4.72v-2.13h-2.6v4.73H22.1v-4.73h-2.6z"/>
+        <path fill="currentColor" d="M21.44 7.09h-8.03V2.06h-2.6v5.03H2.78l9.33 11.09 9.33-11.09Zm-5.59 2.59-3.74 4.46-3.74-4.46h7.48Z"/>
+      </svg></span></a>
+    </li>
+    <li>
+      <a class="mzp-c-button mzp-t-secondary" href="{{ url('mozorg.about.policy.transparency.jan-jun-2024') }}">January 1, 2024 to June 30, 2024</a>
+    </li>
+  </ul>
+</section>
+{% endblock%}
+
+{% block report_nav %}{% endblock%}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -15,7 +15,7 @@
     </li>
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2024') }}">January 1, 2024 to June 30, 2024</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.2024') }}">2024</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -87,6 +87,7 @@ urlpatterns = [
     page("about/policy/transparency/jan-jun-2023/", "mozorg/about/policy/transparency/jan-jun-2023.html"),
     page("about/policy/transparency/jul-dec-2023/", "mozorg/about/policy/transparency/jul-dec-2023.html"),
     page("about/policy/transparency/jan-jun-2024/", "mozorg/about/policy/transparency/jan-jun-2024.html"),
+    page("about/policy/transparency/2024/", "mozorg/about/policy/transparency/2024.html"),
     page("contact/", "mozorg/contact/contact-landing.html"),
     page("contact/spaces/", "mozorg/contact/spaces/spaces-landing.html"),
     page("MPL/", "mozorg/mpl/index.html"),

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -132,3 +132,46 @@ h3 {
 .c-collapsible-section .is-closed[aria-hidden='true'] {
     display: none;
 }
+
+// * -------------------------------------------------------------------------- */
+// Custom 2024 page
+$mzp-v-spacing: var(--v-grid-md);
+
+.c-2024-back-link {
+    display: flex;
+    gap: $spacing-xs;
+    margin-bottom: $spacing-xl;
+
+    @media #{$mq-md} {
+        margin-bottom: $spacing-2xl;
+    }
+
+    img {
+        padding: $spacing-xs;
+        box-sizing: border-box;
+        height: 1.5rem;
+    }
+}
+
+.c-2024-reports {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-md;
+    margin-top: $spacing-2xl;
+
+    a {
+        width: 100%;
+    }
+
+    @media #{$mq-md} {
+        flex-flow: row wrap;
+
+        > * {
+            flex-shrink: 0;
+        }
+
+        a {
+            width: auto;
+        }
+    }
+}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This report needs to be available by Friday. 

## Significant changes and points to review

This report needs to be available by Friday. We have a new 2024 page that doesn't follow the typical report page structure to accommodate this. We may revisit when we have more time. 

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/15987


## Testing
[Figma](https://www.figma.com/design/vrlLvrKml9oFs5xFMLMo7W/Transparency-Pages?node-id=1-30221&m=dev) [Moz only]

- [x] http://localhost:8000/en-US/about/policy/transparency
- the final button is 2024 (the previous jan-jun-2024 report will be included on 2024 page)

- [x] http://localhost:8000/en-US/about/policy/transparency/2024/
-  intro copy matches the doc from the issue
- design matches Figma (with exception of left arrow for back link, I used an existing asset)
- one button downloads report and the other links to jan-jun-2024 report