### PR TITLE
Support locale-prefixed paths in `gone()` 410 matcher (issue #16549)

### DIFF
--- a/bedrock/redirects/tests/test_util.py
+++ b/bedrock/redirects/tests/test_util.py
@@ -12,6 +12,7 @@ from django.urls import URLPattern
 from bedrock.redirects.middleware import RedirectsMiddleware
 from bedrock.redirects.util import (
     get_resolver,
+    gone,
     header_redirector,
     is_firefox_redirector,
     no_redirect,
@@ -398,3 +399,42 @@ class TestRedirectUrlPattern(TestCase):
         resp = middleware.process_request(self.rf.get("/editor/midasdemo/securityprefs.html%3C/span%3E%3C/a%3E%C2%A0"))
         assert resp.status_code == 301
         assert resp["Location"] == "http://www-archive.mozilla.org/editor/midasdemo/securityprefs.html%C2%A0"
+
+
+@patch("bedrock.base.views.page_gone_view", return_value=HttpResponse(status=410))
+class TestGoneUrlPattern(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+
+    def test_gone_locale_prefixed(self, mock_page_gone_view):
+        """A gone() pattern returns a 410 and catches locale-prefixed paths by default."""
+        resolver = get_resolver([gone(r"^iam/the/walrus/$")])
+        middleware = RedirectsMiddleware(get_response=HttpResponse, resolver=resolver)
+        for path in ("/iam/the/walrus/", "/en-US/iam/the/walrus/", "/de/iam/the/walrus/"):
+            resp = middleware.process_request(self.rf.get(path))
+            assert resp is not None, path
+            assert resp.status_code == 410, path
+
+    def test_gone_no_locale_prefix(self, mock_page_gone_view):
+        """With locale_prefix=False only the un-prefixed path is caught."""
+        resolver = get_resolver([gone(r"^iam/the/walrus/$", locale_prefix=False)])
+        middleware = RedirectsMiddleware(get_response=HttpResponse, resolver=resolver)
+
+        resp = middleware.process_request(self.rf.get("/iam/the/walrus/"))
+        assert resp.status_code == 410
+
+        # locale-prefixed path falls through (no match)
+        resp = middleware.process_request(self.rf.get("/en-US/iam/the/walrus/"))
+        assert resp is None
+
+    def test_gone_match_flags(self, mock_page_gone_view):
+        """Should be able to set regex flags for a gone() URL."""
+        resolver = get_resolver([gone(r"^iam/the/walrus/$", re_flags="i")])
+        middleware = RedirectsMiddleware(get_response=HttpResponse, resolver=resolver)
+
+        resp = middleware.process_request(self.rf.get("/IAm/The/Walrus/"))
+        assert resp.status_code == 410
+
+        # also with locale
+        resp = middleware.process_request(self.rf.get("/es-ES/IAm/The/Walrus/"))
+        assert resp.status_code == 410

--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -340,8 +340,23 @@ def gone_view(request, *args, **kwargs):
     return page_gone_view(request)
 
 
-def gone(pattern):
-    """Return a url matcher suitable for urlpatterns that returns a 410."""
+def gone(pattern, locale_prefix=True, re_flags=None):
+    """Return a url matcher suitable for urlpatterns that returns a 410.
+
+    :param pattern: regex URL pattern that will return a 410.
+    :param locale_prefix: automatically prepend `pattern` with a regex for an optional
+        locale in the url, so that e.g. both `/foo` and `/{LANG}/foo` are caught.
+    :param re_flags: optional string of Python `re` flags used to modify how
+        `pattern` is interpreted (see the `re` module docs).
+    :return: a `re_path` matcher that serves a 410 Gone response for `pattern`.
+    """
+    if locale_prefix:
+        pattern = pattern.lstrip("^/")
+        pattern = LOCALE_RE + pattern
+
+    if re_flags:
+        pattern = f"(?{re_flags})" + pattern
+
     return re_path(pattern, gone_view)
 
 


### PR DESCRIPTION
# Summary

`gone()` in `bedrock/redirects/util.py` was the odd one out. `redirect()` and `no_redirect()` both prepend `LOCALE_RE`, but `gone()` did not. So `gone(r"^help-wanted\.html$")` matched `/help-wanted.html` but not `/en-US/help-wanted.html`. The locale-prefixed path fell through to a 404 or whatever view existed.

`gone()` now takes `locale_prefix=True` (default) and `re_flags`, matching `redirect()`. Tests added for the locale-prefixed match, `locale_prefix=False`, and `re_flags`.

Closes issue #16549 (criterion 1).

# Heads up: behavior change

`locale_prefix=True` is now the default. This affects all 41 existing `gone()` callers. Paths like `/{LANG}/foo` that used to fall through now return `410`. This is the intended fix, but flagging it since it touches every caller at once. Pass `locale_prefix=False` to keep the old un-prefixed-only behavior on a given entry.

# Criterion 2: no fix for now

The issue also raises that `page_gone_view` re-does locale logic by hand, because `RedirectsMiddleware` short-circuits before `BedrockLangCodeFixupMiddleware` runs. We are leaving this as-is for now. Per Steve, re-ordering the middleware (especially the lang-fixup middleware) can have awkward side effects that could catch us out. The manual locale shim in `page_gone_view` stays. See comments on issue #16549.