### PR TITLE
Remove undefined utm_params variable from products landing page (Fixes #16225)

### DIFF
--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -126,7 +126,7 @@
     {% if LANG.startswith('en-') %}
       {% set monitor_link = url('products.monitor.landing') %}
     {% else %}
-      {% set monitor_link = "https://monitor.mozilla.org/?" + utm_params %}
+      {% set monitor_link = "https://monitor.mozilla.org/" %}
     {% endif %}
       <h2 class="mzp-c-picto-heading"><a href="{{ monitor_link }}" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
       <p>{% if country_code == 'US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>

--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -126,7 +126,7 @@
     {% if LANG.startswith('en-') %}
       {% set monitor_link = url('products.monitor.landing') %}
     {% else %}
-      {% set monitor_link = "https://monitor.mozilla.org/" %}
+      {% set monitor_link = "https://monitor.mozilla.org/?" + referrals %}
     {% endif %}
       <h2 class="mzp-c-picto-heading"><a href="{{ monitor_link }}" data-cta-text="Monitor" data-cta-position="heading">{{ ftl('firefox-products-mozilla-monitor') }}</a></h2>
       <p>{% if country_code == 'US' %}See if you’ve been part of a data breach. If so, let us automatically get your private info back for you and continually monitor your identity for new leaks.{% else %}{{ ftl('firefox-products-see-if-your-personal-information') }}{% endif %}</p>


### PR DESCRIPTION
## One-line summary

Removes undefined variable

## Issue / Bugzilla link

#16225

## Testing

http://localhost:8000/de/products/