### PR TITLE
fix: check out release SHA directly in deploy-to-stage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,12 +276,12 @@ jobs:
       actions: read    # required to poll workflow run status via gh run list
 
     steps:
-      - name: Checkout main
+      - name: Checkout release SHA
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: main
+          ref: ${{ needs.preflight-checks.outputs.release_sha }}
           # A PAT is required here instead of the default GITHUB_TOKEN because GitHub
           # does not trigger downstream workflow runs (e.g. build-and-push.yml) when a
           # push is made using GITHUB_TOKEN. Using a PAT means the push is attributed
@@ -294,20 +294,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Verify HEAD matches release SHA
-        env:
-          RELEASE_SHA: ${{ needs.preflight-checks.outputs.release_sha }}
-        run: |
-          CURRENT_HEAD=$(git rev-parse HEAD)
-          if [ "$CURRENT_HEAD" != "$RELEASE_SHA" ]; then
-            echo "::error::main has advanced since release started."
-            echo "  Expected: $RELEASE_SHA"
-            echo "  Current:  $CURRENT_HEAD"
-            echo "Aborting to avoid releasing unexpected commits."
-            exit 1
-          fi
-          echo "✓ HEAD matches release SHA: $RELEASE_SHA"
 
       - name: Notify #www — pushing to stage
         uses: ./.github/actions/slack


### PR DESCRIPTION
## Summary

The `deploy-to-stage` job was checking out `ref: main` and then aborting if HEAD had advanced beyond `RELEASE_SHA`. This meant any commit landing on `main` after the release workflow was triggered (but before the stage push) would kill an otherwise healthy release.

Same fix as was already applied to `deploy-to-prod` (mozilla/bedrock#17172): check out `RELEASE_SHA` directly, removing the "Verify HEAD matches release SHA" step. New commits on `main` after the workflow starts no longer block the stage deployment.

## Test plan

- [ ] Trigger the release workflow while a commit lands on main during preflight — confirm the stage push proceeds rather than aborting
- [ ] Confirm the stage branch is updated to exactly `RELEASE_SHA`