### PR TITLE
fix: include new foundation-fundraiser template on CMS homepage

### DIFF
--- a/bedrock/mozorg/templates/mozorg/cms/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/cms/home/home.html
@@ -45,7 +45,7 @@
 
 {% block page_banner %}
   {% if show_fundraising_banner %}
-    {% include 'includes/banners/fundraiser.html' %}
+    {% include 'includes/banners/foundation-fundraiser.html' %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
The CMS-managed homepage (bedrock/mozorg/templates/mozorg/cms/home/home.html) was still including the old `includes/banners/fundraiser.html` (eoy2025) template while loading the new midyear2026 JS bundle. The legacy template doesn't contain `.c-banner-image` or `#foundation-fundraising-banner-midyear2026-link`, so applyVariant() in foundation-fundraising-banner-midyear2026-init.es6.js crashed with `TypeError: can't access property "setAttribute", l is null` when the `FOUNDATION_FUNDRAISING_BANNER_MIDYEAR2026` Waffle switch was enabled in production.