### PR TITLE
Remove unused ALLOW_CIDR code and dependency

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -563,11 +563,6 @@ ALLOWED_HOSTS = list(
         ),
     )
 )
-ALLOWED_CIDR_NETS = config(
-    "ALLOWED_CIDR_NETS",
-    parser=ListOf(str, allow_empty=False),
-    default="",
-)
 
 # The canonical, production URL without a trailing slash
 CANONICAL_URL = "https://www.mozilla.org"
@@ -705,7 +700,6 @@ ENABLE_METRICS_VIEW_TIMING_MIDDLEWARE = config("ENABLE_METRICS_VIEW_TIMING_MIDDL
 
 MIDDLEWARE = [
     # IMPORTANT: this may be extended later in this file or via settings/__init__.py
-    "allow_cidr.middleware.AllowCIDRMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "bedrock.mozorg.middleware.HostnameMiddleware",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -493,7 +493,6 @@ django==4.2.20 \
     # via
     #   -r requirements/prod.txt
     #   dj-database-url
-    #   django-allow-cidr
     #   django-cors-headers
     #   django-crum
     #   django-csp
@@ -518,10 +517,6 @@ django==4.2.20 \
     #   wagtail
     #   wagtail-localize
     #   wagtail-localize-smartling
-django-allow-cidr==0.7.1 \
-    --hash=sha256:11126c5bb9df3a61ff9d97304856ba7e5b26d46c6d456709a6d9e28483bff47f \
-    --hash=sha256:382c5d7a9807279e3e96e4f4892b59163a2b30128c596902bf5f80e133e1ccbb
-    # via -r requirements/prod.txt
 django-cors-headers==4.7.0 \
     --hash=sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b \
     --hash=sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070
@@ -1299,7 +1294,6 @@ packaging==24.2 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
     # via
     #   -r requirements/prod.txt
-    #   django-allow-cidr
     #   django-csp
     #   pipdeptree
     #   pytest

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -9,7 +9,6 @@ contentful==2.3.2
 contextlib2==21.6.0
 dirsync==2.2.5
 dj-database-url==2.3.0
-django-allow-cidr==0.7.1
 django-cors-headers==4.7.0
 django-crum==0.7.9
 django-csp==4.0b4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -323,7 +323,6 @@ django==4.2.20 \
     # via
     #   -r requirements/prod.in
     #   dj-database-url
-    #   django-allow-cidr
     #   django-cors-headers
     #   django-crum
     #   django-csp
@@ -347,10 +346,6 @@ django==4.2.20 \
     #   wagtail
     #   wagtail-localize
     #   wagtail-localize-smartling
-django-allow-cidr==0.7.1 \
-    --hash=sha256:11126c5bb9df3a61ff9d97304856ba7e5b26d46c6d456709a6d9e28483bff47f \
-    --hash=sha256:382c5d7a9807279e3e96e4f4892b59163a2b30128c596902bf5f80e133e1ccbb
-    # via -r requirements/prod.in
 django-cors-headers==4.7.0 \
     --hash=sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b \
     --hash=sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070
@@ -957,9 +952,7 @@ openpyxl==3.1.5 \
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
-    # via
-    #   django-allow-cidr
-    #   django-csp
+    # via django-csp
 pillow==10.4.0 \
     --hash=sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885 \
     --hash=sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea \


### PR DESCRIPTION
## One-line summary

This hasn't been used in awhile since we were using `ALLOWED_HOSTS="*"`. But we recently switched to adding the `POD_ID` and correct hosts to this setting, so this is no longer necessary.

