### PR TITLE
Pass GHA inputs via env for all bash run steps

### DIFF
--- a/.github/workflows/post_deploy_asset_check.yml
+++ b/.github/workflows/post_deploy_asset_check.yml
@@ -41,15 +41,14 @@ jobs:
 
   asset-check:
     runs-on: ubuntu-latest
+    env:
+      GIT_SHA: ${{ inputs.git_sha }}
+      ORIGIN_HOSTNAME: ${{ inputs.origin_hostname }}
+      CDN_HOSTNAME: ${{ inputs.cdn_hostname }}
     steps:
       - name: Pull release image
-        run: docker pull mozmeao/bedrock:${{ inputs.git_sha }}
-
+        run: docker pull mozmeao/bedrock:$GIT_SHA
       - name: Verify deployed assets are available
-        env:
-          GIT_SHA: ${{ inputs.git_sha }}
-          ORIGIN_HOSTNAME: ${{ inputs.origin_hostname }}
-          CDN_HOSTNAME: ${{ inputs.cdn_hostname }}
         run: |
           docker run --rm \
             mozmeao/bedrock:$GIT_SHA \


### PR DESCRIPTION
## One-line summary

Move env vars for inputs one level up, for docker pull tag step to be able to access them too.

## Significant changes and points to review

The `env` context should work (and is interpolated on the runner into the env vars) equally no matter the scope; so this just moves the env scope from step level to job level, and uses that same treatment for the previous step as well.

## Issue / Bugzilla link

#16863 followup

## Testing
