### PR TITLE
Fix deployment order by triggering GAR after GCS

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -165,7 +165,7 @@ jobs:
            username: oauth2accesstoken
            password: ${{ steps.gcp_auth.outputs.access_token }}
 
-      - name: Push existing image to GAR
+      - name: Add deployment tag to existing image and push to GAR
         run: |-
              docker pull $ORG/$IMAGE:${{ needs.build_and_publish_public_images.outputs.long_sha }}
              docker tag $ORG/$IMAGE:${{ needs.build_and_publish_public_images.outputs.long_sha }} ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE }}:${{ needs.build_and_publish_public_images.outputs.image_tag }}


### PR DESCRIPTION
## One-line summary

Eliminates app being deployed before assets finish uploading by triggering the GAR push last.

## Significant changes and points to review

- Static artifact writer pulls the public image, to be able to run before GAR job.
- GCS job has docker login removed, as it does not need any access.
- Setting tags (deployment realms) was moved up to parsing the ref.

## Issue / Bugzilla link

#16499

## Testing

Mock outputs: [`@janbrasna/bedrock`/actions/runs/17899364549/job/50890283669](https://github.com/janbrasna/bedrock/actions/runs/17899364549/job/50890283669)

<details><summary>Expand for output values…</summary>
<p>

Build job:
```
 env:
    APP: bedrock
    GAR_LOCATION: us
    GCP_PROJECT_ID: moz-fx-bedrock-prod
    GAR_REPOSITORY: bedrock-prod
    IMAGE: bedrock
    ORG: mozmeao
    REF_ID: refs/heads/mock
    LONG_SHA: 3e6108f4614729a255fee23a57e693a122e2e1b7
    TAG: stage-3e6108f4614729a255fee23a57e693a122e2e1b7
    DEPLOYMENT_ENV: stage
    DEPLOYMENT_REALM: nonprod
    GIT_COMMIT: 3e6108f4614729a255fee23a57e693a122e2e1b7
```

Upload job:

```
mocked:
  ASSETS_TMP: mozmeao/bedrock:3e6108f4614729a255fee23a57e693a122e2e1b7
  GS_URI: bedrock-nonprod-stage-media/media/
```

Deploy job:

```
mocked:
  DOCKER_PULL: mozmeao/bedrock:3e6108f4614729a255fee23a57e693a122e2e1b7
  DOCKER_TAG:
    from: mozmeao/bedrock:3e6108f4614729a255fee23a57e693a122e2e1b7
      to: us-docker.pkg.dev/moz-fx-bedrock-prod/bedrock-prod/bedrock:stage-3e6108f4614729a255fee23a57e693a122e2e1b7
  DOCKER_PUSH: us-docker.pkg.dev/moz-fx-bedrock-prod/bedrock-prod/bedrock:stage-3e6108f4614729a255fee23a57e693a122e2e1b7
```

</p>
</details> 