### PR TITLE
Revert leadership headshot filter

### DIFF
--- a/bedrock/mozorg/templates/mozorg/cms/about/blocks/leadership_snippet.html
+++ b/bedrock/mozorg/templates/mozorg/cms/about/blocks/leadership_snippet.html
@@ -8,7 +8,7 @@
   <figure class="headshot">
     {% if snippet.image %}
       {# Empty alt: the person's name is in the adjacent figcaption and people kept adding it as the alt text which is not good for a11y #}
-      {{ srcset_image(snippet.image, "fill-{200x200,400x400,600x600}", class="photo", sizes="220px", alt="") }}
+      {{ srcset_image(snippet.image, "width-{200,400,600}", class="photo", sizes="220px", alt="") }}
     {% endif %}
     <figcaption>
       <h3 class="fn" itemprop="name">{{ snippet.name }}</h3>

--- a/media/css/mozorg/org-leadership.scss
+++ b/media/css/mozorg/org-leadership.scss
@@ -72,7 +72,9 @@
     margin-bottom: $spacer-xl;
 
     .photo {
+        aspect-ratio: 1 / 1;
         border: 1px solid $m24-color-light-mid-gray;
+        object-fit: cover;
         transition-duration: $fast;
         transition-property: border-color;
         transition-timing-function: $bezier;


### PR DESCRIPTION
## One-line summary

Revert leadership headshot filter

## Significant changes and points to review

- The updated filter was causing errors because not all renditions exist of the older images.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/actions/runs/27981916633

## Testing

View a leadership page and make sure it still displays. Though, we're not really going to know if this fixes the bug until it hits dev.