### PR TITLE
Remove `template_source_url` context and settings for unused GH edit links

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -262,8 +262,6 @@ def _put_default_lang_first(langs, default_lang=LANGUAGE_CODE):
 # Our accepted production locales are the values from the above, plus an exception.
 PROD_LANGUAGES = _put_default_lang_first(sorted(sum(LOCALES_BY_REGION.values(), [])) + ["ja-JP-mac"])
 
-GITHUB_REPO = "https://github.com/mozilla/bedrock"
-
 # Global L10n files.
 FLUENT_DEFAULT_FILES = [
     "banners/consent-banner",
@@ -304,29 +302,6 @@ FLUENT_PATHS = [
     FLUENT_LOCAL_PATH,
     # remote FTL files from l10n team
     FLUENT_REPO_PATH,
-]
-
-# Templates to exclude from having an "edit this page" link in the footer
-# these are typically ones for which most of the content is in the DB
-EXCLUDE_EDIT_TEMPLATES = [
-    "firefox/releases/nightly-notes.html",
-    "firefox/releases/dev-browser-notes.html",
-    "firefox/releases/esr-notes.html",
-    "firefox/releases/beta-notes.html",
-    "firefox/releases/aurora-notes.html",
-    "firefox/releases/release-notes.html",
-    "firefox/releases/notes.html",
-    "firefox/releases/system_requirements.html",
-    "mozorg/credits.html",
-    "mozorg/about/forums.html",
-    "security/advisory.html",
-    "security/advisories.html",
-    "security/product-advisories.html",
-    "security/known-vulnerabilities.html",
-]
-# Also allow entire directories to be skipped
-EXCLUDE_EDIT_TEMPLATES_DIRECTORIES = [
-    "cms",
 ]
 
 IGNORE_LANG_DIRS = [

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from os.path import relpath, splitext
+from os.path import splitext
 
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
@@ -18,22 +18,6 @@ from bedrock.base.i18n import normalize_language, split_path_and_normalize_langu
 from bedrock.settings.base import language_url_map_with_fallbacks
 
 from .fluent import fluent_l10n, ftl_file_is_active, get_active_locales as ftl_active_locales
-
-
-def template_source_url(template):
-    if template in settings.EXCLUDE_EDIT_TEMPLATES:
-        return None
-
-    if template.split("/")[0] in settings.EXCLUDE_EDIT_TEMPLATES_DIRECTORIES:
-        return None
-
-    try:
-        absolute_path = loader.get_template(template).template.filename
-    except TemplateDoesNotExist:
-        return None
-
-    relative_path = relpath(absolute_path, settings.ROOT)
-    return f"{settings.GITHUB_REPO}/tree/master/{relative_path}"
 
 
 def render_to_string(template_name, context=None, request=None, using=None, ftl_files=None):
@@ -151,7 +135,6 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
 
     context["fluent_files"] = ftl_files or settings.FLUENT_DEFAULT_FILES
     context["template"] = template
-    context["template_source_url"] = template_source_url(template)
 
     # if it's a CMS page, draw the active locales from the Page data.
     # if `active_locales` is given use it as the full list of active translations


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the WMO and FXC label._  👍 ➕ 🔥🦊

## One-line summary

Removes code for "Edit on GitHub" footer links long gone.

## Significant changes and points to review

Since #7373 was labeled _wontfix_ and it's therefore not coming back, there's no reason to keep old code for that around. It might have been actually causing 500s? https://github.com/mozilla/bedrock/issues/14667#issuecomment-2160950302

## Issue / Bugzilla link

Hopefully resolves #14667

## Testing
