### PR TITLE
Update ALLOWED_HOSTS default to empty

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -559,7 +559,7 @@ ALLOWED_HOSTS = list(
                 str,
                 allow_empty=True,
             ),
-            default="www.mozilla.org,www.ipv6.mozilla.org,www.allizom.org",
+            default="",
         ),
     )
 )


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

The current default is old and would not work against are current deployments. Since we set this explicitly in our infra, the default of empty is best here.

