### PR TITLE
Anonym Part 13: Test Fixtures

### DIFF
--- a/bedrock/anonym/fixtures/__init__.py
+++ b/bedrock/anonym/fixtures/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/bedrock/anonym/fixtures/base_fixtures.py
+++ b/bedrock/anonym/fixtures/base_fixtures.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from wagtail.models import Site
+
+from bedrock.anonym.models import AnonymIndexPage, Person
+from bedrock.mozorg.fixtures.base_fixtures import get_placeholder_image  # noqa: F401
+
+
+def get_test_anonym_index_page() -> AnonymIndexPage:
+    """Get or create a test AnonymIndexPage for fixture tests.
+
+    Returns:
+        AnonymIndexPage instance to use as parent for test pages
+    """
+    site = Site.objects.get(is_default_site=True)
+    root_page = site.root_page
+
+    index_page = AnonymIndexPage.objects.filter(slug="tests-anonym-index-page").first()
+    if not index_page:
+        index_page = AnonymIndexPage(
+            slug="tests-anonym-index-page",
+            title="Tests Anonym Index Page",
+        )
+        root_page.add_child(instance=index_page)
+        index_page.save_revision().publish()
+
+    return index_page
+
+
+def get_test_person() -> Person:
+    """Get or create a test Person snippet for fixture tests.
+
+    Returns:
+        Person instance for use in tests
+    """
+    placeholder_image = get_placeholder_image()
+
+    person, _ = Person.objects.get_or_create(
+        name="Test Person",
+        defaults={
+            "image": placeholder_image,
+            "position": "Test Position",
+            "description": "<p>Test description for this person.</p>",
+            "learn_more_link": "https://example.com/person",
+        },
+    )
+    return person

--- a/bedrock/anonym/fixtures/block_fixtures.py
+++ b/bedrock/anonym/fixtures/block_fixtures.py
@@ -1,0 +1,732 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+Block data generators for Anonym test fixtures.
+
+Each function returns a list of block data dictionaries suitable for
+assigning to Wagtail StreamField content fields.
+"""
+
+
+def get_figure_block_variants(image_id: int) -> list[dict]:
+    """Return FigureBlock variants for testing.
+
+    Args:
+        image_id: ID of the placeholder image to use
+
+    Returns:
+        List of figure block data dictionaries
+    """
+    return [
+        {
+            "type": "figure_block",
+            "value": {
+                "settings": {"make_full_width": False},
+                "image": image_id,
+            },
+            "id": "figure-variant-1",
+        },
+        {
+            "type": "figure_block",
+            "value": {
+                "settings": {"make_full_width": True},
+                "image": image_id,
+            },
+            "id": "figure-variant-2-full-width",
+        },
+    ]
+
+
+def get_icon_card_variants() -> list[dict]:
+    """Return IconCardBlock variants for testing.
+
+    Returns:
+        List of icon card block data dictionaries
+    """
+    return [
+        {
+            "type": "icon_card",
+            "value": {
+                "icon": "privacy",
+                "heading": "Privacy First",
+                "text": "<p>Your data stays <strong>yours</strong>.</p>",
+            },
+            "id": "icon-card-variant-1",
+        },
+        {
+            "type": "icon_card",
+            "value": {
+                "icon": "security",
+                "heading": "Built-in Security",
+                "text": "<p>Enterprise-grade security by default.</p>",
+            },
+            "id": "icon-card-variant-2",
+        },
+        {
+            "type": "icon_card",
+            "value": {
+                "icon": "performance",
+                "heading": "High Performance",
+                "text": "<p>Optimized for <em>speed</em> and efficiency.</p>",
+            },
+            "id": "icon-card-variant-3",
+        },
+    ]
+
+
+def get_logo_card_variants(image_id: int) -> list[dict]:
+    """Return LogoCardBlock variants for testing.
+
+    Args:
+        image_id: ID of the placeholder image to use
+
+    Returns:
+        List of logo card block data dictionaries
+    """
+    return [
+        {
+            "type": "logo_card",
+            "value": {
+                "logo": image_id,
+                "heading": "Partner Company",
+                "text": "<p>Trusted by leading brands worldwide.</p>",
+                "button": [
+                    {
+                        "label": "Learn More",
+                        "link": {
+                            "link_to": "custom_url",
+                            "custom_url": "https://example.com/partner",
+                            "new_window": False,
+                        },
+                    }
+                ],
+            },
+            "id": "logo-card-variant-1",
+        },
+        {
+            "type": "logo_card",
+            "value": {
+                "logo": image_id,
+                "heading": "Another Partner",
+                "text": "<p>Building the future together.</p>",
+                "button": [],
+            },
+            "id": "logo-card-variant-2-no-button",
+        },
+    ]
+
+
+def get_person_card_variants(person_id: int) -> list[dict]:
+    """Return PersonCardBlock variants for testing.
+
+    Args:
+        person_id: ID of the Person snippet to use
+
+    Returns:
+        List of person card block data dictionaries
+    """
+    return [
+        {
+            "type": "person_card",
+            "value": {
+                "person": person_id,
+                "link": [
+                    {
+                        "label": "View Profile",
+                        "link": {
+                            "link_to": "custom_url",
+                            "custom_url": "https://example.com/profile",
+                            "new_window": False,
+                        },
+                    }
+                ],
+            },
+            "id": "person-card-variant-1",
+        },
+        {
+            "type": "person_card",
+            "value": {
+                "person": person_id,
+                "link": [],
+            },
+            "id": "person-card-variant-2-no-link",
+        },
+    ]
+
+
+def get_cards_list_variants(image_id: int, person_id: int = None) -> list[dict]:
+    """Return CardsListBlock variants for testing.
+
+    Args:
+        image_id: ID of the placeholder image to use
+        person_id: Optional ID of the Person snippet to use
+
+    Returns:
+        List of cards list block data dictionaries
+    """
+    icon_cards = get_icon_card_variants()[:2]
+    logo_cards = get_logo_card_variants(image_id)[:1]
+
+    variants = [
+        # Variant with icon cards
+        {
+            "type": "cards_list",
+            "value": {
+                "settings": {
+                    "scrollable_on_mobile": False,
+                    "dividers_between_cards_on_desktop": False,
+                },
+                "cards": icon_cards,
+            },
+            "id": "cards-list-icon-cards",
+        },
+        # Variant with logo cards, scrollable
+        {
+            "type": "cards_list",
+            "value": {
+                "settings": {
+                    "scrollable_on_mobile": True,
+                    "dividers_between_cards_on_desktop": True,
+                },
+                "cards": logo_cards,
+            },
+            "id": "cards-list-logo-cards-scrollable",
+        },
+    ]
+
+    # Add person card variant if person_id provided
+    if person_id:
+        person_cards = get_person_card_variants(person_id)[:2]
+        variants.append(
+            {
+                "type": "cards_list",
+                "value": {
+                    "settings": {
+                        "scrollable_on_mobile": False,
+                        "dividers_between_cards_on_desktop": False,
+                    },
+                    "cards": person_cards,
+                },
+                "id": "cards-list-person-cards",
+            }
+        )
+
+    return variants
+
+
+def get_two_column_variants() -> list[dict]:
+    """Return TwoColumnBlock variants for testing.
+
+    Returns:
+        List of two column block data dictionaries
+    """
+    return [
+        {
+            "type": "two_column",
+            "value": {
+                "heading_text": "Key Features",
+                "subheading_text": "<p>Everything you need to know.</p>",
+                "second_column": [
+                    {
+                        "heading_text": "Feature One",
+                        "supporting_text": "<p>Description of feature one.</p>",
+                    },
+                    {
+                        "heading_text": "Feature Two",
+                        "supporting_text": "<p>Description of feature two with <strong>bold</strong> text.</p>",
+                    },
+                ],
+            },
+            "id": "two-column-variant-1",
+        },
+        {
+            "type": "two_column",
+            "value": {
+                "heading_text": "How It Works",
+                "subheading_text": "",
+                "second_column": [
+                    {
+                        "heading_text": "Step 1",
+                        "supporting_text": "<p>First, configure your settings.</p>",
+                    },
+                    {
+                        "heading_text": "Step 2",
+                        "supporting_text": "<p>Then, deploy your solution.</p>",
+                    },
+                    {
+                        "heading_text": "Step 3",
+                        "supporting_text": "<p>Finally, monitor and optimize.</p>",
+                    },
+                ],
+            },
+            "id": "two-column-variant-2",
+        },
+    ]
+
+
+def get_section_block_variants(image_id: int, person_id: int = None) -> list[dict]:
+    """Return SectionBlock variants for testing.
+
+    Args:
+        image_id: ID of the placeholder image to use
+        person_id: Optional ID of the Person snippet to use
+
+    Returns:
+        List of section block data dictionaries
+    """
+    return [
+        # Basic section with figure
+        {
+            "type": "section",
+            "value": {
+                "settings": {
+                    "anchor_id": "overview",
+                    "theme": "index",
+                },
+                "superheading_text": "<p>Introduction</p>",
+                "heading_text": "<p>Welcome to <strong>Anonym</strong></p>",
+                "subheading_text": "<p>Privacy-preserving attribution for the modern web.</p>",
+                "section_content": get_figure_block_variants(image_id)[:1],
+                "action": [
+                    {
+                        "label": "Get Started",
+                        "link": {
+                            "link_to": "custom_url",
+                            "custom_url": "https://example.com/start",
+                            "new_window": False,
+                        },
+                    }
+                ],
+            },
+            "id": "section-with-figure",
+        },
+        # Section with cards
+        {
+            "type": "section",
+            "value": {
+                "settings": {
+                    "anchor_id": "features",
+                    "theme": "top_glow",
+                },
+                "superheading_text": "",
+                "heading_text": "<p>Why Choose <strong>Anonym</strong></p>",
+                "subheading_text": "<p>Built for privacy, designed for performance.</p>",
+                "section_content": get_cards_list_variants(image_id, person_id)[:1],
+                "action": [],
+            },
+            "id": "section-with-cards",
+        },
+        # Section with two column
+        {
+            "type": "section",
+            "value": {
+                "settings": {
+                    "anchor_id": "details",
+                    "theme": "",
+                },
+                "superheading_text": "",
+                "heading_text": "<p>Key <strong>Details</strong></p>",
+                "subheading_text": "",
+                "section_content": get_two_column_variants()[:1],
+                "action": [],
+            },
+            "id": "section-with-two-column",
+        },
+        # Section with rich text
+        {
+            "type": "section",
+            "value": {
+                "settings": {
+                    "anchor_id": "about",
+                    "theme": "",
+                },
+                "superheading_text": "",
+                "heading_text": "<p>About <strong>Us</strong></p>",
+                "subheading_text": "",
+                "section_content": [
+                    {
+                        "type": "rich_text",
+                        "value": (
+                            "<p>Anonym is a privacy-preserving attribution platform.</p>"
+                            "<p>We help advertisers measure campaign effectiveness without "
+                            "compromising user privacy.</p>"
+                        ),
+                        "id": "rich-text-content",
+                    }
+                ],
+                "action": [],
+            },
+            "id": "section-with-rich-text",
+        },
+    ]
+
+
+def get_call_to_action_variants() -> list[dict]:
+    """Return CallToActionBlock variants for testing.
+
+    Returns:
+        List of call to action block data dictionaries
+    """
+    return [
+        {
+            "type": "call_to_action",
+            "value": {
+                "settings": {"anchor_id": "contact-us"},
+                "heading": "<p>Ready to get started? <strong>Contact us today.</strong></p>",
+                "button": [
+                    {
+                        "label": "Contact Sales",
+                        "link": {
+                            "link_to": "custom_url",
+                            "custom_url": "https://example.com/contact",
+                            "new_window": False,
+                        },
+                    }
+                ],
+            },
+            "id": "cta-variant-1",
+        },
+        {
+            "type": "call_to_action",
+            "value": {
+                "settings": {"anchor_id": ""},
+                "heading": "<p>Join the <strong>privacy revolution</strong></p>",
+                "button": [],
+            },
+            "id": "cta-variant-2-no-button",
+        },
+    ]
+
+
+def get_competitor_comparison_table_variants() -> list[dict]:
+    """Return CompetitorComparisonTableBlock variants for testing.
+
+    Returns:
+        List of competitor comparison table block data dictionaries
+    """
+    return [
+        {
+            "type": "competitor_table",
+            "value": {
+                "heading_text": "How We Compare",
+                "subheading_text": "<p>See how Anonym stacks up against traditional attribution methods.</p>",
+                "rows": [
+                    {
+                        "text": "Privacy-preserving attribution",
+                        "tags_pixels_sdks": False,
+                        "conversions_event_apis": False,
+                        "clean_rooms": True,
+                        "anonym": True,
+                    },
+                    {
+                        "text": "No user-level data exposure",
+                        "tags_pixels_sdks": False,
+                        "conversions_event_apis": False,
+                        "clean_rooms": False,
+                        "anonym": True,
+                    },
+                    {
+                        "text": "Works without third-party cookies",
+                        "tags_pixels_sdks": False,
+                        "conversions_event_apis": True,
+                        "clean_rooms": True,
+                        "anonym": True,
+                    },
+                    {
+                        "text": "Real-time measurement",
+                        "tags_pixels_sdks": True,
+                        "conversions_event_apis": True,
+                        "clean_rooms": False,
+                        "anonym": True,
+                    },
+                ],
+            },
+            "id": "comparison-table-variant-1",
+        },
+    ]
+
+
+def get_toggleable_items_variants(image_id: int, person_id: int = None) -> list[dict]:
+    """Return ToggleableItemsBlock variants for testing.
+
+    Args:
+        image_id: ID of the placeholder image to use
+        person_id: Optional ID of the Person snippet to use
+
+    Returns:
+        List of toggleable items block data dictionaries
+    """
+    section_variants = get_section_block_variants(image_id, person_id)
+
+    return [
+        {
+            "type": "toggle_items",
+            "value": {
+                "settings": {"anchor_id": "solutions"},
+                "toggle_items": [
+                    {
+                        "type": "toggle_items",
+                        "value": {
+                            "icon": "privacy",
+                            "toggle_text": "For Publishers",
+                            "toggle_content": [
+                                {
+                                    "type": "two_column_block",
+                                    "value": {
+                                        "first_section": section_variants[0]["value"],
+                                        "second_section": section_variants[1]["value"],
+                                    },
+                                    "id": "two-section-publishers",
+                                }
+                            ],
+                        },
+                        "id": "toggle-item-publishers",
+                    },
+                    {
+                        "type": "toggle_items",
+                        "value": {
+                            "icon": "data-insights",
+                            "toggle_text": "For Advertisers",
+                            "toggle_content": [
+                                {
+                                    "type": "two_column_block",
+                                    "value": {
+                                        "first_section": section_variants[2]["value"],
+                                        "second_section": section_variants[3]["value"],
+                                    },
+                                    "id": "two-section-advertisers",
+                                }
+                            ],
+                        },
+                        "id": "toggle-item-advertisers",
+                    },
+                ],
+            },
+            "id": "toggleable-items-variant-1",
+        },
+    ]
+
+
+def get_news_item_list_variants(news_item_page_ids: list[int]) -> list[dict]:
+    """Return NewsItemListBlock variants for testing.
+
+    Args:
+        news_item_page_ids: List of AnonymNewsItemPage IDs to reference
+
+    Returns:
+        List of news item list block data dictionaries
+    """
+    if not news_item_page_ids:
+        return []
+
+    return [
+        {
+            "type": "news_item_list_block",
+            "value": {
+                "news_items": news_item_page_ids[:3],
+            },
+            "id": "news-item-list-variant-1",
+        },
+    ]
+
+
+def get_case_study_list_variants(case_study_page_ids: list[int]) -> list[dict]:
+    """Return CaseStudyListBlock variants for testing.
+
+    Args:
+        case_study_page_ids: List of AnonymCaseStudyItemPage IDs to reference
+
+    Returns:
+        List of case study list block data dictionaries
+    """
+    if not case_study_page_ids:
+        return []
+
+    return [
+        {
+            "type": "case_study_item_list_block",
+            "value": {
+                "case_study_items": case_study_page_ids[:3],
+            },
+            "id": "case-study-list-variant-1",
+        },
+    ]
+
+
+def get_people_list_variants(person_ids: list[int]) -> list[dict]:
+    """Return PeopleListBlock variants for testing.
+
+    Args:
+        person_ids: List of Person snippet IDs to reference
+
+    Returns:
+        List of people list block data dictionaries
+    """
+    if not person_ids:
+        return []
+
+    return [
+        {
+            "type": "people_list",
+            "value": {
+                "people": person_ids[:4],
+            },
+            "id": "people-list-variant-1",
+        },
+    ]
+
+
+def get_stat_item_variants() -> list[dict]:
+    """Return StatItemBlock variants for testing.
+
+    Returns:
+        List of stat item block data dictionaries
+    """
+    return [
+        {
+            "type": "stat",
+            "value": {
+                "statistic_value": "99%",
+                "statistic_label": "Privacy Compliance",
+            },
+            "id": "stat-item-1",
+        },
+        {
+            "type": "stat",
+            "value": {
+                "statistic_value": "50M+",
+                "statistic_label": "Daily Events Processed",
+            },
+            "id": "stat-item-2",
+        },
+        {
+            "type": "stat",
+            "value": {
+                "statistic_value": "24/7",
+                "statistic_label": "Support Available",
+            },
+            "id": "stat-item-3",
+        },
+    ]
+
+
+def get_form_field_variants() -> list[dict]:
+    """Return form field block variants for testing.
+
+    Returns:
+        List of form field block data dictionaries
+    """
+    return [
+        {
+            "type": "text_field",
+            "value": {
+                "settings": {"internal_identifier": "full_name"},
+                "label": "Full Name",
+                "required": True,
+            },
+            "id": "text-field-name",
+        },
+        {
+            "type": "text_field",
+            "value": {
+                "settings": {"internal_identifier": "company"},
+                "label": "Company",
+                "required": False,
+            },
+            "id": "text-field-company",
+        },
+        {
+            "type": "email_field",
+            "value": {
+                "settings": {"internal_identifier": "email"},
+                "label": "Email Address",
+                "required": True,
+            },
+            "id": "email-field",
+        },
+        {
+            "type": "phone_field",
+            "value": {
+                "settings": {"internal_identifier": "phone"},
+                "label": "Phone Number",
+                "required": False,
+            },
+            "id": "phone-field",
+        },
+        {
+            "type": "select_field",
+            "value": {
+                "settings": {"internal_identifier": "interest"},
+                "label": "Area of Interest",
+                "required": True,
+                "options": [
+                    {"value": "attribution", "label": "Attribution"},
+                    {"value": "measurement", "label": "Measurement"},
+                    {"value": "privacy", "label": "Privacy Solutions"},
+                    {"value": "other", "label": "Other"},
+                ],
+            },
+            "id": "select-field",
+        },
+        {
+            "type": "checkbox_group_field",
+            "value": {
+                "settings": {"internal_identifier": "services"},
+                "label": "Services Interested In",
+                "options": [
+                    {"value": "consulting", "label": "Consulting"},
+                    {"value": "implementation", "label": "Implementation"},
+                    {"value": "support", "label": "Ongoing Support"},
+                ],
+            },
+            "id": "checkbox-group-field",
+        },
+    ]
+
+
+def get_navigation_link_variants() -> list[dict]:
+    """Return navigation link block variants for testing.
+
+    Returns:
+        List of navigation link block data dictionaries
+    """
+    return [
+        {
+            "type": "link",
+            "value": {
+                "link_text": "Overview",
+                "link": {
+                    "link_to": "anchor",
+                    "anchor": "overview",
+                    "custom_url": "",
+                },
+            },
+            "id": "nav-link-overview",
+        },
+        {
+            "type": "link",
+            "value": {
+                "link_text": "Features",
+                "link": {
+                    "link_to": "anchor",
+                    "anchor": "features",
+                    "custom_url": "",
+                },
+            },
+            "id": "nav-link-features",
+        },
+        {
+            "type": "link",
+            "value": {
+                "link_text": "Contact",
+                "link": {
+                    "link_to": "custom_url",
+                    "custom_url": "https://example.com/contact",
+                    "new_window": False,
+                },
+            },
+            "id": "nav-link-contact",
+        },
+    ]

--- a/bedrock/anonym/fixtures/page_fixtures.py
+++ b/bedrock/anonym/fixtures/page_fixtures.py
@@ -1,0 +1,325 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+Page fixture creators for Anonym test data.
+
+Each function creates or updates a test page with appropriate content blocks.
+"""
+
+from bedrock.anonym.fixtures.base_fixtures import (
+    get_placeholder_image,
+    get_test_anonym_index_page,
+    get_test_person,
+)
+from bedrock.anonym.fixtures.block_fixtures import (
+    get_call_to_action_variants,
+    get_competitor_comparison_table_variants,
+    get_form_field_variants,
+    get_navigation_link_variants,
+    get_section_block_variants,
+    get_stat_item_variants,
+    get_toggleable_items_variants,
+)
+from bedrock.anonym.models import (
+    AnonymCaseStudyItemPage,
+    AnonymCaseStudyPage,
+    AnonymContactPage,
+    AnonymContentSubPage,
+    AnonymIndexPage,
+    AnonymNewsItemPage,
+    AnonymNewsPage,
+    AnonymTopAndBottomPage,
+)
+
+
+def get_anonym_index_test_page() -> AnonymIndexPage:
+    """Get or create a test AnonymIndexPage with content.
+
+    Returns:
+        AnonymIndexPage instance with navigation and content blocks
+    """
+    placeholder_image = get_placeholder_image()
+    person = get_test_person()
+
+    index_page = get_test_anonym_index_page()
+
+    # Update with content
+    section_variants = get_section_block_variants(placeholder_image.id, person.id)
+    cta_variants = get_call_to_action_variants()
+
+    index_page.navigation = get_navigation_link_variants()
+    index_page.content = section_variants[:2] + cta_variants[:1]
+    index_page.save_revision().publish()
+
+    return index_page
+
+
+def get_anonym_top_and_bottom_test_page() -> AnonymTopAndBottomPage:
+    """Get or create a test AnonymTopAndBottomPage with content.
+
+    Returns:
+        AnonymTopAndBottomPage instance with top and bottom content
+    """
+    placeholder_image = get_placeholder_image()
+    person = get_test_person()
+    index_page = get_test_anonym_index_page()
+
+    test_page = AnonymTopAndBottomPage.objects.filter(slug="test-top-and-bottom-page").first()
+    if not test_page:
+        test_page = AnonymTopAndBottomPage(
+            slug="test-top-and-bottom-page",
+            title="Test Top And Bottom Page",
+        )
+        index_page.add_child(instance=test_page)
+
+    section_variants = get_section_block_variants(placeholder_image.id, person.id)
+    cta_variants = get_call_to_action_variants()
+    comparison_variants = get_competitor_comparison_table_variants()
+
+    test_page.top_content = section_variants[:2] + cta_variants[:1]
+    test_page.bottom_content = section_variants[2:3] + comparison_variants[:1] + cta_variants[1:2]
+    test_page.save_revision().publish()
+
+    return test_page
+
+
+def get_anonym_content_sub_test_page() -> AnonymContentSubPage:
+    """Get or create a test AnonymContentSubPage with content.
+
+    Returns:
+        AnonymContentSubPage instance with toggleable content
+    """
+    placeholder_image = get_placeholder_image()
+    person = get_test_person()
+    index_page = get_test_anonym_index_page()
+
+    test_page = AnonymContentSubPage.objects.filter(slug="test-content-sub-page").first()
+    if not test_page:
+        test_page = AnonymContentSubPage(
+            slug="test-content-sub-page",
+            title="Test Content Sub Page",
+        )
+        index_page.add_child(instance=test_page)
+
+    section_variants = get_section_block_variants(placeholder_image.id, person.id)
+    toggleable_variants = get_toggleable_items_variants(placeholder_image.id, person.id)
+    cta_variants = get_call_to_action_variants()
+
+    test_page.content = section_variants[:1] + toggleable_variants[:1] + cta_variants[:1]
+    test_page.save_revision().publish()
+
+    return test_page
+
+
+def get_anonym_news_test_page() -> AnonymNewsPage:
+    """Get or create a test AnonymNewsPage.
+
+    Returns:
+        AnonymNewsPage instance
+    """
+    index_page = get_test_anonym_index_page()
+
+    test_page = AnonymNewsPage.objects.filter(slug="test-news-page").first()
+    if not test_page:
+        test_page = AnonymNewsPage(
+            slug="test-news-page",
+            title="Test News Page",
+        )
+        index_page.add_child(instance=test_page)
+        test_page.save_revision().publish()
+
+    return test_page
+
+
+def get_anonym_news_item_test_page(
+    news_page: AnonymNewsPage = None,
+    slug: str = "test-news-item-page",
+    title: str = "Test News Item Page",
+    with_external_link: bool = False,
+) -> AnonymNewsItemPage:
+    """Get or create a test AnonymNewsItemPage with content.
+
+    Args:
+        news_page: Parent AnonymNewsPage (creates one if not provided)
+        slug: Page slug
+        title: Page title
+        with_external_link: If True, sets an external link (excludes from sitemap)
+
+    Returns:
+        AnonymNewsItemPage instance with content
+    """
+    placeholder_image = get_placeholder_image()
+    person = get_test_person()
+
+    if not news_page:
+        news_page = get_anonym_news_test_page()
+
+    test_page = AnonymNewsItemPage.objects.filter(slug=slug).first()
+    if not test_page:
+        test_page = AnonymNewsItemPage(
+            slug=slug,
+            title=title,
+        )
+        news_page.add_child(instance=test_page)
+
+    section_variants = get_section_block_variants(placeholder_image.id, person.id)
+    cta_variants = get_call_to_action_variants()
+    stat_variants = get_stat_item_variants()
+
+    test_page.description = "This is a test news item with detailed content."
+    test_page.category = "Press"
+    test_page.logo = placeholder_image
+    test_page.image = placeholder_image
+    test_page.link = "https://example.com/external-news" if with_external_link else ""
+    test_page.stats = stat_variants[:2]
+    test_page.content = section_variants[:1] + cta_variants[:1]
+    test_page.save_revision().publish()
+
+    return test_page
+
+
+def get_anonym_case_study_test_page() -> AnonymCaseStudyPage:
+    """Get or create a test AnonymCaseStudyPage.
+
+    Returns:
+        AnonymCaseStudyPage instance
+    """
+    index_page = get_test_anonym_index_page()
+
+    test_page = AnonymCaseStudyPage.objects.filter(slug="test-case-study-page").first()
+    if not test_page:
+        test_page = AnonymCaseStudyPage(
+            slug="test-case-study-page",
+            title="Test Case Study Page",
+        )
+        index_page.add_child(instance=test_page)
+        test_page.save_revision().publish()
+
+    return test_page
+
+
+def get_anonym_case_study_item_test_page(
+    case_study_page: AnonymCaseStudyPage = None,
+    slug: str = "test-case-study-item-page",
+    title: str = "Test Case Study Item Page",
+) -> AnonymCaseStudyItemPage:
+    """Get or create a test AnonymCaseStudyItemPage with content.
+
+    Args:
+        case_study_page: Parent AnonymCaseStudyPage (creates one if not provided)
+        slug: Page slug
+        title: Page title
+
+    Returns:
+        AnonymCaseStudyItemPage instance with content
+    """
+    placeholder_image = get_placeholder_image()
+    person = get_test_person()
+
+    if not case_study_page:
+        case_study_page = get_anonym_case_study_test_page()
+
+    test_page = AnonymCaseStudyItemPage.objects.filter(slug=slug).first()
+    if not test_page:
+        test_page = AnonymCaseStudyItemPage(
+            slug=slug,
+            title=title,
+        )
+        case_study_page.add_child(instance=test_page)
+
+    section_variants = get_section_block_variants(placeholder_image.id, person.id)
+    cta_variants = get_call_to_action_variants()
+
+    test_page.logo = placeholder_image
+    test_page.client = "Test Client Company"
+    test_page.description = "A comprehensive case study demonstrating results."
+    test_page.content = section_variants[:2] + cta_variants[:1]
+    test_page.save_revision().publish()
+
+    return test_page
+
+
+def get_anonym_contact_test_page() -> AnonymContactPage:
+    """Get or create a test AnonymContactPage with form fields.
+
+    Returns:
+        AnonymContactPage instance with form fields
+    """
+    index_page = get_test_anonym_index_page()
+
+    test_page = AnonymContactPage.objects.filter(slug="test-contact-page").first()
+    if not test_page:
+        test_page = AnonymContactPage(
+            slug="test-contact-page",
+            title="Test Contact Page",
+        )
+        index_page.add_child(instance=test_page)
+
+    form_field_variants = get_form_field_variants()
+
+    test_page.subheading = "Get in touch with our team"
+    test_page.form_fields = form_field_variants
+    test_page.save_revision().publish()
+
+    return test_page
+
+
+def create_all_test_pages() -> dict:
+    """Create all test pages for Anonym fixtures.
+
+    Returns:
+        Dictionary with all created test pages
+    """
+    # Create base fixtures
+    placeholder_image = get_placeholder_image()
+    person = get_test_person()
+
+    # Create pages in order (respecting parent relationships)
+    index_page = get_anonym_index_test_page()
+    top_and_bottom_page = get_anonym_top_and_bottom_test_page()
+    content_sub_page = get_anonym_content_sub_test_page()
+
+    # News pages
+    news_page = get_anonym_news_test_page()
+    news_item_page_1 = get_anonym_news_item_test_page(
+        news_page=news_page,
+        slug="test-news-item-1",
+        title="Test News Item 1",
+    )
+    news_item_page_2 = get_anonym_news_item_test_page(
+        news_page=news_page,
+        slug="test-news-item-2",
+        title="Test News Item 2 (External)",
+        with_external_link=True,
+    )
+
+    # Case study pages
+    case_study_page = get_anonym_case_study_test_page()
+    case_study_item_page_1 = get_anonym_case_study_item_test_page(
+        case_study_page=case_study_page,
+        slug="test-case-study-item-1",
+        title="Test Case Study Item 1",
+    )
+    case_study_item_page_2 = get_anonym_case_study_item_test_page(
+        case_study_page=case_study_page,
+        slug="test-case-study-item-2",
+        title="Test Case Study Item 2",
+    )
+
+    # Contact page
+    contact_page = get_anonym_contact_test_page()
+
+    return {
+        "placeholder_image": placeholder_image,
+        "person": person,
+        "index_page": index_page,
+        "top_and_bottom_page": top_and_bottom_page,
+        "content_sub_page": content_sub_page,
+        "news_page": news_page,
+        "news_item_pages": [news_item_page_1, news_item_page_2],
+        "case_study_page": case_study_page,
+        "case_study_item_pages": [case_study_item_page_1, case_study_item_page_2],
+        "contact_page": contact_page,
+    }

--- a/bedrock/anonym/management/__init__.py
+++ b/bedrock/anonym/management/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/bedrock/anonym/management/commands/__init__.py
+++ b/bedrock/anonym/management/commands/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/bedrock/anonym/management/commands/load_anonym_fixtures.py
+++ b/bedrock/anonym/management/commands/load_anonym_fixtures.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.core.management.base import BaseCommand
+
+from bedrock.anonym.fixtures.page_fixtures import create_all_test_pages
+
+
+class Command(BaseCommand):
+    help = "Load Anonym page fixtures for testing and visual verification in Wagtail admin."
+
+    def handle(self, *args, **options):
+        self.stdout.write("Creating Anonym test fixtures...")
+
+        result = create_all_test_pages()
+
+        self.stdout.write(self.style.SUCCESS("Created test fixtures:"))
+        self.stdout.write(f"  - Placeholder image: {result['placeholder_image'].title}")
+        self.stdout.write(f"  - Person snippet: {result['person']}")
+        self.stdout.write(f"  - Index page: {result['index_page'].title}")
+        self.stdout.write(f"  - Top and Bottom page: {result['top_and_bottom_page'].title}")
+        self.stdout.write(f"  - Content Sub page: {result['content_sub_page'].title}")
+        self.stdout.write(f"  - News page: {result['news_page'].title}")
+        for page in result["news_item_pages"]:
+            self.stdout.write(f"    - News item: {page.title}")
+        self.stdout.write(f"  - Case Study page: {result['case_study_page'].title}")
+        for page in result["case_study_item_pages"]:
+            self.stdout.write(f"    - Case study item: {page.title}")
+        self.stdout.write(f"  - Contact page: {result['contact_page'].title}")
+
+        self.stdout.write(self.style.SUCCESS("\nAll Anonym fixtures loaded successfully! View them in Wagtail admin at /admin/pages/"))

--- a/bedrock/anonym/tests/conftest.py
+++ b/bedrock/anonym/tests/conftest.py
@@ -3,25 +3,85 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import pytest
-from wagtail.models import Site
 
-from bedrock.anonym.models import AnonymIndexPage
+from bedrock.anonym.fixtures.base_fixtures import (
+    get_placeholder_image,
+    get_test_anonym_index_page,
+    get_test_person,
+)
+from bedrock.anonym.fixtures.page_fixtures import (
+    get_anonym_case_study_item_test_page,
+    get_anonym_case_study_test_page,
+    get_anonym_contact_test_page,
+    get_anonym_content_sub_test_page,
+    get_anonym_index_test_page,
+    get_anonym_news_item_test_page,
+    get_anonym_news_test_page,
+    get_anonym_top_and_bottom_test_page,
+)
 
 
-def get_test_anonym_index_page():
-    site = Site.objects.get(is_default_site=True)
-    root_page = site.root_page
-    anonym_index_page = AnonymIndexPage.objects.filter(slug="tests-anonym-index-page").first()
-    if not anonym_index_page:
-        anonym_index_page = AnonymIndexPage(
-            slug="tests-anonym-index-page",
-            title="Tests Anonym Index Page",
-        )
-        root_page.add_child(instance=anonym_index_page)
-        anonym_index_page.save_revision().publish()
-    return anonym_index_page
+@pytest.fixture
+def placeholder_image():
+    """Fixture providing a placeholder image for testing."""
+    return get_placeholder_image()
+
+
+@pytest.fixture
+def test_person(placeholder_image):
+    """Fixture providing a test Person snippet."""
+    return get_test_person()
 
 
 @pytest.fixture
 def anonym_index_page():
+    """Fixture providing a test AnonymIndexPage (basic, without content)."""
     return get_test_anonym_index_page()
+
+
+@pytest.fixture
+def anonym_index_page_with_content():
+    """Fixture providing a test AnonymIndexPage with full content."""
+    return get_anonym_index_test_page()
+
+
+@pytest.fixture
+def anonym_top_and_bottom_page(anonym_index_page):
+    """Fixture providing a test AnonymTopAndBottomPage."""
+    return get_anonym_top_and_bottom_test_page()
+
+
+@pytest.fixture
+def anonym_content_sub_page(anonym_index_page):
+    """Fixture providing a test AnonymContentSubPage."""
+    return get_anonym_content_sub_test_page()
+
+
+@pytest.fixture
+def anonym_news_page(anonym_index_page):
+    """Fixture providing a test AnonymNewsPage."""
+    return get_anonym_news_test_page()
+
+
+@pytest.fixture
+def anonym_news_item_page(anonym_news_page):
+    """Fixture providing a test AnonymNewsItemPage."""
+    return get_anonym_news_item_test_page(news_page=anonym_news_page)
+
+
+@pytest.fixture
+def anonym_case_study_page(anonym_index_page):
+    """Fixture providing a test AnonymCaseStudyPage."""
+    return get_anonym_case_study_test_page()
+
+
+@pytest.fixture
+def anonym_case_study_item_page(anonym_case_study_page):
+    """Fixture providing a test AnonymCaseStudyItemPage."""
+    return get_anonym_case_study_item_test_page(case_study_page=anonym_case_study_page)
+
+
+@pytest.fixture
+def anonym_contact_page(anonym_index_page):
+    """Fixture providing a test AnonymContactPage."""
+    return get_anonym_contact_test_page()

--- a/bedrock/anonym/tests/test_models.py
+++ b/bedrock/anonym/tests/test_models.py
@@ -1,0 +1,540 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.test import RequestFactory
+
+import pytest
+from bs4 import BeautifulSoup
+from wagtail.models import Site
+
+from bedrock.anonym.fixtures.base_fixtures import (
+    get_placeholder_image,
+    get_test_anonym_index_page,
+    get_test_person,
+)
+from bedrock.anonym.fixtures.block_fixtures import (
+    get_call_to_action_variants,
+    get_competitor_comparison_table_variants,
+    get_form_field_variants,
+    get_navigation_link_variants,
+    get_section_block_variants,
+    get_stat_item_variants,
+    get_toggleable_items_variants,
+)
+from bedrock.anonym.models import (
+    AnonymCaseStudyItemPage,
+    AnonymCaseStudyPage,
+    AnonymContactPage,
+    AnonymContentSubPage,
+    AnonymIndexPage,
+    AnonymNewsItemPage,
+    AnonymNewsPage,
+    AnonymTopAndBottomPage,
+    Person,
+)
+from bedrock.cms.tests.conftest import minimal_site  # noqa: F401
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+def get_text_from_html(html_string: str) -> str:
+    """Extract plain text from an HTML string.
+
+    Args:
+        html_string: HTML content string
+
+    Returns:
+        Plain text with HTML tags stripped
+    """
+    soup = BeautifulSoup(html_string, "html.parser")
+    return soup.get_text()
+
+
+# ============================================================================
+# Person Snippet Tests
+# ============================================================================
+
+
+def test_person_snippet_creation() -> None:
+    """Test that a Person snippet can be created."""
+    image = get_placeholder_image()
+    person = Person.objects.create(
+        name="John Doe",
+        position="Software Engineer",
+        description="<p>A software engineer.</p>",
+        image=image,
+    )
+    assert person.id is not None
+    assert person.name == "John Doe"
+    assert person.position == "Software Engineer"
+
+
+def test_person_snippet_str() -> None:
+    """Test the string representation of a Person snippet."""
+    person = get_test_person()
+    assert str(person) == f"{person.name} - {person.position}"
+
+
+# ============================================================================
+# AnonymIndexPage Tests
+# ============================================================================
+
+
+def test_anonym_index_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymIndexPage can be created."""
+    root_page = minimal_site.root_page
+    page = AnonymIndexPage(
+        title="Anonym Home",
+        slug="anonym-home",
+    )
+    root_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "Anonym Home"
+    assert page.live is True
+
+
+def test_anonym_index_page_get_available_sections(minimal_site: Site) -> None:  # noqa: F811
+    """Test that get_available_sections returns anchor IDs from content blocks."""
+    root_page = minimal_site.root_page
+    image = get_placeholder_image()
+    person = get_test_person()
+
+    section_variants = get_section_block_variants(image.id, person.id)
+    cta_variants = get_call_to_action_variants()
+
+    page = AnonymIndexPage(
+        title="Anonym Home",
+        slug="anonym-home-sections",
+        content=section_variants[:2] + cta_variants[:1],
+    )
+    root_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    sections = page.get_available_sections()
+    # Sections should include anchor IDs from content blocks - derive expected from fixture data
+    expected_sections = {
+        section_variants[0]["value"]["settings"]["anchor_id"],
+        section_variants[1]["value"]["settings"]["anchor_id"],
+        cta_variants[0]["value"]["settings"]["anchor_id"],
+    }
+    assert set(sections) == expected_sections
+
+
+@pytest.mark.parametrize("serving_method", ("serve", "serve_preview"))
+def test_anonym_index_page_serve(
+    minimal_site: Site,  # noqa: F811
+    rf: RequestFactory,
+    serving_method: str,
+) -> None:
+    """Test that AnonymIndexPage can be served."""
+    root_page = minimal_site.root_page
+    image = get_placeholder_image()
+    person = get_test_person()
+
+    section_variants = get_section_block_variants(image.id, person.id)
+    # Use only the first two nav links (overview, features) that match section anchor IDs
+    nav_variants = get_navigation_link_variants()[:2]
+
+    page = AnonymIndexPage(
+        title="Anonym Index",
+        slug="anonym-index-serve",
+        navigation=nav_variants,
+        # Include sections with anchor IDs that match navigation (overview, features)
+        content=section_variants[:2],
+    )
+    root_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    _relative_url = page.relative_url(minimal_site)
+    request = rf.get(_relative_url)
+
+    resp = getattr(page, serving_method)(request)
+    page_content = resp.text
+
+    assert "Anonym Index" in page_content
+    # The heading_text from fixtures contains HTML; parse the page to extract just the text
+    page_soup = BeautifulSoup(page_content, "html.parser")
+    page_text = page_soup.get_text()
+    expected_heading_text = get_text_from_html(section_variants[0]["value"]["heading_text"])
+    assert expected_heading_text in page_text
+
+
+# ============================================================================
+# AnonymTopAndBottomPage Tests
+# ============================================================================
+
+
+def test_anonym_top_and_bottom_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymTopAndBottomPage can be created."""
+    index_page = get_test_anonym_index_page()
+
+    page = AnonymTopAndBottomPage(
+        title="Top and Bottom Test",
+        slug="top-and-bottom-test",
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "Top and Bottom Test"
+
+
+@pytest.mark.parametrize("serving_method", ("serve", "serve_preview"))
+def test_anonym_top_and_bottom_page_serve(
+    minimal_site: Site,  # noqa: F811
+    rf: RequestFactory,
+    serving_method: str,
+) -> None:
+    """Test that AnonymTopAndBottomPage can be served."""
+    index_page = get_test_anonym_index_page()
+    image = get_placeholder_image()
+    person = get_test_person()
+
+    section_variants = get_section_block_variants(image.id, person.id)
+    comparison_variants = get_competitor_comparison_table_variants()
+
+    page = AnonymTopAndBottomPage(
+        title="Top and Bottom Serve Test",
+        slug="top-and-bottom-serve-test",
+        top_content=section_variants[:1],
+        bottom_content=comparison_variants[:1],
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    _relative_url = page.relative_url(minimal_site)
+    request = rf.get(_relative_url)
+
+    resp = getattr(page, serving_method)(request)
+    page_content = resp.text
+
+    assert "Top and Bottom Serve Test" in page_content
+    # Verify content from comparison table block
+    heading_text = comparison_variants[0]["value"]["heading_text"]
+    assert heading_text in page_content
+
+
+# ============================================================================
+# AnonymContentSubPage Tests
+# ============================================================================
+
+
+def test_anonym_content_sub_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymContentSubPage can be created."""
+    index_page = get_test_anonym_index_page()
+
+    page = AnonymContentSubPage(
+        title="Content Sub Test",
+        slug="content-sub-test",
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "Content Sub Test"
+
+
+@pytest.mark.parametrize("serving_method", ("serve", "serve_preview"))
+def test_anonym_content_sub_page_serve(
+    minimal_site: Site,  # noqa: F811
+    rf: RequestFactory,
+    serving_method: str,
+) -> None:
+    """Test that AnonymContentSubPage can be served."""
+    index_page = get_test_anonym_index_page()
+    image = get_placeholder_image()
+    person = get_test_person()
+
+    section_variants = get_section_block_variants(image.id, person.id)
+    toggleable_variants = get_toggleable_items_variants(image.id, person.id)
+
+    page = AnonymContentSubPage(
+        title="Content Sub Serve Test",
+        slug="content-sub-serve-test",
+        content=section_variants[:1] + toggleable_variants[:1],
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    _relative_url = page.relative_url(minimal_site)
+    request = rf.get(_relative_url)
+
+    resp = getattr(page, serving_method)(request)
+    page_content = resp.text
+
+    assert "Content Sub Serve Test" in page_content
+
+
+# ============================================================================
+# AnonymNewsPage Tests
+# ============================================================================
+
+
+def test_anonym_news_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymNewsPage can be created."""
+    index_page = get_test_anonym_index_page()
+
+    page = AnonymNewsPage(
+        title="News Test",
+        slug="news-test",
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "News Test"
+
+
+# ============================================================================
+# AnonymNewsItemPage Tests
+# ============================================================================
+
+
+def test_anonym_news_item_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymNewsItemPage can be created."""
+    index_page = get_test_anonym_index_page()
+    news_page = AnonymNewsPage(
+        title="News Container",
+        slug="news-container-test",
+    )
+    index_page.add_child(instance=news_page)
+    news_page.save_revision().publish()
+
+    image = get_placeholder_image()
+
+    page = AnonymNewsItemPage(
+        title="News Item Test",
+        slug="news-item-test",
+        description="A test news item",
+        category="Press",
+        logo=image,
+        image=image,
+    )
+    news_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "News Item Test"
+    assert page.category == "Press"
+
+
+def test_anonym_news_item_page_exclude_from_sitemap(minimal_site: Site) -> None:  # noqa: F811
+    """Test that AnonymNewsItemPage excludes from sitemap when external link is set."""
+    index_page = get_test_anonym_index_page()
+    news_page = AnonymNewsPage(
+        title="News Container",
+        slug="news-container-sitemap-test",
+    )
+    index_page.add_child(instance=news_page)
+    news_page.save_revision().publish()
+
+    # Page without external link should be in sitemap
+    page_internal = AnonymNewsItemPage(
+        title="Internal News",
+        slug="internal-news-test",
+        link="",
+    )
+    news_page.add_child(instance=page_internal)
+    page_internal.save_revision().publish()
+    assert page_internal.exclude_from_sitemap is False
+
+    # Page with external link should be excluded from sitemap
+    page_external = AnonymNewsItemPage(
+        title="External News",
+        slug="external-news-test",
+        link="https://example.com/external",
+    )
+    news_page.add_child(instance=page_external)
+    page_external.save_revision().publish()
+    assert page_external.exclude_from_sitemap is True
+
+
+@pytest.mark.parametrize("serving_method", ("serve", "serve_preview"))
+def test_anonym_news_item_page_serve(
+    minimal_site: Site,  # noqa: F811
+    rf: RequestFactory,
+    serving_method: str,
+) -> None:
+    """Test that AnonymNewsItemPage can be served."""
+    index_page = get_test_anonym_index_page()
+    news_page = AnonymNewsPage(
+        title="News Container",
+        slug="news-container-serve-test",
+    )
+    index_page.add_child(instance=news_page)
+    news_page.save_revision().publish()
+
+    image = get_placeholder_image()
+    person = get_test_person()
+    section_variants = get_section_block_variants(image.id, person.id)
+    stat_variants = get_stat_item_variants()
+
+    page = AnonymNewsItemPage(
+        title="News Item Serve Test",
+        slug="news-item-serve-test",
+        description="Testing news item serving",
+        category="Blog",
+        logo=image,
+        image=image,
+        stats=stat_variants[:2],
+        content=section_variants[:1],
+    )
+    news_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    _relative_url = page.relative_url(minimal_site)
+    request = rf.get(_relative_url)
+
+    resp = getattr(page, serving_method)(request)
+    page_content = resp.text
+
+    assert "News Item Serve Test" in page_content
+
+
+# ============================================================================
+# AnonymCaseStudyPage Tests
+# ============================================================================
+
+
+def test_anonym_case_study_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymCaseStudyPage can be created."""
+    index_page = get_test_anonym_index_page()
+
+    page = AnonymCaseStudyPage(
+        title="Case Study Test",
+        slug="case-study-test",
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "Case Study Test"
+
+
+# ============================================================================
+# AnonymCaseStudyItemPage Tests
+# ============================================================================
+
+
+def test_anonym_case_study_item_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymCaseStudyItemPage can be created."""
+    index_page = get_test_anonym_index_page()
+    case_study_page = AnonymCaseStudyPage(
+        title="Case Study Container",
+        slug="case-study-container-test",
+    )
+    index_page.add_child(instance=case_study_page)
+    case_study_page.save_revision().publish()
+
+    image = get_placeholder_image()
+
+    page = AnonymCaseStudyItemPage(
+        title="Case Study Item Test",
+        slug="case-study-item-test",
+        client="Test Client",
+        description="A test case study",
+        logo=image,
+    )
+    case_study_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "Case Study Item Test"
+    assert page.client == "Test Client"
+
+
+@pytest.mark.parametrize("serving_method", ("serve", "serve_preview"))
+def test_anonym_case_study_item_page_serve(
+    minimal_site: Site,  # noqa: F811
+    rf: RequestFactory,
+    serving_method: str,
+) -> None:
+    """Test that AnonymCaseStudyItemPage can be served."""
+    index_page = get_test_anonym_index_page()
+    case_study_page = AnonymCaseStudyPage(
+        title="Case Study Container",
+        slug="case-study-container-serve-test",
+    )
+    index_page.add_child(instance=case_study_page)
+    case_study_page.save_revision().publish()
+
+    image = get_placeholder_image()
+    person = get_test_person()
+    section_variants = get_section_block_variants(image.id, person.id)
+
+    page = AnonymCaseStudyItemPage(
+        title="Case Study Item Serve Test",
+        slug="case-study-item-serve-test",
+        client="Acme Corp",
+        description="Testing case study item serving",
+        logo=image,
+        content=section_variants[:1],
+    )
+    case_study_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    _relative_url = page.relative_url(minimal_site)
+    request = rf.get(_relative_url)
+
+    resp = getattr(page, serving_method)(request)
+    page_content = resp.text
+
+    assert "Case Study Item Serve Test" in page_content
+
+
+# ============================================================================
+# AnonymContactPage Tests
+# ============================================================================
+
+
+def test_anonym_contact_page_creation(minimal_site: Site) -> None:  # noqa: F811
+    """Test that an AnonymContactPage can be created."""
+    index_page = get_test_anonym_index_page()
+
+    page = AnonymContactPage(
+        title="Contact Test",
+        slug="contact-test",
+        subheading="Get in touch",
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    assert page.id is not None
+    assert page.title == "Contact Test"
+    assert page.subheading == "Get in touch"
+
+
+@pytest.mark.parametrize("serving_method", ("serve", "serve_preview"))
+def test_anonym_contact_page_serve(
+    minimal_site: Site,  # noqa: F811
+    rf: RequestFactory,
+    serving_method: str,
+) -> None:
+    """Test that AnonymContactPage can be served."""
+    index_page = get_test_anonym_index_page()
+    form_field_variants = get_form_field_variants()
+
+    page = AnonymContactPage(
+        title="Contact Serve Test",
+        slug="contact-serve-test",
+        subheading="Contact us today",
+        form_fields=form_field_variants[:3],
+    )
+    index_page.add_child(instance=page)
+    page.save_revision().publish()
+
+    _relative_url = page.relative_url(minimal_site)
+    request = rf.get(_relative_url)
+
+    resp = getattr(page, serving_method)(request)
+    page_content = resp.text
+
+    assert "Contact Serve Test" in page_content
+    # Verify form field labels from fixture data
+    assert form_field_variants[0]["value"]["label"] in page_content
+    assert form_field_variants[2]["value"]["label"] in page_content


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._

## One-line summary
This pull request adds fixtures and tests for anonym pages.

## Significant changes and points to review

Similar to the pattern in springfield, anonym now includes:
1. fixtures for creating pages with the anonym components. Run `load_anonym_fixtures` to create them, then observe in Wagtail
2. unit tests for the anonym pages

This addresses 2 issues:
1. being able to easily see the anonym components and how they may appear in pages (to match springfield)
2. making sure that the anonym components have a base level of testability (to match springfield)


## Issue / Bugzilla link


## Testing
1. Run `load_anonym_fixtures`
2. Log in to Wagtail, and find the ??? page
3. Run the unit tests and observe that they pass
