### PR TITLE
(feat) Back out WNP 144 redirect

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -84,13 +84,13 @@ WNP_144_PLUS_RE = (
 )
 
 wnp_redirectpatterns = (
-    # Note not an offsite_redirect, so no additional querystring is injected
-    redirect(
-        # Issues 16590 and 16791 for WNP 144+
-        WNP_144_PLUS_RE,
-        f"{settings.FXC_BASE_URL}/" + "{wnp_locale}/whatsnew/{major_version}/",
-        permanent=True,
-    ),
+    # # Note not an offsite_redirect, so no additional querystring is injected
+    # redirect(
+    #     # Issues 16590 and 16791 for WNP 144+
+    #     WNP_144_PLUS_RE,
+    #     f"{settings.FXC_BASE_URL}/" + "{wnp_locale}/whatsnew/{major_version}/",
+    #     permanent=True,
+    # ),
 )
 
 releasenotes_redirectpatterns = (

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -746,6 +746,7 @@ def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(clie
     assert resp.headers["Location"] == f"{settings.FXC_BASE_URL}{dest_path}?redirect_source=mozilla-org"
 
 
+@pytest.mark.skip("Disabled because bedrock.firefox.redirects.WNP_144_PLUS_RE is not in use")
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "source_path, expected_status_code, dest_path",


### PR DESCRIPTION
## One-line summary

Backs out the redirect to firefox.com for WNP 144 added in https://github.com/mozilla/bedrock/pull/16793

ONLY MERGE THIS IF WE KNOW ARE SURE WNP 144 WILL REMAIN ON MOZORG - https://github.com/mozilla/bedrock/pull/16798 is that work.

Will need to reach production ASAP after merging https://github.com/mozilla/bedrock/pull/16798

## Testing

These used to redirect but now will not

- [ ] https://www-demo6.allizom.org/en-US/firefox/144.0/whatsnew/
- [ ] https://www-demo6.allizom.org/en-US/firefox/144.0.1/whatsnew/
- [ ] https://www-demo6.allizom.org/en-GB/firefox/144.0/whatsnew/
- [ ] https://www-demo6.allizom.org/en-CA/firefox/144.0/whatsnew/
- [ ] https://www-demo6.allizom.org/fr/firefox/144.0/whatsnew/
- [ ] https://www-demo6.allizom.org/de/firefox/144.0/whatsnew/
- [ ] https://www-demo6.allizom.org/es-ES/firefox/144.0/whatsnew/
- [ ] https://www-demo6.allizom.org/en-US/firefox/143.0/whatsnew/
- [ ] https://www-demo6.allizom.org/en-US/firefox/145.0/whatsnew/
- [ ] https://www-demo6.allizom.org/en-US/firefox/144.0a1/whatsnew/
