### PR TITLE
add link to contact page (fix #16290)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -25,6 +25,7 @@
       <ul class="mzp-u-list-styled">
         <li><a href="https://support.mozilla.org/">I’m having problems with using Firefox</a></li>
         <li><a href="{{ donate_url(location='contact') }}">I want to donate to Mozilla</a></li>
+        <li><a href="https://mozilla.formstack.com/forms/inbound_partnership_requests">My company is interested in partnering with Firefox</a></li>
         <li><a href="{{ url('foundation.trademarks.policy') }}">I have questions about using Mozilla’s trademarks</a></li>
         <li><a href="{{ url('legal.fraud-report') }}">I’d like to report misuse of a Mozilla trademark</a></li>
         <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines">I want to hold an event in a Mozilla space</a></li>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR adds a new link to the `/contact` page

## Significant changes and points to review

http://localhost:8000/en-US/contact/

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16290

## Testing

http://localhost:8000/en-US/contact/