### PR TITLE
Remove unavailable archs from ESR downloads

### DIFF
--- a/bedrock/firefox/tests/test_firefox_all.py
+++ b/bedrock/firefox/tests/test_firefox_all.py
@@ -244,7 +244,8 @@ def test_firefox_esr(client, os, lang):
     doc = pq(resp.content)
 
     link = doc(".c-download-button")
-    assert len(link) == 2
+    expected_links = 1 if os in ["linux", "linux64-aarch64", "win64-aarch64"] else 2
+    assert len(link) == expected_links
     download_url = link.attr("href")
     if "msi" in os:
         product = "firefox-esr-msi-latest-ssl"
@@ -258,9 +259,9 @@ def test_firefox_esr(client, os, lang):
         assert "https://support.mozilla.org/kb/install-firefox-linux" in linux_link.attr("href")
 
 
-@pytest.mark.parametrize("os, lang", [("win64", "en-US"), ("win64", "de"), ("osx", "en-US"), ("linux", "en-US")])
+@pytest.mark.parametrize("os, lang", [("win64", "en-US"), ("win64", "de"), ("osx", "en-US"), ("linux64", "en-US")])
 def test_firefox_esr_next(client, os, lang):
-    # Note: Only testing a few os/lang pairs to avoid mocking too much. We're mostly checking that 2 buttons show up.
+    # Note: Only testing a few os/lang pairs to avoid mocking too much. We're mostly checking that all button and link types show up.
 
     # Set an esr_next version.
     orig_latest_version = firefox_desktop.latest_version
@@ -281,8 +282,8 @@ def test_firefox_esr_next(client, os, lang):
                         "win64": {
                             "download_url": "https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=win64&lang=en-US",
                         },
-                        "linux": {
-                            "download_url": "https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=linux&lang=en-US",
+                        "linux64": {
+                            "download_url": "https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=linux64&lang=en-US",
                         },
                         "osx": {
                             "download_url": "https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang=en-US",

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -359,8 +359,8 @@ def firefox_all(request, product_slug=None, platform=None, locale=None):
                 # ESR115 builds do not exist for "sat" ans "skr" languages (see issue #15437).
                 if locale in ["sat", "skr"]:
                     download_esr_115_url = None
-                # ESR115 builds do not exist for "linux64-aarch64" platform (see issue mozmeao/springfield#467)
-                if platform == "linux64-aarch64":
+                # ESR115 builds do not exist for "linux64-aarch64" (springfield#467); "linux" (i686) and "win64-aarch64" no longer ship (bug 2040496)
+                if platform in ["linux64-aarch64", "linux", "win64-aarch64"]:
                     download_esr_115_url = None
                 context.update(
                     download_esr_115_url=download_esr_115_url,


### PR DESCRIPTION
## One-line summary

Limits the archs offered for ESR 115 legacy builds.

## Significant changes and points to review

Porting https://github.com/mozmeao/springfield/pull/1530

## Issue / Bugzilla link

Resolves #17284

## Testing

…/sco/firefox/all/desktop-esr/win64-aarch64/sco/