### PR TITLE
Expand scope of redirects for WNP 144 and above

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -76,12 +76,19 @@ def _redirect_to_same_path_on_fxc(request, *args, **kwargs):
     return f"{settings.FXC_BASE_URL}{request.path}"
 
 
+WNP_144_PLUS_RE = (
+    # Issues 16590 and 16791 for WNP 144+ Release (not Nightly, Beta/Developer or ESR)
+    r"^(?P<wnp_locale>en-US|en-GB|en-CA|fr|de)/firefox/"
+    r"(?P<major_version>1(?:4[4-9]|[5-9]\d|\d{3,4})|[2-9]\d{2,4})"
+    r"\.\d{1,3}(?:\.\d{1,3}){0,2}/whatsnew/?$"
+)
+
 wnp_redirectpatterns = (
     # Note not an offsite_redirect, so no additional querystring is injected
     redirect(
-        # issue 16590 for WNP 144
-        r"^en-US/firefox/(?P<version>144\.\d+[.\d]*)/whatsnew/?$",
-        f"{settings.FXC_BASE_URL}/en-US/whatsnew/" + "{version}/",
+        # Issues 16590 and 16791 for WNP 144+
+        WNP_144_PLUS_RE,
+        f"{settings.FXC_BASE_URL}/" + "{wnp_locale}/whatsnew/{major_version}/",
         permanent=True,
     ),
 )


### PR DESCRIPTION
## One-line summary

This changeset makes our redirect strategy for WNP 144 better, and sets a new destination path to match the CMS-based WNPs that are in the works

## Significant changes and points to review

This changeset does two main things

1. Expands the redirect to cover FF Release's WNP 144 for `en-US`, `en-CA`, `en-GB`, `fr` and `de`
2. Amends the version number to just be the main value (144, not 144.0), using that in the new URL structure of /LOCALE/whatsnew/VERSION/

Note that other locales and non-Release versions of FF 144 do not get redirected to www.firefox.com - we are only redirecting traffic that will benefit from the CMS-powered views.

## Issue / Bugzilla link

Resolves #16791

## Testing

You can test that the redirect happens (or does not) even if the destination page isn't live on www.firefox.com yet

- [x] https://www-demo6.allizom.org/en-US/firefox/144.0/whatsnew/  -> https://www.firefox.com/en-US/whatsnew/144/ (404 for now)
- [x] https://www-demo6.allizom.org/en-US/firefox/144.0.1/whatsnew/  -> https://www.firefox.com/en-US/whatsnew/144/ (404 for now)
- [x] https://www-demo6.allizom.org/en-GB/firefox/144.0/whatsnew/  -> https://www.firefox.com/en-GB/whatsnew/144/ (404 for now)
- [x] https://www-demo6.allizom.org/en-CA/firefox/144.0/whatsnew/  -> https://www.firefox.com/en-CA/whatsnew/144/ (404 for now)
- [x] https://www-demo6.allizom.org/fr/firefox/144.0/whatsnew/  -> https://www.firefox.com/fr/whatsnew/144/ (404 for now)
- [x] https://www-demo6.allizom.org/de/firefox/144.0/whatsnew/  -> https://www.firefox.com/de/whatsnew/144/ (404 for now)
- [x] https://www-demo6.allizom.org/es-ES/firefox/144.0/whatsnew/  -> no redirect because of locale
- [x] https://www-demo6.allizom.org/en-US/firefox/143.0/whatsnew/  -> no redirect because pre-144
- [x] https://www-demo6.allizom.org/en-US/firefox/145.0/whatsnew/  -> https://www.firefox.com/en-US/whatsnew/145/ (404 for now)
- [x] https://www-demo6.allizom.org/en-US/firefox/144.0a1/whatsnew/  -> no redirect because it's Nightly


