### PR TITLE
Add Wagtail documents URL to SUPPORTED_NONLOCALES

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -475,6 +475,7 @@ SUPPORTED_NONLOCALES = [
     "revision.txt",  # from root_files
     "locales",
     "csrf_403",
+    "_documents",  # Wagtail documents
 ]
 
 # Paths that can exist either with or without a locale code in the URL.


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Fix document URLs by allowing the `/_documents/` base URL not to have a locale prefix.

## Testing

Upload a document at http://localhost:8000/cms-admin/documents/ and check that the document link works.