### PR TITLE
Support a canonical link from release notes and system requirements pointing at www.firefox.com

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/index.html
+++ b/bedrock/firefox/templates/firefox/releases/index.html
@@ -20,6 +20,11 @@
 
 {% block body_class %}{{ super() }} mzp-t-firefox{% endblock %}
 
+{# We want to denote www.firefox.com as the canonical source of release notes #}
+{% block canonical_urls %}
+    {{ firefox_com_canonical_tag() }}
+{% endblock %}
+
 {% block content %}
   <main id="main-content" class="mzp-l-content">
     <a href="{{ url('firefox.new') }}">

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -19,6 +19,11 @@
 {# header_class is applied to the page header as an additional style hook if needed #}
 {% set header_class = header_class|default('') %}
 
+{# We want to denote www.firefox.com as the canonical source of release notes #}
+{% block canonical_urls %}
+    {{ firefox_com_canonical_tag() }}
+{% endblock %}
+
 {# theme_class is applied to the body as an additional style hook if needed #}
 {% set theme_class = '' %}
 {% set ver = release.major_version_int %}

--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -21,6 +21,11 @@
   {{ css_bundle('firefox_system_requirements') }}
 {% endblock %}
 
+{# We want to denote www.firefox.com as the canonical source of release notes #}
+{% block canonical_urls %}
+    {{ firefox_com_canonical_tag() }}
+{% endblock %}
+
 {% block content %}
   <main class="mzp-l-content mzp-t-content-md">
     <h1 class="c-page-title">Firefox System Requirements</h1>

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -430,6 +430,8 @@ def firefox_com_canonical_tag(ctx, dest_path=None, domain="www.firefox.com"):
         {{ firefox_com_canonical_tag(domain="some-alternate-subdomain.firefox.com") }}
 
     """
+    if settings.ENABLE_FIREFOX_COM_REDIRECTS is False:
+        return ""
 
     request = ctx["request"]
 

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -407,3 +407,36 @@ def send_to_device(
 
     html = render_to_string("firefox/includes/send-to-device.html", context, request=request)
     return Markup(html)
+
+
+@library.global_function
+@jinja2.pass_context
+def firefox_com_canonical_tag(ctx, dest_path=None, domain="www.firefox.com"):
+    """Create a <rel='canonical'...> link based on the URL of the current page, but swapping the
+    hostname for firefox.com (by default).
+
+    By default uses the same path as the current URL
+    By default targets www.firefox.com as the target domain
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ firefox_com_canonical_tag() }}
+        {{ firefox_com_canonical_tag(dest_path="/some/alernative/path") }}
+        {{ firefox_com_canonical_tag(dest_path="/some/alernative/path", domain="some-alternate-subdomain.firefox.com") }}
+        {{ firefox_com_canonical_tag(domain="some-alternate-subdomain.firefox.com") }}
+
+    """
+
+    request = ctx["request"]
+
+    _path = request.path if not dest_path else dest_path
+
+    dest = f"{request.scheme}://{domain}{_path}"
+
+    html = f'<link rel="canonical" href="{dest}">'
+
+    return Markup(html)

--- a/bedrock/releasenotes/tests/test_views.py
+++ b/bedrock/releasenotes/tests/test_views.py
@@ -201,3 +201,19 @@ def test_system_requirements_detail_contains_canonical_tag_pointing_to_firefox_c
         assert _link_is_in_content == enable_redirects
 
     release_cache.clear()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("enable_redirects", (True, False))
+def test_releases_index_contains_canonical_tag_pointing_to_firefox_com_if_redirects_enabled(rf, enable_redirects):
+    # Bootstrap relnotes test data
+    ProductRelease.objects.refresh()
+    release_cache.clear()
+
+    request = rf.get("/en-US/firefox/releases/")
+    with override_settings(ENABLE_FIREFOX_COM_REDIRECTS=enable_redirects):
+        resp = releases_index(request, product="Firefox")
+        _link_is_in_content = '<link rel="canonical" href="http://www.firefox.com/en-US/firefox/releases/">' in str(resp.content)
+        assert _link_is_in_content == enable_redirects
+
+    release_cache.clear()

--- a/bedrock/releasenotes/tests/test_views.py
+++ b/bedrock/releasenotes/tests/test_views.py
@@ -2,11 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from pathlib import Path
 from unittest.mock import patch
+
+from django.core.cache import caches
+from django.test import override_settings
 
 import pytest
 
-from bedrock.releasenotes.views import releases_index, show_android_sys_req
+from bedrock.releasenotes.models import ProductRelease
+from bedrock.releasenotes.views import release_notes, releases_index, show_android_sys_req, system_requirements
+
+RELEASES_PATH = str(Path(__file__).parent)
+release_cache = caches["release-notes"]
 
 
 @pytest.mark.parametrize(
@@ -161,3 +169,35 @@ def test_releases_index__product_other_than_firefox(render_mock, rf):
         "someproduct/releases/index.html",
         {"releases": []},
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("enable_redirects", (True, False))
+def test_release_notes_detail_contains_canonical_tag_pointing_to_firefox_com_if_redirects_enabled(rf, enable_redirects):
+    # Bootstrap relnotes test data
+    ProductRelease.objects.refresh()
+    release_cache.clear()
+
+    request = rf.get("/en-US/firefox/56.0.2/releasenotes/")
+    with override_settings(ENABLE_FIREFOX_COM_REDIRECTS=enable_redirects):
+        resp = release_notes(request, version="56.0.2")
+        _link_is_in_content = '<link rel="canonical" href="http://www.firefox.com/en-US/firefox/56.0.2/releasenotes/">' in str(resp.content)
+        assert _link_is_in_content == enable_redirects
+
+    release_cache.clear()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("enable_redirects", (True, False))
+def test_system_requirements_detail_contains_canonical_tag_pointing_to_firefox_com_if_redirects_enabled(rf, enable_redirects):
+    # Bootstrap relnotes test data
+    ProductRelease.objects.refresh()
+    release_cache.clear()
+
+    request = rf.get("/en-US/firefox/56.0.2/system-requirements/")
+    with override_settings(ENABLE_FIREFOX_COM_REDIRECTS=enable_redirects):
+        resp = system_requirements(request, version="56.0.2")
+        _link_is_in_content = '<link rel="canonical" href="http://www.firefox.com/en-US/firefox/56.0.2/system-requirements/">' in str(resp.content)
+        assert _link_is_in_content == enable_redirects
+
+    release_cache.clear()


### PR DESCRIPTION
As per the #16380 we need to support showing that the releasenotes and system requirements pages on www.firefox.com are actually the source of truth now, not www.mozilla.org's pages. 

This changeset supports that, as long as the setting to enable redirects to from www.mozilla.org/firefox to www.firefox.com is True.

## Significant changes and points to review

Note that the `/firefox/releases/` page used to define itself as the `canonical` source. I wonder whether changing this will have any impact? 

## Issue / Bugzilla link

Resolves #16380

## Testing

- [ ] View source on each of these and validate that the link on www.firefox.com is correct
    - [ ] http://localhost:8000/en-US/firefox/140.0/system-requirements/
    - [ ] http://localhost:8000/en-US/firefox/140.0/releasenotes/
    - [ ] http://localhost:8000/en-US/firefox/releases/
    - [ ] Also please click around and try the same for Android, iOS, Developer/Beta, Nightly and ESR releasenotes
- [ ] Please check for other relnotes-type routes that haven't been patched, but I think we got them here.
