### PR TITLE
Add new Subplat staging URLs for VPN subscriptions (Fixes #16100)

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -11,6 +11,7 @@ from django_jinja import library
 from markupsafe import Markup
 
 from bedrock.base.urlresolvers import reverse
+from bedrock.base.waffle import switch
 from lib.l10n_utils.fluent import ftl
 
 FTL_FILES = ["products/vpn/shared"]
@@ -148,7 +149,12 @@ def vpn_subscribe_link(
     selected_plan = available_plans.get(plan, VPN_12_MONTH_PLAN)
     plan_id = selected_plan.get("id")
 
-    product_url = f"{settings.VPN_SUBSCRIPTION_URL}subscriptions/products/{product_id}?plan={plan_id}"
+    if switch("vpn-subplat-next"):
+        product_slug = "mozillavpnstage"
+        plan_slug = "yearly" if plan == VPN_12_MONTH_PLAN else "monthly"
+        product_url = f"{settings.VPN_SUBSCRIPTION_URL_NEXT}{product_slug}/{plan_slug}/landing/"
+    else:
+        product_url = f"{settings.VPN_SUBSCRIPTION_URL}subscriptions/products/{product_id}?plan={plan_id}"
 
     if "analytics" in selected_plan:
         if class_name is None:

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1266,6 +1266,10 @@ VPN_ENDPOINT = config("VPN_ENDPOINT", default="https://stage.guardian.nonprod.cl
 # ***This URL *MUST* end in a traling slash!***
 VPN_SUBSCRIPTION_URL = config("VPN_SUBSCRIPTION_URL", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
 
+# New URL for VPN subscription links
+# ***This URL *MUST* end in a traling slash!***
+VPN_SUBSCRIPTION_URL_NEXT = config("VPN_SUBSCRIPTION_URL_NEXT", default="https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/")
+
 # Product ID for VPN subscriptions
 VPN_PRODUCT_ID = config("VPN_PRODUCT_ID", default="prod_FiJ42WCzZNRSbS" if DEV else "prod_FvnsFHIfezy3ZI")
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1267,7 +1267,7 @@ VPN_ENDPOINT = config("VPN_ENDPOINT", default="https://stage.guardian.nonprod.cl
 VPN_SUBSCRIPTION_URL = config("VPN_SUBSCRIPTION_URL", default="https://accounts.stage.mozaws.net/" if DEV else "https://accounts.firefox.com/")
 
 # New URL for VPN subscription links
-# ***This URL *MUST* end in a traling slash!***
+# ***This URL *MUST* end in a trailing slash!***
 VPN_SUBSCRIPTION_URL_NEXT = config("VPN_SUBSCRIPTION_URL_NEXT", default="https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/")
 
 # Product ID for VPN subscriptions

--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -9,11 +9,12 @@ const FxaAttribution = {};
 const _allowedDomains = [
     'https://accounts.firefox.com/',
     'https://accounts.stage.mozaws.net/',
-    'https://monitor.mozilla.org/',
     'https://getpocket.com/',
-    'https://vpn.mozilla.org/',
+    'https://guardian-dev.herokuapp.com/',
+    'https://monitor.mozilla.org/',
+    'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
     'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
-    'https://guardian-dev.herokuapp.com/'
+    'https://vpn.mozilla.org/'
 ];
 
 const _allowedUtmParams = [

--- a/media/js/base/fxa-coupon.es6.js
+++ b/media/js/base/fxa-coupon.es6.js
@@ -6,7 +6,11 @@
 
 const FxaCoupon = {};
 
-const _allowedDomains = ['accounts.firefox.com', 'accounts.stage.mozaws.net'];
+const _allowedDomains = [
+    'accounts.firefox.com',
+    'accounts.stage.mozaws.net',
+    'payments-next.stage.fxa.nonprod.webservices.mozgcp.net'
+];
 
 FxaCoupon.getCoupon = (url) => {
     const _validParamChars = /^[\w/.%-]+$/;
@@ -22,7 +26,8 @@ FxaCoupon.getCoupon = (url) => {
 FxaCoupon.verifyLink = (url) => {
     return (
         _allowedDomains.indexOf(url.hostname) !== -1 &&
-        url.pathname.startsWith('/subscriptions/products/')
+        (url.pathname.startsWith('/subscriptions/products/') ||
+            url.pathname.startsWith('/mozillavpnstage/'))
     );
 };
 

--- a/media/js/base/fxa-product-button.es6.js
+++ b/media/js/base/fxa-product-button.es6.js
@@ -12,6 +12,7 @@ const allowedList = [
     'https://getpocket.com/',
     'https://guardian-dev.herokuapp.com/',
     'https://monitor.mozilla.org/',
+    'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
     'https://relay.firefox.com/',
     'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
     'https://vpn.mozilla.org/'


### PR DESCRIPTION
## One-line summary

Adds new Subplat staging URLs for VPN subscriptions behind the switch `VPN_SUBPLAT_NEXT`

## Significant changes and points to review

Note that we do not yet have production URLS, those will come later. For now this is only for testing on www-dev.

Adding as P1 as they have requested this be ready for testing on www-dev by March 26th.

## Issue / Bugzilla link

#16100

## Testing

http://localhost:8000/en-US/products/vpn/

- [x] New URL format is used when switch is activated.
- [x] Old URL format is used when switch is deactivated.
- [x] Exactly the same parameters and data attributes should still be` present.

http://localhost:8000/en-US/products/vpn/?utm_source=test&utm_campaign=test&coupon=FIREFOX105

- [x] UTM params and coupon params are passed through to new subscription URLs.