### PR TITLE
Focus/Klar PN and TOU (Fix #16015)

### DIFF
--- a/bedrock/legal/tests/test_views.py
+++ b/bedrock/legal/tests/test_views.py
@@ -36,3 +36,26 @@ class TestFirefoxSimpleDocView(TestCase):
         view(req)
         template = render_mock.call_args[0][1]
         assert template == "legal/terms/firefox-simple.html"
+
+
+@pytest.mark.django_db
+@patch.object(views, "process_legal_doc")
+@patch.object(legal_docs_views, "load_legal_doc")
+@patch("bedrock.legal_docs.views.l10n_utils.render", return_value=HttpResponse())
+class TestFocusSimpleDocView(TestCase):
+    def test_default_template(self, render_mock, lld_mock, pld_mock):
+        req = RequestFactory().get("/about/legal/terms/firefox-focus/")
+        req.locale = "en-US"
+        view = views.FirefoxTermsOfServiceDocView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "legal/terms/firefox.html"
+
+    @override_settings(DEV=False)
+    def test_simple_template(self, render_mock, lld_mock, pld_mock):
+        req = RequestFactory().get("/about/legal/terms/firefox-focus/?v=product")
+        req.locale = "en-US"
+        view = views.FirefoxTermsOfServiceDocView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "legal/terms/firefox-simple.html"

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -69,8 +69,12 @@ urlpatterns = (
     path("defend-mozilla-trademarks/", views.fraud_report, name="legal.fraud-report"),
     path(
         "terms/firefox/",
-        # Note that the legal_doc_name is decided by a waffle switch - see the view
-        views.FirefoxTermsOfServiceDocView.as_view(legal_doc_name="firefox_about_rights"),
+        views.FirefoxTermsOfServiceDocView.as_view(legal_doc_name="firefox_terms_of_use"),
         name="legal.terms.firefox",
+    ),
+    path(
+        "terms/firefox-focus/",
+        views.FocusTermsOfServiceDocView.as_view(legal_doc_name="focus_terms_of_use"),
+        name="legal.terms.focus",
     ),
 )

--- a/bedrock/legal/views.py
+++ b/bedrock/legal/views.py
@@ -42,11 +42,19 @@ class TermsDocView(LegalDocView):
 
 
 class FirefoxTermsOfServiceDocView(TermsDocView):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def get_legal_doc(self):
+        doc = super().get_legal_doc()
+        variant = self.request.GET.get("v", None)
 
-        self.legal_doc_name = "firefox_terms_of_use"
+        if variant == "product":
+            self.template_name = "legal/terms/firefox-simple.html"
+        else:
+            self.template_name = "legal/terms/firefox.html"
 
+        return doc
+
+
+class FocusTermsOfServiceDocView(TermsDocView):
     def get_legal_doc(self):
         doc = super().get_legal_doc()
         variant = self.request.GET.get("v", None)

--- a/bedrock/privacy/templates/privacy/notices/firefox-intro.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-intro.html
@@ -1,0 +1,27 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "privacy/notices/firefox.html" %}
+{% from "macros-protocol.html" import split, picto with context %}
+
+{% block main_feature %}
+
+  {% include 'privacy/includes/privacy-basics.html' %}
+
+  {{ super() }}
+
+{% endblock %}
+
+{% block side_nav %}
+
+  {{ super() }}
+
+  <aside class="c-extra">
+    <p>{{ ftl('privacy-firefox-take-me-back', attrs='href="#notice"') }}</p>
+    <p>{{ ftl('privacy-firefox-lost-in-the', attrs='href="#basics"') }}</p>
+  </aside>
+
+{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/firefox.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox.html
@@ -32,16 +32,12 @@
 {% block body_class %}{% endblock %}
 
 {% block main_feature %}
-
-  {% include 'privacy/includes/privacy-basics.html' %}
-
   <div class="mzp-l-content c-legal" id="notice">
     <div class="c-legal-heading">
       <h1>{{ title|join|safe }}</h1>
       <time datetime="{{ time['datetime'] }}" itemprop="dateModified">{{ time.string }}</time>
     </div>
   </div>
-
 {% endblock %}
 
 {% block side_nav %}
@@ -53,13 +49,6 @@
       {% endfor %}
     </ul>
   </div>
-
-
-  <aside class="c-extra">
-    <p>{{ ftl('privacy-firefox-take-me-back', attrs='href="#notice"') }}</p>
-    <p>{{ ftl('privacy-firefox-lost-in-the', attrs='href="#basics"') }}</p>
-  </aside>
-
 {% endblock %}
 
 {% block article %}

--- a/bedrock/privacy/tests/test_views.py
+++ b/bedrock/privacy/tests/test_views.py
@@ -21,13 +21,35 @@ class TestFirefoxSimpleDocView(TestCase):
         view = views.firefox_notices
         view(req)
         template = render_mock.call_args[0][1]
-        assert template == "privacy/notices/firefox.html"
+        assert template == "privacy/notices/firefox-intro.html"
 
     def test_simple_template(self, render_mock, lld_mock):
         lld_mock.return_value["content"].select.return_value = None
         req = RequestFactory().get("/privacy/notices/firefox/?v=product")
         req.locale = "en-US"
         view = views.firefox_notices
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "privacy/notices/firefox-simple.html"
+
+
+@patch.object(views.PrivacyDocView, "get_legal_doc")
+@patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
+class TestFocusSimpleDocView(TestCase):
+    def test_default_template(self, render_mock, lld_mock):
+        lld_mock.return_value["content"].select.return_value = None
+        req = RequestFactory().get("/privacy/notices/firefox-focus/")
+        req.locale = "en-US"
+        view = views.firefox_focus_notices
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == "privacy/notices/firefox.html"
+
+    def test_simple_template(self, render_mock, lld_mock):
+        lld_mock.return_value["content"].select.return_value = None
+        req = RequestFactory().get("/privacy/notices/firefox-focus/?v=product")
+        req.locale = "en-US"
+        view = views.firefox_focus_notices
         view(req)
         template = render_mock.call_args[0][1]
         assert template == "privacy/notices/firefox-simple.html"

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -48,13 +48,27 @@ class FirefoxPrivacyDocView(PrivacyDocView):
         if variant == "product":
             self.template_name = "privacy/notices/firefox-simple.html"
         else:
+            self.template_name = "privacy/notices/firefox-intro.html"
+        return doc
+
+
+class FirefoxFocusPrivacyDocView(PrivacyDocView):
+    ftl_files = ["privacy/firefox"]
+
+    def get_legal_doc(self):
+        doc = super().get_legal_doc()
+        variant = self.request.GET.get("v", None)
+
+        if variant == "product":
+            self.template_name = "privacy/notices/firefox-simple.html"
+        else:
             self.template_name = "privacy/notices/firefox.html"
         return doc
 
 
 firefox_notices = FirefoxPrivacyDocView.as_view(legal_doc_name="firefox_privacy_notice")
 
-firefox_focus_notices = PrivacyDocView.as_view(template_name="privacy/notices/firefox-focus.html", legal_doc_name="focus_privacy_notice")
+firefox_focus_notices = FirefoxFocusPrivacyDocView.as_view(legal_doc_name="focus_privacy_notice")
 
 thunderbird_notices = PrivacyDocView.as_view(template_name="privacy/notices/thunderbird.html", legal_doc_name="thunderbird_privacy_policy")
 

--- a/media/css/privacy/privacy-firefox.scss
+++ b/media/css/privacy/privacy-firefox.scss
@@ -106,7 +106,11 @@ $icon-padding: $icon-width + $layout-sm;
 
 .c-legal {
     padding-bottom: $spacing-md;
-    padding-top: $spacing-md;
+    padding-top: $layout-md;
+
+    #basics + & {
+        padding-top: 0;
+    }
 
     .c-legal-heading {
         border-bottom: 1px solid $color-light-gray-30;


### PR DESCRIPTION
## One-line summary

Focus PN and add TOU page updates.

## Significant changes and points to review

- Made the firefox.html template reusable.
  - Moved the intro and sidebar extras to a new file.
  - Added a bit of CSS to adjust spacing if there is/isn't an intro
 - Updated view for PN
 - Added view for TOU

## Issue / Bugzilla link

Fix #16015

## Testing

Run `make preflight` to make sure you have up to date legal-docs.

http://localhost:8000/en-US/privacy/firefox-focus/
http://localhost:8000/en-US/privacy/firefox-focus/?v=product
http://localhost:8000/en-US/about/legal/terms/firefox-focus/
http://localhost:8000/en-US/about/legal/terms/firefox-focus/?v=product

Also http://localhost:8000/en-US/privacy/firefox/ should be unchanged.