### PR TITLE
Remove setting and hardcode all relnotes redirects to use 301

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -83,78 +83,78 @@ releasenotes_redirectpatterns = (
         # issue 14467; 16381
         r"^firefox/125\.0/releasenotes/?$",
         f"{settings.FXC_BASE_URL}/firefox/125.0.1/releasenotes/",
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         r"^firefox/38\.0\.3/releasenotes/$",
         f"{settings.FXC_BASE_URL}/firefox/38.0.5/releasenotes/",
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     # Redirects from Bedrock to Springfield in general
     offsite_redirect(
         f"^firefox/(?:{platform_re}/)?(?:{channel_re}/)?notes/$",
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         "firefox/nightly/notes/feed/",
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         "firefox/(?:latest/)?releasenotes/$",
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         "firefox/android/releasenotes/",
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         "firefox/ios/releasenotes/",
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         f"^firefox/(?:{platform_re}/)?(?:{channel_re}/)?system-requirements/$",
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         releasenotes_re,
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         android_releasenotes_re,
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         ios_releasenotes_re,
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         sysreq_re,
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         android_sysreq_re,
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         ios_sysreq_re,
         _redirect_to_same_path_on_fxc,
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
     offsite_redirect(
         "firefox/releases/$",
         f"{settings.FXC_BASE_URL}/releases/",  # leave Springfield to sort out the local redirect
-        permanent=settings.MAKE_RELNOTES_REDIRECTS_PERMANENT,
+        permanent=True,
     ),
 )
 

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -722,7 +722,7 @@ def test_offsite_redirects_still_work_when_locale_not_in_source_path(
 )
 def test_releasenotes_and_sysreq_redirects(client, path, expected):
     resp = client.get(path)
-    assert resp.status_code == 301 if settings.MAKE_RELNOTES_REDIRECTS_PERMANENT else 302
+    assert resp.status_code == 301
     assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{expected}"
 
 
@@ -742,5 +742,5 @@ def test_releasenotes_and_sysreq_redirects(client, path, expected):
 )
 def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(client, source_path, dest_path):
     resp = client.get(source_path)
-    assert resp.status_code == 301 if settings.MAKE_RELNOTES_REDIRECTS_PERMANENT else 302
+    assert resp.status_code == 301
     assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{dest_path}?redirect_source=mozilla-org"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2489,9 +2489,3 @@ if ENABLE_DJANGO_SILK := config("ENABLE_DJANGO_SILK", default="False", parser=bo
 # but if you use it without a path you must add a trailing slash to avoid a 302 at
 # the firefox.com end, because Django will append a trailing slash if it doesn't exist.
 FXC_BASE_URL = config("FXC_BASE_URL", default="https://www.firefox.com")
-
-MAKE_RELNOTES_REDIRECTS_PERMANENT = config(
-    "MAKE_RELNOTES_REDIRECTS_PERMANENT",
-    default="True",
-    parser=bool,
-)

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -8,7 +8,7 @@ import requests
 
 from .base import flatten, url_test
 
-RELNOTES_REDIRECT_STATUS_CODE = 301 if settings.MAKE_RELNOTES_REDIRECTS_PERMANENT else 302
+RELNOTES_REDIRECT_STATUS_CODE = 301
 
 UA_ANDROID = {"User-Agent": "Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) Gecko/51.0 Firefox/51.0"}
 UA_IOS = {"User-Agent": "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; de-de) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8F190"}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._

## Significant changes and points to review
- Removed `MAKE_RELNOTES_REDIRECTS_PERMANENT` setting and updated all relnotes redirect entries.
- Updated tests to expect 301 status codes


## Issue / Bugzilla link
Resolves #16481