### PR TITLE
WT-536: improve our CSP unsafe-inline config by making it tighter and more specific

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -210,7 +210,7 @@ CMS_ADMIN_IMAGES_CSP = _override_csp(CONTENT_SECURITY_POLICY, append={"img-src":
 CMS_ADMIN_IMAGES_CSP_RO = csp_ro_report_uri and _override_csp(CONTENT_SECURITY_POLICY_REPORT_ONLY, append={"img-src": {"blob:"}})
 
 
-# The CMS admin frames itself for page previews and needs script-src: allow-inline
+# The CMS admin frames itself for page previews and needs script-src: 'unsafe-inline'
 CMS_ADMIN_CSP = _override_csp(
     CONTENT_SECURITY_POLICY,
     replace={"frame-ancestors": {csp.constants.SELF}},

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -109,12 +109,12 @@ _csp_script_src = {
     "www.googletagmanager.com",
     "www.youtube.com",
     csp.constants.UNSAFE_EVAL,
-    # Don't allow csp.constants.UNSAFE_INLINE wholesale in the default CSP. Only allow hashed/nonced inline scripts, r
+    # Don't allow csp.constants.UNSAFE_INLINE wholesale in the default CSP. Be more targetted with it
 }
+
 _csp_style_src = {
     csp.constants.SELF,
     CSP_ASSETS_HOST,
-    csp.constants.UNSAFE_INLINE,
     "cdn.transcend.io",  # Transcend Consent Management
     "transcend-cdn.com",  # Transcend Consent Management
 }
@@ -211,14 +211,10 @@ CMS_ADMIN_IMAGES_CSP_RO = csp_ro_report_uri and _override_csp(CONTENT_SECURITY_P
 
 
 # The CMS admin frames itself for page previews and needs script-src: allow-inline
-cms_admin_script_src = deepcopy(_csp_script_src)
-cms_admin_script_src.add(csp.constants.UNSAFE_INLINE)
 CMS_ADMIN_CSP = _override_csp(
     CONTENT_SECURITY_POLICY,
-    replace={
-        "frame-ancestors": {csp.constants.SELF},
-        "script-src": cms_admin_script_src,
-    },
+    replace={"frame-ancestors": {csp.constants.SELF}},
+    append={"script-src": {csp.constants.UNSAFE_INLINE}},
 )
 CMS_ADMIN_CSP_RO = csp_ro_report_uri and _override_csp(CONTENT_SECURITY_POLICY_REPORT_ONLY, replace={"frame-ancestors": {csp.constants.SELF}})
 

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -109,7 +109,7 @@ _csp_script_src = {
     "www.googletagmanager.com",
     "www.youtube.com",
     csp.constants.UNSAFE_EVAL,
-    csp.constants.UNSAFE_INLINE,
+    # Don't allow csp.constants.UNSAFE_INLINE wholesale in the default CSP. Only allow hashed/nonced inline scripts, r
 }
 _csp_style_src = {
     csp.constants.SELF,
@@ -208,8 +208,18 @@ def _override_csp(
 # /cms-admin/images/ loads just-uploaded images as blobs.
 CMS_ADMIN_IMAGES_CSP = _override_csp(CONTENT_SECURITY_POLICY, append={"img-src": {"blob:"}})
 CMS_ADMIN_IMAGES_CSP_RO = csp_ro_report_uri and _override_csp(CONTENT_SECURITY_POLICY_REPORT_ONLY, append={"img-src": {"blob:"}})
-# The CMS admin frames itself for page previews.
-CMS_ADMIN_CSP = _override_csp(CONTENT_SECURITY_POLICY, replace={"frame-ancestors": {csp.constants.SELF}})
+
+
+# The CMS admin frames itself for page previews and needs script-src: allow-inline
+cms_admin_script_src = deepcopy(_csp_script_src)
+cms_admin_script_src.add(csp.constants.UNSAFE_INLINE)
+CMS_ADMIN_CSP = _override_csp(
+    CONTENT_SECURITY_POLICY,
+    replace={
+        "frame-ancestors": {csp.constants.SELF},
+        "script-src": cms_admin_script_src,
+    },
+)
 CMS_ADMIN_CSP_RO = csp_ro_report_uri and _override_csp(CONTENT_SECURITY_POLICY_REPORT_ONLY, replace={"frame-ancestors": {csp.constants.SELF}})
 
 CSP_PATH_OVERRIDES = {


### PR DESCRIPTION
This changeset is an additional fixup around https://mozilla-hub.atlassian.net/browse/WT-536

It does a few things. My recommendation is to read the code first, then the rest of this description, so you are not swayed (and in case I've not got this right)

1) for `script-src`, it only allows `unsafe-inline` for the Wagtail admin pages which are only enabled for the CMS deployment. This does not _appear_ to affect anything else, but we really need to be sure (eg Transcend, GA, cookie banner)

2) for `style-src` we had code that enabled `unsafe-inline` specifically for Transcend, but a few lines above we also had `unsafe-inline` set as a default. This changeset moves it so that `style-src: unsafe-inline` is only available if transcend is enabled.

### Testing

I'd welcome a Slack chat about approaches here. I've pushed this branch to www-demo6.allizom.org where we can drive around and also try the CMS, but Transcend isn't enabled there - maybe we could enable it in demos too, tbc on  @stephendherrera's blessing 