### PR TITLE
WT-1191 update CMS components and static sections to use the same UTMs

### DIFF
--- a/bedrock/mozorg/templates/mozorg/cms/about/about-us.html
+++ b/bedrock/mozorg/templates/mozorg/cms/about/about-us.html
@@ -21,7 +21,7 @@
   {{ css_bundle('m24-about') }}
 {% endblock %}
 
-{% set utm_params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=m24-about' %}
+{% set utm_params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=about' %}
 
 {% block content %}
 <main>

--- a/bedrock/mozorg/templates/mozorg/cms/blocks/springboard_block.html
+++ b/bedrock/mozorg/templates/mozorg/cms/blocks/springboard_block.html
@@ -23,7 +23,7 @@
 
     {% for item in value.springboard_items %}
       {{ springboard_item(
-      link_url=item.url,
+      link_url=item.url|add_utm_parameters,
       link_attributes=item.preview,
       type=item.type,
       type_icon=item.icon,

--- a/bedrock/mozorg/templates/mozorg/cms/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/cms/home/home.html
@@ -42,7 +42,7 @@
   {% endwith %}
 {% endblock %}
 
-{% set utm_params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=m24-homepage' %}
+{% set utm_params = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=home' %}
 
 {% block page_banner %}
   {% if show_fundraising_banner %}


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR updates the homepage and about page UTM to be consistent between static sections and CMS sections

## Significant changes and points to review

- update static sections to use the same UTM campaign as the CMS page slug
- add auto UTM to springboard item links

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1191

## Testing

http://localhost:8000/en-US/
http://localhost:8000/en-US/about