### PR TITLE
Temporarily disable VPN Windows-arm download button tests #17305

### DIFF
--- a/tests/playwright/specs/products/vpn/vpn-download.spec.js
+++ b/tests/playwright/specs/products/vpn/vpn-download.spec.js
@@ -63,6 +63,7 @@ test.describe(
                 page,
                 browserName
             }) => {
+                test.skip(true, 'bedrock#17305');
                 // Click Windows download link
                 let downloadLink;
 


### PR DESCRIPTION
## One-line summary

Temporarily disable VPN Windows-arm download button tests

## Issue / Bugzilla link

#17305

## Testing
```
cd tests/playwright
npx playwright test vpn
```