### PR TITLE
Update cookie banner docs with debug info

### DIFF
--- a/docs/docs/attribution/0005-consent-management.md
+++ b/docs/docs/attribution/0005-consent-management.md
@@ -19,3 +19,20 @@ For more detail documentation on dependencies used for consent management, see t
 -   [Cookie consent banner repo](https://github.com/mozmeao/consent-banner/)
 -   [Cookie helper repo](https://github.com/mozmeao/cookie-helper/)
 -   [DNT helper repo](https://github.com/mozmeao/dnt-helper/)
+
+## Debugging consent state
+
+Occasionally people will come along and say "I don't see the cookie banner, is something broken!?". The answer is typically that they do not meet the criteria in order to require seeing it. To help debug, you can ask them to paste the following line of code in their browser's web console:
+
+```javascript
+window.Mozilla.getConsentStateMsg()
+```
+
+This will output one of the following state message strings:
+
+- `STATE_GPC_ENABLED` - Their browser has GPC enabled.
+- `STATE_DNT_ENABLED` - Their browser has DNT enabled.
+- `STATE_HAS_CONSENT_COOKIE` - They already have a consent cookie that either accepts or rejects non-essential cookies.
+- `STATE_SHOW_COOKIE_BANNER` - Consent to non-essential cookies is required (the banner should be visible).
+- `STATE_BANNER_NOT_PERMITTED` - The page URL is not in the explicit allow-list for the cookie banner to display.
+- `STATE_COOKIES_PERMITTED` - Non-essential cookies are permitted without explicit consent (e.g. the visitor is located in the US).


### PR DESCRIPTION
## One-line summary

Adds some (hopefully) useful debug info to the cookie consent management docs.

## Issue / Bugzilla link

N/A

## Testing

`make livedocs`