### PR TITLE
Fix nav hover for fx theme

### DIFF
--- a/media/css/m24/components/navigation-refresh.scss
+++ b/media/css/m24/components/navigation-refresh.scss
@@ -364,6 +364,10 @@ $margin-top: 54px; // top margin offset for mobile navigation menu
         text-decoration: none;
     }
 
+    &:hover:is(a) {
+        color: $color-black;
+    }
+    
     .m24-c-menu-title-icon {
         @include bidi(((margin, 0 8px 0 0, 0 0 0 8px),));
     }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 🤷 (most likely 🔥🦊)

## One-line summary

Adds a little specificity to menu anchor colors, to hide flash of Fx–themed palette on some pages.

## Significant changes and points to review

There seems to be some sort of JS delay involved, that applies the final color based on the state of the panel etc. as the final color is often green, not black, and if the link is blue pre-JS, the flash of unexpected color is a bit jarring. This makes the hover anchors on Fx-themed pages consistent with rest of the site.

NB: Went for `:is()` shenanigans only because SASS doesn't allow `a&` (and the selector above is not for anchor but just the pseudo on the class before) and I wanted to keep the rules together with the others, not repeating another block afterwards just for this; technically it's not needed and just `a:hover` would suffice otherwise to resolve this.

(Oh and I'm not adding it to the rule above, as I'm working on underline-based hovers instead of boutique borders in #15855, and the decoration would interfere with that at some point…)

## Issue / Bugzilla link

Fixes #15873
(also closes #16027 as superseded)

## Testing

http://localhost:8000/fr/firefox/challenge-the-default/
http://localhost:8000/en/firefox/family/