### PR TITLE
Add foundation newsletter copy behind switch

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -108,6 +108,12 @@
               <p>{{ ftl('newsletters-to-get-access-to-the-whole', url=url('mozorg.account')) }}</p>
 
               <p>{{ ftl('newsletters-there-are-many-ways-to', url=url('mozorg.about.forums.forums')) }}</p>
+
+              {% if switch('foundation-separate-newsletter') %}
+                <p>{{ ftl('newsletters-newsletter-subscriptions-for', foundation="https://www.mozillafoundation.org") }}</p>
+                <p>{{ ftl('newsletters-to-unsubscribe', unsubscribe="https://www.mozillafoundation.org/newsletter/unsubscribe") }}</p>
+                <p>{{ ftl('newsletters-if-you-arent-already-subscribed', subscribe="https://www.mozillafoundation.org/newsletter/subscribe") }}</p>
+              {% endif %}
             </aside>
           </div> <!-- close .basic-settings -->
         </div>

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -74,6 +74,18 @@ newsletters-to-get-access-to-the-whole = To get access to the whole world of { -
 newsletters-there-are-many-ways-to = There are many ways to engage with { -brand-name-mozilla } and { -brand-name-firefox }. If you didn’t find what you were looking for here, check out our <a href="{ $url }">community pages</a>.
 
 # Variables:
+#   $foundation (url) - link to https://www.mozillafoundation.org
+newsletters-newsletter-subscriptions-for = Newsletter subscriptions for <a href="{ $foundation }">{ -brand-name-mozilla-foundation }</a> are now managed separately.
+
+# Variables:
+#   $unsubscribe (url) - link to https://www.mozillafoundation.org/newsletter/unsubscribe
+newsletters-to-unsubscribe = To unsubscribe from a { -brand-name-mozilla-foundation } newsletter click here: <a href="{ $unsubscribe }">{ $unsubscribe }</a>.
+
+# Variables:
+#   $subscribe (url) - link to https://www.mozillafoundation.org/newsletter/subscribe
+newsletters-if-you-arent-already-subscribed = If you aren’t already subscribed and would like to stay updated, click here: <a href="{ $subscribe }">{ $subscribe }</a>.
+
+# Variables:
 #   $newsletter (string) - newsletter name
 newsletters-is-not-a-valid-newsletter = { $newsletter } is not a valid newsletter
 


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Adds new copy in `aside` section of newsletter pref center

## Significant changes and points to review
I left UTM params off for the external links, am not sure if they will interfere with subscribe/unsubscribe behaviour. These are the expected links but they are not in production yet for testing.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16582


## Testing
`./manage.py waffle_switch --create FOUNDATION_SEPARATE_NEWSLETTER on`
- [ ] http://localhost:8000/newsletter/existing/ has new copy (you may need to go to https://www.mozilla.org/en-US/newsletter/recovery/ to get the nl-token cookie value to see the pref center)
- [ ] `./manage.py waffle_switch FOUNDATION_SEPARATE_NEWSLETTER off` does not have new copy

https://mozmeao.github.io/platform-docs/newsletters/#urls

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/WT-280)
┆Priority: P2
┆Sprint: Backlog
