### PR TITLE
Speed up integration tests CI a little

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -109,7 +109,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-        cache: npm
     - name: Install dependencies
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run Playwright tests


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 💯 

## One-line summary

Adds some tweaks to shave off a few seconds from the CI runs.

## Significant changes and points to review

(Some unquoted text had quotes in the content, I originally added curly quotes to be on the safe side, but eventually just removed the phrases to simplify.)

Slack jobs use sparse checkout to try to speed up the large checkouts, and the initial notifier is no longer a dependency to start the actual tests, saving time spent queuing for a runner later…

Unfortunately the slow and erratic part here is the playwright dependency setup, that does some opaque things apparently via apt-get under the hood. I'll see if there's either anything to cache or prime here, or use toolcache available on the runners alternatively — that's an extra minute there not under our control, so that's something to look into next.

## Issue / Bugzilla link

(Borrows updates from adjacent actions.)

## Testing

The new job layout can be seen here:
https://github.com/janbrasna/bedrock/actions/runs/19496302276