### PR TITLE
Distinguish advisory header from CVEs

### DIFF
--- a/media/css/security/components/advisory.scss
+++ b/media/css/security/components/advisory.scss
@@ -38,7 +38,7 @@
     }
 
     .cve {
-        margin-bottom: $layout-md;
+        margin-top: $layout-md;
 
         h5 {
             @include font-size(16px);


### PR DESCRIPTION
## One-line summary
Add bottom-margin to advisory header summary

## Significant changes and points to review
Might not be the right way to fix this.

## Issue / Bugzilla link
Fixes #16889 