### PR TITLE
Remove embedded Flickr image (Fixes #16265)

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2009/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/index.html
@@ -72,9 +72,4 @@
     <p><cite>Mitchell Baker, on behalf of the Mozilla community<br/>November 18,
       2010</cite></p>
 
-  <a href="https://www.flickr.com/photos/gen/4784616521/"
-     title="Mozilla Summit 2010 by Gen Kanai, on Flickr"><img
-      src="https://farm5.static.flickr.com/4138/4784616521_abb49923c7_z.jpg"
-      width="610" height="443" alt="Mozilla Summit 2010"/></a>
-
 {% endblock %}


### PR DESCRIPTION
## One-line summary

Looks like this has been blocked by CSP for quite some time. I considered embedding it ourselves, but we don't really own the image. Considering it has not been visible for a long time, I think we're fine to remove it today.

## Issue / Bugzilla link

#16265

## Testing

http://localhost:8000/en-US/foundation/annualreport/2009/