### PR TITLE
Move inline style to CSS to fix CSP inline style report

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -111,7 +111,6 @@
           </span>
           <svg class="submit-loading" hidden fill="currentColor" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <title>{{ ftl('newsletter-form-submit-sending') }}</title>
-            <style>.s1{animation:s .8s linear infinite;animation-delay:-.8s}.s2{animation-delay:-.65s}.s3{animation-delay:-.5s}@keyframes s{93.75%,100%{opacity:.2}}</style>
             <circle class="s1" cx="4" cy="12" r="3"/>
             <circle class="s1 s2" cx="12" cy="12" r="3"/>
             <circle class="s1 s3" cx="20" cy="12" r="3"/>

--- a/media/css/protocol/protocol-mozilla.scss
+++ b/media/css/protocol/protocol-mozilla.scss
@@ -59,6 +59,7 @@
     max-width: 30em;
 }
 
+// Protocol issue: https://github.com/mozilla/protocol/issues/1102
 #newsletter-submit {
     position: relative;
 }
@@ -68,6 +69,24 @@
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
+}
+
+@keyframes pulse {
+    93.75%,
+    100% {opacity:.2}
+}
+
+.submit-loading circle {
+    animation: pulse .8s linear infinite;
+    animation-delay:-.8s
+}
+
+.submit-loading circle:nth-child(2) {
+    animation-delay:-.65s
+}
+
+.submit-loading circle:nth-child(3) {
+    animation-delay:-.5s
 }
 
 // style classes automatically added by python to match Protocol form error styles


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Fixes CSP inline style report [[Moz only](https://mozilla.sentry.io/issues/5998984738/?project=4508129260666880&query=is%3Aunresolved&referrer=issue-stream)] 

Report references L1717
<img width="538" height="184" alt="Screenshot 2025-12-15 at 11 01 02 AM" src="https://github.com/user-attachments/assets/e830df89-7bea-425e-a91a-8767ce1fdeb7" />

## Significant changes and points to review

Temporary fix to quiet noise before issue is fixed more permanently in Protocol: https://github.com/mozilla/protocol/issues/1102

## Issue / Bugzilla link



## Testing
http://localhost:8000/en-US/

Newsletter field is at bottom of page.

You can use dev tools to enter a debugger breakpoint at the `send` POST request (L178 under Webpack/newsletter.es6.js)
or use Network throttling to slower speed to see loading animation

<img width="644" height="206" alt="Screenshot 2025-12-15 at 11 43 24 AM" src="https://github.com/user-attachments/assets/10e212a2-8dd5-4ef1-9cba-374b61fdf626" />
