### PR TITLE
feat: Add a DB-backed Switch to make firefox/privacy/next/ either render or redirect

### DIFF
--- a/bedrock/privacy/tests/test_views.py
+++ b/bedrock/privacy/tests/test_views.py
@@ -7,6 +7,9 @@ from unittest.mock import patch
 from django.http import HttpResponse
 from django.test.client import RequestFactory
 
+from waffle.models import Switch
+from waffle.testutils import override_switch
+
 from bedrock.mozorg.tests import TestCase
 from bedrock.privacy import views
 
@@ -53,3 +56,29 @@ class TestFocusSimpleDocView(TestCase):
         view(req)
         template = render_mock.call_args[0][1]
         assert template == "privacy/notices/firefox-simple.html"
+
+
+class TestFirefoxPrivacyNextViewBehaviour(TestCase):
+    def test_redirect_happens_when_switch_is_not_defined(self):
+        assert not Switch.objects.filter(name="ENABLE_FIREFOX_PRIVACY_NEXT").exists()
+        resp = self.client.get("/en-US/privacy/firefox/next/")
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/en-US/privacy/firefox/"
+
+    def test_redirect_happens_when_switch_is_OFF(self):
+        with override_switch("ENABLE_FIREFOX_PRIVACY_NEXT", active=False):
+            resp = self.client.get("/en-US/privacy/firefox/next/")
+            assert resp.status_code == 302
+            assert resp.headers["location"] == "/en-US/privacy/firefox/"
+
+    @patch.object(views.PrivacyDocView, "get_legal_doc")
+    @patch("bedrock.firefox.views.l10n_utils.render", return_value=HttpResponse())
+    def test_redirect_does_not_happen_when_switch_is_ON(self, render_mock, lld_mock):
+        with override_switch("ENABLE_FIREFOX_PRIVACY_NEXT", active=True):
+            lld_mock.return_value["content"].select.return_value = None
+            resp = self.client.get("/en-US/privacy/firefox/next/")
+            assert resp.status_code == 200
+            assert render_mock.call_args_list[0][0][1] == "privacy/notices/firefox-intro.html"
+
+    def test_uses_correct_view_class(self):
+        assert isinstance(views.firefox_notices_preview.view_class(), views.FirefoxPrivacyPreviewDocView)

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -3,8 +3,11 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import re
 
+from django.shortcuts import redirect
+
 from bs4 import BeautifulSoup
 
+from bedrock.base.waffle import switch
 from bedrock.legal_docs.views import LegalDocView, load_legal_doc
 from lib import l10n_utils
 from lib.l10n_utils.fluent import ftl_file_is_active
@@ -58,7 +61,15 @@ class FirefoxPrivacyPreviewDocView(PrivacyDocView):
     # A preview/upcoming PN for Firefox
     # Uses the same templates as the current/effective version,
     # but draws content from a dedicated preview file
+    #
+    # If ENABLE_FIREFOX_PRIVACY_NEXT is Off/False, then this
+    # will redirect to the main Firefox Privacy note
     ftl_files = ["privacy/firefox"]
+
+    def dispatch(self, *args, **kwargs):
+        if not switch("enable-firefox-privacy-next"):
+            return redirect("privacy.notices.firefox")
+        return super().dispatch(*args, **kwargs)
 
     def get_legal_doc(self):
         doc = super().get_legal_doc()
@@ -87,7 +98,7 @@ class FirefoxFocusPrivacyDocView(PrivacyDocView):
 
 firefox_notices = FirefoxPrivacyDocView.as_view(legal_doc_name="firefox_privacy_notice")
 
-firefox_notices_preview = FirefoxPrivacyDocView.as_view(legal_doc_name="firefox_privacy_notice_preview")
+firefox_notices_preview = FirefoxPrivacyPreviewDocView.as_view(legal_doc_name="firefox_privacy_notice_preview")
 
 firefox_focus_notices = FirefoxFocusPrivacyDocView.as_view(legal_doc_name="focus_privacy_notice")
 


### PR DESCRIPTION
This changeset adds a Waffle Switch which can be set in the Django Admin to control whether /privacy/firefox/next/ renders a preview privacy document, or instead redirects to the effective privacy doc at /privacy/firefox/

Includes tests, and a fixup where we weren't actually using the preview view, but the (identical) main one. Now the behaviour of the two has diverged, we definitely use the preview view for the preview notice, and have a test to avoid regression


## Issue / Bugzilla link

Resolves #16952 

## Testing

* https://www-demo7.allizom.org/en-US/privacy/firefox/next/ has the redirect enabled

* https://www-demo6.allizom.org/en-US/privacy/firefox/next/ has the redirect disabled, but will 404 because it hasn't synced in the preview doc - that's unrelated to this changeset; the absence and presence of the redirect are the focus here