### PR TITLE
Remove WIP meta title from pdf by pointing to new asset

### DIFF
--- a/bedrock/mozorg/templates/mozorg/advertising/formats.html
+++ b/bedrock/mozorg/templates/mozorg/advertising/formats.html
@@ -216,7 +216,7 @@
   content_width='xl',
   include_cta=True
 ) %}
-<p><a href="https://assets.mozilla.net/pdf/Mozilla_Advertising_Standards.pdf" class="mzp-c-button" data-cta-text="Download PDF">Download PDF</a></p>
+<p><a href="https://assets.mozilla.net/pdf/Mozilla_Advertising_Standards_2025.pdf" class="mzp-c-button" data-cta-text="Download PDF">Download PDF</a></p>
 {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Updates ad PDF after some upload/caching weirdness 

## Significant changes and points to review

Depends on https://github.com/mozmeao/assets.mozilla.net/pull/38 - Merged

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16389


## Testing
- [x] Confirm http://localhost:8000/en-US/advertising/formats/ has non-WIP title for PDF at bottom of page