### PR TITLE
Add switch-controlled copy for newsletter subscription timing

### DIFF
--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -103,6 +103,9 @@
             <small>{{ ftl('newsletters-not-all-subscriptions-are') }}</small>
 
             <aside>
+              {% if switch('show-newsletter-subscribe-timing') %}
+                <p>{{ ftl('newsletters-it-may-take') }}</p>
+              {% endif %}
               <p>{{ ftl('newsletters-many-of-our-communications-v2', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
 
               <p>{{ ftl('newsletters-to-get-access-to-the-whole', url=url('mozorg.account')) }}</p>

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -60,6 +60,8 @@ newsletters-please-select-country = Please select a country or region
 # Form field error message
 newsletters-please-select-language = Please select a language
 
+newsletters-it-may-take = It may take up to an hour for newly subscribed information to be reflected on this page.
+
 # Variables:
 #   $url (url) - link to https://support.mozilla.org/kb/managing-account-data
 


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Adds copy to document potential delay from Braze

**📆 Needs to be in production by EOD Dec. 9 in preparation for Basket release on 10th**

## Significant changes and points to review



## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-485


## Testing
Turn switch ON
`./manage.py waffle_switch --create SHOW_NEWSLETTER_SUBSCRIBE_TIMING on`

See new copy on http://localhost:8000/en-US/newsletter/existing/ (you will need an `nl-token` cookie, which can be retrieved from prod: https://www.mozilla.org/en-US/newsletter/recovery/)

<img width="697" height="530" alt="new-copy" src="https://github.com/user-attachments/assets/32ced294-4ed1-4814-9d67-a0864f046ae7" />


Turn switch OFF
`./manage.py waffle_switch SHOW_NEWSLETTER_SUBSCRIBE_TIMING off`
No new copy