### PR TITLE
Fix transparency header and footer margins

### DIFF
--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -10,13 +10,13 @@
 // * -------------------------------------------------------------------------- */
 // Index
 
-dt {
+main dt {
     @include text-title-xs;
     font-weight: bold;
     margin-top: $spacing-sm;
 }
 
-dd {
+main dd {
     padding: $spacing-sm;
 }
 
@@ -96,12 +96,12 @@ dd {
     margin: 0 auto $layout-lg;
 }
 
-h2 {
+main h2 {
     @include text-title-md;
     margin-top: $spacing-2xl;
 }
 
-h3 {
+main h3 {
     @include text-title-sm;
     margin-top: $spacing-2xl;
 }


### PR DESCRIPTION
## One-line summary

Constrains heading adjustments only to content, to not interfere with other site components.

## Significant changes and points to review

1. I'm aware the stylistic choice is questionable, I could have nested it in blocks but wanted to make the least meaningless whitespace changes.
2. It all seems to be inside mzp-l-content so that could have been used instead of main however there's a lot of pages to check so went with the simple container constraint.
3. Proper solution should perhaps be constraining that to mzp-c-article or whatever was used there before, and use that as a container; however that's not the case currently, and alas would need more refactoring and careful checking.

## Issue / Bugzilla link

Fixes #16123
(also closes #16124)

## Testing

/about/policy/transparency/
/about/policy/transparency/jan-jun-2024/
/about/policy/transparency/jan-jun-2019/