### PR TITLE
Remove refresh switch and associated fallbacks

### DIFF
--- a/bedrock/base/templates/base-error.html
+++ b/bedrock/base/templates/base-error.html
@@ -16,7 +16,7 @@
   <div class="mzp-l-content">
     <div class="header-image">
       <a class="logo-mozilla" href="{{ url('mozorg.home') }}">
-        <img class="c-navigation-logo-image m24-logo" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('error-page-mozilla') }}"  width="192" height="46">
+        <img class="c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('error-page-mozilla') }}"  width="192" height="46">
       </a>
       <a class="logo-firefox" href="{{ url('firefox') }}"><img src="{{ static('protocol/img/logos/firefox/logo-word-hor.svg') }}" alt="{{ ftl('error-page-firefox') }}" width="140"></a>
     </div>

--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -9,14 +9,10 @@
 {% block body_class %}mzp-t-mozilla{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') %}
     {{ css_bundle('protocol-mozilla-2024') }}
     {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
       {{ css_bundle('m24-navigation-and-footer') }}
     {% else %}
       {{ css_bundle('legacy-navigation-and-footer') }}
     {% endif %}
-  {% else %}
-    {{ css_bundle('protocol-mozilla') }}
-  {% endif %}
 {% endblock %}

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -72,15 +72,11 @@
     <!--[if !IE]><!-->
     {# Global styles, hidden from IE9 and lower #}
     {% block site_css %}
-      {% if switch('m24-website-refresh') %}
-        {{ css_bundle('protocol-mozilla-2024') }}
-        {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
-          {{ css_bundle('m24-navigation-and-footer') }}
-        {% else %}
-          {{ css_bundle('legacy-navigation-and-footer') }}
-        {% endif %}
+      {{ css_bundle('protocol-mozilla-2024') }}
+      {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+        {{ css_bundle('m24-navigation-and-footer') }}
       {% else %}
-        {{ css_bundle('protocol-firefox') }}
+        {{ css_bundle('legacy-navigation-and-footer') }}
       {% endif %}
     {% endblock %}
 
@@ -144,7 +140,7 @@
         {{ js_bundle('lib') }}
         {{ js_bundle('fxa') }}
         {{ js_bundle('data') }}
-        {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+        {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
           {{ js_bundle('m24-ui') }}
         {% else %}
           {{ js_bundle('ui') }}

--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -6,13 +6,13 @@
 
 {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer' %}
 
-{% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+{% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
   {% include 'includes/protocol/footer/footer-refresh.html' %}
 {% else %}
 <footer class="mzp-c-footer {% if theme_class %}{{ theme_class }}{% endif %}" id="colophon" role="contentinfo">
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
-      <div class="mzp-c-footer-primary-logo{% if switch('m24-website-refresh') %} m24-logo{% endif %}">
+      <div class="mzp-c-footer-primary-logo">
         <a href="{{ url('mozorg.home') }}" data-link-position="footer" data-link-text="Mozilla">{{ ftl('footer-mozilla') }}</a>
       </div>
       <div class="mzp-c-footer-sections">

--- a/bedrock/base/templates/includes/protocol/navigation/navigation.html
+++ b/bedrock/base/templates/includes/protocol/navigation/navigation.html
@@ -4,7 +4,7 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+{% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
   {% include 'includes/protocol/navigation/navigation-refresh.html' %}
 {% else %}
   {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
@@ -22,7 +22,7 @@
         <button class="c-navigation-menu-button" type="button" aria-controls="c-navigation-items" data-testid="navigation-menu-button">{{ ftl('navigation-v2-menu') }}</button>
         <div class="c-navigation-logo">
           <a href="{{ url('mozorg.home') }}" data-link-text="mozilla home icon" data-link-position="nav">
-            <img class="c-navigation-logo-image m24-logo" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ logo_alt }}" width="88" height="21">
+            <img class="c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ logo_alt }}" width="88" height="21">
           </a>
         </div>
 

--- a/bedrock/firefox/templates/firefox/built-for-you/landing.de.html
+++ b/bedrock/firefox/templates/firefox/built-for-you/landing.de.html
@@ -14,7 +14,7 @@
 {% block page_image %}{{ static('img/firefox/built-for-you/meta-de.jpg') }}{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/built-for-you/landing.fr.html
+++ b/bedrock/firefox/templates/firefox/built-for-you/landing.fr.html
@@ -14,7 +14,7 @@
 {% block page_image %}{{ static('img/firefox/built-for-you/meta-fr.jpg') }}{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/challenge-the-default/landing-base.html
+++ b/bedrock/firefox/templates/firefox/challenge-the-default/landing-base.html
@@ -13,7 +13,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% block page_desc %}{{ seo_desc }}{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -17,7 +17,7 @@
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/developer/apple-touch-icon.png') }}{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -14,7 +14,7 @@
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/developer/apple-touch-icon.png') }}{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -7,7 +7,7 @@
 {% extends "firefox/base/base-protocol.html" %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -12,7 +12,7 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -10,7 +10,7 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/nothing-personal/index.html
+++ b/bedrock/firefox/templates/firefox/nothing-personal/index.html
@@ -11,7 +11,7 @@
 {% from "firefox/nothing-personal/includes/browser-macro.html" import browser_border %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/welcome/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/base.html
@@ -10,7 +10,7 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/firefox/templates/firefox/whatsnew/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base.html
@@ -16,7 +16,7 @@
 {% block page_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
 
 {% block site_css %}
-  {% if switch('m24-website-refresh') and ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
+  {% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}
     {{ css_bundle('m24-root') }}
     {{ css_bundle('m24-navigation-and-footer') }}
   {% else %}

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -61,13 +61,23 @@ class TestHomePageLocales(TestCase):
         assert resp.status_code == 405
 
     @patch.object(views, "ftl_file_is_active", lambda *x: True)
-    def test_new_homepage_template(self, render_mock):
+    def test_m24_homepage_template(self, render_mock):
         req = RequestFactory().get("/")
         req.locale = "en-US"
         view = views.HomeView.as_view()
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == ["mozorg/home/home-new.html"]
+        assert template == ["mozorg/home/home-m24.html"]
+
+    def test_new_homepage_template(self, render_mock):
+        req = RequestFactory().get("/")
+        req.locale = "en-US"
+        with patch.object(views, "ftl_file_is_active") as active_mock:
+            active_mock.side_effect = [False, True]
+            view = views.HomeView.as_view()
+            view(req)
+            template = render_mock.call_args[0][1]
+            assert template == ["mozorg/home/home-new.html"]
 
     @patch.object(views, "ftl_file_is_active", lambda *x: False)
     def test_old_homepage_template(self, render_mock):
@@ -79,13 +89,24 @@ class TestHomePageLocales(TestCase):
         assert template == ["mozorg/home/home-old.html"]
 
     @patch.object(views, "ftl_file_is_active", lambda *x: True)
-    def test_new_homepage_template_global(self, render_mock):
+    def test_m24_homepage_template_global(self, render_mock):
         req = RequestFactory().get("/")
         req.locale = "es-ES"
         view = views.HomeView.as_view()
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == ["mozorg/home/home-new.html"]
+        assert template == ["mozorg/home/home-m24.html"]
+
+    @patch.object(views, "ftl_file_is_active", lambda *x: True)
+    def test_new_homepage_template_global(self, render_mock):
+        req = RequestFactory().get("/")
+        req.locale = "es-ES"
+        with patch.object(views, "ftl_file_is_active") as active_mock:
+            active_mock.side_effect = [False, True]
+            view = views.HomeView.as_view()
+            view(req)
+            template = render_mock.call_args[0][1]
+            assert template == ["mozorg/home/home-new.html"]
 
     @patch.object(views, "ftl_file_is_active", lambda *x: False)
     def test_old_homepage_template_global(self, render_mock):

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -17,7 +17,6 @@ from django.views.generic import TemplateView
 from jsonview.decorators import json_view
 from product_details import product_details
 
-from bedrock.base.waffle import switch
 from bedrock.contentful.api import ContentfulPage
 from bedrock.mozorg.credits import CreditsFile
 from bedrock.mozorg.forms import MiecoEmailForm
@@ -151,7 +150,7 @@ class HomeView(L10nTemplateView):
     def get_template_names(self):
         experience = self.request.GET.get("xv", None)
 
-        if switch("m24-website-refresh") and ftl_file_is_active("mozorg/home-m24") and experience != "legacy":
+        if ftl_file_is_active("mozorg/home-m24") and experience != "legacy":
             return [self.m24_template_name]
         elif ftl_file_is_active("mozorg/home-new") and experience != "legacy":
             return [self.template_name]
@@ -167,7 +166,7 @@ class AboutView(L10nTemplateView):
     ftl_files_map = {template_name: ["mozorg/about"], m24_template_name: ["mozorg/about-m24"]}
 
     def get_template_names(self):
-        if switch("m24-website-refresh") and ftl_file_is_active("mozorg/about-m24"):
+        if ftl_file_is_active("mozorg/about-m24"):
             return [self.m24_template_name]
 
         return [self.template_name]

--- a/media/css/protocol/components/_navigation.scss
+++ b/media/css/protocol/components/_navigation.scss
@@ -90,6 +90,12 @@
 
     @media #{$mq-md} {
         @include bidi(((margin, $spacing-md ($spacing-sm * 2) $spacing-md 0, $spacing-md 0 $spacing-md ($spacing-sm * 2)),));
+
+        .c-navigation-logo-image {
+            height: 21px;
+            position: relative;
+            top: 1px;
+        }
     }
 
     @media #{$mq-lg} {

--- a/media/css/protocol/navigation-and-footer.scss
+++ b/media/css/protocol/navigation-and-footer.scss
@@ -15,16 +15,8 @@ $image-path: '/media/protocol/img';
 @import 'components/menu';
 @import 'components/menu-item';
 
-// temporary branding refresh tweaks
-.c-navigation-logo .c-navigation-logo-image.m24-logo {
-    @media #{$mq-md} {
-        height: 21px;
-        position: relative;
-        top: 1px;
-    }
-}
 
-.mzp-c-footer-primary-logo.m24-logo a {
+.mzp-c-footer-primary-logo a {
     background-image: url('/media/img/logos/m24/lockup-white.svg');
     height: 27px;
 }

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -564,12 +564,6 @@
     },
     {
       "files": [
-        "css/protocol/protocol-mozilla.scss"
-      ],
-      "name": "protocol-mozilla"
-    },
-    {
-      "files": [
         "css/protocol/protocol-firefox.scss"
       ],
       "name": "protocol-firefox"


### PR DESCRIPTION
## One-line summary

Remove `m24-website-refresh` switch and associated fallbacks.

## Significant changes and points to review

- removed references to switch `m24-website-refresh`
- moved header nav logo override into the css file
  - can't do the same with the footer ones because we're using default Protocol for the legacy footer

## Issue / Bugzilla link

n/a

## Testing

- [ ] New global nav displays when translations exist
- [ ] Old nav displays when translations do not exist

To check that the new logo appears on the old header and footer you can edit `{% if ftl_file_is_active('navigation_refresh') and ftl_file_is_active('footer-refresh') %}` to resolve as False. Or change your local env to `DEV=False` and check an untranslated language.