### PR TITLE
Remove apt-install of xvfb and chromium in GHA

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,18 +9,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-js:
     runs-on: ubuntu-latest
     steps:
-      - name: "Install framebuffer (xvfb) and Chromium"
-        run: |
-          sudo apt-get update
-          sudo apt-get install chromium-browser xvfb
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - name: "Install JS dependencies"
         run: npm ci
       - name: "Run JS tests"


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ 💯 

## One-line summary

Removes a slow and convoluted install step for things already available in the runner.

## Significant changes and points to review

Added caching as the FE/JS testing stack takes some time to install so it might be worth it. Accompanied by an explicitly readonly token to make sure this has no privileges.

I also took the liberty of renaming the workflow file, as the unit tests are not run only for PRs, so to match the content I bit the bullet and made it just plain "unit_tests" if there are no objections. (AFAICT there's no automation to pull the pipeline statuses or anything like that; but to double check in case there's anything in repo settings branch protections to require certain checks to pass before some merges…)

## Issue / Bugzilla link

#16872

## Testing

[`@janbrasna/bedrock` /actions/runs/19473152578/](https://github.com/janbrasna/bedrock/actions/runs/19473152578/job/55725770592#step:2:3) ✅ 