### PR TITLE
Ensure ProductRelease is not in DB export script now it has been dropped from the codebase

### DIFF
--- a/bin/export-db-to-sqlite.sh
+++ b/bin/export-db-to-sqlite.sh
@@ -193,7 +193,6 @@ python manage.py dumpdata \
     security.Product \
     security.SecurityAdvisory \
     security.HallOfFamer \
-    releasenotes.ProductRelease \
     contentcards.ContentCard \
     utils.GitRepoState \
     wordpress.BlogPost \


### PR DESCRIPTION
35668ac9fb remove release note models (#17240) removed the models for releasenotes so the DB export will not work because it can't find that model. This brings the export script into alignment with the model state

