### PR TITLE
fix: clearer error messages when preflight CI runs are cancelled by a new main commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
             if [ "$CONCLUSION" = "success" ]; then
               echo "✓ Unit tests passed"
               break
+            elif [ "$CONCLUSION" = "cancelled" ]; then
+              echo "::error::Unit tests for $RELEASE_SHA were cancelled — likely a new commit landed on main. Re-trigger the release when main is stable."
+              exit 1
             elif [ -n "$CONCLUSION" ] && [ "$CONCLUSION" != "null" ]; then
               echo "::error::Unit tests did not pass (conclusion: $CONCLUSION)"
               exit 1
@@ -164,6 +167,9 @@ jobs:
             if [ "$CONCLUSION" = "success" ]; then
               echo "✓ Pre-commit standards passed"
               break
+            elif [ "$CONCLUSION" = "cancelled" ]; then
+              echo "::error::Pre-commit checks for $RELEASE_SHA were cancelled — likely a new commit landed on main. Re-trigger the release when main is stable."
+              exit 1
             elif [ -n "$CONCLUSION" ] && [ "$CONCLUSION" != "null" ]; then
               echo "::error::Pre-commit standards did not pass (conclusion: $CONCLUSION)"
               exit 1
@@ -201,6 +207,9 @@ jobs:
               echo "dev_build_complete_time=${BUILD_COMPLETE_TIME}" >> "$GITHUB_ENV"
               echo "✓ Docker build completed for main/dev (finished at $BUILD_COMPLETE_TIME)"
               break
+            elif [ "$CONCLUSION" = "cancelled" ]; then
+              echo "::error::Docker build for $RELEASE_SHA was cancelled — likely a new commit landed on main. Re-trigger the release when main is stable."
+              exit 1
             elif [ -n "$CONCLUSION" ] && [ "$CONCLUSION" != "null" ]; then
               echo "::error::Docker build did not succeed on main (conclusion: $CONCLUSION)"
               exit 1


### PR DESCRIPTION
## Summary

When a new commit lands on `main` while the release workflow is in preflight, the unit tests, pre-commit checks, or Docker build for `RELEASE_SHA` may be cancelled by GitHub's concurrency mechanism. Previously these showed a generic "did not pass" error, leaving the deployer unsure whether it was a real failure or just a timing issue.

The error messages for `cancelled` conclusions in the three preflight gates now explicitly say: "were cancelled — likely a new commit landed on main. Re-trigger the release when main is stable."

Stage/prod build-and-push cancellations retain the generic message (those are more likely to be infrastructure issues).

## Test plan

- [ ] Trigger a release while a commit is in flight on main and verify the cancelled-run error message is clear