### PR TITLE
pass github parameter in env variables

### DIFF
--- a/.github/workflows/generate-gh-release-note.yml
+++ b/.github/workflows/generate-gh-release-note.yml
@@ -44,8 +44,8 @@ jobs:
         if: steps.validate.outputs.valid == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_TAG: ${{ steps.validate.outputs.tag_name }}
         run: |
-          CURRENT_TAG="${{ steps.validate.outputs.tag_name }}"
 
           # Create the release with auto-generated notes
           gh release create "$CURRENT_TAG" \


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
pass github parameter in env variables

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
