### PR TITLE
fix: Update paths to static assets which were broken, based on recent logs

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2024/includes/macros.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2024/includes/macros.html
@@ -271,7 +271,7 @@
   {{ ar_gallery_tile(
     class=class,
     image=picture(
-      url='img/foundation/annualreport/2024/section-1/1-5-mobile-21-9-800.png',
+      url='img/foundation/annualreport/2024/section-1/1-4-mobile-21-9-800.png',
       sources=[
         {
           'media': '(max-width: 1311px)',

--- a/bedrock/mozorg/templates/mozorg/contact/contact-base.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-base.html
@@ -31,7 +31,7 @@
 
     <div class="hero-image">
       {{ resp_img(
-        url='img/contact/toronto-office-700.jpeg',
+        url='img/contact/toronto-office-700.jpg',
         srcset={
         'img/contact/toronto-office-700.jpg': '700w',
         'img/contact/toronto-office-1200.jpg': '1200w',

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/ai-gallery.html
@@ -306,7 +306,7 @@
         {{ gallery_tile(
           class='m24-l-grid-quarter',
           image=picture(
-            url="img/home/2024/ai-gallery/mozfest-mobile-720.jpg",
+            url="img/home/2024/ai-gallery/mozfest-mobile-720.png",
             sources=[
               {
                 'media': '(max-width: 1311px)',

--- a/bedrock/products/templates/products/vpn/mac-download.html
+++ b/bedrock/products/templates/products/vpn/mac-download.html
@@ -91,7 +91,7 @@
             base_el='li',
             title=ftl('vpn-login-or-signup'),
             image=resp_img(
-              url='img/products/vpn/download/vpn-app-700.png',
+              url='img/products/vpn/download/vpn-app-mac-700.png',
               srcset={
               "img/products/vpn/download/vpn-app-mac-960.png": "960w",
               "img/products/vpn/download/vpn-app-mac-700.png": "700w",


### PR DESCRIPTION
Trying to rule out as many things that might stop a container starting cleanly. A missing static asset is a hard fail in Django, causing us noise and re-tries