### PR TITLE
migrate away from deprecated @import - WT114 (fix #10896)

### DIFF
--- a/media/css/csrf-failure.scss
+++ b/media/css/csrf-failure.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 body {
     min-height: 350px;

--- a/media/css/legal/terms-firefox.scss
+++ b/media/css/legal/terms-firefox.scss
@@ -9,7 +9,7 @@
 @use '~@mozilla-protocol/core/protocol/css/components/section-heading';
 @use '~@mozilla-protocol/core/protocol/css/templates/multi-column';
 
-@import '../protocol/components/legal-toc';
+@use '../protocol/components/legal-toc';
 
 html {
     scroll-behavior: smooth;

--- a/media/css/mozorg/about-forums.scss
+++ b/media/css/mozorg/about-forums.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 .c-forum-search {
     background-color: $color-marketing-gray-20;

--- a/media/css/mozorg/about-patents.scss
+++ b/media/css/mozorg/about-patents.scss
@@ -2,10 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 
 .mzp-c-article h2 {
     margin: $layout-md 0 $layout-sm;

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -4,8 +4,8 @@
 
 @use 'sass:math';
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
 
 // * -------------------------------------------------------------------------- */
 // Index

--- a/media/css/mozorg/about.scss
+++ b/media/css/mozorg/about.scss
@@ -2,11 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/billboard';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/billboard';
 
 // * -------------------------------------------------------------------------- */
 // Hero image

--- a/media/css/mozorg/account.scss
+++ b/media/css/mozorg/account.scss
@@ -2,16 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
-@import '../protocol/components/fxa-form';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-firefox';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-monitor';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-relay';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-vpn';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-pocket';
+@use '../protocol/components/fxa-form';
 
 // * -------------------------------------------------------------------------- */
 // FxA signup form

--- a/media/css/mozorg/antiharassment-tool.scss
+++ b/media/css/mozorg/antiharassment-tool.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
-@import '@mozilla-protocol/core/protocol/css/components/newsletter-form';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '@mozilla-protocol/core/protocol/css/components/newsletter-form';
 
 $aht-color-secondary: #FDA1DE;
 

--- a/media/css/mozorg/contact-spaces.scss
+++ b/media/css/mozorg/contact-spaces.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 /* -------------------------------------------------------------------------- */
 // Common elements and variables

--- a/media/css/mozorg/contribute.scss
+++ b/media/css/mozorg/contribute.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
-@import '~@mozilla-protocol/core/protocol/css/components/section-heading';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
+@use '~@mozilla-protocol/core/protocol/css/components/section-heading';
 
 .contribute-intro {
     overflow: hidden;

--- a/media/css/mozorg/diversity/diversity.scss
+++ b/media/css/mozorg/diversity/diversity.scss
@@ -2,13 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/feature-card';
-@import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '../../protocol/components/video';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/feature-card';
+@use '~@mozilla-protocol/core/protocol/css/components/modal';
+@use '../../protocol/components/video';
 
 // * -------------------------------------------------------------------------- */
 // Hero image & banner heading

--- a/media/css/mozorg/home/ctd-promo-de.scss
+++ b/media/css/mozorg/home/ctd-promo-de.scss
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
 
 .ctd-promo {
     .ctd-promo-non-fx,

--- a/media/css/mozorg/home/home-new.scss
+++ b/media/css/mozorg/home/home-new.scss
@@ -2,11 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 // July 2024 Mozilla Foundation fundraiser nav CTA experiment
 html.is-firefox {

--- a/media/css/mozorg/home/home-old.scss
+++ b/media/css/mozorg/home/home-old.scss
@@ -2,14 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
-@import '~@mozilla-protocol/core/protocol/css/components/billboard';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
-@import '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/fonts/metropolis';
+@use '~@mozilla-protocol/core/protocol/css/components/billboard';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark';
+@use '~@mozilla-protocol/core/protocol/css/components/logos/wordmark-product-family';
 
 .mzp-c-split .mzp-u-title-md {
     @include font-firefox;

--- a/media/css/mozorg/home/includes/featured-vpn.scss
+++ b/media/css/mozorg/home/includes/featured-vpn.scss
@@ -3,11 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 .vpn-feature {
     font-family: var(--body-font-family);

--- a/media/css/mozorg/home/includes/mofo-donate-promo.scss
+++ b/media/css/mozorg/home/includes/mofo-donate-promo.scss
@@ -3,11 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 .mofo-donate-promo {
     font-family: var(--body-font-family);

--- a/media/css/mozorg/impact.scss
+++ b/media/css/mozorg/impact.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 header {
     background-color: $color-black;

--- a/media/css/mozorg/leadership.scss
+++ b/media/css/mozorg/leadership.scss
@@ -4,15 +4,12 @@
 
 @use 'sass:color';
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/modal';
-@import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
-@import '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
-@import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
-@import '../cms/rich-text';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/modal';
+@use '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
+@use '~@mozilla-protocol/core/protocol/css/includes/mixins/details';
+@use '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
+@use '../cms/rich-text';
 
 @font-face {
     font-family: FA-Icons-Contact;

--- a/media/css/mozorg/lean-data.scss
+++ b/media/css/mozorg/lean-data.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/section-heading';
-@import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/section-heading';
+@use '~@mozilla-protocol/core/protocol/css/templates/multi-column';
 
 .c-section-title {
     @include text-title-md;

--- a/media/css/mozorg/license-faq.scss
+++ b/media/css/mozorg/license-faq.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 .last-updated {
     @include text-body-sm;

--- a/media/css/mozorg/locales.scss
+++ b/media/css/mozorg/locales.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 // note: these styles are used for both /locales and a locale-specific 404 page
 

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 .manifesto-title {
     @include text-title-sm;

--- a/media/css/mozorg/mission.scss
+++ b/media/css/mozorg/mission.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 figure {
     margin: $spacing-lg 0;

--- a/media/css/mozorg/moss.scss
+++ b/media/css/mozorg/moss.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 /* -------------------------------------------------------------------------- */
 // Custom container width

--- a/media/css/mozorg/mozilla-account-promo.scss
+++ b/media/css/mozorg/mozilla-account-promo.scss
@@ -2,16 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-$brand-theme: 'mozilla';
 $promo-md-mq: 1015px;
 $promo-sm-mq: 400px;
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
-@import '~@mozilla-protocol/core/protocol/css/components/forms/field';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img', $brand-theme: 'mozilla');
+@use '~@mozilla-protocol/core/protocol/css/components/forms/button-container';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/form';
+@use '~@mozilla-protocol/core/protocol/css/components/forms/field';
 
 .moz-account-promo {
     background: $color-black;

--- a/media/css/mozorg/participation-reporting.scss
+++ b/media/css/mozorg/participation-reporting.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 .reporting-matrix-container {
     max-width: 100%;

--- a/media/css/mozorg/rise25/_lib.scss
+++ b/media/css/mozorg/rise25/_lib.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 $red: #b75d72;
 $orange: #f37925;

--- a/media/css/mozorg/rise25/components/category.scss
+++ b/media/css/mozorg/rise25/components/category.scss
@@ -4,7 +4,7 @@
 
 @use '../lib' as r25;
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 // * -------------------------------------------------------------------------- */
 // Nomination categories

--- a/media/css/mozorg/rise25/components/hero.scss
+++ b/media/css/mozorg/rise25/components/hero.scss
@@ -4,7 +4,7 @@
 
 @use '../lib' as r25;
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as *;
 
 // * -------------------------------------------------------------------------- */
 // Hero

--- a/media/css/mozorg/sustainability.scss
+++ b/media/css/mozorg/sustainability.scss
@@ -2,10 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
 
 .highlight {
     @include box-decoration-break(clone);

--- a/media/css/mozorg/webvision.scss
+++ b/media/css/mozorg/webvision.scss
@@ -2,12 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/protocol/fonts';
-$image-path: '/media/protocol/img';
-
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
-@import '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
-@import '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($font-path: '/media/protocol/fonts', $image-path: '/media/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/components/sidebar-menu';
+@use '~@mozilla-protocol/core/protocol/css/templates/main-with-sidebar';
 
 .c-webvision-article {
     h2 {

--- a/media/css/privacy/privacy-firefox.scss
+++ b/media/css/privacy/privacy-firefox.scss
@@ -9,7 +9,7 @@
 @use '~@mozilla-protocol/core/protocol/css/components/section-heading';
 @use '~@mozilla-protocol/core/protocol/css/templates/multi-column';
 
-@import '../protocol/components/legal-toc';
+@use '../protocol/components/legal-toc';
 
 // * -------------------------------------------------------------------------- */
 // Smooth Scroll


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR migrates away from deprecated SASS `@import`.

## Significant changes and points to review



## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/10896

## Testing
