### PR TITLE
fix: truncate Bluesky share text before URL-encoding

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -43,7 +43,7 @@
 
 {# Docs: https://docs.bsky.app/docs/advanced-guides/intent-links #}
 {% macro bluesky_share_url(url, text) -%}
-  {{ 'https://bsky.app/intent/compose?text=%s+%s'|format(text|urlencode|truncate(300), url|urlencode)  }}
+  {{ 'https://bsky.app/intent/compose?text=%s+%s'|format(text|truncate(300)|urlencode, url|urlencode)  }}
 {%- endmacro %}
 
 {% macro google_play_button(class_name='', extra_data_attributes={}, extra_img_attributes={}, href=settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS, id='', product='Firefox', target='') -%}


### PR DESCRIPTION
URL-encoding was inflating non-ASCII characters (e.g. Cyrillic, CJK, Arabic) up to 6x, causing the 300-char truncation to cut mid-encoding and produce garbled share text.

The fix is to swap the filter order, so that truncation happens on the raw text first.

## Issue / Bugzilla link

Resolves #17084

## Testing

- `./manage.py l10n_update` to get latest translations
- Visit /sr/about/manifesto/, click the Bluesky share button — confirm the pre-filled text is the complete Serbian sentence, not truncated garbage
- Visit /en-US/about/manifesto/, click the Bluesky share button — confirm ASCII locale still works correctly
