### PR TITLE
Reclaim more space for docker build CI

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -8,7 +8,6 @@ on:
       - run-integration-tests
     tags:
       - '*'
-
   workflow_dispatch:
     inputs:
       ref:
@@ -16,6 +15,7 @@ on:
         type: string
         required: true
         default: refs/heads/main
+
 env:
   APP: bedrock
   GAR_LOCATION: us
@@ -25,6 +25,8 @@ env:
   ORG: mozmeao
   REF_ID: ${{ github.event.inputs.ref || github.ref }}
 
+permissions:
+  contents: read
 
 jobs:
   build_and_publish_public_images:
@@ -43,6 +45,7 @@ jobs:
           sudo rm -rf /home/runner/.rustup
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           docker system df
           df -h
@@ -51,7 +54,7 @@ jobs:
         with:
           buildkitd-flags: "cache-from: type=gha cache-to: type=gha,mode=max"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
             fetch-depth: 10 # get enough so we have a Git history, but not everything
             fetch-tags: true
@@ -156,7 +159,6 @@ jobs:
     needs: [build_and_publish_public_images, upload_static_assets]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write
 
     steps:


### PR DESCRIPTION
## One-line summary

Also removes unused JVM for extra ~1.5GB in <1sec that is the last large yet fast to remove tool.

## Significant changes and points to review

Since there's work going on over at GHA side to actually make the main disk space more useful, the ephemeral mount might be going away in favor of more space available in places that are scarce now. So being no longer productive looking into ways how to move docker dirs from /var to /mnt I'm posting one extra removal instead and calling it good enough for now, the runner currently has about the double of the space needed, from when it hit the capacity earlier.

## Issue / Bugzilla link

Closes #16923

## Testing

(integration test run to step through the build pipeline would be lovely)