### PR TITLE
WT-890 fix springboard data attribution (#17066)

### DIFF
--- a/bedrock/base/templates/macros-m24.html
+++ b/bedrock/base/templates/macros-m24.html
@@ -87,7 +87,7 @@
 ) -%}
 
 <li class="m24-c-springboard-item {{ class }}">
-  <a href="{{ link_url }}" class="m24-c-springboard-link" {{ link_attributes | safe }}>
+  <a href="{{ link_url }}" class="m24-c-springboard-link" {% if link_attributes %}{{ link_attributes | safe }}{% endif %}>
     <div class="m24-c-springboard-thumb">
       {% if type_icon %}
         <span class="m24-c-springboard-icon m24-c-springboard-icon-{{ type_icon|lower }}"></span>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes the springboard data attributes.

## Significant changes and points to review

Springboard data attributes on homepage.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/17066

## Testing

http://localhost:8000/en-US/