### PR TITLE
add Mozilla Advertising section to footer (fix #16075)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -15,7 +15,14 @@
           <div class="moz24-footer-advertising-wrapper">
             <h2>{{ ftl('footer-refresh-mozilla-advertising') }}</h2>
             <p>{{ ftl('footer-refresh-privacy-first') }}</p>
-            <a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Learn more">{{ ftl('footer-refresh-learn-more') }}</a>
+            <a class="moz24-footer-advertising-link" href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Learn more">
+              <span class="mzp-c-button-icon-text">{{ ftl('footer-refresh-learn-more') }}</span>
+              <span class="mzp-c-button-icon-end">
+                <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24" viewBox="0 0 23.4 24">
+                  <path fill="#fff" d="M23.4 12 9.1 0v10.5H0v3h9.1V24l14.3-12zm-11.3-1.5v-4l6.6 5.5-6.6 5.5v-7z"/>
+                </svg>
+              </span>
+            </a>
           </div>
         </div>
         <div class="moz24-footer-links">

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -13,10 +13,10 @@
       <div class="moz24-footer-sections-container">
         <div class="moz24-footer-advertising">
           <div class="moz24-footer-advertising-wrapper">
-            <h2>{{ ftl('footer-refresh-mozilla-advertising') }}</h2>
+            <h2>{{ ftl('footer-refresh-mozilla-advertising', fallback='footer-refresh-advertise') }}</h2>
             <p>{{ ftl('footer-refresh-privacy-first') }}</p>
             <a class="moz24-footer-advertising-link" href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Learn more">
-              <span class="mzp-c-button-icon-text">{{ ftl('footer-refresh-learn-more') }}</span>
+              <span class="mzp-c-button-icon-text">{{ ftl('footer-refresh-learn-more-about-mozilla-advertising') }}</span>
               <span class="mzp-c-button-icon-end">
                 <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24" height="24" viewBox="0 0 23.4 24">
                   <path fill="#fff" d="M23.4 12 9.1 0v10.5H0v3h9.1V24l14.3-12zm-11.3-1.5v-4l6.6 5.5-6.6 5.5v-7z"/>
@@ -59,6 +59,7 @@
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-developers">
               <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-refresh-developer-edition') }}</a></li>
+              <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-refresh-enterprise') }}</a></li>
               <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-refresh-tools') }}</a></li>
               <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn-v2', fallback="footer-refresh-mdn") }}</a></li>
               <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -10,8 +10,15 @@
   {% endif %}
   <div class="moz24-footer-content">
     <div class="moz24-footer-primary">
-      <div class="moz24-footer-sections-wrapper">
-        <div class="moz24-footer-section-wrapper moz24-links-section">
+      <div class="moz24-footer-sections-container">
+        <div class="moz24-footer-advertising">
+          <div class="moz24-footer-advertising-wrapper">
+            <h2>{{ ftl('footer-refresh-mozilla-advertising') }}</h2>
+            <p>{{ ftl('footer-refresh-privacy-first') }}</p>
+            <a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Learn more">{{ ftl('footer-refresh-learn-more') }}</a>
+          </div>
+        </div>
+        <div class="moz24-footer-links">
           <section>
             <h2 class="moz24-footer-label" data-testid="footer-heading-company">
               {{ ftl('footer-refresh-company') }}
@@ -40,49 +47,37 @@
           </section>
 
           <section>
-            <h2 class="moz24-footer-label" data-testid="footer-heading-resources">
-              {{ ftl('footer-refresh-resources') }}
-            </h2>
-            <ul class="moz24-footer-primary-list" data-testid="footer-list-resources">
-              <li><a href="{{ url('mozorg.advertising.landing') }}" data-link-position="footer" data-link-text="Advertise with Mozilla">{{ ftl('footer-refresh-advertise') }}</a></li>
-              <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
-            </ul>
-          </section>
-
-          <section>
             <h2 class="moz24-footer-label" data-testid="footer-heading-developers">
               {{ ftl('footer-refresh-developers') }}
             </h2>
             <ul class="moz24-footer-primary-list" data-testid="footer-list-developers">
               <li><a href="{{ url('firefox.developer.index') }}" data-link-position="footer" data-link-text="Firefox Developer Edition">{{ ftl('footer-refresh-developer-edition') }}</a></li>
-              <li><a href="{{ url('firefox.enterprise.index') }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-refresh-enterprise') }}</a></li>
               <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-refresh-tools') }}</a></li>
               <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn-v2', fallback="footer-refresh-mdn") }}</a></li>
+              <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
             </ul>
           </section>
         </div>
-        <div class="moz24-footer-section-wrapper">
-          <section>
-            <div class="moz24-footer-refresh-social-wrapper">
-              <h2 class="moz24-footer-heading-social">{{ ftl('footer-refresh-follow-mozilla') }}</h2>
-              <ul class="moz24-footer-links-social">
-                <li><a class="bluesky" href="https://bsky.app/profile/mozilla.org" data-link-position="footer" data-link-text="Bluesky (@mozilla.org)" translate="no">Bluesky<span> (@mozilla.org)</span></a></li>
-                <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-position="footer" data-link-text="Instagram (@mozilla)">{{ ftl('footer-refresh-instagram') }}<span> (@mozilla)</span></a></li>
-                <li><a class="linkedin" href="https://www.linkedin.com/company/mozilla-corporation/" data-link-position="footer" data-link-text="LinkedIn (@mozilla)">{{ ftl('footer-refresh-linkedin') }}<span> (@mozilla)</span></a></li>
-                <li><a class="tiktok" href="https://www.tiktok.com/@mozilla" data-link-position="footer" data-link-text="TikTok (@mozilla)">{{ ftl('footer-refresh-tiktok') }}<span> (@mozilla)</span></a></li>
-                <li><a class="spotify" href="https://open.spotify.com/show/0vT7LJMeVDxyQ2ZamHKu08?si=_uDRD6bRR_6M5YZyISGXgA" data-link-position="footer" data-link-text="Spotify (@mozilla)">{{ ftl('footer-refresh-spotify') }}<span> (@mozilla)</span></a></li>
-              </ul>
-            </div>
-            <div class="moz24-footer-refresh-social-wrapper">
-              <h2 class="moz24-footer-heading-social">{{ ftl('footer-refresh-follow-firefox') }}</h2>
-              <ul class="moz24-footer-links-social">
-                <li><a class="bluesky" href="https://bsky.app/profile/firefox.com" data-link-position="footer" data-link-text="Bluesky (@firefox.com)" translate="no">Bluesky<span> (@firefox.com)</span></a></li>
-                <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-position="footer" data-link-text="Instagram (@firefox)">{{ ftl('footer-refresh-instagram') }}<span> (@firefox)</span></a></li>
-                <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-position="footer" data-link-text="YouTube (@firefoxchannel)">{{ ftl('footer-refresh-youtube') }}<span> (@firefoxchannel)</span></a></li>
-                <li><a class="tiktok" href="https://www.tiktok.com/@firefox" data-link-position="footer" data-link-text="TikTok (@firefox)">{{ ftl('footer-refresh-tiktok') }}<span> (@firefox)</span></a></li>
-              </ul>
-            </div>
-          </section>
+        <div class="moz24-footer-socials">
+          <div class="moz24-footer-refresh-social-wrapper">
+            <h2 class="moz24-footer-heading-social">{{ ftl('footer-refresh-follow-mozilla') }}</h2>
+            <ul class="moz24-footer-social-links">
+              <li><a class="bluesky" href="https://bsky.app/profile/mozilla.org" data-link-position="footer" data-link-text="Bluesky (@mozilla.org)" translate="no">Bluesky<span> (@mozilla.org)</span></a></li>
+              <li><a class="instagram" href="{{ mozilla_instagram_url() }}" data-link-position="footer" data-link-text="Instagram (@mozilla)">{{ ftl('footer-refresh-instagram') }}<span> (@mozilla)</span></a></li>
+              <li><a class="linkedin" href="https://www.linkedin.com/company/mozilla-corporation/" data-link-position="footer" data-link-text="LinkedIn (@mozilla)">{{ ftl('footer-refresh-linkedin') }}<span> (@mozilla)</span></a></li>
+              <li><a class="tiktok" href="https://www.tiktok.com/@mozilla" data-link-position="footer" data-link-text="TikTok (@mozilla)">{{ ftl('footer-refresh-tiktok') }}<span> (@mozilla)</span></a></li>
+              <li><a class="spotify" href="https://open.spotify.com/show/0vT7LJMeVDxyQ2ZamHKu08?si=_uDRD6bRR_6M5YZyISGXgA" data-link-position="footer" data-link-text="Spotify (@mozilla)">{{ ftl('footer-refresh-spotify') }}<span> (@mozilla)</span></a></li>
+            </ul>
+          </div>
+          <div class="moz24-footer-refresh-social-wrapper">
+            <h2 class="moz24-footer-heading-social">{{ ftl('footer-refresh-follow-firefox') }}</h2>
+            <ul class="moz24-footer-social-links">
+              <li><a class="bluesky" href="https://bsky.app/profile/firefox.com" data-link-position="footer" data-link-text="Bluesky (@firefox.com)" translate="no">Bluesky<span> (@firefox.com)</span></a></li>
+              <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-position="footer" data-link-text="Instagram (@firefox)">{{ ftl('footer-refresh-instagram') }}<span> (@firefox)</span></a></li>
+              <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-position="footer" data-link-text="YouTube (@firefoxchannel)">{{ ftl('footer-refresh-youtube') }}<span> (@firefoxchannel)</span></a></li>
+              <li><a class="tiktok" href="https://www.tiktok.com/@firefox" data-link-position="footer" data-link-text="TikTok (@firefox)">{{ ftl('footer-refresh-tiktok') }}<span> (@firefox)</span></a></li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -4,8 +4,10 @@
 
 footer-refresh-discover-mozilla-products =Discover { -brand-name-mozilla } products and initiatives. We promise to keep your email private and secure — no sharing, no selling, just great updates.
 footer-refresh-leadership = Leadership
-footer-refresh-advertise = Advertise with { -brand-name-mozilla }
+footer-refresh-mozilla-advertising = { -brand-name-mozilla } Advertising
 footer-refresh-firefox-release-notes = { -brand-name-firefox } Release Notes
+footer-refresh-privacy-first = Privacy-first advertising solutions for brands, publishers, and platforms.
+footer-refresh-learn-more = Learn more
 footer-refresh-mdn-v2 = { -brand-name-mdn }
 # Obsolete string (expires 22-04-2025)
 footer-refresh-mdn = MDN
@@ -25,11 +27,9 @@ footer-refresh-support = Support
 footer-refresh-product-help = Product Help
 footer-refresh-file-a-bug = File a Bug
 footer-refresh-localize-mozilla = Localize { -brand-name-mozilla }
-footer-refresh-resources = Resources
 footer-refresh-brand-standards = Brand Standards
 footer-refresh-developers = Developers
 footer-refresh-developer-edition = { -brand-name-developer-edition }
-footer-refresh-enterprise = { -brand-name-enterprise }
 footer-refresh-tools = Tools
 footer-refresh-donate = Donate
 footer-refresh-visit-mozilla-corporations = Visit <a { $moco_link }>{ -brand-name-mozilla-corporation }’s</a> not-for-profit parent, the <a { $mofo_link }>{ -brand-name-mozilla-foundation }</a>.

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -4,10 +4,12 @@
 
 footer-refresh-discover-mozilla-products =Discover { -brand-name-mozilla } products and initiatives. We promise to keep your email private and secure — no sharing, no selling, just great updates.
 footer-refresh-leadership = Leadership
+footer-refresh-advertise = Advertise with { -brand-name-mozilla }
 footer-refresh-mozilla-advertising = { -brand-name-mozilla } Advertising
+# The content inside the <span> is added to provide information for screen reader users only, and it is visually hidden
+footer-refresh-learn-more-about-mozilla-advertising = Learn more <span>about { footer-refresh-mozilla-advertising }</span>
 footer-refresh-firefox-release-notes = { -brand-name-firefox } Release Notes
 footer-refresh-privacy-first = Privacy-first advertising solutions for brands, publishers, and platforms.
-footer-refresh-learn-more = Learn more
 footer-refresh-mdn-v2 = { -brand-name-mdn }
 # Obsolete string (expires 22-04-2025)
 footer-refresh-mdn = MDN
@@ -30,6 +32,7 @@ footer-refresh-localize-mozilla = Localize { -brand-name-mozilla }
 footer-refresh-brand-standards = Brand Standards
 footer-refresh-developers = Developers
 footer-refresh-developer-edition = { -brand-name-developer-edition }
+footer-refresh-enterprise = { -brand-name-enterprise }
 footer-refresh-tools = Tools
 footer-refresh-donate = Donate
 footer-refresh-visit-mozilla-corporations = Visit <a { $moco_link }>{ -brand-name-mozilla-corporation }’s</a> not-for-profit parent, the <a { $mofo_link }>{ -brand-name-mozilla-foundation }</a>.

--- a/media/css/m24/components/footer-newsletter.scss
+++ b/media/css/m24/components/footer-newsletter.scss
@@ -53,7 +53,7 @@ $max-footer-content-width: $content-max;
         }
 
         @media #{$mq-lg} {
-            width: grid(4);
+            width: calc((100% - $grid-gutter) / 2);
             flex-wrap: nowrap;
         }
 
@@ -63,6 +63,10 @@ $max-footer-content-width: $content-max;
             font-weight: 600;
             font-family: $primary-font;
             text-align: start;
+
+            @media #{$mq-lg} {
+                width: 65%;
+            }
         }
     }
 
@@ -87,7 +91,7 @@ $max-footer-content-width: $content-max;
         }
 
         @media #{$mq-lg} {
-            width: grid(8);
+            width: calc((100% - $grid-gutter) / 2);
         }
 
         h2 {

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -53,6 +53,7 @@ $max-footer-content-width: $content-max;
         flex-direction: row;
         justify-content: space-between;
         align-items: flex-start;
+        gap: $grid-gutter;
     }
 
     @media #{$mq-xl} {
@@ -68,6 +69,10 @@ $max-footer-content-width: $content-max;
     @media #{$mq-lg} {
         max-width: 343px;
         border-bottom: transparent;
+    }
+
+    h2 {
+        color: $m24-color-black;
     }
 }
 
@@ -95,13 +100,14 @@ $max-footer-content-width: $content-max;
     }
 
     @media #{$mq-lg} {
-        width: grid(10);
         justify-content: flex-end;
         border-bottom: transparent;
-    }
+        width: 100%;
+        gap: $grid-gutter;
 
-    @media #{$mq-xl} {
-        gap: grid(2);
+        section {
+            width: calc((100% - 3 * $grid-gutter) / 3);
+        }
     }
 }
 
@@ -292,11 +298,16 @@ $max-footer-content-width: $content-max;
     border-radius: 0;
     font-weight: 600;
     background-color: $m24-color-alt-white;
-    padding: 10px 24px;
+    padding: 9.6px 24px;
     border: $border-width solid $m24-color-black;
     text-align: center;
     max-width: 800px;
     margin-bottom: $spacer-lg;
+
+    @media #{$mq-md} {
+        margin-bottom: 0;
+        min-width: 242px; // total width matching lang switcher width
+    }
 
     &:link,
     &:visited {
@@ -318,10 +329,6 @@ $max-footer-content-width: $content-max;
         .mzp-c-button-icon-text {
             color: $m24-color-white;
         }
-    }
-
-    @media #{$mq-md} {
-        margin-bottom: 0;
     }
 }
 

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -114,6 +114,10 @@ $max-footer-content-width: $content-max;
             color: $m24-color-white;
         }
     }
+
+    .mzp-c-button-icon-text span {
+        @include visually-hidden;
+    }
 }
 
 .moz24-footer-links {

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -342,7 +342,6 @@ $max-footer-content-width: $content-max;
 
     @media #{$mq-md} {
         margin-bottom: 0;
-        min-width: 242px; // total width matching lang switcher width
     }
 
     &:link,

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -80,6 +80,42 @@ $max-footer-content-width: $content-max;
     width: 100%;
 }
 
+.moz24-footer-advertising-link {
+    font-weight: 600;
+    background-color: $m24-color-alt-white;
+    padding: 8px 24px;
+    border: $border-width solid $m24-color-black;
+    text-align: center;
+    margin-top: $spacer-lg;
+    display: block;
+
+    @media #{$mq-sm} {
+        width: fit-content;
+    }
+
+    &:link,
+    &:visited {
+        color: $m24-color-black;
+        text-decoration: none;
+    }
+
+    &:active,
+    &:hover,
+    &:focus,
+    &:focus-visible {
+        background-color: $m24-color-alt-black;
+        color: $m24-color-white;
+
+        .mzp-c-button-icon-end path {
+            fill: $m24-color-white;
+        }
+
+        .mzp-c-button-icon-text {
+            color: $m24-color-white;
+        }
+    }
+}
+
 .moz24-footer-links {
     @include divider-line;
 

--- a/media/css/m24/components/footer-refresh.scss
+++ b/media/css/m24/components/footer-refresh.scss
@@ -32,13 +32,9 @@ $max-footer-content-width: $content-max;
 
 // primary nav
 .moz24-footer-primary {
-    margin: 32px 0;
-}
-
-.moz24-footer-sections-wrapper {
+    margin: $spacer-lg 0;
     display: flex;
     flex-direction: column;
-    gap: $grid-gutter;
 
     @media #{$mq-lg} {
         flex-direction: row;
@@ -47,29 +43,73 @@ $max-footer-content-width: $content-max;
     }
 }
 
-.moz24-footer-primary .moz24-footer-section-wrapper {
+.moz24-footer-sections-container {
+    display: flex;
+    flex-direction: column;
+    gap: $spacer-lg;
     width: 100%;
 
     @media #{$mq-lg} {
-        width: grid(2);
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: flex-start;
     }
 
-    &.moz24-links-section {
-        @media (min-width: #{$screen-xs * 1.25}) {
-            display: grid;
-            grid-template-rows: 1fr 1fr;
-            grid-template-columns: 1fr 1fr;
-            column-gap: $grid-gutter;
-            place-items: stretch start;
-        }
+    @media #{$mq-xl} {
+        gap: grid(1);
+    }
+}
 
-        @media #{$mq-lg} {
-            width: grid(8);
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            align-items: start;
-        }
+.moz24-footer-advertising {
+    @include divider-line;
+    padding-bottom: $spacer-lg;
+    width: 100%;
+
+    @media #{$mq-lg} {
+        max-width: 343px;
+        border-bottom: transparent;
+    }
+}
+
+.moz24-footer-advertising-wrapper {
+    width: 100%;
+}
+
+.moz24-footer-links {
+    @include divider-line;
+
+    @media #{$mq-xs} {
+        display: grid;
+        grid-template-rows: 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
+        column-gap: $grid-gutter;
+        place-items: stretch start;
+    }
+
+    @media #{$mq-sm} {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: start;
+        gap: grid(1);
+    }
+
+    @media #{$mq-lg} {
+        width: grid(10);
+        justify-content: flex-end;
+        border-bottom: transparent;
+    }
+
+    @media #{$mq-xl} {
+        gap: grid(2);
+    }
+}
+
+.moz24-footer-socials {
+    @include divider-line;
+
+    @media #{$mq-lg} {
+        border-bottom: transparent;
     }
 }
 
@@ -103,7 +143,7 @@ $max-footer-content-width: $content-max;
     }
 }
 
-.moz24-footer-links-social {
+.moz24-footer-social-links {
     margin: 0 0 0 $spacer-lg;
     display: flex;
     background-color: #161616; // hard-coded value as a fallback for readability on older browsers
@@ -239,8 +279,12 @@ $max-footer-content-width: $content-max;
         justify-content: space-between;
         align-items: center;
     }
-}
 
+    @media #{$mq-lg} {
+        justify-content: flex-end;
+        gap: $grid-gutter;
+    }
+}
 
 // donation link
 .moz24-footer-donate {
@@ -248,7 +292,7 @@ $max-footer-content-width: $content-max;
     border-radius: 0;
     font-weight: 600;
     background-color: $m24-color-alt-white;
-    padding: 6px 24px;
+    padding: 10px 24px;
     border: $border-width solid $m24-color-black;
     text-align: center;
     max-width: 800px;
@@ -337,10 +381,14 @@ $max-footer-content-width: $content-max;
         border: $border-width solid $m24-color-alt-black;
         color: $m24-color-alt-black;
         font-weight: 600;
-        margin-top: 16px;
         padding-left: 36px;
         max-width: 100%;
-        width: fit-content;
+        width: 100%;
+        margin: 0;
+
+        @media #{$mq-lg} {
+            width: fit-content;
+        }
 
         &:hover,
         &:focus,


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR adds the Mozilla advertising section to footer.

## Significant changes and points to review

- added new Mozilla advertising section in footer
- removed "Resources" link section
- other footer layout changes (see details in Figma file linked in the issue)
- cleaned up some class names in footer to make it consistent and less confusing

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16075

## Testing

http://localhost:8000/