### PR TITLE
Add Adjust opt-in redirect for Firefox Android attribution

### DIFF
--- a/bedrock/firefox/tests/test_redirects.py
+++ b/bedrock/firefox/tests/test_redirects.py
@@ -10,6 +10,10 @@ from django.test import RequestFactory
 import pytest
 
 from bedrock.firefox.redirects import mobile_app, validate_param_value
+from bedrock.redirects.util import mobile_app_redirector
+
+ANDROID_UA = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36"
+IOS_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
 
 
 @pytest.mark.parametrize(
@@ -533,6 +537,55 @@ def test_mobile_app_redirector_does_not_go_to_springfield(client):
     resp = client.get("/en-US/firefox/browsers/mobile/app/")
     assert resp.status_code == 301
     assert resp.headers["Location"] == "https://apps.apple.com/app/apple-store/id989804926"
+
+
+def test_mobile_app_redirector_via_adjust_firefox_android_with_campaign():
+    rf = RequestFactory()
+    req = rf.get("/firefox/app/?via=adjust&campaign=firefox-all", HTTP_USER_AGENT=ANDROID_UA)
+    result = mobile_app_redirector(req, "firefox", "firefox-all")
+    assert result == f"{settings.ADJUST_FIREFOX_ANDROID_LINK}&campaign=firefox-all"
+
+
+def test_mobile_app_redirector_via_adjust_firefox_android_no_campaign():
+    rf = RequestFactory()
+    req = rf.get("/firefox/app/?via=adjust", HTTP_USER_AGENT=ANDROID_UA)
+    assert mobile_app_redirector(req, "firefox", None) == settings.ADJUST_FIREFOX_ANDROID_LINK
+
+
+def test_mobile_app_redirector_via_adjust_ignored_for_focus_android():
+    rf = RequestFactory()
+    req = rf.get("/firefox/app/?via=adjust&campaign=firefox-all", HTTP_USER_AGENT=ANDROID_UA)
+    result = mobile_app_redirector(req, "focus", "firefox-all")
+    assert result.startswith(settings.GOOGLE_PLAY_FOCUS_LINK)
+    assert "utm_campaign%3Dfirefox-all" in result
+    assert "app.adjust.com" not in result
+
+
+def test_mobile_app_redirector_via_adjust_ignored_for_firefox_ios():
+    rf = RequestFactory()
+    req = rf.get("/firefox/app/?via=adjust&campaign=firefox-all", HTTP_USER_AGENT=IOS_UA)
+    result = mobile_app_redirector(req, "firefox", "firefox-all")
+    assert result.startswith("https://apps.apple.com/app/apple-store/id989804926")
+    assert "ct=firefox-all" in result
+    assert "app.adjust.com" not in result
+
+
+def test_mobile_app_redirector_unknown_via_value_falls_back_to_default():
+    rf = RequestFactory()
+    req = rf.get("/firefox/app/?via=bogus&campaign=firefox-all", HTTP_USER_AGENT=ANDROID_UA)
+    result = mobile_app_redirector(req, "firefox", "firefox-all")
+    assert result.startswith(settings.GOOGLE_PLAY_FIREFOX_LINK)
+    assert "utm_campaign%3Dfirefox-all" in result
+    assert "app.adjust.com" not in result
+
+
+def test_mobile_app_redirector_no_via_param_falls_back_to_default():
+    rf = RequestFactory()
+    req = rf.get("/firefox/app/?campaign=firefox-all", HTTP_USER_AGENT=ANDROID_UA)
+    result = mobile_app_redirector(req, "firefox", "firefox-all")
+    assert result.startswith(settings.GOOGLE_PLAY_FIREFOX_LINK)
+    assert "utm_campaign%3Dfirefox-all" in result
+    assert "app.adjust.com" not in result
 
 
 @pytest.mark.parametrize(

--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -92,6 +92,16 @@ def platform_redirector(desktop_dest, android_dest, ios_dest):
 def mobile_app_redirector(request, product, campaign):
     android_re = re.compile(r"\bAndroid\b", flags=re.I)
     value = request.headers.get("User-Agent", "")
+    is_android = bool(android_re.search(value))
+
+    # Opt-in routing through Adjust for Firefox on Android. Any other product,
+    # platform, or `via` value falls through to the default app-store logic.
+    if request.GET.get("via") == "adjust" and product == "firefox" and is_android:
+        adjust_url = settings.ADJUST_FIREFOX_ANDROID_LINK
+        if campaign:
+            separator = "&" if "?" in adjust_url else "?"
+            return f"{adjust_url}{separator}campaign={campaign}"
+        return adjust_url
 
     # Map product names to tracking product codes
     product_mapping = {
@@ -105,7 +115,7 @@ def mobile_app_redirector(request, product, campaign):
 
     tracking_product = product_mapping.get(product, "unrecognized")
 
-    if android_re.search(value):
+    if is_android:
         base_url = getattr(settings, f"GOOGLE_PLAY_{product.upper()}_LINK")
         params = "&referrer=utm_source%3Dwww.mozilla.org%26utm_medium%3Dreferral%26utm_campaign%3D{cmp}"
     else:

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1007,6 +1007,16 @@ from .appstores import (  # noqa: E402, F401
     MICROSOFT_WINDOWS_STORE_FIREFOX_WEB_LINK,
 )
 
+# Adjust attribution link for Firefox on Android, used by mobile_app_redirector
+# when the request includes ?via=adjust. Override per-environment to keep test
+# installs out of production attribution data.
+ADJUST_FIREFOX_ANDROID_LINK = config(
+    "ADJUST_FIREFOX_ANDROID_LINK",
+    default=(
+        "https://app.adjust.com/20kona3j?fallback=https%3A%2F%2Fwww.firefox.com%2Fdownload&redirect_macos=https%3A%2F%2Fwww.firefox.com%2Fdownload"
+    ),
+)
+
 # Locales that should display the 'Send to Device' widget
 SEND_TO_DEVICE_LOCALES = [
     "de",


### PR DESCRIPTION
Add an opt-in path through Adjust on the existing /r/mobile/ redirect so Firefox Android installs from mozilla.org can be attributed in the "mozorg-mobile-redirect" channel in Adjust. Triggered only when the request includes ?via=adjust, the product is firefox, and the User-Agent is Android; all other cases fall through to today's Play Store / App Store logic untouched.

The Adjust link URL is configurable via the ADJUST_FIREFOX_ANDROID_LINK env var so dev/stage can point at a separate link to keep test installs out of production attribution data.

_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary


## Significant changes and points to review



## Issue / Bugzilla link



## Testing

### Local manual (curl) — verify bedrock returns the right destination
With `npm start` running on `localhost:8080`, run each curl and check the `Location:` header:

- [x] **Android + via=adjust + firefox** → expects Adjust URL with `&campaign=` appended
  ```bash
  curl -sI \
    -A "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36" \
    "http://localhost:8080/firefox/browsers/mobile/app/?via=adjust&product=firefox&campaign=test-001" \
    | grep -i ^location
  ```
  Expect: `https://app.adjust.com/20kona3j?fallback=…&redirect_macos=…&campaign=test-001`

- [x] **Android + no via** (regression check) → expects Play Store with UTM referrer
  ```bash
  curl -sI \
    -A "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36" \
    "http://localhost:8080/firefox/browsers/mobile/app/?product=firefox&campaign=test-002" \
    | grep -i ^location
  ```
  Expect: `https://play.google.com/store/apps/details?id=org.mozilla.firefox&referrer=…utm_campaign%3Dtest-002`

- [x] **iOS + via=adjust** (flag should be ignored) → expects App Store
  ```bash
  curl -sI \
    -A "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)" \
    "http://localhost:8080/firefox/browsers/mobile/app/?via=adjust&product=firefox&campaign=test-003" \
    | grep -i ^location
  ```
  Expect: `https://apps.apple.com/app/apple-store/id989804926?pt=373246&ct=test-003…`

- [x] **Android + via=adjust + focus** (flag should be ignored, scope is firefox-only) → expects Play Store Focus
  ```bash
  curl -sI \
    -A "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36" \
    "http://localhost:8080/firefox/browsers/mobile/app/?via=adjust&product=focus&campaign=test-004" \
    | grep -i ^location
  ```
  Expect: `https://play.google.com/store/apps/details?id=org.mozilla.focus&referrer=…`

- [x] **Bogus via value** → expects Play Store fallback (default behavior)
  ```bash
  curl -sI \
    -A "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36" \
    "http://localhost:8080/firefox/browsers/mobile/app/?via=bogus&product=firefox&campaign=test-005" \
    | grep -i ^location
  ```
  Expect: Play Store URL, **not** Adjust

### End-to-end attribution (real Android device)
- [ ] On an Android device or emulator without Firefox installed, navigate to:
      `http://<dev-or-stage-host>/firefox/browsers/mobile/app/?via=adjust&product=firefox&campaign=e2e-pr-test-001`
- [ ] Follow the redirect chain → land on Play Store → install Firefox → open it once
- [ ] In Adjust dashboard (5–10 min later), verify a row appears under:
      **channel** = `mozorg-mobile-redirect`, **campaign** = `e2e-pr-test-001`
- [ ] Repeat with a different campaign value to confirm bedrock forwards distinct values as separate rows
```