### PR TITLE
Release note requirements clean up

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -528,7 +528,6 @@ django==5.2.15 \
     #   django-extensions
     #   django-filter
     #   django-jinja
-    #   django-memoize
     #   django-modelcluster
     #   django-mozilla-product-details
     #   django-permissionedforms
@@ -587,9 +586,6 @@ django-jinja-markdown==1.2 \
 django-jsonview==2.0.0 \
     --hash=sha256:1871983f6c7ab0bec1bad3249b06ce64c47d3bed57cd190f87e5acaf65722ebb \
     --hash=sha256:77345393f8e8bb3279b9ba9fb2db687adfa74d41feab972521545d47103d321b
-    # via -r requirements/prod.txt
-django-memoize==2.3.1 \
-    --hash=sha256:62ac4807710ecf22a7397d008d64d0f798e7230482d4b6072d916cac852a47cd
     # via -r requirements/prod.txt
 django-modelcluster==6.5 \
     --hash=sha256:459cbf0fb3bbc8c15ea9a2a062abc0d1ef935a38e04aa8ac3cb241c826bbc6dd \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -13,7 +13,6 @@ django-extensions==4.1
 django-jinja-markdown==1.2
 django-jinja==2.11.0
 django-jsonview==2.0.0
-django-memoize==2.3.1
 django-mozilla-product-details==1.0.3
 django-rq==4.1.0
 django-rq-email-backend==2.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -376,7 +376,6 @@ django==5.2.15 \
     #   django-extensions
     #   django-filter
     #   django-jinja
-    #   django-memoize
     #   django-modelcluster
     #   django-mozilla-product-details
     #   django-permissionedforms
@@ -432,9 +431,6 @@ django-jinja-markdown==1.2 \
 django-jsonview==2.0.0 \
     --hash=sha256:1871983f6c7ab0bec1bad3249b06ce64c47d3bed57cd190f87e5acaf65722ebb \
     --hash=sha256:77345393f8e8bb3279b9ba9fb2db687adfa74d41feab972521545d47103d321b
-    # via -r requirements/prod.in
-django-memoize==2.3.1 \
-    --hash=sha256:62ac4807710ecf22a7397d008d64d0f798e7230482d4b6072d916cac852a47cd
     # via -r requirements/prod.in
 django-modelcluster==6.5 \
     --hash=sha256:459cbf0fb3bbc8c15ea9a2a062abc0d1ef935a38e04aa8ac3cb241c826bbc6dd \


### PR DESCRIPTION
_If this changeset needs to go into the FXC codebase, please add the `WMO and FXC` label._


## One-line summary

This PR removes stale release note requirements.

## Significant changes and points to review

Dependent on the deployment of https://github.com/mozilla/bedrock/pull/17241

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/pull/17241#pullrequestreview-4519771136
https://github.com/mozilla/bedrock/pull/17241#issuecomment-4774504166
https://mozilla-hub.atlassian.net/browse/WT-1380

## Testing
