### PR TITLE
fix: give DB updates more time to run for demos

### DIFF
--- a/bin/cron.py
+++ b/bin/cron.py
@@ -50,7 +50,8 @@ HEALTH_FILE_BASE = f"{DATA_PATH}/last-run"
 # The jobs are run every five minutes, so should all normally complete within that
 # timeframe. If they don't (eg, they've hung), we set a timeout just before then,
 # so that they are killed and we will try again.
-TIMEOUT_SECS = 290  # Just shy of five minutes.
+# We make this configurable so we can allow more time for the jobs on demos, which are slower
+TIMEOUT_SECS = config("DB_UPDATE_TIMEOUT_SECS", default="290", parser=int)  # Just shy of five minutes.
 
 
 sentry_dsn = config("SENTRY_DSN", raise_error=False)

--- a/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml
+++ b/gcp/bedrock-demos/cloudrun/mozorg-demo.env.yaml
@@ -12,16 +12,22 @@ CONTENT_CARDS_URL: https://www-dev.allizom.org/media/
 CSP_DEFAULT_SRC: "*.allizom.org"
 CSP_EXTRA_FRAME_SRC: "*.mozaws.net,o1069899.sentry.io"
 DB_DOWNLOAD_IGNORE_GIT: "True"
+# Try to update the DB every 15 mins, not 5, to give slow demo instances more
+# time to complete the work, but still kill the job 10s before the next try.
+DB_UPDATE_MINUTES: "15"
+DB_UPDATE_TIMEOUT_SECS: "890"
 DEBUG: "False"
 DEV: "True"
 GTM_CONTAINER_ID: GTM-MW3R8V
 LOG_LEVEL: INFO
+# We always want LOCAL_DB_UPDATE and SKIP_FORCED_DB_DOWNLOAD for Demos, to
+# avoid them trying to upload a DB that we no longer need because demos run on sqlite now
 LOCAL_DB_UPDATE: "True"
+SKIP_FORCED_DB_DOWNLOAD: "True"
 PROD_DETAILS_STORAGE: product_details.storage.PDDatabaseStorage
 RUN_SUPERVISOR: "True"
 SECURE_SSL_REDIRECT: "True"
 SENTRY_DSN: https://97ec0cd426714b728e92f3b3aa62f00b@o1069899.ingest.sentry.io/6260338
 SWITCH_NEWSLETTER_MAINTENANCE_MODE: "False"
 WAGTAIL_ENABLE_ADMIN: "True"
-SKIP_FORCED_DB_DOWNLOAD: "True"
 IS_DEMO: "True"


### PR DESCRIPTION
Taking a swing at #16899 by slowing down the update cadence of demo servers and allowing longer for the job to complete

GH Issue: https://github.com/mozilla/bedrock/issues/16899
JIRA: https://mozilla-hub.atlassian.net/browse/WT-488