### PR TITLE
Restrict z-index selector for animation button (fixes #16151)

### DIFF
--- a/media/css/m24/flag.scss
+++ b/media/css/m24/flag.scss
@@ -51,8 +51,8 @@
     cursor: pointer;
     transition: background-color $fast, border-color $fast;
 
-    // Focused button is always visible: https://bugzilla.mozilla.org/show_bug.cgi?id=1936862
-    &:focus {
+    // Keyboard focused button is always visible: https://bugzilla.mozilla.org/show_bug.cgi?id=1936862
+    &:focus-visible {
         position: relative;
         z-index: 1001; // must be above .m24-navigation-refresh.m24-mzp-is-sticky
     }


### PR DESCRIPTION
## One-line summary
This update restricts the selector to focus-visible, so the button should only be promoted above the nav when keyboard-focused


## Significant changes and points to review
We initially applied this on all focus, but it can seem broken or buggy for mouse users when the button appears over the nav.


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16151



## Testing
http://localhost:8000/en-US/

- [x] When focused with mouse click, button does _not_ appear over the nav
- [x] When focused with keyboard, button appears over nav