### PR TITLE
Mismatched closing tag in showcase-som-2025

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som-2025.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som-2025.html
@@ -19,13 +19,13 @@
       </div>
     </div>
 
-    <header class="m24-c-showcase-text m24-l-two-columns">
+    <footer class="m24-c-showcase-text m24-l-two-columns">
       <h3 class="m24-c-showcase-subtitle">2025</h3>
 
       <p class="m24-c-showcase-body m24-c-section-cta">
         <a href="https://stateof.mozilla.org{{ utm_params }}" class="m24-c-cta" rel="external noopener" data-cta-text="Read the report">{{ ftl('m24-home-read-the-report') }}</a>
       </p>
-    </header>
+    </footer>
 
   </div>
 </section>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som-2025.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som-2025.html
@@ -25,7 +25,7 @@
       <p class="m24-c-showcase-body m24-c-section-cta">
         <a href="https://stateof.mozilla.org{{ utm_params }}" class="m24-c-cta" rel="external noopener" data-cta-text="Read the report">{{ ftl('m24-home-read-the-report') }}</a>
       </p>
-    </footer>
+    </header>
 
   </div>
 </section>

--- a/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som.html
@@ -17,7 +17,7 @@
       </div>
     </div>
 
-    <header class="m24-c-showcase-text m24-l-two-columns">
+    <footer class="m24-c-showcase-text m24-l-two-columns">
       <h3 class="m24-c-showcase-subtitle">2024</h3>
 
       <p class="m24-c-showcase-body m24-c-section-cta">


### PR DESCRIPTION
## One-line summary

In bedrock/mozorg/templates/mozorg/home/includes/m24/showcase-som-2025.html, a `<header>` element is closed with </footer> instead of a matching closing tag. This appears to affect the homepage content shown on https://www.mozilla.org/en-US/.

## Significant changes and points to review

Just a changed closing tag.

---

I've discovered it while developing a HTML5 syntax checker.
