### PR TITLE
Port over of WT-1217 from Springfield: Drop HTML comments from sanitized output

### DIFF
--- a/bedrock/base/sanitization.py
+++ b/bedrock/base/sanitization.py
@@ -6,7 +6,15 @@
 Shared HTML sanitization utilities using justhtml.
 """
 
+import re
+
 from justhtml import JustHTML, SanitizationPolicy, UrlPolicy, UrlRule
+
+# Matches HTML comments. justhtml's DropComments transform cannot drop
+# comments when disallowed_tag_handling="escape" is in effect (the escape
+# pass runs in the same tree walk and wins), so we strip comments before
+# handing the input to justhtml.
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 
 # URL policy that allows common schemes for href and src attributes.
 # Using default_handling="strip" ensures any URL attributes not explicitly
@@ -30,13 +38,16 @@ def strip_all_tags(html: str) -> str:
         disallowed_tag_handling="unwrap",
         drop_content_tags=set(),  # Preserve content from all tags (bleach compat)
     )
+    html = _HTML_COMMENT_RE.sub("", html)
     return JustHTML(html, safe=True, policy=policy, fragment=True).to_html(pretty=False)
 
 
 def sanitize_html(html: str, allowed_tags: set, allowed_attributes: dict) -> str:
     """Sanitize HTML using an allowlist of tags and attributes.
 
-    Disallowed tags are escaped (converted to &lt;tag&gt;).
+    Disallowed tags are escaped (converted to &lt;tag&gt;). HTML comments are
+    dropped: keeping them would reveal authoring notes and, with the
+    current escape policy, surface them as visible &lt;!-- ... --&gt; text.
     """
     policy = SanitizationPolicy(
         allowed_tags=allowed_tags,
@@ -44,4 +55,5 @@ def sanitize_html(html: str, allowed_tags: set, allowed_attributes: dict) -> str
         disallowed_tag_handling="escape",
         url_policy=_URL_POLICY,
     )
+    html = _HTML_COMMENT_RE.sub("", html)
     return JustHTML(html, safe=True, policy=policy, fragment=True).to_html(pretty=False)

--- a/bedrock/base/tests/test_sanitization.py
+++ b/bedrock/base/tests/test_sanitization.py
@@ -22,6 +22,10 @@ class TestStripAllTags:
             ("<p>unclosed", "unclosed"),
             ("before<br/>after", "beforeafter"),
             ("<p>hello   world</p>", "hello   world"),
+            # HTML comments are dropped
+            ("<!-- hidden -->", ""),
+            ("before<!-- mid -->after", "beforeafter"),
+            ("<p>visible<!-- note --></p>", "visible"),
         ],
     )
     def test_strip_all_tags(self, html, expected):
@@ -116,3 +120,27 @@ class TestSanitizeHtml:
         # javascript: should be stripped
         result = sanitize_html("<img src=\"javascript:alert('xss')\">", {"img"}, {"img": ["src"]})
         assert "javascript:" not in result.lower()
+
+    @pytest.mark.parametrize(
+        "html, expected",
+        [
+            # Comment-only input is dropped to empty string
+            ("<!-- only -->", ""),
+            ("<!-- Keep this note until 156 -->", ""),
+            # Comments adjacent to text disappear
+            ("<!-- hidden -->visible", "visible"),
+            # Comments interleaved with allowed tags
+            ("<p>before<!-- mid -->after</p>", "<p>beforeafter</p>"),
+            # Multi-line / multi-word comment content
+            ("<p>x<!-- a\nb\nc -->y</p>", "<p>xy</p>"),
+            # Comments are dropped while unknown tags continue to be escaped
+            (
+                "<!-- drop me --><custom>x</custom>",
+                "&lt;custom&gt;x&lt;/custom&gt;",
+            ),
+        ],
+    )
+    def test_comments_are_dropped(self, html, expected):
+        allowed_tags = {"p"}
+        allowed_attributes = {}
+        assert sanitize_html(html, allowed_tags, allowed_attributes) == expected


### PR DESCRIPTION
Since switching from bleach to justhtml (WT-578), HTML comments in Markdown sources may have been surfaced on the page as literal `<!-- ... -->` text because the markup was HTML escaped. With the setting on `disallowed_tag_handling="escape"`, justhtml's escape pass wins over its DropComments transform, and using an explicit Sanitize() to force ordering discards our custom policy.

This issue was visible on release-notes pages on www.firefox.com and we're making the same change here for consistency.

The fix is to strip `<!--...-->` with a regex before handing the HTML to justhtml. This keeps the escape behaviour for unknown tags so example markup still renders as visible source.

Original PR https://github.com/mozmeao/springfield/pull/1369