### PR TITLE
update career pages theme (fix #16503)

### DIFF
--- a/media/css/careers/components/hero-text.scss
+++ b/media/css/careers/components/hero-text.scss
@@ -8,7 +8,7 @@
 // Header with no video
 .c-careers-text-hero {
     background-color: $color-black;
-    color: cp.$blue-primary;
+    color: $color-white;
 
     h1 {
         color: $color-white;

--- a/media/css/careers/components/hero-video.scss
+++ b/media/css/careers/components/hero-video.scss
@@ -21,7 +21,7 @@
         position: relative;
 
         .overlay {
-            background-color: rgba(0, 256, 256, 0.8);
+            background-color: rgba(255, 255, 255, 0.9);
             content: '';
             display: block;
             height: 100%;

--- a/media/css/careers/components/home.scss
+++ b/media/css/careers/components/home.scss
@@ -8,7 +8,7 @@
 
 .c-careers-intro {
     background-color: $color-black;
-    color: cp.$blue-primary;
+    color: $color-white;
 
     h2 {
         color: $color-white;


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the color theme for career pages.

## Significant changes and points to review

- hero overloay
- hero text color
- callout text color

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16503

## Testing

http://localhost:8000/en-US/careers/
http://localhost:8000/en-US/careers/listings/