### PR TITLE
Handle edge case in locale-list building when prefer_cms is used but there is nothing yet in the CMS

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -171,8 +171,14 @@ def get_locale_options(request, translations):
     # the locale being requested. In this situation _locales_available_via_cms
     # and _locales_for_django_fallback_view are annotated onto the request.
     # We need to use these to create a more accurate view of what locales are
-    # available
-    if hasattr(request, "_locales_available_via_cms") and hasattr(request, "_locales_for_django_fallback_view"):
+    # available. Also note that being decorated with prefer_cms doesn't guarantee
+    # that the annotated lists of locales contain any values, so we must also count
+    # them to be sure they are viable lists.
+
+    cms_locale_count = len(getattr(request, "_locales_available_via_cms", []))
+    django_fallback_locale_count = len(getattr(request, "_locales_for_django_fallback_view", []))
+
+    if cms_locale_count > 0 and django_fallback_locale_count > 0:
         available_locales = get_translations_native_names(sorted(set(request._locales_available_via_cms + request._locales_for_django_fallback_view)))
 
     return available_locales

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -122,9 +122,24 @@ def test_switch():
             ["de", "pt-BR", "ja-JP", "zh-CN"],
         ),
         (
+            # Just use defaults
             ["en-US", "fr", "sco"],
             [],
             [],
+            ["en-US", "fr", "sco"],
+        ),
+        (
+            # Don't use CMS + Django Fallback
+            ["en-US", "fr", "sco"],
+            ["en-US", "de"],
+            [],
+            ["en-US", "fr", "sco"],
+        ),
+        (
+            # Don't use CMS + Django Fallback
+            ["en-US", "fr", "sco"],
+            [],
+            ["en-US", "de"],
             ["en-US", "fr", "sco"],
         ),
     ),
@@ -132,11 +147,12 @@ def test_switch():
 def test_get_locale_options(rf, translations_locales, cms_locales, django_locales, expected):
     native_translations = get_translations_native_names(translations_locales)
     native_expected = get_translations_native_names(expected)
-
     request = rf.get("/dummy/path/")
 
-    if cms_locales and django_locales:
+    if cms_locales is not None:
         request._locales_available_via_cms = cms_locales
+
+    if django_locales is not None:
         request._locales_for_django_fallback_view = django_locales
 
     assert native_expected == helpers.get_locale_options(


### PR DESCRIPTION
## One-line summary

See mozmeao/springfield#276

## Significant changes and points to review

This combination was not hit here before, so it only exhibited itself with empty CMS data.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/268

## Testing

Ideally if this could be pushed to a vacant demo to test drive for a bit, locally all seems fine.