### PR TITLE
Update docs for download pages

### DIFF
--- a/docs/docs/attribution/0002-firefox-desktop.md
+++ b/docs/docs/attribution/0002-firefox-desktop.md
@@ -70,6 +70,12 @@ Mozilla.StubAttribution.experimentVariation = 'v1';
     When setting a experiment parameters using JavaScript like in the example above, it must be done prior to calling `Mozilla.StubAttribution.init()`.
 
 
+## Download as Default
+
+[Download as default](../firefox-downloads/desktop-download-as-default.md) is a feature that communicates to the
+stub installer that the browser should be set as default when downloaded. At the moment this feature is hijacking
+the stub attribution service to communicate this and it will over-write other attribution data.
+
 ## Return to addons.mozilla.org (RTAMO)
 
 [Return to AMO](https://wiki.mozilla.org/Add-ons/QA/Testplan/Return_to_AMO) (RTAMO) is a Firefox feature whereby a first-time installation onboarding flow is initiated, that redirects a user to install the extension they have chosen whilst browsing [AMO](https://addons.mozilla.org/firefox/) using a different browser. RTAMO works by leveraging the existing stub attribution flow, and checking for specific `utm_` parameters that were passed if the referrer is from AMO.

--- a/docs/docs/firefox-downloads/desktop-download-as-default.md
+++ b/docs/docs/firefox-downloads/desktop-download-as-default.md
@@ -8,13 +8,10 @@ browser during installation if the stub attribution code includes the campaign v
 Using stub attribution this way means it cannot be used for acquisition data, though it will still include
 the analytics session IDs if they are present.
 
-At the moment (2025-06-10) if the switch `download_as_default` is enabled a checkbox should
+At the moment (2025-07-14) if the switch `download_as_default` is enabled a checkbox should
 appear for users who match the following criteria:
 
 - their device supports stub attribution
-- they are not in the EU/EAA
-- they have not explicitly declined cookies
-- they have not enabled GCP or DNT
 - their device supports Firefox
 - their device is running a version of Windows higher than 8.1
 
@@ -22,10 +19,8 @@ If they match the criteria a script will:
 
 - reveal the checkboxes
 - strip utm parameters from the URL
-- update the URL to include the `SET_DEFAULT_BROWSER` campaign parameter
-- refresh stub attribution to reflect the updated url
+- update the URL to only include the `SET_DEFAULT_BROWSER` campaign parameter
+- check the users's consent status to see if we should `omitNonEssentialFields` when initializing stubAttribution
+- initialize stub attribution to reflect the updated url
 
-Unchecking the checkbox will not revert to the previous value of the stub attribution code.
-
-Note that it is permitted by EU/EAA law to send the campaign parameter in response to an explicit
-user action so we may enable this for `needs_data_consent` countries in the future.
+Unchecking the checkbox will *not* revert to the previous value of the stub attribution code.

--- a/docs/docs/firefox-downloads/desktop-download-pages.md
+++ b/docs/docs/firefox-downloads/desktop-download-pages.md
@@ -2,64 +2,64 @@
 render_macros: true
 ---
 
-What we typically refer to as the "download page" is [https://www.mozilla.org/en-US/firefox/new/](https://www.mozilla.org/en-US/firefox/new/) the request for that url is handled by the [NewView](https://github.com/mozilla/bedrock/blob/main/bedrock/firefox/views.py#L770) view and will respond with one of a few templates. One of those templates is highly flexible and is frequently served at other URLs as well.
+What we typically refer to as the "download page" is [https://www.firefox.com/en-US/](https://www.firefox.com/en-US/) the request for that url is handled by the [DownloadView](https://github.com/mozmeao/springfield/blob/5ea60084360e5b434d1a2fd5cd4e09fc0a180b94/springfield/firefox/views.py#L438) view and will respond with one of a few templates. One of those templates is highly flexible and is frequently served at other URLs as well.
 
 # By URL
 
-## /new
+## / (home)
 
-When a user requests `/new` the [NewView](https://github.com/mozilla/bedrock/blob/main/bedrock/firefox/views.py#L770) view considers the following:
+When a user requests `/` the [DownloadView](https://github.com/mozmeao/springfield/blob/5ea60084360e5b434d1a2fd5cd4e09fc0a180b94/springfield/firefox/views.py#L438) view considers the following:
 
 - country
 - language (and that language's translation status)
 - active switches
 - URL parameters `v` (variation), `xv` (experience), and `reason` (`outdated`|`manual_update`).
 
-It then responds with a template:
+It then responds with the first template that matches:
 
-- en-US / en-CA:
+- `firefox/download/home.ftl` file is active and `xv` is not basic or legacy
     - *firefox/new/desktop/firefox-new-refresh.html*
-- `firefox/new/desktop.ftl` file is active
+- `firefox/download/desktop` file is active and `xv` is not basic
     - *firefox/new/desktop/download.html*
-- experience = basic or ftl file is not active
+- no ftl files are active or `xv` is basic
     - *firefox/new/basic/base_download.html*
 
 These templates all use the basic `download_firefox_thanks` helper and serve release Firefox in the language of the current page for the platform (aka operating system) that bedrock has auto-detected.
 
 ## /windows, /mac, /linux (the platform pages)
 
-The "platform" pages [windows](https://www.mozilla.org/firefox/windows/), [mac](https://www.mozilla.org/firefox/mac/), [linux](https://www.mozilla.org/firefox/linux/) are based on the templates in *firefox/new/basic/*.
+The "platform" pages [windows](https://www.firefox.com/browsers/desktop/windows/), [mac](https://www.firefox.com/browsers/desktop/mac), [linux](https://www.firefox.com/browsers/desktop/linux/) are based on the templates in *firefox/download/basic/*.
 
 These pages use the more complicated `download_firefox` download helper to link directly to the specified platform.
 
 ## /channel (the channel pages)
 
-[channel](https://www.mozilla.org/firefox/channel/)" pages)
+[channel pages](https://www.firefox.com/channel/desktop/)
 
 ## /all
 
 Firefox is available in more languages than the website is. The /all pages were originally implemented as a way for a user to download a copy of Firefox in a language that the website does not support. It has since ballooned as a way to get a highly configured version of Firefox.
 
-This app is in desperate need of a UX re-think. The templates it uses are in */templates/firefox/new/*
+This app is in desperate need of a UX re-think. The templates it uses are in */templates/firefox/all/*
 
 An older copy of /all is also served as a [fall back page for the entire site](https://github.com/mozmeao/www-error-page) in some conditions.
 
 
 # By Template
 
-## templates/firefox/new/basic/*
+## templates/firefox/download/basic/*
 
 Originally created in 2018, this simple template has been preserved because of its wide translation status. See it in English by appending `?xv=legacy` to the URL. This download page was the first to focus specifically on the desktop version of Firefox, prior to this all platforms were advertised on the download page.
 
 It's also used to create the high converting platform pages which target searches for "Download Firefox for { platform }".
 
-## templates/firefox/new/desktop/base.html
+## templates/firefox/download/desktop/base.html
 
-The base template extends the *firefox/base/base-protocol.html* template with some meta data specific to Firefox downloads.
+The base template extends the *base-protocol.html* template with some meta data specific to Firefox downloads.
 
 The base template frequently gets used for variations and experiments including: [gaming](http://localhost:8000/en-GB/firefox/landing/gaming/) and [education](http://localhost:8000/en-GB/firefox/landing/education/).
 
-### templates/firefox/new/desktop/download.html
+### templates/firefox/download/desktop/download.html
 
 Created in 2020 after a long very through design and user testing process -- this template promotes Desktop Firefox's features, use cases, personalization, mission, and platform support. (iOS and Android visitors get a banner and the download button is hidden.)
 
@@ -67,9 +67,9 @@ The first block on the page, which promotes the latest features, is hard-coded s
 
 The CTAs are in content blocks and can be swapped out for variations and experiments for example: [tech](http://localhost:8000/en-GB/firefox/landing/tech/) and [get](http://localhost:8000/en-GB/firefox/landing/get/).
 
-### templates/firefox/new/desktop/firefox-new-refresh.html
+### templates/firefox/download/home.html
 
-Created in 2025 to reflect the changing Firefox brand this template focuses on our updated messaging, voice, and tone. It is currently available in en-US and en-CA only.
+Created in 2025 to reflect the changing Firefox brand this template focuses on our updated messaging, voice, and tone.
 
 ## Experiments
 

--- a/docs/docs/mozilla-accounts.md
+++ b/docs/docs/mozilla-accounts.md
@@ -60,20 +60,20 @@ The JavaScript files will automatically handle things such as adding metrics par
 
 The sign-up form macro accepts the following parameters (* indicates a required parameter)
 
-| > Parameter name        | > Definition                                                                                                               | > Format                                                | > Example                                      |
+| Parameter name        |Definition                                                                                                               | Format                                                | Example                                      |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------- |
-| > entrypoint*          | Unambiguous identifier for which page of the site is the referrer.                                                         | mozilla.org-directory-page                              | 'mozilla.org-firefox-accounts'               |
-| > entrypoint_experiment | Used to identify experiments.                                                                                              | Experiment ID                                           | 'whatsnew-headlines'                         |
-| > entrypoint_variation  | Used to track page variations in multivariate tests. Usually just a number or letter but could be a short keyword.         | Variant identifier                                      | 'b'                                          |
-| > style                 | An optional parameter used to invoke an alternatively styled page at accounts.firefox.com.                                 | String                                                  | > 'trailhead'                                |
-| > class_name            | Applies a CSS class name to the form. Defaults to: 'fxa-email-form'                                                      | String                                                  | 'fxa-email-form'                             |
-| > form_title            | The main heading to be used in the form (optional with no default).                                                        | Localizable string                                      | 'Join Firefox' .                             |
-| > intro_text            | Introductory copy to be used in the form. Defaults to a well localized string.                                             | Localizable string                                      | 'Enter your email address to get started.' . |
-| > button_text           | Button copy to be used in the form. Defaults to a well localized string.                                                   | Localizable string                                      | 'Sign Up' .                                  |
-| > button_class          | CSS class names to be applied to the submit button.                                                                        | String of one or more CSS class names                   | 'mzp-c-button mzp-t-primary mzp-t-product'   |
-| > utm_campaign          | Used to identify specific marketing campaigns. Defaults to `fxa-embedded-form`                                             | Campaign name prepended to default value                | 'trailhead-fxa-embedded-form'                |
-| > utm_term              | Used for paid search keywords.                                                                                             | Brief keyword                                           | 'existing-users'                             |
-| > utm_content           | Declared when more than one piece of content (on a page or at a URL) links to the same place, to distinguish between them. | Description of content, or name of experiment treatment | 'get-the-rest-of-firefox'                    |
+| entrypoint*          | Unambiguous identifier for which page of the site is the referrer.                                                         | mozilla.org-directory-page                              | 'mozilla.org-firefox-accounts'               |
+| entrypoint_experiment | Used to identify experiments.                                                                                              | Experiment ID                                           | 'whatsnew-headlines'                         |
+| entrypoint_variation  | Used to track page variations in multivariate tests. Usually just a number or letter but could be a short keyword.         | Variant identifier                                      | 'b'                                          |
+| style                 | An optional parameter used to invoke an alternatively styled page at accounts.firefox.com.                                 | String                                                  | 'trailhead'                                |
+| class_name            | Applies a CSS class name to the form. Defaults to: 'fxa-email-form'                                                      | String                                                  | 'fxa-email-form'                             |
+| form_title            | The main heading to be used in the form (optional with no default).                                                        | Localizable string                                      | 'Join Firefox' .                             |
+| intro_text            | Introductory copy to be used in the form. Defaults to a well localized string.                                             | Localizable string                                      | 'Enter your email address to get started.' . |
+| button_text           | Button copy to be used in the form. Defaults to a well localized string.                                                   | Localizable string                                      | 'Sign Up' .                                  |
+| button_class          | CSS class names to be applied to the submit button.                                                                        | String of one or more CSS class names                   | 'mzp-c-button mzp-t-primary mzp-t-product'   |
+| utm_campaign          | Used to identify specific marketing campaigns. Defaults to `fxa-embedded-form`                                             | Campaign name prepended to default value                | 'trailhead-fxa-embedded-form'                |
+| utm_term              | Used for paid search keywords.                                                                                             | Brief keyword                                           | 'existing-users'                             |
+| utm_content           | Declared when more than one piece of content (on a page or at a URL) links to the same place, to distinguish between them. | Description of content, or name of experiment treatment | 'get-the-rest-of-firefox'                    |
 
 Invoking the macro will automatically include a set of default `UTM (Urchin Tracking Module)`{.interpreted-text role="abbr"} parameters as hidden form input fields:
 
@@ -120,15 +120,15 @@ For more information on the available parameters, read the "Common Parameters" s
 
 The `fxa_button` and `monitor_fxa_button` helpers all support the same standard parameters:
 
-| Parameter name      | Definition                                                                                                                                               | Format                            | Example                                                                                                   |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| entrypoint*        | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.                                       | 'mozilla.org-firefox-monitor'    | 'mozilla.org-firefox-monitor'                                                                            |
-| button_text*       | The button copy to be used in the call to action.                                                                                                        | Localizable string                | 'Try Monitor Now'                                                                                        |
-| class_name          | A class name to be applied to the link (typically for styling with CSS).                                                                                 | String of one or more class names | 'monitor-main-cta-button'                                                                                |
-| is_button_class     | A boolean value that dictates if the `CTA (Call To Action)`{.interpreted-text role="abbr"} should be styled as a button or a link. Defaults to 'True'. | Boolean                           | True or False                                                                                             |
-| include_metrics     | A boolean value that dictates if metrics parameters should be added to the button href. Defaults to 'True'.                                            | Boolean                           | True or False                                                                                             |
-| optional_parameters | An dictionary of key value pairs containing additional parameters to append the the href.                                                                | Dictionary                        | {'s': 'ffmonitor'}                                                                                     |
-| optional_attributes | An dictionary of key value pairs containing additional data attributes to include in the button.                                                         | Dictionary                        | {'data-cta-text': 'Try Monitor Now', 'data-cta-type': 'monitor','data-cta-position': 'primary'} |
+| Parameter name | Definition | Format | Example |
+| -------------- | ---------- | ------ | ------- |
+| entrypoint* | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'. | 'mozilla.org-firefox-monitor'    | 'mozilla.org-firefox-monitor' |
+| button_text* | The button copy to be used in the call to action. | Localizable string | 'Try Monitor Now' |
+| class_name | A class name to be applied to the link (typically for styling with CSS). | String of one or more class names | 'monitor-main-cta-button' |
+| is_button_class | A boolean value that dictates if the `CTA (Call To Action)`{.interpreted-text role="abbr"} should be styled as a button or a link. Defaults to 'True'. | Boolean | True or False |
+| include_metrics | A boolean value that dictates if metrics parameters should be added to the button href. Defaults to 'True'. | Boolean | True or False |
+| optional_parameters | An dictionary of key value pairs containing additional parameters to append the the href. | Dictionary | {'s': 'ffmonitor'} |
+| optional_attributes | An dictionary of key value pairs containing additional data attributes to include in the button. | Dictionary                        | {'data-cta-text': 'Try Monitor Now', 'data-cta-type': 'monitor','data-cta-position': 'primary'} |
 
 !!! note
     The `fxa_button` helper also supports an additional `action` parameter, which accepts the values `signup`, `signin`, and `email` for configuring the type of authentication flow.
@@ -148,21 +148,21 @@ Use the `vpn_subscribe_link` helpers to create a `VPN (Virtual Private Network)`
 
 Both helpers for Mozilla `VPN (Virtual Private Network)`{.interpreted-text role="abbr"} support the same parameters (* indicates a required parameter)
 
-| > Parameter name      | > Definition                                                                                                                                          | > Format                          | > Example                                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| > entrypoint*        | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.                                    | 'www.mozilla.org-page-name'     | 'www.mozilla.org-vpn-product-page'                                                                        |
-| > link_text*         | The link copy to be used in the call to action.                                                                                                       | Localizable string                | 'Get Mozilla VPN'                                                                                         |
-| > class_name          | A class name to be applied to the link (typically for styling with CSS).                                                                              | String of one or more class names | 'vpn-button'                                                                                              |
-| > lang                | Page locale code. Used to query the right subscription plan ID in conjunction to country code.                                                        | Locale string                     | 'de'                                                                                                      |
-| > country_code        | Country code provided by the `CDN (Content Delivery Network)`{.interpreted-text role="abbr"}. Used to determine the appropriate subscription plan ID. | Two digit, uppercase country code | 'DE'                                                                                                      |
-| > optional_parameters | An dictionary of key value pairs containing additional parameters to append the the href.                                                             | Dictionary                        | {'utm_campaign': 'vpn-product-page'}                                                                    |
-| > optional_attributes | An dictionary of key value pairs containing additional data attributes to include in the button.                                                      | Dictionary                        | {'data-cta-text': 'VPN Sign In', 'data-cta-type': 'fxa-vpn', 'data-cta-position': 'navigation'} |
+| Parameter name | Definition | Format | Example |
+| -------------- | ---------- | ------ | ------- |
+| entrypoint* | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'. | 'www.mozilla.org-page-name' | 'www.mozilla.org-vpn-product-page' |
+| link_text* | The link copy to be used in the call to action. | Localizable string | 'Get Mozilla VPN' |
+| class_name | A class name to be applied to the link (typically for styling with CSS). | String of one or more class names | 'vpn-button' |
+| lang | Page locale code. Used to query the right subscription plan ID in conjunction to country code. | Locale string | 'de' |
+| country_code | Country code provided by the `CDN (Content Delivery Network)`{.interpreted-text role="abbr"}. Used to determine the appropriate subscription plan ID. | Two digit, uppercase country code | 'DE' |
+| optional_parameters | An dictionary of key value pairs containing additional parameters to append the the href. | Dictionary | {'utm_campaign': 'vpn-product-page'} |
+| optional_attributes | An dictionary of key value pairs containing additional data attributes to include in the button. | Dictionary | {'data-cta-text': 'VPN Sign In', 'data-cta-type': 'fxa-vpn', 'data-cta-position': 'navigation'} |
 
 The `vpn_subscribe_link` helper has an additional `plan` parameter to support linking to different subscription plans.
 
-| > Parameter name | > Definition                                     | > Format     | > Example                   |
-| ---------------- | ------------------------------------------------ | ------------ | --------------------------- |
-| > plan           | Subscription plan ID. Defaults to 12-month plan. | '12-month' | '12-month' or 'monthly' |
+| Parameter name | Definition | Format | Example |
+| -------------- | ---------- | ------ | ------- |
+| plan | Subscription plan ID. Defaults to 12-month plan. | '12-month' | '12-month' or 'monthly' |
 
 ## Firefox Sync and UITour
 


### PR DESCRIPTION
## One-line summary

Update docs for download pages.

## Significant changes and points to review

Update docs to reflect changes in https://github.com/mozmeao/springfield/pull/366

## Issue / Bugzilla link

n/a

## Testing

[`make livedocs`](https://mozilla.github.io/bedrock/install/?h=livedoc#local_2)

http://127.0.0.1:8765/bedrock/firefox-downloads/desktop-download-as-default/