### PR TITLE
Add transcend domains to CSP connect and style srcs

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -47,6 +47,8 @@ _csp_connect_src = {
     "region1.google-analytics.com",
     "telemetry.transcend.io",  # Transcend Consent Management
     "telemetry.us.transcend.io",  # Transcend Consent Management
+    "cdn.transcend.io",  # Transcend Consent Management
+    "transcend-cdn.com",  # Transcend Consent Management
     "www.google-analytics.com",
     "www.googletagmanager.com",
     # This is for glean pings and deletion requests.
@@ -113,6 +115,8 @@ _csp_style_src = {
     csp.constants.SELF,
     CSP_ASSETS_HOST,
     csp.constants.UNSAFE_INLINE,
+    "cdn.transcend.io",  # Transcend Consent Management
+    "transcend-cdn.com",  # Transcend Consent Management
 }
 
 # 2. TEST-SPECIFIC SETTINGS


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
ensure switch exists and is ON
`./manage.py waffle_switch --create TRANSCEND_CONSENT on`
http://localhost:8000/en-US/
- no console errors