### PR TITLE
Add cdn(prod) markers to config

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -43,7 +43,7 @@ jobs:
           - LABEL: test-ie-saucelabs
             BROWSER_NAME: internet explorer
             DRIVER: SauceLabs
-            MARK_EXPRESSION: "smoke or sanity"
+            MARK_EXPRESSION: smoke
             PLATFORM: Windows 10
             PYTEST_PROCESSES: 8
           - LABEL: test-headless

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,10 @@ testpaths =
     tests
 # Declare custom pytest markers to reduce test-output noise
 markers =
+    cdn
+    cdnprod
     download
     headless
-    sanity
     skip_if_firefox
     skip_if_internet_explorer
     skip_if_not_firefox


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 🤷  

## One-line summary

Properly configure custom pytest markers.

## Significant changes and points to review

Warnings pile up with new deprecations every update so this aims to cut down the noise a bit by satisfying at least the undefined marker chatter in the outputs.

## Issue / Bugzilla link

#16339
(also resolves #14909)

## Testing

Sanity in `sanity` already tested in lieu https://github.com/mozmeao/springfield/pull/160