### PR TITLE
remove WNP newsletter inline styles

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/newsletter_form.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/newsletter_form.html
@@ -36,9 +36,9 @@
           <select class="wnp-custom-select" name="{{ form.country.name }}" id="{{ form.country.id_for_label }}">
             <option value="" disabled selected>{{ ftl('newsletter-form-please-select-country') }}</option>
             {% for choice in form.country.field.choices %}
-            {% if choice.0 %}
-            <option value="{{ choice.0 }}">{{ choice.1 }}</option>
-            {% endif %}
+              {% if choice.0 %}
+                <option value="{{ choice.0 }}">{{ choice.1 }}</option>
+              {% endif %}
             {% endfor %}
           </select>
           <svg class="wnp-select-arrow" width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -84,7 +84,7 @@
     </div>
     {% set submit_label = 'Sign Up' if LANG.startswith('en-') else ftl('newsletter-form-sign-me-up') %}
     <button id="newsletter-submit" class="wnp-button wnp-button-outline" type="submit" disabled>{{ submit_label }}</button>
-    <div id="newsletter-details" style="display:block;"></div>
+    <div id="newsletter-details"></div>
     <div class="wnp-body wnp-form-feedback wnp-form-error mzp-c-form-errors hidden" id="newsletter-errors" data-testid="newsletter-error-message">
       <ul class="wnp-form-error-list mzp-u-list-styled">
         <li class="error-email-invalid hidden">{{ ftl('newsletter-form-please-enter-a-valid') }}</li>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR removes the new themed WNP newsletter inline styles.

## Significant changes and points to review

- WNP newsletter styles with new theme

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/16597

## Testing

http://localhost:8000/en-US/firefox/143.0/whatsnew/
`success@example.com` for successful submission
`failture@example.com` for error message
