### PR TITLE
Remove test-pilot newsletter l10n strings

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
+++ b/bedrock/newsletter/templates/newsletter/includes/newsletter-strings.json
@@ -152,10 +152,6 @@
       "description": "{{ ftl('newsletters-add-your-voice')|striptags }}",
       "title": "{{ ftl('newsletters-take-action')|striptags }}"
   },
-  "test-pilot": {
-      "description": "{{ ftl('newsletters-help-us-make-a-better-v2')|striptags }}",
-      "title": "{{ ftl('newsletters-new-product-testing')|striptags }}"
-  },
   "webmaker": {
       "description": "{{ ftl('newsletters-special-announcements-helping-you')|striptags }}",
       "title": "{{ ftl('newsletters-webmaker')|striptags }}"

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -227,12 +227,6 @@ newsletters-take-action = Take Action for the Internet
 newsletters-add-your-voice = Add your voice to petitions, events and initiatives that fight for the future of the web.
 
 # Name for the newsletter in Newsletter subscription page
-newsletters-new-product-testing = New Product Testing
-
-# Description for the newsletter in Newsletter subscription page (New Product Testing)
-newsletters-help-us-make-a-better-v2 = Help us make a better { -brand-name-mozilla } for you by test-driving our latest products and features.
-
-# Name for the newsletter in Newsletter subscription page
 newsletters-mozilla-community = { -brand-name-mozilla } Community
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Community)


### PR DESCRIPTION
## One-line summary

The `test-pilot` newsletter is being rebranded and started up again as an English only newsletter. As an English only newsletter the thought is we can remove l10n and let the strings from Basket be used as-is, which the marketing team has configured to their liking.

