### PR TITLE
Fix advisory label

### DIFF
--- a/media/css/security/components/level.scss
+++ b/media/css/security/components/level.scss
@@ -49,7 +49,7 @@
             gap: 0.5rem;
         }
 
-        span {
+        .level {
             height: fit-content;
         }
     }


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes the security advisory label issues:
- no space between label and text on mobile
- mis-aligned vertically on desktop view

## Significant changes and points to review

Before:
<img width="561" height="217" alt="before-desktop" src="https://github.com/user-attachments/assets/c2301bde-4666-490a-b04f-fb80af587632" />
<img width="366" height="268" alt="before-mobile" src="https://github.com/user-attachments/assets/d1c21b35-c62c-4aa7-b961-f8066985e02d" />

After:
<img width="577" height="240" alt="after-desktop" src="https://github.com/user-attachments/assets/975d4132-813f-4405-a4ac-f7ad6d0271eb" />
<img width="319" height="368" alt="after-mobile" src="https://github.com/user-attachments/assets/fa1cdba1-29f1-45a3-8bae-86df73696276" />


## Issue / Bugzilla link



## Testing
http://localhost:8000/en-US/security/advisories/