### PR TITLE
feat: support serving a dedicated Preview privacy notice, in parallel with the effective one

### DIFF
--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -13,6 +13,7 @@ urlpatterns = (
     path("faq/", views.FAQView.as_view(), name="privacy.faq"),
     page("email/", "privacy/email.html", active_locales=["en-US", "de", "fr"]),
     path("firefox/", views.firefox_notices, name="privacy.notices.firefox"),
+    path("firefox/preview/", views.firefox_notices_preview, name="privacy.notices.firefox_preview"),
     path("firefox-focus/", views.firefox_focus_notices, name="privacy.notices.firefox-focus"),
     # bug 1319207 - special URL for Firefox Focus in de locale
     path("firefox-klar/", views.firefox_focus_notices, name="privacy.notices.firefox-klar"),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -39,6 +39,25 @@ class PrivacyDocView(LegalDocView):
 
 
 class FirefoxPrivacyDocView(PrivacyDocView):
+    # The current/effective PN for Firefox
+    # Uses the same templates as the preview/upcoming version
+    ftl_files = ["privacy/firefox"]
+
+    def get_legal_doc(self):
+        doc = super().get_legal_doc()
+        variant = self.request.GET.get("v", None)
+
+        if variant == "product":
+            self.template_name = "privacy/notices/firefox-simple.html"
+        else:
+            self.template_name = "privacy/notices/firefox-intro.html"
+        return doc
+
+
+class FirefoxPrivacyPreviewDocView(PrivacyDocView):
+    # A preview/upcoming PN for Firefox
+    # Uses the same templates as the current/effective version,
+    # but draws content from a dedicated preview file
     ftl_files = ["privacy/firefox"]
 
     def get_legal_doc(self):
@@ -67,6 +86,8 @@ class FirefoxFocusPrivacyDocView(PrivacyDocView):
 
 
 firefox_notices = FirefoxPrivacyDocView.as_view(legal_doc_name="firefox_privacy_notice")
+
+firefox_notices_preview = FirefoxPrivacyDocView.as_view(legal_doc_name="firefox_privacy_notice_preview")
 
 firefox_focus_notices = FirefoxFocusPrivacyDocView.as_view(legal_doc_name="focus_privacy_notice")
 


### PR DESCRIPTION
## One-line summary

Adds a new page for a future/preview FF privacy notice. When it becomes active, the content will be copied over (by legal, not automation) to the regular PN page. So this just shows a new document, basically, which already exists in the legal-docs repo.

Note that this is a full copy-over of the main Privacy Notice page, including the blocks of content at the top.

It's currently deploying to https://www-demo4.allizom.org/en-US/privacy/firefox/preview/

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-487

## Testing

* ./manage.py update_legal_docs
* visit http://localhost:8000/en-US/privacy/firefox/preview/ and you should see 'Preview' in the title. All other contnet is the same right now
* Adjust the URL to other locales such as `fr` and `de` - you will see 'Preview' in there too