### PR TITLE
Add style file specific to advertising/formats

### DIFF
--- a/bedrock/mozorg/templates/mozorg/advertising/formats.html
+++ b/bedrock/mozorg/templates/mozorg/advertising/formats.html
@@ -15,6 +15,7 @@
   {{ css_bundle('protocol-picto') }}
   {{ css_bundle('protocol-split') }}
   {{ css_bundle('mozilla-ads') }}
+  {{ css_bundle('mozilla-ads-format') }}
 {% endblock %}
 
 {% block sub_navigation %}

--- a/media/css/mozorg/advertising-format.scss
+++ b/media/css/mozorg/advertising-format.scss
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+
+// HACK: quick fix for /advertising/formats m24 base styles overriding Protocol mzp-c-button styles
+// Separated out to avoid affecting /advertising page styles
+a.mzp-c-button {
+    &:link,
+    &:visited {
+        color: $color-white;
+
+        &:hover,
+        &:active {
+            color: $color-black;
+        }
+
+        &:focus {
+            color: $color-white;
+        }
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1146,6 +1146,12 @@
     },
     {
       "files": [
+        "css/mozorg/advertising-format.scss"
+      ],
+      "name": "mozilla-ads-format"
+    },
+    {
+      "files": [
         "css/mozorg/webvision.scss"
       ],
       "name": "webvision"


### PR DESCRIPTION
Quick fix for selector issue that arose from inclusion of m24 base in https://github.com/mozilla/bedrock/pull/16778

<img width="507" height="228" alt="Screenshot 2025-10-22 at 10 36 02 AM" src="https://github.com/user-attachments/assets/9e712694-3aae-465b-86fb-9df2902b6169" />

<img width="397" height="150" alt="Screenshot 2025-10-22 at 10 39 18 AM" src="https://github.com/user-attachments/assets/a686d504-ee25-4fb8-96e0-a532106ada1d" />

_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
Changes only affect the format template. Button text should be visible in all states
http://localhost:8000/en-US/advertising/formats/