### PR TITLE
feat(WT-870): add support for environment-driven CSP connect-src

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -143,6 +143,8 @@ if (len(sys.argv) > 1 and sys.argv[1] == "test") or "pytest" in sys.modules:
 # 3. DJANGO-CSP SETTINGS
 if csp_extra_default_src := config("CSP_DEFAULT_SRC", default="", parser=ListOf(str, allow_empty=False)):
     _csp_default_src |= set(csp_extra_default_src)
+if extra_csp_connect_src := config("CSP_CONNECT_SRC", default="", parser=ListOf(str, allow_empty=False)):
+    _csp_connect_src |= set(extra_csp_connect_src)
 if csp_extra_frame_src := config("CSP_EXTRA_FRAME_SRC", default="", parser=ListOf(str, allow_empty=False)):
     _csp_frame_src |= set(csp_extra_frame_src)
 csp_report_uri = config("CSP_REPORT_URI", default="") or None


### PR DESCRIPTION
This changeset brings in the ability to extend `connect-src` in the [same way we already do in Springfield](https://github.com/mozmeao/springfield/blob/da5bd51045d7d3df78a1450d4a825074dced5cc8/springfield/settings/__init__.py#L147-L148)

## Testing

add this to your `.env` and load a page, then look at the CSP

`CSP_CONNECT_SRC="test.example.com,bar.foo.example.com:8080"`

<img width="1578" height="420" alt="Screenshot 2026-03-04 at 13 49 37" src="https://github.com/user-attachments/assets/33365217-2e64-4bed-a3db-ce9694ecda24" />

