### PR TITLE
Prepare tests for offsite 301 Moved Permanently

### DIFF
--- a/tests/redirects/test_urls.py
+++ b/tests/redirects/test_urls.py
@@ -7,6 +7,8 @@
 import pytest
 import requests
 
+from bedrock import settings
+
 from .base import assert_valid_url
 from .map_410 import URLS_410
 
@@ -59,6 +61,10 @@ def test_301_urls(url, base_url, follow_redirects=False):
     assert_valid_url(url, base_url=base_url, follow_redirects=follow_redirects)
 
 
+@pytest.mark.skipif(
+    settings.MAKE_FIREFOX_COM_REDIRECTS_PERMANENT is True,
+    reason="Redirected offsite as 301, not 302 locally",
+)
 @pytest.mark.headless
 @pytest.mark.nondestructive
 @pytest.mark.django_db


### PR DESCRIPTION
## One-line summary

These are the only ones unhappy about HTTP 301 observed after setting MAKE_FIREFOX_COM_REDIRECTS_PERMANENT.

## Significant changes and points to review

They are basic vanity url tests and are OK to skip as these are handled on springfield.

## Issue / Bugzilla link

#16355

## Testing
