### PR TITLE
(feat) Add 302 redirects from release notes and system requirement pages over to www.firefox.com

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -7,6 +7,16 @@ from functools import partial
 
 from django.conf import settings
 
+from bedrock.firefox.urls import (
+    android_releasenotes_re,
+    android_sysreq_re,
+    channel_re,
+    ios_releasenotes_re,
+    ios_sysreq_re,
+    platform_re,
+    releasenotes_re,
+    sysreq_re,
+)
 from bedrock.redirects.util import mobile_app_redirector, no_redirect, platform_redirector, redirect
 
 PRODUCT_OPTIONS = ["firefox", "focus", "klar"]
@@ -52,6 +62,86 @@ offsite_redirect = partial(
     redirect,
     query={"redirect_source": "mozilla-org"},  # additional querystring to add to every redirection
     merge_query=True,  # ensure we don't lose existing querystrings during redirection
+)
+
+
+def _redirect_to_same_path_on_fxc(request, *args, **kwargs):
+    """Returns the same path but on the Firefox domain.
+
+    Note that this is meant to be called from the offsite_redirect helper,
+    which has merge_query enabled and also adds on the redirect_source
+    querystring, so we don't need to explicitly [re]set the querystring in the
+    URL we return.
+    """
+    return f"{settings.FXC_BASE_URL}{request.path}"
+
+
+releasenotes_redirectpatterns = (
+    offsite_redirect(
+        f"^firefox/(?:{platform_re}/)?(?:{channel_re}/)?notes/$",
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        "firefox/nightly/notes/feed/",
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        "firefox/(?:latest/)?releasenotes/$",
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        "firefox/android/releasenotes/",
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        "firefox/ios/releasenotes/",
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        f"^firefox/(?:{platform_re}/)?(?:{channel_re}/)?system-requirements/$",
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        releasenotes_re,
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        android_releasenotes_re,
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        ios_releasenotes_re,
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        sysreq_re,
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        android_sysreq_re,
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        ios_sysreq_re,
+        _redirect_to_same_path_on_fxc,
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
+    offsite_redirect(
+        "firefox/releases/",
+        f"{settings.FXC_BASE_URL}/releases/",  # leave Springfield to sort out the local redirect
+        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+    ),
 )
 
 # Issue 16355
@@ -690,6 +780,4 @@ bedrock_redirectpatterns = (
     redirect(r"^/firefox/?$", f"{FXC}/"),
 )
 
-redirectpatterns = (
-    bedrock_redirectpatterns + springfield_redirectpatterns
-)  # bedrock redirects first, to keep tests happy, then off to springfield, if relevant
+redirectpatterns = releasenotes_redirectpatterns + bedrock_redirectpatterns + springfield_redirectpatterns

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -523,26 +523,6 @@ def test_mobile_app_redirector_does_not_go_to_springfield(client):
     assert resp.headers["Location"] == "https://apps.apple.com/app/apple-store/id989804926"
 
 
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "path",
-    (
-        "/firefox/releasenotes/",
-        "/firefox/system-requirements/",
-        "/firefox/android/releasenotes/",
-        "/firefox/android/system-requirements/",
-        "/firefox/ios/releasenotes/",
-        "/firefox/ios/system-requirements/",
-        "/firefox/releases/",
-    ),
-)
-def test_releasenotes_generic_urls_not_rediected_to_springfield(client, path):
-    resp = client.get(path)
-    assert resp.status_code == 302
-    assert settings.FXC_BASE_URL not in resp.headers["Location"]
-    assert resp.headers["Location"].startswith("/")
-
-
 @pytest.mark.parametrize(
     "path, expected_dest",
     (
@@ -588,3 +568,187 @@ def test_offsite_redirects_still_work_when_locale_not_in_source_path(
     resp = client.get(path, secure=True)
     assert resp.status_code == 301
     assert resp.headers["Location"] == expected_dest
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "path, expected",
+    (
+        (
+            "/en-US/firefox/notes/",
+            "/en-US/firefox/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/notes/?foo=bar",
+            "/en-US/firefox/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/android/notes/",
+            "/en-US/firefox/android/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/android/notes/?foo=bar",
+            "/en-US/firefox/android/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/ios/notes/",
+            "/en-US/firefox/ios/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/ios/notes/?foo=bar",
+            "/en-US/firefox/ios/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/aurora/notes/",
+            "/en-US/firefox/aurora/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/aurora/notes/?foo=bar",
+            "/en-US/firefox/aurora/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/beta/notes/",
+            "/en-US/firefox/beta/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/beta/notes/?foo=bar",
+            "/en-US/firefox/beta/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/developer/notes/",
+            "/en-US/firefox/developer/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/developer/notes/?foo=bar",
+            "/en-US/firefox/developer/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/nightly/notes/",
+            "/en-US/firefox/nightly/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/nightly/notes/?foo=bar",
+            "/en-US/firefox/nightly/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/organizations/notes/",
+            "/en-US/firefox/organizations/notes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/organizations/notes/?foo=bar",
+            "/en-US/firefox/organizations/notes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/releasenotes/",
+            "/en-US/firefox/releasenotes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/releasenotes/?foo=bar",
+            "/en-US/firefox/releasenotes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/latest/releasenotes/",
+            "/en-US/firefox/latest/releasenotes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/latest/releasenotes/?foo=bar",
+            "/en-US/firefox/latest/releasenotes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/android/releasenotes/",
+            "/en-US/firefox/android/releasenotes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/android/releasenotes/?foo=bar",
+            "/en-US/firefox/android/releasenotes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/ios/releasenotes/",
+            "/en-US/firefox/ios/releasenotes/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/ios/releasenotes/?foo=bar",
+            "/en-US/firefox/ios/releasenotes/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/nightly/notes/feed/",
+            "/en-US/firefox/nightly/notes/feed/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/nightly/notes/feed/?foo=bar",
+            "/en-US/firefox/nightly/notes/feed/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/android/system-requirements/",
+            "/en-US/firefox/android/system-requirements/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/android/system-requirements/?foo=bar",
+            "/en-US/firefox/android/system-requirements/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/system-requirements/",
+            "/en-US/firefox/system-requirements/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/system-requirements/?foo=bar",
+            "/en-US/firefox/system-requirements/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/ios/system-requirements/",
+            "/en-US/firefox/ios/system-requirements/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/ios/system-requirements/?foo=bar",
+            "/en-US/firefox/ios/system-requirements/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/android/system-requirements/",
+            "/en-US/firefox/android/system-requirements/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/android/system-requirements/?foo=bar",
+            "/en-US/firefox/android/system-requirements/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/system-requirements/",
+            "/en-US/firefox/system-requirements/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/system-requirements/?foo=bar",
+            "/en-US/firefox/system-requirements/?redirect_source=mozilla-org&foo=bar",
+        ),
+        (
+            "/en-US/firefox/ios/system-requirements/",
+            "/en-US/firefox/ios/system-requirements/?redirect_source=mozilla-org",
+        ),
+        (
+            "/en-US/firefox/ios/system-requirements/?foo=bar",
+            "/en-US/firefox/ios/system-requirements/?redirect_source=mozilla-org&foo=bar",
+        ),
+    ),
+)
+def test_releasenotes_and_sysreq_redirects(client, path, expected):
+    resp = client.get(path)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{expected}"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "source_path, dest_path",
+    (
+        (
+            "/en-US/firefox/system-requirements/",
+            "/en-US/firefox/system-requirements/",
+        ),
+        (
+            "/en-US/firefox/releases/",
+            "/releases/",
+        ),
+    ),
+)
+def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(client, source_path, dest_path):
+    resp = client.get(source_path)
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{dest_path}?redirect_source=mozilla-org"

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -10,6 +10,8 @@ from bedrock.mozorg.util import page
 from bedrock.releasenotes import version_re
 from bedrock.utils.views import VariationTemplateView
 
+# Note that these regular expressions are also used in bedrock.firefox.redirects,
+# so if they become redundant here, they will need to be moved to that module.
 latest_re = r"^firefox(?:/(?P<version>%s))?/%s/$"
 firstrun_re = latest_re % (version_re, "firstrun")
 whatsnew_re = latest_re % (version_re, "whatsnew")

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2512,3 +2512,9 @@ if ENABLE_DJANGO_SILK := config("ENABLE_DJANGO_SILK", default="False", parser=bo
 # be sure NOT to include `locale` - we add that in the redirects as and when needed
 # NOTE THE LACK OF TRAILING SLASH, too - this is deliberate and should be followed
 FXC_BASE_URL = config("FXC_BASE_URL", default="https://www.firefox.com")
+
+MAKE_RELNOTES_REDIRECTS_PERMANENT = config(
+    "MAKE_RELNOTES_REDIRECTS_PERMANENT",
+    default="False",
+    parser=bool,
+)


### PR DESCRIPTION
## One-line summary
Relnotes and sysreq pages already reference www.firefox.com as the canonical source of these pages. This changeset sends people there automatically, with a 302


## Significant changes and points to review

Question: 302 for now, or shall we go straight to 301? What's the SEO impact if we leave these pages (which have the canonical ref set to www.firefox.com) live for more than 72hrs? @slightlyoffbeat @stephaniehobson 


## Issue / Bugzilla link

Resolves #16381

## Testing

These should all send uses to the correct page on www.firefox.com with no 404s and retaining querystrings where appropriate

- [ ] http://localhost:8000/en-US/firefox/releases/
- [ ] http://localhost:8000/en-US/firefox/releases/?foo=bar
- [ ] http://localhost:8000/en-US/firefox/android/releasenotes/
- [ ] http://localhost:8000/en-US/firefox/ios/releasenotes/
- [ ] http://localhost:8000/en-US/firefox/latest/releasenotes/

- [ ] Check that http://localhost:8000/firefox/nightly/notes/feed/ also gets an RSS/Atom feed from www.firefox.com - you'll have to use the network tab in Devtools to be sure
