### PR TITLE
Stop serving cve-feed.json

### DIFF
--- a/bedrock/security/redirects.py
+++ b/bedrock/security/redirects.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from bedrock.redirects.util import redirect
+from bedrock.redirects.util import gone, redirect
 
 redirectpatterns = (
     # bug 818323
@@ -16,4 +16,6 @@ redirectpatterns = (
     redirect(
         r"^security/iSECPartners_Phishing\.pdf$", "http://website-archive.mozilla.org/www.mozilla.org/security/security/iSECPartners_Phishing.pdf"
     ),
+    # issue 16519
+    gone(r"^security/advisories/cve-feed\.json$"),
 )


### PR DESCRIPTION
## One-line summary

Sends 410 Gone for the Mitre CVE feed.

## Significant changes and points to review

Removal of the app would be a next step, after verifying there are no consumers relying on this endpoint.

## Issue / Bugzilla link

#16519

## Testing

http://localhost:8000/security/advisories/cve-feed.json