### PR TITLE
mobile navigation keyboard focus trap [fix #16090]

### DIFF
--- a/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
+++ b/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
@@ -7,9 +7,9 @@
 /**
  * Trap keyboard focus on mobile navigation.
  * Issue #16090
- * @param {Boolean} isFocusTrapped - determine if keyoard focus trap is active.
+ * @param {Boolean} isFocusTrapped - determine if keyboard focus trap is active.
  * @param {String} element - element to trap keyboard focus within.
- * @param {String} focusableClassList - a string of clsss names of focusable elements.
+ * @param {String} focusableClassList - a string of class names of focusable elements.
  */
 function trapKeyboardFocus(isFocusTrapped, element, focusableClassList) {
     const focusableEles = element.querySelectorAll(focusableClassList);

--- a/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
+++ b/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
@@ -9,14 +9,10 @@
  * Issue #16090
  * @param {Boolean} isFocusTrapped - determine if keyboard focus trap is active.
  * @param {String} element - element to trap keyboard focus within.
- * @param {String} focusableClassList - a string of class names of focusable elements.
+ * @param {Function} focusableClassList - a function that returns a string of class names of focusable elements.
  * @returns {Function} - an arrow function that removes the same event listener that is added to the element
  */
 function trapKeyboardFocus(isFocusTrapped, element, focusableClassList) {
-    const focusableEles = element.querySelectorAll(focusableClassList);
-    const firstFocusableEle = focusableEles[0];
-    const lastFocusableEle = focusableEles[focusableEles.length - 1];
-
     const listener = function (e) {
         if (!isFocusTrapped()) {
             return;
@@ -27,6 +23,10 @@ function trapKeyboardFocus(isFocusTrapped, element, focusableClassList) {
         if (!isTabPressed) {
             return;
         }
+
+        const focusableEles = element.querySelectorAll(focusableClassList());
+        const firstFocusableEle = focusableEles[0];
+        const lastFocusableEle = focusableEles[focusableEles.length - 1];
 
         if (e.shiftKey) {
             // shift + tab

--- a/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
+++ b/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
@@ -10,6 +10,7 @@
  * @param {Boolean} isFocusTrapped - determine if keyboard focus trap is active.
  * @param {String} element - element to trap keyboard focus within.
  * @param {String} focusableClassList - a string of class names of focusable elements.
+ * @returns {Function} - an arrow function that removes the same event listener that is added to the element
  */
 function trapKeyboardFocus(isFocusTrapped, element, focusableClassList) {
     const focusableEles = element.querySelectorAll(focusableClassList);

--- a/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
+++ b/media/js/base/protocol/m24-keyboard-focus-trap.es6.js
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Trap keyboard focus on mobile navigation.
+ * Issue #16090
+ * @param {Boolean} isFocusTrapped - determine if keyoard focus trap is active.
+ * @param {String} element - element to trap keyboard focus within.
+ * @param {String} focusableClassList - a string of clsss names of focusable elements.
+ */
+function trapKeyboardFocus(isFocusTrapped, element, focusableClassList) {
+    const focusableEles = element.querySelectorAll(focusableClassList);
+    const firstFocusableEle = focusableEles[0];
+    const lastFocusableEle = focusableEles[focusableEles.length - 1];
+
+    const listener = function (e) {
+        if (!isFocusTrapped()) {
+            return;
+        }
+
+        const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+
+        if (!isTabPressed) {
+            return;
+        }
+
+        if (e.shiftKey) {
+            // shift + tab
+            if (document.activeElement === firstFocusableEle) {
+                lastFocusableEle.focus();
+                e.preventDefault();
+            }
+        } else {
+            // tab
+            if (document.activeElement === lastFocusableEle) {
+                firstFocusableEle.focus();
+                e.preventDefault();
+            }
+        }
+    };
+
+    element.addEventListener('keydown', listener);
+
+    return () => element.removeEventListener('keydown', listener);
+}
+
+export { trapKeyboardFocus };

--- a/media/js/base/protocol/m24-menu.es6.js
+++ b/media/js/base/protocol/m24-menu.es6.js
@@ -74,6 +74,9 @@ MzpMenu.close = () => {
         _options.onMenuClose();
     }
 
+    // reset keyboard navigation focus trap for MzpNavigation
+    window.MzpNavigation.resetFocusListFunction();
+
     return current.length > 0;
 };
 

--- a/media/js/base/protocol/m24-menu.es6.js
+++ b/media/js/base/protocol/m24-menu.es6.js
@@ -42,9 +42,13 @@ MzpMenu.open = (el, animate) => {
     }
 
     if (typeof window.MzpNavigation !== 'undefined') {
-        // disable navigation focus trap
+        // disable focus trap for MzpNavigation menu category list items(.m24-c-menu-title),
+        // this prevents two "keydown" event listeners running at the same time
+        // on the global navigation (.m24-navigation-refresh)
         window.MzpNavigation.disableKeyboardFcousTrap();
-        // focus trap for only mobile screens
+        // enable keyboard focus trap for selected menu category(.m24-c-menu-category.mzp-is-selected)
+        // global navigation (.m24-navigation-refresh) "keydown" event listening is now handled by MzpMenu
+        // trap focus for only mobile screens
         _menuKeyboardFocusTrapCleanUp = trapKeyboardFocus(
             () => !window.MzpNavigation.isLargeViewport(),
             document.querySelector('.m24-navigation-refresh'),
@@ -127,13 +131,13 @@ MzpMenu.toggle = (el) => {
             _options.onMenuClose();
         }
 
-        // remove mobile menu keyboard focus trap
+        // remove mobile MzpMenu keyboard focus trap
         if (_menuKeyboardFocusTrapCleanUp !== null) {
             _menuKeyboardFocusTrapCleanUp();
             _menuKeyboardFocusTrapCleanUp = null;
         }
 
-        // enable navigation keyboard focus trap
+        // hand off keyboard focus trap back to MzpNavigation
         if (
             typeof window.MzpNavigation !== 'undefined' &&
             !window.MzpNavigation.isLargeViewport()

--- a/media/js/base/protocol/m24-menu.es6.js
+++ b/media/js/base/protocol/m24-menu.es6.js
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { trapKeyboardFocus } from './m24-keyboard-focus-trap.es6';
+
 const MzpMenu = {};
 let _menuOpen = false;
 let _hoverTimeout;
@@ -16,6 +18,8 @@ const _options = {
     onMenuClose: null,
     onMenuButtonClose: null
 };
+
+let _menuKeyboardFocusTrapCleanUp = null;
 
 /**
  * Opens a menu panel.
@@ -35,6 +39,17 @@ MzpMenu.open = (el, animate) => {
 
     if (typeof _options.onMenuOpen === 'function') {
         _options.onMenuOpen(el);
+    }
+
+    if (typeof window.MzpNavigation !== 'undefined') {
+        // disable navigation focus trap
+        window.MzpNavigation.disableKeyboardFcousTrap();
+        // focus trap for only mobile screens
+        _menuKeyboardFocusTrapCleanUp = trapKeyboardFocus(
+            () => !window.MzpNavigation.isLargeViewport(),
+            document.querySelector('.m24-navigation-refresh'),
+            '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .mzp-is-selected a'
+        );
     }
 };
 
@@ -110,6 +125,20 @@ MzpMenu.toggle = (el) => {
 
         if (typeof _options.onMenuClose === 'function') {
             _options.onMenuClose();
+        }
+
+        // remove mobile menu keyboard focus trap
+        if (_menuKeyboardFocusTrapCleanUp !== null) {
+            _menuKeyboardFocusTrapCleanUp();
+            _menuKeyboardFocusTrapCleanUp = null;
+        }
+
+        // enable navigation keyboard focus trap
+        if (
+            typeof window.MzpNavigation !== 'undefined' &&
+            !window.MzpNavigation.isLargeViewport()
+        ) {
+            window.MzpNavigation.enableKeyboardFcousTrap();
         }
     }
 };

--- a/media/js/base/protocol/m24-menu.es6.js
+++ b/media/js/base/protocol/m24-menu.es6.js
@@ -138,7 +138,7 @@ MzpMenu.toggle = (el) => {
             typeof window.MzpNavigation !== 'undefined' &&
             !window.MzpNavigation.isLargeViewport()
         ) {
-            window.MzpNavigation.enableKeyboardFcousTrap();
+            window.MzpNavigation.enableKeyboardFocusTrap();
         }
     }
 };

--- a/media/js/base/protocol/m24-menu.es6.js
+++ b/media/js/base/protocol/m24-menu.es6.js
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { trapKeyboardFocus } from './m24-keyboard-focus-trap.es6';
-
 const MzpMenu = {};
 let _menuOpen = false;
 let _hoverTimeout;
@@ -18,8 +16,6 @@ const _options = {
     onMenuClose: null,
     onMenuButtonClose: null
 };
-
-let _menuKeyboardFocusTrapCleanUp = null;
 
 /**
  * Opens a menu panel.
@@ -41,19 +37,13 @@ MzpMenu.open = (el, animate) => {
         _options.onMenuOpen(el);
     }
 
+    // set new nav focusable elements to be focusable elements on MzpMenu
     if (typeof window.MzpNavigation !== 'undefined') {
-        // disable focus trap for MzpNavigation menu category list items(.m24-c-menu-title),
-        // this prevents two "keydown" event listeners running at the same time
-        // on the global navigation (.m24-navigation-refresh)
-        window.MzpNavigation.disableKeyboardFcousTrap();
-        // enable keyboard focus trap for selected menu category(.m24-c-menu-category.mzp-is-selected)
-        // global navigation (.m24-navigation-refresh) "keydown" event listening is now handled by MzpMenu
-        // trap focus for only mobile screens
-        _menuKeyboardFocusTrapCleanUp = trapKeyboardFocus(
-            () => !window.MzpNavigation.isLargeViewport(),
-            document.querySelector('.m24-navigation-refresh'),
-            '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .mzp-is-selected a'
-        );
+        if (typeof window.MzpNavigation.setFocusList === 'function') {
+            window.MzpNavigation.setFocusList(
+                '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .mzp-is-selected a'
+            );
+        }
     }
 };
 
@@ -131,19 +121,8 @@ MzpMenu.toggle = (el) => {
             _options.onMenuClose();
         }
 
-        // remove mobile MzpMenu keyboard focus trap
-        if (_menuKeyboardFocusTrapCleanUp !== null) {
-            _menuKeyboardFocusTrapCleanUp();
-            _menuKeyboardFocusTrapCleanUp = null;
-        }
-
-        // hand off keyboard focus trap back to MzpNavigation
-        if (
-            typeof window.MzpNavigation !== 'undefined' &&
-            !window.MzpNavigation.isLargeViewport()
-        ) {
-            window.MzpNavigation.enableKeyboardFocusTrap();
-        }
+        // reset keyboard navigation focus trap for MzpNavigation
+        window.MzpNavigation.resetFocusListFunction();
     }
 };
 

--- a/media/js/base/protocol/m24-navigation.es6.js
+++ b/media/js/base/protocol/m24-navigation.es6.js
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { trapKeyboardFocus } from './m24-keyboard-focus-trap.es6';
+
 const MzpNavigation = {};
 let _navElem;
 let _navItemsLists;
@@ -20,6 +22,22 @@ const _wideBreakpoint = '768px';
 const _tallBreakpoint = '600px';
 let _mqLargeNav;
 const _viewport = document.getElementsByTagName('html')[0];
+let _enableKeyboardFcousTrap = false;
+let _navigationKeyboardFocusTrapCleanUp = null;
+
+/**
+ * Enable the keyboard focus trapfor navigation
+ */
+MzpNavigation.enableKeyboardFcousTrap = () => {
+    _enableKeyboardFcousTrap = true;
+};
+
+/**
+ * Disable the keyboard focus trapfor navigation
+ */
+MzpNavigation.disableKeyboardFcousTrap = () => {
+    _enableKeyboardFcousTrap = false;
+};
 
 /**
  * Does the viewport meet the minimum width and height
@@ -176,9 +194,21 @@ MzpNavigation.onClick = (e) => {
         if (typeof _options.onNavOpen === 'function') {
             _options.onNavOpen(thisNavItemList);
         }
+
+        _enableKeyboardFcousTrap = true;
+        _navigationKeyboardFocusTrapCleanUp = trapKeyboardFocus(
+            () => _enableKeyboardFcousTrap && !MzpNavigation.isLargeViewport(),
+            document.querySelector('.m24-navigation-refresh'),
+            '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .m24-c-menu-title'
+        );
     } else {
         if (typeof _options.onNavClose === 'function') {
             _options.onNavClose(thisNavItemList);
+        }
+
+        if (_navigationKeyboardFocusTrapCleanUp !== null) {
+            _navigationKeyboardFocusTrapCleanUp();
+            _navigationKeyboardFocusTrapCleanUp = null;
         }
     }
 };

--- a/media/js/base/protocol/m24-navigation.es6.js
+++ b/media/js/base/protocol/m24-navigation.es6.js
@@ -22,21 +22,21 @@ const _wideBreakpoint = '768px';
 const _tallBreakpoint = '600px';
 let _mqLargeNav;
 const _viewport = document.getElementsByTagName('html')[0];
-let _enableKeyboardFcousTrap = false;
+let _enableKeyboardFocusTrap = false;
 let _navigationKeyboardFocusTrapCleanUp = null;
 
 /**
- * Enable the keyboard focus trapfor navigation
+ * Enable the keyboard focus trap for navigation
  */
-MzpNavigation.enableKeyboardFcousTrap = () => {
-    _enableKeyboardFcousTrap = true;
+MzpNavigation.enableKeyboardFocusTrap = () => {
+    _enableKeyboardFocusTrap = true;
 };
 
 /**
- * Disable the keyboard focus trapfor navigation
+ * Disable the keyboard focus trap for navigation
  */
 MzpNavigation.disableKeyboardFcousTrap = () => {
-    _enableKeyboardFcousTrap = false;
+    _enableKeyboardFocusTrap = false;
 };
 
 /**
@@ -195,9 +195,9 @@ MzpNavigation.onClick = (e) => {
             _options.onNavOpen(thisNavItemList);
         }
 
-        _enableKeyboardFcousTrap = true;
+        _enableKeyboardFocusTrap = true;
         _navigationKeyboardFocusTrapCleanUp = trapKeyboardFocus(
-            () => _enableKeyboardFcousTrap && !MzpNavigation.isLargeViewport(),
+            () => _enableKeyboardFocusTrap && !MzpNavigation.isLargeViewport(),
             document.querySelector('.m24-navigation-refresh'),
             '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .m24-c-menu-title'
         );

--- a/media/js/base/protocol/m24-navigation.es6.js
+++ b/media/js/base/protocol/m24-navigation.es6.js
@@ -22,21 +22,26 @@ const _wideBreakpoint = '768px';
 const _tallBreakpoint = '600px';
 let _mqLargeNav;
 const _viewport = document.getElementsByTagName('html')[0];
-let _enableKeyboardFocusTrap = false;
 let _navigationKeyboardFocusTrapCleanUp = null;
 
+// MzpNavigation focusable element class list
+const _defaultFocusList =
+    '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .m24-c-menu-title';
+let _focusList = _defaultFocusList;
+
 /**
- * Enable the keyboard focus trap for navigation
+ * set class list for focusable elements
+ * @param {String} list - class list to determine focusable elements.
  */
-MzpNavigation.enableKeyboardFocusTrap = () => {
-    _enableKeyboardFocusTrap = true;
+MzpNavigation.setFocusList = (list) => {
+    _focusList = list;
 };
 
 /**
- * Disable the keyboard focus trap for navigation
+ * reset class list for focusable elements as the default one
  */
-MzpNavigation.disableKeyboardFcousTrap = () => {
-    _enableKeyboardFocusTrap = false;
+MzpNavigation.resetFocusListFunction = () => {
+    _focusList = _defaultFocusList;
 };
 
 /**
@@ -195,11 +200,11 @@ MzpNavigation.onClick = (e) => {
             _options.onNavOpen(thisNavItemList);
         }
 
-        _enableKeyboardFocusTrap = true;
+        // trap keyboard navigation focus for MzpNavigation
         _navigationKeyboardFocusTrapCleanUp = trapKeyboardFocus(
-            () => _enableKeyboardFocusTrap && !MzpNavigation.isLargeViewport(),
+            () => !MzpNavigation.isLargeViewport(),
             document.querySelector('.m24-navigation-refresh'),
-            '.m24-c-navigation-logo-link, .m24-c-navigation-menu-button, .m24-c-menu-title'
+            () => _focusList
         );
     } else {
         if (typeof _options.onNavClose === 'function') {


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the m24 navigation to allow mobile navigation keyboard focus trap.

## Significant changes and points to review

- Mobile navigation should have proper keyboard focus trap
- Desktop navigation should have the same behavior as the prod, following document flow

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16090

## Testing

1. Checkout this PR
2. Resize screen to mobile size
3. Click on "Menu" to review navigation focus trap
4. Select a menu category to review menu focus trap
5. Return to opened navigation to review navigation focus trap
6. Resize screen to desktop size to review that full sized navigation is not affected