### PR TITLE
Fix typeof check for MzpSupports in navigation

### DIFF
--- a/media/js/base/protocol/m24-navigation.es6.js
+++ b/media/js/base/protocol/m24-navigation.es6.js
@@ -225,7 +225,7 @@ MzpNavigation.onClick = (e) => {
 MzpNavigation.menuButtonVisible = (callback) => {
     // check if Intersection observer is supported
     if (
-        window.MzpSupports !== 'undefined' &&
+        typeof window.MzpSupports !== 'undefined' &&
         window.MzpSupports.intersectionObserver
     ) {
         const observer = new IntersectionObserver(
@@ -249,7 +249,7 @@ MzpNavigation.menuButtonVisible = (callback) => {
  */
 MzpNavigation.setAria = () => {
     if (
-        window.MzpSupports !== 'undefined' &&
+        typeof window.MzpSupports !== 'undefined' &&
         window.MzpSupports.intersectionObserver
     ) {
         MzpNavigation.menuButtonVisible((isVisible, menuButton) => {


### PR DESCRIPTION
## One-line summary

Checks for the object availability correctly.

## Significant changes and points to review

Will need porting upstream, too.

## Issue / Bugzilla link

https://github.com/mozmeao/springfield/issues/380

## Testing

_(should be in fxc prod already, have the reports calmed down?)_