### PR TITLE
Update platform download tests to handle mac or osx in url

### DIFF
--- a/tests/playwright/specs/products/firefox/firefox-platforms.spec.js
+++ b/tests/playwright/specs/products/firefox/firefox-platforms.spec.js
@@ -55,7 +55,7 @@ test.describe(
             await downloadButton.click();
 
             const download = await downloadPromise;
-            expect(download.url()).toContain('mac');
+            expect(download.url()).toEqual(expect.stringMatching(/mac|osx/));
 
             // Cancel download
             await download.cancel();
@@ -82,7 +82,7 @@ test.describe(
             await downloadButton.click();
 
             const download = await downloadPromise;
-            expect(download.url()).toContain('mac');
+            expect(download.url()).toEqual(expect.stringMatching(/mac|osx/));
 
             // Cancel download
             await download.cancel();


### PR DESCRIPTION
## One-line summary

Update platform download tests to handle mac or osx in url

## Significant changes and points to review

- accept `mac` or `osx` in download URL

## Issue / Bugzilla link

#16294 

## Testing
