### PR TITLE
fix(attribution): Allow passing attribution parameters to SubPlat 3 (VPN-7226)

### DIFF
--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -13,6 +13,7 @@ const _allowedDomains = [
     'https://guardian-dev.herokuapp.com/',
     'https://monitor.mozilla.org/',
     'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
+    'https://payments.firefox.com/',
     'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
     'https://vpn.mozilla.org/'
 ];

--- a/media/js/base/fxa-coupon.es6.js
+++ b/media/js/base/fxa-coupon.es6.js
@@ -9,7 +9,8 @@ const FxaCoupon = {};
 const _allowedDomains = [
     'accounts.firefox.com',
     'accounts.stage.mozaws.net',
-    'payments-next.stage.fxa.nonprod.webservices.mozgcp.net'
+    'payments-next.stage.fxa.nonprod.webservices.mozgcp.net',
+    'payments.firefox.com'
 ];
 
 FxaCoupon.getCoupon = (url) => {

--- a/media/js/base/fxa-product-button.es6.js
+++ b/media/js/base/fxa-product-button.es6.js
@@ -13,6 +13,7 @@ const allowedList = [
     'https://guardian-dev.herokuapp.com/',
     'https://monitor.mozilla.org/',
     'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
+    'https://payments.firefox.com/',
     'https://relay.firefox.com/',
     'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
     'https://vpn.mozilla.org/'


### PR DESCRIPTION
## One-line summary
Allow passing attribution parameters to SubPlat 3's new `payments.firefox.com` domain.

## Significant changes and points to review
SubPlat 3 pages are hosted on the `payments.firefox.com` domain rather than `accounts.firefox.com` like before, so the new `payments.firefox.com` domain should be allowed to receive attribution parameters like the `accounts.firefox.com` is.


## Issue / Bugzilla link
* [VPN-7226](https://mozilla-hub.atlassian.net/browse/VPN-7226): Fix attribution problem in Mozilla VPNs website


## Testing
* Upon landing on the [Mozilla VPN product page](https://www.mozilla.org/en-US/products/vpn/) with any of the Bedrock-supported UTM parameters, clicking on the "Get annual subscription" and "Get monthly subscription" links should take users to the SubPlat 3.0 URL with the same UTM parameter values propagated through.