### PR TITLE
Add Release, Beta, and Developer Edition Linux/ARM64 builds to firefox/all

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -86,8 +86,8 @@ class FirefoxDesktop(_ProductDetails):
         else:
             platforms = self.platform_labels.copy()
 
-        # Linux ARM64/AArch64 installers are only currently available for Nightly builds.
-        if channel != "nightly":
+        # Linux ARM64/AArch64 installers not available for ESR builds.
+        if channel == "esr":
             del platforms["linux64-aarch64"]
 
         return list(platforms.items())

--- a/bedrock/firefox/tests/test_firefox_all.py
+++ b/bedrock/firefox/tests/test_firefox_all.py
@@ -64,10 +64,10 @@ def test_all_step_1(client):
 @pytest.mark.parametrize(
     "product_slug, name, count",
     (
-        ("desktop-release", "Firefox", 9),
+        ("desktop-release", "Firefox", 10),
         ("desktop-esr", "Firefox Extended Support Release", 8),
-        ("desktop-beta", "Firefox Beta", 9),
-        ("desktop-developer", "Firefox Developer Edition", 8),
+        ("desktop-beta", "Firefox Beta", 10),
+        ("desktop-developer", "Firefox Developer Edition", 9),
         ("desktop-nightly", "Firefox Nightly", 9),
     ),
 )

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -161,14 +161,14 @@ class TestDownloadButtons(TestCase):
         get_request.locale = "fr"
         doc = pq(render("{{ download_firefox() }}", {"request": get_request, "fluent_l10n": self.get_l10n(get_request.locale)}))
 
-        # The first 8 links should be for desktop.
+        # The first 9 links should be for desktop.
         links = doc(".download-list a")
 
-        for link in links[:8]:
+        for link in links[:9]:
             assert pq(link).attr("data-direct-link").startswith(settings.BOUNCER_URL)
 
-        # The ninth link is mobile and should not have the attr
-        assert pq(links[8]).attr("data-direct-link") is None
+        # The 10th link is mobile and should not have the attr
+        assert pq(links[9]).attr("data-direct-link") is None
 
     def test_nightly_desktop(self):
         """
@@ -208,7 +208,7 @@ class TestDownloadButtons(TestCase):
         )
 
         list = doc(".download-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
@@ -216,7 +216,8 @@ class TestDownloadButtons(TestCase):
         assert pq(list[4]).attr("class") == "os_win-msi"
         assert pq(list[5]).attr("class") == "os_osx"
         assert pq(list[6]).attr("class") == "os_linux64"
-        assert pq(list[7]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[8]).attr("class") == "os_linux"
 
     def test_beta_desktop(self):
         """The Beta channel should not have Windows 64 build yet"""
@@ -228,7 +229,7 @@ class TestDownloadButtons(TestCase):
         )
 
         list = doc(".download-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
@@ -236,7 +237,8 @@ class TestDownloadButtons(TestCase):
         assert pq(list[4]).attr("class") == "os_win-msi"
         assert pq(list[5]).attr("class") == "os_osx"
         assert pq(list[6]).attr("class") == "os_linux64"
-        assert pq(list[7]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[8]).attr("class") == "os_linux"
 
     def test_firefox_desktop(self):
         """The Release channel should not have Windows 64 build yet"""
@@ -246,7 +248,7 @@ class TestDownloadButtons(TestCase):
         doc = pq(render("{{ download_firefox(platform='desktop') }}", {"request": get_request, "fluent_l10n": self.get_l10n(get_request.locale)}))
 
         list = doc(".download-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
@@ -254,7 +256,8 @@ class TestDownloadButtons(TestCase):
         assert pq(list[4]).attr("class") == "os_win-msi"
         assert pq(list[5]).attr("class") == "os_osx"
         assert pq(list[6]).attr("class") == "os_linux64"
-        assert pq(list[7]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[8]).attr("class") == "os_linux"
 
     def test_latest_nightly_android(self):
         """The download button should have a Google Play link"""
@@ -406,15 +409,16 @@ class TestDownloadList(TestCase):
 
         # Check that links classes are ordered as expected.
         list = doc(".download-platform-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
         assert pq(list[3]).attr("class") == "os_osx"
         assert pq(list[4]).attr("class") == "os_linux64"
-        assert pq(list[5]).attr("class") == "os_linux"
-        assert pq(list[6]).attr("class") == "os_win"
-        assert pq(list[7]).attr("class") == "os_win-msi"
+        assert pq(list[5]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[6]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_win"
+        assert pq(list[8]).attr("class") == "os_win-msi"
 
         links = doc(".download-platform-list a")
 
@@ -439,15 +443,16 @@ class TestDownloadList(TestCase):
 
         # Check that links classes are ordered as expected.
         list = doc(".download-platform-list li")
-        assert list.length == 8
+        assert list.length == 9
         assert pq(list[0]).attr("class") == "os_win64"
         assert pq(list[1]).attr("class") == "os_win64-msi"
         assert pq(list[2]).attr("class") == "os_win64-aarch64"
         assert pq(list[3]).attr("class") == "os_osx"
         assert pq(list[4]).attr("class") == "os_linux64"
-        assert pq(list[5]).attr("class") == "os_linux"
-        assert pq(list[6]).attr("class") == "os_win"
-        assert pq(list[7]).attr("class") == "os_win-msi"
+        assert pq(list[5]).attr("class") == "os_linux64-aarch64"
+        assert pq(list[6]).attr("class") == "os_linux"
+        assert pq(list[7]).attr("class") == "os_win"
+        assert pq(list[8]).attr("class") == "os_win-msi"
 
         links = doc(".download-platform-list a")
 


### PR DESCRIPTION
Adds new Linux/ARM64 builds for Release, Beta, and Developer Edition.

Fixes #16065 

https://bugzilla.mozilla.org/show_bug.cgi?id=1678342#c18
https://bugzilla.mozilla.org/show_bug.cgi?id=1934634