### PR TITLE
add MOFO donation pencil banner experiment (fix #16329)

### DIFF
--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -11,9 +11,9 @@
 {% elif LANG == 'es-ES' %}
   {% set cta_text = "Donar ♥" %}
 {% elif LANG == 'pt-BR' %}
-  {% set cta_text = "Doe ♥" %}
+  {% set cta_text = "Doe agora ♥" %}
 {% elif LANG == 'pl' %}
-  {% set cta_text = "Wesprzyj ♥" %}
+  {% set cta_text = "Wpłać datek ♥" %}
 {% elif LANG == 'it' %}
   {% set cta_text = "Dona ♥" %}
 {% else %}

--- a/bedrock/base/templates/includes/banners/pencil-banner.html
+++ b/bedrock/base/templates/includes/banners/pencil-banner.html
@@ -4,24 +4,101 @@
  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if switch('show-pencil-banner') and not hide_pencil_banner and is_homepage and LANG.startswith('en-') %}
+{% if LANG == 'fr' %}
+  {% set cta_text = "Faire un don  ♥" %}
+{% elif LANG == 'de' %}
+  {% set cta_text = "Spenden ♥" %}
+{% elif LANG == 'es-ES' %}
+  {% set cta_text = "Donar ♥" %}
+{% elif LANG == 'pt-BR' %}
+  {% set cta_text = "Doe ♥" %}
+{% elif LANG == 'pl' %}
+  {% set cta_text = "Wesprzyj ♥" %}
+{% elif LANG == 'it' %}
+  {% set cta_text = "Dona ♥" %}
+{% else %}
+  {% set cta_text = "Donate ♥" %}
+{% endif %}
+
+{% if variant == 'a' %}
+  {% set cta_link = "https://mozillafoundation.org/?form=pencil-banner-A" %}
+
+  {% if LANG == 'fr' %}
+    {% set banner_content = "Faites un don à la Fondation Mozilla avant le 30 juin" %}
+  {% elif LANG == 'de' %}
+    {% set banner_content = "Spenden Sie bis 30. Juni an die Mozilla Foundation" %}
+  {% elif LANG == 'es-ES' %}
+    {% set banner_content = "Dona a la Fundación Mozilla antes del 30 de junio" %}
+  {% elif LANG == 'pt-BR' %}
+    {% set banner_content = "Doe para a Fundação Mozilla até 30 de junho" %}
+  {% elif LANG == 'pl' %}
+    {% set banner_content = "Przekaż datek Fundacji Mozilla do 30 czerwca" %}
+  {% elif LANG == 'it' %}
+    {% set banner_content = "Dona a Mozilla Foundation entro il 30 giugno" %}
+  {% else %}
+    {% set banner_content = "Donate to Mozilla Foundation by June 30" %}
+  {% endif %}
+{% elif variant == 'b' %}
+  {% set cta_link = "https://mozillafoundation.org/?form=pencil-banner-B" %}
+
+  {% if LANG == 'fr' %}
+    {% set banner_content = "Faites un don à la Fondation Mozilla aujourd’hui" %}
+  {% elif LANG == 'de' %}
+    {% set banner_content = "Spenden Sie noch heute an die Mozilla Foundation" %}
+  {% elif LANG == 'es-ES' %}
+    {% set banner_content = "Dona a la Fundación Mozilla hoy" %}
+  {% elif LANG == 'pt-BR' %}
+    {% set banner_content = "Doe para a Fundação Mozilla hoje" %}
+  {% elif LANG == 'pl' %}
+    {% set banner_content = "Przekaż datek Fundacji Mozilla jeszcze dzisiaj" %}
+  {% elif LANG == 'it' %}
+    {% set banner_content = "Dona oggi stesso a Mozilla Foundation" %}
+  {% else %}
+    {% set banner_content = "Donate to Mozilla Foundation today" %}
+  {% endif %}
+{% elif variant == 'c' %}
+  {% set cta_link = "https://mozillafoundation.org/?form=pencil-banner-C" %}
+
+  {% if LANG == 'fr' %}
+    {% set banner_content = "Faites un don pour un meilleur futur technologique" %}
+  {% elif LANG == 'de' %}
+    {% set banner_content = "Spenden Sie für eine bessere Technologiezukunft" %}
+  {% elif LANG == 'es-ES' %}
+    {% set banner_content = "Dona para construir un mejor futuro tecnológico" %}
+  {% elif LANG == 'pt-BR' %}
+    {% set banner_content = "Doe e ajude a melhorar o futuro da tecnologia" %}
+  {% elif LANG == 'pl' %}
+    {% set banner_content = "Przekaż datek i zadbaj o lepszą przyszłość technologii" %}
+  {% elif LANG == 'it' %}
+    {% set banner_content = "Dona e crea un futuro migliore in ambito tecnologico" %}
+  {% else %}
+    {% set banner_content = "Donate to build a better tech future" %}
+  {% endif %}
+{% else %}
+  {% set cta_link = "https://mozillafoundation.org/?form=pencil-banner-mid-year" %}
+
+  {% if LANG == 'fr' %}
+    {% set banner_content = "Faites un don à la Fondation Mozilla aujourd’hui" %}
+  {% elif LANG == 'de' %}
+    {% set banner_content = "Spenden Sie noch heute an die Mozilla Foundation" %}
+  {% elif LANG == 'es-ES' %}
+    {% set banner_content = "Dona a la Fundación Mozilla hoy" %}
+  {% elif LANG == 'pt-BR' %}
+    {% set banner_content = "Doe para a Fundação Mozilla hoje" %}
+  {% elif LANG == 'pl' %}
+    {% set banner_content = "Przekaż datek Fundacji Mozilla jeszcze dzisiaj" %}
+  {% elif LANG == 'it' %}
+    {% set banner_content = "Dona oggi stesso a Mozilla Foundation" %}
+  {% else %}
+    {% set banner_content = "Donate to Mozilla Foundation today" %}
+  {% endif %}
+{% endif %}
+
+{% if switch('show-pencil-banner') and not hide_pencil_banner and is_homepage and (LANG  in ['fr', 'de', 'es-ES', 'pt-BR', 'pl', 'it'] or LANG.startswith('en-')) %}
   {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
   <aside class="m24-pencil-banner" aria-label="{{ ftl('ui-promo-label') }}" data-nosnippet="true">
     <div class="m24-pencil-banner-copy">
-      <p>Take control of your privacy —
-        <strong>
-          {{ vpn_product_referral_link(
-            referral_id='evergreen',
-            link_text='Get Mozilla VPN today',
-            is_cta_button_styled=False,
-            optional_attributes= {
-                'data-cta-text' : 'Get Mozilla VPN today',
-                'data-cta-type' : 'fxa-vpn',
-                'data-cta-position' : 'banner',
-            }
-          ) }}
-        </strong>.
-      </p>
+      <p>{{banner_content}}. – <strong><a href={{cta_link}}>{{cta_text}}</a></strong></p>
     </div>
     <button class="m24-pencil-banner-close" type="button">{{ ftl('ui-close') }}</button>
   </aside>

--- a/bedrock/mozorg/templates/mozorg/home/home-m24.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-m24.html
@@ -22,6 +22,12 @@
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 
+{% block experiments %}
+  {% if switch('show-pencil-banner') and not hide_pencil_banner and is_homepage and (LANG  in ['fr', 'de', 'es-ES', 'pt-BR', 'pl', 'it'] or LANG.startswith('en-')) %}
+    {{ js_bundle('pencil-banner-mofo-experiment') }}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {{ css_bundle('m24-root') }}
   {{ css_bundle('m24-base') }}

--- a/media/js/base/banners/m24-pencil-banner-mofo-experiment.es6.js
+++ b/media/js/base/banners/m24-pencil-banner-mofo-experiment.es6.js
@@ -1,0 +1,55 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import TrafficCop from '@mozmeao/trafficcop';
+import { isApprovedToRun } from '../../base/experiment-utils.es6.js';
+
+if (typeof window.dataLayer === 'undefined') {
+    window.dataLayer = [];
+}
+
+const href = window.location.href;
+
+const initTrafficCop = () => {
+    if (href.indexOf('v=') !== -1) {
+        if (href.indexOf('v=a') !== -1) {
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'pencil-banner-MOFO-donation',
+                variant: 'mofo-donation-a'
+            });
+        } else if (href.indexOf('v=b') !== -1) {
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'pencil-banner-MOFO-donation',
+                variant: 'mofo-donation-b'
+            });
+        } else if (href.indexOf('v=c') !== -1) {
+            // GA4
+            window.dataLayer.push({
+                event: 'experiment_view',
+                id: 'pencil-banner-MOFO-donation',
+                variant: 'mofo-donation-c'
+            });
+        }
+    } else if (TrafficCop) {
+        const cop = new TrafficCop({
+            variations: {
+                'v=a': 33, // MoFo donate (version 1)
+                'v=b': 34, // MoFo donate (version 2)
+                'v=c': 33 // MoFo donate (version 3)
+            }
+        });
+        cop.init();
+    }
+};
+
+// Avoid entering automated tests into random experiments.
+if (isApprovedToRun()) {
+    initTrafficCop();
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1666,6 +1666,12 @@
     },
     {
       "files": [
+        "js/base/banners/m24-pencil-banner-mofo-experiment.es6.js"
+      ],
+      "name": "pencil-banner-mofo-experiment"
+    },
+    {
+      "files": [
         "js/base/banners/firefox-newsletter-banner-init.es6.js",
         "js/base/banners/firefox-newsletter-banner-check.js"
       ],


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR adds MOFO donation pencil banner experiment

## Significant changes and points to review

- variations
- languages
- DNT/GPC enabled users see content in variant b and has a different cta link

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16329

## Testing

Test for `en`, `fr`, `de`, `pt-BR`, `pl`, `it`, `es-ES`

http://localhost:8000/en-US/
http://localhost:8000/en-US/?v=a
http://localhost:8000/en-US/?v=b
http://localhost:8000/en-US/?v=c
