### PR TITLE
Use image helper to get hashed assets

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx144.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx144.html
@@ -287,14 +287,13 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <div class="wnp-feature">
           <div class="wnp-feature-media">
             <div class="wnp-media-frame wnp-media-frame--settings">
-              <img
-                src="/media/img/firefox/whatsnew/whatsnew144/web-apps.png"
-                alt="Web apps illustration"
-                loading="lazy"
-                srcset="
-                  /media/img/firefox/whatsnew/whatsnew144/web-apps@2x.png 2x
-                "
-              />
+              {{ resp_img(
+                  url="img/firefox/whatsnew/whatsnew144/web-apps.png",
+                  srcset={
+                      "img/firefox/whatsnew/whatsnew144/web-apps@2x.png": "2x",
+                  },
+                  optional_attributes={"loading": 'lazy'}
+              ) }}
             </div>
           </div>
           <div class="wnp-feature-content">


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Use image helper to ensure src goes through [staticfiles_storage.url](https://github.com/mozilla/bedrock/blob/c03e41b9dfd934565bfd1ba1bf4e4252fb30bada/bedrock/base/templatetags/helpers.py#L124) and gets a hashed pathname

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
