### PR TITLE
Fix a11y test issue (fixes #16787)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/advertising/includes/home-ads-solutions.html
+++ b/bedrock/mozorg/templates/mozorg/advertising/includes/home-ads-solutions.html
@@ -1,3 +1,9 @@
+{#
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <section class="mozads-c-home-solutions m24-c-content has-scroll-padding" id="solutions">
     <hgroup class="mozads-hgroup">
       <p class="mozads-eyebrow">Our Solutions</p>
@@ -5,12 +11,12 @@
     </hgroup>
 
     <div class="mozads-figure-grid reversed-on-large">
-      <aside class="mozads-stat">
+      <div class="mozads-stat">
         <span class="mozads-stat-text">
           <span class="mozads-stat-number">200M+</span>
           <span class="mozads-stat-label">monthly active Firefox users</span>
         </span>
-      </aside>
+      </div>
       <figure class="mozads-figure">
         {{ resp_img(
           url="img/mozorg/advertising/ads-solution-1.png",
@@ -27,12 +33,12 @@
     </div>
 
     <div class="mozads-figure-grid">
-      <aside class="mozads-stat">
+      <div class="mozads-stat">
         <span class="mozads-stat-text">
           <span class="mozads-stat-number">16.2M</span>
           <span class="mozads-stat-label">monthly active MDN users</span>
         </span>
-      </aside>
+      </div>
 
       <figure class="mozads-figure">
         {{ resp_img(


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Removes nested landmark semantics

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16787


## Testing
No visual regression in "Our Solutions" section: http://localhost:8000/en-US/advertising/#solutions

a11y tests pass
`cd tests/playwright && npm install && npm run install-deps` 
`npm run a11y-tests`