### PR TITLE
Preserve HTML entities in `remove_p_tag` output (WT-1133)

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -257,5 +257,8 @@ def remove_p_tag(value: str) -> str:
     soup = BeautifulSoup(html_content, "html.parser")
     content = ""
     if soup and soup.p:
-        content = "<br/>".join("".join(str(c) for c in tag.contents) for tag in soup.find_all("p"))
+        # `decode_contents()` re-encodes HTML entities in text nodes, so an
+        # entity-encoded payload like `&lt;img onerror=...&gt;` stays inert
+        # instead of round-tripping back into live markup (XSS).
+        content = "<br/>".join(tag.decode_contents() for tag in soup.find_all("p"))
     return mark_safe(content)

--- a/bedrock/base/tests/test_templatetags.py
+++ b/bedrock/base/tests/test_templatetags.py
@@ -15,3 +15,11 @@ def test_remove_p_tag_with_inner_tags():
     input_html = '<p class="test-class">This is a <strong>paragraph</strong>.</p><p>This is another paragraph.</p>'
     expected_output = "This is a <strong>paragraph</strong>.<br/>This is another paragraph."
     assert remove_p_tag(input_html) == expected_output
+
+
+def test_remove_p_tag_preserves_escaped_entities():
+    # Regression: `remove_p_tag` must not convert entity-encoded HTML inside text
+    # nodes back into live markup (XSS).
+    input_html = "<p>&lt;img src=x onerror=alert(1)&gt;</p>"
+    expected_output = "&lt;img src=x onerror=alert(1)&gt;"
+    assert remove_p_tag(input_html) == expected_output


### PR DESCRIPTION
# Summary

* `remove_p_tag` reparsed richtext-rendered HTML and serialized children with `str(c)`, which emits text-node contents without re-encoding HTML entities.
* As a result, entity-encoded content like `&lt;example&gt;` in a richtext field rendered as literal `<example>` on the page instead of displayed text.
* Switch to `Tag.decode_contents()` so text nodes are re-encoded on the way out.
* Add a regression test covering the entity round-trip.