### PR TITLE
Increase visibility of help link on download thanks

### DIFF
--- a/media/css/firefox/new/basic/thanks.scss
+++ b/media/css/firefox/new/basic/thanks.scss
@@ -64,6 +64,7 @@ main {
 }
 
 .c-support-install {
+    font-weight: bold;
     margin: 0 auto;
     max-width: 30em;
     padding: $spacing-xl $spacing-lg $spacing-lg;

--- a/media/css/firefox/new/desktop/thanks.scss
+++ b/media/css/firefox/new/desktop/thanks.scss
@@ -98,6 +98,7 @@ main {
 // --------------------------------------------------------------------------
 
 .c-support-install {
+    font-weight: bold;
     margin: 0 auto;
     max-width: 30em;
     padding: $spacing-xl $spacing-lg $spacing-lg;


### PR DESCRIPTION
## One-line summary

Increase visibility of help link on download thanks

## Issue / Bugzilla link

User testing with low-vision users turned up that this was hard to see.

## Testing

http://localhost:8000/en-US/firefox/download/thanks/