### PR TITLE
Add switches around feature blocks with as-yet unpublished links

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx144.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx144.html
@@ -228,55 +228,61 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 <!-- Section 2: Headlines / Sub Features -->
     <section class="wnp-section" aria-labelledby="features-heading">
       <div class="wnp-container">
-        <h2 id="features-heading" class="wnp-subtitle text-center">{{ features_title }}</h2>
-        <p class="wnp-body wnp-is-centered">{{ features_subtitle }}</p>
+        {% if switch('wnp144-google-lens') and switch('wnp144-perplexity') %}
+          <h2 id="features-heading" class="wnp-subtitle text-center">{{ features_title }}</h2>
+          <p class="wnp-body wnp-is-centered">{{ features_subtitle }}</p>
+        {% endif %}
 
-        <div class="wnp-feature">
-          <div class="wnp-feature-media">
-            <div class="wnp-media-frame wnp-media-frame--settings">
-              {{resp_img(
-                url="img/firefox/wnp-144/google-lens.png",
-                srcset={
-                    "img/firefox/wnp-144/google-lens@2x.png": "2x",
-                },
-                optional_attributes={"l10n": True, "alt": "", "role": "presentation", "loading": "lazy"}
-            )}}
+        {% if switch('wnp144-google-lens') %}
+          <div class="wnp-feature">
+            <div class="wnp-feature-media">
+              <div class="wnp-media-frame wnp-media-frame--settings">
+                {{resp_img(
+                  url="img/firefox/wnp-144/google-lens.png",
+                  srcset={
+                      "img/firefox/wnp-144/google-lens@2x.png": "2x",
+                  },
+                  optional_attributes={"l10n": True, "alt": "", "role": "presentation", "loading": "lazy"}
+              )}}
+              </div>
+            </div>
+            <div class="wnp-feature-content">
+              <p class="wnp-feature-eyebrow">{{ google_lens_eyebrow }}</p>
+              <h3 class="wnp-subtitle">{{ google_lens_headline }}</h3>
+              <p class="wnp-body">{{ google_lens_body | safe }}</p>
+              <div class="wnp-btn-wrap">
+                <a class="wnp-button wnp-button-outline" href="https://support.mozilla.org/kb/search-web-images-firefox-google-lens?{{ utm_params }}" aria-label="{{ learn_more }} {{ google_lens_eyebrow }}" data-cta-priority="outline" data-cta-position="section_1.row_1.button_1" data-cta-text="{{ learn_more }} - {{ google_lens_eyebrow }}">{{ learn_more}}
+                  <span class="wnp-button-icon wnp-button-icon-arrow" aria-hidden="true"></span>
+                </a>
+              </div>
             </div>
           </div>
-          <div class="wnp-feature-content">
-            <p class="wnp-feature-eyebrow">{{ google_lens_eyebrow }}</p>
-            <h3 class="wnp-subtitle">{{ google_lens_headline }}</h3>
-            <p class="wnp-body">{{ google_lens_body | safe }}</p>
-            <div class="wnp-btn-wrap">
-              <a class="wnp-button wnp-button-outline" href="https://support.mozilla.org/kb/search-web-images-firefox-google-lens?{{ utm_params }}" aria-label="{{ learn_more }} {{ google_lens_eyebrow }}" data-cta-priority="outline" data-cta-position="section_1.row_1.button_1" data-cta-text="{{ learn_more }} - {{ google_lens_eyebrow }}">{{ learn_more}}
-                <span class="wnp-button-icon wnp-button-icon-arrow" aria-hidden="true"></span>
-              </a>
-            </div>
-          </div>
-        </div>
+        {% endif %}
 
-        <div class="wnp-feature wnp-feature--reverse">
-          <div class="wnp-feature-media">
-            <div class="wnp-media-frame wnp-media-frame--settings">
-              {{resp_img(
-                url="img/firefox/wnp-144/perplexity.png",
-                srcset={
-                    "img/firefox/wnp-144/perplexity@2x.png": "2x",
-                },
-                optional_attributes={"l10n": True, "alt": "", "role": "presentation", "loading": "lazy"}
-            )}}
+        {% if switch('wnp144-perplexity') %}
+          <div class="wnp-feature {% if switch('wnp144-google-lens') %}wnp-feature--reverse{% endif %}">
+            <div class="wnp-feature-media">
+              <div class="wnp-media-frame wnp-media-frame--settings">
+                {{resp_img(
+                  url="img/firefox/wnp-144/perplexity.png",
+                  srcset={
+                      "img/firefox/wnp-144/perplexity@2x.png": "2x",
+                  },
+                  optional_attributes={"l10n": True, "alt": "", "role": "presentation", "loading": "lazy"}
+              )}}
+              </div>
+            </div>
+            <div class="wnp-feature-content">
+              <p class="wnp-feature-eyebrow">{{ perplexity_eyebrow }}</p>
+              <h3 class="wnp-subtitle">{{ perplexity_headline }}</h3>
+              <p class="wnp-body">{{ perplexity_body }}</p>
+              <div class="wnp-btn-wrap"><a class="wnp-button wnp-button-outline" href="https://blog.mozilla.org/firefox/firefox-144?{{ utm_params }}" aria-label="{{ learn_more }} {{ perplexity_eyebrow }}" data-cta-priority="outline" data-cta-position="section_1.row_2.button_1" data-cta-text="{{ learn_more }} - {{ perplexity_eyebrow }}">{{ learn_more }}
+                  <span class="wnp-button-icon wnp-button-icon-arrow" aria-hidden="true"></span>
+                </a>
+              </div>
             </div>
           </div>
-          <div class="wnp-feature-content">
-            <p class="wnp-feature-eyebrow">{{ perplexity_eyebrow }}</p>
-            <h3 class="wnp-subtitle">{{ perplexity_headline }}</h3>
-            <p class="wnp-body">{{ perplexity_body }}</p>
-            <div class="wnp-btn-wrap"><a class="wnp-button wnp-button-outline" href="https://blog.mozilla.org/firefox/firefox-144?{{ utm_params }}" aria-label="{{ learn_more }} {{ perplexity_eyebrow }}" data-cta-priority="outline" data-cta-position="section_1.row_2.button_1" data-cta-text="{{ learn_more }} - {{ perplexity_eyebrow }}">{{ learn_more }}
-                <span class="wnp-button-icon wnp-button-icon-arrow" aria-hidden="true"></span>
-              </a>
-            </div>
-          </div>
-        </div>
+        {% endif %}
 
         <div class="wnp-feature">
           <div class="wnp-feature-media">


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

- heading/subheading only available when all features are displayed (they don't really make sense otherwise)
- if only two features, both use image on left

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
Switches are on in dev by default
To check when they are off:
./manage.py waffle_switch --create WNP144_GOOGLE_LENS off
./manage.py waffle_switch --create WNP144_PERPLEXITY off
Toggle as needed to check different combinations
http://localhost:8000/en-US/firefox/144.0/whatsnew/