### PR TITLE
Add vars on monitor article lib import

### DIFF
--- a/media/css/products/monitor/article.scss
+++ b/media/css/products/monitor/article.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 @use '~@mozilla-protocol/core/protocol/css/components/article';
 @use '~@mozilla-protocol/core/protocol/css/components/breadcrumb';


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
should fix CI issue from https://github.com/mozilla/bedrock/actions/runs/14200072847/job/39784617561
`Post-processing 'css/monitor-article.css' failed!`

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
test the monitor pages show as expected