### PR TITLE
fix VPN bundle icon glitch (fix #16551)

### DIFF
--- a/media/css/products/vpn/bundle-promo.scss
+++ b/media/css/products/vpn/bundle-promo.scss
@@ -223,26 +223,31 @@
                             }
                         }
 
-                        .bundle-option-icon {
-                            background-repeat: no-repeat;
-                            background-size: 100%;
-                            display: inline-block;
-                            height: 20px;
-                            width: 20px;
+                        @supports (mask-image: url('logo.svg')) {
+                            .bundle-option-icon {
+                                background-color: currentColor; // match the color property
+                                background-repeat: no-repeat;
+                                background-size: 100%;
+                                display: inline-block;
+                                height: 20px;
+                                width: 20px;
 
-                            &.option-vpn {
-                                background-image: url('/media/img/logos/vpn/logo.svg');
-                            }
+                                &.option-vpn {
+                                    -webkit-mask-image: url('/media/img/logos/vpn/logo.svg');
+                                    mask-image: url('/media/img/logos/vpn/logo.svg');
+                                }
 
-                            &.option-monitor {
-                                background-image: url('/media/img/logos/monitor/logo.svg');
-                            }
+                                &.option-monitor {
+                                    -webkit-mask-image: url('/media/img/logos/monitor/logo.svg');
+                                    mask-image: url('/media/img/logos/monitor/logo.svg');
+                                }
 
-                            &.option-relay {
-                                background-image: url('/media/img/logos/relay/logo.svg');
+                                &.option-relay {
+                                    -webkit-mask-image: url('/media/img/logos/relay/logo.svg');
+                                    mask-image: url('/media/img/logos/relay/logo.svg');
+                                }
                             }
                         }
-
                     }
 
                     strong {


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes the VPN bundle icon glitch on hover issue.

## Significant changes and points to review

US VPN landing

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16551

## Testing

http://localhost:8000/en-US/products/vpn/