### PR TITLE
Cms homepage shuffle papercuts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,8 @@ Fetch the latest version of all the checklists mentioned on https://mozmeao.gith
 
 Read AGENTS.md for supplementary instructions.
 
-If a mirrored copy of these instructions exists at `custom-instructions/repo/.github/copilot-instructions.md`, keep it fully synchronized with this file and any referenced AGENTS.md guidance, including section renumbering and DB schema guidance, or remove it to avoid drift and inconsistent Copilot behavior.
+If a mirrored copy of these instructions exists at `custom-instructions/repo/.github/copilot-instructions.md`, keep it fully synchronized with this file and any referenced AGENTS.md guidance, including section renumbering and DB schema guidance, or remove it to avoid drift and inconsistent Copilot behavior. If the mirrored version is out of sync, use this version as the canonical source and overwrite the mirrored version.
+
 Try to use Conventional Comments to indicate the kind of feedback you are providing, and whether it's blocking or non-blocking.
 
 Also, confirm in a comment on the PR that you are using this custom instructions file, please.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,8 @@ Be particularly aware of CMS-backed content that is not richtext. Ensure it's es
 
 * If a new Snippet (a Django model decorated with @register_snippet) is added, add a reminder in a comment to ensure that the Editors have permission to see and edit the new Snippet. That permission is added manually via the Wagtail UI.
 
+* If a Django view is being decorated for the first time with the `prefer_cms()` decorator and there is no `fallback_ftl_files=` parameter being passed in to `prefer_cms()`, add a non-blocking comment questioning whether it should be present, because without it, the page will only show the locales available in the CMS in the footer links on the page
+
 ## 8. Database schema changes
 
 * We use Django migrations to manage database schema state and also sometimes to adjust data. Django migrations are the ONLY permissible way to change database schema.

--- a/bedrock/mozorg/models.py
+++ b/bedrock/mozorg/models.py
@@ -440,7 +440,6 @@ class HomePage(AbstractBedrockCMSPage):
     """CMS-managed homepage for mozilla.org."""
 
     max_count = 1  # Ensure there's only one instance of this page
-    subpage_types = []  # This page type cannot have any children
     ftl_files = ["mozorg/home-m24"]
 
     content = StreamField(

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -21,8 +21,8 @@ from . import views
 from .util import page
 
 urlpatterns = [
-    path("", prefer_cms(views.HomeView.as_view(), fallback_ftl_files=["mozorg/home-m24", "mozorg/home-new", "mozorg/home"]), name="mozorg.home"),
-    path("about/", prefer_cms(views.AboutView.as_view(), fallback_ftl_files=["mozorg/about", "mozorg/about-m24"]), name="mozorg.about.index"),
+    path("", prefer_cms(views.HomeView.as_view(), fallback_ftl_files=views.HomeView.activation_files), name="mozorg.home"),
+    path("about/", prefer_cms(views.AboutView.as_view(), fallback_ftl_files=views.AboutView.activation_files), name="mozorg.about.index"),
     page("about/manifesto/", "mozorg/about/manifesto.html", ftl_files=["mozorg/about/manifesto"]),
     page("about/manifesto/details/", "mozorg/about/manifesto-details.html", ftl_files=["mozorg/about/manifesto"]),
     page("account/", "mozorg/account.html", ftl_files=["firefox/accounts"]),

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -21,8 +21,8 @@ from . import views
 from .util import page
 
 urlpatterns = [
-    path("", prefer_cms(views.HomeView.as_view()), name="mozorg.home"),
-    path("about/", prefer_cms(views.AboutView.as_view()), name="mozorg.about.index"),
+    path("", prefer_cms(views.HomeView.as_view(), fallback_ftl_files=["mozorg/home-m24", "mozorg/home-new", "mozorg/home"]), name="mozorg.home"),
+    path("about/", prefer_cms(views.AboutView.as_view(), fallback_ftl_files=["mozorg/about", "mozorg/about-m24"]), name="mozorg.about.index"),
     page("about/manifesto/", "mozorg/about/manifesto.html", ftl_files=["mozorg/about/manifesto"]),
     page("about/manifesto/details/", "mozorg/about/manifesto-details.html", ftl_files=["mozorg/about/manifesto"]),
     page("account/", "mozorg/account.html", ftl_files=["firefox/accounts"]),

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -15,8 +15,6 @@ from watchman import views as watchman_views
 from bedrock.base import views as base_views
 from bedrock.base.i18n import bedrock_i18n_patterns
 from bedrock.cms import wagtail_urls
-from bedrock.cms.decorators import prefer_cms
-from bedrock.mozorg import views as mozorg_views
 
 # The default django 404 and 500 handler doesn't run the ContextProcessors,
 # which breaks the base template page. So we replace them with views that do!
@@ -28,7 +26,6 @@ locale404 = "lib.l10n_utils.locale_selection"
 # Paths that should have a locale prefix
 urlpatterns = bedrock_i18n_patterns(
     # Main pages
-    path("", prefer_cms(mozorg_views.HomeView.as_view()), name="mozorg.home"),
     path("foundation/", include("bedrock.foundation.urls")),
     path("about/legal/", include("bedrock.legal.urls")),
     path("press/", include("bedrock.press.urls")),


### PR DESCRIPTION
This changeset deals with some small tweaks needed ahead of us moving to a CMS-backed homepage for Mozorg.

Notably it:
* ensures the new HomePage can be a parent of any other page type - without this we can't reshuffle the page tree
* ensures the footer's locale picker does contain all the languages the homepage (CMS and hard-coded) is available in.

To test, 
1. Pull down a copy of prod with `AWS_DB_S3_BUCKET=bedrock-db-prod make preflight` and get prod images with `./manage.py download_media_to_local --environment=prod`
2. Find the new Homepage in the CMS's en-US branch, change the slug to `home` and move it to be a child of the `Root` page (not the on that's `www.mozilla.org base root`) You may have to change the slug on `www.mozilla.org base root` to something else.
3. Publish the new homepage and view it.
4. Confirm the footer locale picker has all the locales
5. Confirm you can move the Anonym Structural Page to be a child of the new Home Page