### PR TITLE
Combined manifesto display tweaks

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto-combo.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto-combo.html
@@ -38,7 +38,7 @@
 {% block content %}
 <main>
   <header class="m24-c-content">
-    <div class="m24-c-intro">
+    <div class="m24-c-intro m24-t-intro-snug">
       <h1 class="m24-c-intro-title">{{ ftl('manifesto-the-mozilla-manifesto') }}</h1>
       {% if ftl_has_messages('manifesto-written-in-2007') %}
       <p>{{ ftl('manifesto-written-in-2007') }}</p>

--- a/media/css/mozorg/m24-manifesto.scss
+++ b/media/css/mozorg/m24-manifesto.scss
@@ -35,13 +35,13 @@
         position: relative;
         font-size: $text-body-lg;
         font-weight: 500;
-        grid-column: span 9 / -1;
+        grid-column: 1/-1;
         padding-top: $spacer-xl;
         text-align: start;
 
         &::before {
             @include bidi(((left, 0, right, auto),));
-            background-color: $m24-color-black;
+            background-color: var(--m24-light-gray);
             content: '';
             display: block;
             height: 2px;
@@ -51,7 +51,7 @@
         }
 
         @media #{$mq-md} {
-            grid-column: span 9 / -1;
+            grid-column: span 9;
         }
     }
 }


### PR DESCRIPTION
## One-line summary

Combined manifesto display tweaks.

## Significant changes and points to review

- left align manifesto 
- decrease contrast of lines

## Issue / Bugzilla link

[WT-1321](https://mozilla-hub.atlassian.net/browse/WT-1321)

## Testing

http://localhost:8000/en-US/about/manifesto/ (switch should be on by default locally)