### PR TITLE
fix: repair Smartling CAT visual context

### DIFF
--- a/bedrock/cms/tests/test_callbacks.py
+++ b/bedrock/cms/tests/test_callbacks.py
@@ -4,6 +4,8 @@
 
 from unittest import mock
 
+from django.test import override_settings
+
 import pytest
 import wagtail_factories
 from wagtail.models import Page
@@ -15,6 +17,7 @@ from bedrock.cms.wagtail_localize_smartling.callbacks import _get_html_for_shari
 
 
 @pytest.mark.django_db
+@override_settings(WAGTAILADMIN_BASE_URL="https://cms.example.com")
 def test_visual_context__for_page(client):
     top_level_page = SimpleRichTextPageFactory()
 
@@ -38,9 +41,41 @@ def test_visual_context__for_page(client):
     # light checks because we're not testing wagtaildraftsharing itself
     assert "<body" in html
     assert "Test SimpleRichTextPage" in html
+    assert '<base href="https://www.mozilla.org/">' in html
 
     sharing_link_key = WagtaildraftsharingLink.objects.get().key
-    assert url == f"http://testserver:81/_internal_draft_preview/{sharing_link_key}/"
+    assert url == f"https://cms.example.com/_internal_draft_preview/{sharing_link_key}/"
+
+
+@pytest.mark.django_db
+@override_settings(WAGTAILADMIN_BASE_URL="https://cms.example.com")
+@mock.patch("bedrock.cms.wagtail_localize_smartling.callbacks._get_html_for_sharing_link")
+def test_visual_context__cms_hostname_stripped_and_base_tag_injected(mock_get_html, client):
+    top_level_page = SimpleRichTextPageFactory()
+    page = SimpleRichTextPageFactory(parent=top_level_page, slug="visual-context-text-page")
+    page.save_revision()
+
+    site = wagtail_factories.SiteFactory(
+        root_page=top_level_page,
+        is_default_site=True,
+        hostname="cms-internal.example.com",
+        port=8080,
+    )
+    cms_root_url = site.root_url  # e.g. "http://cms-internal.example.com:8080"
+
+    mock_get_html.return_value = f'<html><head></head><body><img src="{cms_root_url}/media/image.jpg"></body></html>'
+
+    user = WagtailUserFactory()
+    mock_job = mock.Mock()
+    mock_job.translation_source.get_source_instance.return_value = page
+    mock_job.user = user
+
+    _, html = visual_context(smartling_job=mock_job)
+
+    assert cms_root_url not in html
+    assert "https://cms.example.com" not in html
+    assert '<base href="https://www.mozilla.org/">' in html
+    assert '<img src="/media/image.jpg">' in html
 
 
 def test_visual_context__for_inviable_object(client):
@@ -86,6 +121,27 @@ def test_visual_context__for_page__with_no_revision(mock_capture_message, client
         "Object was not visually previewable because it didn't have a saved revision. Are you a developer with a local export?"
     )
     mock_capture_message.assert_called_once_with(f"Unable to get a latest_revision for {page} so unable to send visual context.")
+
+
+@override_settings(WAGTAILADMIN_BASE_URL="https://cms.example.com")
+@mock.patch("bedrock.cms.wagtail_localize_smartling.callbacks.SharingLinkView.as_view")
+@mock.patch("bedrock.cms.wagtail_localize_smartling.callbacks.RequestFactory")
+def test__get_html_for_sharing_link__uses_cms_hostname_and_path_only(mock_factory_cls, mock_as_view):
+    # sharing_link.url is a full URL — we should extract just the path and use
+    # the CMS hostname as SERVER_NAME so make_preview_request doesn't fall back
+    # to 'localhost' / 'testserver' and return a 400 error page.
+    mock_response = mock.Mock()
+    mock_response.text = "<html><body>page content</body></html>"
+    mock_as_view.return_value = mock.Mock(return_value=mock_response)
+
+    sharing_link = mock.Mock()
+    sharing_link.url = "http://localhost/_internal_draft_preview/abc123/"
+
+    result = _get_html_for_sharing_link(sharing_link)
+
+    mock_factory_cls.assert_called_once_with(SERVER_NAME="cms.example.com")
+    mock_factory_cls.return_value.get.assert_called_once_with("/_internal_draft_preview/abc123/")
+    assert result == "<html><body>page content</body></html>"
 
 
 # The happy path is implicitly tested in test_visual_context__*, above

--- a/bedrock/cms/wagtail_localize_smartling/callbacks.py
+++ b/bedrock/cms/wagtail_localize_smartling/callbacks.py
@@ -51,7 +51,7 @@ def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
 
 def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
     url = f"{settings.WAGTAILADMIN_BASE_URL}{sharing_link.url}"
-    logger.debug("Page URL being sent to Smartling for path %s", sharing_link.url)
+    logger.debug("Page URL being sent to Smartling: %s", url)
     return url
 
 

--- a/bedrock/cms/wagtail_localize_smartling/callbacks.py
+++ b/bedrock/cms/wagtail_localize_smartling/callbacks.py
@@ -8,12 +8,14 @@
 #
 # The README.md of that repo covers what inputs are
 # provided and what outputs are needed
-
+import logging
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
+from django.conf import settings
 from django.test import RequestFactory
 
-from wagtail.models import Page
+from wagtail.models import Page, Site
 from wagtail_localize_smartling.exceptions import IncapableVisualContextCallback
 
 if TYPE_CHECKING:
@@ -22,9 +24,18 @@ from sentry_sdk import capture_exception, capture_message
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 from wagtaildraftsharing.views import SharingLinkView
 
+logger = logging.getLogger(__name__)
+
 
 def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
-    request = RequestFactory().get(sharing_link.url)
+    # Use the CMS hostname (guaranteed to be in ALLOWED_HOSTS) so that
+    # Wagtail's make_preview_request doesn't fall back to 'testserver' /
+    # 'localhost', which would cause DisallowedHost inside the middleware
+    # chain and return a 400 error page instead of the real page HTML.
+    # Also extract just the path from sharing_link.url in case it's absolute.
+    cms_hostname = urlparse(settings.WAGTAILADMIN_BASE_URL).hostname
+    path = urlparse(sharing_link.url).path
+    request = RequestFactory(SERVER_NAME=cms_hostname).get(path)
     view_func = SharingLinkView.as_view()
     try:
         resp = view_func(
@@ -38,8 +49,10 @@ def _get_html_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
         raise IncapableVisualContextCallback("Was not able to get a HTML export from the sharing link")
 
 
-def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink, page: "Page") -> str:
-    return f"{page.get_site().root_url}{sharing_link.url}"
+def _get_full_url_for_sharing_link(sharing_link: WagtaildraftsharingLink) -> str:
+    url = f"{settings.WAGTAILADMIN_BASE_URL}{sharing_link.url}"
+    logger.debug("Page URL being sent to Smartling for path %s", sharing_link.url)
+    return url
 
 
 def visual_context(smartling_job: "Job") -> tuple[str, str]:
@@ -73,6 +86,16 @@ def visual_context(smartling_job: "Job") -> tuple[str, str]:
         max_ttl=-1,  # -1 signifies "No expiry". If we pass None we get the default TTL
     )
 
-    url = _get_full_url_for_sharing_link(sharing_link=sharing_link, page=content_obj)
+    url = _get_full_url_for_sharing_link(sharing_link=sharing_link)
     html = _get_html_for_sharing_link(sharing_link=sharing_link)
+
+    # Strip the CMS hostname from URLs in the HTML so they become relative,
+    # then inject a <base> tag so Smartling resolves them against the public
+    # domain rather than the IAP-protected CMS host.
+    default_site = Site.objects.filter(is_default_site=True).first()
+    if default_site:
+        html = html.replace(default_site.root_url, "")
+    base_tag = f'<base href="{settings.CANONICAL_URL}/">'
+    html = html.replace("<head>", f"<head>{base_tag}", 1)
+
     return (url, html)


### PR DESCRIPTION
Porting over fixups from Smartling to make Smartling's CAT tool work again.

* Ensure we don't have a DisallowedHost error during the generation of the HTML artifact, else we get no auto-matched strings in Smartling, which looks like no context was provided at all
* Ensure that the context references assets on the prod CDN, so they are not blocked by GCP IAP

Jira: https://mozilla-hub.atlassian.net/browse/WT-1184
