### PR TITLE
Fix l10n download tests for a subset of channels for now

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -95,7 +95,7 @@ def pytest_generate_tests(metafunc):
             product_urls = [a.attrib["href"] for a in doc("ul.c-product-list a")]
             # FIXME: sanity checks after first scene is redirected to FXC:
             if product_urls and product_urls[0].startswith("/en-US/download/all/"):
-                product_urls = ["/en-US/firefox/all/desktop-release/", "/en-US/firefox/all/desktop-nightly/"]
+                product_urls = ["/en-US/firefox/all/desktop-release/", "/en-US/firefox/all/desktop-esr/"]
             # If product url links outside of /firefox/all/ ignore it. (e.g. testflight)
             product_urls = [url for url in product_urls if url.startswith("/en-US/firefox/all/")]
             for url in product_urls:


### PR DESCRIPTION
## One-line summary

Removes Nightly from l10n download tests as i686 builds listed are no longer available.

## Significant changes and points to review

Following up from #16425 — the tests did their job and surfaced `firefox-145.0a1.*.linux-i686` are not available going forward. This will need resolving via #16367 but this gives us some sanity check utility of the tests otherwise running for a while now.

## Issue / Bugzilla link

https://bugzil.la/1987132
See also #16765, #16367

## Testing

`docker compose run test pytest --base-url https://www.mozilla.org -m download`