### PR TITLE
fix landing page pricing section issue when there is no variation

### DIFF
--- a/bedrock/products/templates/products/vpn/landing-refresh-bundle-promo-experiment.html
+++ b/bedrock/products/templates/products/vpn/landing-refresh-bundle-promo-experiment.html
@@ -162,6 +162,15 @@
           {% include 'products/vpn/includes/pricing-refresh.html' %}
         </section>
       </div>
+    {% else %}
+      <div id="pricing">
+        <section class="mzp-l-content mzp-t-content-xl">
+          <header class="c-pricing-main-header">
+            <h3 class="c-section-title">{{ ftl('vpn-landing-one-subscription-for-all-your') }}</h3>
+          </header>
+          {% include 'products/vpn/includes/pricing-refresh.html' %}
+        </section>
+      </div>
     {% endif %}
   {% else %}
     <div id="pricing">


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

The pricing section is missing when the variation is manually removed from the URL. This also happens going to the VPN homepage from Google on a PBM window

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
