### PR TITLE
(feat) Add support for a 'daily' VPN subscription for QA purposes ONLY

### DIFF
--- a/bedrock/products/templatetags/misc.py
+++ b/bedrock/products/templatetags/misc.py
@@ -159,7 +159,11 @@ def vpn_subscribe_link(
 
     if switch("vpn-subplat-next"):
         product_slug = "mozillavpnstage"
-        plan_slug = "yearly" if plan == VPN_12_MONTH_PLAN else "monthly"
+        # For testing/QA we support a test 'daily' API endpoint on the staging API only
+        if settings.VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY:
+            plan_slug = "daily"
+        else:
+            plan_slug = "yearly" if plan == VPN_12_MONTH_PLAN else "monthly"
         product_url = f"{settings.VPN_SUBSCRIPTION_URL_NEXT}{product_slug}/{plan_slug}/landing/"
     else:
         product_url = f"{settings.VPN_SUBSCRIPTION_URL}subscriptions/products/{product_id}?plan={plan_id}"

--- a/bedrock/products/tests/test_helper_misc.py
+++ b/bedrock/products/tests/test_helper_misc.py
@@ -1235,6 +1235,7 @@ class TestVPNSubscribeLink(TestCase):
     VPN_PRODUCT_ID=TEST_VPN_PRODUCT_ID,
     VPN_SUBSCRIPTION_URL=TEST_VPN_SUBSCRIPTION_URL,
     VPN_VARIABLE_PRICING=TEST_VPN_VARIABLE_PRICING,
+    VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY=False,
 )
 @override_switch("VPN_SUBPLAT_NEXT", active=True)
 class TestVPNSubscribeLinkNext(TestCase):
@@ -1305,6 +1306,29 @@ class TestVPNSubscribeLinkNext(TestCase):
         )
         expected = (
             '<a href="https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/mozillavpnstage/monthly/landing/'
+            "?entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page"
+            '&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
+            'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Mozilla VPN monthly" '
+            "data-cta-type=\"fxa-vpn\" data-cta-position=\"primary\" data-ga-item=\"{'id' : 'price_1Iw7qSJNcmPzuWtRMUZpOwLm','brand' : 'vpn',"
+            "'plan' : 'vpn','period' : 'monthly','price' : '9.99','discount' : '0','currency' : 'USD'}\">Get Mozilla VPN</a>"
+        )
+        self.assertEqual(markup, expected)
+
+    def test_vpn_subscribe_link_daily__for_staging_testing_only(self):
+        """Should return expected markup for a link to a daily subscription that ONLY exists on the staging server for QA"""
+
+        with override_settings(VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY=True):
+            markup = self._render(
+                plan="monthly",
+                country_code="US",
+                lang="en-US",
+                optional_parameters={"utm_campaign": "vpn-product-page"},
+                optional_attributes={"data-cta-text": "Get Mozilla VPN monthly", "data-cta-type": "fxa-vpn", "data-cta-position": "primary"},
+            )
+
+        # The only change compared to monthly sub is the /daily/ in the URL, not any of the params
+        expected = (
+            '<a href="https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/mozillavpnstage/daily/landing/'
             "?entrypoint=www.mozilla.org-vpn-product-page&form_type=button&service=e6eb0d1e856335fc&utm_source=www.mozilla.org-vpn-product-page"
             '&utm_medium=referral&utm_campaign=vpn-product-page&data_cta_position=primary" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-product-cta-link js-fxa-product-button mzp-c-button ga-begin-checkout" data-cta-text="Get Mozilla VPN monthly" '

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1261,6 +1261,9 @@ VPN_SUBSCRIPTION_URL = config("VPN_SUBSCRIPTION_URL", default="https://accounts.
 # ***This URL *MUST* end in a trailing slash!***
 VPN_SUBSCRIPTION_URL_NEXT = config("VPN_SUBSCRIPTION_URL_NEXT", default="https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/")
 
+# For testing/QA we support a test 'daily' API endpoint on the staging API only
+VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY = config("VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY", default="False", parser=bool)
+
 # Product ID for VPN subscriptions
 VPN_PRODUCT_ID = config("VPN_PRODUCT_ID", default="prod_FiJ42WCzZNRSbS" if DEV else "prod_FvnsFHIfezy3ZI")
 


### PR DESCRIPTION
**DO NOT MERGE until I've had confirmation, but please review**

In order to support easier/quicker QA of VPN subscriptions (see https://mozilla-hub.atlassian.net/browse/VPN-6985), this changeset allows the setting of 'daily'-duration subscriptions, using a special endpoint set up only on the Staging SubPlat API.


## Significant changes and points to review

Setting the env var VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY (default: False) will override the annual and monthly plan buttons on /products/vpn/ to hit a daily endpoint on subplat/

The env var must only ever be set on Bedrock Staging, hence the naming.


## Issue / Bugzilla link

Resolves #16335


## Testing

- [ ] Without any addition to your `.env` file locally, go to http://localhost:8000/en-US/products/vpn/?geo=gb
- [ ] Click Annual or Monthly sub and confirm the destination is for a monthly or annual subscription
- [ ] Now set `VPN_SUBSCRIPTION_USE_DAILY_MODE__QA_ONLY=True` in your `.env` file
- [ ] Restart runserver
- [ ] Go to http://localhost:8000/en-US/products/vpn/?geo=gb
- [ ] Click Annual or Monthly sub and confirm the destination is for a "daily" subscription (which is for testing and NOT a real product option in production)

![Screenshot 2025-06-11 at 14 14 30](https://github.com/user-attachments/assets/f18e0af9-766b-4696-a2f3-a04bcfc47393)
