### PR TITLE
Cache offsite redirects normally

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -54,7 +54,6 @@ offsite_redirect = partial(
     redirect,
     query={"redirect_source": "mozilla-org"},  # additional querystring to add to every redirection
     merge_query=True,  # ensure we don't lose existing querystrings during redirection
-    cache_timeout=3,  # 3 hour timeout, lower than default 12hr
 )
 
 # Issue 16355


### PR DESCRIPTION
# 🚨 <mark>DNM</mark> before ready to apply across all stages! 🚢

This is not gated behind any preference or a switch of any kind, so can't be changed without shipping actual code changes.

Once this merges, if any other thing needs to ship, this might sail with it all the way… so only merge once comfortable with the longer cache (for BOTH the location, AND the 301 actual code)

## One-line summary

Removes shorter caching applied wholesale to all fxc offiste redirects.

## Significant changes and points to review

Given how 301s are cached aggressively, as a code+location lookahead, often way beyond the max-age headers, this should not make that much difference now, as even the 3hr 301s will most likely be cached for way longer already.

## Issue / Bugzilla link

#16355

## Testing

`make test`
`curl -I http://localhost:8000/firefox/all/`