### PR TITLE
Bump @mozmeao/trafficcop to v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mozmeao/consent-banner": "^1.1.0",
         "@mozmeao/cookie-helper": "^1.1.0",
         "@mozmeao/dnt-helper": "^1.0.0",
-        "@mozmeao/trafficcop": "^3.0.0",
+        "@mozmeao/trafficcop": "^3.1.0",
         "@sentry/browser": "^8.53.0",
         "babel-loader": "^9.2.1",
         "caniuse-lite": "^1.0.30001696",
@@ -2084,9 +2084,9 @@
       "integrity": "sha512-Q+fu1VBdG8x/WtJV+5mLXTF5/QJTiHQNWlE4Jf5kqsQw5cEKxjUHLD4qfxcuvwRkbErXyDz1xpWuTglBzIhedw=="
     },
     "node_modules/@mozmeao/trafficcop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-3.0.0.tgz",
-      "integrity": "sha512-pV3ZCbTwjO8dEcUCFeNLWcQIskSvYxUl1DDMF5GuA5cZhwBesV4WAjPLiM65j8J5LHq5qVYi9aI6F/nOe46oBQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mozmeao/trafficcop/-/trafficcop-3.1.0.tgz",
+      "integrity": "sha512-FKpKBIJWaFG+aRZ/RkAsFsjQ8QmJkmvvmxT1ThnaFprVY5m1VCES7rvZ4mani/MvGpuJ4zlyw2bltL42VpENNw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mozmeao/consent-banner": "^1.1.0",
     "@mozmeao/cookie-helper": "^1.1.0",
     "@mozmeao/dnt-helper": "^1.0.0",
-    "@mozmeao/trafficcop": "^3.0.0",
+    "@mozmeao/trafficcop": "^3.1.0",
     "@sentry/browser": "^8.53.0",
     "babel-loader": "^9.2.1",
     "caniuse-lite": "^1.0.30001696",


### PR DESCRIPTION
## One-line summary

See https://github.com/mozmeao/trafficcop/releases/tag/v3.1.0

## Significant changes and points to review

There should be no changes that impact any active experiments

## Issue / Bugzilla link

N/A

## Testing

Test in a browser with DNT/GPC disabled

- [x] Home page donation banner experiment should still redirect as expected: http://localhost:8000/en-US/