### PR TITLE
Remove top menu test for firefox link (now under products submenu)

### DIFF
--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -12,8 +12,6 @@ from pages.home import HomePage
 def test_navigation(base_url, selenium):
     page = HomePage(selenium, base_url, locale="de").open()
 
-    assert page.navigation.is_firefox_menu_displayed
-
     page.navigation.open_products_menu()
     assert page.navigation.is_products_menu_displayed
 

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -42,7 +42,6 @@ class BasePage(ScrollElementIntoView, Page):
         _root_locator = (By.CLASS_NAME, "m24-navigation-refresh")
         _toggle_locator = (By.CLASS_NAME, "m24-c-navigation-menu-button")
         _menu_locator = (By.CLASS_NAME, "m24-c-navigation-items")
-        _firefox_menu_link_locator = (By.CSS_SELECTOR, '.m24-c-menu-title[data-testid="m24-navigation-link-firefox"]')
         _products_menu_link_locator = (By.CSS_SELECTOR, '.m24-c-menu-title[aria-controls="m24-c-menu-panel-products"]')
         _products_menu_locator = (By.ID, "m24-c-menu-panel-products")
         _about_menu_link_locator = (By.CSS_SELECTOR, '.m24-c-menu-title[aria-controls="m24-c-menu-panel-about"]')
@@ -56,10 +55,6 @@ class BasePage(ScrollElementIntoView, Page):
         def open_navigation_menu(self, locator):
             menu = self.find_element(*locator)
             menu.click()
-
-        @property
-        def is_firefox_menu_displayed(self):
-            return self.is_element_displayed(*self._firefox_menu_link_locator)
 
         @property
         def is_products_menu_displayed(self):


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing
successful test run: https://github.com/mozilla/bedrock/actions/runs/21640269153