### PR TITLE
Ensure locales fall back to evergreen WNP if 146 FTL file is not active

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -627,7 +627,17 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = "firefox/whatsnew/index.html"
         elif version.startswith("146."):
-            if locale in ["es-AR", "es-CL", "es-ES", "es-MX", "it", "ja", "pl", "pt-PT", "pt-BR"]:
+            if ftl_file_is_active("firefox/whatsnew/whatsnew-donate") and locale in [
+                "es-AR",
+                "es-CL",
+                "es-ES",
+                "es-MX",
+                "it",
+                "ja",
+                "pl",
+                "pt-PT",
+                "pt-BR",
+            ]:
                 template = "firefox/whatsnew/whatsnew-fx146-donate.html"
             else:
                 template = "firefox/whatsnew/index.html"


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
Check current active locales: 
`./manage.py l10n_update`
`./manage.py active_locales firefox/whatsnew/whatsnew-fx146-donate`

Run [prod mode](https://mozmeao.github.io/platform-docs/install/#prod-mode) and check
- [ ] an active FTL file locale shows 146 donate template (http://localhost:8000/it/firefox/146.0/whatsnew/)
- [ ] an inactive FTL file locale show evergreen template (this may be out of date by time of review: http://localhost:8000/ja/firefox/146.0/whatsnew/)