### PR TITLE
Fix product logo on features/tips

### DIFF
--- a/media/css/firefox/features/tips.scss
+++ b/media/css/firefox/features/tips.scss
@@ -10,6 +10,7 @@ $image-path: '/media/protocol/img';
 @import '~@mozilla-protocol/core/protocol/css/components/section-heading';
 @import '~@mozilla-protocol/core/protocol/css/components/zap';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo';
+@import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-firefox';
 @import '~@mozilla-protocol/core/protocol/css/components/logos/logo-product-mozilla';
 @import '../../protocol/components/video';
 


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 👍 

## One-line summary

Adds a missing import to have the asset available.  

## Significant changes and points to review

When rebranding FxA, another CTA in footer was perhaps moved from -firefox to -mozilla product, and this occurrence was forgotten along the way. So it needs both.

## Issue / Bugzilla link

Fixes #16322 

## Testing

/firefox/features/tips