### PR TITLE
WT-1125: Fix WNP 145+ redirect regex to match all locales

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -78,7 +78,8 @@ def _redirect_to_same_path_on_fxc(request, *args, **kwargs):
 
 WNP_145_PLUS_RE = (
     # Issues 16590 and 16791 for WNP 145+ Release (not Nightly, Beta/Developer or ESR)
-    r"^(?P<wnp_locale>en-US|en-GB|en-CA|fr|de)/firefox/"
+    # https://mozilla-hub.atlassian.net/browse/WT-1125 -> need to expand WNP Release to all locales
+    r"^(?P<wnp_locale>[a-z]{2}(?:-[A-Z]{2})?)/firefox/"
     r"(?P<major_version>1(?:4[5-9]|[5-9]\d|\d{3,4})|[2-9]\d{2,4})"
     r"\.\d{1,3}(?:\.\d{1,3}){0,2}/whatsnew/?$"
 )

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -822,12 +822,18 @@ def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(clie
             301,
             "/en-US/whatsnew/145/?query=string.here&with=extra",
         ),
+        (
+            "/es-ES/firefox/145.0.1.2/whatsnew/",
+            301,
+            "/es-ES/whatsnew/145/",
+        ),
+        (
+            "/uk/firefox/145.0.1.2/whatsnew/",
+            301,
+            "/uk/whatsnew/145/",
+        ),
         # Routes NOT matching the redirect
-        # Only en-US, en-GB, en-CA, fr and de should redirect
-        ("/es-ES/firefox/145.0/whatsnew/", 200, None),
-        ("/uk/firefox/145.0/whatsnew/", 200, None),
-        ("/ru/firefox/145.0/whatsnew/", 200, None),
-        # And Nightly, Beta/Developer and ESR should not redirect
+        # Nightly, Beta/Developer and ESR should not redirect
         ("/en-US/firefox/145.0a/whatsnew/", 200, None),
         ("/en-US/firefox/146.0b/whatsnew/", 200, None),
         ("/en-US/firefox/146.0beta/whatsnew/", 200, None),


### PR DESCRIPTION
## Summary

- Replaces the hardcoded locale list (`en-US|en-GB|en-CA|fr|de`) in `WNP_145_PLUS_RE` with a regex matching any valid two-letter or five-character (`xx-XX`) locale code
- Fixes a stray `$` anchor inside the locale group that prevented five-character locales (e.g. `en-US`, `es-ES`) from matching
- Updates tests to reflect that all locales now redirect for WNP 145+

## Test plan

- [ ] Run `pytest bedrock/firefox/tests/test_redirects.py::test_wnp145_redirects_to_fxc_when_appropriate`
- [ ] Verify previously failing locale paths (`en-US`, `en-CA`, `en-GB`, `es-ES`, etc.) now return 301
- [ ] Verify non-release channels (Nightly `a`, Beta `b`/`beta`, ESR) and versions below 145 still return 200