### PR TITLE
Fix newsletter signup JS errors on WNP page

### DIFF
--- a/media/js/newsletter/newsletter.es6.js
+++ b/media/js/newsletter/newsletter.es6.js
@@ -41,8 +41,12 @@ const MzpNewsletter = {
         const submitLoading = form.querySelector('.submit-loading');
 
         // Hide text and show loader
-        submitText.style.opacity = 0;
-        submitLoading.removeAttribute('hidden');
+        if (submitText) {
+            submitText.style.opacity = 0;
+        }
+        if (submitLoading) {
+            submitLoading.removeAttribute('hidden');
+        }
 
         const formFields = form.querySelectorAll('input, button, select');
 
@@ -60,8 +64,12 @@ const MzpNewsletter = {
         const submitLoading = form.querySelector('.submit-loading');
 
         // Hide loader and show text
-        submitLoading.setAttribute('hidden', true);
-        submitText.style.opacity = 1;
+        if (submitLoading) {
+            submitLoading.setAttribute('hidden', true);
+        }
+        if (submitText) {
+            submitText.style.opacity = 1;
+        }
 
         const formFields = form.querySelectorAll('input, button, select');
 
@@ -96,9 +104,7 @@ const MzpNewsletter = {
                 error = form.querySelector('.error-email-invalid');
                 break;
             case ERROR_LIST.NEWSLETTER_ERROR:
-                form.querySelector(
-                    '.error-newsletter-checkbox'
-                ).classList.remove('hidden');
+                error = form.querySelector('.error-newsletter-checkbox');
                 break;
             case ERROR_LIST.COUNTRY_ERROR:
                 error = form.querySelector('.error-select-country');


### PR DESCRIPTION
## One-line summary

Fixes JS errors by safely checking for DOM elements that don't exist in the new WNP newsletter template.

## Significant changes and points to review

Also added a few other safe checks to elements that don't exist in the WNP newsletter template.

## Issue / Bugzilla link

@stephaniehobson via Slack:

> I get a JS error when trying to subscribe to the newsletter on https://www-demo1.allizom.org/en-US/firefox/144.0/whatsnew/

Uncaught TypeError: can't access property "style", t is null

## Testing

Submit the newsletter signup form on /en-US/firefox/144.0/whatsnew/
