### PR TITLE
Add bouncer GCP stage to known domains for front-end code checking

### DIFF
--- a/media/js/base/datalayer-productdownload.es6.js
+++ b/media/js/base/datalayer-productdownload.es6.js
@@ -6,7 +6,8 @@
 
 const TrackProductDownload = {};
 const prodURL = /^https:\/\/download.mozilla.org/;
-const stageURL = /^https:\/\/bouncer-bouncer.stage.mozaws.net/;
+const stageURL =
+    /^https:\/\/(bouncer-bouncer.stage.mozaws.net|stage.bouncer.nonprod.webservices.mozgcp.net)/;
 const devURL = /^https:\/\/dev.bouncer.nonprod.webservices.mozgcp.net/;
 const iTunesURL = /^https:\/\/itunes.apple.com/;
 const appStoreURL = /^https:\/\/apps.apple.com/;

--- a/media/js/base/stub-attribution/stub-attribution.js
+++ b/media/js/base/stub-attribution/stub-attribution.js
@@ -174,14 +174,17 @@ if (typeof window.Mozilla === 'undefined') {
             var directLink;
             // Append stub attribution data to direct download links.
             if (
-                (link.href &&
-                    (link.href.indexOf('https://download.mozilla.org') !== -1 ||
-                        link.href.indexOf(
-                            'https://bouncer-bouncer.stage.mozaws.net/'
-                        ) !== -1)) ||
-                link.href.indexOf(
-                    'https://dev.bouncer.nonprod.webservices.mozgcp.net'
-                ) !== -1
+                link.href &&
+                (link.href.indexOf('https://download.mozilla.org') !== -1 ||
+                    link.href.indexOf(
+                        'https://bouncer-bouncer.stage.mozaws.net/'
+                    ) !== -1 ||
+                    link.href.indexOf(
+                        'https://stage.bouncer.nonprod.webservices.mozgcp.net'
+                    ) !== -1 ||
+                    link.href.indexOf(
+                        'https://dev.bouncer.nonprod.webservices.mozgcp.net'
+                    ) !== -1)
             ) {
                 version = link.getAttribute('data-download-version');
 

--- a/tests/unit/spec/base/datalayer-productdownload.js
+++ b/tests/unit/spec/base/datalayer-productdownload.js
@@ -24,6 +24,12 @@ describe('TrackProductDownload.isValidDownloadURL', function () {
         );
         expect(testBouncerURL).toBe(true);
     });
+    it('should recognize bouncer GCP stage as a valid URL', function () {
+        const testBouncerURL = TrackProductDownload.isValidDownloadURL(
+            'https://stage.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=osx&lang=en-US'
+        );
+        expect(testBouncerURL).toBe(true);
+    });
     it('should recognize bouncer dev as a valid URL', function () {
         const testBouncerURL = TrackProductDownload.isValidDownloadURL(
             'https://dev.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=osx&lang=en-US'

--- a/tests/unit/spec/base/stub-attribution/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution/stub-attribution.js
@@ -840,6 +840,8 @@ describe('stub-attribution.js', function () {
             'https://www.mozilla.org/firefox/download/thanks/';
         const winStageUrl =
             'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win&lang=en-US';
+        const winGCPStageUrl =
+            'https://stage.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US';
         const win64StageUrl =
             'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win64&lang=en-US';
         const winDevUrl =
@@ -863,6 +865,7 @@ describe('stub-attribution.js', function () {
                     <li><a id="link-direct-win" class="download-link" data-download-version="win" href="${winUrl}">Download</a></li>
                     <li><a id="link-direct-win64" class="download-link" data-download-version="win64" href="${win64Url}">Download</a></li>
                     <li><a id="link-stage-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winStageUrl}">Download</a></li>
+                    <li><a id="link-gcp-stage-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winGCPStageUrl}">Download</a></li>
                     <li><a id="link-stage-direct-win" class="download-link" data-download-version="win" href="${winStageUrl}">Download</a></li>
                     <li><a id="link-stage-direct-win64" class="download-link" data-download-version="win64" href="${win64StageUrl}">Download</a></li>
                     <li><a id="link-dev-transitional" class="download-link" data-download-version="win" href="${transitionalUrl}" data-direct-link="${winDevUrl}">Download</a></li>
@@ -924,6 +927,14 @@ describe('stub-attribution.js', function () {
                 document.getElementById('link-stage-direct-win64').href
             ).toEqual(
                 'https://bouncer-bouncer.stage.mozaws.net/?product=firefox-latest-ssl&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
+            );
+
+            expect(
+                document
+                    .getElementById('link-gcp-stage-transitional')
+                    .getAttribute('data-direct-link')
+            ).toEqual(
+                'https://stage.bouncer.nonprod.webservices.mozgcp.net/?product=firefox-latest-ssl&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig'
             );
 
             // dev download links


### PR DESCRIPTION
## One-line summary

Allow bouncer GCP staging instance

## Significant changes and points to review

n/a

## Issue / Bugzilla link

Fixes https://github.com/mozilla/bedrock/issues/16310

## Testing