### PR TITLE
Point `download_firefox_thanks` buttons to firefox.com domain

### DIFF
--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -207,11 +207,11 @@ def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button
     channel = "release"
     locale = locale or get_locale(ctx["request"])
     dom_id = dom_id or "download-button-thanks"
-    transition_url = "/firefox/download/thanks/"
+    transition_url = f"{settings.FXC_BASE_URL}/thanks/"
     version = firefox_desktop.latest_version(channel)
 
     if locale_in_transition:
-        transition_url = f"/{locale}{transition_url}"
+        transition_url = f"{settings.FXC_BASE_URL}/{locale}/thanks/"
 
     download_link_direct = firefox_desktop.get_download_url(
         channel,

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -326,7 +326,7 @@ class TestDownloadThanksButton(TestCase):
 
     def test_download_firefox_thanks_button(self):
         """
-        Download link should point to /firefox/download/thanks/
+        Download link should point to firefox.com/thanks/
         """
         rf = RequestFactory()
         get_request = rf.get("/fake")
@@ -340,7 +340,7 @@ class TestDownloadThanksButton(TestCase):
         link = pq(links)
         href = link.attr("href")
 
-        assert href == "/firefox/download/thanks/"
+        assert href == f"{settings.FXC_BASE_URL}/thanks/"
         assert button.attr("id") == "download-button-thanks"
         assert link.attr("data-cta-text") == "Download Firefox"
 
@@ -369,7 +369,7 @@ class TestDownloadThanksButton(TestCase):
         link = pq(links)
         href = link.attr("href")
 
-        assert href == "/en-US/firefox/download/thanks/"
+        assert href == f"{settings.FXC_BASE_URL}/en-US/thanks/"
         assert button.attr("id") == "test-download"
         assert link.attr("data-cta-position") == "primary cta"
         assert "test-css-class" in link.attr("class")


### PR DESCRIPTION
# Summary

* `download_firefox_thanks()` helper now sends users to `https://www.firefox.com/thanks/` instead of `/firefox/download/thanks/` on www.mozilla.org
* When `locale_in_transition=True`, the known locale is included in the path (`/de/thanks/`) to skip the redirect, firefox.com would otherwise issue via Accept-Language detection (confirmed via `curl -sI -H "Accept-Language: de"`)
* Tests updated to assert against `settings.FXC_BASE_URL` rather than a hardcoded path

Closes #16366.