### PR TITLE
update VPN branding l10n string (fix #16496)

### DIFF
--- a/.github/l10n/linter_config.yml
+++ b/.github/l10n/linter_config.yml
@@ -27,4 +27,6 @@ CO01:
     - "{ -brand-name-mozilla } VPN"
   exclusions:
     files: []
-    messages: []
+    messages:
+      # This exclusion should be removed when this fallback string is removed
+      - vpn-windows-protect-your-windows

--- a/.github/l10n/linter_config.yml
+++ b/.github/l10n/linter_config.yml
@@ -24,6 +24,7 @@ CO01:
     - MDN
     - Mozilla
     - "{ -brand-name-mozilla } account"
+    - "{ -brand-name-mozilla } VPN"
   exclusions:
     files: []
     messages: []

--- a/.github/l10n/linter_config.yml
+++ b/.github/l10n/linter_config.yml
@@ -28,5 +28,5 @@ CO01:
   exclusions:
     files: []
     messages:
-      # This exclusion should be removed when this fallback string is removed
+      # Obsolete string (expires 2025-12-19) - This exclusion should be removed when the string is removed
       - vpn-windows-protect-your-windows

--- a/bedrock/products/templates/products/vpn/platforms/windows.html
+++ b/bedrock/products/templates/products/vpn/platforms/windows.html
@@ -8,7 +8,7 @@
 
 {% block page_title_full %}{{ ftl('vpn-windows-get-a-vpn') }}{% endblock %}
 
-{% block page_desc %}{{ ftl('vpn-windows-protect-your-windows', fallback=vpn-windows-protect-your-windows-v2') }}{% endblock %}
+{% block page_desc %}{{ ftl('vpn-windows-protect-your-windows-v2', fallback='vpn-windows-protect-your-windows') }}{% endblock %}
 
 {% block body_id %}mozilla-vpn-platforms-windows{% endblock %}
 

--- a/bedrock/products/templates/products/vpn/platforms/windows.html
+++ b/bedrock/products/templates/products/vpn/platforms/windows.html
@@ -8,7 +8,7 @@
 
 {% block page_title_full %}{{ ftl('vpn-windows-get-a-vpn') }}{% endblock %}
 
-{% block page_desc %}{{ ftl('vpn-windows-protect-your-windows') }}{% endblock %}
+{% block page_desc %}{{ ftl('vpn-windows-protect-your-windows', fallback=vpn-windows-protect-your-windows-v2') }}{% endblock %}
 
 {% block body_id %}mozilla-vpn-platforms-windows{% endblock %}
 

--- a/l10n/en/products/vpn/platforms/windows_v2.ftl
+++ b/l10n/en/products/vpn/platforms/windows_v2.ftl
@@ -6,7 +6,9 @@
 
 # New strings for updated page
 vpn-windows-get-a-vpn = Get a VPN for Windows from { -brand-name-mozilla }
+# Obsolete string (expires 2025-12-19)
 vpn-windows-protect-your-windows = Protect your Windows device with a VPN. { -brand-name-mozilla } VPN is backed by a non-for-profit company. Learn about how a VPN protects you and why you should trust { -brand-name-mozilla } with your privacy and security.
+vpn-windows-protect-your-windows-v2 = Protect your Windows device with a VPN. { -brand-name-mozilla-vpn } is backed by a non-for-profit company. Learn about how a VPN protects you and why you should trust { -brand-name-mozilla } with your privacy and security.
 vpn-windows-stay-safe = Stay safe and secure on your Windows device with a VPN
 vpn-windows-windows-is-one = Windows is one of the most popular operating systems in the world. As a result, Windows devices are usually highly targeted by hackers and may be especially vulnerable if you don’t take proper precautions. You can protect your digital life by using a VPN to encrypt your online activity, as well as some other steps such as, keeping your software up to date, creating unique and strong passwords, and using { -brand-name-relay } masks to keep your email protected.
 vpn-windows-a-vpn-creates = A VPN creates an encrypted “tunnel” for your internet data between your Windows computer and the internet, and masks your location from the websites you visit. This helps to prevent third parties and network spies from learning things about you that they don’t need to know.


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR update VPN branding l10n string to be `{ -brand-name-mozilla-vpn }`

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16496

## Testing

