### PR TITLE
Fix bug #15944: weird gap on mobile articles with sidebar

### DIFF
--- a/media/css/protocol/basic-article.scss
+++ b/media/css/protocol/basic-article.scss
@@ -8,6 +8,12 @@
 @import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
 @import 'components/newsletter-form';
 
+.mzp-l-content.mzp-has-sidebar:has(> .mzp-l-sidebar:first-child) {
+    @media screen and (max-width: #{$screen-md - 1px}) {
+        padding-top: 0;
+    }
+}
+
 .c-article-meta-updated {
     @include text-display-xs;
 }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Removes top padding on smaller screens in the legal articles 

## Significant changes and points to review
I chose not to edit article-base since the [privacy notice page](https://www.mozilla.org/en-US/privacy/) uses it.

I think it makes more sense to reverse the media query. Instead of using min-width we could use max-width and set padding to 0 below a certain screen size. I couldn't find a preset breakpoint variable to use though, like I could for `$mq-md`. 
 
## Issue / Bugzilla link
#15944



## Testing
