### PR TITLE
add VPN promo pencil banner (fix #16198)

### DIFF
--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -16,7 +16,7 @@
             is_cta_button_styled=False,
             optional_attributes= {
                 'data-cta-text' : 'Get Mozilla VPN today',
-                'data-cta-type' : 'link',
+                'data-cta-type' : 'fxa-vpn',
                 'data-cta-position' : 'top-banner',
             }
           ) }}

--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -8,7 +8,17 @@
   {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
   <aside class="m24-pencil-banner" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
     <div class="m24-pencil-banner-copy">
-      <p>Create a website for your business and connect a custom domain for free. <strong><a href="https://soloist.ai/?utm_source=mozilla&utm_medium=top_bar&utm_campaign=mozilla_homepage" data-cta-type="link" data-cta-text="Try Solo AI" data-cta-position="banner">Try Solo AI</a></strong></p>
+      <p>Take control of your privacy —
+        {{ vpn_product_referral_link(
+          referral_id='evergreen',
+          link_text='Get Mozilla VPN today',
+          class_name='mzp-t-secondary m24-pencil-banner-vpn-referral-link',
+          optional_attributes= {
+              'data-cta-text' : 'Get Mozilla VPN today',
+              'data-cta-type' : 'link',
+              'data-cta-position' : 'top-banner',
+          }
+        ) }}.</p>
     </div>
     <button class="m24-pencil-banner-close" type="button">{{ ftl('ui-close') }}</button>
   </aside>

--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -17,7 +17,7 @@
             optional_attributes= {
                 'data-cta-text' : 'Get Mozilla VPN today',
                 'data-cta-type' : 'fxa-vpn',
-                'data-cta-position' : 'top-banner',
+                'data-cta-position' : 'banner',
             }
           ) }}
         </strong>.

--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -9,16 +9,19 @@
   <aside class="m24-pencil-banner" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
     <div class="m24-pencil-banner-copy">
       <p>Take control of your privacy —
-        {{ vpn_product_referral_link(
-          referral_id='evergreen',
-          link_text='Get Mozilla VPN today',
-          class_name='mzp-t-secondary m24-pencil-banner-vpn-referral-link',
-          optional_attributes= {
-              'data-cta-text' : 'Get Mozilla VPN today',
-              'data-cta-type' : 'link',
-              'data-cta-position' : 'top-banner',
-          }
-        ) }}.</p>
+        <strong>
+          {{ vpn_product_referral_link(
+            referral_id='evergreen',
+            link_text='Get Mozilla VPN today',
+            is_cta_button_styled=False,
+            optional_attributes= {
+                'data-cta-text' : 'Get Mozilla VPN today',
+                'data-cta-type' : 'link',
+                'data-cta-position' : 'top-banner',
+            }
+          ) }}
+        </strong>.
+      </p>
     </div>
     <button class="m24-pencil-banner-close" type="button">{{ ftl('ui-close') }}</button>
   </aside>

--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -327,6 +327,7 @@ def vpn_product_referral_link(
     link_to_pricing_page=False,
     page_anchor="",
     link_text=None,
+    is_cta_button_styled=True,
     class_name=None,
     optional_attributes=None,
     optional_parameters=None,
@@ -344,7 +345,7 @@ def vpn_product_referral_link(
     """
 
     href = reverse("products.vpn.pricing") if link_to_pricing_page else reverse("products.vpn.landing")
-    css_class = "mzp-c-button js-fxa-product-referral-link"
+    css_class = "mzp-c-button js-fxa-product-referral-link" if is_cta_button_styled else "js-fxa-product-referral-link"
     attrs = f'data-referral-id="{referral_id}" '
 
     if optional_attributes:

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -2111,6 +2111,7 @@ class TestVPNProductReferralLink(TestCase):
         link_to_pricing_page=False,
         page_anchor="",
         link_text=None,
+        is_cta_button_styled=True,
         class_name=None,
         optional_attributes=None,
         optional_parameters=None,
@@ -2120,8 +2121,16 @@ class TestVPNProductReferralLink(TestCase):
             req.locale = "en-US"
 
             return render(
-                f"""{{{{ vpn_product_referral_link('{referral_id}', {link_to_pricing_page}, '{page_anchor}',
-                                                   '{link_text}', '{class_name}', {optional_attributes}, {optional_parameters}) }}}}""",
+                f"""{{{{ vpn_product_referral_link(
+                    '{referral_id}',
+                    {link_to_pricing_page},
+                    '{page_anchor}',
+                    '{link_text}',
+                    {is_cta_button_styled},
+                    '{class_name}',
+                    {optional_attributes},
+                    {optional_parameters}
+                ) }}}}""",
                 {"request": req},
             )
 
@@ -2163,12 +2172,13 @@ class TestVPNProductReferralLink(TestCase):
             referral_id="navigation",
             link_to_pricing_page=True,
             link_text="Get Mozilla VPN",
+            is_cta_button_styled=False,
             class_name="mzp-t-product mzp-t-secondary mzp-t-md",
             optional_attributes={"data-cta-text": "Get Mozilla VPN", "data-cta-type": "vpn"},
             optional_parameters={"coupon": "cyber20"},
         )
         expected = (
-            '<a href="/en-US/products/vpn/pricing/?coupon=cyber20" class="mzp-c-button js-fxa-product-referral-link '
+            '<a href="/en-US/products/vpn/pricing/?coupon=cyber20" class="js-fxa-product-referral-link '
             'mzp-t-product mzp-t-secondary mzp-t-md" data-referral-id="navigation" '
             'data-cta-text="Get Mozilla VPN" data-cta-type="vpn">Get Mozilla VPN</a>'
         )

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -17,6 +17,7 @@
         p {
             color: $m24-color-black;
             margin-bottom: 0;
+            text-wrap: balance;
         }
 
         :link,

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -52,3 +52,30 @@ html[data-pencil-banner-closed="true"] {
         display: none;
     }
 }
+
+.m24-pencil-banner-vpn-referral-link,
+.m24-pencil-banner-vpn-referral-link:link,
+.m24-pencil-banner-vpn-referral-link:visited {
+    background-color: transparent;
+    border: none;
+    border-radius: 2px;
+    text-decoration: underline !important;
+    padding: 0;
+    line-height: 1.2;
+
+    &.mzp-c-button.mzp-t-secondary:hover {
+        text-decoration: none !important;
+        background-color: transparent;
+    }
+
+    &.mzp-c-button.mzp-t-secondary:active {
+        text-decoration: none !important;
+        border: none;
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    &.mzp-c-button.mzp-t-secondary:focus {
+        text-decoration: none !important;
+        border: none;
+    }
+}

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -53,9 +53,9 @@ html[data-pencil-banner-closed="true"] {
     }
 }
 
-.m24-pencil-banner-vpn-referral-link,
-.m24-pencil-banner-vpn-referral-link:link,
-.m24-pencil-banner-vpn-referral-link:visited {
+.mzp-c-button.mzp-t-secondary.m24-pencil-banner-vpn-referral-link,
+.mzp-c-button.mzp-t-secondary.m24-pencil-banner-vpn-referral-link:link,
+.mzp-c-button.mzp-t-secondary.m24-pencil-banner-vpn-referral-link:visited {
     background-color: transparent;
     border: none;
     border-radius: 2px;
@@ -63,19 +63,17 @@ html[data-pencil-banner-closed="true"] {
     padding: 0;
     line-height: 1.2;
 
-    &.mzp-c-button.mzp-t-secondary:hover {
+    &:hover {
         text-decoration: none !important;
         background-color: transparent;
     }
 
-    &.mzp-c-button.mzp-t-secondary:active {
+    &:active {
         text-decoration: none !important;
-        border: none;
         background-color: rgba(0, 0, 0, 0.05);
     }
 
-    &.mzp-c-button.mzp-t-secondary:focus {
+    &:focus {
         text-decoration: none !important;
-        border: none;
     }
 }

--- a/media/css/m24/components/pencil-banner.scss
+++ b/media/css/m24/components/pencil-banner.scss
@@ -52,28 +52,3 @@ html[data-pencil-banner-closed="true"] {
         display: none;
     }
 }
-
-.mzp-c-button.mzp-t-secondary.m24-pencil-banner-vpn-referral-link,
-.mzp-c-button.mzp-t-secondary.m24-pencil-banner-vpn-referral-link:link,
-.mzp-c-button.mzp-t-secondary.m24-pencil-banner-vpn-referral-link:visited {
-    background-color: transparent;
-    border: none;
-    border-radius: 2px;
-    text-decoration: underline !important;
-    padding: 0;
-    line-height: 1.2;
-
-    &:hover {
-        text-decoration: none !important;
-        background-color: transparent;
-    }
-
-    &:active {
-        text-decoration: none !important;
-        background-color: rgba(0, 0, 0, 0.05);
-    }
-
-    &:focus {
-        text-decoration: none !important;
-    }
-}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR:
- adds VPN promo pencil banner
- modified the VPN referral link helper function to make CTA button style optional

## Significant changes and points to review

1. Homepage pencil banner
2. Existing VPN referral links

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16198

## Testing

Pencil banner
1. Pencil banner on homepage in English: http://localhost:8000/en-US/
2. Pencil banner not showing on non-homepage English pages: http://localhost:8000/en-US/firefox/new/
3. Pencil banner not showing on non-English homepage: http://localhost:8000/fr/

VPN referral link default button style
- http://localhost:8000/en-US/firefox/welcome/17a/