### PR TITLE
Add light/dark support to body of new WNP templates

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-142.scss
+++ b/media/css/firefox/whatsnew/whatsnew-142.scss
@@ -217,8 +217,8 @@ body {
     font-family: var(--fds-font-family-secondary);
     font-size: var(--fds-font-size-base);
     line-height: 1.6;
-    color: var(--fds-color-gray-90);
-    background-color: var(--fds-color-ash);
+    background: light-dark(var(--fds-color-ash), var(--fds-color-black));
+    color: light-dark(var(--fds-color-gray-90), var(--fds-color-white));
 }
 
 // ============================================================================


### PR DESCRIPTION
## One-line summary

Add light/dark support to body of new WNP templates.

## Significant changes and points to review

Body of what's new pages based on the wnp-new aka 142 templates now reflect dark mode like the rest of page content.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-461

## Testing

- clear your local storage
- do **NOT** interact with the dark mode debug toggle
- change to dark mode in your system settings or using dev tools
- verify that the body of the page is readable