### PR TITLE
Move from an allow-list to a regex validator for mobile redirects

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -2,66 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import re
+
 from bedrock.redirects.util import mobile_app_redirector, no_redirect, platform_redirector, redirect
 
 PRODUCT_OPTIONS = ["firefox", "focus", "klar"]
-CAMPAIGN_OPTIONS = [
-    "firefox-whatsnew",
-    "firefox-welcome-4",
-    "firefox-welcome-6",
-    "firefox-welcome-17-en",
-    "firefox-welcome-17-de",
-    "firefox-welcome-17-fr",
-    "firefox-browsers-mobile-get-app",
-    "firefox-browsers-mobile-focus",
-    "mzaonboardingemail-de",
-    "mzaonboardingemail-fr",
-    "mzaonboardingemail-es",
-    "mzaonboardingemail-it",
-    "mzaonboardingemail-nl",
-    "mzaonboardingemail-pl",
-    "firefox-all",
-    "fxshare1",
-    "fxshare2",
-    "fxshare3",
-    "fxshare4",
-    "fxshare5",
-    "fxshare6",
-    "fxshare7",
-    "fxshare8",
-    "fxshare9",
-    "fxshare10",
-    "fxshare11",
-    "fxshare12",
-    "fxshare13",
-    "fxshare14",
-    "fxshare15",
-    "DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_a",
-    "DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_b",
-    "wnp134-de-a",
-    "wnp134-de-b",
-    "wnp134-de-c",
-    "wnp134-en-ca-a",
-    "wnp134-en-ca-b",
-    "wnp134-en-ca-c",
-    "wnp134-en-na-a",
-    "wnp134-en-na-b",
-    "wnp134-en-na-c",
-    "wnp134-en-uk-a",
-    "wnp134-en-uk-b",
-    "wnp134-en-uk-c",
-    "wnp134-fr-a",
-    "wnp134-fr-b",
-    "wnp134-fr-c",
-    "smi-marvintsp",
-    "smi-koschtaaa",
-    "smi-itsmanjuu",
-    "smi-domiip",
-    "smi-drfaye",
-    "smi-shessdly",
-    "smi-bytereview",
-    "pocket-test",
-]
+# matches only ASCII letters (ignoring case), numbers, dashes, periods, and underscores.
+PARAM_VALUES_RE = re.compile(r"[\w.-]+", flags=re.ASCII)
 
 
 def firefox_mobile_faq(request, *args, **kwargs):
@@ -76,10 +23,21 @@ def firefox_channel(*args, **kwargs):
     return platform_redirector("firefox.channel.desktop", "firefox.channel.android", "firefox.channel.ios")
 
 
+def validate_param_value(param: str | None) -> str | None:
+    """
+    Returns the value passed in if it matches the regex `PARAM_VALUES_RE`.
+    Otherwise returns `None`.
+    """
+    if param and PARAM_VALUES_RE.fullmatch(param):
+        return param
+
+    return None
+
+
 def mobile_app(request, *args, **kwargs):
     c = request.GET.get("campaign")
     p = request.GET.get("product")
-    campaign = c if c in CAMPAIGN_OPTIONS else None
+    campaign = validate_param_value(c)
     product = p if p in PRODUCT_OPTIONS else "firefox"
     return mobile_app_redirector(request, product, campaign)
 

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -6,7 +6,57 @@ from unittest.mock import patch
 
 from django.test import RequestFactory
 
-from bedrock.firefox.redirects import mobile_app
+import pytest
+
+from bedrock.firefox.redirects import mobile_app, validate_param_value
+
+
+@pytest.mark.parametrize(
+    "test_param, is_valid",
+    (
+        ("firefox-whatsnew", True),
+        ("firefox-welcome-4", True),
+        ("firefox-welcome-6", True),
+        ("firefox-welcome-17-en", True),
+        ("firefox-welcome-17-de", True),
+        ("firefox-welcome-17-fr", True),
+        ("firefox-browsers-mobile-get-app", True),
+        ("firefox-browsers-mobile-focus", True),
+        ("mzaonboardingemail-de", True),
+        ("mzaonboardingemail-fr", True),
+        ("mzaonboardingemail-es", True),
+        ("firefox-all", True),
+        ("fxshare1", True),
+        ("fxshare2", True),
+        ("fxshare3", True),
+        ("fxshare4", True),
+        ("fxshare12", True),
+        ("fxshare14", True),
+        ("fxshare15", True),
+        ("DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_a", True),
+        ("DESKTOP_FEATURE_CALLOUT_SIGNED_INTO_ACCOUNT.treatment_b", True),
+        ("wnp134-de-a", True),
+        ("wnp134-de-b", True),
+        ("wnp134-de-c", True),
+        ("wnp134-en-ca-a", True),
+        ("wnp134-en-ca-b", True),
+        ("smi-marvintsp", True),
+        ("smi-koschtaaa", True),
+        ("smi-bytereview", True),
+        ("pocket-test", True),
+        ("some<nefarious$thing", False),
+        ("ano+h3r=ne", False),
+        ("ǖnicode", False),
+        ("♪♫♬♭♮♯", False),
+        ("", False),
+        (None, False),
+    ),
+)
+def test_param_verification(test_param, is_valid):
+    if is_valid:
+        assert validate_param_value(test_param) == test_param
+    else:
+        assert validate_param_value(test_param) is None
 
 
 def test_mobile_app():
@@ -25,7 +75,7 @@ def test_mobile_app():
         mar.assert_called_with(req, "firefox", None)
 
     # both args exist but invalid values
-    req = rf.get("/firefox/app/?product=dude&campaign=walter")
+    req = rf.get("/firefox/app/?product=dude&campaign=walter$")
     with patch("bedrock.firefox.redirects.mobile_app_redirector") as mar:
         mobile_app(req)
         mar.assert_called_with(req, "firefox", None)

--- a/docs/docs/attribution/0003-firefox-mobile.md
+++ b/docs/docs/attribution/0003-firefox-mobile.md
@@ -36,7 +36,12 @@ https://apps.apple.com/us/app/apple-store/id1055677337?pt=373246&ct=firefox-brow
 
 ## App store redirects
 
-Occasionally we need to create a link that can auto redirect to either the Apple App Store or the Google Play Store depending on user agent. A common use case is to embed inside a QR Code, which people can then scan on their phone to get a shortcut to the app. To make this easier bedrock has a special redirect URL to which you can add product and campaign query strings. When someone hits the redirect URL, bedrock will attempt to detect their mobile platform and then auto redirect to the appropriate app store.
+Occasionally we need to create a link that can auto redirect to either the Apple App Store or
+the Google Play Store depending on user agent. A common use case is to embed inside a QR Code,
+which people can then scan on their phone to get a shortcut to the app. To make this easier
+bedrock has a special redirect URL to which you can add product and campaign query strings.
+When someone hits the redirect URL, bedrock will attempt to detect their mobile platform and
+then auto redirect to the appropriate app store.
 
 The base redirect URL is `https://www.mozilla.org/firefox/browsers/mobile/app/`, and to it you can add both a `product` and `campaign` query parameter. For example, the following URL would redirect to either Firefox on the Apple App Store or on the Google Play Store, with the specified campaign parameter.
 
@@ -45,7 +50,8 @@ https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=fi
 ```
 
 !!! note
-    The `product` and `campaign` parameters are limited to a set of strictly trusted values. To add more product and campaign options, you can add those values to the `mobile_app` helper function in [firefox/redirects.py](https://github.com/mozilla/bedrock/blob/main/bedrock/firefox/redirects.py).
+    The `product` parameter is limited to only `firefox`, `focus`, or `klar`, and the `campaign`
+    parameter is limited to values that only contain letters, numbers, dashes, underscores, and periods.
 
 
 ## Where can I find mobile attribution data?


### PR DESCRIPTION
Allowed characters in param values are:
- ASCII leters in upper and lower case
- numbers
- period
- dash
- underscore