### PR TITLE
Stop exposing release_notes_urls to sitemaps

### DIFF
--- a/bedrock/sitemaps/tests/test_utils.py
+++ b/bedrock/sitemaps/tests/test_utils.py
@@ -269,7 +269,6 @@ def test_get_wagtail_urls__ensure_locale_codes_not_stripped(dummy_wagtail_pages)
 
 
 @patch("bedrock.sitemaps.utils.get_static_urls")
-@patch("bedrock.sitemaps.utils.get_release_notes_urls")
 @patch("bedrock.sitemaps.utils.get_security_urls")
 @patch("bedrock.sitemaps.utils.get_contentful_urls")
 @patch("bedrock.sitemaps.utils.get_wagtail_urls")
@@ -279,24 +278,21 @@ def test_update_sitemaps(
     mock_get_wagtail_urls,
     mock_get_contentful_urls,
     mock_get_security_urls,
-    mock_get_release_notes_urls,
     mock_get_static_urls,
 ):
     "Light check to ensure we've not added _new_ things we haven't added tests for"
 
-    mock_get_wagtail_urls.return_value = {"wagtail": "dummy1"}
-    mock_get_contentful_urls.return_value = {"contentful": "dummy2"}
-    mock_get_security_urls.return_value = {"security": "dummy3"}
-    mock_get_release_notes_urls.return_value = {"release_notes": "dummy4"}
-    mock_get_static_urls.return_value = {"static_urls": "dummy5"}
+    mock_get_wagtail_urls.return_value = {"wagtail": "walterite"}
+    mock_get_contentful_urls.return_value = {"contentful": "gutterball"}
+    mock_get_security_urls.return_value = {"security": "grainwave"}
+    mock_get_static_urls.return_value = {"static_urls": "rubberduck"}
 
     update_sitemaps()
     expected = {
-        "wagtail": "dummy1",
-        "contentful": "dummy2",
-        "security": "dummy3",
-        "release_notes": "dummy4",
-        "static_urls": "dummy5",
+        "wagtail": "walterite",
+        "contentful": "gutterball",
+        "security": "grainwave",
+        "static_urls": "rubberduck",
     }
 
     mock_output_json.assert_called_once_with(expected)

--- a/bedrock/sitemaps/utils.py
+++ b/bedrock/sitemaps/utils.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import json
 import re
 from collections import defaultdict
@@ -19,7 +20,6 @@ from bedrock.contentful.constants import (
     VRC_ROOT_PATH,
 )
 from bedrock.contentful.models import ContentfulEntry
-from bedrock.releasenotes.models import ProductRelease
 from bedrock.security.models import SecurityAdvisory
 
 SEC_KNOWN_VULNS = [
@@ -62,32 +62,6 @@ def get_security_urls():
             adv_url = adv_url[6:]
 
         urls[adv_url] = ["en-US"]
-
-    return urls
-
-
-def get_release_notes_urls():
-    urls = {}
-    for release in ProductRelease.objects.exclude(product="Thunderbird"):
-        # we redirect all release notes for versions 28.x and below to an archive
-        # and Firefox for iOS uses a different version numbering scheme
-        if release.product != "Firefox for iOS" and release.major_version_int < 29:
-            continue
-
-        try:
-            rel_path = release.get_absolute_url()
-            req_path = release.get_sysreq_url()
-        except resolvers.NoReverseMatch:
-            continue
-
-        # strip "/en-US" off the front
-        if rel_path.startswith("/en-US"):
-            rel_path = rel_path[6:]
-        if req_path.startswith("/en-US"):
-            req_path = req_path[6:]
-
-        urls[rel_path] = ["en-US"]
-        urls[req_path] = ["en-US"]
 
     return urls
 
@@ -226,7 +200,6 @@ def get_wagtail_urls():
 
 def get_all_urls():
     urls = get_static_urls()
-    urls.update(get_release_notes_urls())
     urls.update(get_security_urls())
     urls.update(get_contentful_urls())
     urls.update(get_wagtail_urls())


### PR DESCRIPTION
## One-line summary

Removes releases-related URLs from sitemap generation data.

## Significant changes and points to review

These are exposed in FXC sitemaps that are the canonical source of the pages now.

## Issue / Bugzilla link

#16381 
[`@mozmeao/www-site-checker`/actions/runs/16883546251/job/47825284604](https://github.com/mozmeao/www-site-checker/actions/runs/16883546251/job/47825284604)

## Testing
