### PR TITLE
Remove dead `email-mieco/` email gateway (WT-1315)

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -6,7 +6,6 @@ import re
 from datetime import datetime
 from random import randrange
 
-from django import forms
 from django.forms import widgets
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -75,20 +74,3 @@ class TelInput(widgets.TextInput):
 
 class NumberInput(widgets.TextInput):
     input_type = "number"
-
-
-class MiecoEmailForm(forms.Form):
-    """
-    A form class used to validate the data coming from the MIECO site.
-    """
-
-    MESSAGE_ID_CHOICES = (
-        ("innovations", "innovations"),
-        ("mieco", "mieco"),
-    )
-
-    name = forms.CharField(required=False, max_length=100)
-    email = forms.EmailField()
-    interests = forms.CharField(required=False, max_length=100)
-    description = forms.CharField(required=False, max_length=750)
-    message_id = forms.ChoiceField(required=False, choices=MESSAGE_ID_CHOICES)

--- a/bedrock/mozorg/templates/mozorg/emails/mieco-email.txt
+++ b/bedrock/mozorg/templates/mozorg/emails/mieco-email.txt
@@ -1,9 +1,0 @@
-The following was submitted on the MIECO form:
-
-Name: {{ data.name }}
-E-mail: {{ data.email }}
-
-Interests: {{ data.interests }}
-
-Message:
-{{ data.description }}

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -2,10 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
 from unittest.mock import patch
 
-from django.core import mail
 from django.http.response import HttpResponse
 from django.test import override_settings
 from django.test.client import RequestFactory
@@ -167,102 +165,3 @@ class TestMozorgRedirects(TestCase):
                 resp = self.client.get(path, follow=True, headers={"accept-language": "en"})
                 self.assertEqual(resp.redirect_chain[0], ("/about/webvision/", 301))
                 self.assertEqual(resp.redirect_chain[1], ("/en-US/about/webvision/", 302))
-
-
-class TestMiecoEmail(TestCase):
-    def setUp(self):
-        self.factory = RequestFactory()
-        self.view = views.mieco_email_form
-        with self.activate_locale("en-US"):
-            self.url = reverse("mozorg.email_mieco")
-
-        self.data = {
-            "name": "The Dude",
-            "email": "foo@bar.com",
-            "interests": "abiding, bowling",
-            "description": "The rug really tied the room together.",
-        }
-
-    def tearDown(self):
-        mail.outbox = []
-
-    def test_not_post(self):
-        resp = self.client.get(self.url)
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.text, '{"error": 400, "message": "Only POST requests are allowed"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    def test_bad_json(self):
-        resp = self.client.post(self.url, content_type="application/json", data='{{"bad": "json"}')
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.text, '{"error": 400, "message": "Error decoding JSON"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    def test_invalid_email(self):
-        resp = self.client.post(self.url, content_type="application/json", data='{"email": "foo@bar"}')
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.text, '{"error": 400, "message": "Invalid form data"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    def test_invalid_message_id(self):
-        self.data["message_id"] = "the-dude"
-        resp = self.client.post(self.url, content_type="application/json", data=json.dumps(self.data))
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.text, '{"error": 400, "message": "Invalid form data"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    @patch("bedrock.mozorg.views.render_to_string", return_value="rendered")
-    @patch("bedrock.mozorg.views.EmailMessage")
-    def test_success(self, mock_emailMessage, mock_render_to_string):
-        resp = self.client.post(self.url, content_type="application/json", data=json.dumps(self.data))
-
-        self.assertEqual(resp.status_code, 200)
-        mock_emailMessage.assert_called_once_with(
-            views.MIECO_EMAIL_SUBJECT["mieco"], "rendered", views.MIECO_EMAIL_SENDER, views.MIECO_EMAIL_TO["mieco"]
-        )
-        self.assertEqual(resp.text, '{"status": "ok"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    @patch("bedrock.mozorg.views.render_to_string", return_value="rendered")
-    @patch("bedrock.mozorg.views.EmailMessage")
-    def test_success_mieco(self, mock_emailMessage, mock_render_to_string):
-        self.data["message_id"] = "mieco"
-        resp = self.client.post(self.url, content_type="application/json", data=json.dumps(self.data))
-
-        self.assertEqual(resp.status_code, 200)
-        mock_emailMessage.assert_called_once_with(
-            views.MIECO_EMAIL_SUBJECT["mieco"], "rendered", views.MIECO_EMAIL_SENDER, views.MIECO_EMAIL_TO["mieco"]
-        )
-        self.assertEqual(resp.text, '{"status": "ok"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    @patch("bedrock.mozorg.views.render_to_string", return_value="rendered")
-    @patch("bedrock.mozorg.views.EmailMessage")
-    def test_success_innovations(self, mock_emailMessage, mock_render_to_string):
-        self.data["message_id"] = "innovations"
-        resp = self.client.post(self.url, content_type="application/json", data=json.dumps(self.data))
-
-        self.assertEqual(resp.status_code, 200)
-        mock_emailMessage.assert_called_once_with(
-            views.MIECO_EMAIL_SUBJECT["innovations"], "rendered", views.MIECO_EMAIL_SENDER, views.MIECO_EMAIL_TO["innovations"]
-        )
-        self.assertEqual(resp.text, '{"status": "ok"}')
-        self.assertIn("Access-Control-Allow-Origin", resp.headers)
-        self.assertIn("Access-Control-Allow-Headers", resp.headers)
-
-    def test_outbox(self):
-        resp = self.client.post(self.url, content_type="application/json", data=json.dumps(self.data))
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(mail.outbox), 1)
-
-        email = mail.outbox[0]
-        self.assertIn(f"Name: {self.data['name']}", email.body)
-        self.assertIn(f"E-mail: {self.data['email']}", email.body)
-        self.assertIn(f"Interests: {self.data['interests']}", email.body)
-        self.assertIn(f"Message:\n{self.data['description']}", email.body)

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -140,7 +140,6 @@ urlpatterns = [
         name="mozorg.about.webvision.full",
     ),
     page("analytics-tests/", "mozorg/analytics-tests/ga-index.html"),
-    path("email-mieco/", views.mieco_email_form, name="mozorg.email_mieco"),
     path("antiharassment-tool/", views.anti_harassment_tool_view, name="mozorg.antiharassment-tool"),
     page("rise25/nominate/", "mozorg/rise25/landing.html"),
     redirect("advertising/formats/", "/advertising/solutions/", prepend_locale=False),

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -2,21 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import json
-
 from django.conf import settings
-from django.core.mail import EmailMessage
 from django.http import Http404
 from django.shortcuts import render as django_render
-from django.template.loader import render_to_string
 from django.views.decorators.http import require_safe
 from django.views.generic import TemplateView
 
-from jsonview.decorators import json_view
 from product_details import product_details
 
 from bedrock.mozorg.credits import CreditsFile
-from bedrock.mozorg.forms import MiecoEmailForm
 from bedrock.mozorg.models import WebvisionDoc
 from bedrock.newsletter.forms import NewsletterFooterForm
 from lib import l10n_utils
@@ -196,64 +190,6 @@ class WebvisionDocView(RequireSafeMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         context[self.doc_context_name] = doc.content
         return context
-
-
-MIECO_EMAIL_SUBJECT = {"mieco": "MIECO Interest Form", "innovations": "Innovations Interest Form"}
-MIECO_EMAIL_SENDER = settings.DEFAULT_FROM_EMAIL
-MIECO_EMAIL_TO = {
-    "mieco": ["mieco@mozilla.com"],
-    "innovations": ["innovations@mozilla.com"],
-}
-
-
-@json_view
-def mieco_email_form(request):
-    """
-    This form accepts a POST request from future.mozilla.org/mieco and will send
-    an email with the data included in the email.
-    """
-    CORS_HEADERS = {
-        "Access-Control-Allow-Origin": "https://future.mozilla.org",
-        "Access-Control-Allow-Headers": "accept, accept-encoding, content-type, dnt, origin, user-agent, x-csrftoken, x-requested-with",
-    }
-
-    if request.method == "OPTIONS":
-        return {}, 200, CORS_HEADERS
-
-    if request.method != "POST":
-        return {"error": 400, "message": "Only POST requests are allowed"}, 400, CORS_HEADERS
-
-    try:
-        json_data = json.loads(request.body.decode("utf-8"))
-    except json.decoder.JSONDecodeError:
-        return {"error": 400, "message": "Error decoding JSON"}, 400, CORS_HEADERS
-
-    form = MiecoEmailForm(
-        {
-            "email": json_data.get("email", ""),
-            "name": json_data.get("name", ""),
-            "interests": json_data.get("interests", ""),
-            "description": json_data.get("description", ""),
-            "message_id": json_data.get("message_id", ""),
-        }
-    )
-
-    if not form.is_valid():
-        return {"error": 400, "message": "Invalid form data"}, 400, CORS_HEADERS
-
-    message_id = form.cleaned_data.pop("message_id") or "mieco"
-    email_to = MIECO_EMAIL_TO[message_id]
-    email_msg = render_to_string("mozorg/emails/mieco-email.txt", {"data": form.cleaned_data}, request=request)
-    email_sub = MIECO_EMAIL_SUBJECT[message_id]
-
-    email = EmailMessage(email_sub, email_msg, MIECO_EMAIL_SENDER, email_to)
-
-    try:
-        email.send()
-    except Exception as e:
-        return {"error": 400, "message": str(e)}, 400, CORS_HEADERS
-
-    return {"status": "ok"}, 200, CORS_HEADERS
 
 
 @require_safe


### PR DESCRIPTION
# Summary

The static Netlify build of `future.mozilla.org` used to POST its contact-form submissions to bedrock's `email-mieco/` endpoint, which relayed them as email. That site was decommissioned long ago, so the endpoint and everything supporting it has just been sitting around as dead code.

# Changes

This removes it entirely:

* the `email-mieco/` URL and the `mieco_email_form` view (plus the `MIECO_EMAIL_*` config)
* the `MiecoEmailForm` form and the `mieco-email.txt` email template
* the `TestMiecoEmail` tests
* imports left unused once the above were gone

# Companion changes

The Fastly WAF keeps a `POST` allowlist that still exempts this route from the mutating-method block. That entry is removed separately in `webservices-infra`. Land this PR first so the route `404`s, then apply the WAF change.

# Context

* https://mozilla-hub.atlassian.net/browse/WT-1315