### PR TITLE
Redirect old in-product anchors to sumo articles

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/firefox-2025.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-2025.html
@@ -14,6 +14,11 @@
   {% endif %}
 {% endblock %}
 
+{% block extrahead %}
+  {# redirects for in product links issue 16080  #}
+  {{ js_bundle('privacy_redirects') }}
+{% endblock %}
+
 {% do doc.select('ul')|htmlattr(class="mzp-u-list-styled") %}
 {% do doc.select('ol')|htmlattr(class="mzp-u-list-styled") %}
 {% do doc.select('table')|htmlattr(class="mzp-u-data-table") %}
@@ -74,8 +79,3 @@
 
 {# Exclude stub attribution for in-product pages: issus 9620 #}
 {% block stub_attribution %}{% endblock %}
-
-{% block js %}
-  {{ super() }}
-  {{ js_bundle('privacy_redirects') }}
-{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/firefox-2025.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-2025.html
@@ -74,3 +74,8 @@
 
 {# Exclude stub attribution for in-product pages: issus 9620 #}
 {% block stub_attribution %}{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('privacy_redirects') }}
+{% endblock %}

--- a/media/js/privacy/redirects.es6.js
+++ b/media/js/privacy/redirects.es6.js
@@ -11,7 +11,5 @@ if (window.location.hash.indexOf('#health-report') === 0) {
 }
 
 if (window.location.hash.indexOf('#crash-reporter') === 0) {
-    window.location.replace(
-        'https://support.mozilla.org/en-US/kb/crash-report'
-    );
+    window.location.replace('https://support.mozilla.org/kb/crash-report');
 }

--- a/media/js/privacy/redirects.es6.js
+++ b/media/js/privacy/redirects.es6.js
@@ -4,13 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-if (window.location.hash === '#health-report') {
+if (window.location.hash.indexOf('#health-report') === 0) {
     window.location.replace(
         'https://support.mozilla.org/kb/technical-and-interaction-data'
     );
 }
 
-if (window.location.hash === '#crash-reporter') {
+if (window.location.hash.indexOf('#crash-reporter') === 0) {
     window.location.replace(
         'https://support.mozilla.org/en-US/kb/crash-report'
     );

--- a/media/js/privacy/redirects.es6.js
+++ b/media/js/privacy/redirects.es6.js
@@ -1,0 +1,17 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+if (window.location.hash === '#health-report') {
+    window.location.replace(
+        'https://support.mozilla.org/kb/technical-and-interaction-data'
+    );
+}
+
+if (window.location.hash === '#crash-reporter') {
+    window.location.replace(
+        'https://support.mozilla.org/en-US/kb/crash-report'
+    );
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1424,6 +1424,12 @@
     },
     {
       "files": [
+        "js/privacy/redirects.es6.js"
+      ],
+      "name": "privacy_redirects"
+    },
+    {
+      "files": [
         "js/mozorg/about-transparency.js"
       ],
       "name": "about-transparency"

--- a/tests/playwright/specs/privacy-firefox-crash-reporter.spec.js
+++ b/tests/playwright/specs/privacy-firefox-crash-reporter.spec.js
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/legal/privacy/firefox.html#crash-reporter';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('health report redirect', async ({ page }) => {
+            // Expected redirect URL
+            const expectedRedirectUrl =
+                'https://support.mozilla.org/en-US/kb/crash-report';
+
+            // Wait for the redirect to happen
+            await page.waitForURL(expectedRedirectUrl, { timeout: 5000 }); // Wait up to 5 seconds for the redirect
+
+            // Get the current URL
+            const currentUrl = page.url();
+
+            // Assert that the current URL is the expected redirect URL
+            expect(currentUrl).toBe(expectedRedirectUrl);
+        });
+    }
+);

--- a/tests/playwright/specs/privacy-firefox-crash-reporter.spec.js
+++ b/tests/playwright/specs/privacy-firefox-crash-reporter.spec.js
@@ -26,7 +26,9 @@ test.describe(
                 'https://support.mozilla.org/en-US/kb/crash-report';
 
             // Wait for the redirect to happen
-            await page.waitForURL(expectedRedirectUrl, { timeout: 5000 }); // Wait up to 5 seconds for the redirect
+            await page.waitForURL(expectedRedirectUrl, {
+                waitUntil: 'commit'
+            });
 
             // Get the current URL
             const currentUrl = page.url();

--- a/tests/playwright/specs/privacy-firefox-health-report.spec.js
+++ b/tests/playwright/specs/privacy-firefox-health-report.spec.js
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const openPage = require('../scripts/open-page');
+const url = '/legal/privacy/firefox.html#health-report';
+
+test.describe(
+    `${url} page`,
+    {
+        tag: '@mozorg'
+    },
+    () => {
+        test.beforeEach(async ({ page, browserName }) => {
+            await openPage(url, page, browserName);
+        });
+
+        test('health report redirect', async ({ page }) => {
+            // Expected redirect URL
+            const expectedRedirectUrl =
+                'https://support.mozilla.org/en-US/kb/technical-and-interaction-data';
+
+            // Wait for the redirect to happen
+            await page.waitForURL(expectedRedirectUrl, { timeout: 5000 }); // Wait up to 5 seconds for the redirect
+
+            // Get the current URL
+            const currentUrl = page.url();
+
+            // Assert that the current URL is the expected redirect URL
+            expect(currentUrl).toBe(expectedRedirectUrl);
+        });
+    }
+);

--- a/tests/playwright/specs/privacy-firefox-health-report.spec.js
+++ b/tests/playwright/specs/privacy-firefox-health-report.spec.js
@@ -26,7 +26,9 @@ test.describe(
                 'https://support.mozilla.org/en-US/kb/technical-and-interaction-data';
 
             // Wait for the redirect to happen
-            await page.waitForURL(expectedRedirectUrl, { timeout: 5000 }); // Wait up to 5 seconds for the redirect
+            await page.waitForURL(expectedRedirectUrl, {
+                waitUntil: 'commit'
+            });
 
             // Get the current URL
             const currentUrl = page.url();


### PR DESCRIPTION
## One-line summary

Redirect old in-product anchors to sumo articles

## Significant changes and points to review

There's two old links in-product that used to redirect to anchors on the privacy notice page. These anchors are gone and the associated content was removed. Now we need to redirect to SUMO articles with similar content. Unfortunately we can't catch the anchor links at the django level so we need to redirect after the page loads using javascript.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16080

## Testing

I think this is probably an abuse of the Playwright tests so feedback welcome.

| URL | Forwards to |
| ------------- | ------------- |
| http://localhost:8000/legal/privacy/firefox.html#health-report  | `https://support.mozilla.org/kb/technical-and-interaction-data`  |
| http://localhost:8000/legal/privacy/firefox.html#crash-reporter  | `https://support.mozilla.org/en-US/kb/crash-report`  |
