### PR TITLE
fix l10n strings in www-l10n #556

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/media-springboard.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/media-springboard.html
@@ -52,7 +52,7 @@
       type_icon='article',
       topic=ftl('m24-home-topic-products'),
       author='Ryan Sipes',
-      preview=ftl('m24-home-introducing-thundermail-and')
+      preview=ftl('m24-home-introducing-thundermail-and-v2', fallback='m24-home-introducing-thundermail-and')
     ) }}
     {{ springboard_item(
       link_url="https://www.youtube.com/watch?v=HiZGWrN1zrU" + utm_params,
@@ -69,7 +69,7 @@
       type=ftl('m24-home-tag-article'),
       type_icon='article',
       topic=ftl('m24-home-topic-open-source-ai'),
-      author=ftl('m24-home-tech-crunch'),
+      author=ftl('m24-home-tech-crunch-v2', fallback='m24-home-tech-crunch'),
       preview=ftl('m24-home-how-ventures-investee')
     ) }}
     {{ springboard_item(

--- a/l10n/en/mozorg/home-m24.ftl
+++ b/l10n/en/mozorg/home-m24.ftl
@@ -120,10 +120,14 @@ m24-home-shake-to-summarize = Shake to Summarize in TIME’s Best Inventions of 
 m24-home-mozilla-welcomes-raffi = { -brand-name-mozilla } welcomes Raffi Krikorian as Chief Technology Officer
 m24-home-tech-target = Tech Target
 m24-home-mozilla-ai-ceo = { -brand-name-mozilla-ai-v2 } CEO talks open source AI advantages
+# Obsolete string (expires 2026-03-01)
 m24-home-introducing-thundermail-and = Introducing Thundermail and Thunderbird Pro
+m24-home-introducing-thundermail-and-v2 = Introducing { -brand-name-thundermail } and { -brand-name-thunderbird-pro }
 m24-home-what-comes-next = What comes next in tech is a choice. Choose with us.
 m24-home-how-ventures-investee = How Ventures Investee Germ is Strengthening Encryption
+# Obsolete string (expires 2026-03-01)
 m24-home-tech-crunch = Tech Crunch
+m24-home-tech-crunch-v2 = TechCrunch
 m24-home-a-good-moment = ‘A good moment in time for us’: { -brand-name-firefox } head on AI browsers and what’s next for the web
 m24-home-the-guardian = The Guardian
 m24-home-interview-take-open = Interview: Taking Open Source Into the AI Era


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes latest l10n issues in https://github.com/mozilla-l10n/www-l10n/pull/556

## Significant changes and points to review

- `Tech Crunch` should be `TechCrunch`
- We should use newly added brand names for `Thundermail` and `Thunderbird Pro`


## Issue / Bugzilla link

https://github.com/mozilla-l10n/www-l10n/pull/556


## Testing

http://localhost:8000/en-US/
