### PR TITLE
fix high severity vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2113,9 +2113,9 @@
       "license": "MPL-2.0"
     },
     "node_modules/@mozilla/glean": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.3.tgz",
-      "integrity": "sha512-zSCOOoFPC+W7rwwj9qPVMWnPwroHQkqNYe6SH9492RMPbDeWwxzqaeacX6ZmpPXopbcqfxQgyTET5Jbh1xLhHA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.8.tgz",
+      "integrity": "sha512-8Y2GVhOUVCBssE8vNEgG7pzUUviyt+KzGOXh1Ewy23FKz55Rd0kcpnaHksqp6WldORgMdTKI+qN+M7C+6bv7aA==",
       "dependencies": {
         "fflate": "^0.8.0",
         "tslib": "^2.3.1",
@@ -5561,6 +5561,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10229,9 +10230,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10684,9 +10690,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR fixes high severity npm vulnerabilities.

`uuid` package issue -> won't fix: https://github.com/advisories/GHSA-w5hq-g745-h8pq doesn't apply to how it's used in this codebase (v4 only)

## Significant changes and points to review



## Issue / Bugzilla link



## Testing

`npm audit` should results no high severity vulnerabilities