### PR TITLE
Add a subset of paths to Download tests CI cron to check at least a few

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -93,6 +93,9 @@ def pytest_generate_tests(metafunc):
             urls = []
             doc = get_web_page(f"{base_url}/en-US/firefox/all/")
             product_urls = [a.attrib["href"] for a in doc("ul.c-product-list a")]
+            # FIXME: sanity checks after first scene is redirected to FXC:
+            if product_urls and product_urls[0].startswith("/en-US/download/all/"):
+                product_urls = ["/en-US/firefox/all/desktop-release/", "/en-US/firefox/all/desktop-nightly/"]
             # If product url links outside of /firefox/all/ ignore it. (e.g. testflight)
             product_urls = [url for url in product_urls if url.startswith("/en-US/firefox/all/")]
             for url in product_urls:


### PR DESCRIPTION
## One-line summary

Patches up some missing scenes' values to keep testing a subset of downloads.

## Significant changes and points to review

This will get disabled or removed over time, but the latter scenes with some sanity check utility are still present, so this just tweaks a few paths to enable skipping to them.

This is not pretty, but… next step will be deleting it most likely.

(Or rewriting to a form of VPN download tests or something along that way.)

## Issue / Bugzilla link

#16355

## Testing

`docker compose run test pytest --base-url https://www.mozilla.org -m download`