### PR TITLE
Add WNP-specific theme colors

### DIFF
--- a/media/css/firefox/whatsnew/includes/_base.scss
+++ b/media/css/firefox/whatsnew/includes/_base.scss
@@ -5,3 +5,15 @@
 @import 'header';
 @import 'sign-off';
 @import 'release-notes';
+
+.content-wrapper {
+    background: var(--wnp-color-background);
+}
+
+.wnp-content-main {
+    color: var(--wnp-color-text);
+
+    h1, h2, h3, h4 {
+        color: var(--wnp-color-title);
+    }
+}

--- a/media/css/firefox/whatsnew/includes/_dark-mode.scss
+++ b/media/css/firefox/whatsnew/includes/_dark-mode.scss
@@ -6,13 +6,13 @@
     html,
     body,
     .content-wrapper {
-        background: $color-dark-gray-60;
-        color: $color-white;
+        background: var(--wnp-color-background, $color-dark-gray-60);
+        color: var(--wnp-color-text, $color-white);
     }
 
     .wnp-content-main {
         h1, h2, h3, h4 {
-            color: $color-white;
+            color: var(--wnp-color-title, $color-white);
         }
     }
 

--- a/media/css/firefox/whatsnew/includes/_theme-colors.scss
+++ b/media/css/firefox/whatsnew/includes/_theme-colors.scss
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+
+:root {
+    --wnp-color-background: #{$color-white};
+    --wnp-color-text: #757575;
+    --wnp-color-title: #{$color-black};
+
+    @media (prefers-color-scheme: dark) {
+        --wnp-color-background: #{$color-dark-gray-60};
+        --wnp-color-text: #{$color-moz-light-gray};
+        --wnp-color-title: #{$color-white};
+    }
+}


### PR DESCRIPTION


_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Adds optional theme-colors import for light and dark mode WNP pages

## Significant changes and points to review

We've run into some drift between the code-based color tokens and Figma design variables. Design asked if we could align the code values to match Figma and we can do that going forward by adding a theme-colors import to the WNP file.

There may be further changes ahead. Once things settle, ideally we can remove this WNP-specific theme coloring and rely on protocol theme colors

## Issue / Bugzilla link

n/a - from internal slack discussion 

## Testing
TBD