### PR TITLE
(feat) Add Arabic to list of locales supported by Firefox's Translate feature

### DIFF
--- a/bedrock/firefox/templates/firefox/features/translate.html
+++ b/bedrock/firefox/templates/firefox/features/translate.html
@@ -23,6 +23,7 @@
 
 <ul class="c-lang-list mzp-u-list-styled">
 {% if LANG.startswith('en-') %}
+  <li>Arabic</li>
   <li>Bulgarian</li>
   <li>Catalan</li>
   <li>Chinese (Simplified)</li>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -923,6 +923,7 @@ def firefox_welcome_page1(request):
 @require_safe
 def firefox_features_translate(request):
     translate_langs = [
+        "ar",
         "bg",
         "ca",
         "zh-CN",


### PR DESCRIPTION
## Issue / Bugzilla link

Resolves #16341

## Testing

- [x] http://localhost:8000/en-US/firefox/features/translate/
- [x] http://localhost:8000/de/firefox/features/translate/ and confirm that Arabic (written in Arabic) 
- [x] Compare with https://www.mozilla.org/en-US/firefox/features/translate/ which currently does not have Arabic 
