### PR TITLE
Use the nocookie domain for privacy-enhanced YouTube embed

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -80,6 +80,7 @@ _csp_frame_src = {
     "www.google-analytics.com",
     "www.googletagmanager.com",
     "www.youtube.com",
+    "www.youtube-nocookie.com",
 }
 _csp_img_src = {
     csp.constants.SELF,
@@ -108,6 +109,7 @@ _csp_script_src = {
     "www.google-analytics.com",
     "www.googletagmanager.com",
     "www.youtube.com",
+    "www.youtube-nocookie.com",
     csp.constants.UNSAFE_EVAL,
     csp.constants.UNSAFE_INLINE,
 }

--- a/media/js/base/video-inline-embed.es6.js
+++ b/media/js/base/video-inline-embed.es6.js
@@ -35,6 +35,7 @@ function playVideo() {
     }
 
     new window.YT.Player(videoLink, {
+        host: 'https://www.youtube-nocookie.com', // privacy-enhanced mode
         width: 640,
         height: 360,
         videoId: videoId,


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link

as part of investigation for https://github.com/mozmeao/springfield/issues/846, we decided to use the nocookie YT domain across all YT embeds

## Testing
http://localhost:8000/en-US/firefox/136.0/whatsnew/?geo=US

in dev tools console, `dataLayer` should still show expected video events: start, progress, complete
<img width="310" height="626" alt="Screenshot 2025-12-16 at 3 42 21 PM" src="https://github.com/user-attachments/assets/1ac9f217-c2ce-4190-9b0f-43c605c894f2" />
