### PR TITLE
Remove Firefox family logo (Fixes #16252)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -27,7 +27,7 @@
       title={
         'text':  ftl('sub-navigation-firefox'),
         'href':  url('firefox.new'),
-        'icon':  static('protocol/img/logos/firefox/logo.svg'),
+        'icon':  static('protocol/img/logos/firefox/browser/logo.svg'),
         'cta_name': 'Firefox'
       },
       links=[

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -23,7 +23,7 @@
       title={
         'text':  ftl('sub-navigation-firefox'),
         'href':  url('firefox.new'),
-        'icon':  static('protocol/img/logos/firefox/logo.svg'),
+        'icon':  static('protocol/img/logos/firefox/browser/logo.svg'),
         'cta_name': 'Firefox'
       },
       links=[

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -26,7 +26,7 @@
     'text':  ftl('sub-navigation-firefox'),
     'href':  url('firefox.new'),
     'cta_name': "Firefox",
-    'icon': static('protocol/img/logos/firefox/logo.svg')
+    'icon': static('protocol/img/logos/firefox/browser/logo.svg')
   },
   links=[
   {

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -37,7 +37,7 @@
     title={
       'text':  ftl('sub-navigation-firefox'),
       'href':  url('firefox.new'),
-      'icon':  static('protocol/img/logos/firefox/logo.svg'),
+      'icon':  static('protocol/img/logos/firefox/browser/logo.svg'),
       'cta_name': 'Firefox'
     },
     links=[

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -23,7 +23,7 @@
       title={
         'text':  ftl('sub-navigation-firefox'),
         'href':  url('firefox.new'),
-        'icon':  static('protocol/img/logos/firefox/logo.svg'),
+        'icon':  static('protocol/img/logos/firefox/browser/logo.svg'),
         'cta_name': 'Firefox'
       },
       links=[

--- a/bedrock/firefox/templates/firefox/includes/sub-nav-firefox.html
+++ b/bedrock/firefox/templates/firefox/includes/sub-nav-firefox.html
@@ -11,7 +11,7 @@
   title={
     'text':  ftl('sub-navigation-firefox'),
     'href':  url('firefox.new'),
-    'icon':  static('protocol/img/logos/firefox/logo.svg')
+    'icon':  static('protocol/img/logos/firefox/browser/logo.svg')
   },
   links=[
     {

--- a/bedrock/privacy/templates/privacy/archive/firefox-relay-2022-10.html
+++ b/bedrock/privacy/templates/privacy/archive/firefox-relay-2022-10.html
@@ -10,7 +10,7 @@
 
 {% block body_id %}firefox-relay-archived{% endblock %}
 
-{% block article_header_logo %}{{ static('protocol/img/logos/firefox/logo.svg') }}{% endblock %}
+{% block article_header_logo %}{{ static('protocol/img/logos/firefox/browser/logo.svg') }}{% endblock %}
 
 {% block title %}Firefox Relay Privacy Notice{% endblock %}
 


### PR DESCRIPTION
## One-line summary

Replaces outdated Firefox family logo with regular Firefox browser logo.

## Issue / Bugzilla link

#16252

## Testing

- http://localhost:8000/en-US/firefox/new/
- http://localhost:8000/en-US/firefox/channel/desktop/
- http://localhost:8000/en-US/firefox/developer/
- http://localhost:8000/en-US/firefox/faq/
- http://localhost:8000/en-US/firefox/browsers/browser-history/
- http://localhost:8000/en-US/firefox/browsers/what-is-a-browser/
- http://localhost:8000/en-US/privacy/archive/firefox-relay/2022-10/