### PR TITLE
Add CSP allowance for img-src to prod

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -80,6 +80,7 @@ _csp_img_src = {
     CSP_ASSETS_HOST,
     "data:",
     "blog.mozilla.org",  # For careers pages.
+    "www.mozilla.org",  # For release notes.
     "www.googletagmanager.com",
     "www.google-analytics.com",
     "images.ctfassets.net",


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

The release notes team tests release notes on dev and stage but the image assets are hosted on production. This allows them to view the release notes as they would appear in production environments.

