### PR TITLE
update VPN extension download link (fix #16087)

### DIFF
--- a/bedrock/products/templates/products/vpn/windows-download.html
+++ b/bedrock/products/templates/products/vpn/windows-download.html
@@ -152,7 +152,7 @@
           ),
           body=True,
           ) %}
-          <p>{{ ftl('vpn-download-and-install', extension='https://addons.mozilla.org/firefox/addon/mozilla-vpn-extension/') }}</p>
+          <p>{{ ftl('vpn-download-and-install', extension='https://addons.mozilla.org/firefox/addon/mozilla-vpn-extension/?utm_medium=referral&utm_source=mozilla-vpn-website&utm_campaign=evergreen&utm_content=thank-you-page') }}</p>
         {% endcall %}
       </ol>
     </section>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the VPN Windows extension download link.

## Significant changes and points to review

http://localhost:8000/en-US/products/vpn/download/windows/thanks/ step 5

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16087

## Testing

http://localhost:8000/en-US/products/vpn/download/windows/thanks/