### PR TITLE
fix URL redirection from remote source XSS Unvalidated Redirects

### DIFF
--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -15,6 +15,7 @@ from django.http import (
 from django.urls import NoReverseMatch, URLResolver, re_path, reverse
 from django.urls.resolvers import RegexPattern
 from django.utils.html import strip_tags
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.vary import vary_on_headers
 
 import commonware.log
@@ -277,6 +278,11 @@ def redirect(
 
         if PROTOCOL_RELATIVE_RE.match(redirect_url):
             redirect_url = "/" + redirect_url.lstrip("/")
+
+        # Validate the redirect URL
+        if not url_has_allowed_host_and_scheme(redirect_url, allowed_hosts=settings.ALLOWED_HOSTS):
+            log.warning("Unsafe redirect URL detected: %s", redirect_url)
+            redirect_url = "/"
 
         return redirect_class(redirect_url)
 


### PR DESCRIPTION
https://github.com/mozilla/bedrock/blob/a389d52c62e99e3001598c2665e587e1321bc33c/bedrock/redirects/util.py#L281-L281

fix the issue need to validate the `redirect_url` to ensure it is safe for redirection. The best approach is to use Django's `url_has_allowed_host_and_scheme` function, which checks that the URL is either relative or belongs to an allowed host. This function is specifically designed to prevent untrusted URL redirection vulnerabilities.

1. Import `url_has_allowed_host_and_scheme` from `django.utils.http`.
2. Before returning the redirect response, validate `redirect_url` using `url_has_allowed_host_and_scheme`. If the URL is not safe, redirect to a default safe location (the home page `/`).
3. Ensure that the allowed hosts are configured appropriately in the Django settings.

Directly incorporating user input into a URL redirect request without validating the input can facilitate phishing attacks. In these attacks, unsuspecting users can be redirected to a malicious site that looks very similar to the real site they intend to visit, but which is controlled by the attacker.

## POC
The following shows an HTTP request parameter being used directly in a URL redirect without validating the input, which facilitates phishing attacks:
```py
from flask import Flask, request, redirect

app = Flask(__name__)

@app.route('/')
def hello():
    target = request.args.get('target', '')
    return redirect(target, code=302)
```
If you know the set of valid redirect targets, you can maintain a list of them on the server and check that the user input is in that list:
```py
from flask import Flask, request, redirect

VALID_REDIRECT = "http://cwe.mitre.org/data/definitions/601.html"

app = Flask(__name__)

@app.route('/')
def hello():
    target = request.args.get('target', '')
    if target == VALID_REDIRECT:
        return redirect(target, code=302)
    else:
        # ignore the target and redirect to the home page
        return redirect('/', code=302)
```
Often this is not possible, so an alternative is to check that the target URL does not specify an explicit host name, you can use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty.

Note, however, that some cases are not handled as we desire out-of-the-box by `urlparse`, so we need to adjust two things, as shown in the below:
- Many browsers accept backslash characters (`\`) as equivalent to forward slash characters (`/`) in URLs, but the `urlparse` function does not.
- Mistyped URLs such as `https:/redacted.com` or `https:///redacted.com` are parsed as having an empty `netloc` attribute, while browsers will still redirect to the correct site.

```py
from flask import Flask, request, redirect
from urllib.parse import urlparse

app = Flask(__name__)

@app.route('/')
def hello():
    target = request.args.get('target', '')
    target = target.replace('\\', '')
    if not urlparse(target).netloc and not urlparse(target).scheme:
        # relative path, safe to redirect
        return redirect(target, code=302)
    # ignore the target and redirect to the home page
    return redirect('/', code=302)
```
For Django application, you can use the function `url_has_allowed_host_and_scheme` to check that a URL is safe to redirect to, as shown in the following:
```py
from django.http import HttpResponseRedirect
from django.shortcuts import redirect
from django.utils.http import url_has_allowed_host_and_scheme
from django.views import View

class RedirectView(View):
    def get(self, request, *args, **kwargs):
        target = request.GET.get('target', '')
        if url_has_allowed_host_and_scheme(target, allowed_hosts=None):
            return HttpResponseRedirect(target)
        else:
            # ignore the target and redirect to the home page
            return redirect('/')
```
Note that `url_has_allowed_host_and_scheme` handles backslashes correctly, so no additional processing is required.

## References
[XSS Unvalidated Redirects and Forwards Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)
[urllib.parse](https://docs.python.org/3/library/urllib.parse.html)
[CWE-601](https://cwe.mitre.org/data/definitions/601.html)