### PR TITLE
Add `.well-known/matrix/support` file.

### DIFF
--- a/root_files/.well-known/matrix/support
+++ b/root_files/.well-known/matrix/support
@@ -1,0 +1,13 @@
+{
+    "contacts": [
+        {
+            "email_address": "matrix-admins@mozilla.com",
+            "role": "m.role.admin"
+        },
+        {
+            "email_address": "matrix-admins@mozilla.com",
+            "role": "m.role.security"
+        }
+    ],
+    "support_page": "https://matrix.to/#/#synchronicity:mozilla.org"
+}


### PR DESCRIPTION
This adds a static JSON file for `.well-known/matrix/support`, which [is part of the spec nowadays](https://spec.matrix.org/v1.14/client-server-api/#getwell-knownmatrixsupport_response-200_contact) to point people and tooling towards a way to report service abuse. This points to [this group](https://groups.google.com/u/0/a/mozilla.com/g/matrix-admins/about), in which I'm an owner.