### PR TITLE
Add workflow to auto-generate GitHub releases for production tags

### DIFF
--- a/.github/workflows/generate-gh-release-note.yml
+++ b/.github/workflows/generate-gh-release-note.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   create-release:
     name: Generate GitHub Release entry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'mozilla/bedrock'
     permissions:
       contents: write


### PR DESCRIPTION
This changeset does nothing to replace our existing release workflow -- it complements ith by creating a [GitHub Release](https://github.com/mozilla/bedrock/releases) entry automatically, so that it's easier for people to see what has just shipped.

When a production tag (`YYYY-MM-DD` or `YYYY-MM-DD.integer`) is pushed, the workflow added here uses GitHub's automatic release-note generation to document changes between tags.

## Testing

We'll have to test this with the next prod push, but it's non-blocking