### PR TITLE
Fix Makefile test-cdn marker selected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test: .docker-build-pull
 	${DC} run --rm test
 
 test-cdn: .docker-build-pull test_infra/fixtures/tls.json
-	${DC} run test pytest --base-url https://${TEST_DOMAIN} test_infra
+	${DC} run test pytest --base-url https://${TEST_DOMAIN} -m cdn
 
 test-image: .docker-build
 	${DC} run test-image


### PR DESCRIPTION
_This is a trivial patch to mainly verify CI changes…_

## One-line summary

Porting https://github.com/mozmeao/springfield/pull/320/commits/506d94b1fabac8f7f0e4339aafa8eb5b6f26f1bf

Updates local _make_ command to _make_ it _make_ sense (and do anything).

## Significant changes and points to review

This is not being used in CI — it's only a local convenience utility, so unless you're developing CDN tests, this has no impact. Production CI uses bin/sh magic to run that via functional testing infra tooling, so this could have been left no-op for years without anyone noticing;)

## Issue / Bugzilla link

#16339

## Testing

`make test-cdn`