### PR TITLE
Tweaks to leadership page, copy tweak for manifesto.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto-combo.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto-combo.html
@@ -48,8 +48,8 @@
         </div>
         <div class="m24-c-prose-body">
           <p>{{ ftl('manifesto-details-the-internet-is-becoming') }}</p>
-          <p>{{ ftl('manifesto-details-the-mozilla-project-global') }}</p>
-          <p>{{ ftl('manifesto-details-the-mozilla-project-community') }}</p>
+          <p>{{ ftl('manifesto-details-the-mozilla-project-global-v2', fallback='manifesto-details-the-mozilla-project-global') }}</p>
+          <p>{{ ftl('manifesto-details-the-mozilla-project-community-v2', fallback='manifesto-details-the-mozilla-project-community') }}</p>
           <p>{{ ftl('manifesto-details-as-a-result-of') }}</p>
           <p>{{ ftl('manifesto-details-the-goals-for') }}</p>
           <ol class="mzp-u-list-styled">

--- a/bedrock/mozorg/templates/mozorg/cms/about/blocks/leadership_snippet.html
+++ b/bedrock/mozorg/templates/mozorg/cms/about/blocks/leadership_snippet.html
@@ -8,7 +8,7 @@
   <figure class="headshot">
     {% if snippet.image %}
       {# Empty alt: the person's name is in the adjacent figcaption and people kept adding it as the alt text which is not good for a11y #}
-      {{ srcset_image(snippet.image, "width-{200,400,600}", class="photo", sizes="220px", alt="") }}
+      {{ srcset_image(snippet.image, "fill-{200x200,400x400,600x600}", class="photo", sizes="220px", alt="") }}
     {% endif %}
     <figcaption>
       <h3 class="fn" itemprop="name">{{ snippet.name }}</h3>

--- a/bedrock/mozorg/templates/mozorg/cms/about/organization_leadership_index_page.html
+++ b/bedrock/mozorg/templates/mozorg/cms/about/organization_leadership_index_page.html
@@ -56,7 +56,7 @@
           {% endif %}
 
           {% if page.exec_leaders %}
-            <div class="c-group-gallery">
+            <div class="c-group-gallery l-group-gallery-narrow">
               {% for block in page.exec_leaders %}
                 {% set snippet = block.value.profile %}
                 {% set job_title_override = block.value.job_title %}

--- a/l10n/en/mozorg/about/manifesto.ftl
+++ b/l10n/en/mozorg/about/manifesto.ftl
@@ -30,8 +30,16 @@ manifesto-we-are-committed-to-diverse = We are committed to an internet that cat
 manifesto-an-internet-with-these = An internet with these qualities will not come to life on its own. Individuals and organizations must embed these aspirations into internet technology and into the human experience with the internet. The { -brand-name-mozilla } Manifesto and Addendum represent { -brand-name-mozilla }’s commitment to advancing these aspirations. We aim to work together with people and organizations everywhere who share these goals to make the internet an even better place for everyone.
 manifesto-details-introduction = Introduction
 manifesto-details-the-internet-is-becoming = The internet is becoming an increasingly important part of our lives.
+manifesto-details-the-mozilla-project-global-v2 = The { -brand-name-mozilla } Project is a global community of people who believe that openness, innovation, and opportunity are key to the continued health of the internet. We have worked together since 1998 to ensure that the internet is developed in a way that benefits everyone. We are best known for creating the { -brand-name-mozilla } { -brand-name-firefox } web browser.
+
+# Obsolete string (expires 2026-09-20)
 manifesto-details-the-mozilla-project-global = The { -brand-name-mozilla } project is a global community of people who believe that openness, innovation, and opportunity are key to the continued health of the internet. We have worked together since 1998 to ensure that the internet is developed in a way that benefits everyone. We are best known for creating the { -brand-name-mozilla } { -brand-name-firefox } web browser.
+
+manifesto-details-the-mozilla-project-community-v2 = The { -brand-name-mozilla } Project uses a community-based approach to create world-class open source software and to develop new types of collaborative activities. We create communities of people involved in making the internet experience better for all of us.
+
+# Obsolete string (expires 2026-09-20)
 manifesto-details-the-mozilla-project-community = The { -brand-name-mozilla } project uses a community-based approach to create world-class open source software and to develop new types of collaborative activities. We create communities of people involved in making the internet experience better for all of us.
+
 manifesto-details-as-a-result-of = As a result of these efforts, we have distilled a set of principles that we believe are critical for the internet to continue to benefit the public good as well as commercial aspects of life. We set out these principles below.
 manifesto-details-the-goals-for = The goals for the Manifesto are to:
 manifesto-details-articulate-a-vision-v2 = articulate a vision for the internet that { -brand-name-mozilla } participants want { -brand-name-mozilla-foundation } to pursue;
@@ -114,7 +122,7 @@ manifesto-details-the-effectiveness = The effectiveness of the internet as a pub
 manifesto-details-free-and-open = Free and open source software promotes the development of the internet as a public resource.
 manifesto-details-commercial-involvement = Commercial involvement in the development of the internet brings many benefits; a balance between commercial profit and public benefit is critical.
 manifesto-details-magnifying-the = Magnifying the public benefit aspects of the internet is an important goal, worthy of time, attention and commitment.
-manifesto-details-there-are-many = There are many different ways of advancing the principles of the { -brand-name-mozilla } Manifesto. We welcome a broad range of activities, and anticipate the same creativity that { -brand-name-mozilla } participants have shown in other areas of the project. For individuals not deeply involved in the { -brand-name-mozilla } project, one basic and very effective way to support the Manifesto is to use { -brand-name-mozilla } { -brand-name-firefox } and other products that embody the principles of the Manifesto.
+manifesto-details-there-are-many = There are many different ways of advancing the principles of the { -brand-name-mozilla } Manifesto. We welcome a broad range of activities, and anticipate the same creativity that { -brand-name-mozilla } participants have shown in other areas of the project. For individuals not deeply involved in the { -brand-name-mozilla } Project, one basic and very effective way to support the Manifesto is to use { -brand-name-mozilla } { -brand-name-firefox } and other products that embody the principles of the Manifesto.
 manifesto-details-some-foundation-v2 = Some Foundation activities—currently the creation, delivery and promotion of consumer products—are conducted primarily through { -brand-name-mozilla-foundation }’s wholly owned subsidiary, the { -brand-name-mozilla-corporation }.
 manifesto-details-invitation = Invitation
 manifesto-details-the-mozilla-foundation-invites-v2 = { -brand-name-mozilla-foundation } invites all others who support the principles of the { -brand-name-mozilla } Manifesto to join with us, and to find new ways to make this vision of the internet a reality.

--- a/media/css/m24/vars/_grid.scss
+++ b/media/css/m24/vars/_grid.scss
@@ -23,6 +23,17 @@ $mobile-square-img-max-width: 363px;
     @return calc($one-column * #{$n} - #{$minus});
 }
 
+// returns the value of $n columns within a $context-column-wide parent
+// examples:
+//   max-width: grid(6);     => 6 of 12 columns
+//   max-width: grid(3, 6);  => 3 columns inside a 6-column parent
+@function sub-grid($n, $context: $grid-columns) {
+    $one-column: calc(100% / #{$context});
+    $minus: calc(#{$grid-gutter} * (#{$context} - #{$n}) / #{$context});
+
+    @return calc(#{$one-column} * #{$n} - #{$minus});
+}
+
 // creates the standard 12 column grid
 @mixin grid {
     // can only be used inside a container that is full width with $content-padding on each side

--- a/media/css/m24/vars/_grid.scss
+++ b/media/css/m24/vars/_grid.scss
@@ -25,8 +25,8 @@ $mobile-square-img-max-width: 363px;
 
 // returns the value of $n columns within a $context-column-wide parent
 // examples:
-//   max-width: grid(6);     => 6 of 12 columns
-//   max-width: grid(3, 6);  => 3 columns inside a 6-column parent
+//   max-width: sub-grid(6);     => 6 of 12 columns
+//   max-width: sub-grid(3, 6);  => 3 columns inside a 6-column parent
 @function sub-grid($n, $context: $grid-columns) {
     $one-column: calc(100% / #{$context});
     $minus: calc(#{$grid-gutter} * (#{$context} - #{$n}) / #{$context});

--- a/media/css/mozorg/org-leadership.scss
+++ b/media/css/mozorg/org-leadership.scss
@@ -55,6 +55,13 @@
 
     @media #{$mq-md} {
         grid-template-columns: repeat(8, 1fr);
+
+        // optional 3 column display
+        &.l-group-gallery-narrow {
+            grid-template-columns: repeat(6, 1fr);
+            max-width: sub-grid(6,8);
+            margin: $layout-sm 0;
+        }
     }
 }
 
@@ -181,6 +188,10 @@
         &:hover,
         &:focus {
             cursor: auto;
+
+            .photo {
+                border-color: $m24-color-light-mid-gray;
+            }
 
             .fn {
                 text-decoration: none;


### PR DESCRIPTION
## One-line summary

Tweaks to leadership page, copy tweak for manifesto.

## Significant changes and points to review

- Capitalize Mozilla Project on manifesto page
- Crop Leadership headshots to 1:1
- Arrange leadership photos in 3x3 grid 
  - Long term this should probably be a config option but this felt like an acceptable solution because it doesn't make sense to show a 3x3 grid on the same page as a 4x3 grids (it makes it unclear that there's another row beneath if there's more than 3)

## Issue / Bugzilla link

[WT-1372](https://mozilla-hub.atlassian.net/browse/WT-1372)

## Testing

- http://localhost:8000/en-US/about/leadership/ 
- http://localhost:8000/en-US/about/manifesto/
- Swap the image on a leadership profile for one that is not square, view the profile and check that its square.