### PR TITLE
Filter out Foundation newsletters

### DIFF
--- a/media/js/newsletter/management.es6.js
+++ b/media/js/newsletter/management.es6.js
@@ -8,6 +8,15 @@ import FormUtils from './form-utils.es6';
 
 const FXA_NEWSLETTERS = ['firefox-accounts-journey', 'test-pilot'];
 
+const FOUNDATION_NEWSLETTERS = [
+    'mozilla-foundation',
+    'take-action-for-the-internet',
+    'mozilla-festival',
+    'internet-health-report',
+    'common-voice',
+    'mozilla-fellowship-awardee-alumni'
+];
+
 const FXA_NEWSLETTERS_LOCALES = ['en', 'de', 'fr'];
 
 const UNSUB_UNSUBSCRIBED_ALL = 1;
@@ -220,7 +229,11 @@ const NewsletterManagementForm = {
                     NewsletterManagementForm.isFxANewsletter(newsletter) &&
                     isFxALocale);
 
-            if (!shouldDisplayNewsletter) {
+            // Temporary filter for Foundation newsletters, they are handled in separate system
+            if (
+                !shouldDisplayNewsletter ||
+                FOUNDATION_NEWSLETTERS.includes(obj.slug)
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Specifically filter out Foundation newsletters

## Significant changes and points to review

These have been deleted from Basket, but we currently allow existing subscribers to see inactive newsletters if they are still subscribed.

The Foundation newsletters are now active in a different system so we don't want to display them in the pref center. There is copy to indicate where users may unsubscribe from Foundation newsletters.

## Issue / Bugzilla link



## Testing
localhost:8000/en-US/newsletter/existing/
Before: mozilla festival, etc.
<img width="3028" height="1304" alt="Screenshot 2025-10-22 at 18-34-33 Newsletter Subscriptions — Mozilla" src="https://github.com/user-attachments/assets/f97df251-b130-4b89-bce8-7e6ea477c344" />
After: no mozilla festival
<img width="3028" height="1304" alt="Screenshot 2025-10-22 at 18-39-43 Newsletter Subscriptions — Mozilla" src="https://github.com/user-attachments/assets/b557f5e4-c9ae-4dc0-8278-c7a5934b1173" />
