### PR TITLE
Updating CPG, Dec '25

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
@@ -51,7 +51,7 @@
   </p>
 
   <p>
-  {{ ftl('reporting-if-you-have-a-report-involving', employee_hotline='https://mozilla.integrityline.com/') }}
+  {{ ftl('reporting-if-you-have-a-report-involving-v2', employee_hotline='https://mozilla.integrityline.com/') }}
   </p>
 
   <p>

--- a/l10n/en/mozorg/about/governance/policies/reporting.ftl
+++ b/l10n/en/mozorg/about/governance/policies/reporting.ftl
@@ -16,7 +16,7 @@ reporting-how-to-give-a-report = How to Give a Report
 reporting-if-you-believe-someone = If you believe someone is in physical danger, call your local emergency number.
 reporting-if-you-have-a-report-by = If you have a report <strong>by <em>and</em> about</strong> a contributor (for example, the report is made <strong>by</strong> one contributor <strong>about</strong> another contributor), then you should make your report at the <a href="{ $community_hotline }">Community Participation Guidelines hotline</a>.
 reporting-if-you-have-a-report-by-email = If you have a report <strong>by <em>and</em> about</strong> a contributor (for example, the report is made <strong>by</strong> one contributor <strong>about</strong> another contributor), then you should make your report at the <a href="{ $mailto_report }">cpg-report@mozilla.com</a>.
-reporting-if-you-have-a-report-involving = If you have a report by a contributor about <strong>an employee</strong>, then you should report at the <a href="{ $employee_hotline }">{ -brand-name-mozilla } Employee hotline</a>. If you are an employee and need to submit a report, please consult { -brand-name-mozilla }'s internal policies and procedures to understand the reporting options available to you.
+reporting-if-you-have-a-report-involving-v2 = If you have a report by a contributor about <strong>an employee</strong>, then you should report at the <a href="{ $employee_hotline }">{ -brand-name-mozilla } Employee hotline</a>. If you are an employee and need to submit a report, please consult { -brand-name-mozilla }'s internal policies and procedures to understand the reporting options available to you.
 reporting-put-another-way = Put another way…
 reporting-by = By
 reporting-employee = Employee


### PR DESCRIPTION
## One-line summary
Updating our CPG guidelines.

## Significant changes and points to review
- Replaced the Convercent hotline URLs with mozilla.integrityline.com
- updated reporting instructions for employees, contractors, and vendors to refer to Mozilla's internal policies.
- Adjusted localization strings to clarify reporting procedures and reflect these changes.


## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-516?atlOrigin=eyJpIjoiN2FmZWYzMzgyZWE4NGQ1ZjliMTY0ZWNmYmQyNWQ3MTMiLCJwIjoiaiJ9


## Notes
No fallback strings during transition because old URLs are outdated and now incorrect.