### PR TITLE
Add .well-known/org.flathub.VerifiedApps.txt for org.mozilla.vpn

### DIFF
--- a/root_files/.well-known/org.flathub.VerifiedApps.txt
+++ b/root_files/.well-known/org.flathub.VerifiedApps.txt
@@ -1,0 +1,3 @@
+# org.mozilla.vpn
+bae02cc7-9600-4568-b6d7-f452e5551956
+


### PR DESCRIPTION
## One-line summary
Add .well-known/org.flathub.VerifiedApps.txt for org.mozilla.vpn

## Significant changes and points to review

This adds a static file to the `.well-known` directory to complete [app verification](https://docs.flathub.org/docs/for-app-authors/verification) for the [org.mozilla.vpn](https://flathub.org/apps/org.mozilla.vpn) app on Flathub.


## Issue / Bugzilla link

Github: flathub/org.mozilla.vpn#1
JIRA:
- [SREIN-173](https://mozilla-hub.atlassian.net/browse/SREIN-173)
- [VPN-7151](https://mozilla-hub.atlassian.net/browse/VPN-7151)

## Testing
