### PR TITLE
WT-1125: Fix WNP 145+ redirect regex to match all locales

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -78,7 +78,8 @@ def _redirect_to_same_path_on_fxc(request, *args, **kwargs):
 
 WNP_145_PLUS_RE = (
     # Issues 16590 and 16791 for WNP 145+ Release (not Nightly, Beta/Developer or ESR)
-    r"^(?P<wnp_locale>en-US|en-GB|en-CA|fr|de)/firefox/"
+    # https://mozilla-hub.atlassian.net/browse/WT-1125 -> need to expand WNP Release to all locales
+    r"^(?P<wnp_locale>[a-z]{2}(?:-[A-Z]{2})?)/firefox/"
     r"(?P<major_version>1(?:4[5-9]|[5-9]\d|\d{3,4})|[2-9]\d{2,4})"
     r"\.\d{1,3}(?:\.\d{1,3}){0,2}/whatsnew/?$"
 )

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -822,12 +822,18 @@ def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(clie
             301,
             "/en-US/whatsnew/145/?query=string.here&with=extra",
         ),
+        (
+            "/es-ES/firefox/145.0.1.2/whatsnew/",
+            301,
+            "/es-ES/whatsnew/145/",
+        ),
+        (
+            "/uk/firefox/145.0.1.2/whatsnew/",
+            301,
+            "/uk/whatsnew/145/",
+        ),
         # Routes NOT matching the redirect
-        # Only en-US, en-GB, en-CA, fr and de should redirect
-        ("/es-ES/firefox/145.0/whatsnew/", 200, None),
-        ("/uk/firefox/145.0/whatsnew/", 200, None),
-        ("/ru/firefox/145.0/whatsnew/", 200, None),
-        # And Nightly, Beta/Developer and ESR should not redirect
+        # Nightly, Beta/Developer and ESR should not redirect
         ("/en-US/firefox/145.0a/whatsnew/", 200, None),
         ("/en-US/firefox/146.0b/whatsnew/", 200, None),
         ("/en-US/firefox/146.0beta/whatsnew/", 200, None),

--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -823,11 +823,13 @@ def test_releasenotes_and_sysreq_generic_urls_are_redirected_to_springfield(clie
             "/en-US/whatsnew/145/?query=string.here&with=extra",
         ),
         (
+            # Confirm non-default locale with region code and patch version number redirects
             "/es-ES/firefox/145.0.1.2/whatsnew/",
             301,
             "/es-ES/whatsnew/145/",
         ),
         (
+            # Confirm locale with without region code and patch version number redirects
             "/uk/firefox/145.0.1.2/whatsnew/",
             301,
             "/uk/whatsnew/145/",


### PR DESCRIPTION
The redirection from www.mozilla.org to www.firefox.com was only scoped to `en-*`, `fr` and `de` locales. This changeset expands that behaviour to cover all locales.

For greater context please see Jira: https://mozilla-hub.atlassian.net/browse/WT-1125


## Test plan

* Confirm these redirect to www.firefox.com/<locale>/whatsnew/146

- [ ] http://localhost:8000/en-US/firefox/146.0/whatsnew/
- [ ] http://localhost:8000/en-GB/firefox/146.0.1/whatsnew/
- [ ] http://localhost:8000/fr/firefox/146.0/whatsnew/
- [ ] http://localhost:8000/es-ES/firefox/146.0/whatsnew/
- [ ] http://localhost:8000/es-MX/firefox/146.0/whatsnew/
- [ ] http://localhost:8000/pt-BR/firefox/151.0/whatsnew/ -> redirects to https://www.firefox.com/pt-BR/whatsnew/general/?version=151 (because 151 isn't available yet)

* Confirm these do not redirect and remain on localhost
- [ ] http://localhost:8000/en-US/firefox/150.0a1/whatsnew/
- [ ] http://localhost:8000/es-ES/firefox/150.0a2/whatsnew/
- [ ] http://localhost:8000/en-CA/firefox/150.0beta/whatsnew/
- [ ] http://localhost:8000/de/firefox/150.0a1/whatsnew/
- [ ] http://localhost:8000/fr/firefox/150.0a2/whatsnew/
- [ ] http://localhost:8000/ru/firefox/150.0beta/whatsnew/

