### PR TITLE
Fix product logos in downloads

### DIFF
--- a/media/css/firefox/all.scss
+++ b/media/css/firefox/all.scss
@@ -114,7 +114,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-product-list {
-    @include bidi(((padding-left, 36px, padding-right, 0),)); // to match the desktop & mobile icons
+    @include bidi(((padding-left, $spacer-lg, padding-right, 0),)); // indent from desktop/mobile icons
 
     li,
     .release {

--- a/media/css/firefox/all.scss
+++ b/media/css/firefox/all.scss
@@ -124,7 +124,7 @@ $image-path: '/media/protocol/img';
             ));
         background-size: 1.5em auto;
         background-repeat: no-repeat;
-        margin-bottom: 0.6rem;
+        padding-bottom: 0.6rem;
     }
 
     .release,


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._  🤷~ish

## One-line summary

Product logos had their parent's box clipped based on font height, this moves the whitespace from outside to inside, to not clip the logo components as the type scale changes…

## Significant changes and points to review

There's no change in the box metric with this, with the only exception being it adds a little bottom spacing under the end of every list/section, that I actually find pretty neat. So didn't bother with how to un-collapse whatever is being added there.

This also uses the spacing vars being dynamic across viewports to make the indent smaller on screens that really need to use that space better, so it's moved to a token instead of a fixed size matching the icon in the parent heading exactly.

## Issue / Bugzilla link

Fixes #15952

## Testing

/firefox/all/ (both desktop and mobile)