### PR TITLE
Fix WNP attribution of major_version

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/base-new-theme.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base-new-theme.html
@@ -6,6 +6,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 {% set major_version = version.split('.')[0] %}
 
+{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
+
 {% if LANG == 'fr' %}
   {% set footer_portions_of_this_content = "Certaines parties de ce contenu sont ©1998–2025 par les contributeurs individuels de mozilla.org. <br> Ce contenu est disponible sous <a class='wnp-footer-link' rel='license' href='/fr/foundation/licensing/website-content/'>licence Creative Commons</a>." %}
   {% set donate_cta = "Faire un don à la Fondation Mozilla" %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx142.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx142.html
@@ -7,8 +7,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {# The 142 release is a new design, so we use a new base template #}
 {% extends "firefox/whatsnew/base-new-theme.html" %}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
-
 {% block wnp_content %}
 <div class="wnp-page">
   <main class="wnp-main">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx142.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx142.html
@@ -7,7 +7,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {# The 142 release is a new design, so we use a new base template #}
 {% extends "firefox/whatsnew/base-new-theme.html" %}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp142' %}
+{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
 
 {% block wnp_content %}
 <div class="wnp-page">
@@ -213,7 +213,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <div class="wnp-qr">
           <div class="wnp-qr-layout">
             <div class="wnp-qr-media" aria-hidden="true">
-              <div class="wnp-qr-qr" data-href="https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-{{ major_version }}" aria-label="QR code to download Firefox Mobile" role="img">{{ qrcode("https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-{{ major_version }}", 12) }}</div>
+              <div class="wnp-qr-qr" data-href="https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-{{ major_version }}" aria-label="QR code to download Firefox Mobile" role="img">{{ qrcode("https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-" ~ major_version, 12) }}</div>
             </div>
             <div class="wnp-qr-content">
               <div class="wnp-qr-content-inner">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-row.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-row.html
@@ -7,7 +7,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {# We use a new base template introduced with WNP142 #}
 {% extends "firefox/whatsnew/base-new-theme.html" %}
 
-{% set params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp143' %}
+{% set params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
 
 {% if LANG == 'de' %}
   {% set hero_eyebrow = 'Was gibt’s Neues?' %}
@@ -258,7 +258,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <div class="wnp-qr">
           <div class="wnp-qr-layout">
             <div class="wnp-qr-media" aria-hidden="true">
-              <div class="wnp-qr-qr" data-href="https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-143" role="img">{{ qrcode("https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-143", 12) }}</div>
+              <div class="wnp-qr-qr" data-href="https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-{{ major_version }}" role="img">{{ qrcode("https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-" ~ major_version, 12) }}</div>
             </div>
             <div class="wnp-qr-content">
               <div class="wnp-qr-content-inner">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-row.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-row.html
@@ -7,8 +7,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {# We use a new base template introduced with WNP142 #}
 {% extends "firefox/whatsnew/base-new-theme.html" %}
 
-{% set params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
-
 {% if LANG == 'de' %}
   {% set hero_eyebrow = 'Was gibt’s Neues?' %}
   {% set hero_title = 'Suche, was du siehst mit visueller Suche' %}
@@ -201,7 +199,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
             <p class="wnp-feature-eyebrow">{{ feature_2_eyebrow }}</p>
             <h3 class="wnp-subtitle">{{ feature_2_title }}</h3>
             <p class="wnp-body">{{ feature_2_body | safe }}</p>
-            <div class="wnp-btn-wrap"><a class="wnp-button wnp-button-outline" href="{{ feature_2_link }}{{ params }}" data-cta-text="Learn more - unload tabs">{{ learn_more }}
+            <div class="wnp-btn-wrap"><a class="wnp-button wnp-button-outline" href="{{ feature_2_link }}?{{ utm_params }}" data-cta-text="Learn more - unload tabs">{{ learn_more }}
                 <span class="wnp-button-icon wnp-button-icon-arrow" aria-hidden="true"></span>
               </a>
             </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-us.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-us.html
@@ -11,8 +11,6 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   {{ css_bundle('firefox_whatsnew_143') }}
 {% endblock %}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
-
 {% block wnp_content %}
 <div class="wnp-page">
   <main class="wnp-main">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-us.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx143-us.html
@@ -7,11 +7,11 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% extends "firefox/whatsnew/base-new-theme.html" %}
 
 {% block site_css %}
-  {{ css_bundle('firefox_whatsnew_new_theme') }}
+  {{ super() }}
   {{ css_bundle('firefox_whatsnew_143') }}
 {% endblock %}
 
-{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp143' %}
+{% set utm_params = 'utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp' ~ major_version %}
 
 {% block wnp_content %}
 <div class="wnp-page">
@@ -150,7 +150,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <div class="wnp-qr">
           <div class="wnp-qr-layout">
             <div class="wnp-qr-media">
-              <div class="wnp-qr-qr" data-href="https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-{{ major_version }}" aria-label="QR code to download Firefox Mobile" role="img">{{ qrcode("https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-143", 12) }}</div>
+              <div class="wnp-qr-qr" data-href="https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-{{ major_version }}" aria-label="QR code to download Firefox Mobile" role="img">{{ qrcode("https://www.mozilla.org/firefox/browsers/mobile/app/?product=firefox&campaign=whatsnew-" ~ major_version, 12) }}</div>
             </div>
             <div class="wnp-qr-content">
               <div class="wnp-qr-content-inner">


### PR DESCRIPTION
## One-line summary

Fixes a campaign bug in the generated QR code, and updates other hardcoded places that avoided said bug.

## Significant changes and points to review

Fixes QR code attribution in refresh template. Moves the following ones to that pattern.

Uses inheritance where possible to keep things in one place.

## Issue / Bugzilla link

Fixes #16574

## Testing

http://localhost:8000/en-US/firefox/142.0/whatsnew/
http://localhost:8000/en-US/firefox/143.0/whatsnew/
http://localhost:8000/en-GB/firefox/143.0/whatsnew/