### PR TITLE
Update from Node 20 to Node 24

### DIFF
--- a/.github/actions/slack/action.yaml
+++ b/.github/actions/slack/action.yaml
@@ -67,13 +67,13 @@ runs:
         esac" >> $GITHUB_ENV
 
     - id: slack-notification
-      uses: slackapi/slack-github-action@v1.25.0
-      env:
-        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       with:
-        channel-id: ${{ inputs.channel_id }}
+        method: chat.postMessage
+        token: ${{ inputs.slack_bot_token }}
         payload: |
           {
+            "channel": "${{ inputs.channel_id }}",
             "text": "${{ inputs.label }}",
             "attachments": [
               {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
       - dependency-name: '@mozmeao/trafficcop'
       # Pin sass at 1.91.0 until mozilla/protocol#982
       - dependency-name: 'sass'
+      # (related to above sass version) Avoid unrelated @parcel changes in dep updates
+      - dependency-name: '@parcel/watcher*'
       # Need to be kept in sync with pre-commit-config.yaml.
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-config-prettier'

--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
     - name: Install dependencies
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run accessibility tests

--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -39,14 +39,14 @@ jobs:
       CI: true
     steps:
     - uses: actions/checkout@v5
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
     - name: Install dependencies
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run accessibility tests
       run: cd tests/playwright && npm run a11y-tests
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
       if: ${{ !cancelled() }}
       with:
         name: test-results-a11y-${{ github.sha }}

--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -39,7 +39,7 @@ jobs:
       CI: true
     steps:
     - uses: actions/checkout@v5
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: 24
     - name: Install dependencies

--- a/.github/workflows/a11y_tests.yml
+++ b/.github/workflows/a11y_tests.yml
@@ -46,7 +46,7 @@ jobs:
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run accessibility tests
       run: cd tests/playwright && npm run a11y-tests
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: ${{ !cancelled() }}
       with:
         name: test-results-a11y-${{ github.sha }}

--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: test-results
           path: results-${{github.run_id}}

--- a/.github/workflows/download_tests.yml
+++ b/.github/workflows/download_tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results
           path: results-${{github.run_id}}

--- a/.github/workflows/ensure_pre_commit_standards.yml
+++ b/.github/workflows/ensure_pre_commit_standards.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.13"
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: "Install npm dependencies"
         run: npm ci
       - name: "Cache pre-commit environments"

--- a/.github/workflows/ensure_pre_commit_standards.yml
+++ b/.github/workflows/ensure_pre_commit_standards.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - name: "Install npm dependencies"

--- a/.github/workflows/ensure_pre_commit_standards.yml
+++ b/.github/workflows/ensure_pre_commit_standards.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
       - name: "Install npm dependencies"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
     - name: Install dependencies
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run Playwright tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: test-results
           path: results-${{github.run_id}}-${{matrix.label}}
@@ -114,7 +114,7 @@ jobs:
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run Playwright tests
       run: cd tests/playwright && npm run integration-tests
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: ${{ !cancelled() }}
       with:
         name: test-results-${{ github.event.inputs.git_sha }}-${{ github.run_id }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -107,7 +107,7 @@ jobs:
       CI: true
     steps:
     - uses: actions/checkout@v5
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: 24
     - name: Install dependencies

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Store artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results
           path: results-${{github.run_id}}-${{matrix.label}}
@@ -107,14 +107,14 @@ jobs:
       CI: true
     steps:
     - uses: actions/checkout@v5
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24
     - name: Install dependencies
       run: cd tests/playwright && npm ci && npm run install-deps
     - name: Run Playwright tests
       run: cd tests/playwright && npm run integration-tests
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       if: ${{ !cancelled() }}
       with:
         name: test-results-${{ github.event.inputs.git_sha }}-${{ github.run_id }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: "Install JS dependencies"
         run: npm ci

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
           docker cp $CONTAINER_ID:/app/python_coverage .
         timeout-minutes: 60
       - name: "Store coverage as an artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage-results
           path: python_coverage

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
@@ -37,7 +37,7 @@ jobs:
           docker cp $CONTAINER_ID:/app/python_coverage .
         timeout-minutes: 60
       - name: "Store coverage as an artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-results
           path: python_coverage

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --require-hashes --no-cache-dir -r requirements/prod.txt
 ########
 # assets builder and dev server
 #
-FROM node:20.14.0-slim AS assets
+FROM node:24-slim AS assets
 
 ENV PATH=/app/node_modules/.bin:$PATH
 WORKDIR /app


### PR DESCRIPTION
Also adds Sass-related deps to dependabot ignore settings. They can be removed from this setting at the same time Sass is unpinned.

_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

## Significant changes and points to review



## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/16910
Twinned with https://github.com/mozmeao/springfield/pull/1180


## Testing
~Successful integration test run: https://github.com/mozilla/bedrock/actions/runs/25670980573~

Successful integration test (May 26, 2026) with no Node 20 warnings: https://github.com/mozilla/bedrock/actions/runs/26446688757