### PR TITLE
Allow crawl of whatsnew and firstrun so they are deindexed (#16275)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/robots.txt
+++ b/bedrock/mozorg/templates/mozorg/robots.txt
@@ -2,8 +2,6 @@ user-agent: *
 {% if disallow_all -%}
 disallow: /
 {% else -%}
-disallow: /*/firstrun/
 disallow: /*/newsletter/existing/
-disallow: /*/whatsnew/
 disallow: /*/etc/
 {% endif -%}


### PR DESCRIPTION
## One-line summary

Allow crawl of whatsnew and first run so they are deindexed

## Significant changes and points to review

- Remove whatsnew and firstrun from robots.txt
- Check tags on both have no-index

## Issue / Bugzilla link

#16275

## Testing

🤷‍♀️ Mostly we need to rely on Adria to make sure it's working as intended.