### PR TITLE
No-index, no-follow /all with different syntax (#16104)

### DIFF
--- a/bedrock/firefox/templates/firefox/all/base.html
+++ b/bedrock/firefox/templates/firefox/all/base.html
@@ -19,8 +19,8 @@
 
 {% block canonical_urls %}
   {% if product %}
-    {# do not index or follow child pages, we prefer people visit more user friendly pages from search results #}
-    <meta name="robots" content="noindex,nofollow">
+    {# do not index or follow child pages, we prefer people visit more user friendly pages from search results bedrock/16104 #}
+    <meta name="robots" content="none">
   {% else %}
     {{ super() }}
   {% endif %}


### PR DESCRIPTION
## One-line summary

No-index, no-follow /all with different syntax

## Significant changes and points to review

Google is still crawling these pages and we don't want them to. We'll try this before disallowing.

## Issue / Bugzilla link

#16104
