### PR TITLE
fix missing French translation for moments page (fix #15986)

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page25.html
+++ b/bedrock/firefox/templates/firefox/welcome/page25.html
@@ -22,7 +22,7 @@
   {% set cta_text = 'Jetzt aktualisieren' %}
   {% set description = 'Dauert normalerweise 2–3 Minuten' %}
 {% elif LANG == 'fr' %}
-  {% set old_version = 'You’re on an older version of Firefox' %}
+  {% set old_version = 'Vous utilisez une ancienne version de Firefox' %}
   {% set main_title = 'Des fonctionnalités de Firefox cesseront de fonctionner le 14 mars 2025' %}
   {% set main_tagline = 'Les vidéos en streaming, les extensions et d’autres fonctionnalités de votre version de Firefox cesseront de fonctionner car un certificat racine arrive à expiration.' %}
   {% set read_more = 'En savoir plus' %}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR adds the missing French translation for the moments page.

## Significant changes and points to review

Review notification content for `fr` locale

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/15986

## Testing

http://localhost:8000/fr/firefox/welcome/25/