### PR TITLE
WT-547 update wagtail preview desktop size

### DIFF
--- a/bedrock/cms/models/base.py
+++ b/bedrock/cms/models/base.py
@@ -45,6 +45,16 @@ class AbstractBedrockCMSPage(WagtailBasePage):
         SynchronizedField("slug"),
     ]
 
+    preview_sizes = [
+        {"name": "mobile", "icon": "mobile-alt", "device_width": 320, "label": "Mobile"},
+        {"name": "tablet", "icon": "tablet-alt", "device_width": 768, "label": "Tablet"},
+        {"name": "desktop", "icon": "desktop", "device_width": 1312, "label": "Desktop"},
+    ]
+
+    @property
+    def default_preview_size(self):
+        return "desktop"
+
     class Meta:
         abstract = True
 


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the Wagtail preview desktop size to match our design system.

## Significant changes and points to review

Wagtail preview desktop size

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-547?focusedCommentId=1401901

## Testing

http://localhost:8000/cms-admin/