### PR TITLE
Update VPN subscription URLs (Fix #16564)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1233,7 +1233,7 @@ VPN_SUBSCRIPTION_URL = config("VPN_SUBSCRIPTION_URL", default="https://accounts.
 # New URL for VPN subscription links
 # ***This URL *MUST* end in a trailing slash!***
 VPN_SUBSCRIPTION_URL_NEXT = config(
-    "VPN_SUBSCRIPTION_URL_NEXT", default="https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/" if DEV else "https://payments.firefox.com/"
+    "VPN_SUBSCRIPTION_URL_NEXT", default="https://payments-next.allizom.org/" if DEV else "https://payments.firefox.com/"
 )
 
 # For testing/QA we support a test 'daily' API endpoint on the staging API only

--- a/media/js/base/fxa-attribution.es6.js
+++ b/media/js/base/fxa-attribution.es6.js
@@ -12,7 +12,7 @@ const _allowedDomains = [
     'https://getpocket.com/',
     'https://guardian-dev.herokuapp.com/',
     'https://monitor.mozilla.org/',
-    'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
+    'https://payments-next.allizom.org/',
     'https://payments.firefox.com/',
     'https://stage.guardian.nonprod.cloudops.mozgcp.net/',
     'https://vpn.mozilla.org/'

--- a/media/js/base/fxa-coupon.es6.js
+++ b/media/js/base/fxa-coupon.es6.js
@@ -9,7 +9,7 @@ const FxaCoupon = {};
 const _allowedDomains = [
     'accounts.firefox.com',
     'accounts.stage.mozaws.net',
-    'payments-next.stage.fxa.nonprod.webservices.mozgcp.net',
+    'payments-next.allizom.org',
     'payments.firefox.com'
 ];
 

--- a/media/js/base/fxa-product-button.es6.js
+++ b/media/js/base/fxa-product-button.es6.js
@@ -12,7 +12,7 @@ const allowedList = [
     'https://getpocket.com/',
     'https://guardian-dev.herokuapp.com/',
     'https://monitor.mozilla.org/',
-    'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
+    'https://payments-next.allizom.org/',
     'https://payments.firefox.com/',
     'https://relay.firefox.com/',
     'https://stage.guardian.nonprod.cloudops.mozgcp.net/',


### PR DESCRIPTION
## One-line summary

Update VPN subscription URLs

## Issue / Bugzilla link

Fix #16564 

## Testing

Test links for annual and monthly subscriptions (the URLs forward so inspect source to see they're inserted properly)

http://localhost:8000/en-US/products/vpn/ 

_Note: this is for staging so make sure you're not in prod mode._