### PR TITLE
Remove `MitreCVE` feed backend (#16519)

### DIFF
--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -14,7 +14,7 @@ from django.db.models import Count
 from dateutil.parser import parse as parsedate
 
 from bedrock.base.sanitization import sanitize_html
-from bedrock.security.models import HallOfFamer, MitreCVE, Product, SecurityAdvisory
+from bedrock.security.models import HallOfFamer, Product, SecurityAdvisory
 from bedrock.security.utils import (
     FILENAME_RE,
     check_hof_data,
@@ -22,7 +22,6 @@ from bedrock.security.utils import (
     parse_md_file,
     parse_yml_file,
     parse_yml_file_base,
-    update_advisory_bugs,
 )
 from bedrock.utils.git import GitRepo
 from bedrock.utils.management.cron_command import CronCommand
@@ -177,50 +176,6 @@ def add_hofers(filename, data):
         )
 
 
-def parse_cve_id(cve_id):
-    cve_year, cve_order = cve_id.split("-")[1:]
-    return int(cve_year), int(cve_order)
-
-
-def add_or_update_cve(data):
-    for cve_id, advisory in data["advisories"].items():
-        if not cve_id.startswith("CVE-"):
-            # skip advisories that are not CVE
-            continue
-
-        if not advisory.get("feed", True):
-            # skip advisories with `feed: false`
-            continue
-
-        cve_year, cve_order = parse_cve_id(cve_id)
-        update_advisory_bugs(advisory)
-        cve_title = advisory.get("cve_problemtype", advisory.get("title")) or ""
-        cve_data = {
-            "id": cve_id,
-            "year": cve_year,
-            "order": cve_order,
-            "title": cve_title,
-            "impact": advisory["impact"] or "",
-            "reporter": advisory["reporter"] or "",
-            "description": advisory.get("description", "") or "",
-            "bugs": advisory["bugs"],
-        }
-        try:
-            cve = MitreCVE.objects.get(id=cve_id)
-        except MitreCVE.DoesNotExist:
-            cve = MitreCVE(**cve_data)
-            cve.products = data["fixed_in"]
-            cve.mfsa_ids.append(data["mfsa_id"])
-        else:
-            cve.products = list(set(cve.products).union(data["fixed_in"]))
-            cve.mfsa_ids = list(set(cve.mfsa_ids).union([data["mfsa_id"]]))
-            for prop, value in cve_data.items():
-                if value:
-                    setattr(cve, prop, value)
-
-        cve.save()
-
-
 def update_db_from_file(filename):
     """
     Parse file for YAML and Markdown and update database.
@@ -240,8 +195,6 @@ def update_db_from_file(filename):
 
     data, html = parser(filename)
     html = sanitize_advisory_html(html)
-    if "advisories" in data:
-        add_or_update_cve(data)
     return add_or_update_advisory(data, html)
 
 
@@ -325,7 +278,6 @@ class Command(CronCommand):
             printout("Clearing all security advisories.")
             SecurityAdvisory.objects.all().delete()
             Product.objects.all().delete()
-            MitreCVE.objects.all().delete()
 
         if not no_git:
             printout("Updating repository.")

--- a/bedrock/security/tests/test_models.py
+++ b/bedrock/security/tests/test_models.py
@@ -5,7 +5,7 @@
 from datetime import date
 
 from bedrock.mozorg.tests import TestCase
-from bedrock.security.models import HallOfFamer, MitreCVE, Product
+from bedrock.security.models import HallOfFamer, Product
 
 
 class TestProduct(TestCase):
@@ -41,47 +41,3 @@ class TestHallOfFamer(TestCase):
         assert hf3.quarter_string == "3rd Quarter 2016"
         assert hf4.year_quarter == (2015, 4)
         assert hf4.quarter_string == "4th Quarter 2015"
-
-
-class TestMitreCVE(TestCase):
-    cve_id_order = 100
-
-    def _create_cve(self, products=None):
-        self.cve_id_order += 1
-        products = products or ["Firefox 60", "Firefox 60.0.1"]
-        return MitreCVE.objects.create(
-            id=f"CVE-2018-{self.cve_id_order}",
-            year=2018,
-            order=self.cve_id_order,
-            title="A Testing Problem",
-            description="There was a problem.",
-            products=products,
-            mfsa_ids=["2018-11"],
-            bugs=[{"url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1234567", "desc": "Bug 1234567"}],
-        )
-
-    def test_product_versions(self):
-        cve = self._create_cve()
-        assert cve.product_versions() == {"Firefox": ["60", "60.0.1"]}
-        cve = self._create_cve(["Firefox ESR 60.0.1", "Firefox ESR 52.8.0", "Firefox 60.0.1"])
-        assert cve.product_versions() == {"Firefox": ["60.0.1"], "Firefox ESR": ["60.0.1", "52.8.0"]}
-
-    def test_get_reference_data(self):
-        cve = self._create_cve()
-        assert cve.get_reference_data() == [
-            {"url": "https://www.mozilla.org/security/advisories/mfsa2018-11/"},
-            {"url": "https://bugzilla.mozilla.org/show_bug.cgi?id=1234567"},
-        ]
-
-    def test_get_description(self):
-        cve = self._create_cve()
-        assert cve.get_description() == "There was a problem. This vulnerability affects Firefox < 60 and Firefox < 60.0.1."
-        cve = self._create_cve(["Firefox ESR 60.0.1", "Firefox ESR 52.8.0", "Firefox 60.0.1"])
-        assert cve.get_description() == (
-            "There was a problem. This vulnerability affects Firefox ESR < 60.0.1, Firefox ESR < 52.8.0, and Firefox < 60.0.1."
-        )
-        cve = self._create_cve(["Firefox ESR 60.0.1"])
-        cve.description = "No punctuation"
-        assert cve.get_description() == "No punctuation. This vulnerability affects Firefox ESR < 60.0.1."
-        cve.description = "Punctuation but extra space. \n"
-        assert cve.get_description() == "Punctuation but extra space. This vulnerability affects Firefox ESR < 60.0.1."

--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -28,8 +28,6 @@ urlpatterns = (
     path("bug-bounty/web-hall-of-fame/", HallOfFameView.as_view(program="web"), name="security.bug-bounty.web-hall-of-fame"),
     path("advisories/", AdvisoriesView.as_view(), name="security.advisories"),
     re_path(r"^advisories/mfsa(?P<pk>\d{4}-\d{2,3})/$", AdvisoryView.as_view(), name="security.advisory"),
-    # FIXME: remove via issue 16519
-    # re_path(r"^advisories/cve-feed\.json$", mitre_cve_feed, name="security.advisories.cve_feed"),
     page("known-vulnerabilities/", "security/known-vulnerabilities.html"),
     page("known-vulnerabilities/older-vulnerabilities/", "security/older-vulnerabilities.html"),
     re_path(r"^known-vulnerabilities/(?P<slug>[a-z-]+)/$", ProductView.as_view(), name="security.product-advisories"),

--- a/bedrock/security/views.py
+++ b/bedrock/security/views.py
@@ -6,23 +6,15 @@ import re
 from django.db.models import Q
 from django.urls import NoReverseMatch
 from django.utils.decorators import method_decorator
-from django.views.decorators.http import require_safe
 from django.views.generic import DetailView, ListView, RedirectView
 
-from jsonview.decorators import json_view
 from product_details import product_details
 from product_details.version_compare import Version
 
 from bedrock.base.urlresolvers import reverse
 from bedrock.mozorg.decorators import cache_control_expires
-from bedrock.security.models import HallOfFamer, MitreCVE, Product, SecurityAdvisory
+from bedrock.security.models import HallOfFamer, Product, SecurityAdvisory
 from lib.l10n_utils import LangFilesMixin, RequireSafeMixin
-
-
-@json_view
-@require_safe
-def mitre_cve_feed(request):
-    return [cve.feed_entry() for cve in MitreCVE.objects.all()]
 
 
 def product_is_obsolete(prod_name, version):


### PR DESCRIPTION
# Summary

* Deletes the `mitre_cve_feed` view, `parse_cve_id` and `add_or_update_cve` functions, and all related imports and tests
* Removes the commented-out `cve-feed.json` URL pattern (FIXME from #16542)

# Notes

The `gone()` redirect in `redirects.py` (#16521) is intentionally kept so the old URL continues to return 410. The `security/partials/cve.html` template is also kept. It renders CVE entries on advisory detail pages and is unrelated to the feed.