### PR TITLE
feat: Parse advisories without a description correctly

### DIFF
--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -141,7 +141,7 @@ def add_or_update_cve(data):
             "title": cve_title,
             "impact": advisory["impact"] or "",
             "reporter": advisory["reporter"] or "",
-            "description": advisory["description"] or "",
+            "description": advisory.get("description") or "",
             "bugs": advisory["bugs"],
         }
         try:


### PR DESCRIPTION
Fix parsing of CVEs without a description