### PR TITLE
(fix) Update CDN tests to test paths that will 302 to a locale-prefixed path

### DIFF
--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -62,9 +62,9 @@ def get_ssllabs_results(base_url):
     "url",
     (
         "/",
-        "/firefox/",
         "/firefox/new/",
         "/about/",
+        "/products/",
     ),
 )
 @pytest.mark.nondestructive


### PR DESCRIPTION
...not 301 to a different path altogether (which is currently what happens with `/firefox/` --[301]--> `/firefox/new/`

Resolves #16215
