### PR TITLE
Updating the PDF for advertising standard

### DIFF
--- a/bedrock/mozorg/templates/mozorg/advertising/formats.html
+++ b/bedrock/mozorg/templates/mozorg/advertising/formats.html
@@ -301,7 +301,7 @@
   content_width='xl',
   include_cta=True
 ) %}
-<p><a href="https://assets.mozilla.net/pdf/Mozilla_Advertising_Standards_2025.pdf" class="mzp-c-button" data-cta-text="Download PDF">Download PDF</a></p>
+<p><a href="https://assets.mozilla.net/pdf/Mozilla_Advertising_Standards_October_2025.pdf" class="mzp-c-button" data-cta-text="Download PDF">Download PDF</a></p>
 {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
## One-line summary
We have a new advertising standards PDF. The team prefers to have a new name, and let the old one 404 if anyone goes to the direct link.

Depends on this being merged: https://github.com/mozmeao/assets.mozilla.net/pull/43