### PR TITLE
remove obsolete l10n strings (fix #16085)

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base-article.html" %}
 
-{% block page_desc %}{{ ftl('features-translate-firefox-translations-is-a-built-in-v2', fallback='features-translate-firefox-translations-is-a-built-in') }}{% endblock %}
+{% block page_desc %}{{ ftl('features-translate-firefox-translations-is-a-built-in-v2') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/features/translate/og.png') }}{% endblock %}
 
 {% block article_title_short %}{{ ftl('features-translate-translate-the-web') }}{% endblock %}
@@ -14,13 +14,13 @@
 
 {% block article_content %}
 <p>{{ ftl('features-translate-one-of-the-best-things-about') }}</p>
-<p>{{ ftl('features-translate-while-other-browsers-rely-on-v2', fallback='features-translate-while-other-browsers-rely-on') }}</p>
+<p>{{ ftl('features-translate-while-other-browsers-rely-on-v2') }}</p>
 
 <h2>{{ ftl('features-translate-when-you-translate-a-webpage') }}</h2>
 <p>{{ ftl('features-translate-when-your-translations-are') }}</p>
 
 <h2>{{ ftl('features-translate-what-languages-are-currently') }}</h2>
-<p>{{ ftl('features-translate-the-languages-below-are-what-v2', fallback='features-translate-the-languages-below-are-what') }}</p>
+<p>{{ ftl('features-translate-the-languages-below-are-what-v2') }}</p>
 
 <ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
@@ -72,9 +72,5 @@
 <p>{{ ftl('features-translate-and-more-languages-are-in') }}</p>
 
 <h2>{{ ftl('features-translate-firefox-speaks-your-language') }}</h2>
-{% if ftl_has_messages('features-translate-the-firefox-translations-feature-v2') %}
 <p>{{ ftl('features-translate-the-firefox-translations-feature-v2', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox.new'))) }}</p>
-{% else %}
-<p>{{ ftl('features-translate-the-firefox-translations-feature', download='href="%s" data-cta-text="Get started in your preferred language"'|safe|format(url('firefox.new'))) }}</p>
-{% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/includes/m24/community.html
+++ b/bedrock/mozorg/templates/mozorg/about/includes/m24/community.html
@@ -7,7 +7,7 @@
 <section class="m24-c-showcase m24-t-pink">
   <div class="m24-c-content">
     <header class="m24-c-showcase-text m24-l-two-columns">
-      <h2 class="m24-c-showcase-title">{{ ftl('m24-about-community-love-v2', fallback='m24-about-community-love') }}</h2>
+      <h2 class="m24-c-showcase-title">{{ ftl('m24-about-community-love-v2') }}</h2>
 
       <div class="m24-c-showcase-body">
         <p>{{ ftl('m24-about-mozilla-is-a') }}</p>

--- a/bedrock/mozorg/templates/mozorg/about/includes/m24/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/includes/m24/manifesto.html
@@ -67,9 +67,9 @@
       ),
       body=True,
       heading_level=3,
-      title=ftl('m24-about-research', fallback='m24-about-monitor')
+      title=ftl('m24-about-research')
     ) %}
-      <p>{{ ftl('m24-about-we-uncover-insights', fallback='m24-about-we-monitor-developments') }}</p>
+      <p>{{ ftl('m24-about-we-uncover-insights') }}</p>
     {% endcall %}
 
     {% call picto(

--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -257,7 +257,7 @@
         media_after=False
     ) %}
     <h2>{{ ftl('home-so-what-is-mozilla') }}</h2>
-    <p>{{ ftl('home-at-its-core-v2', fallback='home-at-its-core', ventures=moz_ventures, mozai=moz_ai) }}</p>
+    <p>{{ ftl('home-at-its-core-v2', ventures=moz_ventures, mozai=moz_ai) }}</p>
     <a href="https://foundation.mozilla.org/{{ utm_params }}" rel="external noopener" class="mzp-c-button">
       {{ ftl('home-learn-about-mofo') }}
     </a>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/media-springboard.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/media-springboard.html
@@ -7,7 +7,7 @@
 {% from "macros-m24.html" import grid_tile, springboard_item with context %}
 
 <section class="m24-c-content" id="media">
-  <h3 class="m24-c-intro-title m24-t-sm">{{ ftl('m24-home-headline-you-ai-v2', fallback='m24-home-headline-you-ai') }}</h3>
+  <h3 class="m24-c-intro-title m24-t-sm">{{ ftl('m24-home-headline-you-ai-v2') }}</h3>
   <ul class="m24-c-springboard" id="ai-media">
     <li class="m24-c-springboard-item m24-c-springboard-headings">
       <div class="m24-c-springboard-link">

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -125,9 +125,6 @@
 -brand-name-mozilla-social = Mozilla.social
 -brand-name-mozilla-builders = Mozilla Builders
 -brand-name-builders = Builders
-
-# Obsolete string (expires: 2025-01-05)
--brand-name-mozilla-ai = Mozilla AI
 -brand-name-mozilla-ai-v2 = Mozilla.ai
 -brand-name-mozilla-ventures = Mozilla Ventures
 -brand-name-rise25 = Rise25

--- a/l10n/en/firefox/features/translate.ftl
+++ b/l10n/en/firefox/features/translate.ftl
@@ -10,25 +10,17 @@ features-translate-translate-the-web = Translate the web
 
 # HTML page description
 features-translate-firefox-translations-is-a-built-in-v2 = { -brand-name-firefox-translations } is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
-# Obsolete string (expires: 2025-02-17)
-features-translate-firefox-translations-is-a-built-in = { -brand-name-firefox } Translations is a built-in translation feature that allows you to easily browse the web in your preferred language. Learn more about how this feature in { -brand-name-firefox } works, and how { -brand-name-mozilla } helps keep what you translate private.
 features-translate-one-of-the-best-things-about = One of the best things about the internet is that we can access content worldwide. Whether it’s news articles, blogs, or even a review of your latest tech gadget, you can find it all on the seemingly never-ending web. With { -brand-name-firefox }’s latest translation feature, this tool will continuously translate a webpage in real-time.
 features-translate-while-other-browsers-rely-on-v2 = While other browsers rely on cloud services, the { -brand-name-firefox-translations } language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
-# Obsolete string (expires: 2025-02-17)
-features-translate-while-other-browsers-rely-on = While other browsers rely on cloud services, the { -brand-name-firefox } Translations language models are downloaded on the user’s browser and translations are done locally, so { -brand-name-mozilla } doesn’t record what webpages you translate.
 features-translate-when-you-translate-a-webpage = When you translate a webpage, it stays private
 features-translate-when-your-translations-are = When your translations are processed locally, no data from your chosen device leaves your device or relies on cloud services for translation. This means that { -brand-name-mozilla } doesn’t know what web page you translate, and makes our translation feature stand out in comparison to other translation tools.
 features-translate-what-languages-are-currently = What languages are currently supported?
 
 # This is followed by a localized list of supported languages
 features-translate-the-languages-below-are-what-v2 = The languages below are currently supported by the { -brand-name-firefox-translations } feature:
-# Obsolete string (expires: 2025-02-17)
-features-translate-the-languages-below-are-what = The languages below are currently supported by the { -brand-name-firefox } Translations feature:
 features-translate-and-more-languages-are-in = And more languages are in development!
 features-translate-firefox-speaks-your-language = { -brand-name-firefox } speaks your language
 
 # Variables:
 #   $download (url) = link to https://www.mozilla.org/firefox/new/
 features-translate-the-firefox-translations-feature-v2 = The { -brand-name-firefox-translations } feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>
-# Obsolete string (expires: 2025-02-17)
-features-translate-the-firefox-translations-feature = The { -brand-name-firefox } Translations feature is another way { -brand-name-mozilla } keeps your internet personalized and more private. { -brand-name-mozilla } doesn’t track what webpages you translate. With millions of users worldwide, { -brand-name-mozilla } wants to ensure that those who use { -brand-name-firefox } are learning, communicating, sharing, and staying informed on their own terms. <a { $download }>Get started in your preferred language by downloading { -brand-name-firefox }.</a>

--- a/l10n/en/mozorg/about-m24.ftl
+++ b/l10n/en/mozorg/about-m24.ftl
@@ -24,11 +24,7 @@ m24-about-a-group-of = A group of thinkers sitting in a circle on the floor shar
 m24-about-advocate = Advocate
 m24-about-we-advocate-for = We advocate for better products, holding governments and tech corporations accountable for what they create.
 m24-about-research = Research
-# Obsolete string (expires: 2025-02-03)
-m24-about-monitor = Monitor
 m24-about-we-uncover-insights = We uncover insights, campaign to improve products and drive policies that represent your interests.
-# Obsolete string (expires: 2025-02-03)
-m24-about-we-monitor-developments = We monitor developments, conduct research and campaign to improve products and drive policies that represent your interests.
 m24-about-build = Build
 m24-about-we-build-products = We build products that put you in control — like { -brand-name-firefox }, { -brand-name-fakespot } and more.
 m24-about-fund = Fund
@@ -70,8 +66,6 @@ m24-about-see-open-positions = See open positions
 ## Community
 
 m24-about-community-love-v2 = Community love, our driving force
-# Obsolete string (expires: 2025-02-03)
-m24-about-community-love = Community love —<br> our driving force
 m24-about-mozilla-is-a = { -brand-name-mozilla } is a global community of passionate volunteers, fellows and contributors who have been building, protecting and shaping the internet with us since 1998.
 m24-about-from-writing-code = From writing code and spotting bugs to advocating for privacy and keeping the internet open for everyone — our community members are the backbone of everything we do. Their passion and dedication inspire us every day.
 # Used as an accessible text alternative for an image

--- a/l10n/en/mozorg/home-m24.ftl
+++ b/l10n/en/mozorg/home-m24.ftl
@@ -97,8 +97,6 @@ m24-home-tag-video = Video
 m24-home-topic-news = News
 m24-home-topic-ai = Artificial Intelligence
 m24-home-topic-ps = Privacy & Security
-# Obsolete string (expires: 2025-02-03)
-m24-home-headline-you-ai = Headline: You, AI and the internet — what’s really going on?
 m24-home-headline-you-ai-v2 = You, AI and the internet — what’s really going on?
 m24-home-introducing-anonym = Introducing { -brand-name-anonym }: Raising the bar for privacy-preserving digital advertising.
 m24-home-keeping-genai-technologies = Keeping GenAI technologies secure is a shared responsibility.

--- a/l10n/en/mozorg/home-new.ftl
+++ b/l10n/en/mozorg/home-new.ftl
@@ -42,9 +42,6 @@ home-read-more = Read more
 
 home-so-what-is-mozilla = So, what is { -brand-name-mozilla }?
 
-# Obsolete string (expires: 2025-01-05)
-home-at-its-core = At its core, { -brand-name-mozilla } is an activist organization led by the { -brand-name-mozilla-foundation } that makes change in the world through a variety of ventures including { -brand-name-mozilla-corporation }, MZLA, <a {$ventures}>{ -brand-name-mozilla-ventures }</a> and <a {$mozai}>{ -brand-name-mozilla-ai }</a>. How are we different? Because we’re mission-driven, it means we have the freedom to make all of our decisions based on what’s best for the internet and for everyone online, not based on the demands of shareholders — we don’t actually have any of those.
-
 # Variables
 #   $ventures - link to https://mozilla.vc/
 #   $mozai - link to https://mozilla.ai/

--- a/l10n/en/navigation_refresh.ftl
+++ b/l10n/en/navigation_refresh.ftl
@@ -23,17 +23,7 @@ navigation-refresh-blog = Blog
 navigation-refresh-our-mission = Our Mission
 navigation-refresh-our-work = Our Work
 navigation-refresh-mozilla-builders = { -brand-name-mozilla-builders }
-
-# Obsolete string (expires: 2025-01-05)
-navigation-refresh-mozilla-ai = { -brand-name-mozilla } AI
-
-# Obsolete string (expires: 2025-01-05)
-navigation-refresh-mozilla-ai-v2 = { -brand-name-mozilla-ai }
-
 navigation-refresh-mozilla-ai-v3 = { -brand-name-mozilla-ai-v2 }
-
-# Obsolete string (expires: 2025-01-05)
-navigation-refresh-mozilla-ventures = { -brand-name-mozilla } Ventures
 navigation-refresh-mozilla-ventures-v2 = { -brand-name-mozilla-ventures }
 navigation-refresh-mozilla-advertising = { -brand-name-mozilla } Advertising
 


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR removes obsolete l10n strings.

## Significant changes and points to review

https://github.com/mozilla/bedrock/issues/16085

## Issue / Bugzilla link



## Testing
