### PR TITLE
Temporarily disable VPN Windows ARM downloads #17305

### DIFF
--- a/bedrock/products/templates/products/vpn/download.html
+++ b/bedrock/products/templates/products/vpn/download.html
@@ -85,9 +85,11 @@
                 <a class="mzp-c-button ga-product-download" href="{{ url('products.vpn.windows-download') }}" data-cta-text="VPN Download (Windows x64)" class="platform-download-link" data-testid="vpn-download-link-primary-64-windows">
                 {{ ftl('vpn-download-windows') }}
                 </a>
+                {# bedrock#17305
                 <a class="mzp-c-button ga-product-download" href="{{ url('products.vpn.windows-arm-download') }}" data-cta-text="VPN Download (Windows ARM)" class="platform-download-link" data-testid="vpn-download-link-primary-arm-windows">
                 {{ ftl('vpn-download-windows-arm') }}
                 </a>
+                #}
               </div>
             </div>
           </div>
@@ -184,10 +186,12 @@
                 <span class="platform-download-arrow"></span>
                 {{ ftl('vpn-download-windows') }}
               </a>
+              {# bedrock#17305
               <a class="mzp-c-button mzp-t-secondary ga-product-download" href="{{ url('products.vpn.windows-arm-download') }}" data-cta-text="VPN Download (Windows ARM)" class="platform-download-link" data-testid="vpn-download-link-secondary-arm-windows">
                 <span class="platform-download-arrow" aria-hidden="true"></span>
                 {{ ftl('vpn-download-windows-arm') }}
               </a>
+              #}
             </div>
           </li>
           <!-- Mac OS -->

--- a/bedrock/products/templates/products/vpn/windows-arm-download.html
+++ b/bedrock/products/templates/products/vpn/windows-arm-download.html
@@ -142,9 +142,12 @@
         {% endcall %}
       </ol>
     </section>
+    #}
   </div>
+  {# hide per bedrock#17305
   {% include 'products/vpn/includes/download-faq.html' %}
-#}
+  #}
+
 
   {% endif %}
   <footer class="vpn-footer">

--- a/bedrock/products/templates/products/vpn/windows-arm-download.html
+++ b/bedrock/products/templates/products/vpn/windows-arm-download.html
@@ -31,6 +31,19 @@
     {% endif %}
 
     {% if not block_download %}
+
+    {# download unavailable message bedrock#17305 #}
+      <header class="platform-download-header">
+        <div class="mzp-l-content platform-download-header-wrapper">
+          <div class="vpn-logo">
+            <img src="{{ static('img/logos/vpn/vpn-dark-logo.svg') }}" alt="">
+          </div>
+          <h1>Mozilla VPN for Windows ARM</h1>
+          <p>This download is temporarily unavailable.</p>
+        </div>
+      </header>
+
+  {# hide per bedrock#17305
     <header class="platform-download-header">
       <div class="mzp-l-content platform-download-header-wrapper">
         <div class="vpn-logo">
@@ -131,6 +144,8 @@
     </section>
   </div>
   {% include 'products/vpn/includes/download-faq.html' %}
+#}
+
   {% endif %}
   <footer class="vpn-footer">
       {% include 'products/vpn/includes/footer-legal.html' %}


### PR DESCRIPTION
## One-line summary

Temporarily disable VPN Windows ARM downloads

## Significant changes and points to review

- hides buttons (there are 2)
- displays a message on the download page.

## Issue / Bugzilla link

Fix #17305

## Testing

http://localhost:8000/en-US/products/vpn/download/
http://localhost:8000/en-US/products/vpn/download/windows-arm/thanks/