### PR TITLE
Apply py-svg-hush sanitized output to SVG uploads and reject oversized sanitized output

### DIFF
--- a/bedrock/cms/fields.py
+++ b/bedrock/cms/fields.py
@@ -6,6 +6,7 @@ import os
 import re
 
 from django.core.exceptions import ValidationError
+from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
 
 import defusedxml.ElementTree as ET
@@ -74,6 +75,10 @@ class SanitizingWagtailImageField(WagtailImageField):
         )
 
         self.error_messages["svg_sanitization_error"] = _("Unable to process this SVG file. Please ensure it is a valid SVG.")
+
+        self.error_messages["svg_sanitized_too_large"] = _(
+            "This SVG file is too large after sanitization (%(file_size)s). Maximum filesize is %(max_filesize)s."
+        )
 
     def _is_svg_file(self, f) -> bool:
         """
@@ -189,16 +194,15 @@ class SanitizingWagtailImageField(WagtailImageField):
     def _sanitize_svg(self, f) -> ValidationError | None:
         """
         Hybrid SVG sanitization approach.
-
         This uses a three-layer defense:
         1. Fast regex check for obvious dangerous patterns (scripts, event handlers)
         2. XML parsing to detect dangerous elements/attributes more reliably
-        3. py-svg-hush as a final safety net (but we don't reject based on normalization)
-
-        This approach avoids false positives from py-svg-hush's normalization
-        (attribute reordering, encoding changes) while still catching actual threats.
-
-        Returns None if file is safe, otherwise returns a ValidationError.
+        3. `py-svg-hush`, whose sanitized output replaces the uploaded bytes.
+        Layers 1 and 2 reject inputs that clearly look unsafe so editors get a
+        useful error. Subtler content is silently normalized by `py-svg-hush`,
+        which interprets SVG and URL syntax through a real parser rather than
+        by substring matching.
+        Returns `None` if file is safe (possibly after rewrite), otherwise a `ValidationError`.
         """
         try:
             # Read original content
@@ -218,26 +222,45 @@ class SanitizingWagtailImageField(WagtailImageField):
                     code="svg_dangerous_content",
                 )
 
-            # Layer 3: Run py-svg-hush as defense-in-depth
-            # We don't reject based on changes - this is just a safety net
-            # in case our detection missed something
+            # Layer 3: Run `py-svg-hush` and adopt its sanitized output.
+            # Using its output (not just its parse result) is what closes the
+            # long tail of SVG bypasses that `defusedxml`'s substring checks
+            # miss, e.g. `<a xlink:href="java&#x0a;script:...">` where the
+            # browser strips the encoded newline at URL resolution time.
             try:
-                # Run sanitization to catch edge cases our detection missed
-                # Allow common image data URLs in SVGs
-                filter_svg(
+                sanitized_content = filter_svg(
                     original_content,
                     keep_data_url_mime_types=ALLOWED_DATA_URL_MIME_TYPES,
                 )
-                # If py-svg-hush succeeds without errors, the SVG structure is valid
-                # We accept it regardless of normalization changes
             except (ValueError, ET.ParseError) as ex:
-                # py-svg-hush failed to process it - SVG might be malformed
                 return ValidationError(
                     f"{self.error_messages['svg_sanitization_error']}: {ex}",
                     code="svg_sanitization_error",
                 )
 
-            # All checks passed - file is safe
+            # The upload size was validated before sanitization, but `filter_svg`
+            # can expand nested SVGs into a much larger file, so re-check it here.
+            if self.max_upload_size is not None and len(sanitized_content) > self.max_upload_size:
+                return ValidationError(
+                    self.error_messages["svg_sanitized_too_large"],
+                    code="svg_sanitized_too_large",
+                    params={
+                        "file_size": filesizeformat(len(sanitized_content)),
+                        "max_filesize": self.max_upload_size_text,
+                    },
+                )
+
+            # Write the sanitized output back in place.
+            f.seek(0)
+            f.truncate()
+            f.write(sanitized_content)
+            f.seek(0)
+            # `f.size` is cached on the upload object at construction time,
+            # not derived from the buffer. Keep it in sync or length-aware
+            # downstream code reads a stale value.
+            if hasattr(f, "size"):
+                f.size = len(sanitized_content)
+
             return None
 
         except OSError as ex:

--- a/bedrock/cms/tests/test_svg_sanitization.py
+++ b/bedrock/cms/tests/test_svg_sanitization.py
@@ -43,6 +43,31 @@ SVG_WITH_ALLOWED_DATA_URL = """<?xml version="1.0" encoding="UTF-8"?>
     <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" />
 </svg>"""
 
+# Byte-sensitive regression samples: leave as bytes and do not reformat or
+# pretty-print. The encoded entities must survive verbatim for these fixtures
+# to exercise the intended sanitizer path.
+MALICIOUS_SVG_WITH_ENCODED_JS_URL = b"""<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="200" height="200">
+  <a xlink:href="java&#x0a;script:alert('XSS')">
+    <rect width="200" height="200" fill="red"/>
+  </a>
+</svg>"""
+
+# The href body is base64 of `<script>alert('XSS')</script>` so the payload
+# matches the shape of the other fixtures in this file, but its bytes never
+# spell out anything Layers 1/2 can recognise (no literal `<script`, no
+# `on*=`, no `javascript:`). That's deliberate: the assertion is about the
+# disallowed scheme/MIME (`data:text/html`), and any cleartext payload
+# would trip an earlier layer and mask whether Layer 3 is doing its job.
+MALICIOUS_SVG_WITH_ENCODED_HTML_DATA_URL = b"""<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="200" height="200">
+  <a xlink:href="data:te&#x78;t/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">
+    <rect width="200" height="200" fill="red"/>
+  </a>
+</svg>"""
+
 pytestmark = [pytest.mark.django_db]
 
 
@@ -361,3 +386,108 @@ class SVGSanitizationFieldTestCase(TestCase):
             content_type="text/xml",
         )
         self.assertTrue(self.field._is_svg_file(svg_file_2))
+
+    # Tests for `py-svg-hush` rewriting the uploaded bytes
+    def test_sanitizer_writes_back_to_file(self):
+        """`_sanitize_svg` writes the sanitized output back to the upload."""
+        svg_file = SimpleUploadedFile(
+            "test.svg",
+            CLEAN_SVG.encode("utf-8"),
+            content_type="image/svg+xml",
+        )
+        sentinel = b"<svg>sanitized</svg>"
+
+        with mock.patch("bedrock.cms.fields.filter_svg", return_value=sentinel):
+            result = self.field._sanitize_svg(svg_file)
+        self.assertIsNone(result)
+
+        svg_file.seek(0)
+        self.assertEqual(svg_file.read(), sentinel)
+
+        # `f.size` must track the rewritten buffer length.
+        self.assertEqual(svg_file.size, len(sentinel))
+
+    def test_encoded_javascript_url_is_neutralized(self):
+        """
+        An encoded `javascript:` URL that slips past Layers 1+2 must not
+        survive `py-svg-hush`'s rewrite of the uploaded bytes.
+        """
+        svg_file = SimpleUploadedFile(
+            "encoded_javascript_url.svg",
+            MALICIOUS_SVG_WITH_ENCODED_JS_URL,
+            content_type="image/svg+xml",
+        )
+
+        result = self.field._sanitize_svg(svg_file)
+        self.assertIsNone(result)
+
+        svg_file.seek(0)
+        rewritten = svg_file.read()
+
+        # The encoded byte sequence from the fixture must not survive.
+        self.assertNotIn(b"java&#x0a;script:", rewritten)
+
+    def test_encoded_html_data_url_is_neutralized(self):
+        """
+        Disallowed data-URL MIME types must not survive sanitization, even
+        when their byte representation is broken up so substring checks miss.
+        """
+        # The earlier layers can only spot `data:text/html` if it appears
+        # literally in the raw bytes. An encoded entity inside the MIME type
+        # slips past both the regex and the `defusedxml` walk (the latter only
+        # special-cases `javascript:`). Layer 3 is the line that has to hold:
+        # `py-svg-hush` parses the URL properly and strips any data URL whose
+        # MIME type is not in `ALLOWED_DATA_URL_MIME_TYPES`.
+        #
+        # Because this test depends on Layer 3 alone, it doubles as an early-
+        # warning signal: if someone removes the `filter_svg` call or loosens
+        # `ALLOWED_DATA_URL_MIME_TYPES` to include `text/html` (or `*`), this
+        # assertion is what should start failing.
+        svg_file = SimpleUploadedFile(
+            "html_data_url.svg",
+            MALICIOUS_SVG_WITH_ENCODED_HTML_DATA_URL,
+            content_type="image/svg+xml",
+        )
+
+        result = self.field._sanitize_svg(svg_file)
+        self.assertIsNone(result)
+
+        svg_file.seek(0)
+        rewritten = svg_file.read()
+
+        # The encoded byte sequence from the fixture must not survive.
+        self.assertNotIn(b"data:te&#x78;t/html", rewritten)
+
+    def test_sanitized_output_exceeding_max_upload_size_rejected(self):
+        """SVG whose sanitized output exceeds Wagtail max upload size is rejected."""
+        svg_file = SimpleUploadedFile(
+            "nested.svg",
+            CLEAN_SVG.encode("utf-8"),
+            content_type="image/svg+xml",
+        )
+        bloated = b"x" * 20_000
+
+        with mock.patch.object(self.field, "max_upload_size", 10_000):
+            with mock.patch("bedrock.cms.fields.filter_svg", return_value=bloated):
+                result = self.field._sanitize_svg(svg_file)
+
+        self.assertIsInstance(result, ValidationError)
+        self.assertEqual(result.code, "svg_sanitized_too_large")
+        # Upload buffer must not be rewritten when rejected.
+        svg_file.seek(0)
+        self.assertEqual(svg_file.read(), CLEAN_SVG.encode("utf-8"))
+
+    def test_deeply_nested_svg_rejected_when_sanitized_output_too_large(self):
+        """Regression: compact nested <g> SVG must not persist after ~56x expansion."""
+        compact = b"<svg xmlns='http://www.w3.org/2000/svg'>" + b"<g>" * 200 + b"<rect width='1' height='1'/>" + b"</g>" * 200 + b"</svg>"
+        svg_file = SimpleUploadedFile(
+            "nested.svg",
+            compact,
+            content_type="image/svg+xml",
+        )
+
+        with mock.patch.object(self.field, "max_upload_size", 50_000):
+            result = self.field._sanitize_svg(svg_file)
+
+        self.assertIsInstance(result, ValidationError)
+        self.assertEqual(result.code, "svg_sanitized_too_large")


### PR DESCRIPTION
Fixes vulnerabilities referenced in HackerOne report [#3688002](https://hackerone.com/reports/3688002)

- _sanitize_svg() now captures filter_svg() output and writes it back to the upload buffer, with f.size kept in sync.
- Post-sanitization size validation rejects expanded nested SVGs before persistence.
- Five regression tests added covering write-back, encoded URL neutralization, and oversized sanitized output rejection.