### PR TITLE
fix Firefox logo style for legacy navigation (fix #16494)

### DIFF
--- a/media/css/protocol/components/_menu.scss
+++ b/media/css/protocol/components/_menu.scss
@@ -139,6 +139,10 @@
             padding: 0 $spacing-md;
         }
     }
+
+    .c-menu-title-icon {
+        @include bidi(((margin, 0 $spacing-sm 0 0, 0 0 0 $spacing-sm),));
+    }
 }
 
 // Basic hover interactions with JavaScript disabled or not supported..


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes the Firefox logo style for legacy navigation

## Significant changes and points to review

Firefox logo style for legacy navigation (desktop and mobile)

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16494

## Testing

1. set `DEV=False` in `.env`
2. http://localhost:8000/sco/
3. Resize screen to verify both mobile and desktop style
4. Update <html> `dir="rtl"` to test rtl styling