### PR TITLE
Pin sass at 1.91.0 until mozilla/protocol#982

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       - dependency-name: '@mozmeao/cookie-helper'
       - dependency-name: '@mozmeao/dnt-helper'
       - dependency-name: '@mozmeao/trafficcop'
+      # Pin sass at 1.91.0 until mozilla/protocol#982
+      - dependency-name: 'sass'
       # Need to be kept in sync with pre-commit-config.yaml.
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-config-prettier'

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.2",
         "mini-css-extract-plugin": "^2.9.4",
-        "sass": "^1.91.0",
+        "sass": "1.91.0",
         "sass-loader": "^16.0.5",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^5.3.14",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.2",
     "mini-css-extract-plugin": "^2.9.4",
-    "sass": "^1.91.0",
+    "sass": "1.91.0",
     "sass-loader": "^16.0.5",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.14",


### PR DESCRIPTION
## Description

[1.92.0 will contain a breaking change](https://github.com/sass/sass/issues/3893#issuecomment-2248982984)

### Issue

mozilla/protocol#982

