### PR TITLE
Hotfix hardcode Glean probe scraper CI locally for now

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,4 +1,3 @@
----
 name: Glean probe-scraper
 on:
   push:
@@ -8,4 +7,15 @@ on:
 jobs:
   glean-probe-scraper:
     if: github.repository == 'mozilla/bedrock'
-    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main
+    #uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main
+    # FIXME: same-org workflow calls failing: https://bugzil.la/1983348
+    # this inlines mozilla/probe-scraper@78f5c5f callable directly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call Glean probe-scraper manually (bugzil.la/1983348)
+        run: |-
+          curl --fail-with-body https://us-west1-moz-fx-data-probe-s-prod-2bc3.cloudfunctions.net/glean-push --data '{
+            "url": "${{github.server_url}}/${{github.repository}}",
+            "commit":"${{github.sha}}",
+            "branch":"${{github.ref_name}}"
+          }'


### PR DESCRIPTION
## One-line summary

In case the Glean probe needs passing to successfully promote stages / tag releases, this is a workaround.

## Significant changes and points to review

This seems like a GH bug:
> "Error: The reusable workflow **mozilla**/probe-scraper/.github/workflows/glean.yaml@main is not allowed in **mozilla**/bedrock because all reusable workflows must be from a **repository owned by your enterprise** or match one of the patterns: ./**, […]"

_(which is owned by that, given it's the same org, but…)_

Alternative could be commenting out the whole workflow as it's not crucial, and just running that GHA empty ("hello world" basically).

## Issue / Bugzilla link

https://bugzil.la/1983348

## Testing

The action is currently disabled. If it needs passing, it ought to be enabled first, and then this should pass dereferenced.