### PR TITLE
Remove trafficop for green only

### DIFF
--- a/bedrock/base/templates/includes/banners/foundation-fundraiser.html
+++ b/bedrock/base/templates/includes/banners/foundation-fundraiser.html
@@ -53,7 +53,7 @@
       <div class="c-banner-copy">
         <h2 class="c-banner-title">{{ banner_title }}</h2>
         <p class="c-banner-tagline">{{ banner_tagline }}</p>
-        <a id="foundation-fundraising-banner-midyear2026-link" class="c-banner-button mzp-c-button mzp-t-secondary mzp-t-lg" data-cta-text="Donate" data-cta-position="banner">
+        <a id="foundation-fundraising-banner-midyear2026-link" class="c-banner-button mzp-c-button mzp-t-secondary mzp-t-lg" data-cta-text="Donate" data-cta-position="banner" href="https://www.mozillafoundation.org/?form=26MY-PBW ">
           {{ banner_button }}
         </a>
       </div>

--- a/media/js/base/banners/foundation-fundraising-banner-midyear2026-init.es6.js
+++ b/media/js/base/banners/foundation-fundraising-banner-midyear2026-init.es6.js
@@ -5,82 +5,9 @@
  */
 
 import MozBanner from './mozilla-banner.es6';
-import TrafficCop from '@mozmeao/trafficcop';
-import { isApprovedToRun } from '../../base/experiment-utils.es6.js';
 
 MozBanner.init('foundation-fundraising-banner-midyear2026', true);
 
 if (typeof window.dataLayer === 'undefined') {
     window.dataLayer = [];
 }
-
-const href = window.location.href;
-
-const initTrafficCop = () => {
-    if (href.indexOf('v=') !== -1) {
-        if (href.indexOf('v=2') !== -1) {
-            // GA4
-            window.dataLayer.push({
-                event: 'experiment_view',
-                id: 'MOFO-donation-green',
-                variant: 'mofo-donation-v2'
-            });
-        } else if (href.indexOf('v=3') !== -1) {
-            // GA4
-            window.dataLayer.push({
-                event: 'experiment_view',
-                id: 'MOFO-donation-orange',
-                variant: 'mofo-donation-v3'
-            });
-        }
-    } else if (TrafficCop) {
-        const cop = new TrafficCop({
-            variations: {
-                'v=2': 50, // MoFo donate green
-                'v=3': 50 // MoFo donate orange
-            }
-        });
-        cop.init();
-    }
-};
-
-const applyVariant = () => {
-    const bannerImage = document.querySelector('.c-banner-image');
-    const donateButton = document.querySelector(
-        '#foundation-fundraising-banner-midyear2026-link'
-    );
-
-    if (href.indexOf('v=3') !== -1) {
-        bannerImage.setAttribute(
-            'src',
-            '/media/img/banners/fundraiser/banner-orange.png'
-        );
-        document
-            .querySelector('.c-banner-fundraising')
-            .classList.add('c-variant-orange');
-        donateButton.setAttribute(
-            'href',
-            'https://www.mozillafoundation.org/?form=26MY-PBB'
-        );
-    } else {
-        bannerImage.setAttribute(
-            'src',
-            '/media/img/banners/fundraiser/banner-green.png'
-        );
-        document
-            .querySelector('.c-banner-fundraising')
-            .classList.add('c-variant-green');
-        donateButton.setAttribute(
-            'href',
-            'https://www.mozillafoundation.org/?form=26MY-PBA'
-        );
-    }
-};
-
-// Avoid entering automated tests into random experiments.
-if (isApprovedToRun()) {
-    initTrafficCop();
-}
-
-// Run on page load (after TrafficCop may have redirected back)
-applyVariant();


### PR DESCRIPTION
## One-line summary
Replaces trafficop fundraiser with just the green variant as the winner.

## Issue / Bugzilla link
https://mozilla-hub.atlassian.net/browse/WT-1131

## Testing
- [x] Checkout this PR
- [x] Run the site
- [x] The ?v= variant from the URL should be gone
- [x] The green fundraiser banner should render
- [x] It should link to https://www.mozillafoundation.org/en/?form=26MY-PBW