### PR TITLE
Update Monitor link in nav

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -23,7 +23,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="https://monitor.mozilla.org/?{{ utm_params }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
+              <a class="m24-c-menu-item-link" href="{{ url('products.monitor.landing') }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor-v2') }}</h2>
               </a>

--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/products.html
@@ -23,7 +23,12 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
           </li>
           <li>
             <section class="m24-c-menu-item mzp-has-icon">
-              <a class="m24-c-menu-item-link" href="{{ url('products.monitor.landing') }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
+              {% if LANG.startswith('en-') %}
+                {% set monitor_link = url('products.monitor.landing') %}
+              {% else %}
+                {% set monitor_link = "https://monitor.mozilla.org/?" + utm_params %}
+              {% endif %}
+              <a class="m24-c-menu-item-link" href="{{ monitor_link }}" data-link-text="Mozilla Monitor" data-link-position="topnav - products">
                 <img loading="lazy" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="m24-c-menu-item-icon" width="32" height="32" alt="">
                 <h2 class="m24-c-menu-item-title">{{ ftl('navigation-refresh-mozilla-monitor-v2') }}</h2>
               </a>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
@@ -43,7 +43,12 @@
         </a>
       </li>
       <li class="m24-c-launchpad-item">
-        <a class="m24-c-launchpad-link m24-t-product-monitor" href="{{ url('products.monitor.landing') }}" data-cta-text="Monitor" data-cta-position="product-list">
+        {% if LANG.startswith('en-') %}
+          {% set monitor_link = url('products.monitor.landing') %}
+        {% else %}
+          {% set monitor_link = "https://monitor.mozilla.org/?" + utm_params %}
+        {% endif %}
+        <a class="m24-c-launchpad-link m24-t-product-monitor" href="{{monitor_link }}" data-cta-text="Monitor" data-cta-position="product-list">
           <strong class="m24-c-launchpad-title">{{ ftl('m24-home-mozilla-monitor') }}<b>:</b></strong>
           <span class="m24-c-launchpad-info">{{ ftl('m24-home-get-a-headsup') }}</span>
         </a>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
@@ -43,7 +43,7 @@
         </a>
       </li>
       <li class="m24-c-launchpad-item">
-        <a class="m24-c-launchpad-link m24-t-product-monitor" href="https://monitor.mozilla.org/{{ utm_params }}" data-cta-text="Monitor" data-cta-position="product-list">
+        <a class="m24-c-launchpad-link m24-t-product-monitor" href="{{ url('products.monitor.landing') }}" data-cta-text="Monitor" data-cta-position="product-list">
           <strong class="m24-c-launchpad-title">{{ ftl('m24-home-mozilla-monitor') }}<b>:</b></strong>
           <span class="m24-c-launchpad-info">{{ ftl('m24-home-get-a-headsup') }}</span>
         </a>

--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -123,7 +123,12 @@
         }
       ),
     ) %}
-      <h2 class="mzp-c-picto-heading"><a href="{{ url('products.monitor.landing') }}" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
+    {% if LANG.startswith('en-') %}
+      {% set monitor_link = url('products.monitor.landing') %}
+    {% else %}
+      {% set monitor_link = "https://monitor.mozilla.org/?" + utm_params %}
+    {% endif %}
+      <h2 class="mzp-c-picto-heading"><a href="{{ monitor_link }}" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
       <p>{% if country_code == 'US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://monitor.mozilla.org/{{ referrals }}" data-cta-text="Check for breaches">{% if LANG == 'en-US' %}Check for breaches now{% else %}{{ ftl('firefox-products-check-for-breaches') }}{% endif %} {{ icon_external|safe }}</a></p>
     {% endcall %}

--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -123,7 +123,7 @@
         }
       ),
     ) %}
-      <h2 class="mzp-c-picto-heading"><a href="https://monitor.mozilla.org/{{ referrals }}" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
+      <h2 class="mzp-c-picto-heading"><a href="{{ url('products.monitor.landing') }}" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
       <p>{% if country_code == 'US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>
       <p><a class="mzp-c-button mzp-t-product mzp-t-secondary" href="https://monitor.mozilla.org/{{ referrals }}" data-cta-text="Check for breaches">{% if LANG == 'en-US' %}Check for breaches now{% else %}{{ ftl('firefox-products-check-for-breaches') }}{% endif %} {{ icon_external|safe }}</a></p>
     {% endcall %}


### PR DESCRIPTION
## One-line summary

Update Monitor link in nav, hompage, and /products.

## Significant changes and points to review

- Links to Monitor in the nav, homepage, and /products pages now go to the monitor CMS landing page.

## Issue / Bugzilla link

Fix #15751

## Testing

- Run `make preflight` to get a copy of the database that includes the /products/monitor/ page
- http://localhost:8000/ click Products > Mozilla Monitor in the gobal nav.