### PR TITLE
Fix strings for dev VNP, add MDN to Fluent linter

### DIFF
--- a/.github/l10n/linter_config.yml
+++ b/.github/l10n/linter_config.yml
@@ -22,9 +22,11 @@ CO01:
   brands:
     - Fakespot
     - Firefox
+    - MDN
     - Mozilla
     - Pocket
     - "{ -brand-name-mozilla } account"
   exclusions:
     files: []
-    messages: []
+    messages:
+      - footer-refresh-mdn

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -57,7 +57,7 @@
               <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-refresh-developer-edition') }}</a></li>
               <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-refresh-enterprise') }}</a></li>
               <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-refresh-tools') }}</a></li>
-              <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn') }}</a></li>
+              <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn-v2', fallback="footer-refresh-mdn") }}</a></li>
             </ul>
           </section>
         </div>

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -88,10 +88,10 @@ firefox-developer-mdn-web-docs = { -brand-name-mdn-web-docs }
 firefox-developer-resources-for-developers = Resources for Developers, by Developers
 firefox-developer-mdn-playground = Playground
 firefox-developer-mdn-write-test-and-share = Write, test and share your code. Your playground to learn and share your amazing work with the world.
-firefox-developer-mdn-blog = MDN Blog
-firefox-developer-mdn-unlock-the-world = Unlock the world of web development with the MDN Blog - your go-to hub for expert insights, latest web standards, and coding tips.
+firefox-developer-mdn-blog = { -brand-name-mdn } Blog
+firefox-developer-mdn-unlock-the-world = Unlock the world of web development with the { -brand-name-mdn } Blog — your go-to hub for expert insights, latest web standards, and coding tips.
 firefox-developer-mdn-updates = Updates
-firefox-developer-mdn-the-web-doesnt-have = The Web doesn’t have a changelog, but MDN can help. You can personalize and filter compatibility changes based on browsers or the tech category you are interested in whether that is JavaScript, CSS, etc.
+firefox-developer-mdn-the-web-doesnt-have = The web doesn’t have a changelog, but { -brand-name-mdn } can help. You can personalize and filter compatibility changes based on browsers or the tech category you are interested in whether that is JavaScript, CSS, etc.
 # Obsolete string (expires 18-04-2025)
 firefox-developer-mdn-references = { -brand-name-mdn } References
 # Obsolete string (expires 18-04-2025)

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -6,6 +6,8 @@ footer-refresh-discover-mozilla-products =Discover { -brand-name-mozilla } produ
 footer-refresh-leadership = Leadership
 footer-refresh-advertise = Advertise with { -brand-name-mozilla }
 footer-refresh-firefox-release-notes = { -brand-name-firefox } Release Notes
+footer-refresh-mdn-v2 = { -brand-name-mdn }
+# Obsolete string (expires 22-04-2025)
 footer-refresh-mdn = MDN
 footer-refresh-follow-mozilla = Follow @{ -brand-name-mozilla }
 footer-refresh-mastodon = Mastodon


### PR DESCRIPTION
## One-line summary

This fixes string issues introduced in #16007. It also introduces a brand check on MDN, and fixes a previous string used in the footer.

The strings are still stuck in review in https://github.com/mozilla-l10n/www-l10n/pull/479, no need for new IDs (cc @peiying2) 
