### PR TITLE
firefox link style regression fix (fix #16508)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menus-refresh/firefox.html
@@ -6,7 +6,7 @@
 
  {% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=nav&utm_content=firefox' %}
 
-<li class="m24-c-menu-category">
+<li class="m24-c-menu-category m24-c-menu-category-has-icon">
   <a class="m24-c-menu-title" href="{{ settings.FXC_BASE_URL }}?{{ utm_params }}" data-testid="m24-navigation-link-firefox">
     <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" class="m24-c-menu-title-icon" width="16" height="16" alt="">
     {{ ftl('navigation-refresh-firefox-browsers') }}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes the firefox link style regression in navigation.

## Significant changes and points to review

Navigation Firefox link.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16508

## Testing

http://localhost:8000/en-US/