### PR TITLE
[UITour] Adds ability to pin to taskbar/dock

### DIFF
--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -340,4 +340,15 @@ if (typeof window.Mozilla === 'undefined') {
     Mozilla.UITour.closeTab = function () {
         _sendEvent('closeTab');
     };
+
+    /**
+     * Pin Firefox to the taskbar (Windows) or Dock (macOS).
+     * getConfiguration('appinfo') should first be used to check data.needsPin
+     * before calling this.
+     *
+     * @since 152
+     */
+    Mozilla.UITour.pinToTaskbar = function () {
+        _sendEvent('pinToTaskbar');
+    };
 })();


### PR DESCRIPTION
## One-line summary

Adds ability to check for current pin state and pin to taskbar/dock.


## Significant changes and points to review
Adding pin to taskbar action.

## Issue / Bugzilla link
[Bugzilla Link](https://bugzilla.mozilla.org/show_bug.cgi?id=2034898)


## Testing
Testing this in browser console using local build:
```
Mozilla.UITour.getConfiguration('appinfo', d => console.log('needsPin', d.needsPin));
Mozilla.UITour.pinToTaskbar();
```