### PR TITLE
Escape interpolated values in Firefox Account button markup (WT-1397)

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -15,6 +15,7 @@ from django.template.defaultfilters import slugify as django_slugify
 from django.template.defaulttags import CsrfTokenNode
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
+from django.utils.html import format_html, format_html_join
 
 import jinja2
 from django_jinja import library
@@ -653,10 +654,6 @@ def _fxa_product_button(
 ):
     href = _fxa_product_url(product_url, entrypoint, optional_parameters)
     css_class = "js-fxa-cta-link"
-    attrs = ""
-
-    if optional_attributes:
-        attrs += " ".join(f'{attr}="{val}"' for attr, val in optional_attributes.items())
 
     if include_metrics:
         css_class += " js-fxa-product-button"
@@ -667,7 +664,21 @@ def _fxa_product_button(
     if class_name:
         css_class += f" {class_name}"
 
-    markup = f'<a href="{href}" data-action="{settings.FXA_ENDPOINT}" class="{css_class}" {attrs}>{button_text}</a>'
+    # Build the anchor with contextual escaping. `button_text`, the
+    # `optional_attributes` values, and the label-derived `href` can all carry
+    # caller- or l10n-supplied data (e.g. a translated button label,
+    # `data-cta-*` attributes, or the `entrypoint`/`utm_campaign` that flows
+    # into the `href`). Every interpolated value must therefore be escaped to
+    # prevent XSS.
+    attrs = format_html_join(" ", '{}="{}"', (optional_attributes or {}).items())
+    markup = format_html(
+        '<a href="{}" data-action="{}" class="{}" {}>{}</a>',
+        href,
+        settings.FXA_ENDPOINT,
+        css_class,
+        attrs,
+        button_text,
+    )
 
     return Markup(markup)
 

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -939,8 +939,8 @@ class TestRelayFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In to Relay", "data-cta-type": "fxa-relay", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://relay.firefox.com/accounts/fxa/login/?process=login&entrypoint=mozilla.org-whatsnew&form_type=button'
-            '&utm_source=mozilla.org-whatsnew&utm_medium=referral&utm_campaign=whatsnew96" data-action="https://accounts.firefox.com/" '
+            '<a href="https://relay.firefox.com/accounts/fxa/login/?process=login&amp;entrypoint=mozilla.org-whatsnew&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-whatsnew&amp;utm_medium=referral&amp;utm_campaign=whatsnew96" data-action="https://accounts.firefox.com/" '
             'class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product relay-main-cta-button" '
             'data-cta-text="Sign In to Relay" data-cta-type="fxa-relay" data-cta-position="primary">Sign In to Relay</a>'
         )
@@ -982,8 +982,8 @@ class TestMonitorFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In to Monitor", "data-cta-type": "fxa-monitor", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://monitor.mozilla.org/user/dashboard?entrypoint=mozilla.org-firefox-accounts&form_type=button'
-            '&utm_source=mozilla.org-firefox-accounts&utm_medium=referral&utm_campaign=skyline" '
+            '<a href="https://monitor.mozilla.org/user/dashboard?entrypoint=mozilla.org-firefox-accounts&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-accounts&amp;utm_medium=referral&amp;utm_campaign=skyline" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button '
             'monitor-main-cta-button" data-cta-text="Sign In to Monitor" data-cta-type="fxa-monitor" '
             'data-cta-position="primary">Sign In to Monitor</a>'
@@ -1028,8 +1028,8 @@ class TestFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign Up", "data-cta-type": "fxa-sync", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
-            '&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            '<a href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-whatsnew73&amp;utm_medium=referral&amp;utm_campaign=whatsnew73" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary">Sign Up</a>'
         )
@@ -1048,8 +1048,8 @@ class TestFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign In", "data-cta-type": "fxa-sync", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://accounts.firefox.com/signin?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
-            '&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            '<a href="https://accounts.firefox.com/signin?entrypoint=mozilla.org-firefox-whatsnew73&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-whatsnew73&amp;utm_medium=referral&amp;utm_campaign=whatsnew73" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             'fxa-main-cta-button" data-cta-text="Sign In" data-cta-type="fxa-sync" data-cta-position="primary">Sign In</a>'
         )
@@ -1068,12 +1068,56 @@ class TestFxAButton(TestCase):
             optional_attributes={"data-cta-text": "Sign Up", "data-cta-type": "fxa-sync", "data-cta-position": "primary"},
         )
         expected = (
-            '<a href="https://accounts.firefox.com/?action=email&entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
-            '&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            '<a href="https://accounts.firefox.com/?action=email&amp;entrypoint=mozilla.org-firefox-whatsnew73&amp;form_type=button'
+            '&amp;utm_source=mozilla.org-firefox-whatsnew73&amp;utm_medium=referral&amp;utm_campaign=whatsnew73" '
             'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary">Sign Up</a>'
         )
         self.assertEqual(markup, expected)
+
+
+@override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+class TestFxAButtonXSS(TestCase):
+    """Hardening tests for the FxA button sink.
+
+    `_fxa_product_button` is the single place that assembles the anchor. Its
+    `button_text`, its `optional_attributes` values, and the label-derived
+    `href` can all carry caller- or l10n-supplied data. Every value
+    interpolated into the anchor must therefore be contextually escaped, so
+    that a translated label, or any future caller, cannot inject markup.
+    """
+
+    PRODUCT_URL = "https://accounts.firefox.com/signup"
+
+    def test_button_text_is_escaped(self):
+        """The button label must not render as live HTML."""
+        markup = misc._fxa_product_button(
+            self.PRODUCT_URL,
+            "mozilla.org-page",
+            button_text="<img src=x onerror=\"alert('XSS')\">",
+        )
+        assert "<img" not in markup
+        assert "&lt;img src=x" in markup
+
+    def test_optional_attribute_value_is_escaped(self):
+        """Attribute values must not break out of the attribute."""
+        markup = misc._fxa_product_button(
+            self.PRODUCT_URL,
+            "mozilla.org-page",
+            button_text="Sign In",
+            optional_attributes={"data-cta-text": '"><script>alert(1)</script>'},
+        )
+        assert "<script>" not in markup
+        assert "&lt;script&gt;" in markup
+
+    def test_label_in_href_entrypoint_is_escaped(self):
+        """A label flowing into `utm_campaign`/`entrypoint`, and into the
+        `href`, must not break out of the `href` attribute value."""
+        entrypoint = "mozilla.org-" + '"><img src=x onerror=alert(1)>'.lower().replace(" ", "_")
+        markup = misc._fxa_product_button(self.PRODUCT_URL, entrypoint, button_text="ok")
+        assert "<img" not in markup
+        assert '"><img' not in markup
+        assert "&lt;img_src=x" in markup
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)


### PR DESCRIPTION
# Summary

`_fxa_product_button` assembled the Firefox Account button anchor by string concatenation and returned it as `Markup`, so `button_text`, the `optional_attributes` values and the label-derived `href` were emitted without escaping. Unlike springfield, bedrock does not expose this sink to CMS content (no Firefox Account button block and no rich-text `<fxa>` tag), so this is not a reachable stored XSS here. The values that do reach the sink are l10n-supplied button labels and any future caller, so this change is a hardening that mirrors the springfield fix.

# Fix

Build the anchor with `format_html` and `format_html_join` so all interpolated values are escaped. Bedrock has no `inner_html` slot, so the change is smaller than the springfield one.

Escaping the `href` renders its `&` separators as `&amp;`, which is valid HTML and decodes identically, so the existing exact-string button tests are updated to match.

# Tests

New `TestFxAButtonXSS` class:

* `test_button_text_is_escaped` confirms a label payload renders as inert text in the anchor body.
* `test_optional_attribute_value_is_escaped` confirms an attribute value cannot break out of its attribute.
* `test_label_in_href_entrypoint_is_escaped` confirms a label reaching the `href` cannot break out of the URL.

The three tests were confirmed to fail against the unpatched sink.

# Context

* https://mozilla-hub.atlassian.net/browse/WT-1397
* https://bugzilla.mozilla.org/show_bug.cgi?id=2044038
* PR mozmeao/springfield#1552