### PR TITLE
clean up expired l10n strings (fix #16413)

### DIFF
--- a/.github/l10n/linter_config.yml
+++ b/.github/l10n/linter_config.yml
@@ -26,5 +26,4 @@ CO01:
     - "{ -brand-name-mozilla } account"
   exclusions:
     files: []
-    messages:
-      - footer-refresh-mdn
+    messages: []

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -66,7 +66,7 @@
                 <li><a href="{{ settings.FXC_BASE_URL }}/browsers/enterprise/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox for Enterprise">{{ ftl('footer-refresh-enterprise') }}</a></li>
               {% endif %}
               <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-refresh-tools') }}</a></li>
-              <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn-v2', fallback="footer-refresh-mdn") }}</a></li>
+              <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn-v2') }}</a></li>
               <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
             </ul>
           </section>

--- a/bedrock/firefox/templates/firefox/developer/includes/mdn-features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/mdn-features.html
@@ -16,31 +16,16 @@
     </div>
     <div class="mzp-l-columns mzp-t-columns-three">
       <div>
-        {% if ftl_has_messages('firefox-developer-mdn-playground', 'firefox-developer-mdn-write-test-and-share') %}
-          <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/en-US/play/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-playground') }}</a></h3>
-          <p>{{ ftl('firefox-developer-mdn-write-test-and-share') }}</p>
-        {% else %}
-          <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/docs/Web{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-references') }}</a></h3>
-          <p>{{ ftl('firefox-developer-mdn-is-a') }}</p>
-        {% endif %}
+        <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/en-US/play/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-playground') }}</a></h3>
+        <p>{{ ftl('firefox-developer-mdn-write-test-and-share') }}</p>
       </div>
       <div>
-        {% if ftl_has_messages('firefox-developer-mdn-blog', 'firefox-developer-mdn-unlock-the-world') %}
-          <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/en-US/blog/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-blog') }}</a></h3>
-          <p>{{ ftl('firefox-developer-mdn-unlock-the-world') }}</p>
-        {% else %}
-          <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/curriculum/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-curriculum') }}</a></h3>
-          <p>{{ ftl('firefox-developer-a-structured-guide') }}</p>
-        {% endif %}
+        <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/en-US/blog/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-blog') }}</a></h3>
+        <p>{{ ftl('firefox-developer-mdn-unlock-the-world') }}</p>
       </div>
       <div>
-        {% if ftl_has_messages('firefox-developer-mdn-updates', 'firefox-developer-mdn-the-web-doesnt-have') %}
-          <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/en-US/plus/updates/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-updates') }}</a></h3>
-          <p>{{ ftl('firefox-developer-mdn-the-web-doesnt-have') }}</p>
-        {% else %}
-          <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/plus/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-plus') }}</a></h3>
-          <p>{{ ftl('firefox-developer-support-mdn-and') }}</p>
-        {% endif %}
+        <h3 class="mzp-u-title-xs"><a href="https://developer.mozilla.org/en-US/plus/updates/{{ utm_params }}" rel="external">{{ ftl('firefox-developer-mdn-updates') }}</a></h3>
+        <p>{{ ftl('firefox-developer-mdn-the-web-doesnt-have') }}</p>
       </div>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -99,7 +99,7 @@
       <div class="c-block-body">
         <h1 class="mzp-c-wordmark mzp-t-wordmark-md mzp-t-product-firefox">{{ ftl('firefox-desktop-download-firefox') }}</h1>
           <h2 class="mzp-has-zap-7">{{ ftl('firefox-desktop-download-get-the-browser') }}</h2>
-          <p>{{ ftl('firefox-desktop-download-fast-reliable-private', fallback='firefox-desktop-download-no-shady') }}</p>
+          <p>{{ ftl('firefox-desktop-download-fast-reliable-private') }}</p>
         <div class="c-intro-download">
           {% block primary_cta %}
             {{ default_browser_checkbox(id='default-browser-checkbox-primary') }}
@@ -249,7 +249,7 @@
 {% endif %}
 
   <section class="t-highlights">
-    <h2 class="mzp-c-section-heading mzp-has-zap-11">{{ ftl('firefox-desktop-download-do-what-you-do-v2', fallback='firefox-desktop-download-do-what-you-do') }}</h2>
+    <h2 class="mzp-c-section-heading mzp-has-zap-11">{{ ftl('firefox-desktop-download-do-what-you-do-v2') }}</h2>
 
     <div class="t-block c-block l-reversed">
       <div class="c-block-container">
@@ -513,7 +513,7 @@
         ) }}
         <h3 class="mzp-u-title-xs">{{ ftl('firefox-desktop-download-your-privacy-comes') }}</h3>
         {% set internet_attrs = 'href="%s" data-cta-text="Personal Data Promise"'|safe|format(url('privacy')) %}
-        <p>{{ ftl('firefox-desktop-download-as-the-internet-v2', fallback='firefox-desktop-download-as-the-internet', attrs=internet_attrs) }}</p>
+        <p>{{ ftl('firefox-desktop-download-as-the-internet-v2', attrs=internet_attrs) }}</p>
       </div>
     </div>
   </section>

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -72,7 +72,7 @@
 
       <p>{{ ftl('nightly-whatsnew-this-is-a-good') }}</p>
 
-      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v4', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mastodon.social/@FirefoxNightly"', bluesky='href="https://bsky.app/profile/firefoxnightly.bsky.social"', fallback='nightly-whatsnew-if-you-want-to-v3') }}</p>
+      <p>{{ ftl('nightly-whatsnew-if-you-want-to-v4', blog='href="https://blog.nightly.mozilla.org/"', twitter='href="https://twitter.com/FirefoxNightly"', mastodon='href="https://mastodon.social/@FirefoxNightly"', bluesky='href="https://bsky.app/profile/firefoxnightly.bsky.social"') }}</p>
 
       <p>
           {% set attrs = 'href="#" class="nightly-experiments-link"' %}

--- a/bedrock/privacy/templates/privacy/includes/privacy-basics.html
+++ b/bedrock/privacy/templates/privacy/includes/privacy-basics.html
@@ -187,8 +187,8 @@
       <p>{{ ftl('privacy-firefox-firefox-makes-it') }}</p>
       <div class="c-settings-buttons">
         <p class="c-settings-manage"><strong>{{ ftl('privacy-firefox-manage-your-privacy') }}</strong></p>
-        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/manage-firefox-data-collection-privacy-settings">{{ ftl('privacy-firefox-firefox-for-desktop-v2', fallback='privacy-firefox-firefox-for-desktop') }}</a>
-        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/mobile-manage-firefox-data-collection-and-privacy">{{ ftl('privacy-firefox-firefox-for-mobile-v2', fallback='privacy-firefox-firefox-for-mobile') }}</a>
+        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/manage-firefox-data-collection-privacy-settings">{{ ftl('privacy-firefox-firefox-for-desktop-v2') }}</a>
+        <a class="mzp-c-button mzp-t-secondary" href="https://support.mozilla.org/kb/mobile-manage-firefox-data-collection-and-privacy">{{ ftl('privacy-firefox-firefox-for-mobile-v2') }}</a>
       </div>
   {% endcall %}
 

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -87,15 +87,3 @@ firefox-developer-mdn-blog = { -brand-name-mdn } Blog
 firefox-developer-mdn-unlock-the-world = Unlock the world of web development with the { -brand-name-mdn } Blog — your go-to hub for expert insights, latest web standards, and coding tips.
 firefox-developer-mdn-updates = Updates
 firefox-developer-mdn-the-web-doesnt-have = The web doesn’t have a changelog, but { -brand-name-mdn } can help. You can personalize and filter compatibility changes based on browsers or the tech category you are interested in whether that is JavaScript, CSS, etc.
-# Obsolete string (expires 18-04-2025)
-firefox-developer-mdn-references = { -brand-name-mdn } References
-# Obsolete string (expires 18-04-2025)
-firefox-developer-mdn-is-a = { -brand-name-mdn } is an open-source, collaborative project documenting web platform technologies, including CSS, HTML, JavaScript and web APIs.
-# Obsolete string (expires 18-04-2025)
-firefox-developer-mdn-curriculum = { -brand-name-mdn } Curriculum
-# Obsolete string (expires 18-04-2025)
-firefox-developer-a-structured-guide = A structured guide to the essential skills and practices for being a successful front-end developer, along with recommended learning resources.
-# Obsolete string (expires 18-04-2025)
-firefox-developer-mdn-plus = { -brand-name-mdn-plus }
-# Obsolete string (expires 18-04-2025)
-firefox-developer-support-mdn-and = Support { -brand-name-mdn } and make it your own with collections, notifications, and playgrounds.

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -26,17 +26,11 @@ firefox-desktop-download-fast-reliable-private = Fast, reliable and private — 
 
 firefox-desktop-set-as-default = Set { -brand-name-firefox } as your default browser.
 
-# Obsolete string (expires: 2025-04-17)
-firefox-desktop-download-no-shady = No shady privacy policies or back doors for advertisers. Just a lightning fast browser that doesn’t sell you out.
-
 firefox-desktop-download-download-options = Download options and other languages
 firefox-desktop-download-browser-support = { -brand-name-firefox-browser } support
 
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
 firefox-desktop-download-do-what-you-do-v2 = Do what you do online.<br> { -brand-name-firefox-browser } has got you <strong>covered</strong>.
-
-# Obsolete string (expires: 2025-04-17)
-firefox-desktop-download-do-what-you-do = Do what you do online.<br> { -brand-name-firefox-browser } <strong>isn’t</strong> watching.
 
 firefox-desktop-download-we-block-the-ad = We block the ad trackers. You explore the internet faster.
 firefox-desktop-download-ads-are-distracting = Ads are distracting and make web pages load slower while their trackers watch every move you make online. The { -brand-name-firefox-browser } blocks most trackers automatically, so there’s no need to dig into your security settings.
@@ -129,11 +123,6 @@ firefox-desktop-download-firefox-was-created = { -brand-name-firefox } was creat
 # Variables:
 #   $attrs (attrs) - link to https://www.mozilla.org/privacy/firefox/
 firefox-desktop-download-as-the-internet-v2 = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy — that’s always been our thing. Learn more about our data practices in our <a { $attrs }>Privacy Notice</a>.
-
-# Obsolete string (expires: 2025-04-17)
-# Variables:
-#   $attrs (attrs) - link to https://www.mozilla.org/firefox/privacy/
-firefox-desktop-download-as-the-internet = As the internet grows and changes, { -brand-name-firefox } continues to focus on your right to privacy  — we call it the <a { $attrs }>Personal Data Promise</a>: Take less. Keep it safe. No secrets. Your data, your web activity, your life online is protected with { -brand-name-firefox }.
 
 # Variables:
 #   $attrs (attrs) - link to https://accounts.firefox.com/signin

--- a/l10n/en/firefox/nightly/whatsnew.ftl
+++ b/l10n/en/firefox/nightly/whatsnew.ftl
@@ -23,13 +23,6 @@ nightly-whatsnew-this-is-a-good = This is a good time to thank you for helping u
 nightly-whatsnew-if-you-want-to-v4 = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a { $blog }>blog</a> and following us on <a { $mastodon }>Mastodon</a> or <a { $bluesky }>Bluesky</a> are good starting points!
 
 # Variables:
-#   $blog (url) - link to https://blog.nightly.mozilla.org/
-#   $mastodon (url) - link to https://mastodon.social/@FirefoxNightly
-#   $twitter (url) - link to https://twitter.com/FirefoxNightly
-# Obsolete string (expires: 2025-04-18)
-nightly-whatsnew-if-you-want-to-v3 = If you want to know what’s happening around { -brand-name-nightly } and its community, reading our <a { $blog }>blog</a> and following us on <a { $mastodon }>Mastodon</a> or <a { $twitter }>X</a> are good starting points!
-
-# Variables:
 #   $attrs (string) - link href and additional attributes
 nightly-whatsnew-want-to-know-which-v3 = Want to know which platform features you could test on { -brand-name-nightly } and can’t see yet on other { -brand-name-firefox } channels? Then have a look at the <a { $attrs }>{ -brand-name-firefox-labs }</a> preferences page.
 

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -11,8 +11,6 @@ footer-refresh-learn-more-about-mozilla-advertising = Learn more <span>about { f
 footer-refresh-firefox-release-notes = { -brand-name-firefox } Release Notes
 footer-refresh-privacy-first = Privacy-first advertising solutions for brands, publishers, and platforms.
 footer-refresh-mdn-v2 = { -brand-name-mdn }
-# Obsolete string (expires 22-04-2025)
-footer-refresh-mdn = MDN
 footer-refresh-follow-mozilla = Follow @{ -brand-name-mozilla }
 footer-refresh-instagram = Instagram
 footer-refresh-linkedin = LinkedIn

--- a/l10n/en/privacy/firefox.ftl
+++ b/l10n/en/privacy/firefox.ftl
@@ -27,11 +27,7 @@ privacy-firefox-firefox-protects-you = { -brand-name-firefox } protects you from
 privacy-firefox-privacy-that-works = Privacy that works for you
 privacy-firefox-firefox-makes-it = { -brand-name-firefox } makes it easy to manage your data with built-in privacy and security features, plus settings that let you fine-tune your browsing experience.
 privacy-firefox-manage-your-privacy = Manage your privacy settings:
-# Obsolete string (expires: 2025-04-24)
-privacy-firefox-firefox-for-desktop = { -brand-name-firefox } for Desktop
 privacy-firefox-firefox-for-desktop-v2 = { -brand-name-firefox } for desktop
-# Obsolete string (expires: 2025-04-24)
-privacy-firefox-firefox-for-mobile = { -brand-name-firefox } for Mobile
 privacy-firefox-firefox-for-mobile-v2 = { -brand-name-firefox } for mobile
 
 # heading for the table of contents, a shorter heading is better


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR removes expired l10n strings

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16413

## Testing
