### PR TITLE
Monitor articles are ordered using wagtail "path" field

### DIFF
--- a/bedrock/products/models.py
+++ b/bedrock/products/models.py
@@ -266,7 +266,7 @@ class MonitorArticleIndexPage(AbstractBedrockCMSPage):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
-        context["articlepages"] = MonitorArticlePage.objects.live().public().in_menu().order_by("path")
+        context["articlepages"] = MonitorArticlePage.objects.live().public().order_by("path")
         return context
 
 

--- a/bedrock/products/models.py
+++ b/bedrock/products/models.py
@@ -266,9 +266,7 @@ class MonitorArticleIndexPage(AbstractBedrockCMSPage):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
-        context["articlepages"] = (
-            MonitorArticlePage.objects.live().public().order_by("-first_published_at")
-        )  # live() and public() are wagtail filters
+        context["articlepages"] = MonitorArticlePage.objects.live().public().in_menu().order_by("path")
         return context
 
 


### PR DESCRIPTION
## One-line summary

Monitor articles are ordered using wagtail "path" field.

## Issue / Bugzilla link

#16150

## Testing

- Create monitor articles.
- Edit the order in Wagtail
- Check they are in the right order on the index page

Here's where the reorder option is :
<img src="https://github.com/user-attachments/assets/2f408e48-f14d-4bd6-8491-f409ac5ae92c" width="300">
