### PR TITLE
Add a version of bedrock.firefox.redirects that points to www.firefox.com instead

### DIFF
--- a/bedrock/base/legacy_firefox_redirects.py
+++ b/bedrock/base/legacy_firefox_redirects.py
@@ -1,0 +1,1169 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import re
+
+from django.conf import settings
+
+from bedrock.redirects.util import mobile_app_redirector, no_redirect, platform_redirector, redirect
+
+PRODUCT_OPTIONS = ["firefox", "focus", "klar"]
+# matches only ASCII letters (ignoring case), numbers, dashes, periods, and underscores.
+PARAM_VALUES_RE = re.compile(r"[\w.-]+", flags=re.ASCII)
+
+REDIRECT_SOURCE_QUERYSTRING = {
+    "redirect_source": "mozilla-org",
+}
+
+_permanent_redirect = settings.ENABLE_PERMANENT_FIREFOX_COM_REDIRECTS
+
+
+def firefox_mobile_faq(request, *args, **kwargs):
+    qs = request.META.get("QUERY_STRING", "")
+    if "os=firefox-os" in qs:
+        return "https://support.mozilla.org/products/firefox-os"
+
+    return "https://support.mozilla.org/products/mobile"
+
+
+def firefox_channel(*args, **kwargs):
+    return platform_redirector(
+        "https://www.firefox.com/channel/desktop/",
+        "https://www.firefox.com/channel/android/",
+        "https://www.firefox.com/channel/ios/",
+    )
+
+
+def validate_param_value(param: str | None) -> str | None:
+    """
+    Returns the value passed in if it matches the regex `PARAM_VALUES_RE`.
+    Otherwise returns `None`.
+    """
+    if param and PARAM_VALUES_RE.fullmatch(param):
+        return param
+
+    return None
+
+
+def mobile_app(request, *args, **kwargs):
+    c = request.GET.get("campaign")
+    p = request.GET.get("product")
+    campaign = validate_param_value(c)
+    product = p if p in PRODUCT_OPTIONS else "firefox"
+    return mobile_app_redirector(request, product, campaign)
+
+
+# We only enable these redirects deliberately
+if not settings.ENABLE_FIREFOX_COM_REDIRECTS:
+    redirectpatterns = ()
+else:
+    redirectpatterns = (
+        redirect(
+            r"^firefox/beta/all/?$",
+            "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org#beta",
+            permanent=False,
+        ),
+        redirect(
+            r"^firefox/developer/all/?$",
+            "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org#developer",
+            permanent=False,
+        ),
+        redirect(
+            r"^firefox/aurora/all/?$",
+            "https://www.firefox.com/channel/desktop/developer/",
+            permanent=False,
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        redirect(
+            r"^firefox/nightly/all/?$",
+            "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org#nightly",
+            permanent=False,
+        ),
+        redirect(
+            r"^firefox/organizations/all/?$",
+            "https://www.firefox.com/browsers/enterprise/",
+            permanent=False,
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        redirect(
+            r"^firefox/android/all/?$",
+            "https://www.firefox.com/browsers/mobile/android/",
+            permanent=False,
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        redirect(
+            r"^firefox/android/beta/all/?$",
+            "https://www.firefox.com/download/all/android-beta/",
+            permanent=False,
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        redirect(
+            r"^firefox/android/nightly/all/?$",
+            "https://www.firefox.com/download/all/android-nightly/",
+            permanent=False,
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        # bug 831810 & 1142583 & 1239960, 1329931
+        redirect(r"^mwc/?$", "https://support.mozilla.org/products/firefox-os", re_flags="i"),
+        # originall bug 748503 // GH 16159: remains in bedrock, not going to springfield yet
+        redirect(r"^projects/firefox/[^/]+a[0-9]+/firstrun(?P<p>.*)$", "/firefox/nightly/firstrun{p}"),
+        # bug 1275483 // GH 16159: remains in bedrock, not going to springfield yet
+        redirect(r"^firefox/nightly/whatsnew/?", "firefox.nightly.firstrun"),
+        # bug 840814
+        redirect(
+            r"^projects/firefox"
+            r"(?P<version>/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))"
+            r"(?P<page>/(?:firstrun|whatsnew))"
+            r"(?P<rest>/.*)?$",
+            "/firefox{version}{page}{rest}",
+        ),
+        # bug 877165
+        redirect(r"^firefox/connect", "mozorg.home"),
+        # bug 657049, 1238851
+        redirect(r"^firefox/accountmanager/?$", "https://developer.mozilla.org/Persona"),
+        # Bug 1009247, 1101220, 1299947, 1314603, 1328409
+        redirect(r"^(firefox/)?beta/?$", firefox_channel(), cache_timeout=0, anchor="beta"),
+        redirect(r"^(firefox/)?aurora/?$", firefox_channel(), cache_timeout=0, anchor="aurora"),
+        redirect(r"^(firefox/)?nightly/?$", firefox_channel(), cache_timeout=0, anchor="nightly"),
+        # Note: these are all Android-only:
+        redirect(
+            r"^mobile/beta/?$",
+            "https://www.firefox.com/channel/android/?redirect_source=mozilla-org#beta",
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^mobile/aurora/?$",
+            "https://www.firefox.com/channel/android/?redirect_source=mozilla-org#aurora",
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^mobile/nightly/?$",
+            "https://www.firefox.com/channel/android/?redirect_source=mozilla-org#nightly",
+            permanent=_permanent_redirect,
+        ),
+        # bug 988044
+        redirect(
+            r"^firefox/unsupported-systems\.html$",
+            "https://www.firefox.com/browsers/unsupported-systems/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 736934, 860865, 1101220, 1153351
+        redirect(
+            r"^mobile/notes/?$",
+            "https://www.firefox.com/firefox/android/notes/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^mobile/(?P<channel>(beta|aurora))/notes/?$",
+            "https://www.firefox.com/firefox/android/{channel}/notes/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/system-requirements(\.html)?$",
+            "https://www.firefox.com/firefox/system-requirements/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/(?P<channel>(beta|aurora|organizations))/system-requirements(\.html)?$",
+            "https://www.firefox.com/firefox/{channel}/system-requirements/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1155870
+        redirect(r"^firefox/os/(releases|notes)/?$", "https://developer.mozilla.org/Firefox_OS/Releases"),
+        redirect(r"^firefox/os/(?:release)?notes/(?P<v>[^/]+)/?$", "https://developer.mozilla.org/Firefox_OS/Releases/{v}"),
+        # bug 878871
+        redirect(r"^firefoxos", "/firefox/os/"),
+        # bug 1438302
+        no_redirect(r"^firefox/download/thanks/?$"),
+        redirect(
+            r"^download/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^(firefox|mobile)/download",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^firefox/firefox\.exe$", "mozorg.home", re_flags="i"),
+        redirect(
+            r"^firefox/all(\.html)?$",
+            "https://www.firefox.com/download/all/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 727561
+        redirect(
+            r"^firefox/search(?:\.html)?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 860865, 1101220, issue 8096
+        redirect(
+            r"^firefox/all-(?:beta|rc)(?:/|\.html)?$",
+            "https://www.firefox.com/download/all/desktop-beta/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/all-aurora(?:/|\.html)?$",
+            "https://www.firefox.com/download/all/desktop-developer/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/aurora/all/?$",
+            "https://www.firefox.com/channel/desktop/developer/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/aurora/(?P<page>notes|system-requirements)/?$",
+            "https://www.firefox.com/firefox/developer/{page}/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/organizations/all\.html$",
+            "https://www.firefox.com/download/all/desktop-esr/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 729329
+        redirect(
+            r"^mobile/sync",
+            "https://www.firefox.com/features/sync/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 882845
+        redirect(
+            r"^firefox/toolkit/download-to-your-devices",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1014823
+        redirect(r"^(products/)?firefox/releases/whatsnew/?$", "firefox.whatsnew"),
+        # bug 929775
+        redirect(
+            r"^firefox/update",
+            "https://www.firefox.com/",
+            query={
+                "redirect_source": "mozilla-org",
+                "utm_source": "firefox-browser",
+                "utm_medium": "firefox-browser",
+                "utm_campaign": "firefox-update-redirect",
+            },
+            permanent=_permanent_redirect,
+        ),
+        # Bug 868182, 986174
+        redirect(
+            r"^(m|(firefox/)?mobile)/features/?$",
+            "https://www.firefox.com/browsers/mobile/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^(m|(firefox/)?mobile)/faq/?$", firefox_mobile_faq, query=False),
+        # bug 884933
+        redirect(r"^(m|(firefox/)?mobile)/platforms/?$", "https://support.mozilla.org/kb/will-firefox-work-my-mobile-device"),
+        redirect(
+            r"^m/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # Bug 730488 deprecate /firefox/all-older.html
+        redirect(
+            r"^firefox/all-older\.html$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1120658
+        redirect(r"^seamonkey-transition\.html$", "http://www-archive.mozilla.org/seamonkey-transition.html"),
+        # Bug 1186373
+        redirect(r"^firefox/hello/npssurvey/?$", "https://www.surveygizmo.com/s3/2227372/Firefox-Hello-Product-Survey", permanent=False),
+        # Bug 1221739
+        redirect(r"^firefox/hello/feedbacksurvey/?$", "https://www.surveygizmo.com/s3/2319863/d2b7dc4b5687", permanent=False),
+        # Bug 1110927
+        redirect(
+            r"^(products/)?firefox/start/central\.html$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/sync/firstrun\.html$",
+            "https://www.firefox.com/features/sync/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # Bug 920212
+        redirect(
+            r"^firefox/fx(/.*)?",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # Bug 979531, 1003727, 979664, 979654, 979660
+        redirect(r"^firefox/customize/?$", "https://support.mozilla.org/kb/customize-firefox-controls-buttons-and-toolbars"),
+        redirect(
+            r"^firefox/(?:performance|happy|speed|memory)/?$",
+            "https://www.firefox.com/features/fast/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/security/?$",
+            "https://www.firefox.com/features/private/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^firefox/technology/?$", "https://developer.mozilla.org/docs/Tools"),
+        # Previously Bug 979527 / Github #10004 "Getting Started" Page
+        redirect(
+            r"^(products/)?firefox/central(/|\.html|-lite\.html)?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 868169
+        redirect(
+            r"^mobile/android-download\.html$", "https://play.google.com/store/apps/details", query={"id": "org.mozilla.firefox"}, merge_query=True
+        ),
+        redirect(
+            r"^mobile/android-download-beta\.html$",
+            "https://play.google.com/store/apps/details",
+            query={"id": "org.mozilla.firefox_beta"},
+            merge_query=True,
+        ),
+        # bug 675031
+        redirect(
+            r"^projects/fennec(?P<page>/[\/\w\.-]+)?", "http://website-archive.mozilla.org/www.mozilla.org/fennec_releasenotes/projects/fennec{page}"
+        ),
+        # bug 876581
+        redirect(r"^firefox/phishing-protection(/?)$", "https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work"),
+        # bug 1006079
+        redirect(r"^mobile/home/?(?:index\.html)?$", "https://blog.mozilla.org/services/2012/08/31/retiring-firefox-home/"),
+        # bug 949562
+        redirect(
+            r"^mobile/home/1\.0/releasenotes(?:/(?:index\.html)?)?$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_home/mobile/home/1.0/releasenotes/",
+        ),
+        redirect(
+            r"^mobile/home/1\.0\.2/releasenotes(?:/(?:index\.html)?)?$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_home/mobile/home/1.0.2/releasenotes/",
+        ),
+        redirect(r"^mobile/home/faq(?:/(?:index\.html)?)?$", "http://website-archive.mozilla.org/www.mozilla.org/firefox_home/mobile/home/faq/"),
+        # bug 960064
+        redirect(r"^firefox/(?P<num>vpat-[.1-5]+)(?:\.html)?$", "http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-{num}.html"),
+        redirect(r"^firefox/vpat(?:\.html)?", "http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-vpat-3.html"),
+        # bug 1017564
+        redirect(r"^mobile/.+/system-requirements/?$", "https://support.mozilla.org/kb/will-firefox-work-my-mobile-device"),
+        # bug 858315
+        redirect(r"^projects/devpreview/firstrun(?:/(?:index\.html)?)?$", "/firefox/firstrun/"),
+        redirect(
+            r"^projects/devpreview/(?P<page>[\/\w\.-]+)?$",
+            "http://website-archive.mozilla.org/www.mozilla.org/devpreview_releasenotes/projects/devpreview/{page}",
+        ),
+        # bug 1001238, 1025056
+        no_redirect(r"^firefox/(24\.[5678]\.\d|28\.0)/releasenotes/?$"),
+        # bug 1235082
+        no_redirect(r"^firefox/23\.0(\.1)?/releasenotes/?$"),
+        # bug 947890, 1069902
+        redirect(
+            r"^firefox/releases/(?P<v>[01]\.(?:.*))$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/{v}",
+        ),
+        redirect(
+            r"^(?P<path>(?:firefox|mobile)/(?:\d)\.(?:.*)/releasenotes(?:.*))$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/{path}",
+        ),
+        #
+        # bug 988746, 989423, 994186, 1153351
+        redirect(
+            r"^mobile/(?P<v>2[38]\.0(?:\.\d)?|29\.0(?:beta|\.\d)?)/releasenotes/?$",
+            "https://www.firefox.com/firefox/android/{v}/releasenotes/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        redirect(
+            r"^mobile/(?P<v>[3-9]\d\.\d(?:a2|beta|\.\d)?)/(?P<p>aurora|release)notes/?$",
+            "https://www.firefox.com/firefox/android/{v}/{p}notes/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+        ),
+        # bug 1041712, 1069335, 1069902
+        redirect(
+            r"^(?P<prod>firefox|mobile)/(?P<vers>([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta|a2|\.\d+)?))"
+            r"/(?P<channel>release|aurora)notes/(?P<page>[\/\w\.-]+)?$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/{prod}/{vers}/{channel}notes/{page}",
+        ),
+        # bug 767614 superceeded by bug 957711 and 1003718 and 1239960
+        redirect(
+            r"^(fennec)/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 8749
+        redirect(
+            r"^(mobile)/?$",
+            "https://www.firefox.com/browser/mobile/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 876668
+        redirect(
+            r"^mobile/customize(?:/.*)?$",
+            "https://www.firefox.com/browsers/mobile/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1211907
+        redirect(
+            r"^firefox/independent/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/personal/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1003703, 1009630
+        redirect(
+            r"^firefox(?P<vers>/.+)/firstrun/eu/?$",
+            "/firefox{vers}/firstrun/",
+            query={
+                "utm_source": "direct",
+                "utm_medium": "none",
+                "utm_campaign": "redirect",
+                "utm_content": "eu-firstrun-redirect",
+            },
+        ),
+        # bug 960543
+        redirect(r"^firefox/(?P<vers>[23])\.0/eula", "/legal/eula/firefox-{vers}/"),
+        # bug 1150713
+        redirect(
+            r"^firefox/sms(?:/.*)?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # Redirects for SeaMonkey project website, now living at seamonkey-project.org
+        redirect(r"^projects/seamonkey/$", "http://www.seamonkey-project.org/"),
+        redirect(r"^projects/seamonkey/artwork\.html$", "http://www.seamonkey-project.org/dev/artwork"),
+        redirect(r"^projects/seamonkey/community\.html$", "http://www.seamonkey-project.org/community"),
+        redirect(r"^projects/seamonkey/get-involved\.html$", "http://www.seamonkey-project.org/dev/get-involved"),
+        redirect(r"^projects/seamonkey/index\.html$", "http://www.seamonkey-project.org/"),
+        redirect(r"^projects/seamonkey/news\.html$", "http://www.seamonkey-project.org/news"),
+        redirect(r"^projects/seamonkey/project-areas\.html$", "http://www.seamonkey-project.org/dev/project-areas"),
+        redirect(r"^projects/seamonkey/releases/$", "http://www.seamonkey-project.org/releases/"),
+        redirect(r"^projects/seamonkey/releases/index\.html$", "http://www.seamonkey-project.org/releases/"),
+        redirect(r"^projects/seamonkey/review-and-flags\.html$", "http://www.seamonkey-project.org/dev/review-and-flags"),
+        redirect(r"^projects/seamonkey/releases/(?P<vers>1\..*)\.html$", "http://www.seamonkey-project.org/releases/{vers}"),
+        redirect(r"^projects/seamonkey/releases/seamonkey(?P<x>.*)/index\.html$", "http://www.seamonkey-project.org/releases/seamonkey{x}/"),
+        redirect(r"^projects/seamonkey/releases/seamonkey(?P<x>.*/.*)\.html$", "http://www.seamonkey-project.org/releases/seamonkey{x}"),
+        redirect(r"^projects/seamonkey/releases/updates/(?P<x>.*)$", "http://www.seamonkey-project.org/releases/updates/{x}"),
+        redirect(r"^projects/seamonkey/start/$", "http://www.seamonkey-project.org/start/"),
+        # Bug 638948 redirect beta privacy policy link
+        redirect(r"^firefox/beta/feedbackprivacypolicy/?$", "/privacy/firefox/"),
+        # Bug 1238248
+        redirect(r"^firefox/push/?$", "https://support.mozilla.org/kb/push-notifications-firefox"),
+        # Bug 1239960
+        redirect(r"^firefox/partners/?$", "https://support.mozilla.org/products/firefox-os"),
+        # Bug 1243060
+        redirect(r"^firefox/tiles/?$", "https://support.mozilla.org/kb/about-tiles-new-tab"),
+        # Bug 1239863, 1329931
+        redirect(r"^firefox/os(/.*)?$", "https://support.mozilla.org/products/firefox-os"),
+        # Bug 1252332
+        redirect(
+            r"^sync/?$",
+            "https://www.firefox.com/features/sync/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # Bug 424204
+        redirect(r"^firefox/help/?$", "https://support.mozilla.org/"),
+        redirect(
+            r"^fxandroid/?$",
+            "https://www.firefox.com/browsers/mobile/android/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # Bug 1255882
+        redirect(
+            r"^firefox/personal",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/upgrade",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/ie",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # must go above the bug 1255882 stuff below
+        redirect(r"^projects/xul/joy-of-xul\.html$", "https://developer.mozilla.org/docs/Mozilla/Tech/XUL/The_Joy_of_XUL"),
+        redirect(r"^projects/xul/xre(old)?\.html$", "https://developer.mozilla.org/docs/Archive/Mozilla/XULRunner"),
+        redirect(
+            r"^projects/xslt/js-interface\.html$",
+            "https://developer.mozilla.org/docs/Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations",
+        ),
+        redirect(r"^projects/xslt/faq\.html$", "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/XSL_Transformations_in_Mozilla_FAQ"),
+        redirect(r"^projects/xslt/standalone\.html$", "https://developer.mozilla.org/docs/Archive/Mozilla/Building_TransforMiiX_standalone"),
+        redirect(r"^projects/plugins/first-install-problem\.html$", "https://developer.mozilla.org/Add-ons/Plugins/The_First_Install_Problem"),
+        redirect(
+            r"^projects/plugins/install-scheme\.html$", "https://developer.mozilla.org/docs/Installing_plugins_to_Gecko_embedding_browsers_on_Windows"
+        ),
+        redirect(
+            r"^projects/plugins/npruntime-sample-in-visual-studio\.html$",
+            "https://developer.mozilla.org/docs/Compiling_The_npruntime_Sample_Plugin_in_Visual_Studio",
+        ),
+        redirect(r"^projects/plugins/npruntime\.html$", "https://developer.mozilla.org/docs/Plugins/Guide/Scripting_plugins"),
+        redirect(
+            r"^projects/plugins/plugin-host-control\.html$",
+            "https://developer.mozilla.org/docs/Archive/Mozilla/ActiveX_Control_for_Hosting_Netscape_Plug-ins_in_IE",
+        ),
+        redirect(
+            r"^projects/plugins/xembed-plugin-extension\.html$", "https://developer.mozilla.org/Add-ons/Plugins/XEmbed_Extension_for_Mozilla_Plugins"
+        ),
+        redirect(r"^projects/netlib/http/http-debugging\.html$", "https://developer.mozilla.org/docs/Mozilla/Debugging/HTTP_logging"),
+        redirect(r"^projects/netlib/integrated-auth\.html$", "https://developer.mozilla.org/docs/Mozilla/Integrated_authentication"),
+        redirect(r"^projects/netlib/Link_Prefetching_FAQ\.html$", "https://developer.mozilla.org/docs/Web/HTTP/Link_prefetching_FAQ"),
+        redirect(r"^projects/embedding/GRE\.html$", "https://developer.mozilla.org/docs/Archive/Mozilla/GRE"),
+        redirect(r"^projects/embedding/windowAPIs\.html$", "https://developer.mozilla.org/docs/Mozilla/Tech/Embedded_Dialog_API"),
+        redirect(r"^projects/embedding/howto/config\.html$", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla/Roll_your_own_browser"),
+        redirect(
+            r"^projects/embedding/howto/Initializations\.html$", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla/Roll_your_own_browser"
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasicsTOC\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#toc",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics\.html$", "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics"
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics2\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#Why_Gecko",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics3\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#What_You_Need_to_Embed",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics4\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#Getting_the_Code",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics5\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#Understanding_the_Coding_Environment",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics6\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#XPCOM",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics7\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#XPIDL",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics8\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#XPConnect_and_XPT_files",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics9\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#String_classes",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics10\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#XUL.2FXBL",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics11\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#Choosing_Additional_Functionalities",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics12\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#What_Gecko_Provides",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics13\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#What_You_Provide",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics14\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#Common_Embedding_Tasks",
+        ),
+        redirect(
+            r"^projects/embedding/embedoverview/EmbeddingBasics16\.html$",
+            "https://developer.mozilla.org/docs/Mozilla/Gecko/Gecko_Embedding_Basics#Appendix:_Data_Flow_Inside_Gecko",
+        ),
+        redirect(r"^projects/embedding/examples/", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla/Roll_your_own_browser"),
+        # Bug 1255882
+        redirect(r"^projects/bonecho/anti-phishing/?$", "https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work"),
+        redirect(
+            r"^projects/bonecho(/.*)?$",
+            "https://www.firefox.com/channel/desktop/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^projects/bonsai(/.*)?$", "https://wiki.mozilla.org/Bonsai"),
+        redirect(r"^projects/camino(/.*)?$", "http://caminobrowser.org/"),
+        redirect(r"^projects/cck(/.*)?$", "https://wiki.mozilla.org/CCK"),
+        redirect(r"^projects/chimera(/.*)?$", "http://caminobrowser.org/"),
+        redirect(
+            r"^projects/deerpark(/.*)?$",
+            "https://www.firefox.com/channel/desktop/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^projects/embedding/faq\.html$", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla/FAQ/How_do_I..."),
+        redirect(r"^projects/embedding(/.*)?$", "https://developer.mozilla.org/docs/Gecko/Embedding_Mozilla"),
+        redirect(
+            r"^projects/granparadiso(/.*)?$",
+            "https://www.firefox.com/channel/desktop/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^projects/inspector/faq\.html$", "https://developer.mozilla.org/docs/Tools/Add-ons/DOM_Inspector/DOM_Inspector_FAQ"),
+        redirect(r"^projects/inspector(/.*)?$", "https://developer.mozilla.org/docs/Tools/Add-ons/DOM_Inspector"),
+        redirect(r"^projects/javaconnect(/.*)?$", "http://developer.mozilla.org/en/JavaXPCOM"),
+        redirect(
+            r"^projects/minefield(/.*)?$",
+            "https://www.firefox.com/channel/desktop/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^projects/minimo(/.*)?$", "https://wiki.mozilla.org/Mobile"),
+        redirect(
+            r"^projects/namoroka(/.*)?$",
+            "https://www.firefox.com/channel/desktop/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^projects/nspr(?:/.*)?$", "https://developer.mozilla.org/docs/NSPR"),
+        redirect(r"^projects/netlib(/.*)?$", "https://developer.mozilla.org/docs/Mozilla/Projects/Necko"),
+        redirect(r"^projects/plugins(/.*)?$", "https://developer.mozilla.org/Add-ons/Plugins"),
+        redirect(r"^projects/rt-messaging(/.*)?$", "http://chatzilla.hacksrus.com/"),
+        redirect(
+            r"^projects/shiretoko(/.*)?$",
+            "https://www.firefox.com/channel/desktop/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^projects/string(/.*)?$", "https://developer.mozilla.org/en/XPCOM_string_guide"),
+        redirect(r"^projects/tech-evangelism(/.*)?$", "https://wiki.mozilla.org/Evangelism"),
+        redirect(r"^projects/venkman(/.*)?$", "https://developer.mozilla.org/docs/Archive/Mozilla/Venkman"),
+        redirect(r"^projects/webservices/examples/babelfish-wsdl(/.*)?$", "https://developer.mozilla.org/docs/SOAP_in_Gecko-based_Browsers"),
+        redirect(r"^projects/xbl(/.*)?$", "https://www.w3.org/TR/xbl/"),
+        redirect(r"^projects/xforms(/.*)?$", "https://wiki.mozilla.org/XForms"),
+        redirect(r"^projects/xpcom(/.*)?$", "https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM"),
+        redirect(r"^projects/xpinstall(/.*)?$", "https://developer.mozilla.org/docs/Archive/Mozilla/XPInstall"),
+        redirect(r"^projects/xslt(/.*)?$", "https://developer.mozilla.org/docs/Web/XSLT"),
+        redirect(r"^projects/xul(/.*)?$", "https://wiki.mozilla.org/XUL"),
+        redirect(r"^quality/help(/.*)?$", "http://quality.mozilla.org/get-involved"),
+        redirect(r"^quality(/.*)?$", "http://quality.mozilla.org/"),
+        # Bug 654614 /blocklist -> addons.m.o/blocked
+        redirect(r"^blocklist(/.*)?$", "https://addons.mozilla.org/blocked/"),
+        redirect(
+            r"^products/firebird/compare/?$",
+            "https://www.firefox.com",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firebird/?$",
+            "https://www.firefox.com",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firebird/download/$",
+            "https://www.firefox.com",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^products/firefox/add-engines\.html$", "https://addons.mozilla.org/search-engines.php"),
+        redirect(
+            r"^products/firefox/all$",
+            "https://www.firefox.com/download/all/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/all\.html$",
+            "https://www.firefox.com/download/all/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^products/firefox/banners\.html$", "/contribute/"),
+        redirect(r"^products/firefox/buttons\.html$", "/contribute/"),
+        redirect(
+            r"^products/firefox/download",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/get$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/live-bookmarks",
+            "https://www.firefox.com/features/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^products/firefox/mirrors\.html$", "http://www-archive.mozilla.org/mirrors.html"),
+        redirect(
+            r"^products/firefox/releases/$",
+            "https://www.firefox.com/releases/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/releases/0\.9\.2\.html$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/0.9.1.html",
+        ),
+        redirect(
+            r"^products/firefox/releases/0\.10\.1\.html$",
+            "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/0.10.html",
+        ),
+        redirect(
+            r"^products/firefox/search",
+            "https://www.firefox.com/features/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^products/firefox/shelf\.html$", "https://blog.mozilla.org/press/awards/"),
+        redirect(r"^products/firefox/smart-keywords\.html$", "https://support.mozilla.org/en-US/kb/Smart+keywords"),
+        redirect(r"^products/firefox/support/$", "https://support.mozilla.org/"),
+        redirect(
+            r"^products/firefox/switch",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/system-requirements",
+            "https://www.firefox.com/firefox/system-requirements/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/tabbed-browsing",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^products/firefox/text-zoom\.html$", "https://support.mozilla.org/kb/font-size-and-zoom-increase-size-of-web-pages"),
+        redirect(r"^products/firefox/themes$", "https://addons.mozilla.org/themes/"),
+        redirect(r"^products/firefox/themes\.html$", "https://addons.mozilla.org/themes/"),
+        redirect(r"^products/firefox/ui-customize\.html$", "https://support.mozilla.org/kb/customize-firefox-controls-buttons-and-toolbars"),
+        redirect(
+            r"^products/firefox/upgrade",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^products/firefox/why/$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 857246 redirect /products/firefox/start/  to start.mozilla.org
+        redirect(r"^products/firefox/start/?$", "http://start.mozilla.org"),
+        # issue 9008
+        redirect(r"^products/firefox(/.*)?$", "products.landing"),
+        # bug 1260423
+        redirect(
+            r"^firefox/choose/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1288552 - redirect /secondrun/ traffic from funnelcake test
+        redirect(r"^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/secondrun(?:/.*)?", "https://www.firefox.com/browsers/mobile/", query=False),
+        # bug 1293539
+        redirect(r"^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/tour/?$", "https://support.mozilla.org/kb/get-started-firefox-overview-main-features"),
+        # bug 1295332
+        redirect(r"^hello/?$", "https://support.mozilla.org/kb/hello-status"),
+        redirect(r"^firefox/hello/?$", "https://support.mozilla.org/kb/hello-status"),
+        redirect(r"^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/hello/start/?$", "https://support.mozilla.org/kb/hello-status"),
+        # bug 1299947, 1326383
+        redirect(r"^firefox/channel/?$", firefox_channel(), cache_timeout=0),
+        # Bug 1277196
+        redirect(
+            r"^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/firstrun/learnmore/?$",
+            "firefox.features.index",
+            query={
+                "utm_source": "firefox-browser",
+                "utm_medium": "firefox-browser",
+                "utm_campaign": "redirect",
+                "utm_content": "learnmore-tab",
+            },
+        ),
+        redirect(
+            r"^firefox/windows-10/welcome/?$",
+            "https://support.mozilla.org/kb/how-change-your-default-browser-windows-10",
+            query={
+                "utm_source": "firefox-browser",
+                "utm_medium": "firefox-browser",
+                "utm_campaign": "redirect",
+                "utm_content": "windows10-welcome-tab",
+            },
+        ),
+        # bug 1369732
+        redirect(
+            r"^Firefox/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1386112
+        redirect(r"^firefox/android/faq/?", "https://support.mozilla.org/products/mobile"),
+        # bug 1392796
+        redirect(
+            r"^firefox/desktop/fast/?",
+            "https://www.firefox.com/features/fast/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/desktop/trust/?",
+            "https://www.firefox.com/features/private/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/desktop/tips/?",
+            "https://www.firefox.com/features/tips/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^firefox/desktop/customize/?", "https://support.mozilla.org/kb/customize-firefox-controls-buttons-and-toolbars"),
+        redirect(r"^firefox/private-browsing/?", "firefox.features.private-browsing"),
+        # bug 1405436
+        redirect(
+            r"^firefox/organic",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/landing/better",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^firefox/(new/)?addon", "https://addons.mozilla.org"),
+        redirect(
+            r"^firefox/tips",
+            "https://www.firefox.com/features/tips/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/new/.+",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/38\.0\.3/releasenotes/$",
+            "https://www.firefox.com/firefox/38.0.5/releasenotes/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/default\.htm",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/android/(?P<version>\d+\.\d+(?:\.\d+)?)$",
+            "https://www.firefox.com/firefox/android/{version}/releasenotes/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/stats/",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1416706
+        redirect(
+            r"^firefox/desktop/?",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1418500
+        redirect(
+            r"^firefox/android/?$",
+            "https://www.firefox.com/browsers/mobile/android/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/focus/?$",
+            "https://www.firefox.com/browsers/mobile/focus/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 14141
+        redirect(
+            r"^firefox/browsers/mobile/compare/?$",
+            "https://www.firefox.com/browsers/mobile/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/ios/?$",
+            "https://www.firefox.com/browsers/mobile/ios/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1421584, issue 7491
+        redirect(
+            r"^firefox/organizations/faq/?$",
+            "https://www.firefox.com/enterprise/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1425865 - Amazon Fire TV goes to SUMO until we have a product page.
+        redirect(
+            r"^firefox/fire-tv/?$",
+            "https://support.mozilla.org/products/firefox-fire-tv/",
+            permanent=False,
+        ),
+        # bug 1430894
+        redirect(r"^firefox/interest-dashboard/?", "https://support.mozilla.org/kb/firefox-add-technology-modernizing"),
+        # bug 1419244
+        redirect(
+            r"^firefox/mobile-download(/.*)?",
+            "https://www.firefox.com/browsers/mobile/index/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 960651, 1436973
+        redirect(
+            r"(firefox|mobile)/([^/]+)/details(/|/.+\.html)?$",
+            "https://www.firefox.com/browsers/unsupported-systems/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/unsupported/",
+            "https://www.firefox.com/browsers/unsupported-systems/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # bug 1428783
+        redirect(r"^firefox/dnt/?$", "https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature"),
+        # issue 6209
+        redirect(r"^pocket/?", "https://support.mozilla.org/en-US/kb/future-of-pocket"),
+        # issue 6186
+        redirect(
+            r"^vote/?",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 9391
+        redirect(
+            r"^/firefox/election/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # fxa
+        redirect(r"^firefox/accounts/features/?", "mozorg.account"),
+        # bug 1577449
+        redirect(r"^firefox/features/send-tabs/?", "https://support.mozilla.org/kb/send-tab-firefox-desktop-other-devices"),
+        # issue 6512
+        redirect(
+            r"^firefox/firefox\.html$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 6979
+        redirect(
+            r"^firefoxfightsforyou/?",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 14240
+        redirect(r"^firefox/accounts/?$", "mozorg.account"),
+        # issue 7210
+        redirect(r"^firefox/account/?$", "mozorg.account"),
+        # issue 7436
+        redirect(r"^firefox/feedback/?$", "https://support.mozilla.org/questions/new/desktop"),
+        # issue 7491
+        redirect(
+            r"^firefox/organizations/?$",
+            "https://www.firefox.com/enterprise/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 7670
+        redirect(
+            r"^/firefox/fights-for-you/?",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue #7424
+        redirect(r"^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/content-blocking/start/?$", "https://support.mozilla.org/kb/content-blocking"),
+        # issue #7424
+        redirect(r"^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/tracking-protection/start/?$", "https://support.mozilla.org/kb/tracking-protection"),
+        # issue 8596
+        redirect(r"firefox/xr/?$", "https://support.mozilla.org/kb/webxr-permission-info-page"),
+        # issue 8419
+        redirect(r"firefox/this-browser-comes-highly-recommended/?$", "firefox.developer.index"),
+        # issue 8420
+        redirect(r"firefox/dedicated-profiles/?$", "https://support.mozilla.org/kb/dedicated-profiles-firefox-installation"),
+        # issue 8641
+        redirect(
+            r"^/firefox/windows-64-bit/?$",
+            "https://www.firefox.com/more/windows-64-bit/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^/firefox/best-browser/?$",
+            "https://www.firefox.com/more/best-browser/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 9148
+        redirect(
+            r"^/firefox/campaign/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 9788
+        redirect(
+            r"^/firefox/enterprise/signup(/.*)?$",
+            "https://www.firefox.com/enterprise/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 9953
+        redirect(
+            r"^/firefox/features/pip/?$",
+            "https://www.firefox.com/features/picture-in-picture/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 10182
+        redirect(
+            r"^/firefox/mobile/?$",
+            "https://www.firefox.com/browsers/mobile/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 10292, 10590
+        redirect(r"^firefox/(?P<version>[^/]+)/whatsnew/(india|africa|france|en|all|china)/?$", "/firefox/{version}/whatsnew/"),
+        redirect(r"^firefox/whatsnew/(india|africa|france|en|all|china)/?$", "firefox.whatsnew"),
+        # issue 10703
+        redirect(r"firefox/lockwise/?", "https://support.mozilla.org/kb/end-of-support-firefox-lockwise"),
+        # issue 12107
+        redirect(r"^/firefox/families/?$", "firefox.family.index"),
+        redirect(
+            r"^firefox/features/memory/?$",
+            "https://www.firefox.com/features/fast/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/features/independent/?$",
+            "https://www.firefox.com/features/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/features/safebrowser/?$",
+            "https://www.firefox.com/features/private/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(
+            r"^firefox/sync/?$",
+            "https://www.firefox.com/features/sync/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 13732
+        redirect(r"^firefox/welcome/3/?$", "mozorg.account"),
+        redirect(
+            r"^firefox/mobile/get-app/?$",
+            "https://www.firefox.com/browsers/mobile/get-app/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 14172 and MUST be retained as a redirect available on Mozorg
+        redirect(r"^firefox/browsers/mobile/app/?$", mobile_app, cache_timeout=0, query=False),
+        # issue 14231
+        redirect(
+            r"^firefox/flashback/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 14222
+        redirect(
+            r"^firefox/browsers/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        # issue 14248
+        redirect(r"^firefox/privacy/?$", "privacy"),
+        redirect(r"^firefox/privacy/products/?$", "products.landing"),
+        redirect(
+            r"^firefox/privacy/safe-passwords/?$",
+            "https://www.firefox.com/features/password-manager/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+        redirect(r"^firefox/privacy/book/?$", "https://support.mozilla.org/kb/how-stay-safe-web"),
+        redirect(r"^firefox/nothingpersonal/?$", "firefox.nothing-personal.index"),
+        # issue 15841
+        redirect(r"^firefox/tech/?$", "firefox.landing.tech"),  # TODO point to www.firefox.com/landing/tech/ when/if the page is moved
+        # issue 16089
+        redirect(
+            r"^/firefox/?$",
+            "https://www.firefox.com/",
+            query=REDIRECT_SOURCE_QUERYSTRING,
+            permanent=_permanent_redirect,
+        ),
+    )

--- a/bedrock/base/redirects.py
+++ b/bedrock/base/redirects.py
@@ -4,7 +4,10 @@
 
 from bedrock.redirects.util import redirect
 
-redirectpatterns = (
+# These redirects used to be part of the bedrock/firefox app
+from .legacy_firefox_redirects import redirectpatterns as firefox_legacy_redirectpatterns
+
+redirectpatterns = firefox_legacy_redirectpatterns + (
     # Issue 11875
     # Placed redirect here instead of products/redirects.py because of a conflicting redirect to `/firefox/new` happening in map_globalconf.py,
     # and this file would be placed before the file with the conflicting redirect

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -4,6 +4,8 @@
 
 import re
 
+from django.conf import settings
+
 from bedrock.redirects.util import mobile_app_redirector, no_redirect, platform_redirector, redirect
 
 PRODUCT_OPTIONS = ["firefox", "focus", "klar"]
@@ -42,6 +44,8 @@ def mobile_app(request, *args, **kwargs):
     return mobile_app_redirector(request, product, campaign)
 
 
+# These are enabled IFF the redirects to springfield (bedrock/base/legacy_firefox_redirects.py)
+# are NOT enabled, and vice-versa. Look for the if clause at the end of this file
 redirectpatterns = (
     # overrides
     # issue 8096
@@ -597,3 +601,7 @@ redirectpatterns = (
     # issue 16089
     redirect(r"^/firefox/?$", "firefox.new"),
 )
+
+# If we're redirecting to www.firefox.com, the above redirects are all redundant
+if settings.ENABLE_FIREFOX_COM_REDIRECTS:
+    redirectpatterns = ()

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2486,7 +2486,6 @@ if DEV is True:
 else:
     CMS_ALLOWED_PAGE_MODELS = _allowed_page_models
 
-
 # Our use of django-waffle relies on the following 2 settings to be set this way so that if a switch
 # doesn't exist, we get `None` back from `switch_is_active`.
 WAFFLE_SWITCH_DEFAULT = None
@@ -2504,3 +2503,18 @@ if ENABLE_DJANGO_SILK := config("ENABLE_DJANGO_SILK", default="False", parser=bo
     MIDDLEWARE.insert(0, "silk.middleware.SilkyMiddleware")
     SUPPORTED_NONLOCALES.append("silk")
     SILKY_PYTHON_PROFILER = config("SILKY_PYTHON_PROFILER", default="False", parser=bool)
+
+# Whether or not to redirect appropriate /firefox/* pages to www.firefox.com instead
+ENABLE_FIREFOX_COM_REDIRECTS = config(
+    "ENABLE_FIREFOX_COM_REDIRECTS",
+    default="False",
+    parser=bool,
+)
+
+# Whether or not the redirects to www.firefox.com should generally be
+# HTTP 301 Moved Permanently (True) or 302 Found (False)
+ENABLE_PERMANENT_FIREFOX_COM_REDIRECTS = config(
+    "ENABLE_PERMANENT_FIREFOX_COM_REDIRECTS",
+    default="False",
+    parser=bool,
+)

--- a/tests/redirects/map_legacy_firefox_redirects.py
+++ b/tests/redirects/map_legacy_firefox_redirects.py
@@ -1,0 +1,366 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.conf import settings
+
+from .base import flatten, url_test
+
+UA_ANDROID = {"User-Agent": "Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) Gecko/51.0 Firefox/51.0"}
+UA_IOS = {"User-Agent": "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; de-de) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8F190"}
+
+FXC_WITH_DEFAULT_QS = "https://www.firefox.com/?redirect_source=mozilla-org"
+FIREFOX_UPDATE_URL = (
+    "https://www.firefox.com/?redirect_source=mozilla-org&utm_source=firefox-browser&utm_medium=firefox-browser&utm_campaign=firefox-update-redirect"
+)
+
+QUERY_STRING = {"redirect_source": "mozilla-org"}
+
+if settings.ENABLE_PERMANENT_FIREFOX_COM_REDIRECTS:
+    STATUS_CODE = 301
+else:
+    STATUS_CODE = 302
+
+URLS = flatten(
+    (
+        url_test("/firefox/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # firefox/beta/all
+        url_test(
+            "/firefox/beta/all/",
+            "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org#beta",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/developer/all
+        url_test(
+            "/firefox/developer/all/",
+            "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org#developer",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/aurora/all
+        url_test(
+            "/firefox/aurora/all/",
+            "https://www.firefox.com/channel/desktop/developer/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/nightly/all
+        url_test(
+            "/firefox/nightly/all/",
+            "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org#nightly",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/organizations/all
+        url_test(
+            "/firefox/organizations/all/",
+            "https://www.firefox.com/browsers/enterprise/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/android/all
+        url_test(
+            "/firefox/android/all/",
+            "https://www.firefox.com/browsers/mobile/android/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/android/beta/all
+        url_test(
+            "/firefox/android/beta/all/",
+            "https://www.firefox.com/download/all/android-beta/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/android/nightly/all
+        url_test(
+            "/firefox/android/nightly/all/",
+            "https://www.firefox.com/download/all/android-nightly/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # mobile beta/aurora/nightly
+        url_test(
+            "/mobile/beta/",
+            "https://www.firefox.com/channel/android/?redirect_source=mozilla-org#beta",
+            status_code=STATUS_CODE,
+        ),
+        url_test(
+            "/mobile/aurora/",
+            "https://www.firefox.com/channel/android/?redirect_source=mozilla-org#aurora",
+            status_code=STATUS_CODE,
+        ),
+        url_test(
+            "/mobile/nightly/",
+            "https://www.firefox.com/channel/android/?redirect_source=mozilla-org#nightly",
+            status_code=STATUS_CODE,
+        ),
+        # firefox/unsupported-systems.html
+        url_test(
+            "/firefox/unsupported-systems.html",
+            "https://www.firefox.com/browsers/unsupported-systems/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # mobile/notes
+        url_test("/mobile/notes/", "https://www.firefox.com/firefox/android/notes/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/mobile/beta/notes/", "https://www.firefox.com/firefox/android/beta/notes/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test(
+            "/mobile/aurora/notes/", "https://www.firefox.com/firefox/android/aurora/notes/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        # system requirements
+        url_test(
+            "/firefox/system-requirements",
+            "https://www.firefox.com/firefox/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        url_test(
+            "/firefox/system-requirements.html",
+            "https://www.firefox.com/firefox/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        url_test(
+            "/firefox/beta/system-requirements",
+            "https://www.firefox.com/firefox/beta/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        url_test(
+            "/firefox/aurora/system-requirements",
+            "https://www.firefox.com/firefox/aurora/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        url_test(
+            "/firefox/organizations/system-requirements",
+            "https://www.firefox.com/firefox/organizations/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # download URLs
+        url_test("/download/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/download", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/mobile/download", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # all downloads
+        url_test("/firefox/all", "https://www.firefox.com/download/all/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/all.html", "https://www.firefox.com/download/all/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # search
+        url_test("/firefox/search", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/search.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # beta/aurora downloads
+        url_test("/firefox/all-beta", "https://www.firefox.com/download/all/desktop-beta/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/all-beta.html", "https://www.firefox.com/download/all/desktop-beta/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/all-rc", "https://www.firefox.com/download/all/desktop-beta/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/all-rc.html", "https://www.firefox.com/download/all/desktop-beta/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test(
+            "/firefox/all-aurora", "https://www.firefox.com/download/all/desktop-developer/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test(
+            "/firefox/all-aurora.html", "https://www.firefox.com/download/all/desktop-developer/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test("/firefox/aurora/all/", "https://www.firefox.com/channel/desktop/developer/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # aurora pages
+        url_test("/firefox/aurora/notes/", "https://www.firefox.com/firefox/developer/notes/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test(
+            "/firefox/aurora/system-requirements/",
+            "https://www.firefox.com/firefox/developer/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # ESR downloads
+        url_test(
+            "/firefox/organizations/all.html",
+            "https://www.firefox.com/download/all/desktop-esr/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # mobile sync
+        url_test("/mobile/sync", "https://www.firefox.com/features/sync/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # toolkit download to devices
+        url_test("/firefox/toolkit/download-to-your-devices", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # firefox update
+        url_test("/firefox/update", FIREFOX_UPDATE_URL, status_code=STATUS_CODE),
+        # mobile features
+        url_test("/mobile/features/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/mobile/features/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/m/features/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # m/ redirect
+        url_test("/m/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # all-older.html
+        url_test("/firefox/all-older.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # central/sync pages
+        url_test("/firefox/start/central.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/products/firefox/start/central.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/sync/firstrun.html", "https://www.firefox.com/features/sync/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # fx redirects
+        url_test("/firefox/fx", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/fx/whatever", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # performance pages
+        url_test("/firefox/performance/", "https://www.firefox.com/features/fast/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/happy/", "https://www.firefox.com/features/fast/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/speed/", "https://www.firefox.com/features/fast/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/memory/", "https://www.firefox.com/features/fast/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/security/", "https://www.firefox.com/features/private/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # central pages
+        url_test("/firefox/central/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/central.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/central-lite.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/products/firefox/central/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # SMS redirects
+        url_test("/firefox/sms/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/sms/whatever/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Code name redirects
+        url_test("/projects/bonecho/", "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/projects/deerpark/", "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/projects/granparadiso/", "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/projects/minefield/", "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/projects/namoroka/", "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/projects/shiretoko/", "https://www.firefox.com/channel/desktop/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Firebird
+        url_test("/products/firebird/compare/", "https://www.firefox.com?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/products/firebird/", "https://www.firefox.com?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/products/firebird/download/", "https://www.firefox.com?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Fennic
+        url_test("/fennec/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Mobile
+        url_test("/mobile/", "https://www.firefox.com/browser/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/mobile/customize/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/mobile/customize/whatever/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Firefox independent/personal
+        url_test("/firefox/independent/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/personal/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Firefox upgrade/IE
+        url_test("/firefox/upgrade", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/ie", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Sync
+        url_test("/sync/", "https://www.firefox.com/features/sync/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # FxAndroid
+        url_test("/fxandroid/", "https://www.firefox.com/browsers/mobile/android/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Upper-case Firefox
+        url_test("/Firefox/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # firefox/desktop pages
+        url_test("/firefox/desktop/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/desktop/fast/", "https://www.firefox.com/features/fast/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/desktop/trust/", "https://www.firefox.com/features/private/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/desktop/tips/", "https://www.firefox.com/features/tips/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Firefox Android/Focus/iOS
+        url_test("/firefox/android/", "https://www.firefox.com/browsers/mobile/android/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/focus/", "https://www.firefox.com/browsers/mobile/focus/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test(
+            "/firefox/browsers/mobile/compare/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test("/firefox/ios/", "https://www.firefox.com/browsers/mobile/ios/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Organizations
+        url_test("/firefox/organizations/faq/", "https://www.firefox.com/enterprise/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/organizations/", "https://www.firefox.com/enterprise/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Mobile download
+        url_test("/firefox/mobile-download/", "https://www.firefox.com/browsers/mobile/index/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test(
+            "/firefox/mobile-download/whatever/",
+            "https://www.firefox.com/browsers/mobile/index/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # details redirects
+        url_test(
+            "/firefox/56.0/details/", "https://www.firefox.com/browsers/unsupported-systems/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test(
+            "/mobile/56.0/details/", "https://www.firefox.com/browsers/unsupported-systems/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test(
+            "/firefox/unsupported/", "https://www.firefox.com/browsers/unsupported-systems/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        # Various redirects
+        url_test("/firefox/tips", "https://www.firefox.com/features/tips/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/new/something", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test(
+            "/firefox/38.0.3/releasenotes/",
+            "https://www.firefox.com/firefox/38.0.5/releasenotes/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        url_test("/firefox/default.htm", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test(
+            "/firefox/android/56.0", "https://www.firefox.com/firefox/android/56.0/releasenotes/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test("/firefox/stats/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # vote and election
+        url_test("/vote/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/election/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Firefox HTML
+        url_test("/firefox/firefox.html", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Misc promotional pages
+        url_test("/firefoxfightsforyou/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/fights-for-you/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/flashback/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/browsers/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/firefox/campaign/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Enterprise
+        url_test("/firefox/enterprise/signup/", "https://www.firefox.com/enterprise/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Features
+        url_test(
+            "/firefox/features/pip/", "https://www.firefox.com/features/picture-in-picture/?redirect_source=mozilla-org", status_code=STATUS_CODE
+        ),
+        url_test("/firefox/features/memory/", "https://www.firefox.com/features/fast/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/features/independent/", "https://www.firefox.com/features/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/features/safebrowser/", "https://www.firefox.com/features/private/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/sync/", "https://www.firefox.com/features/sync/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/mobile/get-app/", "https://www.firefox.com/browsers/mobile/get-app/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test(
+            "/firefox/privacy/safe-passwords/",
+            "https://www.firefox.com/features/password-manager/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        # Windows/browser specific
+        url_test("/firefox/windows-64-bit/", "https://www.firefox.com/more/windows-64-bit/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/firefox/best-browser/", "https://www.firefox.com/more/best-browser/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Product pages
+        url_test("/firefox/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Product features
+        url_test("/products/firefox/live-bookmarks", "https://www.firefox.com/features/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/products/firefox/search", "https://www.firefox.com/features/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        url_test("/products/firefox/switch", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test(
+            "/products/firefox/system-requirements",
+            "https://www.firefox.com/firefox/system-requirements/?redirect_source=mozilla-org",
+            status_code=STATUS_CODE,
+        ),
+        url_test("/products/firefox/tabbed-browsing", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/products/firefox/upgrade", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        url_test("/products/firefox/why/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+        # Mobile
+        url_test("/firefox/mobile/", "https://www.firefox.com/browsers/mobile/?redirect_source=mozilla-org", status_code=STATUS_CODE),
+        # Choose
+        url_test("/firefox/choose/", FXC_WITH_DEFAULT_QS, status_code=STATUS_CODE),
+    )
+)
+
+# List of redirects not covered by tests:
+"""
+Redirects not tested:
+1. mwc: redirects to support.mozilla.org/products/firefox-os
+2. projects/firefox firstrun paths: redirect to internal firefox.nightly.firstrun
+3. nightly/whatsnew: redirect to firefox.nightly.firstrun
+4. project firefox path redirects: complex URL patterns
+5. firefox/connect: redirect to mozorg.home
+6. firefox/accountmanager: redirect to developer.mozilla.org/Persona
+7. firefox/beta/aurora/nightly channel redirects: use platform_redirector function
+8. firefox/os/(releases|notes): redirect to developer.mozilla.org
+9. firefoxos: redirect to /firefox/os/
+10. no_redirect for download/thanks
+11. firefox/firefox.exe: redirect to mozorg.home
+12. mobile/faq: uses the firefox_mobile_faq function
+13. mobile/platforms: redirect to support.mozilla.org
+14. firefox/releases/whatsnew redirects
+15. seamonkey transition: redirect to archive.mozilla.org
+16. hello survey redirects
+17. firefox/customize: redirects to support.mozilla.org
+18. firefox/technology: redirects to developer.mozilla.org
+19. android download redirects: merge_query=True used
+20. fennec projects: redirect to website-archive.mozilla.org
+21. phishing protection: redirect to support.mozilla.org
+22. home pages: redirect to blog.mozilla.org
+23. vpat pages: redirect to website-archive.mozilla.org
+24. mobile system requirements: redirect to support.mozilla.org
+25. devpreview: redirects to firefox/firstrun or website-archive
+26. no_redirect for certain Firefox release notes
+27. mobile release notes: complex URL patterns using regex groups
+28. firefox/mobile/platforms: redirect to support page
+29. firefox/private-browsing: redirect to internal page
+30. addon redirects: redirect to addons.mozilla.org
+31. firefox/help: redirect to support.mozilla.org
+32. Various project redirects to developer.mozilla.org or wiki.mozilla.org
+33. firefox/org signup: more complex pattern
+34. firefox/android/faq: redirect to support.mozilla.org
+35. firefox/desktop/customize: redirect to support.mozilla.org
+36. firefox welcome pages with version numbers
+37. firefox browsers/mobile/app: uses mobile_app function
+38. firefox/nothingpersonal and firefox/tech: internal redirects
+39. firefox version-specific redirects
+"""

--- a/tests/redirects/test_redirects.py
+++ b/tests/redirects/test_redirects.py
@@ -6,15 +6,19 @@
 
 from operator import itemgetter
 
+from django.test import override_settings
+
 import pytest
 
 from .base import assert_valid_url
 from .map_301 import URLS as REDIRECT_URLS
 from .map_globalconf import URLS as GLOBAL_URLS
 from .map_htaccess import URLS as HTA_URLS
+from .map_legacy_firefox_redirects import URLS as LEGACY_FIREFOX_REDIRECTS
 from .map_locales import URLS as LOCALE_URLS
 
 
+@override_settings(ENABLE_FIREFOX_COM_REDIRECTS=False)
 @pytest.mark.headless
 @pytest.mark.nondestructive
 @pytest.mark.django_db
@@ -24,6 +28,7 @@ def test_301_url(url, base_url):
     assert_valid_url(**url)
 
 
+@override_settings(ENABLE_FIREFOX_COM_REDIRECTS=False)
 @pytest.mark.headless
 @pytest.mark.nondestructive
 @pytest.mark.django_db
@@ -33,6 +38,7 @@ def test_global_conf_url(url, base_url):
     assert_valid_url(**url)
 
 
+@override_settings(ENABLE_FIREFOX_COM_REDIRECTS=False)
 @pytest.mark.headless
 @pytest.mark.nondestructive
 @pytest.mark.django_db
@@ -42,10 +48,21 @@ def test_htaccess_url(url, base_url):
     assert_valid_url(**url)
 
 
+@override_settings(ENABLE_FIREFOX_COM_REDIRECTS=False)
 @pytest.mark.headless
 @pytest.mark.nondestructive
 @pytest.mark.django_db
 @pytest.mark.parametrize("url", LOCALE_URLS)
 def test_locale_url(url, base_url):
+    url["base_url"] = base_url
+    assert_valid_url(**url)
+
+
+@override_settings(ENABLE_FIREFOX_COM_REDIRECTS=True)
+@pytest.mark.headless
+@pytest.mark.nondestructive
+@pytest.mark.django_db
+@pytest.mark.parametrize("url", LEGACY_FIREFOX_REDIRECTS, ids=itemgetter("url"))
+def test_legacy_firefox_redirects(url, base_url):
     url["base_url"] = base_url
     assert_valid_url(**url)


### PR DESCRIPTION
WIP commits - the override_settings doesn't work and generally this overlaps too much between sets of redirects
