### PR TITLE
Adjust .well-known/matrix/client to support MAS

### DIFF
--- a/root_files/.well-known/matrix/client
+++ b/root_files/.well-known/matrix/client
@@ -1,9 +1,13 @@
 {
     "m.homeserver": {
-        "base_url": "https://mozilla.modular.im"
+        "base_url": "https://mozilla.modular.im/"
     },
     "m.identity_server": {
         "base_url": "https://vector.im"
+    },
+    "org.matrix.msc2965.authentication": {
+        "issuer": "https://chat.mozilla.org/",
+        "account": "https://chat.mozilla.org/account/account"
     },
     "org.matrix.msc4143.rtc_foci": [
         {


### PR DESCRIPTION
This PR adjusts the `.well-known/matrix/client` to finalize a switchover we did today.