### PR TITLE
Fix newsletter & 404 bidi arrows direction

### DIFF
--- a/media/css/base/page-not-found.scss
+++ b/media/css/base/page-not-found.scss
@@ -74,7 +74,7 @@
     cursor: pointer;
 
     &::before {
-        content: '\2190\0020';
+        @include bidi(((content, '\2190\0020', '\2192\0020'),));
     }
 }
 

--- a/media/css/newsletter/newsletter-updated.scss
+++ b/media/css/newsletter/newsletter-updated.scss
@@ -50,7 +50,7 @@
     margin-top: $spacing-lg;
 
     a::before {
-        content: '\2190\0020';
+        @include bidi(((content, '\2190\0020', '\2192\0020'),));
     }
 
     /* only show back link for JS enabled clients */


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 🤷
 yeah 🔥🦊

## One-line summary

Uses bidi mixin to prepend different glyphs based on the direction necessary.

## Significant changes and points to review

It might seem the space is on the wrong side of the RTL content, but this is actually correct (it would get flipped from LTR to RTL when applied.)

## Issue / Bugzilla link

Fixes #16282

## Testing

http://localhost:8000/he/404/
http://localhost:8000/he/newsletter/updated/