### PR TITLE
Add missing alt attribute

### DIFF
--- a/bedrock/base/templates/includes/banners/foundation-fundraiser.html
+++ b/bedrock/base/templates/includes/banners/foundation-fundraiser.html
@@ -48,7 +48,7 @@
 
 {% block banner_content %}
   <div class="c-banner-outer">
-    <img class="c-banner-image" src="/media/img/banners/fundraiser/banner-green.png" />
+    <img class="c-banner-image" src="/media/img/banners/fundraiser/banner-green.png" alt="" />
     <div class="c-banner-inner">
       <div class="c-banner-copy">
         <h2 class="c-banner-title">{{ banner_title }}</h2>


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

Fixes failing "Images must have alternative text" accessibility test

## Significant changes and points to review


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/actions/runs/27096790054/job/79970294708


## Testing
Run accessibility tests locally to verify no errors: https://mozmeao.github.io/platform-docs/testing/axe/