### PR TITLE
Update img src attributes on about news section (fixes #16346)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/includes/m24/news.html
+++ b/bedrock/mozorg/templates/mozorg/about/includes/m24/news.html
@@ -15,7 +15,7 @@
       {{ gallery_tile(
         class='m24-l-grid-three-quarters m24-l-gallery-no-desc',
         image=picture(
-          url='img/mozorg/about/m24/news/projects-mobile-1450.jpg',
+          url='img/mozorg/about/m24/news/builders-mobile-1450.jpg',
           sources=[
             {
               'media': '(max-width: 767px)',
@@ -63,7 +63,7 @@
       {{ gallery_tile(
         class='m24-l-grid-five m24-l-gallery-no-desc',
         image=picture(
-          url="img/mozorg/about/m24/rise25-mobile-720.jpg",
+          url="img/mozorg/about/m24/news/rise25-mobile-720.jpg",
           sources=[
             {
               'media': '(max-width: 1311px)',
@@ -109,7 +109,7 @@
       {{ gallery_tile(
         class='m24-l-grid-third m24-l-gallery-no-desc',
         image=picture(
-          url="img/mozorg/about/m24/chicago-mobile-720.jpg",
+          url="img/mozorg/about/m24/news/chicago-mobile-720.jpg",
           sources=[
             {
               'media': '(max-width: 1311px)',


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Fixes outdated image paths that are used as fallback when `picture` element is not supported

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16346


## Testing
- Check the image `url` matches one of the `srcset` urls in `sources` argument
- News section images should load as usual
http://localhost:8000/en-US/about/