### PR TITLE
Update sitemaps data on clock pod instead of external repo

### DIFF
--- a/bedrock/sitemaps/models.py
+++ b/bedrock/sitemaps/models.py
@@ -2,25 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
-
 from django.conf import settings
 from django.db import models, transaction
 
-SITEMAPS_DATA = settings.SITEMAPS_PATH.joinpath("data")
+from bedrock.sitemaps.utils import get_all_urls
+
 NO_LOCALE = "__"  # special value for no locale
-
-
-def load_sitemaps_data():
-    with SITEMAPS_DATA.joinpath("sitemap.json").open() as fh:
-        sitemap = json.load(fh)
-
-    return sitemap
 
 
 def get_sitemap_objs():
     objs = []
-    sitemap = load_sitemaps_data()
+    sitemap = get_all_urls()
     for url, locales in sitemap.items():
         if not locales:
             locales = [NO_LOCALE]

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -227,13 +227,17 @@ def get_wagtail_urls():
     return urls
 
 
-def update_sitemaps():
+def get_all_urls():
     urls = get_static_urls()
     urls.update(get_release_notes_urls())
     urls.update(get_security_urls())
     urls.update(get_contentful_urls())
     urls.update(get_wagtail_urls())
+    return urls
 
+
+def update_sitemaps():
+    urls = get_all_urls()
     # Output static files
     output_json(urls)
 

--- a/bin/run-db-update.sh
+++ b/bin/run-db-update.sh
@@ -32,6 +32,8 @@ failure_detected=false
 
 # Please ensure all new command calls are suffixed with || failure_detected=true
 
+# make sure l10n files are here for use in other commands
+python manage.py l10n_update || failure_detected=true
 python manage.py update_product_details_files || failure_detected=true
 python manage.py update_security_advisories --quiet || failure_detected=true
 python manage.py update_wordpress --quiet || failure_detected=true


### PR DESCRIPTION
I think the main thing left to investigate for whether this will work or not is whether the clock pod keeps the l10n files updated locally or not. I'm pretty sure it does, but that is something we need to double check.