### PR TITLE
(feat) Support a redirect to www.firefox.com for WNP 144.0

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -76,6 +76,16 @@ def _redirect_to_same_path_on_fxc(request, *args, **kwargs):
     return f"{settings.FXC_BASE_URL}{request.path}"
 
 
+wnp_redirectpatterns = (
+    # Note not an offsite_redirect, so no additional querystring is injected
+    redirect(
+        # issue 16590
+        r"^en-US/firefox/144\.0/whatsnew/?$",
+        f"{settings.FXC_BASE_URL}/en-US/whatsnew/144.0/",
+        permanent=True,
+    ),
+)
+
 releasenotes_redirectpatterns = (
     # Special-case redirects that existed before the Bedrock->Springfield redirects;
     # pulled together here in one place
@@ -798,4 +808,4 @@ bedrock_redirectpatterns = (
     redirect(r"^/firefox/?$", f"{FXC}/"),
 )
 
-redirectpatterns = releasenotes_redirectpatterns + bedrock_redirectpatterns + springfield_redirectpatterns
+redirectpatterns = wnp_redirectpatterns + releasenotes_redirectpatterns + bedrock_redirectpatterns + springfield_redirectpatterns

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -79,9 +79,9 @@ def _redirect_to_same_path_on_fxc(request, *args, **kwargs):
 wnp_redirectpatterns = (
     # Note not an offsite_redirect, so no additional querystring is injected
     redirect(
-        # issue 16590
-        r"^en-US/firefox/144\.0/whatsnew/?$",
-        f"{settings.FXC_BASE_URL}/en-US/whatsnew/144.0/",
+        # issue 16590 for WNP 144
+        r"^en-US/firefox/(?P<version>144\.\d+[.\d]*)/whatsnew/?$",
+        f"{settings.FXC_BASE_URL}/en-US/whatsnew/" + "{version}/",
         permanent=True,
     ),
 )

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -744,3 +744,27 @@ def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(clie
     resp = client.get(source_path)
     assert resp.status_code == 301 if settings.MAKE_RELNOTES_REDIRECTS_PERMANENT else 302
     assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{dest_path}?redirect_source=mozilla-org"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "source_path, dest_path",
+    (
+        (
+            "/en-US/firefox/144.0/whatsnew/",
+            "/en-US/whatsnew/144.0/",
+        ),
+        (
+            "/en-US/firefox/144.0/whatsnew/?query=string.here",
+            "/en-US/whatsnew/144.0/?query=string.here",
+        ),
+        (
+            "/en-US/firefox/144.0/whatsnew/?query=string.here&with=extra",
+            "/en-US/whatsnew/144.0/?query=string.here&with=extra",
+        ),
+    ),
+)
+def test_wnp144_redirects_to_fxc(client, source_path, dest_path):
+    resp = client.get(source_path)
+    assert resp.status_code == 301 if settings.MAKE_RELNOTES_REDIRECTS_PERMANENT else 302
+    assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{dest_path}"

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -755,6 +755,14 @@ def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(clie
             "/en-US/whatsnew/144.0/",
         ),
         (
+            "/en-US/firefox/144.0.1/whatsnew/",
+            "/en-US/whatsnew/144.0.1/",
+        ),
+        (
+            "/en-US/firefox/144.1.2/whatsnew/",
+            "/en-US/whatsnew/144.1.2/",
+        ),
+        (
             "/en-US/firefox/144.0/whatsnew/?query=string.here",
             "/en-US/whatsnew/144.0/?query=string.here",
         ),


### PR DESCRIPTION
Readying this redirect for WNP 144, which will be on www.firefox.com but we can't guarantee that all sources of the traffic from FF itself will be pointing straight to www.firefox.com, so this covers that angle - but only for `144.0`

## Significant changes and points to review

We need to double-check the destination path on www.firefox.com is definitely correct.

If it is, we can probably merge this now because there's an evergreen WNP waiting at the destination, thanks to @maureenlholland 

## Issue / Bugzilla link

Resolves #16590 

## Testing

- [x] http://localhost:8000/en-US/firefox/144.0/whatsnew/ redirects to https://www.firefox.com/en-US/whatsnew/144.0/
- [x] http://localhost:8000/en-US/firefox/144.1/whatsnew/ redirects to https://www.firefox.com/en-US/whatsnew/144.1/
- [x] http://localhost:8000/en-US/firefox/144.1.2/whatsnew/ redirects to https://www.firefox.com/en-US/whatsnew/144.1.2/
- [x] http://localhost:8000/en-US/firefox/144.0.2/whatsnew/ redirects to https://www.firefox.com/en-US/whatsnew/144.0.2/