### PR TITLE
Remove superfluous JS bundle from new privacy/firefox notice (Fixes #16031)

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/firefox-2025.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-2025.html
@@ -68,11 +68,6 @@
   {{ doc|safe }}
 {% endblock %}
 
-{% block js %}
-  {{ super() }}
-  {{ js_bundle('privacy_firefox') }}
-{% endblock %}
-
 {# disable GA on Fx Privacy Notice. Bug 1576673 #}
 {% block google_analytics %}{% endblock %}
 {% block glean %}{% endblock %}


### PR DESCRIPTION
## One-line summary

It seems like this bundle is only applicable to the old privacy notice.

## Issue / Bugzilla link

#16031

## Testing

http://localhost:8000/en-US/privacy/firefox/