### PR TITLE
Update default google_play_button macro referrer

### DIFF
--- a/bedrock/settings/appstores.py
+++ b/bedrock/settings/appstores.py
@@ -11,7 +11,9 @@ GOOGLE_PLAY_FIREFOX_LINK = "https://play.google.com/store/apps/details?id=org.mo
 # campaign parameters.
 # To clarify below, 'referrer' key value must be a URL encoded string of utm_*
 # key/values (https://bugzilla.mozilla.org/show_bug.cgi?id=1099429#c0).
-GOOGLE_PLAY_FIREFOX_LINK_UTMS = GOOGLE_PLAY_FIREFOX_LINK + "&referrer=" + quote("utm_source=mozilla&utm_medium=Referral&utm_campaign=mozilla-org")
+GOOGLE_PLAY_FIREFOX_LINK_UTMS = (
+    GOOGLE_PLAY_FIREFOX_LINK + "&referrer=" + quote("utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=download")
+)
 
 # Link to Firefox for iOS on the Apple App Store.
 APPLE_APPSTORE_FIREFOX_LINK = "https://apps.apple.com/{country}/app/apple-store/id989804926"


### PR DESCRIPTION
## One-line summary

Aligning with https://github.com/mozmeao/springfield/pull/737

## Significant changes and points to review

Most of CTAs left set custom params so these should not be currently used anywhere visible after moving things to fxc, so there should be no impact.

## Issue / Bugzilla link

Resolves https://github.com/mozmeao/springfield/issues/666

## Testing
