### PR TITLE
update VPN ubuntu min version (fix #16451)

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -108,7 +108,7 @@
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-linux-long', fallback='vpn-download-for-linux') }}</h2>
               <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-              <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
+              <p>{{ ftl('vpn-download-for-linux-requirements', version='22.04') }}</p>
               <a class="mzp-c-button" href="{{ linux_download_url }}" data-cta-text="VPN Download (Linux)" class="platform-download-link">
               {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
               </a>
@@ -193,7 +193,7 @@
             </div>
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-linux') }}</h2>
-              <p>{{ ftl('vpn-download-for-linux-requirements', version='20.04') }}</p>
+              <p>{{ ftl('vpn-download-for-linux-requirements', version='22.04') }}</p>
             </div>
             <a href="{{ linux_download_url }}" data-cta-text="VPN Download (Linux)" class="platform-download-link">
               <span class="visually-hidden">{{ ftl('vpn-download-for-linux-long') }}</span>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the min Ubuntu version for VPN on VPN download page.

## Significant changes and points to review

VPN for Linux sections

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16451

## Testing

http://localhost:8000/en-US/products/vpn/download/