### PR TITLE
remove experiment from US VPN landing page (#16562)

### DIFF
--- a/tests/playwright/specs/products/vpn/vpn-landing.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-landing.spec.js
@@ -9,15 +9,11 @@
 const { test, expect } = require('@playwright/test');
 const openPage = require('../../../scripts/open-page');
 const url = '/en-US/products/vpn/';
-const availableCountries = ['us', 'ca', 'gb', 'de', 'fr'];
+const availableCountries = ['ca', 'gb', 'de', 'fr'];
 const mobileOnlyCountries = ['au', 'in', 'mx', 'ua'];
 const androidOnlyCountries = ['br', 'ma'];
 const unavailableCountries = ['cn'];
 const vpnBundleAvailableCountry = ['us'];
-const experimentVariant =
-    '&entrypoint_experiment=vpn-landing-bundle-promo&entrypoint_variation=c';
-const experimenControltVariant =
-    '&entrypoint_experiment=vpn-landing-bundle-promo&entrypoint_variation=a';
 
 test.describe(
     `${url} page`,
@@ -27,23 +23,9 @@ test.describe(
     () => {
         for (const country of availableCountries) {
             test.describe('VPN available', () => {
-                if (country === 'us') {
-                    test.beforeEach(async ({ page, browserName }) => {
-                        await openPage(
-                            url + `?geo=${country}${experimenControltVariant}`,
-                            page,
-                            browserName
-                        );
-                    });
-                } else {
-                    test.beforeEach(async ({ page, browserName }) => {
-                        await openPage(
-                            url + `?geo=${country}`,
-                            page,
-                            browserName
-                        );
-                    });
-                }
+                test.beforeEach(async ({ page, browserName }) => {
+                    await openPage(url + `?geo=${country}`, page, browserName);
+                });
 
                 test(`Country code: ${country}`, async ({ page }) => {
                     const getVpnHeroButton = page.getByTestId(
@@ -339,8 +321,7 @@ test.describe(
             test.describe('VPN bundle available', () => {
                 test.beforeEach(async ({ page, browserName }) => {
                     await openPage(
-                        url +
-                            `?geo=${vpnBundleAvailableCountry}${experimentVariant}`,
+                        url + `?geo=${vpnBundleAvailableCountry}`,
                         page,
                         browserName
                     );


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR removes the VPN bundle related experiment from the tests.

## Significant changes and points to review

Integration tests should all pass

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/actions/runs/17810374722
https://github.com/mozilla/bedrock/issues/16562

## Testing

`cd tests/playwright && npm run integration-tests`