### PR TITLE
Fix failing tests: remove smooth scroll

### DIFF
--- a/media/css/protocol/protocol-mozilla-2024.scss
+++ b/media/css/protocol/protocol-mozilla-2024.scss
@@ -34,15 +34,6 @@
 @import '../m24/vars/fonts';
 @import '../m24/vars/text';
 
-// smooth scroll
-html {
-    scroll-behavior: smooth;
-
-    @media (prefers-reduced-motion: reduce) {
-        scroll-behavior: auto;
-    }
-}
-
 // Temporary styling until the newsletter component is updated in Protocol
 // https://github.com/mozilla/protocol/issues/578
 


### PR DESCRIPTION
## One-line summary

Remove smooth scroll.

## Significant changes and points to review

- integration tests are complaining about not being able to scroll elements into view, this should fix it.

## Issue / Bugzilla link

n/a

## Testing
