### PR TITLE
Update general CDN test URLs to something more permanent

### DIFF
--- a/tests/functional/test_cdn.py
+++ b/tests/functional/test_cdn.py
@@ -62,9 +62,9 @@ def get_ssllabs_results(base_url):
     "url",
     (
         "/",
-        "/firefox/new/",
         "/about/",
         "/products/",
+        "/privacy/",
     ),
 )
 @pytest.mark.nondestructive
@@ -117,7 +117,7 @@ def test_query_params(base_url):
 @pytest.mark.cdn
 @pytest.mark.nondestructive
 def test_cdn_cache(base_url):
-    full_url = "{}/{}{}".format(base_url, "en-US", "/firefox/new/")
+    full_url = "{}/{}{}".format(base_url, "en-US", "/products/")
 
     # hit the url once to make sure the cache is warm
     resp = requests.get(full_url, timeout=5)


### PR DESCRIPTION
## One-line summary

Use different pages to verify caches, accept-language vary, or locale fixups.

## Significant changes and points to review

Nothing too specific was being checked on that exact pages so any that are supposed to stay active for /de/ too should just do.

## Issue / Bugzilla link

#16355

## Testing

`docker compose run test pytest --base-url https://www.mozilla.org -m cdn`