### PR TITLE
chore(csp_frame_src): add gtm.mozilla.org to CSP frame-src directive

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -76,6 +76,7 @@ _csp_frame_ancestors = {
 _csp_frame_src = {
     csp.constants.SELF,
     "accounts.firefox.com",
+    "gtm.mozilla.org",
     "js.stripe.com",
     "www.google-analytics.com",
     "www.googletagmanager.com",


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Add gtm.mozilla.org to CSP frame-src directive

## Significant changes and points to review
Added gtm.mozilla.org to _csp_frame_src in bedrock/settings/__init__.py
This unblocks the sGTM service worker iframe (gtm.mozilla.org/_/service_worker/...) which was previously blocked by the enforced CSP and the report-only CSP


## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1117


## Testing

- [ ] Verify no CSP console errors for frame-src on gtm.mozilla.org after deploy
- [ ] Confirm the sGTM service worker iframe loads successfully
- [ ] Check Sentry/CSP report endpoint to confirm the violation no longer fires