### PR TITLE
update VPN support versions - WT661

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -94,7 +94,7 @@
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-mac-long', fallback='vpn-download-for-mac') }}</h2>
               <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-              <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='13.0') }}</p>
               <a class="mzp-c-button ga-product-download" href="{{ url('products.vpn.mac-download') }}" data-cta-text="VPN Download (macOS)" class="platform-download-link" data-testid="vpn-download-link-primary-mac">
               {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}
               </a>
@@ -141,7 +141,7 @@
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-android-long', fallback='vpn-download-for-android') }}</h2>
               <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-              <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='9.0') }}</p>
               <a class="platform-download-link ga-product-download" href="{{ android_download_url }}" data-cta-text="VPN Download (Android)" target="_blank" rel="noopener noreferrer">
                 <img src="{{ static('img/products/vpn/download/google-play-badge.png') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
               </a>
@@ -185,7 +185,7 @@
             </div>
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-mac') }}</h2>
-              <p>{{ ftl('vpn-download-version-requirements', version='11.0') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='13.0') }}</p>
             </div>
             <a href="{{ url('products.vpn.mac-download') }}" data-cta-text="VPN Download (macOS)" class="platform-download-link ga-product-download" data-testid="vpn-download-link-secondary-mac">
               <span class="visually-hidden">{{ ftl('vpn-download-for-mac-long') }}</span>
@@ -231,7 +231,7 @@
             </div>
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-android') }}</h2>
-              <p>{{ ftl('vpn-download-version-requirements', version='8.0') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='9.0') }}</p>
             </div>
             <a href="{{ android_download_url }}" data-cta-text="VPN Download (Android)" class="platform-download-link ga-product-download">
               <span class="visually-hidden">{{ ftl('vpn-download-for-android-long') }}</span>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the VPN supported versions for MacOS and Android.

## Significant changes and points to review

Versions numbers in both primary and secondary lists.

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-661

## Testing

http://localhost:8000/en-US/products/vpn/download/