### PR TITLE
fix: Strip HTML comments from security advisory HTML before sanitization

### DIFF
--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -82,8 +82,19 @@ ADVISORY_ALLOWED_ATTRS = {
 }
 
 
+def strip_html_comments(html):
+    """Remove HTML comments (<!-- ... -->) from advisory HTML.
+
+    Some older advisories contain HTML comments (e.g. commented-out CVE
+    placeholders).  The sanitizer escapes these into visible &lt;!-- … --&gt;
+    text, so we strip them before sanitization.
+    """
+    return re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)
+
+
 def sanitize_advisory_html(html):
     """Sanitize advisory HTML using an allowlist of tags and attributes."""
+    html = strip_html_comments(html)
     return sanitize_html(html, ADVISORY_ALLOWED_TAGS, ADVISORY_ALLOWED_ATTRS)
 
 


### PR DESCRIPTION
Some older advisories (e.g. mfsa2009-33) contain HTML comments with placeholder content commented out, generally CVE references.

However, the the justhtml sanitizer escapes these into visible `&lt;!-- … --&gt;` text on the rendered page, making them visible.

The fix is a new strip_html_comments() function that removes comments before sanitization runs, preventing them from being escaped into visible page content.

_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-668

## Testing

- `make preflight` to get current data
- view http://localhost:8000/en-US/security/advisories/mfsa2009-33/ and note the appearance of comment-like text - this is because the `<` and `>` have been escaped, so don't mark the start of an ignorable comment.
- on this branch, run `python manage.py update_security_advisories` to re-import the data
- Confirm the pseudo-comment is no longer in the page