### PR TITLE
WT-1252 expand domains to add UTMs to

### DIFF
--- a/bedrock/mozorg/templatetags/cms_tags.py
+++ b/bedrock/mozorg/templatetags/cms_tags.py
@@ -14,7 +14,8 @@ from jinja2 import pass_context
 def add_utm_parameters(context: dict, value: str) -> str:
     """
     Appends UTM parameters to URLs pointing to *.mozilla.org,
-    *.mozillafoundation.org, and *.firefox.com (except www.mozilla.org itself).
+    *.mozillafoundation.org, *.firefox.com, *.mozilla.ai, *.mozilla.vc,
+    *.thunderbird.net, and *.mozilla.com (except www.mozilla.org itself).
     """
     utm_parameters = context.get("utm_parameters", {})
     if utm_parameters and value:
@@ -22,7 +23,7 @@ def add_utm_parameters(context: dict, value: str) -> str:
         host = parsed_url.netloc if value.startswith(("http://", "https://", "//")) else ""
 
         pattern = re.compile(
-            r"^(\w+\.)?((mozilla\.org)|(mozillafoundation\.org)|(firefox\.com))",
+            r"^(\w+\.)?((mozilla\.org)|(mozillafoundation\.org)|(firefox\.com)|(mozilla\.ai)|(mozilla\.vc)|(thunderbird\.net)|(mozilla\.com))",
             re.IGNORECASE,
         )
         # Exclude www.mozilla.org (the current site) from UTM modification

--- a/bedrock/mozorg/tests/test_cms_tags.py
+++ b/bedrock/mozorg/tests/test_cms_tags.py
@@ -52,6 +52,44 @@ class TestAddUtmParameters:
         assert "utm_medium=referral" in result
         assert "utm_campaign=homepage" in result
 
+    def test_adds_utm_to_mozilla_ai(self, utm_context):
+        """Should add UTM parameters to mozilla.ai URLs."""
+        url = "https://www.mozilla.ai/some-page/"
+        result = add_utm_parameters(utm_context, url)
+        assert "utm_source=www.mozilla.org" in result
+        assert "utm_medium=referral" in result
+        assert "utm_campaign=homepage" in result
+
+    def test_adds_utm_to_mozilla_vc(self, utm_context):
+        """Should add UTM parameters to mozilla.vc URLs."""
+        url = "https://www.mozilla.vc/some-page/"
+        result = add_utm_parameters(utm_context, url)
+        assert "utm_source=www.mozilla.org" in result
+        assert "utm_medium=referral" in result
+        assert "utm_campaign=homepage" in result
+
+    def test_adds_utm_to_thunderbird_net(self, utm_context):
+        """Should add UTM parameters to thunderbird.net URLs."""
+        url = "https://www.thunderbird.net/en-US/"
+        result = add_utm_parameters(utm_context, url)
+        assert "utm_source=www.mozilla.org" in result
+        assert "utm_medium=referral" in result
+        assert "utm_campaign=homepage" in result
+
+    def test_adds_utm_to_mozilla_com(self, utm_context):
+        """Should add UTM parameters to mozilla.com URLs."""
+        url = "https://www.mozilla.com/some-page/"
+        result = add_utm_parameters(utm_context, url)
+        assert "utm_source=www.mozilla.org" in result
+        assert "utm_medium=referral" in result
+        assert "utm_campaign=homepage" in result
+
+    def test_exclusion_list_only_applies_to_mozilla_org(self, utm_context):
+        """Only bare mozilla.org is excluded; bare versions of other allowed domains still get UTMs."""
+        url = "https://mozilla.ai/some-page/"
+        result = add_utm_parameters(utm_context, url)
+        assert "utm_source=www.mozilla.org" in result
+
     def test_excludes_www_mozilla_org(self, utm_context):
         """Should NOT add UTM parameters to www.mozilla.org (same site)."""
         url = "https://www.mozilla.org/firefox/"


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR expands domains for UTM addition.

## Significant changes and points to review



## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1252

## Testing

1. edit any CMS page in Wagtail admin
2. update a URL to use any of the added domain
3. preview the link on the edited page
4. link should have the page slug as UTM campaign
