### PR TITLE
Remove subpage restriction from MonitorArticleIndexPage

### DIFF
--- a/bedrock/products/models.py
+++ b/bedrock/products/models.py
@@ -180,8 +180,6 @@ class MonitorCallToActionSnippet(TranslatableMixin):
 
 
 class MonitorArticleIndexPage(AbstractBedrockCMSPage):
-    subpage_types = ["MonitorArticlePage"]
-
     split_heading = models.CharField(
         max_length=255,
         blank=False,


### PR DESCRIPTION
## One-line summary

Remove subpage restriction from MonitorArticleIndexPage

## Significant changes and points to review

It's preventing child pages from being made under the index. Not sure why though.

## Issue / Bugzilla link

n/a

## Testing
