### PR TITLE
Doc updates

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -21,7 +21,7 @@ It's possible to test more than 2 variants.
 
 Traffic Cop sends users to experiments and then we use Google Analytics (GA) to
 analyze which variation is more successful. (If the user has :abbr:`DNT (Do Not Track)`
-enabled they do not participate in experiments.)
+or :abbr:`GPC (Global Privacy Control)` enabled they do not participate in experiments.)
 
 All a/b tests should have a `mana page <https://mana.mozilla.org/wiki/display/EN/Details+of+experiments+by+mozilla.org+team>`_
 detailing the experiment and recording the results.

--- a/docs/attribution/0002-firefox-desktop.rst
+++ b/docs/attribution/0002-firefox-desktop.rst
@@ -27,8 +27,8 @@ Scope and requirements
 - Attribution now also works on macOS. The flow does not yet work for Linux, Android
   or iOS devices.
 - Attribution will only be passed if a website visitor has their
-  `Do Not Track (DNT)`_ preference disabled in their browser. Visitors can opt-out
-  by enabling DNT. This is covered in our `privacy policy`_.
+  `Do Not Track (DNT)`_ and `Global Privacy Control (GPC) <https://support.mozilla.org/kb/global-privacy-control>`_ preferences disabled in their browser. Visitors can opt-out
+  by enabling DNT or GPC. This is covered in our `privacy policy`_.
 
 How does attribution work?
 --------------------------

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -852,10 +852,14 @@ the proper template for the country from which the request originated.
         }
         template_name = "mozorg/everywhere-else-is-also-good.html"
 
+Testing Geo Views
+~~~~~~~~~~~~~~~~~
+
 For testing purposes while you're developing or on any deployment that is not
 accessed via the production domain (www.mozilla.org) you can append your URL
 with a ``geo`` query param (e.g. ``/firefox/?geo=DE``) and that will take
-precedence over the country from the request header.
+precedence over the country from the request header. Remember to use a valid
+`ISO country code <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements>`_ as param value.
 
 Other Geo Stuff
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Minor updates for bedrock docs


## Issue / Bugzilla link
n/a


## Testing

Go to `docs` folder locally and run `make livehtml` (you may need to run `make install-local-python-deps` first)

We check GPC in the same places we check DNT
- http://127.0.0.1:8100/abtest.html
- http://127.0.0.1:8100/attribution/0002-firefox-desktop.html

We can easily link to geo param docs for testing: http://127.0.0.1:8100/coding.html#testing-geo-views
