### PR TITLE
Remove Pocket-related strings from the Mozilla account page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/account.html
+++ b/bedrock/mozorg/templates/mozorg/account.html
@@ -94,10 +94,6 @@
             <li>{{ ftl('firefox-accounts-travel-the-internet') }}</li>
           {% endif %}
         </ul>
-        <ul class="mzp-u-list-styled">
-          <li>{{ ftl('firefox-accounts-save-articles') }}</li>
-          <li>{{ ftl('firefox-accounts-read-in-a') }}</li>
-        </ul>
       </div>
 
       <p class="c-accounts-tagline">{{ ftl('firefox-accounts-get-it-all-on-every') }}</p>

--- a/l10n/en/firefox/accounts.ftl
+++ b/l10n/en/firefox/accounts.ftl
@@ -36,8 +36,6 @@ firefox-accounts-keep-your-passwords = Keep your passwords protected and portabl
 firefox-accounts-travel-the-internet = Travel the internet with protection, on every device.
 firefox-accounts-encrypt-your = Encrypt your network activity and hide your IP address
 firefox-accounts-we-never = We never log, track, or share your network data
-firefox-accounts-save-articles = Save articles from across the web
-firefox-accounts-read-in-a = Read in a quiet, private space
 
 firefox-accounts-get-it-all-on-every = Get it all on every device, without feeling trapped in a single operating system.
 


### PR DESCRIPTION
## One-line summary
Remove Pocket-related strings from the [Mozilla account](https://www.mozilla.org/account/) page.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=2012644

## Notes
Not sure about correct labeling, as I'm new to the project. Would appreciate some help here.