### PR TITLE
(feat) Point to new advertising standards PDF,

### DIFF
--- a/bedrock/mozorg/templates/mozorg/advertising/formats.html
+++ b/bedrock/mozorg/templates/mozorg/advertising/formats.html
@@ -306,7 +306,7 @@
   content_width='xl',
   include_cta=True
 ) %}
-<p><a href="https://assets.mozilla.net/pdf/Mozilla_Advertising_Standards_2024.pdf" class="mzp-c-button" data-cta-text="Download PDF">Download PDF</a></p>
+<p><a href="https://assets.mozilla.net/pdf/Mozilla_Advertising_Standards.pdf" class="mzp-c-button" data-cta-text="Download PDF">Download PDF</a></p>
 {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
… already uploaded to assets.mozilla.net


## Issue / Bugzilla link

Resolves #16368 

## Testing

Check the target of the `Download PDF` link on http://localhost:8000/en-US/advertising/formats/ 