### PR TITLE
Prevent ToS modal links opening in new tab (Fixes #15998)

### DIFF
--- a/bedrock/legal/templates/legal/terms/firefox-simple.html
+++ b/bedrock/legal/templates/legal/terms/firefox-simple.html
@@ -32,4 +32,8 @@
 {% block sentry_client %}{% endblock %}
 {% block consent_banner_js %}{% endblock %}
 
+{% block js %}
+  {{ js_bundle('tos_modal_link') }}
+{% endblock %}
+
 {% block site_footer %}{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/firefox-simple-2025.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-simple-2025.html
@@ -31,10 +31,10 @@
   </div>
 {% endblock %}
 
-{% block site_js %}
-{% endblock %}
+{% block site_js %}{% endblock %}
 
 {% block js %}
+  {{ js_bundle('tos_modal_link') }}
 {% endblock %}
 
 {# disable GA on Fx Privacy Notice. Bug 1576673 #}

--- a/media/js/privacy/privacy-modal-link.es6.js
+++ b/media/js/privacy/privacy-modal-link.es6.js
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+function preventNewTabAction(e) {
+    const href = e.target.href;
+    // Detect keyboard shortcuts, auxiliary mouse buttons.
+    if (href && (e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1)) {
+        e.preventDefault();
+
+        // Force the navigation to open in the same tab.
+        window.location.href = href;
+    }
+}
+
+document.querySelectorAll('a').forEach((link) => {
+    // Prevent links being opened in a new tab.
+    link.addEventListener('click', preventNewTabAction);
+
+    // Prevent context menu from opening with right click.
+    link.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+    });
+});

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1411,9 +1411,16 @@
         "js/base/uitour-lib.js",
         "js/base/mozilla-client.js",
         "js/base/protocol/utils.es6.js",
-        "js/base/protocol/init-details.es6.js"
+        "js/base/protocol/init-details.es6.js",
+        "js/privacy/privacy-modal-link.es6.js"
       ],
       "name": "privacy_firefox_simple"
+    },
+    {
+      "files": [
+        "js/privacy/privacy-modal-link.es6.js"
+      ],
+      "name": "tos_modal_link"
     },
     {
       "files": [


### PR DESCRIPTION
## One-line summary

See https://github.com/mozilla/bedrock/issues/15998 for requirements

## Issue / Bugzilla link

#15998

## Testing

- http://localhost:8000/en-US/privacy/firefox/?v=product
- http://localhost:8000/en-US/about/legal/terms/firefox/?v=product