### PR TITLE
Update privacy/faq page copy (Fixes #16029)

### DIFF
--- a/bedrock/privacy/templates/privacy/faq-v2.html
+++ b/bedrock/privacy/templates/privacy/faq-v2.html
@@ -86,7 +86,7 @@
           {{ ftl('privacy-faq-v2-sort-of') }}
         </p>
         <p>
-          {{ ftl('privacy-faq-v2-we-may-also', attrs='href="https://support.mozilla.org/kb/shield')}}
+          {{ ftl('privacy-faq-v2-we-may-also', attrs='href="https://support.mozilla.org/kb/shield"')}}
         </p>
         <p>
           {{ ftl('privacy-faq-v2-mozilla-pre-release') }}

--- a/bedrock/privacy/templates/privacy/faq-v2.html
+++ b/bedrock/privacy/templates/privacy/faq-v2.html
@@ -1,0 +1,148 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "privacy/base-protocol.html" %}
+
+{% block page_title %}{{ ftl('privacy-faq-v2-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('privacy-faq-v2-desc') }}{% endblock %}
+
+{% block body_id %}privacy-faq{% endblock %}
+{% block body_class %}mzp-t-mozilla{% endblock %}
+
+{% block article %}
+  <header>
+    <h1 class="mzp-c-article-title" itemprop="name">{{ self.page_title() }}</h1>
+  </header>
+  <div itemprop="articleBody" class="mzp-c-article">
+    <h2>
+      {{ ftl('privacy-faq-v2-heading') }}
+    </h2>
+    <p>
+      {{ ftl('privacy-faq-v2-intro') }}
+    </p>
+    <p>
+      {{ ftl('privacy-faq-v2-at-mozilla') }}
+    </p>
+
+    <ul class="mzp-u-list-styled">
+      <li>
+        {{ ftl('privacy-faq-v2-we-follow', attrs='href="' + url('privacy.principles') + '"') }}
+      </li>
+      <li>
+        {{ ftl('privacy-faq-v2-we-strive-collect-data') }}
+      </li>
+      <li>
+        {{ ftl('privacy-faq-v2-we-work-to') }}
+      </li>
+      <li>
+        {{ ftl('privacy-faq-v2-we-adhere') }}
+      </li>
+    </ul>
+
+    <p>
+      {{ ftl('privacy-faq-v2-following-questions') }}
+    </p>
+
+    <dl class="mzp-u-list-styled">
+      <dt>
+        {{ ftl('privacy-faq-v2-i-use-firefox') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-mozilla-does-not-know') }}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-it-seems-like') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-mozilla-does-not-sell', attrs='href="https://support.mozilla.org/kb/ohttp-explained"') }}
+        </p>
+      <dt>
+         {{ ftl('privacy-faq-v2-wait-so-how') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-mozilla-is-not', attrs='href="https://stateof.mozilla.org/"')}}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-softballs') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-mozilla-does-collect', privacy='href="' + url('privacy.notices.firefox') + '"', data='href="https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry"')}}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-do-you-collect') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-sort-of') }}
+        </p>
+        <p>
+          {{ ftl('privacy-faq-v2-we-may-also', attrs='href="https://support.mozilla.org/kb/shield')}}
+        </p>
+        <p>
+          {{ ftl('privacy-faq-v2-mozilla-pre-release') }}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-but-why-do-you') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-if-we-dont-know', attrs='href="https://support.mozilla.org/kb/ohttp-explained"')}}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-data-collection-bugs-me') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-yes-user-control', privacy='href="https://support.mozilla.org/kb/firefox-options-preferences-and-settings"', data='href="https://support.mozilla.org/kb/technical-and-interaction-data"') }}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-what-about-my-account') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-we-are-big-believers') }}
+        </p>
+        <p>
+          {{ ftl('privacy-faq-v2-you-dont-need-an-account', attrs='href="' + url('mozorg.account') + '"')}}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-you-use-digital') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-no-we-do-not-buy') }}
+        </p>
+        <p>
+          {{ ftl('privacy-faq-v2-we-do-not-ask') }}
+        </p>
+      </dd>
+      <dt>
+        {{ ftl('privacy-faq-v2-well-it-seems') }}
+      </dt>
+      <dd>
+        <p>
+          {{ ftl('privacy-faq-v2-yes-we-do') }}
+        </p>
+      </dd>
+    </dl>
+
+    <p>
+      <a href="https://internethealthreport.org/">{{ ftl('privacy-faq-v2-find-out-more') }}</a>
+    </p>
+
+  </div>
+{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -10,7 +10,7 @@ from bedrock.privacy import views
 urlpatterns = (
     path("", views.privacy, name="privacy"),
     page("principles/", "privacy/principles.html", ftl_files=["privacy/principles", "privacy/index"]),
-    page("faq/", "privacy/faq.html", ftl_files=["privacy/faq", "privacy/index"]),
+    path("faq/", views.FAQView.as_view(), name="privacy.faq"),
     page("email/", "privacy/email.html", active_locales=["en-US", "de", "fr"]),
     path("firefox/", views.firefox_notices, name="privacy.notices.firefox"),
     path("firefox-focus/", views.firefox_focus_notices, name="privacy.notices.firefox-focus"),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 
 from bedrock.legal_docs.views import LegalDocView, load_legal_doc
 from lib import l10n_utils
+from lib.l10n_utils.fluent import ftl_file_is_active
 
 HN_PATTERN = re.compile(r"^h(\d)$")
 HREF_PATTERN = re.compile(r"^https?\:\/\/www\.mozilla\.org")
@@ -88,3 +89,18 @@ def privacy(request):
     }
 
     return l10n_utils.render(request, "privacy/index.html", template_vars, ftl_files="privacy/index")
+
+
+class FAQView(l10n_utils.L10nTemplateView):
+    ftl_files_map = {
+        "privacy/faq-v2.html": ["privacy/faq-v2", "privacy/index"],
+        "privacy/faq.html": ["privacy/faq", "privacy/index"],
+    }
+
+    def get_template_names(self):
+        if ftl_file_is_active("privacy/faq-v2"):
+            template_name = "privacy/faq-v2.html"
+        else:
+            template_name = "privacy/faq.html"
+
+        return [template_name]

--- a/l10n/en/privacy/faq-v2.ftl
+++ b/l10n/en/privacy/faq-v2.ftl
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/privacy/faq
+
+# HTML page title
+privacy-faq-v2-title = { -brand-name-mozilla }’s Data Privacy FAQ
+
+# HTML page description
+privacy-faq-v2-desc = At { -brand-name-mozilla }, we respect and protect your personal information.
+
+privacy-faq-v2-heading = We Stand for People Over Profit.
+privacy-faq-v2-intro = It can be tricky for people to know what to expect of any software or services they use today. The technology that powers our lives is complex and people don’t have the time to dig into the details. That is still true for { -brand-name-firefox }, where we find that people have many different ideas of what is happening under the hood in their browser.
+privacy-faq-v2-at-mozilla = At { -brand-name-mozilla }, we respect and protect your personal information:
+
+# Variables:
+#   $attrs (url) - link to https://www.mozilla.org/privacy/principles/
+privacy-faq-v2-we-follow = We follow a set of <a { $attrs }>Data Privacy Principles</a> that shape our approach to privacy in the { -brand-name-firefox } desktop and mobile browsers.
+
+privacy-faq-v2-we-strive-collect-data = We strive to only collect the data we need to make the best products.
+privacy-faq-v2-we-work-to = We work to put people in control of their data and online experiences.
+privacy-faq-v2-we-adhere = We adhere to the “no surprises” principle, meaning we work hard to ensure people’s understanding of { -brand-name-firefox } matches reality.
+privacy-faq-v2-following-questions = The following questions and answers should help you understand what to expect from { -brand-name-mozilla } and { -brand-name-firefox }:
+
+## FAQ
+
+privacy-faq-v2-i-use-firefox = I use { -brand-name-firefox } for almost everything on the web. You folks at { -brand-name-mozilla } must know a ton of stuff about me, right?
+privacy-faq-v2-mozilla-does-not-know = { -brand-name-mozilla } doesn’t know as much as you’d expect about how people browse the web. { -brand-name-firefox }, the web browser that runs on your device or computer, is your gateway to the internet. Your browser will manage a lot of information about the websites you visit, but that information generally stays on your device.
+privacy-faq-v2-it-seems-like = It seems like every company on the web is buying and selling my data. You’re probably no different.
+
+# Variables:
+#   $attrs (url) - link to https://support.mozilla.org/kb/ohttp-explained
+privacy-faq-v2-mozilla-does-not-sell = { -brand-name-mozilla } doesn’t sell data about you (in the way that most people think about “selling data“), and we don’t buy data about you. Since we strive for transparency, and the LEGAL definition of “sale of data“ is extremely broad in some places, we’ve had to step back from making the definitive statements you know and love. We still put a lot of work into making sure that the data that we share with our partners (which we need to do to make { -brand-name-firefox } commercially viable) is stripped of any identifying information, or shared only in the aggregate, or is put through our privacy preserving technologies (like <a { $attrs }>OHTTP</a>).
+
+privacy-faq-v2-wait-so-how = Wait, so how do you make money?
+
+# Variables:
+#   $attrs (url) - link to https://stateof.mozilla.org
+privacy-faq-v2-mozilla-is-not = { -brand-name-mozilla } is not your average organization. Founded as a community open source project in 1998, { -brand-name-mozilla } is a mission-driven organization working towards a more healthy internet. The majority of { -brand-name-mozilla-corporation }’s revenue is from royalties earned through { -brand-name-firefox } web browser search partnerships and distribution deals around the world. You can learn more about how we make money in our <a { $attrs }">annual financial report</a>.
+
+privacy-faq-v2-softballs = Okay, those first few were softballs. What data do you collect?
+
+# Variables:
+#   $privacy (url) - link to https://www.mozilla.org/privacy/firefox/
+#   $data (url) - link to https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/
+privacy-faq-v2-mozilla-does-collect = { -brand-name-mozilla } does collect a limited set of data by default from { -brand-name-firefox } that helps us to understand how people use the browser. You can read more about that in our <a { $privacy }>privacy notice</a> and read the <a { $data }>full documentation for that data collection</a>. We also make our documentation public so that anyone can verify what we say is true, tell us if we need to improve, and have confidence that we aren’t hiding anything.
+
+privacy-faq-v2-do-you-collect = Do you collect more data in pre-release versions of { -brand-name-firefox }?
+privacy-faq-v2-sort-of = Sort-of. In addition to the data described above, we receive crash and error reports by default in pre-release versions of { -brand-name-firefox }.
+
+# Variables:
+#   $privacy (url) - link to https://support.mozilla.org/kb/shield
+privacy-faq-v2-we-may-also = We may also collect additional data in pre-release for one of our <a { $attrs }>studies</a>. For example, some studies require what we call “browsing data”, which may include URLs and other information about certain websites. This helps us answer specific questions to improve { -brand-name-firefox }, such as, how to better integrate popular websites in specific locales.
+
+privacy-faq-v2-mozilla-pre-release = { -brand-name-mozilla }’s pre-release versions of { -brand-name-firefox } are development platforms, frequently updated with experimental features. We collect more data in pre-release than what we do after release in order to understand how these experimental features are working. You can opt out of having this data collected in preferences.
+
+privacy-faq-v2-but-why-do-you = But why do you collect any data at all?
+
+# Variables:
+#   $privacy (url) - link to https://support.mozilla.org/kb/ohttp-explained
+privacy-faq-v2-if-we-dont-know = If we don’t know how the browser is performing or which features people use, we can’t make it better and deliver the great product you want. We’ve invested in building data collection and analysis tools that allow us to make smart decisions about our product while respecting people’s privacy. You can read more about some of the privacy preserving technologies we use, like <a { $attrs }>OHTTP</a>.
+
+privacy-faq-v2-data-collection-bugs-me = Data collection still bugs me. Can I turn it off?
+
+# Variables:
+#   $privacy (url) - link to https://support.mozilla.org/kb/firefox-options-preferences-and-settings
+#   $data (url) - link to https://support.mozilla.org/kb/technical-and-interaction-data
+privacy-faq-v2-yes-user-control = Yes. User control is one of our data privacy principles. We put that into practice in { -brand-name-firefox } on our <a { $privacy }>privacy settings page</a>, which serves as a one-stop shop for anyone looking to take control of their privacy in { -brand-name-firefox }. You can <a { $data }>turn off data collection</a> there.
+
+privacy-faq-v2-what-about-my-account = What about my account data?
+privacy-faq-v2-we-are-big-believers = We are big believers of data minimization and not asking for things we don’t need.
+
+# Variables:
+#   $attrs (url) - link to https://www.mozilla.org/account/
+privacy-faq-v2-you-dont-need-an-account = You don’t need an account to use { -brand-name-firefox }. <a { $attrs }>Accounts</a> are required to sync data across devices, but we only ask you for an email address and your age (just to make sure you’re not a child).
+
+privacy-faq-v2-you-use-digital = You use digital advertising as part of your marketing mix. Do you buy people’s data to better target your online ads?
+privacy-faq-v2-no-we-do-not-buy = No, we do not buy people’s data to target advertising.
+privacy-faq-v2-we-do-not-ask = We do ask our advertising partners to use only first party data that websites and publishers know about all users, such as the browser you are using and the device you are on.
+privacy-faq-v2-well-it-seems = Well, it seems like you really have my back on this privacy stuff.
+privacy-faq-v2-yes-we-do = Yes, we do.
+privacy-faq-v2-find-out-more = Find out more about how { -brand-name-mozilla } protects the internet.


### PR DESCRIPTION
## One-line summary

Updates `/privacy/faq/` page copy. There were many edits, so I went with a whole new FTL file to keep things cleaner.

## Issue / Bugzilla link

#16029

## Testing

http://localhost:8000/privacy/faq/