### PR TITLE
Reduce Risk Of Dependency 0 Day Vulnerability Issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,11 @@ check-requirements: .docker-build-pull
 
 preflight:
 	${MAKE} install-local-python-deps
-	@npm install
+	# --min-release-age=7 avoids packages uploaded in the last 7 days
+	# reducing supply-chain risk. Requires npm >= 11.10.0.
+	# To apply urgent security patch sooner, run:
+	# npm install package-name@version --min-release-age=0
+	@npm install --min-release-age=7
 	@$(if $(findstring --retain-db,$(MAKECMDGOALS)),bin/sync-all.sh --retain-db,bin/sync-all.sh)
 	@python manage.py bootstrap_local_admin
 

--- a/bin/compile-requirements.sh
+++ b/bin/compile-requirements.sh
@@ -15,6 +15,10 @@ pip install -U uv
 # Drop the compiled reqs files, to help us pick up automatic subdep updates, too
 rm -f requirements/*.txt
 
-uv pip compile --generate-hashes --no-strip-extras --python-version 3.13 requirements/prod.in -o requirements/prod.txt
-uv pip compile --generate-hashes --no-strip-extras --python-version 3.13 requirements/dev.in -o requirements/dev.txt
-uv pip compile --generate-hashes --no-strip-extras --python-version 3.13 requirements/docs.in -o requirements/docs.txt
+# --exclude-newer='7 days' avoids packages uploaded in the last 7 days
+# reducing supply-chain risk. To apply urgent security patch (e.g. Django):
+# update version pin in requirements/prod.in, then run:
+# uv pip compile --upgrade-package Django --exclude-newer='7 days' --generate-hashes --no-strip-extras --python-version 3.13 requirements/prod.in -o requirements/prod.txt
+uv pip compile --exclude-newer='7 days' --generate-hashes --no-strip-extras --python-version 3.13 requirements/prod.in -o requirements/prod.txt
+uv pip compile --exclude-newer='7 days' --generate-hashes --no-strip-extras --python-version 3.13 requirements/dev.in -o requirements/dev.txt
+uv pip compile --exclude-newer='7 days' --generate-hashes --no-strip-extras --python-version 3.13 requirements/docs.in -o requirements/docs.txt


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary
Update code for upgrading Python and JavaScript dependencies to only install packages that are at least 7 days old.

## Significant changes and points to review



## Issue / Bugzilla link



## Testing
1. Run `make compile-requirements` on this branch, and compare the results to running `make compile-requirements` on the `main` branch. This branch should not have any versions released in the last 7 days.
2. verify that you can still upgrade any specific dependency to ignore the 7 day rule if needed: `uv pip compile --upgrade-package Django --generate-hashes --no-strip-extras --python-version 3.13 requirements/prod.in -o requirements/prod.txt`

Note: the `npm` change requires an npm of 11.10 or newer, which the project does not currently require, but the next frontend upgrade should take advantage of npm's `min-release-age` parameter.

Note: the same change in springfield: https://github.com/mozmeao/springfield/pull/1317