### PR TITLE
Run open-ftl-pr after artifact build+push

### DIFF
--- a/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
+++ b/.github/workflows/send_mozorg_fluent_strings_to_l10n_org.yml
@@ -1,24 +1,29 @@
 # Workflow to open a PR on mozilla-l10n/www-l10n with
 # new strings that exist in Bedrock and need localising
 
-name: Open Fluent PR for Mozorg
+name: Open Fluent PR in www-l10n
 
 on:
-  push:
-    paths:
-      - "l10n/**/*"
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build and push a Docker image"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
   schedule:
-    - cron: "0 0/3 * * *" # Every 3 hours
+    - cron: "25 5 * * *" # Every 5:25 AM UTC
 
 jobs:
   open_l10n_pr:
-    if: github.repository == 'mozilla/bedrock'
+    if: |
+      github.repository == 'mozilla/bedrock' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run')
     runs-on: ubuntu-latest
+    env:
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.HEAD_SHA }}
       - name: Run PR-opening script
         shell: bash
         run: FLUENT_REPO_AUTH=${{ secrets.FLUENT_REPO_AUTH }} bin/open-ftl-pr.sh


### PR DESCRIPTION
## One-line summary

Moves running the l10n PR for a given SHA from push to workflow completion.

## Significant changes and points to review

This will be run for every commit on main, not just those touching l10n files. — Tuning down the cron schedule to compensate for that and rut it only once a day as a fallback.

Set to run a few minutes after springfield intentionally.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/250#issuecomment-2941088776

## Testing

Similar to [`send_firefox_fluent_strings_to_l10n_org.yml`](https://github.com/mozmeao/springfield/actions/workflows/send_firefox_fluent_strings_to_l10n_org.yml)