### PR TITLE
Reclaim additional space in CI runners for docker builds

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,6 +38,15 @@ jobs:
       image_tag: ${{ env.TAG }}
 
     steps:
+      - name: Reclaim disk space
+        run: |
+          sudo rm -rf /home/runner/.rustup
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system df
+          df -h
+
       - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: "cache-from: type=gha cache-to: type=gha,mode=max"


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._ ⏳ 

## One-line summary

Improves the space available from 20G to 30G by removing things we won't need in less than 10sec.

## Significant changes and points to review

There are larger SDKs to remove, but the recursive i/o operations take dozens of seconds, so this is a tradeoff between the space gained, and the time spent pruning it. Some additional tools are commented out in 3a6fcce for future reference.

There's a 60G+ disk available at /mnt so having the docker tools use that instead would be ideal, however given the daemon's already pre-set and running in the image, it doesn't look too straightforward. I'm leaving notes for other/followup options in the tracking ticket.

## Issue / Bugzilla link

#16923

## Testing

[/actions/runs/19962842415/](https://github.com/mozilla/bedrock/actions/runs/19962842415/job/57247225911) ✅ 