### PR TITLE
restore l10n string for Firefox sub navigation (fix #16209)

### DIFF
--- a/l10n/en/sub_navigation.ftl
+++ b/l10n/en/sub_navigation.ftl
@@ -15,6 +15,7 @@ sub-navigation-ios = { -brand-name-ios }
 sub-navigation-desktop-beta-and-developer = Desktop { -brand-name-beta } & { -brand-name-developer-edition }
 sub-navigation-desktop-nightly = Desktop { -brand-name-nightly }
 sub-navigation-features = Features
+sub-navigation-more = More
 sub-navigation-chromebook = { -brand-name-chromebook }
 sub-navigation-windows = { -brand-name-windows }
 sub-navigation-windows-64-bit = { -brand-name-windows } 64-bit


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR restores the l10n string for Firefox sub navigation `sub-navigation-more`

## Significant changes and points to review

http://localhost:8000/en-US/firefox/new/ Sub navigation "More"

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16209

## Testing

http://localhost:8000/en-US/firefox/new/