### PR TITLE
Amend redirects from /firefox/ to go straight to www.firefox.com

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -689,7 +689,7 @@ bedrock_redirectpatterns = (
     redirect(r"^firefox/nothingpersonal/?$", "firefox.nothing-personal.index"),
     # issue 15841
     redirect(r"^firefox/tech/?$", "firefox.landing.tech"),
-    # Switch to using www.firefox.com as main site for Firefox content
+    # issue 16089, 16159
     redirect(r"^/firefox/?$", f"{FXC}/"),
 )
 

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -562,7 +562,7 @@ bedrock_redirectpatterns = (
         },
     ),
     # bug 1369732
-    redirect(r"^Firefox/?$", "firefox.new"),
+    redirect(r"^Firefox/?$", f"{FXC}/"),
     # bug 1386112
     redirect(r"^firefox/android/faq/?", "https://support.mozilla.org/products/mobile"),
     # bug 1392796
@@ -689,8 +689,8 @@ bedrock_redirectpatterns = (
     redirect(r"^firefox/nothingpersonal/?$", "firefox.nothing-personal.index"),
     # issue 15841
     redirect(r"^firefox/tech/?$", "firefox.landing.tech"),
-    # issue 16089
-    redirect(r"^/firefox/?$", "firefox.new"),
+    # Switch to using www.firefox.com as main site for Firefox content
+    redirect(r"^/firefox/?$", f"{FXC}/"),
 )
 
 if settings.ENABLE_FIREFOX_COM_REDIRECTS is True:

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1342,7 +1342,7 @@ URLS = flatten(
         url_test("/products/vpn/resource-center/no-Logging-vpn-from-mozilla/", "/products/vpn/resource-center/no-logging-vpn-from-mozilla/"),
         # Issue 15841
         url_test("/firefox/tech/", "/firefox/landing/tech/"),
-        # Switching to www.firefox.com from www.m.o
+        # Issue 16159
         url_test(
             "/firefox/",
             "https://www.firefox.com/",

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -959,7 +959,8 @@ URLS = flatten(
         # Bug 1384370
         url_test("/developers", "https://developer.mozilla.com/"),
         # Bug 1369732
-        url_test("{/en-US,}/Firefox", "{/en-US,}/firefox/new/"),
+        url_test("/en-US/Firefox", "https://www.firefox.com/en-US/"),
+        url_test("/Firefox", "https://www.firefox.com/"),
         # Bug 1380845
         url_test("/persona/privacy-policy/", "/privacy/archive/persona/2017-07/"),
         url_test("/persona/terms-of-service/", "/privacy/archive/persona/2017-07/#terms-of-service"),
@@ -1341,7 +1342,10 @@ URLS = flatten(
         url_test("/products/vpn/resource-center/no-Logging-vpn-from-mozilla/", "/products/vpn/resource-center/no-logging-vpn-from-mozilla/"),
         # Issue 15841
         url_test("/firefox/tech/", "/firefox/landing/tech/"),
-        # Issue 16089
-        url_test("/firefox/", "/firefox/new/"),
+        # Switching to www.firefox.com from www.m.o
+        url_test(
+            "/firefox/",
+            "https://www.firefox.com/",
+        ),
     )
 )


### PR DESCRIPTION
There are still quite a few other routes that target the `firefox.new` view, or `/firefox/new/` as a path, but we'll tackle those in a separate cleanup: https://github.com/mozilla/bedrock/issues/16431

This is being done to remove the extra hop, for SEO good vibes