### PR TITLE
Remove whatsnew-developer-mdnplus.ftl from Pontoon TOML config file

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -249,9 +249,6 @@ locales = [
     reference = "en/firefox/whatsnew/whatsnew.ftl"
     l10n = "{locale}/firefox/whatsnew/whatsnew.ftl"
 [[paths]]
-    reference = "en/firefox/whatsnew/whatsnew-developer-mdnplus.ftl"
-    l10n = "{locale}/firefox/whatsnew/whatsnew-developer-mdnplus.ftl"
-[[paths]]
     reference = "en/mozorg/contribute.ftl"
     l10n = "{locale}/mozorg/contribute.ftl"
 [[paths]]


### PR DESCRIPTION
File was removed in https://github.com/mozilla/bedrock/commit/64672b841f0997b8c1706d809bc549ae6aa1ae97
