### PR TITLE
Restore "Does Firefox sell your personal data?" entry within structured-data-firefox-faq.html

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/structured-data-firefox-faq.html
+++ b/bedrock/firefox/templates/firefox/includes/structured-data-firefox-faq.html
@@ -57,6 +57,14 @@
                     "text": "Not only is Firefox safe to use, it also helps keep your data and private information safe. The Firefox browser automatically blocks known third party trackers, social media trackers, cryptominers and fingerprinters from collecting your data. Learn more about the privacy in our products."
                 }
             },
+              {
+                "@type": "Question",
+                "name": "Does Firefox sell your personal data?", 1
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Nope. Never have, never will. And we protect you from many of the advertisers who do. Firefox products are designed to protect your privacy. That’s a promise. " 9+
+                }
+            },
             {
                 "@type": "Question",
                 "name": "Why is Firefox so slow?",


### PR DESCRIPTION
Mozilla recently made changes to their FAQ document that resulted in the deletion of a very important section that details a promise to users to not sell their data.

This pull request has been submitted not only as a form of protest, but also in an honest to God hope that Mozilla reconsiders their position on abandoning their virtues.