### PR TITLE
Add New Thunderbird App Id to .well-known/org.flathub.VerifiedApps.txt

### DIFF
--- a/root_files/.well-known/org.flathub.VerifiedApps.txt
+++ b/root_files/.well-known/org.flathub.VerifiedApps.txt
@@ -1,2 +1,8 @@
 # org.mozilla.vpn
 bae02cc7-9600-4568-b6d7-f452e5551956
+
+# org.mozilla.thunderbird
+c0b3aecc-1ba9-40df-8194-d82f9611db4f
+
+# org.mozilla.thunderbird_esr
+2e0404b9-fd19-4fce-b3a7-8fef8bcdebae


### PR DESCRIPTION
## One-line summary

Adds org.mozilla.thunderbird to .well-known/org.flathub.VerifiedApps.txt

## Significant changes and points to review

This extends a static file in the .well-known directory to complete [app verification](https://docs.flathub.org/docs/for-app-authors/verification) for the [org.mozilla.thunderbird](https://flathub.org/apps/org.mozilla.thunderbird) app on Flathub.

## Issue / Bugzilla link

Relates to: https://bugzilla.mozilla.org/show_bug.cgi?id=2015223

## Testing
