### PR TITLE
Stop serving cve-feed.json on any path

### DIFF
--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -28,8 +28,8 @@ urlpatterns = (
     path("bug-bounty/web-hall-of-fame/", HallOfFameView.as_view(program="web"), name="security.bug-bounty.web-hall-of-fame"),
     path("advisories/", AdvisoriesView.as_view(), name="security.advisories"),
     re_path(r"^advisories/mfsa(?P<pk>\d{4}-\d{2,3})/$", AdvisoryView.as_view(), name="security.advisory"),
-    # issue 16519
-    #re_path(r"^advisories/cve-feed\.json$", mitre_cve_feed, name="security.advisories.cve_feed"),
+    # FIXME: remove via issue 16519
+    # re_path(r"^advisories/cve-feed\.json$", mitre_cve_feed, name="security.advisories.cve_feed"),
     page("known-vulnerabilities/", "security/known-vulnerabilities.html"),
     page("known-vulnerabilities/older-vulnerabilities/", "security/older-vulnerabilities.html"),
     re_path(r"^known-vulnerabilities/(?P<slug>[a-z-]+)/$", ProductView.as_view(), name="security.product-advisories"),

--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -14,7 +14,6 @@ from bedrock.security.views import (
     OldAdvisoriesView,
     ProductVersionView,
     ProductView,
-    mitre_cve_feed,
 )
 
 urlpatterns = (
@@ -29,7 +28,8 @@ urlpatterns = (
     path("bug-bounty/web-hall-of-fame/", HallOfFameView.as_view(program="web"), name="security.bug-bounty.web-hall-of-fame"),
     path("advisories/", AdvisoriesView.as_view(), name="security.advisories"),
     re_path(r"^advisories/mfsa(?P<pk>\d{4}-\d{2,3})/$", AdvisoryView.as_view(), name="security.advisory"),
-    re_path(r"^advisories/cve-feed\.json$", mitre_cve_feed, name="security.advisories.cve_feed"),
+    # issue 16519
+    #re_path(r"^advisories/cve-feed\.json$", mitre_cve_feed, name="security.advisories.cve_feed"),
     page("known-vulnerabilities/", "security/known-vulnerabilities.html"),
     page("known-vulnerabilities/older-vulnerabilities/", "security/older-vulnerabilities.html"),
     re_path(r"^known-vulnerabilities/(?P<slug>[a-z-]+)/$", ProductView.as_view(), name="security.product-advisories"),


### PR DESCRIPTION
## One-line summary

Hides the json URL to start sending 404s to users before complete decommissioning.

## Significant changes and points to review

Currently gone() redirect helpers don't handle locale prefixes, so a path removal is necessary to send error codes on all the locale prefixes for the feed path.

## Issue / Bugzilla link

#16519

## Testing

/pt-CV/security/advisories/cve-feed.json