### PR TITLE
update mobile styles for 404 pages (fix #16522)

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -27,15 +27,21 @@
     <ul class="content-list">
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-        {{ ftl('not-found-page-learn-about-mozilla-the-non', about=url('mozorg.about.index')) }}
+        <span>
+          {{ ftl('not-found-page-learn-about-mozilla-the-non', about=url('mozorg.about.index')) }}
+        </span>
       </li>
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
-        {{ ftl('not-found-page-download-the-firefox-browser', download="https://www.firefox.com/") }}
+        <span>
+          {{ ftl('not-found-page-download-the-firefox-browser', download="https://www.firefox.com/") }}
+        </span>
       </li>
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
-        {{ ftl('not-found-page-donate-to-mozilla-reclaim-from-v2', fallback='not-found-page-donate-to-mozilla-reclaim-from', donate='href="%s"'|safe|format(donate_url(location='donate-404'))) }}
+        <span>
+          {{ ftl('not-found-page-donate-to-mozilla-reclaim-from-v2', fallback='not-found-page-donate-to-mozilla-reclaim-from', donate='href="%s"'|safe|format(donate_url(location='donate-404'))) }}
+        </span>
       </li>
     </ul>
   </main>

--- a/bedrock/base/templates/base-error.html
+++ b/bedrock/base/templates/base-error.html
@@ -18,7 +18,6 @@
       <a class="logo-mozilla" href="{{ url('mozorg.home') }}">
         <img class="c-navigation-logo-image" src="{{ static('img/logos/m24/lockup-black.svg') }}" alt="{{ ftl('error-page-mozilla') }}"  width="192" height="46">
       </a>
-      <a class="logo-firefox" href="https://www.firefox.com/"><img src="{{ static('protocol/img/logos/firefox/logo-word-hor.svg') }}" alt="{{ ftl('error-page-firefox') }}" width="140"></a>
     </div>
   </div>
 </header>

--- a/bedrock/careers/templates/careers/404.html
+++ b/bedrock/careers/templates/careers/404.html
@@ -30,15 +30,21 @@
     <ul class="content-list">
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/mozilla.svg') }}" width="30" height="30">
-        <a href="{{ url('mozorg.about.index') }}">Learn</a> about Mozilla, the not-for-profit behind Firefox.
+        <span>
+          <a href="{{ url('mozorg.about.index') }}">Learn</a> about Mozilla, the not-for-profit behind Firefox.
+        </span>
       </li>
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/desktop.svg') }}" width="30" height="30">
-        <a href="https://www.firefox.com/">Download</a> the Firefox browser for your mobile device or desktop.
+        <span>
+          <a href="https://www.firefox.com/">Download</a> the Firefox browser for your mobile device or desktop.
+        </span>
       </li>
       <li>
         <img class="list-icon" alt="" src="{{ static('protocol/img/icons/default-browser.svg') }}" width="30" height="30">
-        <a href="{{ donate_url(location='donate-404') }}">Donate</a> to Mozilla Foundation and reclaim the internet from big tech.
+        <span>
+          <a href="{{ donate_url(location='donate-404') }}">Donate</a> to Mozilla Foundation and reclaim the internet from big tech.
+        </span>
       </li>
     </ul>
   </main>

--- a/media/css/base/page-not-found.scss
+++ b/media/css/base/page-not-found.scss
@@ -13,20 +13,6 @@
     .header-image {
         .logo-mozilla {
             display: inline-block;
-
-            &::after {
-                @include bidi(((float, right, left),));
-                background: $color-marketing-gray-30;
-                content: '';
-                height: 60px;
-                margin: -10px $spacing-lg 0;
-                width: 2px;
-            }
-        }
-
-        .logo-firefox {
-            @include bidi(((transform, translateX(-5px), translateX(5px)),));
-            display: inline-block;
         }
     }
 }
@@ -50,6 +36,9 @@
 
     & > li {
         margin-bottom: $spacing-lg;
+        display: flex;
+        justify-content: flex-start;
+        align-items: flex-start;
     }
 
     a:link,
@@ -61,8 +50,8 @@
 
     .list-icon {
         @include bidi((
-            (padding-left, auto, $spacing-md),
-            (padding-right, $spacing-md, auto),
+            (padding-left, unset, $spacing-md),
+            (padding-right, $spacing-md, unset),
         ));
         vertical-align: top;
     }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the mobile styles for 404 pages

## Significant changes and points to review

- Firefox logo removal
- list alignment

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16522

## Testing

http://localhost:8000/en-US/404/
http://localhost:8000/en-US/careers/404/