### PR TITLE
Fixup missing fx/more update description

### DIFF
--- a/bedrock/firefox/templates/firefox/more.html
+++ b/bedrock/firefox/templates/firefox/more.html
@@ -102,7 +102,7 @@
         title=ftl('update-your-browser'),
         ga_title='Update Browser',
         image=resp_img('img/firefox/more/update-browser.jpg', optional_attributes={"loading": "lazy", "class": "mzp-c-card-image"}),
-        desc=ftl('the-firefox-browser-the-only'),
+        desc=ftl('the-firefox-browser'),
         link_url=url('firefox.browsers.update-browser'),
       )}}
 


### PR DESCRIPTION
## One-line summary

Reverts one string id change that wasn't intentional.

## Significant changes and points to review

The string id was a false friend (at the time used in /more as well as /faq) that got swept away with instances of an id being replaced elsewhere. This one was okay to stay nonetheless.

## Issue / Bugzilla link

Fixes #16307

## Testing

/firefox/more/