### PR TITLE
Only build/deploy docs on commits to mozilla/bedrock repo

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'mozilla/bedrock'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +37,7 @@ jobs:
         with:
           path: ./docs/site
   deploy:
+    if: github.repository == 'mozilla/bedrock'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           path: ./docs/site
   deploy:
-    if: github.repository == 'mozilla/bedrock'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## One-line summary

This action currently fails with an (expected) error every time someone commits to their fork of bedrock. This added check makes it so we only try building and deploying the docs when commits are made here.

## Issue / Bugzilla link

N/A