### PR TITLE
Sanitise CMS locale lookup better + fixup existing tests that failed on postgres

### DIFF
--- a/bedrock/careers/tests/test_views.py
+++ b/bedrock/careers/tests/test_views.py
@@ -9,11 +9,11 @@ from django.utils import timezone
 
 from bedrock.careers.forms import PositionFilterForm
 from bedrock.careers.tests import PositionFactory
-from bedrock.mozorg.tests import TestCase
+from bedrock.mozorg.tests import TransactionTestCase
 from bedrock.wordpress.models import BlogPost
 
 
-class PositionTests(TestCase):
+class PositionTests(TransactionTestCase):
     def test_context(self):
         response = self.client.get(reverse("careers.listings"), follow=True)
         self.assertEqual(response.status_code, 200)
@@ -49,7 +49,7 @@ class PositionTests(TestCase):
         self.assertTemplateUsed(response, "careers/404.html")
 
 
-class BlogTests(TestCase):
+class BlogTests(TransactionTestCase):
     blog_data = {
         "wp_blog_slug": "careers",
         "excerpt": "",

--- a/bedrock/cms/middleware.py
+++ b/bedrock/cms/middleware.py
@@ -33,7 +33,9 @@ class CMSLocaleFallbackMiddleware:
         response = self.get_response(request)
 
         if response.status_code == HTTPStatus.NOT_FOUND:
-            if self._run_null_byte_check(request) is True:
+            if self._has_null_byte(request) is True:
+                # Don't bother processing URLs with null-byte content - they
+                # are fake/vuln scan requests
                 return response
 
             # At this point we have a request that has resulted in a 404,
@@ -124,7 +126,7 @@ class CMSLocaleFallbackMiddleware:
 
         return response
 
-    def _run_null_byte_check(self, request):
+    def _has_null_byte(self, request):
         if "\x00" in request.path:
             logger.warning("Null byte found in request path: %s", request.path)
             # This gets called as a 404, so let's just treat it as Not Found

--- a/bedrock/mozorg/tests/__init__.py
+++ b/bedrock/mozorg/tests/__init__.py
@@ -4,13 +4,24 @@
 
 from contextlib import contextmanager
 
-from django.test import TestCase as DjTestCase
+from django.test import TestCase as DjTestCase, TransactionTestCase as DjTransactionTestCase
 
 from lib.l10n_utils import translation
 
 
 class TestCase(DjTestCase):
     """Base class for Bedrock test cases."""
+
+    @contextmanager
+    def activate_locale(self, locale):
+        """Context manager that temporarily activates a locale."""
+        translation.activate(locale)
+        yield
+        translation.deactivate()
+
+
+class TransactionTestCase(DjTransactionTestCase):
+    """Base class for Bedrock test cases that need transaction management or autoid truncation."""
 
     @contextmanager
     def activate_locale(self, locale):

--- a/bedrock/products/tests/test_models.py
+++ b/bedrock/products/tests/test_models.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from datetime import timedelta
+
+from django.utils.timezone import now as utc_now
+
 import pytest
 from wagtail.rich_text import RichText
 
@@ -38,12 +42,15 @@ def test_vpn_resource_center_index_page(minimal_site, rf, serving_method):  # no
 
     test_detail_pages = {}
 
+    _now = utc_now()
+
     for i in range(1, 13):
         test_detail_pages[f"test_detail_page_{i}"] = factories.VPNResourceCenterDetailPageFactory(
             parent=test_index_page,
             slug=f"test-detail-{i}",
             desc=f"Test Detail Page {i} Description",
             content=RichText(f"Test Detail Page {i} Content"),
+            first_published_at=_now - timedelta(minutes=i),
         )
         test_detail_pages[f"test_detail_page_{i}"].save()
 

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -79,7 +79,9 @@ if (len(sys.argv) > 1 and sys.argv[1] == "test") or "pytest" in sys.modules:
     # use default product-details data
     PROD_DETAILS_STORAGE = "product_details.storage.PDFileStorage"
 
-    DATABASES["default"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
+    # If we're using sqlite, run tests on an in-memory version, else use the configured default DB engine
+    if DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3":
+        DATABASES["default"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
 
 
 # 3. DJANGO-CSP SETTINGS

--- a/bedrock/wordpress/models.py
+++ b/bedrock/wordpress/models.py
@@ -69,7 +69,7 @@ class BlogPostQuerySet(models.QuerySet):
         return self.filter(wp_blog_slug__in=blog_slugs)
 
     def filter_by_tags(self, *tags):
-        tag_qs = [Q(tags__contains=f'"{t}"') for t in tags]
+        tag_qs = [Q(tags__icontains=f'"{t}"') for t in tags]
         return self.filter(reduce(operator.or_, tag_qs))
 
 


### PR DESCRIPTION
This changeset
* Handles null bytes in URLs when trying to find fallback CMS pages - previously this would 500, but now we continue to 404. This only showed when running tests against postgres
* Adds support for running tests on postgres: if your .env specs a PG database, then the tests will run on that, else will use the default in-memory sqlite database
* Fixes a few small tests that were failing under postgres

## Significant changes and points to review

Please check over each commit for sense :)


## Issue / Bugzilla link

Reolves #16222

## Testing

Unit tests passing + code review should be enough. If you want to run it against postgres locally, too, go for it
