### PR TITLE
Add link to Mozilla Security to footer

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -50,6 +50,7 @@
               <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-position="footer" data-link-text="Product Help">{{ ftl('footer-refresh-product-help', fallback='footer-refresh-support') }}</a></li>
               <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-position="footer" data-link-text="File a Bug">{{ ftl('footer-refresh-file-a-bug') }}</a></li>
               <li><a href="https://pontoon.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-position="footer" data-link-text="Localise Mozilla">{{ ftl('footer-refresh-localize-mozilla') }}</a></li>
+              <li><a href="https://www.mozilla.org/security/" data-link-position="footer" data-link-text="Security">{{ ftl('footer-refresh-security') }}</a></li>
             </ul>
           </section>
 

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -50,7 +50,7 @@
               <li><a href="https://support.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-position="footer" data-link-text="Product Help">{{ ftl('footer-refresh-product-help', fallback='footer-refresh-support') }}</a></li>
               <li><a href="https://bugzilla.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-position="footer" data-link-text="File a Bug">{{ ftl('footer-refresh-file-a-bug') }}</a></li>
               <li><a href="https://pontoon.mozilla.org/?{{ utm_params }}&utm_content=support" data-link-position="footer" data-link-text="Localise Mozilla">{{ ftl('footer-refresh-localize-mozilla') }}</a></li>
-              <li><a href="https://www.mozilla.org/security/" data-link-position="footer" data-link-text="Security">{{ ftl('footer-refresh-security') }}</a></li>
+              <li><a href="{{ url('security.index') }}" data-link-position="footer" data-link-text="Security">{{ ftl('footer-refresh-security') }}</a></li>
             </ul>
           </section>
 

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -26,6 +26,7 @@ footer-refresh-support = Support
 footer-refresh-product-help = Product Help
 footer-refresh-file-a-bug = File a Bug
 footer-refresh-localize-mozilla = Localize { -brand-name-mozilla }
+footer-refresh-security = Security
 footer-refresh-developers = Developers
 footer-refresh-developer-edition = { -brand-name-developer-edition }
 footer-refresh-enterprise = { -brand-name-enterprise }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Add a localized "Security" link to the Support section in the footer.

## Significant changes and points to review

- Added `footer-refresh-security` string to FTL.
- Inserted a new link under the Support section in the footer template pointing to https://www.mozilla.org/security/ .


## Issue / Bugzilla link
Closes #16239 