### PR TITLE
Add 410 error page

### DIFF
--- a/bedrock/base/exceptions.py
+++ b/bedrock/base/exceptions.py
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Django doesn't have a 410 exception, so we create our own.
+class Http410(Exception):
+    pass

--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -27,6 +27,7 @@ from commonware.middleware import FrameOptionsHeader as OldFrameOptionsHeader
 from csp.contrib.rate_limiting import RateLimitedCSPMiddleware
 
 from bedrock.base import metrics
+from bedrock.base.exceptions import Http410
 from bedrock.base.i18n import (
     check_for_bedrock_language,
     get_language_from_headers,
@@ -250,6 +251,8 @@ class MetricsStatusMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         if isinstance(exception, Http404):
             self._record(404)
+        elif isinstance(exception, Http410):
+            self._record(410)
         else:
             self._record(500)
 
@@ -295,6 +298,8 @@ class MetricsViewTimingMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         if isinstance(exception, Http404):
             self._record_timing(request, 404)
+        elif isinstance(exception, Http410):
+            self._record_timing(request, 410)
         else:
             self._record_timing(request, 500)
 

--- a/bedrock/base/templates/410.html
+++ b/bedrock/base/templates/410.html
@@ -6,7 +6,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% extends "base-error.html" %}
 
-{% block page_title %}{{ ftl('gone-page-gone-page-page-gone') }}{% endblock %}
+{% block page_title %}{{ ftl('page-gone-title') }}{% endblock %}
 
 {% block page_css %}
 {{ css_bundle('page_not_found') }}
@@ -17,8 +17,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% block content %}
 <main class="mzp-l-content message-section">
-  <h1 class="error-title">{{ ftl('gone-page-sorry-that-page-is-gone') }}</h1>
-  <p>{{ ftl('gone-page-you-may-be-able-to-find-more', blog='https://blog.mozilla.org/') }}</p>
+  <h1 class="error-title">{{ ftl('page-gone-title') }}</h1>
+  <p>{{ ftl('page-gone-body', blog='href="https://blog.mozilla.org/"') }}</p>
 
   <p class="hide-back" id="go-back">
     <a class="back-button" data-testid="link-go-back">{{ ftl('gone-page-go-back') }}</a>
@@ -26,16 +26,20 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
   <ul class="content-list">
     <li>
+      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/home.svg') }}" width="30" height="30">
+      {{ ftl('gone-page-go-home', home='href="/"') }}
+      </li>
+      <li>
       <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-learn-about-mozilla-the-non', about=url('mozorg.about.index')) }}
+      {{ ftl('gone-page-browse-products', products='href="%s"'|safe|format(url('products.landing'))) }}
     </li>
     <li>
-      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-download-the-firefox-browser', download=url('firefox.new')) }}
+      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/blog.svg') }}" width="30" height="30">
+      {{ ftl('gone-page-search-blog', blog='href="https://blog.mozilla.org/"') }}
     </li>
     <li>
-      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-donate-to-mozilla-reclaim-from', donate='href="%s"'|safe|format(donate_url(location='donate-410'))) }}
+      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/help.svg') }}" width="30" height="30">
+      {{ ftl('gone-page-visit-support', support='href="https://support.mozilla.org/"') }}
     </li>
   </ul>
   </main>

--- a/bedrock/base/templates/410.html
+++ b/bedrock/base/templates/410.html
@@ -18,7 +18,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% block content %}
 <main class="mzp-l-content message-section">
   <h1 class="error-title">{{ ftl('page-gone-title') }}</h1>
-  <p>{{ ftl('page-gone-body', blog='href="https://blog.mozilla.org/"') }}</p>
+  <p>{{ ftl('page-gone-body') }}</p>
 
   <p class="hide-back" id="go-back">
     <a class="back-button" data-testid="link-go-back">{{ ftl('gone-page-go-back') }}</a>

--- a/bedrock/base/templates/410.html
+++ b/bedrock/base/templates/410.html
@@ -1,0 +1,46 @@
+{#
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "base-error.html" %}
+
+{% block page_title %}{{ ftl('gone-page-gone-page-page-gone') }}{% endblock %}
+
+{% block page_css %}
+{{ css_bundle('page_not_found') }}
+{% endblock %}
+
+{# 410 pages must not include canonical and hreflang x-default: https://github.com/mozilla/bedrock/issues/5895 #}
+{% block canonical_urls %}{% endblock %}
+
+{% block content %}
+<main class="mzp-l-content message-section">
+  <h1 class="error-title">{{ ftl('gone-page-sorry-that-page-is-gone') }}</h1>
+  <p>{{ ftl('gone-page-you-may-be-able-to-find-more', blog='https://blog.mozilla.org/') }}</p>
+
+  <p class="hide-back" id="go-back">
+    <a class="back-button" data-testid="link-go-back">{{ ftl('gone-page-go-back') }}</a>
+  </p>
+
+  <ul class="content-list">
+    <li>
+      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
+      {{ ftl('gone-page-learn-about-mozilla-the-non', about=url('mozorg.about.index')) }}
+    </li>
+    <li>
+      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
+      {{ ftl('gone-page-download-the-firefox-browser', download=url('firefox.new')) }}
+    </li>
+    <li>
+      <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
+      {{ ftl('gone-page-donate-to-mozilla-reclaim-from', donate='href="%s"'|safe|format(donate_url(location='donate-410'))) }}
+    </li>
+  </ul>
+  </main>
+{% endblock %}
+
+{% block js %}
+{{ js_bundle('page_not_found') }}
+{% endblock %}

--- a/bedrock/base/templates/410.html
+++ b/bedrock/base/templates/410.html
@@ -27,19 +27,27 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <ul class="content-list">
     <li>
       <img class="list-icon" alt="" src="{{ static('protocol/img/icons/home.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-go-home', home='href="/"') }}
+      <span>
+        {{ ftl('gone-page-go-home', home='href="/"') }}
+      </span>
       </li>
       <li>
       <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-browse-products', products='href="%s"'|safe|format(url('products.landing'))) }}
+      <span>
+        {{ ftl('gone-page-browse-products', products='href="%s"'|safe|format(url('products.landing'))) }}
+      </span>
     </li>
     <li>
       <img class="list-icon" alt="" src="{{ static('protocol/img/icons/blog.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-search-blog', blog='href="https://blog.mozilla.org/"') }}
+      <span>
+        {{ ftl('gone-page-search-blog', blog='href="https://blog.mozilla.org/"') }}
+      </span>
     </li>
     <li>
       <img class="list-icon" alt="" src="{{ static('protocol/img/icons/help.svg') }}" width="30" height="30">
-      {{ ftl('gone-page-visit-support', support='href="https://support.mozilla.org/"') }}
+      <span>
+        {{ ftl('gone-page-visit-support', support='href="https://support.mozilla.org/"') }}
+      </span>
     </li>
   </ul>
   </main>

--- a/bedrock/base/templates/410.html
+++ b/bedrock/base/templates/410.html
@@ -30,8 +30,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
       <span>
         {{ ftl('gone-page-go-home', home='href="/"') }}
       </span>
-      </li>
-      <li>
+    </li>
+    <li>
       <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
       <span>
         {{ ftl('gone-page-browse-products', products='href="%s"'|safe|format(url('products.landing'))) }}

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -89,6 +89,19 @@ class TestMetricsStatusMiddleware(TestCase):
             assert resp.status_code == 404
             mm.assert_incr_once("response.status", tags=["status_code:404"])
 
+    def test_raises_410(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_410"))
+                assert resp.status_code == 410
+            mm.assert_incr_once("response.status", tags=["status_code:410"])
+
+    def test_returns_410(self):
+        with MetricsMock() as mm:
+            resp = Client().get(reverse("returns_410"))
+            assert resp.status_code == 410
+            mm.assert_incr_once("response.status", tags=["status_code:410"])
+
     def test_raises_500(self):
         with MetricsMock() as mm:
             with suppress(UndefinedError):
@@ -151,6 +164,25 @@ class TestMetricsViewTimingMiddleware(TestCase):
             mm.assert_timing_once(
                 "view.timings",
                 tags=["view_path:bedrock.base.tests.urls.returns_404.GET", "module:bedrock.base.tests.urls.GET", "method:GET", "status_code:404"],
+            )
+
+    def test_raises_410(self):
+        with MetricsMock() as mm:
+            with suppress(UndefinedError):
+                resp = Client().get(reverse("raises_410"))
+                assert resp.status_code == 410
+            mm.assert_timing_once(
+                "view.timings",
+                tags=["view_path:bedrock.base.tests.urls.raises_410.GET", "module:bedrock.base.tests.urls.GET", "method:GET", "status_code:410"],
+            )
+
+    def test_returns_410(self):
+        with MetricsMock() as mm:
+            resp = Client().get(reverse("returns_410"))
+            assert resp.status_code == 410
+            mm.assert_timing_once(
+                "view.timings",
+                tags=["view_path:bedrock.base.tests.urls.returns_410.GET", "module:bedrock.base.tests.urls.GET", "method:GET", "status_code:410"],
             )
 
     def test_raises_500(self):

--- a/bedrock/base/tests/test_views.py
+++ b/bedrock/base/tests/test_views.py
@@ -46,6 +46,34 @@ class TestGeoTemplateView(TestCase):
         assert template == "firefox-mobile.html"
 
 
+class TestErrorPages(TestCase):
+    """Test error pages using the debug URLs that are set up in DEBUG mode."""
+
+    def test_404_page_returns_correct_status(self):
+        response = self.client.get("/en-US/404/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_page_uses_correct_template(self):
+        response = self.client.get("/en-US/404/")
+        self.assertTemplateUsed(response, "404.html")
+
+    def test_410_page_returns_correct_status(self):
+        response = self.client.get("/en-US/410/")
+        self.assertEqual(response.status_code, 410)
+
+    def test_410_page_uses_correct_template(self):
+        response = self.client.get("/en-US/410/")
+        self.assertTemplateUsed(response, "410.html")
+
+    def test_500_page_returns_correct_status(self):
+        response = self.client.get("/en-US/500/")
+        self.assertEqual(response.status_code, 500)
+
+    def test_500_page_uses_correct_template(self):
+        response = self.client.get("/en-US/500/")
+        self.assertTemplateUsed(response, "500.html")
+
+
 @patch("bedrock.base.views.tz_now")
 @patch("bedrock.base.views.timeago.format")
 @pytest.mark.django_db

--- a/bedrock/base/tests/urls.py
+++ b/bedrock/base/tests/urls.py
@@ -11,6 +11,8 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.http.multipartparser import MultiPartParserError
 from django.urls import path
 
+from bedrock.base.exceptions import Http410
+
 
 def index(request):
     return HttpResponse("test")
@@ -48,6 +50,14 @@ def raises_404(request):
     raise Http404
 
 
+def returns_410(request):
+    return HttpResponse("410", status=410)
+
+
+def raises_410(request):
+    raise Http410
+
+
 def returns_500(request):
     return HttpResponse("500", status=500)
 
@@ -66,6 +76,8 @@ urlpatterns = [
     path("returns_400/", returns_400, name="returns_400"),
     path("raises_404/", raises_404, name="raises_404"),
     path("returns_404/", returns_404, name="returns_404"),
+    path("raises_410/", raises_410, name="raises_410"),
+    path("returns_410/", returns_410, name="returns_410"),
     path("raises_500/", raises_500, name="raises_500"),
     path("returns_500/", returns_500, name="returns_500"),
 ]

--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -191,5 +191,10 @@ def page_not_found_view(request, exception=None, template_name="404.html"):
     return l10n_utils.render(request, template_name, ftl_files=["404", "500"], status=404)
 
 
+def page_gone_view(request, exception=None, template_name="410.html"):
+    """410 error handler that runs context processors."""
+    return l10n_utils.render(request, template_name, ftl_files=["410", "500"], status=410)
+
+
 def csrf_failure(request, reason="CSRF failure", template_name="403_csrf.html"):
     return render(request, template_name, status=403)

--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -193,7 +193,8 @@ def page_not_found_view(request, exception=None, template_name="404.html"):
 
 def page_gone_view(request, exception=None, template_name="410.html"):
     """410 error handler that runs context processors."""
-    return l10n_utils.render(request, template_name, ftl_files=["410", "500"], status=410)
+
+    return l10n_utils.render(request, template_name, ftl_files=["410", "500"], status=410, non_locale_url=True)
 
 
 def csrf_failure(request, reason="CSRF failure", template_name="403_csrf.html"):

--- a/bedrock/base/views.py
+++ b/bedrock/base/views.py
@@ -10,6 +10,7 @@ from time import time
 
 from django.conf import settings
 from django.shortcuts import render
+from django.utils.decorators import decorator_from_middleware
 from django.utils.timezone import now as tz_now
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
@@ -18,6 +19,8 @@ import timeago
 from waffle.models import Switch
 
 from bedrock.base.geo import get_country_from_request
+from bedrock.base.i18n import get_language_from_headers
+from bedrock.base.middleware import BedrockLocaleMiddleware
 from bedrock.contentful.models import ContentfulEntry
 from bedrock.utils import git
 from lib import l10n_utils
@@ -194,7 +197,18 @@ def page_not_found_view(request, exception=None, template_name="404.html"):
 def page_gone_view(request, exception=None, template_name="410.html"):
     """410 error handler that runs context processors."""
 
-    return l10n_utils.render(request, template_name, ftl_files=["410", "500"], status=410, non_locale_url=True)
+    # In a normal request, this would happen in bedrock.base.middleware.BedrockLangCodeFixupMiddleware
+    # But requests that get here don't go through that middleware
+    lang_code = request.GET.get("lang", None) or get_language_from_headers(request)
+    request.locale = lang_code if lang_code else ""
+
+    locale_middleware = decorator_from_middleware(BedrockLocaleMiddleware)
+
+    @locale_middleware
+    def _view(request):
+        return l10n_utils.render(request, template_name, ftl_files=["410", "500"], status=410, non_locale_url=True)
+
+    return _view(request)
 
 
 def csrf_failure(request, reason="CSRF failure", template_name="403_csrf.html"):

--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -10,7 +10,6 @@ from urllib.parse import parse_qs, urlencode
 from django.conf import settings
 from django.http import (
     Http404,
-    HttpResponseGone,
     HttpResponsePermanentRedirect,
     HttpResponseRedirect,
 )
@@ -326,7 +325,9 @@ def redirect(
 
 
 def gone_view(request, *args, **kwargs):
-    return HttpResponseGone()
+    from bedrock.base.views import page_gone_view
+
+    return page_gone_view(request)
 
 
 def gone(pattern):

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -36,9 +36,6 @@ urlpatterns = bedrock_i18n_patterns(
     path("", include("bedrock.mozorg.urls")),  # these are locale-needing URLs, vs mozorg.nonlocale_urls
     path("", include("bedrock.newsletter.urls")),
     path("careers/", include("bedrock.careers.urls")),
-    path("404/", import_string(handler404)),
-    path("410/", import_string(handler410)),
-    path("500/", import_string(handler500)),
 )
 
 # Paths that must not have a locale prefix
@@ -58,6 +55,11 @@ if settings.DEV:
     )
 
 if settings.DEBUG:
+    urlpatterns += bedrock_i18n_patterns(
+        path("404/", import_string(handler404)),
+        path("410/", import_string(handler410)),
+        path("500/", import_string(handler500)),
+    )
     urlpatterns += (path("csrf_403/", base_views.csrf_failure, {}),)
 
 if settings.WAGTAIL_ENABLE_ADMIN:

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -36,6 +36,9 @@ urlpatterns = bedrock_i18n_patterns(
     path("", include("bedrock.mozorg.urls")),  # these are locale-needing URLs, vs mozorg.nonlocale_urls
     path("", include("bedrock.newsletter.urls")),
     path("careers/", include("bedrock.careers.urls")),
+    path("404/", import_string(handler404)),
+    path("410/", import_string(handler410)),
+    path("500/", import_string(handler500)),
 )
 
 # Paths that must not have a locale prefix
@@ -55,11 +58,6 @@ if settings.DEV:
     )
 
 if settings.DEBUG:
-    urlpatterns += bedrock_i18n_patterns(
-        path("404/", import_string(handler404)),
-        path("410/", import_string(handler410)),
-        path("500/", import_string(handler500)),
-    )
     urlpatterns += (path("csrf_403/", base_views.csrf_failure, {}),)
 
 if settings.WAGTAIL_ENABLE_ADMIN:

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -19,6 +19,7 @@ from bedrock.base.i18n import bedrock_i18n_patterns
 # The default django 404 and 500 handler doesn't run the ContextProcessors,
 # which breaks the base template page. So we replace them with views that do!
 handler500 = "bedrock.base.views.server_error_view"
+handler410 = "bedrock.base.views.page_gone_view"
 handler404 = "bedrock.base.views.page_not_found_view"
 locale404 = "lib.l10n_utils.locale_selection"
 
@@ -56,6 +57,7 @@ if settings.DEV:
 if settings.DEBUG:
     urlpatterns += bedrock_i18n_patterns(
         path("404/", import_string(handler404)),
+        path("410/", import_string(handler410)),
         path("500/", import_string(handler500)),
     )
     urlpatterns += (path("csrf_403/", base_views.csrf_failure, {}),)

--- a/l10n/en/410.ftl
+++ b/l10n/en/410.ftl
@@ -2,16 +2,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+### URL: https://www-dev.allizom.org/410/
+
 page-gone-title = This page is no longer available
 
-# Variables:
-#   $home (attr) - e.g., href="/"
-#   $blog (attr) - e.g., href="https://blog.mozilla.org/"
-#   $support (attr) - e.g., href="https://support.mozilla.org/"
 page-gone-body = This page used to exist, but it was intentionally removed and isn’t available anywhere on our site. You may find what you’re looking for on the pages below.
 
 gone-page-go-back = Go Back
+
+# Variables:
+#   $home (attr) - attributes to be added to the <a> tag - href="https://mozilla.org"
 gone-page-go-home = Go to the <a { $home }>home page</a>.
+
+# Variables:
+#   $blog (attr) - attributes to be added to the <a> tag - href="https://blog.mozilla.org/"
 gone-page-search-blog = Search the <a { $blog }>{ -brand-name-mozilla } Blog</a>.
+
+# Variables:
+#   $products (attr) - attributes to be added to the <a> tag - href="/products/"
 gone-page-browse-products = Browse our <a { $products }>products</a>.
+
+# Variables:
+#   $support (attr) - attributes to be added to the <a> tag - href="https://support.mozilla.org/"
 gone-page-visit-support = Visit <a { $support }>{ -brand-name-mozilla } Support</a>.

--- a/l10n/en/410.ftl
+++ b/l10n/en/410.ftl
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/410/
+
+gone-page-gone-page-page-gone = 410: Page Gone
+gone-page-sorry-that-page-is-gone = Sorry, that page is gone
+
+# Variables:
+#   $blog (url) - link to https://blog.mozilla.org/
+gone-page-you-may-be-able-to-find-more = You may be able to find more information about what you were looking for by searching on <a href="{ $blog }">The { -brand-name-mozilla } Blog</a>
+
+gone-page-go-back = Go Back
+
+# Variables:
+#   $about (url) - link to https://www.mozilla.org/about/
+gone-page-learn-about-mozilla-the-non = <a href="{ $about }">Learn</a> about { -brand-name-mozilla }, the not-for-profit behind { -brand-name-firefox }.
+
+# Variables:
+#   $download (url) - link to https://www.mozilla.org/firefox/new/
+gone-page-download-the-firefox-browser = <a href={ $download }>Download</a> the { -brand-name-firefox } browser for your mobile device or desktop
+
+# Variables:
+#   $donate (url) - link to https://foundation.mozilla.org/?form=donate-410
+gone-page-donate-to-mozilla-reclaim-from = <a { $donate }>Donate</a> to the { -brand-name-mozilla-foundation } and reclaim the internet from big tech.

--- a/l10n/en/410.ftl
+++ b/l10n/en/410.ftl
@@ -4,15 +4,15 @@
 
 ### URL: https://www-dev.allizom.org/410/
 
-page-gone-title = This page is no longer available
+page-gone-title = This page has been removed
 
-page-gone-body = This page used to exist, but it was intentionally removed and isn’t available anywhere on our site. You may find what you’re looking for on the pages below.
+page-gone-body = We are sorry, but this content is no longer available. You can follow some of the links below to find more current information.
 
 gone-page-go-back = Go Back
 
 # Variables:
 #   $home (attr) - attributes to be added to the <a> tag - href="https://mozilla.org"
-gone-page-go-home = Go to the <a { $home }>home page</a>.
+gone-page-go-home = Start exploring the site from its <a { $home }>home page</a>.
 
 # Variables:
 #   $blog (attr) - attributes to be added to the <a> tag - href="https://blog.mozilla.org/"

--- a/l10n/en/410.ftl
+++ b/l10n/en/410.ftl
@@ -2,25 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-### URL: https://www-dev.allizom.org/410/
-
-gone-page-gone-page-page-gone = 410: Page Gone
-gone-page-sorry-that-page-is-gone = Sorry, that page is gone
+page-gone-title = This page is no longer available
 
 # Variables:
-#   $blog (url) - link to https://blog.mozilla.org/
-gone-page-you-may-be-able-to-find-more = You may be able to find more information about what you were looking for by searching on <a href="{ $blog }">The { -brand-name-mozilla } Blog</a>
+#   $home (attr) - e.g., href="/"
+#   $blog (attr) - e.g., href="https://blog.mozilla.org/"
+#   $support (attr) - e.g., href="https://support.mozilla.org/"
+page-gone-body = This page used to exist, but it was intentionally removed and isn’t available anywhere on our site. You may find what you’re looking for on the pages below.
 
 gone-page-go-back = Go Back
-
-# Variables:
-#   $about (url) - link to https://www.mozilla.org/about/
-gone-page-learn-about-mozilla-the-non = <a href="{ $about }">Learn</a> about { -brand-name-mozilla }, the not-for-profit behind { -brand-name-firefox }.
-
-# Variables:
-#   $download (url) - link to https://www.mozilla.org/firefox/new/
-gone-page-download-the-firefox-browser = <a href={ $download }>Download</a> the { -brand-name-firefox } browser for your mobile device or desktop
-
-# Variables:
-#   $donate (url) - link to https://foundation.mozilla.org/?form=donate-410
-gone-page-donate-to-mozilla-reclaim-from = <a { $donate }>Donate</a> to the { -brand-name-mozilla-foundation } and reclaim the internet from big tech.
+gone-page-go-home = Go to the <a { $home }>home page</a>.
+gone-page-search-blog = Search the <a { $blog }>{ -brand-name-mozilla } Blog</a>.
+gone-page-browse-products = Browse our <a { $products }>products</a>.
+gone-page-visit-support = Visit <a { $support }>{ -brand-name-mozilla } Support</a>.

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -90,7 +90,7 @@ def locale_selection(request, available_locales=None):
     return response
 
 
-def render(request, template, context=None, ftl_files=None, activation_files=None, **kwargs):
+def render(request, template, context=None, ftl_files=None, activation_files=None, non_locale_url=False, **kwargs):
     """
     Same as django's render() shortcut, but with l10n template support.
     If used like this::
@@ -112,7 +112,7 @@ def render(request, template, context=None, ftl_files=None, activation_files=Non
 
     # is this a non-locale page?
     name_prefix = request.path_info.split("/", 2)[1]
-    non_locale_url = name_prefix in settings.SUPPORTED_NONLOCALES or request.path_info in settings.SUPPORTED_LOCALE_IGNORE
+    non_locale_url = non_locale_url or name_prefix in settings.SUPPORTED_NONLOCALES or request.path_info in settings.SUPPORTED_LOCALE_IGNORE
 
     # is this a CMS page?
     is_cms_page = hasattr(request, "is_cms_page") and request.is_cms_page


### PR DESCRIPTION
## One-line summary

Add 410 Gone error handling with custom view, template, and localization support

## Significant changes and points to review

- Implemented a new 410 error handler in views and middleware
- Added URL routing for 410 errors in urls.py
- Created a 410 error template (410.html) for user-friendly messaging
- Updated tests to cover 404, 410 and 500 error scenarios
- Added localization support for 410 error messages in 410.ftl

> Note: I am not sure about the process for adding new localization strings to Pontoon/Smartling.

## Issue / Bugzilla link

Fixes https://github.com/mozilla/bedrock/issues/8964

## Testing

- Visit /en-US/410/ in development mode to verify 410 error page displays correctly
- Confirm proper status code (410) is returned
- Verify template renders with all localized strings
- Run `pytest lib bedrock`
