### PR TITLE
update Firefox links (fix #16422)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -67,7 +67,7 @@
               {% endif %}
               <li><a href="https://firefox-source-docs.mozilla.org/devtools-user/?{{ utm_params }}&utm_content=developers" rel="external" data-link-position="footer" data-link-text="Tools">{{ ftl('footer-refresh-tools') }}</a></li>
               <li><a href="https://developer.mozilla.org/?{{ utm_params }}" data-link-position="footer" data-link-text="MDN">{{ ftl('footer-refresh-mdn-v2') }}</a></li>
-              <li><a href="/firefox/{{ latest_firefox_version }}/releasenotes/" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
+              <li><a href="https://www.firefox.com/firefox/{{ latest_firefox_version }}/releasenotes/?{{ utm_params }}" data-link-position="footer" data-link-text="Firefox Release Notes">{{ ftl('footer-refresh-firefox-release-notes') }}</a></li>
             </ul>
           </section>
         </div>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/products.html
@@ -13,7 +13,7 @@
 
     <ul class="m24-c-launchpad">
       <li class="m24-c-launchpad-item">
-        <a class="m24-c-launchpad-link m24-t-product-firefox" href="{{ url('firefox.new') }}" data-cta-text="Firefox" data-cta-position="product-list">
+        <a class="m24-c-launchpad-link m24-t-product-firefox" href="https://www.firefox.com/{{ utm_params }}" data-cta-text="Firefox" data-cta-position="product-list">
           <strong class="m24-c-launchpad-title">{{ ftl('m24-home-firefox') }}<b>:</b></strong>
           <span class="m24-c-launchpad-info">{{ ftl('m24-home-get-the-gold') }}</span>
         </a>

--- a/bedrock/products/templates/products/landing.html
+++ b/bedrock/products/templates/products/landing.html
@@ -61,7 +61,7 @@
         }
       ),
     ) %}
-      <h2 class="mzp-c-picto-heading"><a href="{{ url('firefox.new') }}" data-cta-text="Firefox" data-cta-position="heading">{{ ftl('firefox-products-firefox') }}</a></h2>
+      <h2 class="mzp-c-picto-heading"><a href="https://www.firefox.com/{{ referrals }}" data-cta-text="Firefox" data-cta-position="heading">{{ ftl('firefox-products-firefox') }}</a></h2>
       <p>{{ ftl('firefox-products-get-the-browser-that-blocks') }}</p>
       {% set alt_copy = ftl('download-button-download-firefox') + " " + icon_download|safe %}
       <div class="show-else">{{ download_firefox_thanks(alt_copy=alt_copy, button_class='mzp-t-secondary mzp-t-lg') }}</div>
@@ -82,7 +82,7 @@
         }
       ),
     ) %}
-      <h2 class="mzp-c-picto-heading"><a href="{{ url('firefox.browsers.mobile.focus') }}" data-cta-text="Focus" data-cta-position="heading">{{ ftl('firefox-products-firefox-focus') }}</a></h2>
+      <h2 class="mzp-c-picto-heading"><a href="https://www.firefox.com/browsers/mobile/focus/{{ referrals }}" data-cta-text="Focus" data-cta-position="heading">{{ ftl('firefox-products-firefox-focus') }}</a></h2>
       <p>{{ ftl('firefox-products-your-dedicated-privacy') }}</p>
       <p>
         <span class="hide-ios">{{ google_play_button(href=fc_android_url, id='playStoreLink-focus') }}</span>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates current Firefox links to use `firefox.com` links

## Significant changes and points to review

- home page product section
- product page (Firefox, Firefox Focus)
- release notes link in footer

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16422

## Testing

- http://localhost:8000/ (home page product, release notes link in footer)
- http://localhost:8000/en-US/products/ (Firefox, Firefox Focus)
