### PR TITLE
Remove missing cover reference from translate feature

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -7,7 +7,6 @@
 {% extends "firefox/features/base-article.html" %}
 
 {% block page_desc %}{{ ftl('features-translate-firefox-translations-is-a-built-in-v2') }}{% endblock %}
-{% block page_image %}{{ static('img/firefox/features/translate/og.png') }}{% endblock %}
 
 {% block article_title_short %}{{ ftl('features-translate-translate-the-web') }}{% endblock %}
 {% block article_title %}{{ ftl('features-translate-translate-a-webpage-with-firefox') }}{% endblock %}


### PR DESCRIPTION
## One-line summary

Custom SEO preview/covers were removed in [#13119](https://github.com/mozilla/bedrock/pull/13119/files#diff-29fd6dd7e15e98241ae9acefae642b20fdbcdf0066889e20917157169585df8a), this removes forgotten (=broken) reference.

## Significant changes and points to review

Has caused 500 on springfield. For some reason here the static helper while not resolving the asset just prints out its literal value without crashing the app.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/167

## Testing

Before: https://opengraph.dev/panel?url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Ffirefox%2Ffeatures%2Ftranslate%2F

After: https://opengraph.dev/panel?url=https%3A%2F%2Fwww-dev.springfield.moz.works%2Fen-US%2Ffeatures%2Ftranslate%2F