### PR TITLE
Add affordance to progressive rollout indicator on release notes

### DIFF
--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -455,6 +455,7 @@ $image-path: '/media/protocol/img';
                 font-weight: bold;
                 padding: 0 0 $spacing-xs;
                 position: static;
+                text-decoration: underline;
 
                 &::before {
                     content:none;


### PR DESCRIPTION
## One-line summary

Add affordance to progressive rollout indicator on release notes

## Issue / Bugzilla link

User testing turned up that this didn't seem clickable. Adding an underline as a hint.

## Testing

http://localhost:8000/en-US/firefox/138.0/releasenotes/