### PR TITLE
fix: deploy-to-prod should not be blocked by new commits landing on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,12 +462,12 @@ jobs:
       tag: ${{ steps.tag-release.outputs.tag }}
 
     steps:
-      - name: Checkout main
+      - name: Checkout release SHA
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: main
+          ref: ${{ needs.preflight-checks.outputs.release_sha }}
           # A PAT is required here instead of the default GITHUB_TOKEN — see the
           # equivalent comment in deploy-to-stage for the full explanation.
           token: ${{ secrets.BEDROCK_GHA_RELEASE_WORKFLOW_PAT }} # zizmor: ignore[secrets-outside-env]
@@ -477,20 +477,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Verify HEAD still matches release SHA
-        env:
-          RELEASE_SHA: ${{ needs.preflight-checks.outputs.release_sha }}
-        run: |
-          CURRENT_HEAD=$(git rev-parse HEAD)
-          if [ "$CURRENT_HEAD" != "$RELEASE_SHA" ]; then
-            echo "::error::main has advanced since release started."
-            echo "  Expected: $RELEASE_SHA"
-            echo "  Current:  $CURRENT_HEAD"
-            echo "Aborting to avoid releasing unexpected commits."
-            exit 1
-          fi
-          echo "✓ HEAD matches release SHA: $RELEASE_SHA"
 
       - name: Record prod push time
         id: record-time

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -31,7 +31,13 @@ done
 echo "Comparing main branch to staging..."
 git fetch "$moz_git_remote"
 stage_hash=$(git rev-parse "${moz_git_remote}/stage")
-main_hash=$(git rev-parse main)
+if [[ "$ci_mode" == true ]]; then
+    # In CI mode we check out a specific SHA (detached HEAD), so 'main' branch
+    # reference is unavailable. Compare HEAD directly against origin/stage.
+    main_hash=$(git rev-parse HEAD)
+else
+    main_hash=$(git rev-parse main)
+fi
 if [[ "$stage_hash" != "$main_hash" ]]; then
     if [[ "$ci_mode" == true ]]; then
         echo "ERROR: Main branch does NOT match stage branch. Aborting release."


### PR DESCRIPTION
## Summary

On a busy repo, any commit landing on `main` during the ~40-minute staging window would cause `deploy-to-prod` to abort — even though the new commits have nothing to do with the release being deployed.

**Root cause:** `deploy-to-prod` checked out `ref: main`, then verified HEAD == `RELEASE_SHA`. If main advanced, HEAD would be ahead of `RELEASE_SHA` and the step would abort. Here's a real example https://github.com/mozilla/bedrock/actions/runs/25792697016

**Fix:** Check out the pinned `RELEASE_SHA` directly (detached HEAD). The release always deploys exactly what was tested on stage, regardless of what lands on main in the meantime.

Also updates `bin/tag-release.sh --ci` to use `git rev-parse HEAD` instead of `git rev-parse main` for the main/stage comparison, since `main` branch ref is unavailable in a detached HEAD checkout.

## Test plan

- [ ] Trigger the release workflow while a commit lands on main during staging — confirm it completes rather than aborting
- [ ] Confirm the tag is created on `RELEASE_SHA`, not any newer commit
- [x] Confirm `zizmor --pedantic` passes (verified locally — 0 findings)
- [ ] Confirm `bin/tag-release.sh` interactive mode is unchanged