### PR TITLE
Revert "Remove set-as-default experiment code (Fixes #16095) (#16096)"

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -8,6 +8,14 @@
 
 {% extends "firefox/new/desktop/base.html" %}
 
+{% set show_firefox_default_experiment = switch('experiment-firefox-new-default', ['en']) and country_code in ['US', 'CA'] %}
+
+{% block experiments %}
+  {% if show_firefox_default_experiment %}
+    {{ js_bundle('experiment-firefox-new-default') }}
+  {% endif %}
+{% endblock %}
+
 {% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-desktop' %}
 {% set ios_url = app_store_url('firefox', 'mozilla-org-firefox-new') %}
 

--- a/bedrock/firefox/templates/firefox/new/desktop/experiment-firefox-new-default.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/experiment-firefox-new-default.html
@@ -1,0 +1,42 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "firefox/new/desktop/download.html" %}
+
+{% block experiments %}
+  {{ js_bundle('experiment-firefox-new-default') }}
+{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('experiment-firefox-new-default') }}
+{% endblock %}
+
+{% macro default_browser_checkbox(id='default-browser-checkbox') -%}
+  <label for="{{ id }}" class="default-browser-checkbox-label hidden">
+    <input type="checkbox" id="{{ id }}" class="default-browser-checkbox-input">
+    Set Firefox as your default browser.
+  </label>
+{%- endmacro %}
+
+{% block primary_cta %}
+  {{ default_browser_checkbox(id='default-browser-checkbox-primary') }}
+  {{ download_firefox_thanks(dom_id='download-primary', locale_in_transition=True, download_location='primary cta') }}
+{% endblock %}
+
+{% block features_cta %}
+  {{ default_browser_checkbox(id='default-browser-checkbox-features') }}
+  {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
+{% endblock %}
+
+{% block discover_cta %}
+  {{ default_browser_checkbox(id='default-browser-checkbox-discover') }}
+  {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-new-default-opt-out') }}
+{% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -753,6 +753,7 @@ class NewView(L10nTemplateView):
     ftl_files_map = {
         "firefox/new/basic/base_download.html": ["firefox/new/download"],
         "firefox/new/desktop/download.html": ["firefox/new/desktop"],
+        "firefox/new/desktop/experiment-firefox-new-default.html": ["firefox/new/desktop"],
     }
     activation_files = [
         "firefox/new/download",
@@ -760,7 +761,7 @@ class NewView(L10nTemplateView):
     ]
 
     # place expected ?v= values in this list
-    variations = []
+    variations = ["treatment", "control"]
 
     def get(self, *args, **kwargs):
         # Remove legacy query parameters (Bug 1236791)
@@ -801,13 +802,18 @@ class NewView(L10nTemplateView):
     def get_template_names(self):
         variation = self.request.GET.get("variation", None)
         experience = self.request.GET.get("xv", None)
+        locale = l10n_utils.get_locale(self.request)
+        country = get_country_from_request(self.request)
 
         # ensure variant matches pre-defined value
         if variation not in self.variations:
             variation = None
 
         if ftl_file_is_active("firefox/new/desktop") and experience != "basic":
-            template = "firefox/new/desktop/download.html"
+            if variation == "treatment" and locale in ["en-US", "en-CA"] and country in ["US", "CA"]:
+                template = "firefox/new/desktop/experiment-firefox-new-default.html"
+            else:
+                template = "firefox/new/desktop/download.html"
         else:
             template = "firefox/new/basic/base_download.html"
 

--- a/media/css/firefox/new/desktop/default-experiment.scss
+++ b/media/css/firefox/new/desktop/default-experiment.scss
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
+.default-browser-checkbox-label {
+    margin: 0 auto $spacing-lg;
+    font-weight: normal;
+    display: block;
+    width: max-content;
+
+    &.hidden {
+        display: none;
+    }
+
+    input[type="checkbox"] {
+        margin-right: $spacing-sm;
+        vertical-align: top;
+    }
+
+    .c-intro-download & {
+        margin: 0 0 $spacing-lg;
+    }
+}

--- a/media/js/firefox/new/desktop/default-experiment-criteria.es6.js
+++ b/media/js/firefox/new/desktop/default-experiment-criteria.es6.js
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    hasConsentCookie,
+    getConsentCookie
+} from '../../../base/consent/utils.es6';
+
+const experimentCookieID = 'download-as-default';
+
+const utmParams = [
+    'utm_source=',
+    'utm_medium=',
+    'utm_campaign=',
+    'utm_term=',
+    'utm_content='
+];
+
+function meetsExperimentCriteria(platform, params) {
+    // Experiment specific feature detection.
+    if (
+        typeof window.URL !== 'function' ||
+        typeof window.URLSearchParams !== 'function' ||
+        !window.history.replaceState
+    ) {
+        return false;
+    }
+
+    // Experiment should only trigger for Windows.
+    if (platform !== 'windows') {
+        return false;
+    }
+
+    // Don't enter into experiment if cookies are disabled.
+    if (!Mozilla.Cookies.enabled()) {
+        return false;
+    }
+
+    // Don't enter into experiment if visitor has previously rejected analytics.
+    if (hasConsentCookie()) {
+        const cookie = getConsentCookie();
+
+        if (!cookie.analytics) {
+            return false;
+        }
+    }
+
+    /**
+     * Don't enter into experiment if there are any existing UTM parameters in
+     * the page URL. We do not want to clobber those and overwrite existing
+     * campaign data.
+     */
+    if (params) {
+        const queryString = decodeURIComponent(params);
+        return utmParams.every((param) => {
+            return queryString.indexOf(param) === -1;
+        });
+    }
+
+    // Don't enter into experiment if we already have an attribution cookie.
+    if (
+        (Mozilla.Cookies.hasItem('moz-stub-attribution-code') ||
+            Mozilla.Cookies.hasItem('moz-stub-attribution-sig')) &&
+        !Mozilla.Cookies.hasItem(experimentCookieID)
+    ) {
+        return false;
+    }
+
+    return true;
+}
+
+export { meetsExperimentCriteria, experimentCookieID };

--- a/media/js/firefox/new/desktop/default-experiment.es6.js
+++ b/media/js/firefox/new/desktop/default-experiment.es6.js
@@ -1,0 +1,119 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrafficCop from '@mozmeao/trafficcop';
+import { isApprovedToRun } from '../../../base/experiment-utils.es6';
+import {
+    meetsExperimentCriteria,
+    experimentCookieID
+} from './default-experiment-criteria.es6';
+
+const href = window.location.href;
+const ATTRIBUTION_COOKIE_CODE_ID = 'moz-stub-attribution-code';
+const ATTRIBUTION_COOKIE_SIGNATURE_ID = 'moz-stub-attribution-sig';
+
+if (typeof window.dataLayer === 'undefined') {
+    window.dataLayer = [];
+}
+
+/**
+ * Sets a cookie to remember which experiment variation has been seen.
+ * @param {Object} traffic cop config
+ */
+function setVariationCookie(exp) {
+    // set cookie to expire in 24 hours
+    const date = new Date();
+    date.setTime(date.getTime() + 1 * 24 * 60 * 60 * 1000);
+    const expires = date.toUTCString();
+
+    window.Mozilla.Cookies.setItem(
+        exp.id,
+        exp.chosenVariation,
+        expires,
+        undefined,
+        undefined,
+        false,
+        'lax'
+    );
+}
+
+/**
+ * Removes existing stub attribution cookie
+ */
+function removeAttributionCookie() {
+    window.Mozilla.Cookies.removeItem(
+        ATTRIBUTION_COOKIE_CODE_ID,
+        '/',
+        undefined,
+        false,
+        'lax'
+    );
+
+    window.Mozilla.Cookies.removeItem(
+        ATTRIBUTION_COOKIE_SIGNATURE_ID,
+        '/',
+        undefined,
+        false,
+        'lax'
+    );
+}
+
+const init = () => {
+    if (
+        href.indexOf('experiment=download-as-default&variation=control') !== -1
+    ) {
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: experimentCookieID,
+            variant: 'control'
+        });
+    } else if (
+        href.indexOf('experiment=download-as-default&variation=treatment') !==
+        -1
+    ) {
+        /**
+         * People only enter into this experiment if they do not already have stub
+         * attribution data. However there's still the edge case that someone may
+         * not download right away, and return back later. If that's the case,
+         * then we don't know if they checked or unchecked the input originally.
+         * To circumvent this, we delete their original attribution cookie,
+         * which will then be created fresh when they load the page again.
+         */
+        if (
+            window.Mozilla.Cookies.hasItem(ATTRIBUTION_COOKIE_CODE_ID) ||
+            window.Mozilla.Cookies.hasItem(ATTRIBUTION_COOKIE_SIGNATURE_ID)
+        ) {
+            removeAttributionCookie();
+        }
+
+        window.dataLayer.push({
+            event: 'experiment_view',
+            id: experimentCookieID,
+            variant: 'treatment'
+        });
+    } else if (TrafficCop) {
+        if (
+            isApprovedToRun() &&
+            meetsExperimentCriteria(
+                window.site.platform,
+                window.location.search
+            )
+        ) {
+            const cop = new TrafficCop({
+                id: experimentCookieID,
+                variations: {
+                    'experiment=download-as-default&variation=control': 25,
+                    'experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER': 25
+                }
+            });
+            cop.init();
+
+            setVariationCookie(cop);
+        }
+    }
+};
+
+init();

--- a/media/js/firefox/new/desktop/default-opt-out-init.es6.js
+++ b/media/js/firefox/new/desktop/default-opt-out-init.es6.js
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import DefaultOptOut from './default-opt-out.es6.js';
+
+DefaultOptOut.init();

--- a/media/js/firefox/new/desktop/default-opt-out.es6.js
+++ b/media/js/firefox/new/desktop/default-opt-out.es6.js
@@ -1,0 +1,247 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    hasConsentCookie,
+    getConsentCookie,
+    consentRequired,
+    dntEnabled,
+    gpcEnabled
+} from '../../../base/consent/utils.es6';
+
+const DefaultOptOut = {};
+
+/**
+ * Removes UTM parameters from a given URL, preserving
+ * all other parameters and URL information.
+ * @param {String} href
+ * @returns {String} href
+ */
+DefaultOptOut.removeUTMParams = (href) => {
+    const url = new URL(href);
+    const searchParams = new URLSearchParams(url.search);
+
+    // List of UTM parameters to remove
+    const utmParams = [
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content'
+    ];
+
+    // Remove UTM parameters
+    utmParams.forEach((param) => searchParams.delete(param));
+
+    // Construct new URL without UTM parameters
+    const newUrl =
+        url.origin +
+        url.pathname +
+        (searchParams.toString() ? '?' + searchParams.toString() : '') +
+        url.hash;
+
+    return newUrl;
+};
+
+/**
+ * Adds UTM parameters to a given URL that are needed to trigger
+ * the set-as-default functionality when Firefox is installed.
+ * @param {String} href
+ * @returns {String} href
+ */
+DefaultOptOut.addUTMParams = (href) => {
+    const url = new URL(href);
+    const searchParams = new URLSearchParams(url.search);
+
+    searchParams.append('utm_source', 'www.mozilla.org');
+    searchParams.append('utm_campaign', 'SET_DEFAULT_BROWSER');
+
+    // Construct new URL without UTM parameters
+    const newUrl =
+        url.origin +
+        url.pathname +
+        (searchParams.toString() ? '?' + searchParams.toString() : '') +
+        url.hash;
+
+    return newUrl;
+};
+
+/**
+ * Processes attribution changes depending on checkbox state.
+ * @param {Boolean} checked - checkbox target value.
+ */
+DefaultOptOut.processAttributionRequest = (checked) => {
+    let url = window.location.href;
+
+    // First remove all existing attribution data.
+    window.Mozilla.StubAttribution.removeAttributionData();
+
+    /**
+     * If the checkbox has been unchecked, remove UTM parameters
+     * from the page URL (`utm_campaign=SET_DEFAULT_BROWSER` is
+     * what triggers the browser default functionality).
+     */
+    if (!checked) {
+        url = DefaultOptOut.removeUTMParams(url);
+    } else {
+        url = DefaultOptOut.addUTMParams(url);
+    }
+
+    // Update the browser's URL without reloading
+    window.history.replaceState({}, document.title, url);
+
+    /**
+     * Finally, re-initiate attribution based on the new URL
+     * parameters. Only rebind events after attribution
+     * request has been successful.
+     */
+    window.Mozilla.StubAttribution.init(() => {
+        DefaultOptOut.bindEvents();
+    });
+};
+
+/**
+ * Handles checkbox change event. Because checkbox state must be
+ * synced between all checkboxes on the page, we must temporarily
+ * unbind event listeners to avoid triggering multiple change
+ * events at once.
+ * @param {Object} e - change event object.
+ */
+DefaultOptOut.handleChangeEvent = (e) => {
+    DefaultOptOut.unbindEvents();
+    DefaultOptOut.setCheckboxState(e.target.checked);
+    DefaultOptOut.processAttributionRequest(e.target.checked);
+};
+
+/**
+ * Unbinds checkbox change event listeners and disables
+ * inputs when unbound.
+ */
+DefaultOptOut.unbindEvents = () => {
+    const checkboxes = document.querySelectorAll(
+        '.default-browser-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].removeEventListener(
+            'change',
+            DefaultOptOut.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = true;
+    }
+};
+
+/**
+ * Binds checkbox change event listeners and removes
+ * disabled states on inputs when bound.
+ */
+DefaultOptOut.bindEvents = () => {
+    const checkboxes = document.querySelectorAll(
+        '.default-browser-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].addEventListener(
+            'change',
+            DefaultOptOut.handleChangeEvent,
+            false
+        );
+        checkboxes[i].disabled = false;
+    }
+};
+
+/**
+ * Sets the checked state of all checkbox inputs.
+ * @param {Boolean} checked state
+ */
+DefaultOptOut.setCheckboxState = (checked) => {
+    const checkboxes = document.querySelectorAll(
+        '.default-browser-checkbox-input'
+    );
+
+    for (let i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].checked = checked;
+    }
+};
+
+DefaultOptOut.shouldSetChecked = () => {
+    return (
+        window.location.href.indexOf('utm_campaign=SET_DEFAULT_BROWSER') !== -1
+    );
+};
+
+/**
+ * Displays checkboxes via CSS by removing the `hidden`
+ * class on their corresponding `<label>` parent elements.
+ * Also sets `checked=true` to enforce opt-out state.
+ */
+DefaultOptOut.showCheckbox = () => {
+    const labels = document.querySelectorAll('.default-browser-checkbox-label');
+
+    for (let i = 0; i < labels.length; i++) {
+        labels[i].classList.remove('hidden');
+
+        // Only preselect the checkbox if `utm_campaign=SET_DEFAULT_BROWSER` is present.
+        if (DefaultOptOut.shouldSetChecked()) {
+            labels[i].querySelector('.default-browser-checkbox-input').checked =
+                true;
+        }
+    }
+};
+
+/**
+ * Determines if set-as-default checkbox should display.
+ * @returns {Boolean}
+ */
+DefaultOptOut.meetsRequirements = () => {
+    if (
+        // Experiment specific feature detection.
+        typeof window.URL !== 'function' ||
+        typeof window.URLSearchParams !== 'function' ||
+        !window.history.replaceState
+    ) {
+        return false;
+    } else if (window.site.platform !== 'windows') {
+        // Ensure the visitor is on Windows OS
+        return false;
+    } else if (dntEnabled() || gpcEnabled()) {
+        // Has the visitor set a browser-level privacy flag?
+        return false;
+    } else if (hasConsentCookie()) {
+        // Does the visitor have an existing analytics consent cookie?
+        const cookie = getConsentCookie();
+        return cookie.analytics ? true : false;
+    } else if (consentRequired()) {
+        // Is the visitor in EU/EAA?
+        return false;
+    } else if (
+        // Are requirements for stub attribution met?
+        typeof window.Mozilla.StubAttribution === 'undefined' ||
+        !window.Mozilla.StubAttribution.meetsRequirements()
+    ) {
+        return false;
+    }
+
+    return true;
+};
+
+/**
+ * Init Firefox set-as-default opt-out flow.
+ * @returns {Boolean}.
+ */
+DefaultOptOut.init = () => {
+    if (!DefaultOptOut.meetsRequirements()) {
+        return false;
+    }
+
+    DefaultOptOut.showCheckbox();
+    DefaultOptOut.bindEvents();
+
+    return true;
+};
+
+export default DefaultOptOut;

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -148,6 +148,12 @@
     },
     {
       "files": [
+        "css/firefox/new/desktop/default-experiment.scss"
+      ],
+      "name": "experiment-firefox-new-default"
+    },
+    {
+      "files": [
         "css/security/security.scss"
       ],
       "name": "security"
@@ -1310,6 +1316,19 @@
         "js/firefox/landing/get/marketing-opt-out-init.es6.js"
       ],
       "name": "firefox_marketing_opt_out"
+    },
+    {
+      "files": [
+        "js/firefox/new/desktop/default-experiment.es6.js"
+      ],
+      "name": "experiment-firefox-new-default"
+    },
+    {
+      "files": [
+        "js/base/stub-attribution/stub-attribution.js",
+        "js/firefox/new/desktop/default-opt-out-init.es6.js"
+      ],
+      "name": "firefox-new-default-opt-out"
     },
     {
       "files": [

--- a/tests/unit/spec/firefox/new/desktop/default-experiment-criteria.js
+++ b/tests/unit/spec/firefox/new/desktop/default-experiment-criteria.js
@@ -1,0 +1,86 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import { meetsExperimentCriteria } from '../../../../../../media/js/firefox/new/desktop/default-experiment-criteria.es6';
+
+describe('default-experiment-criteria.es6.js', function () {
+    describe('meetsExperimentCriteria', function () {
+        it('should return false if platform is not windows', function () {
+            expect(meetsExperimentCriteria('osx')).toBeFalse();
+            expect(meetsExperimentCriteria('linux')).toBeFalse();
+            expect(meetsExperimentCriteria('ios')).toBeFalse();
+            expect(meetsExperimentCriteria('android')).toBeFalse();
+            expect(meetsExperimentCriteria('other')).toBeFalse();
+        });
+
+        it('should return false if cookies are disabled', function () {
+            spyOn(window.Mozilla.Cookies, 'enabled').and.returnValue(false);
+            expect(meetsExperimentCriteria('windows')).toBeFalse();
+        });
+
+        it('should return false if consent cookie rejects analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'enabled').and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem').and.returnValue(
+                JSON.stringify({
+                    analytics: false,
+                    preference: true
+                })
+            );
+
+            expect(meetsExperimentCriteria('windows')).toBeFalse();
+        });
+
+        it('should return false if UTM params are already present', function () {
+            spyOn(window.Mozilla.Cookies, 'enabled').and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(false);
+
+            expect(
+                meetsExperimentCriteria(
+                    'windows',
+                    'utm_source=test&utm_campaign=test'
+                )
+            ).toBeFalse();
+            expect(
+                meetsExperimentCriteria(
+                    'osx',
+                    'utm_medium=test&utm_term=test&utm_content=test'
+                )
+            ).toBeFalse();
+        });
+
+        it('should return false if attribution cookie already exists', function () {
+            spyOn(window.Mozilla.Cookies, 'enabled').and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false)
+                .withArgs('download-as-default')
+                .and.returnValue(false)
+                .withArgs('moz-stub-attribution-code')
+                .and.returnValue(true)
+                .withArgs('moz-stub-attribution-sig')
+                .and.returnValue(true);
+
+            expect(meetsExperimentCriteria('windows')).toBeFalse();
+        });
+
+        it('should return true if all criteria are met', function () {
+            spyOn(window.Mozilla.Cookies, 'enabled').and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'hasItem').and.returnValue(false);
+            expect(
+                meetsExperimentCriteria('windows', 'param1=test&param2=test')
+            ).toBeTrue();
+            expect(meetsExperimentCriteria('windows')).toBeTrue();
+        });
+    });
+});

--- a/tests/unit/spec/firefox/new/desktop/default-opt-out.js
+++ b/tests/unit/spec/firefox/new/desktop/default-opt-out.js
@@ -1,0 +1,324 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+import DefaultOptOut from '../../../../../../media/js/firefox/new/desktop/default-opt-out.es6';
+
+describe('default-opt-out.es6.js', function () {
+    beforeEach(function () {
+        const optOut = `<div id="opt-out">
+            <label for="default-opt-out-primary" class="default-browser-checkbox-label hidden">
+                <input type="checkbox" id="default-opt-out-primary"" class="default-browser-checkbox-input">
+                Set Firefox as your default browser.
+            </label>
+            <label for="default-opt-out-secondary" class="default-browser-checkbox-label hidden">
+                <input type="checkbox" id="default-opt-out-secondary" class="default-browser-checkbox-input">
+                Set Firefox as your default browser.
+            </label>
+        </div>`;
+
+        document.body.insertAdjacentHTML('beforeend', optOut);
+    });
+
+    beforeEach(function () {
+        spyOn(DefaultOptOut, 'shouldSetChecked').and.returnValue(true);
+
+        window.site.platform = 'windows';
+    });
+
+    afterEach(function () {
+        const optOut = document.getElementById('opt-out');
+        optOut.parentNode.removeChild(optOut);
+
+        document
+            .getElementsByTagName('html')[0]
+            .removeAttribute('data-needs-consent');
+
+        window.site.platform = 'other';
+    });
+
+    describe('init()', function () {
+        it('should return false if OS is not Windows', function () {
+            window.site.platform = 'osx';
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeFalse();
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return false if GPC is enabled', function () {
+            window.Mozilla.gpcEnabled = sinon.stub().returns(true);
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeFalse();
+            delete window.Mozilla.gpcEnabled;
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return false if DNT is enabled', function () {
+            window.Mozilla.dntEnabled = sinon.stub().returns(true);
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeFalse();
+            delete window.Mozilla.dntEnabled;
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return true if consent cookie accepts analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(
+                    JSON.stringify({
+                        analytics: true,
+                        preference: true
+                    })
+                );
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeTrue();
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+        });
+
+        it('should return false if consent cookie rejects analytics', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(true);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(
+                    JSON.stringify({
+                        analytics: false,
+                        preference: true
+                    })
+                );
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeFalse();
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return false if visitor is in EU/EAA country', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'True');
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeFalse();
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should return true if visitor is outside EU/EAA', function () {
+            window.Mozilla.gpcEnabled = sinon.stub().returns(false);
+            window.Mozilla.gpcEnabled = sinon.stub().returns(false);
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+            spyOn(window.Mozilla.Cookies, 'getItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(true);
+
+            document
+                .getElementsByTagName('html')[0]
+                .setAttribute('data-needs-consent', 'False');
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeTrue();
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+
+            document
+                .getElementsByTagName('html')[0]
+                .removeAttribute('data-needs-consent');
+        });
+
+        it('should return false if attribution requirements are not satisfied', function () {
+            spyOn(window.Mozilla.Cookies, 'hasItem')
+                .withArgs('moz-consent-pref')
+                .and.returnValue(false);
+            spyOn(
+                window.Mozilla.StubAttribution,
+                'meetsRequirements'
+            ).and.returnValue(false);
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeFalse();
+
+            const checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should refresh attribution data and and update URL when visitor unchecks input', function () {
+            spyOn(DefaultOptOut, 'meetsRequirements').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'removeAttributionData');
+            spyOn(window.Mozilla.StubAttribution, 'init');
+            spyOn(DefaultOptOut, 'removeUTMParams');
+            spyOn(window.history, 'replaceState');
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeTrue();
+
+            let checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+
+            document.getElementById('default-opt-out-primary').click();
+            expect(
+                window.Mozilla.StubAttribution.removeAttributionData
+            ).toHaveBeenCalled();
+            expect(DefaultOptOut.removeUTMParams).toHaveBeenCalled();
+            expect(window.history.replaceState).toHaveBeenCalled();
+            expect(window.Mozilla.StubAttribution.init).toHaveBeenCalled();
+
+            checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+        });
+
+        it('should opt back into analytics and init attribution if visitor re-checks input', function () {
+            spyOn(DefaultOptOut, 'meetsRequirements').and.returnValue(true);
+            spyOn(window.Mozilla.StubAttribution, 'removeAttributionData');
+            spyOn(window.Mozilla.StubAttribution, 'init').and.callFake(
+                (callback) => {
+                    callback();
+                }
+            );
+            spyOn(DefaultOptOut, 'addUTMParams');
+            spyOn(DefaultOptOut, 'removeUTMParams');
+            spyOn(window.history, 'replaceState');
+
+            const result = DefaultOptOut.init();
+            expect(result).toBeTrue();
+
+            let checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+
+            // Opt out
+            document.getElementById('default-opt-out-primary').click();
+
+            checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(0);
+
+            // Opt in
+            document.getElementById('default-opt-out-secondary').click();
+
+            expect(
+                window.Mozilla.StubAttribution.removeAttributionData
+            ).toHaveBeenCalledTimes(2);
+            expect(DefaultOptOut.removeUTMParams).toHaveBeenCalledTimes(1);
+            expect(DefaultOptOut.addUTMParams).toHaveBeenCalledTimes(1);
+            expect(window.history.replaceState).toHaveBeenCalledTimes(2);
+            expect(window.Mozilla.StubAttribution.init).toHaveBeenCalledTimes(
+                2
+            );
+
+            checkboxes = document.querySelectorAll(
+                '.default-browser-checkbox-input:checked'
+            );
+            expect(checkboxes.length).toEqual(2);
+        });
+    });
+
+    describe('removeUTMParams', function () {
+        it('should remove UTM parameters from a URL as expected', function () {
+            const href =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER';
+            const expected =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment';
+            const result = DefaultOptOut.removeUTMParams(href);
+            expect(result).toEqual(expected);
+
+            const href2 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment';
+            const result2 = DefaultOptOut.removeUTMParams(href2);
+            expect(result2).toEqual(href2);
+
+            const href3 = 'https://www.mozilla.org/en-US/firefox/new/';
+            const result3 = DefaultOptOut.removeUTMParams(href3);
+            expect(result3).toEqual(href3);
+
+            const href4 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER#download';
+            const expected4 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment#download';
+            const result4 = DefaultOptOut.removeUTMParams(href4);
+            expect(result4).toEqual(expected4);
+        });
+    });
+
+    describe('addUTMParams', function () {
+        it('should add UTM parameters to a URL as expected', function () {
+            const href =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment';
+            const expected =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER';
+            const result = DefaultOptOut.addUTMParams(href);
+            expect(result).toEqual(expected);
+
+            const href2 = 'https://www.mozilla.org/en-US/firefox/new/';
+            const expected2 =
+                'https://www.mozilla.org/en-US/firefox/new/?utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER';
+            const result2 = DefaultOptOut.addUTMParams(href2);
+            expect(result2).toEqual(expected2);
+
+            const href3 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment#download';
+            const expected3 =
+                'https://www.mozilla.org/en-US/firefox/new/?experiment=download-as-default&variation=treatment&utm_source=www.mozilla.org&utm_campaign=SET_DEFAULT_BROWSER#download';
+            const result3 = DefaultOptOut.addUTMParams(href3);
+            expect(result3).toEqual(expected3);
+        });
+    });
+});


### PR DESCRIPTION
## One-line summary

This reverts commit 52f448f984d837fe19eca24903247b15beba16af.

## Significant changes and points to review

Basically there was an error on the product side of things that meant people saw an older version of the on-boarding flow and not the one this test should display, so the product team have asked to run this again.

This code has already been reviewed and tested in https://github.com/mozilla/bedrock/pull/16020, so should hopefully be a quick and simple review this time around.

## Issue / Bugzilla link

#16096

## Testing

http://localhost:8000/en-US/firefox/new/