### PR TITLE
Fixup css@supports url value to pass collectstatic and build

### DIFF
--- a/media/css/products/vpn/bundle-promo.scss
+++ b/media/css/products/vpn/bundle-promo.scss
@@ -223,7 +223,7 @@
                             }
                         }
 
-                        @supports (mask-image: url('logo.svg')) {
+                        @supports (mask-image: url('/media/img/logos/vpn/logo.svg')) {
                             .bundle-option-icon {
                                 background-color: currentColor; // match the color property
                                 background-repeat: no-repeat;


### PR DESCRIPTION
## One-line summary

Fixup bundle-promo css feature detection using a placeholder asset — as that is collected to be hashed and not found, failing the build.

## Significant changes and points to review

It has no function there really, but given it's a url() path, it's considered a resource necessary for hashing and deployment.

Using the first nearest asset instead to reference in here — that should be kept around for this functionality anyway.

## Issue / Bugzilla link

[/actions/runs/17957484179/job/51072450332](https://github.com/mozilla/bedrock/actions/runs/17957484179/job/51072450332#step:10:7233) ❌ 

## Testing

`make build-prod`