### PR TITLE
about/this-site content tweak (fix #16450)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/this-site.html
+++ b/bedrock/mozorg/templates/mozorg/about/this-site.html
@@ -33,7 +33,8 @@
     </p>
 
     <p>
-      {{ ftl('about-this-site-today',
+      {{ ftl('about-this-site-today-v2',
+             fallback='about-this-site-today',
              firefox=url('firefox.new'),
              vpn=url('products.vpn.landing'),
              mozilla=url('mozorg.about.index'),

--- a/l10n/en/mozorg/about/this-site.ftl
+++ b/l10n/en/mozorg/about/this-site.ftl
@@ -18,7 +18,9 @@ about-this-site-this-website = The website www.mozilla.org has been online for o
 #   $mozilla (url) link to https://www.mozilla.org/about/
 #   $book (url) link to https://www.mozilla.org/book/
 #   A suitable substitute phrase for "Easter eggs" could be "Secrets".
+# Obsolete string (expires 28-11-2025)
 about-this-site-today = Today, this is the site where people come to download <a href="{ $firefox }">{ -brand-name-firefox }</a>, try <a href="{ $vpn }">{ -brand-name-mozilla-vpn }</a>, and learn more <a href="{ $mozilla }">about { -brand-name-mozilla }</a>. You can also discover a few <a href="{ $book }">Easter eggs</a> along the way.
+about-this-site-today-v2 = Today, this is the site where people learn more <a href="{ $mozilla }">about { -brand-name-mozilla }</a> and try <a href="{ $vpn }">{ -brand-name-mozilla-vpn }</a>. You can also discover a few <a href="{ $book }">Easter eggs</a> along the way.
 
 about-this-site-like-many = Like many of our products, this website is also open source:
 about-this-site-view-source = View the source code on { -brand-name-github }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the content on `about/this-site` page to remove the statement this is the site to download Firefox.

## Significant changes and points to review

"About this site" section paragraph two.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16450

## Testing

http://localhost:8000/en-US/about/this-site/