### PR TITLE
16150 Richtext Image alignment

### DIFF
--- a/bedrock/products/templates/products/monitor/cms/article.html
+++ b/bedrock/products/templates/products/monitor/cms/article.html
@@ -22,6 +22,7 @@
 {% set _params = '?utm_source=' ~ _utm_source ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign %}
 
 {% block page_css %}
+  {{ css_bundle('cms-base')}}
   {{ css_bundle('monitor-article') }}
 {% endblock %}
 
@@ -43,7 +44,7 @@
     </aside>
 
     <main class="mzp-l-main">
-    <article class="mzp-c-article">
+    <article class="mzp-c-article w-rich-text">
       <h1 class="mzp-c-article-title">{{ page.title }}</h1>
       <p class="c-subhead">{{ page.subheading|richtext }}</p>
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2359,6 +2359,8 @@ def lazy_wagtail_langs():
         ("ru", "Russian"),
         ("zh-CN", "Chinese (China-Simplified)"),
     ]
+    if DEV:
+        enabled_wagtail_langs.append(("ar", "Arabic"))  # To test the RTL support in the CMS
     enabled_language_codes = [x[0] for x in LANGUAGES]
     retval = [wagtail_lang for wagtail_lang in enabled_wagtail_langs if wagtail_lang[0] in enabled_language_codes]
     return retval

--- a/media/css/cms/rich-text.scss
+++ b/media/css/cms/rich-text.scss
@@ -59,11 +59,11 @@
 
         @media #{$mq-md} {
             &.left {
-                @include bidi(((margin-left, 0, margin-right, 0),));
+                margin-inline-end: auto;
             }
 
             &.right {
-                @include bidi(((margin-right, 0, margin-left, 0),));
+                margin-inline-start: auto;
             }
         }
     }

--- a/media/css/cms/rich-text.scss
+++ b/media/css/cms/rich-text.scss
@@ -59,11 +59,13 @@
 
         @media #{$mq-md} {
             &.left {
-                margin-inline-end: auto;
+                @include bidi(((margin-left, 0, auto),));
+                @include bidi(((margin-right, auto, 0),));
             }
 
             &.right {
-                margin-inline-start: auto;
+                @include bidi(((margin-left, auto, 0),));
+                @include bidi(((margin-right, 0, auto),));
             }
         }
     }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Add styles to left and right align images in Monitor Article Page richtext blocks.

## Significant changes and points to review

- Add Arabic to the available CMS languages when on DEV to make it eaasier to test CMS content on RTL layouts
- Apply CMS styles to the Monitor Article page
- Add styles to left and right align images on richtext blocks


## Issue / Bugzilla link

#16150 

## Testing

- Go to `http://localhost:8000/cms-admin/locales/new/` and create the Arabic locale
- Create a Monitor Article page and add left and right aligned images to the content
<img width="1636" height="707" alt="image" src="https://github.com/user-attachments/assets/9a0524d2-1363-426d-9f01-619693739d35" />
- Translate the page to Arabic
- Preview the translated page to check that the image alignments are inverted
<img width="1474" height="780" alt="image" src="https://github.com/user-attachments/assets/b4b5c24e-8f91-43c8-b709-b483741b0ab1" />
