### PR TITLE
fix: ensure privacy table alignment for Moz Accounts works across all locales

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/mozilla-accounts.html
+++ b/bedrock/privacy/templates/privacy/notices/mozilla-accounts.html
@@ -8,4 +8,6 @@
 
 {% set body_id = "mozilla-accounts" %}
 
+{% block body_class %}{{ super() }} mozilla-accounts{% endblock %}
+
 {% block article_header_logo %}{{ static('img/trademarks/symbol.svg') }}{% endblock %}

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -296,6 +296,8 @@ $border: 2px solid $color-marketing-gray-20;
 // * -------------------------------------------------------------------------- */
 // Mozilla accounts page variant
 
-#lawful-bases + .mzp-u-data-table td {
-  vertical-align: top;
+.mozilla-accounts {
+    .mzp-u-data-table td {
+        vertical-align: top;
+    }
 }


### PR DESCRIPTION
The previous implementation dependended on an ID overlooked the fact that it was drawn from localisable content

## Testing

`./manage.py update_legal_docs --force`

Restart your server

Confirm all locales benefit from the top alignment in their tables

http://localhost:8000/en-US/privacy/mozilla-accounts/
http://localhost:8000/it/privacy/mozilla-accounts/
http://localhost:8000/fr/privacy/mozilla-accounts/