### PR TITLE
fix: explicitly set git remote URL with PAT before pushing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,9 +315,11 @@ jobs:
         id: stage-push
         env:
           RELEASE_SHA: ${{ needs.preflight-checks.outputs.release_sha }}
+          GHA_PAT: ${{ secrets.BEDROCK_GHA_RELEASE_WORKFLOW_PAT }}
         run: |
           STAGE_PUSH_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "stage_push_time=${STAGE_PUSH_TIME}" >> "$GITHUB_OUTPUT"
+          git remote set-url origin "https://x-access-token:${GHA_PAT}@github.com/mozilla/bedrock.git"
           git push origin "${RELEASE_SHA}:refs/heads/stage"
           echo "Pushed $RELEASE_SHA to stage at $STAGE_PUSH_TIME"
 
@@ -498,7 +500,10 @@ jobs:
 
       - name: Tag release and push to prod
         id: tag-release
+        env:
+          GHA_PAT: ${{ secrets.BEDROCK_GHA_RELEASE_WORKFLOW_PAT }}
         run: |
+          git remote set-url origin "https://x-access-token:${GHA_PAT}@github.com/mozilla/bedrock.git"
           # --ci: skips interactive prompts; exits non-zero if main != stage
           # --push: creates the tag, pushes tag and HEAD to prod branch
           ./bin/tag-release.sh --ci --push


### PR DESCRIPTION
## Summary

- Fixes the `403 Permission denied to MozmarRobot` error when the release workflow pushes to `stage` and `prod`
- `actions/checkout`'s `token:` parameter sets up credentials for checkout but does not reliably override the runner's default git credential for subsequent `git push` operations in separate `run:` steps
- Fix: explicitly call `git remote set-url origin "https://x-access-token:${GHA_PAT}@..."` immediately before each push, making the credential unambiguous

## Affected steps

- `deploy-to-stage` → "Push to stage and record push time"
- `deploy-to-prod` → "Tag release and push to prod" (before calling `bin/tag-release.sh --ci --push`)

## Test plan

- [ ] Trigger the release workflow and verify the stage push succeeds
- [ ] Verify the prod tag push and branch update succeed
- [ ] Confirm `zizmor --pedantic` still passes (already verified locally — 0 findings)