### PR TITLE
feat: Update footer links on Anonym pages to feature only its legal docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ default_language_version:
 repos:
   # Note: hooks that add content must run before ones which check formatting, lint, etc
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-shebang-scripts-are-executable
     -   id: check-yaml
@@ -26,7 +26,7 @@ repos:
         args:
           - --markdown-linebreak-ext=md
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: v1.5.6
     hooks:
     -   id: insert-license
         language: python
@@ -71,18 +71,18 @@ repos:
           - --comment-style
           - "|#|"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.9
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/mozilla-l10n/moz-fluent-linter
-    rev: v0.4.7
+    rev: v0.4.9
     hooks:
       - id: fluent_linter
         files: \.ftl$
         args: [--config, .github/l10n/linter_config.yml, l10n/en/, l10n/en-US/]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         additional_dependencies:
@@ -97,7 +97,7 @@ repos:
           - "postcss-scss@4.0.9"
           - "postcss@8.4.38"
   - repo: https://github.com/eslint/eslint
-    rev: v9.13.0
+    rev: v10.2.0
     hooks:
       - id: eslint
         additional_dependencies:
@@ -113,12 +113,12 @@ repos:
     -   id: check-unapplied-migrations
     -   id: check-absent-migrations
   - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.19.1"
+    rev: "v3.21.2"
     hooks:
     - id: pyupgrade
       args: [--py313]
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.24.0"  # replace with latest tag on GitHub
+    rev: "1.30.0"  # replace with latest tag on GitHub
     hooks:
     -   id: django-upgrade
         args: [--target-version, "5.2"]

--- a/bedrock/anonym/templates/anonym/anonym_case_study.html
+++ b/bedrock/anonym/templates/anonym/anonym_case_study.html
@@ -68,7 +68,7 @@
 {% endblock %}
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/anonym/templates/anonym/anonym_case_study_item_page.html
+++ b/bedrock/anonym/templates/anonym/anonym_case_study_item_page.html
@@ -98,7 +98,7 @@
 
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/anonym/templates/anonym/anonym_contact.html
+++ b/bedrock/anonym/templates/anonym/anonym_contact.html
@@ -87,7 +87,7 @@
 {% endblock %}
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/anonym/templates/anonym/anonym_content_sub_page.html
+++ b/bedrock/anonym/templates/anonym/anonym_content_sub_page.html
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/anonym/templates/anonym/anonym_index_page.html
+++ b/bedrock/anonym/templates/anonym/anonym_index_page.html
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/anonym/templates/anonym/anonym_news.html
+++ b/bedrock/anonym/templates/anonym/anonym_news.html
@@ -137,7 +137,7 @@
 {% endblock %}
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/anonym/templates/anonym/anonym_top_and_bottom_page.html
+++ b/bedrock/anonym/templates/anonym/anonym_top_and_bottom_page.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block site_footer %}
-  {% with branding_only=True %}
+  {% with branding_only=True, anonym_links=True %}
     {% include 'includes/protocol/footer/footer.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -114,8 +114,7 @@
           {{ ftl('footer-refresh-portions-of-this-content', href='href="%s"'|safe|format(url('foundation.licensing.website-content')), current_year=current_year|string) }}
         </p>
         <ul class="moz24-footer-terms">
-        {% set anonym_root_path="/"+LANG+"/anonym/" %}
-        {% if request.path.startswith(anonym_root_path) %}
+        {% if anonym_links %}
           {#
             For pages in the Anonym section, we ONLY show links to Anonym's legal docs, to
             avoid confusion with MoCo legals such as the Website Privacy Notice, DSAR page, etc

--- a/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-refresh.html
@@ -114,6 +114,19 @@
           {{ ftl('footer-refresh-portions-of-this-content', href='href="%s"'|safe|format(url('foundation.licensing.website-content')), current_year=current_year|string) }}
         </p>
         <ul class="moz24-footer-terms">
+        {% set anonym_root_path="/"+LANG+"/anonym/" %}
+        {% if request.path.startswith(anonym_root_path) %}
+          {#
+            For pages in the Anonym section, we ONLY show links to Anonym's legal docs, to
+            avoid confusion with MoCo legals such as the Website Privacy Notice, DSAR page, etc
+          #}
+          <li><a href="{{ url('anonym.privacy-policy') }}" data-link-position="footer" data-link-text="Anonym Privacy Policy">{{ ftl('footer-refresh-anonym-privacy-policy') }}</a></li>
+          <li><a href="{{ url('anonym.terms-and-conditions') }}" data-link-position="footer" data-link-text="Anonym Terms and Conditions">{{ ftl('footer-refresh-anonym-terms-and-conditions') }}</a></li>
+          <li>
+            {# Link to /privacy/websites/cookie-settings/ is a legal requirement and should not be removed. It must be present on every page (Issue 14213). #}
+            <a href="{{ url('privacy.cookie-settings') }}" data-link-position="footer" data-link-text="Cookies">{{ ftl('footer-refresh-websites-cookies') }}</a>
+          </li>
+        {% else %}
           <li><a href="{{ url('privacy.notices.websites') }}" data-link-position="footer" data-link-text="Privacy">{{ ftl('footer-refresh-websites-privacy-notice') }}</a></li>
           <li>
             {# Link to /privacy/websites/cookie-settings/ is a legal requirement and should not be removed. It must be present on every page (Issue 14213). #}
@@ -124,6 +137,7 @@
           {% if ftl_has_messages('footer-about-this-site') %}
             <li><a href="{{ url('mozorg.about.this-site') }}" data-link-position="footer" data-link-text="About this site">{{ ftl('footer-refresh-about-this-site') }}</a></li>
           {% endif %}
+        {% endif %}
         </ul>
       </div>
     </div>

--- a/bedrock/cms/cms_only_urls.py
+++ b/bedrock/cms/cms_only_urls.py
@@ -36,4 +36,6 @@ urlpatterns = bedrock_i18n_patterns(
     path("products/vpn/resource-center/", dummy_view, name="products.vpn.resource-center.landing"),
     path("products/vpn/resource-center/<slug:slug>/", dummy_view, name="products.vpn.resource-center.article"),
     path("advertising/", dummy_view, name="mozorg.advertising.landing"),
+    path("anonym/privacy-policy/", dummy_view, name="anonym.privacy-policy"),
+    path("anonym/terms-and-conditions/", dummy_view, name="anonym.terms-and-conditions"),
 )

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -46,5 +46,5 @@ footer-refresh-community-participation-guidelines = Community Participation Guid
 footer-refresh-about-this-site = About this site
 footer-refresh-all-languages = All languages
 footer-refresh-language = Language
-footer-refresh-anonym-privacy-policy = Anonym Privacy Policy
+footer-refresh-anonym-privacy-policy = { -brand-name-anonym } Privacy Policy
 footer-refresh-anonym-terms-and-conditions = { -brand-name-anonym } Terms and Conditions

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -46,3 +46,5 @@ footer-refresh-community-participation-guidelines = Community Participation Guid
 footer-refresh-about-this-site = About this site
 footer-refresh-all-languages = All languages
 footer-refresh-language = Language
+footer-refresh-anonym-privacy-policy = Anonym Privacy Policy
+footer-refresh-anonym-terms-and-conditions = Anonym Terms and Conditions

--- a/l10n/en/footer-refresh.ftl
+++ b/l10n/en/footer-refresh.ftl
@@ -47,4 +47,4 @@ footer-refresh-about-this-site = About this site
 footer-refresh-all-languages = All languages
 footer-refresh-language = Language
 footer-refresh-anonym-privacy-policy = Anonym Privacy Policy
-footer-refresh-anonym-terms-and-conditions = Anonym Terms and Conditions
+footer-refresh-anonym-terms-and-conditions = { -brand-name-anonym } Terms and Conditions


### PR DESCRIPTION
To avoid confusion between Anonym's privacy policy and T&Cs with the overall MoCo ones, when we're rendering the Anonym pages we only show Anonym-specific docs. The rest of www.m.o shows the regular MoCo links.

Note that the Cookies link is required on every single page on www.mozilla.org so appears in the footer for Anonym pages, too.

----

*Anonym pages*

<img width="2982" height="1208" alt="Screenshot 2026-04-08 at 10 51 00" src="https://github.com/user-attachments/assets/bf3f0e28-8a25-405e-93e2-140b71f2f954" />

----


*Non-Anonym pages* (no change from normal, basically)

 
<img width="3076" height="502" alt="Screenshot 2026-04-08 at 10 49 13" src="https://github.com/user-attachments/assets/699383d0-200d-4e6c-a501-0dd2673c4a3c" />


----


## Issue / Bugzilla link

Jira: https://mozilla-hub.atlassian.net/browse/WT-1016
#17120 

## Testing
* Get a prod DB export with `AWS_DB_S3_BUCKET=bedrock-db-prod make preflight`
* view Anonym pages on localhost and check the footer
* view regular pages on localhost and check the footer