### PR TITLE
Add some fun to 142beta WNP layout

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx142beta.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx142beta.html
@@ -13,6 +13,8 @@
 {% block wnp_content %}
   <section class="wnp-content-main">
     <div class="mzp-l-content mzp-t-content-md">
+      <h1>Try and Help Shape Firefox’s New Semantic Search</h1>
+
       {{ resp_img(
         url='img/firefox/whatsnew/whatsnew142beta/foxfood.png',
         srcset={
@@ -25,8 +27,6 @@
           'alt': 'Cartoon illustration of a swashbuckling fox, wearing black gloves and boots with a red sash, swinging from a rope and wielding a rapier like Robin Hood. A banner reads “Defend your fox!”'
         }
       ) }}
-
-      <h1>Try and Help Shape Firefox’s New Semantic Search</h1>
 
       <p>Firefox is introducing Semantic History Search, a new feature that makes
         it easier to search your Firefox history by understanding the meaning and

--- a/media/css/firefox/whatsnew/whatsnew-142beta.scss
+++ b/media/css/firefox/whatsnew/whatsnew-142beta.scss
@@ -8,12 +8,12 @@
 @import 'includes/dark-mode';
 @import 'includes/mofo-donate-cta';
 
-.wnp-footer {
-    text-align: center;
-}
-
 .wnp-content-main {
     text-align: center;
+
+    p {
+      margin: 2em 0;
+    }
 
     @media (prefers-color-scheme: dark) {
         a:link,
@@ -21,4 +21,17 @@
             color: white;
         }
     }
+}
+
+@media ($mq-sm) {
+    .wnp-main-image {
+        float: left;
+        margin-bottom: 0.5em;
+        shape-outside: url('/media/img/firefox/whatsnew/whatsnew142beta/foxfood.png');
+        shape-margin: $spacing-xl;
+    }
+}
+
+.wnp-footer {
+    text-align: center;
 }


### PR DESCRIPTION
## One-line summary

Use alpha-PNG of the image to float the text content against the cartoon.

## Significant changes and points to review

Also move the heading to the top.

## Issue / Bugzilla link

#16429 

## Testing

http://localhost:8000/en-US/firefox/142.3beta/whatsnew/

I've reserved demo7 for stakeholder review if I could ask for a deploy when convenient, but this has been pre-approved already.