### PR TITLE
Fix FxA form link contrasts

### DIFF
--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -125,10 +125,13 @@ $promo-sm-mq: 400px;
         }
     }
 
-    a {
+    a:link,
+    a:visited {
         color: $color-white;
 
-        &:hover {
+        &:hover,
+        &:focus,
+        &:active {
             color: $color-white;
         }
     }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 🤷 (the promo is included in more places so most likely yes 🔥🦊)

## One-line summary

Needs more specificity for active, focus, visited inherited from base style.

## Significant changes and points to review

Not sure if these are regressions from overriding fonts and colors in base not yet in protocol theme, or was a preexisting issue so I'm not adding any comments to review if/once MZP v20 lands some of that in defaults. Figured being as explicit about (non-)inheritance can't hurt either way.

## Issue / Bugzilla link

Resolves #15925

## Testing

http://localhost:8000/en/firefox/
http://localhost:8000/en/products/