### PR TITLE
Enable E2EE A/V for chat.m.o

### DIFF
--- a/root_files/.well-known/matrix/client
+++ b/root_files/.well-known/matrix/client
@@ -4,5 +4,11 @@
     },
     "m.identity_server": {
         "base_url": "https://vector.im"
-    }
+    },
+    "org.matrix.msc4143.rtc_foci": [
+        {
+            "type": "livekit",
+            "livekit_service_url": "https://jwt.call.element.io"
+        }
+    ]
 }


### PR DESCRIPTION
## One-line summary

Users currently get `MISSING_MATRIX_RTC_FOCUS` error for audio and video calls — this adds the missing Element Call endpoint.

## Significant changes and points to review

Contrary to the assumption and understanding from #8414 that any delegation to EMS should cover things like this (as it has its own well knowns: https://mozilla.modular.im/.well-known/matrix/client …) the client supposedly only reads the JSON at the apex domain, not the actual cloud/origin instance.

Which would mean bedrock has to actually track any changes to the upstream config, or serve its content instead, proxying, redirecting etc. — I'm trying to understand the options and what's the best practice with hosted EMS in the meantime. This is nonetheless a hotfix for now, to unblock any *RTC usage in the client.

(Users reporting it worked well before the migration, and is only broken as of lately.)

Context: https://element.io/blog/end-to-end-encrypted-voice-and-video-for-self-hosted-community-users/ — Apparently EMS has sent the request to update the JSON config some time ago, it just never reached the right people to be aware of the update.

Pre-approved by @denschub 

## Issue / Bugzilla link

I'll follow up with a more meta issue about how to keep the config in sync with the origin, and whether that's the right thing to do (i.e. if that config is actually correct and here to stay at the origin when it's actually not being picked up at all… also verifying 302 possibilities… TBD.)

## Testing

Analogous to https://kde.org/.well-known/matrix/client using the same EMS.

Content for chat.m.o can be verified at https://mozilla.modular.im/.well-known/matrix/client (the MSC3575 is no longer used since the move to native sliding sync and will most likely get removed over time from the cloud instance…)

(JSONlint: https://jsonlint.com/?url=https://raw.githubusercontent.com/janbrasna/bedrock/40b8c3e2767f3e87255ba5bf1eca5844a243f542/root_files/.well-known/matrix/client ✅…)