### PR TITLE
Update links for managing privacy settings

### DIFF
--- a/bedrock/privacy/templates/privacy/includes/privacy-basics.html
+++ b/bedrock/privacy/templates/privacy/includes/privacy-basics.html
@@ -187,8 +187,8 @@
       <p>{{ ftl('privacy-firefox-firefox-makes-it') }}</p>
       <div class="c-settings-buttons">
         <p class="c-settings-manage"><strong>{{ ftl('privacy-firefox-manage-your-privacy') }}</strong></p>
-        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop">{{ ftl('privacy-firefox-firefox-for-desktop-v2', fallback='privacy-firefox-firefox-for-desktop') }}</a>
-        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-ios">{{ ftl('privacy-firefox-firefox-for-mobile-v2', fallback='privacy-firefox-firefox-for-mobile') }}</a>
+        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/share-data-mozilla-help-improve-firefox">{{ ftl('privacy-firefox-firefox-for-desktop-v2', fallback='privacy-firefox-firefox-for-desktop') }}</a>
+        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/send-usage-data-firefox-mobile-browsers">{{ ftl('privacy-firefox-firefox-for-mobile-v2', fallback='privacy-firefox-firefox-for-mobile') }}</a>
       </div>
   {% endcall %}
 


### PR DESCRIPTION
## One-line summary

Update links for managing privacy settings

## Significant changes and points to review

- 2 URL changes
- URLs should not have language in them

## Issue / Bugzilla link

n/a

## Testing

This is the two buttons under "Privacy that works for you"

http://localhost:8000/en-US/privacy/firefox/