### PR TITLE
Switch to complex `:not()` notation

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -35,7 +35,6 @@
                 ]
             }
         ],
-        "selector-not-notation": "simple",
         "media-feature-range-notation": "prefix"
     },
     "ignoreFiles": ["media/css/libs/**/*"]

--- a/media/css/anonym/_section.scss
+++ b/media/css/anonym/_section.scss
@@ -348,7 +348,7 @@
         }
     }
 
-    &:not([hidden]):not(.mzan-half-grid) + &:not([hidden]):not(.mzan-half-grid) {
+    &:not([hidden], .mzan-half-grid) + &:not([hidden], .mzan-half-grid) {
         &::before {
             content: none;
         }


### PR DESCRIPTION
## One-line summary

This syncs with a change made in mozmeao/springfield#1480, where we switched from `:not()`’s “simple” notation to “complex,” as the latter (stylelint’s default value) is now well supported and helps reduce creeping specificity.

## Significant changes and points to review

There was only one relevant case where the simple notation `:not()` chaining was happening and needed to updated.

## Issue / Bugzilla link

- mozmeao/springfield#1480
- Original decision from 2022 to use `simple` notation in Bedrock: https://github.com/mozilla/bedrock/pull/12464

## Testing

- Running `npm run lint-css` should have no warnings.
- Visual regression tests pass for affected content.