### PR TITLE
updating fundraising banner to be ready for final push.

### DIFF
--- a/bedrock/base/templates/includes/banners/fundraiser.html
+++ b/bedrock/base/templates/includes/banners/fundraiser.html
@@ -12,39 +12,35 @@
 
 {% if LANG =="de" %}
   {% set banner_title = 'Spende jetzt an die Mozilla Foundation' %}
-  {% set banner_tagline = 'Hilf zum „Giving Tuesday“ mit, die digitale Zukunft zu gestalten, die wir alle uns wünschen.' %}
+  {% set banner_tagline = 'Wir brauchen deine Hilfe, um unser Ziel für 2025 bis zum 31. Dezember zu erreichen.' %}
   {% set banner_button = 'Spenden' %}
 {% elif LANG.startswith('es-') %}
   {% set banner_title = 'Dona a la Fundación Mozilla' %}
-  {% set banner_tagline = 'Este Día para Dar, ayuda a construir el futuro digital que merecemos.' %}
+  {% set banner_tagline = 'Necesitamos tu ayuda para alcanzar nuestra meta de 2025 para el 31 de diciembre.' %}
   {% set banner_button = 'Donar' %}
 {% elif LANG == "fr" %}
   {% set banner_title = 'Faites un don à la Fondation Mozilla' %}
-  {% set banner_tagline = 'Profitez du Giving Tuesday pour contribuer à créer l’avenir numérique que nous méritons.' %}
+  {% set banner_tagline = 'Nous avons besoin de votre aide pour atteindre notre objectif 2025 d\'ici le 31 décembre.' %}
   {% set banner_button = 'Je fais un don' %}
 {% elif LANG == "it" %}
   {% set banner_title = 'Dona a Mozilla Foundation' %}
-  {% set banner_tagline = 'Per la giornata del dono, aiutaci a creare il futuro digitale che tutti meritiamo.' %}
+  {% set banner_tagline = 'Abbiamo bisogno del tuo aiuto per raggiungere il nostro obiettivo 2025 entro il 31 dicembre.' %}
   {% set banner_button = 'Dona' %}
-{% elif LANG == "nl" %}
-  {% set banner_title = 'Doneer aan de Mozilla Foundation' %}
-  {% set banner_tagline = 'Deze Giving Tuesday kun je helpen bij het bouwen aan de digitale toekomst die we verdienen.' %}
-  {% set banner_button = 'Doneer' %}
 {% elif LANG == "pl" %}
   {% set banner_title = 'Wesprzyj Fundację Mozilla' %}
-  {% set banner_tagline = 'Z okazji Giving Tuesday pomóż nam tworzyć przyszłość cyfrową, na którą wszyscy zasługujemy.' %}
+  {% set banner_tagline = 'Potrzebujemy Twojej pomocy, aby osiągnąć nasz cel na 2025 rok do 31 grudnia.' %}
   {% set banner_button = 'Wpłać datek ' %}
 {% elif LANG.startswith('pt-') %}
   {% set banner_title = 'Doe para a Fundação Mozilla' %}
-  {% set banner_tagline = 'Neste Dia de Doar, ajude a criar o futuro digital que merecemos.' %}
+  {% set banner_tagline = 'Precisamos da sua ajuda para alcançar a nossa meta de 2025 até 31 de dezembro.' %}
   {% set banner_button = 'Doe agora' %}
 {% else %}
   {% set banner_title = 'Donate to Mozilla Foundation' %}
-  {% set banner_tagline = 'This Giving Tuesday, help build the digital future we deserve.' %}
+  {% set banner_tagline = 'We need your help to reach our 2025 goal by December 31.' %}
   {% set banner_button = 'Donate' %}
 {% endif %}
 
-{% set banner_link = 'https://www.mozillafoundation.org/?form=gt25-moco-banner' %}
+{% set banner_link = 'https://www.mozillafoundation.org/?form=eoy25-fp-moco-banner' %}
 
 {% block banner_content %}
   <div class="c-banner-outer">

--- a/bedrock/mozorg/templates/mozorg/home/home-m24.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-m24.html
@@ -22,7 +22,7 @@
 
 {% set show_firefox_app_store_banner = switch('firefox-app-store-banner') %}
 
-{% set fundraising_banner_langs = ['en-US', 'en-GB', 'en-CA', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'de', 'fr', 'it', 'nl', 'pl', 'pt-PT', 'pt-BR'] %}
+{% set fundraising_banner_langs = ['en-US', 'en-GB', 'en-CA', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'de', 'fr', 'it', 'pl', 'pt-PT', 'pt-BR'] %}
 {% set show_fundraising_banner = switch('fundraising-banner-2025eoy') and LANG in fundraising_banner_langs %}
 
 {% block page_css %}


### PR DESCRIPTION
This updates our fundraising banner that was last used for Giving Tuesday (and is currently disabled) to have copy ready for end of year final push.

- Updated taglines for all languages
- updated CTA link for all languages
- removed Dutch copy block (no dutch for this banner)
- Removed 'nl' from fundraising_banner_langs

Addresses: https://mozilla-hub.atlassian.net/browse/WT-473?atlOrigin=eyJpIjoiOTI5Nzk3ZjBjNDc5NGI4ZmI2OTIxN2FiZWUwZWRhNzciLCJwIjoiaiJ9