### PR TITLE
Hotfix optout of bake builder in CI

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -60,9 +60,11 @@ jobs:
 
       - id: build_and_push_docker_hub_images
         name: Build and push public images to Docker hub
-        run: |-
-          ./bin/build-release-image.sh --push
-
+        run: |
+            # FIXME: GitHub provides compose version enabling bake but timing out
+            export COMPOSE_BAKE=false
+            ./bin/build-release-image.sh --push
+        timeout-minutes: 45
         env:
             GIT_COMMIT: ${{ steps.long-sha.outputs.LONG_SHA }}
 

--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -35,9 +35,12 @@ jobs:
           python-version: "3.13"  # matches current Python in production
       - name: "Run Python tests (on Docker)"
         run: |
+            # FIXME: GitHub provides compose version enabling bake but timing out
+            export COMPOSE_BAKE=false
             make clean test-image
             CONTAINER_ID=$(docker ps -alq)
             docker cp $CONTAINER_ID:/app/python_coverage .
+        timeout-minutes: 30
       - name: Store coverage as an artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._
⬆️🔥🦊

## One-line summary

Until GHA update to a patched version in the runner image and deploy.

## Significant changes and points to review

https://github.com/actions/runner-images/pull/12669 made a breaking update that enabled `COMPOSE_BAKE` by default. That also had followup fixes released that are necessary for successful runs, however the current GHA runner images deployed ship a version that leaves the build process hanging indefinitely. https://github.com/docker/compose/issues/12998

We need to disable it until a new runner image ships with a version bumped further. Also note it's already reported as deprecated, to `COMPOSE_BAKE=false` be ignored/removed completely in an upcoming release.

## Issue / Bugzilla link

https://github.com/actions/runner-images/issues/12685

(Supersedes #16463)

## Testing

[/actions/runs/16663214340/job/47164637902](https://github.com/mozilla/bedrock/actions/runs/16663214340/job/47164637902) 💚 