### PR TITLE
Change aurora to beta for dev release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -36,7 +36,7 @@
   <div class="mzp-l-content mzp-t-content-md t-center">
     <div class="mzp-c-logo mzp-t-logo-xl mzp-t-product-developer mzp-l-logo-center"></div>
     <h1>{{ ftl('firefox-developer-congrats-you-now-have-latest-v2') }}</h1>
-    {% set attrs = 'href="' ~ url('firefox.notes', channel='beta') ~ '"' %}
+    {% set attrs = 'href="https://www.firefox.com/firefox/developer/notes/"' %}
     {% if LANG.startswith('en-') %}
       <p>View the <a {{ attrs|safe }}>release notes</a> to see what’s new.</p>
     {% else %}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Fixes "aurora" channel URL not properly redirecting on Springfield

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16509


## Testing
http://localhost:8000/en-US/firefox/143.0a2/whatsnew
Release notes link should redirect to https://www.firefox.com/en-US/firefox/143.0beta/releasenotes/

NOTE: https://github.com/mozilla/bedrock/pull/16511#issuecomment-3205530206