### PR TITLE
Remove logo padding from org links [WT-1319]

### DIFF
--- a/media/css/mozorg/org-leadership.scss
+++ b/media/css/mozorg/org-leadership.scss
@@ -269,7 +269,6 @@
     border: 1px solid transparent;
     box-sizing: border-box;
     aspect-ratio: 16/9;
-    padding: $spacing-lg $spacing-md;
     transition-duration: $fast;
     transition-property: border-color;
     transition-timing-function: $bezier;


### PR DESCRIPTION
## One-line summary

Remove logo padding from org links

## Significant changes and points to review

That's it, that's the change.

## Issue / Bugzilla link

WT-1319
