### PR TITLE
Fix typo in FR wnp

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx136-eu-pip.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx136-eu-pip.html
@@ -20,7 +20,7 @@
   {% set main_cta = 'Probiers aus' %}
 {% elif LANG == 'fr' %}
   {% set main_title = 'Le multitâche en toute simplicité' %}
-  {% set main_tagline = '<p>Vous le savez, nous le savons, votre patron le sait problement aussi. Parfois, vous regardez des vidéos pendant le travail.</p><p>Avec l’incrustation vidéo de Firefox, vous pouvez extraire le lecteur vidéo tout en continuant à travailler dans une autre fenêtre du navigateur.</p>' %}
+  {% set main_tagline = '<p>Vous le savez, nous le savons, votre patron le sait probablement aussi. Parfois, vous regardez des vidéos pendant le travail.</p><p>Avec l’incrustation vidéo de Firefox, vous pouvez extraire le lecteur vidéo tout en continuant à travailler dans une autre fenêtre du navigateur.</p>' %}
   {% set main_cta = 'Essayer l’incrustation vidéo' %}
 {% else %}
   {% set main_title = 'Multitasking made easy' %}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
typo fix: problement to probablement

## Significant changes and points to review



## Issue / Bugzilla link

n/a - reported in slack

## Testing
http://localhost:8000/fr/firefox/136.0/whatsnew/
