### PR TITLE
WT-1156: Update min iOS version

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -127,7 +127,7 @@
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-ios-long-v2', fallback='vpn-download-for-ios') }}</h2>
               <p class="current-platform-lede">{{ ftl('vpn-download-based-on-your') }}</p>
-              <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='17.0') }}</p>
               <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link ga-product-download">
                 <img src="{{ static('img/products/vpn/download/apple-app-store-badge.svg') }}" alt=" {{ ftl('vpn-download-get-mozilla-vpn', fallback='vpn-shared-subscribe-link') }}">
               </a>
@@ -218,7 +218,7 @@
             </div>
             <div class="platform-body">
               <h2>{{ ftl('vpn-download-for-ios') }}</h2>
-              <p>{{ ftl('vpn-download-version-requirements', version='15.0') }}</p>
+              <p>{{ ftl('vpn-download-version-requirements', version='17.0') }}</p>
             </div>
             <a href="{{ ios_download_url }}" data-cta-text="VPN Download (iOS)" class="platform-download-link ga-product-download">
               <span class="visually-hidden">{{ ftl('vpn-download-for-ios-long-v2') }}</span>


### PR DESCRIPTION
Updates the minimum iOS version on the VPN page to 17.0

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1156


## Testing
- [x] Checkout this PR
- [x] Start bedrock
- [x] Navigate to http://localhost:8000/en-CA/products/vpn/download/
- [x] Ensure the minimum version under iOS is 17.0 (bumped from 15.0)