### PR TITLE
Add autocomplete attributes for email input fields

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -147,7 +147,7 @@
     <div class="fxa-email-field-container">
       <div class="mzp-c-field mzp-l-stretch">
         <label class="mzp-c-field-label" for="fxa-email-field">{{ ftl('fxa-form-email-address') }}</label>
-        <input type="email" name="email" id="fxa-email-field" class="mzp-c-field-control" placeholder="user@example.com" required data-testid="fxa-form-email-field">
+        <input type="email" name="email" id="fxa-email-field" class="mzp-c-field-control" placeholder="user@example.com" autocomplete="email" required data-testid="fxa-form-email-field">
       </div>
 
       <div class="mzp-c-button-container mzp-l-stretch">

--- a/bedrock/firefox/templates/firefox/includes/send-to-device.html
+++ b/bedrock/firefox/templates/firefox/includes/send-to-device.html
@@ -41,7 +41,7 @@
               {{ ftl('send-to-device-enter-your-email') }}
             {% endif %}
           </label>
-          <input id="{{ dom_id }}-input" class="mzp-c-field-control send-to-device-input" name="email" type="text" required data-testid="send-to-device-form-email-field">
+          <input id="{{ dom_id }}-input" class="mzp-c-field-control send-to-device-input" name="email" type="email" autocomplete="email" placeholder="{{ ftl('send-to-device-enter-your-email') }}" required data-testid="send-to-device-form-email-field">
         </div>
         <div class="mzp-c-button-container mzp-l-stretch">
           <button type="submit" class="button mzp-c-button {% if button_class %} {{ button_class }} {% else %} mzp-t-product {% endif %}" data-testid="send-to-device-form-submit-button">

--- a/bedrock/firefox/templates/firefox/includes/send-to-device.html
+++ b/bedrock/firefox/templates/firefox/includes/send-to-device.html
@@ -41,7 +41,7 @@
               {{ ftl('send-to-device-enter-your-email') }}
             {% endif %}
           </label>
-          <input id="{{ dom_id }}-input" class="mzp-c-field-control send-to-device-input" name="email" type="email" autocomplete="email" placeholder="{{ ftl('send-to-device-enter-your-email') }}" required data-testid="send-to-device-form-email-field">
+          <input id="{{ dom_id }}-input" class="mzp-c-field-control send-to-device-input" name="email" type="email" autocomplete="email" placeholder="{{ ftl('send-to-device-email-placeholder') }}" required data-testid="send-to-device-form-email-field">
         </div>
         <div class="mzp-c-button-container mzp-l-stretch">
           <button type="submit" class="button mzp-c-button {% if button_class %} {{ button_class }} {% else %} mzp-t-product {% endif %}" data-testid="send-to-device-form-submit-button">

--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -68,7 +68,7 @@ Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestF
 
         <div>
           <label for="id_email">Email</label>
-          <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" data-testid="newsletter-email-input">
+          <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" autocomplete="email" placeholder="user@example.com" data-testid="newsletter-email-input">
         </div>
 
         <div id="newsletter-details" class="mzp-c-newsletter-details">

--- a/bedrock/mozorg/templates/mozorg/antiharassment-tool.html
+++ b/bedrock/mozorg/templates/mozorg/antiharassment-tool.html
@@ -113,7 +113,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <label for="id_email">
           What is your email address?
         </label>
-        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true"
+        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" autocomplete="email"
           placeholder="yourname@example.com">
       </div>
       <div id="newsletter-details" class="mzp-c-newsletter-details">

--- a/bedrock/products/templates/products/vpn/invite.html
+++ b/bedrock/products/templates/products/vpn/invite.html
@@ -51,7 +51,7 @@
           {{ ftl('vpn-landing-invite-email-label') }}
           <em class="mzp-c-fieldnote">{{ ftl('vpn-landing-invite-required-label') }}</em>
         </label>
-        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" placeholder="{{ ftl('vpn-landing-invite-email-placeholder') }}" data-testid="vpn-invite-email-input">
+        <input type="email" class="mzp-js-email-field" id="id_email" name="email" required aria-required="true" autocomplete="email" placeholder="{{ ftl('vpn-landing-invite-email-placeholder') }}" data-testid="vpn-invite-email-input">
       </div>
 
       <div id="newsletter-details" class="mzp-c-newsletter-details">

--- a/l10n/en/send_to_device.ftl
+++ b/l10n/en/send_to_device.ftl
@@ -7,6 +7,8 @@ send-to-device-your-download-link = Your download link was sent.
 send-to-device-please-enter-an-email = Please enter an email address.
 send-to-device-an-error-occured = An error occurred in our system. Please try again later.
 send-to-device-enter-your-email = Enter your email
+# Only localize "yourname". Do not change "@example.com".
+send-to-device-email-placeholder = yourname@example.com
 send-to-device-send = Send
 send-to-device-intended-recipient-email = The intended recipient of the email must have consented.
 send-to-device-check-your-device-email = Check your device for the email!


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._

## One-line summary
Add different attributes to email input fields across templates to resolve DevTools warnings.

## Issue / Bugzilla link
Fixes #15889 

## Testing
- [x] Confirm DevTools shows no autocomplete warnings
- [x] Test existing form functionality is preserved