### PR TITLE
Make mozilla-foundation newsletter migration permanent

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer-newsletter.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer-newsletter.html
@@ -13,7 +13,7 @@
 
     <div class="moz24-newsletter">
       {{ email_newsletter_form(
-        newsletters='mozilla-foundation' if switch('foundation-separate-newsletter') else 'mozilla-foundation, mozilla-and-you',
+        newsletters='mozilla-foundation',
         title=None
         )}}
       </div>

--- a/bedrock/foundation/templates/foundation/annualreport/2009/base.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/base.html
@@ -45,7 +45,7 @@
         {% if LANG.startswith('en-') %}
           {{ email_newsletter_form(newsletters='mozilla-foundation', title='Sign up. Read up.<br> Make a difference.'|safe, desc='Get the Mozilla newsletter and help us keep the Web free and open.', button_class='button-red') }}
         {% else %}
-          {{ email_newsletter_form(button_class='button-red') }}
+          {{ email_newsletter_form(newsletters='mozilla-foundation', button_class='button-red') }}
         {% endif %}
       </div>
     </aside>

--- a/bedrock/foundation/templates/foundation/annualreport/2010/base.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/base.html
@@ -45,7 +45,7 @@
         {% if LANG.startswith('en-') %}
           {{ email_newsletter_form(newsletters='mozilla-foundation', title='Sign up. Read up.<br> Make a difference.'|safe, desc='Get the Mozilla newsletter and help us keep the Web free and open.', button_class='button-red') }}
         {% else %}
-          {{ email_newsletter_form(button_class='button-red') }}
+          {{ email_newsletter_form(newsletters='mozilla-foundation', button_class='button-red') }}
         {% endif %}
       </div>
     </aside>

--- a/bedrock/foundation/templates/foundation/base.html
+++ b/bedrock/foundation/templates/foundation/base.html
@@ -49,7 +49,7 @@
         {% if LANG.startswith('en-') %}
           {{ email_newsletter_form(newsletters='mozilla-foundation', title='Sign up. Read up.<br> Make a difference.'|safe, desc='Get the Mozilla newsletter and help us keep the Web free and open.', button_class='button-red') }}
         {% else %}
-          {{ email_newsletter_form(button_class='button-red') }}
+          {{ email_newsletter_form(newsletters='mozilla-foundation', button_class='button-red') }}
         {% endif %}
       </div>
     </aside>

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -108,10 +108,11 @@
     <div class="newsletter-content">
       {% if LANG.startswith('en-') %}
       {{ email_newsletter_form(
+            newsletters='mozilla-foundation',
             title='Love the Web?',
             desc='Get the Mozilla newsletter and help us keep it open and free.') }}
       {% else %}
-      {{ email_newsletter_form() }}
+      {{ email_newsletter_form(newsletters='mozilla-foundation') }}
       {% endif %}
     </div>
   </div>

--- a/bedrock/mozorg/templates/mozorg/about-base.html
+++ b/bedrock/mozorg/templates/mozorg/about-base.html
@@ -56,7 +56,7 @@
       {% if LANG.startswith('en-') %}
         {{ email_newsletter_form(newsletters='mozilla-foundation', title='Love the Web?', desc='Get the Mozilla newsletter and help us keep it open and free.', button_class='button-hollow button-light', spinner_color='#fff') }}
       {% else %}
-        {{ email_newsletter_form(button_class='button-hollow button-light', spinner_color='#fff') }}
+        {{ email_newsletter_form(newsletters='mozilla-foundation', button_class='button-hollow button-light', spinner_color='#fff') }}
       {% endif %}
     </div>
   </div>

--- a/bedrock/mozorg/templates/mozorg/about/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/index.html
@@ -177,9 +177,8 @@
     </div>
 
     <div class="newsletter-content">
-      {% set newsletter_id = 'mozilla-foundation' if LANG.startswith('en-') else 'mozilla-and-you' %}
       {{ email_newsletter_form(
-          newsletters=newsletter_id,
+          newsletters='mozilla-foundation',
           title=ftl('about-get-the-mozilla-newsletter'),
           desc=ftl('about-stay-informed-about-the-issues'),
           button_class='button-dark',

--- a/bedrock/mozorg/templates/mozorg/base.html
+++ b/bedrock/mozorg/templates/mozorg/base.html
@@ -16,11 +16,7 @@
     </div>
 
     <div class="newsletter-content">
-      {% if LANG.startswith('en-') %}
-        {{ email_newsletter_form(newsletters='mozilla-foundation', title=ftl('newsletter-form-get-mozilla-updates')) }}
-      {% else %}
-        {{ email_newsletter_form() }}
-      {% endif %}
+      {{ email_newsletter_form(newsletters='mozilla-foundation') }}
     </div>
   </aside>
 </div>

--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -262,13 +262,13 @@
   <aside class="c-newsletter" aria-label="{{ ftl('newsletter-form-label') }}">
     <div class="c-newsletter-wrapper mzp-l-content mzp-t-content-lg">
       <div class="c-newsletter-info">
-        <h2>{{ ftl('newsletter-form-join-the-community', fallback='newsletter-form-get-firefox-news') }}</h2>
-        <p>{{ ftl('newsletter-form-sign-up-to-receive', fallback='newsletter-form-get-firefox-tips') }}</p>
+        <h2>{{ ftl('newsletter-form-join-the-community', fallback='newsletter-form-get-mozilla-updates') }}</h2>
+        <p>{{ ftl('multi-newsletter-form-desc') }}</p>
       </div>
 
       <div class="c-newsletter-content">
         {{ email_newsletter_form(
-          newsletters='mozilla-and-you',
+          newsletters='mozilla-foundation',
           title=None,
           button_class='button-dark',
           )}}

--- a/bedrock/mozorg/templates/mozorg/home/home-old.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-old.html
@@ -184,11 +184,12 @@
       <div class="newsletter-content">
         {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc', 'multi-newsletter-form-checkboxes-legend') %}
           {{ email_newsletter_form(
-            newsletters='mozilla-foundation' if switch('foundation-separate-newsletter') else 'mozilla-foundation, mozilla-and-you',
+            newsletters='mozilla-foundation',
             button_class='button-dark'
           )}}
         {% else %}
           {{ email_newsletter_form(
+            newsletters='mozilla-foundation',
             button_class='button-dark',
             submit_text=ftl('newsletter-form-sign-up-now')
           )}}

--- a/bedrock/mozorg/templates/mozorg/mission.html
+++ b/bedrock/mozorg/templates/mozorg/mission.html
@@ -65,13 +65,13 @@
       <div class="newsletter-content">
         {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc', 'multi-newsletter-form-checkboxes-legend') %}
           {{ email_newsletter_form(
-            newsletters='mozilla-foundation' if switch('foundation-separate-newsletter') else 'mozilla-foundation, mozilla-and-you',
+            newsletters='mozilla-foundation',
             button_class='button-dark'
           )}}
         {% elif LANG.startswith('en-') %}
           {{ email_newsletter_form(newsletters='mozilla-foundation', title='Sign up. Read up.<br> Make a difference.'|safe, desc='Get the Mozilla newsletter and help us keep the Web free and open.') }}
         {% else %}
-          {{ email_newsletter_form() }}
+          {{ email_newsletter_form(newsletters='mozilla-foundation') }}
         {% endif %}
       </div>
     </aside>

--- a/bedrock/newsletter/templates/newsletter/family.html
+++ b/bedrock/newsletter/templates/newsletter/family.html
@@ -37,7 +37,7 @@
     {{ email_newsletter_form(
       title=newsletter_title|safe,
       desc='Firefox is made in part by lots of real-life, tired yet strangely optimistic parents, and we’re backed by an awesome non-profit too.',
-      newsletters='mozilla-and-you' if switch('foundation-separate-newsletter') else 'mozilla-foundation, mozilla-and-you',
+      newsletters='mozilla-and-you',
       button_class='mzp-t-dark',
       include_title=True,
       include_country=False,

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -22,7 +22,7 @@
     </header>
     {% elif include_title %}
     <header class="mzp-c-newsletter-header">
-      <h3 class="mzp-c-newsletter-title">{{ title|d(ftl('newsletter-form-get-firefox-news'), true) }}</h3>
+      <h3 class="mzp-c-newsletter-title">{{ title|d(ftl('newsletter-form-get-firefox-news') if id == 'mozilla-and-you' else ftl('newsletter-form-get-mozilla-updates'), true) }}</h3>
       {% if subtitle %}
       <h4 class="mzp-c-newsletter-subtitle">{{ subtitle }}</h4>
       {% endif %}

--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -17,7 +17,7 @@
   <div class="mzp-l-content mzp-t-content-sm">
     {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc', 'multi-newsletter-form-checkboxes-legend') %}
       {{ email_newsletter_form(
-        newsletters='mozilla-foundation' if switch('foundation-separate-newsletter') else 'mozilla-foundation, mozilla-and-you',
+        newsletters='mozilla-foundation',
         button_class='button-dark'
       ) }}
     {% else %}

--- a/bedrock/newsletter/templates/newsletter/management.html
+++ b/bedrock/newsletter/templates/newsletter/management.html
@@ -114,11 +114,9 @@
 
               <p>{{ ftl('newsletters-there-are-many-ways-to', url=url('mozorg.about.forums.forums')) }}</p>
 
-              {% if switch('foundation-separate-newsletter') %}
-                <p>{{ ftl('newsletters-newsletter-subscriptions-for', foundation="https://www.mozillafoundation.org") }}</p>
-                <p>{{ ftl('newsletters-to-unsubscribe', unsubscribe="https://www.mozillafoundation.org/newsletter/unsubscribe") }}</p>
-                <p>{{ ftl('newsletters-if-you-arent-already-subscribed', subscribe="https://www.mozillafoundation.org/newsletter") }}</p>
-              {% endif %}
+              <p>{{ ftl('newsletters-newsletter-subscriptions-for', foundation="https://www.mozillafoundation.org") }}</p>
+              <p>{{ ftl('newsletters-to-unsubscribe', unsubscribe="https://www.mozillafoundation.org/newsletter/unsubscribe") }}</p>
+              <p>{{ ftl('newsletters-if-you-arent-already-subscribed', subscribe="https://www.mozillafoundation.org/newsletter") }}</p>
             </aside>
           </div> <!-- close .basic-settings -->
         </div>

--- a/bedrock/newsletter/templates/newsletter/mozilla.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla.html
@@ -32,15 +32,7 @@
   <section class="section section-subscribe" id="subscribe">
     <div class="mzp-l-content mzp-t-content-sm">
       <h2 class="section-title">{{ self.page_desc() }}</h2>
-      {% if ftl_has_messages('multi-newsletter-form-title', 'multi-newsletter-form-desc', 'multi-newsletter-form-checkboxes-legend') %}
-        {{ email_newsletter_form(
-          newsletters='mozilla-foundation' if switch('foundation-separate-newsletter') else 'mozilla-foundation, mozilla-and-you',
-          include_title=False,
-          button_class='button-dark'
-        )}}
-      {% else %}
         {{ email_newsletter_form(newsletters='mozilla-foundation', include_title=False, spinner_color='#c13832') }}
-      {% endif %}
     </div>
   </section>
 </main>

--- a/bedrock/newsletter/templatetags/helpers.py
+++ b/bedrock/newsletter/templatetags/helpers.py
@@ -11,7 +11,6 @@ import jinja2
 from django_jinja import library
 from markupsafe import Markup
 
-from bedrock.base.waffle import switch
 from bedrock.newsletter.forms import NewsletterFooterForm
 from lib.l10n_utils import get_locale
 
@@ -46,9 +45,9 @@ def email_newsletter_form(
     context = ctx.get_all()
     languages_override = None
 
-    if switch("foundation-separate-newsletter") and newsletters == "mozilla-foundation":
+    if newsletters == "mozilla-foundation":
         action = settings.FOUNDATION_SUBSCRIBE_URL
-        languages_override = settings.FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGUES
+        languages_override = settings.FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGES
     else:
         action = settings.BASKET_SUBSCRIBE_URL
 

--- a/bedrock/newsletter/tests/test_footer_form.py
+++ b/bedrock/newsletter/tests/test_footer_form.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 from pyquery import PyQuery as pq
-from waffle.testutils import override_switch
 
 from bedrock.base.urlresolvers import reverse
 from bedrock.mozorg.tests import TestCase
@@ -47,43 +46,43 @@ class TestNewsletterFooter(TestCase):
         The correct language for the locale should be initially selected or
         'en' if it's not an option.
         """
-        for foundation_separate_newsletter_enabled in (True, False):
-            with self.subTest(foundation_separate_newsletter_enabled=foundation_separate_newsletter_enabled):
-                with override_switch("FOUNDATION_SEPARATE_NEWSLETTER", active=foundation_separate_newsletter_enabled):
-                    with self.activate_locale("fr"):
-                        resp = self.client.get(reverse(self.view_name))
-                    doc = pq(resp.content)
-                    assert doc('#id_lang option[selected="selected"]').val() == "fr"
+        with self.activate_locale("fr"):
+            resp = self.client.get(reverse(self.view_name))
+        doc = pq(resp.content)
+        assert doc('#id_lang option[selected="selected"]').val() == "fr"
 
-                    # with hyphenated regional locale, should have only lang
-                    with self.activate_locale("pt-BR"):
-                        resp = self.client.get(reverse(self.view_name))
-                    doc = pq(resp.content)
-                    assert doc('#id_lang option[selected="selected"]').val() == "pt"
+        # with hyphenated regional locale, should have only lang
+        with self.activate_locale("pt-BR"):
+            resp = self.client.get(reverse(self.view_name))
+        doc = pq(resp.content)
+        assert doc('#id_lang option[selected="selected"]').val() == "pt"
 
-                    # not supported. should default to ''
-                    with self.activate_locale("af"):
-                        resp = self.client.get(reverse(self.view_name))
-                    doc = pq(resp.content)
-                    assert doc('#id_lang option[selected="selected"]').val() == ""
+        # not supported. should default to ''
+        with self.activate_locale("af"):
+            resp = self.client.get(reverse(self.view_name))
+        doc = pq(resp.content)
+        assert doc('#id_lang option[selected="selected"]').val() == ""
 
     @override_settings(DEV=True)
     def test_newsletter_action(self):
         """
         Newsletter points to correct POST URL.
+        The /newsletter/ page uses mozilla-foundation, which always posts to FOUNDATION_SUBSCRIBE_URL.
         """
+        with self.activate_locale("en-US"):
+            resp = self.client.get(reverse(self.view_name))
+        doc = pq(resp.content)
+        assert doc("#newsletter-form").attr("action") == settings.FOUNDATION_SUBSCRIBE_URL
 
-        with override_switch("FOUNDATION_SEPARATE_NEWSLETTER", active=True):
-            with self.activate_locale("en-US"):
-                resp = self.client.get(reverse(self.view_name))
-            doc = pq(resp.content)
-            assert doc("#newsletter-form").attr("action") == settings.FOUNDATION_SUBSCRIBE_URL
-
-        with override_switch("FOUNDATION_SEPARATE_NEWSLETTER", active=False):
-            with self.activate_locale("en-US"):
-                resp = self.client.get(reverse(self.view_name))
-            doc = pq(resp.content)
-            assert doc("#newsletter-form").attr("action") == settings.BASKET_SUBSCRIBE_URL
+    @override_settings(DEV=True)
+    def test_non_foundation_newsletter_routes_to_basket(self):
+        """
+        Non-Foundation newsletters post to BASKET_SUBSCRIBE_URL.
+        """
+        with self.activate_locale("en-US"):
+            resp = self.client.get(reverse("newsletter.family"))
+        doc = pq(resp.content)
+        assert doc("#newsletter-form").attr("action") == settings.BASKET_SUBSCRIBE_URL
 
 
 @patch(

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -217,7 +217,8 @@ def recovery(request):
 def newsletter_subscribe(request):
     if request.method == "POST":
         newsletters = request.POST.getlist("newsletters")
-        form = NewsletterFooterForm(newsletters, l10n_utils.get_locale(request), request.POST)
+        languages_override = settings.FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGES if newsletters == ["mozilla-foundation"] else None
+        form = NewsletterFooterForm(newsletters, l10n_utils.get_locale(request), request.POST, languages_override=languages_override)
         errors = []
         if form.is_valid():
             data = form.cleaned_data

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -927,8 +927,8 @@ FOUNDATION_SUBSCRIBE_URL = f"{FOUNDATION_URL}/api/newsletter/mozillaorg"
 
 # Custom languages for the Foundation signup form; need specifying directly
 # because the form config is not provided by Basket
-FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGUES = config(
-    "FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGUES",
+FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGES = config(
+    "FOUNDATION_SUBSCRIBE_AVAILABLE_LANGUAGES",
     default="en,de,fr,es,pl,pt",
     parser=ListOf(str),
 )

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.13"


### PR DESCRIPTION
## One-line summary

Route all newsletter signups to `mozilla-foundation`, excluding ones specifically Firefox branded.

## Significant changes and points to review

- The `foundation-separate-newsletter` switch is retired and mozilla-foundation now unconditionally routes to FOUNDATION_SUBSCRIBE_URL.
- Removes the fallback to Firefox for non-English users (displays the foundation form with available languages instead).
- Default form titles and the new homepage hero copy are updated to use existing Mozilla-focused FTL strings.

## Issue / Bugzilla link

n/a

## Testing

> [!NOTE]
> This is still the AI generated list. Feel free to jump in but I'll write better testing steps on Wednesday and this is not urgent. 

- Verify form action equals FOUNDATION_SUBSCRIBE_URL on Mozilla pages in English and a non-English locale (home, /about/, /about/mission/, foundation pages, footer, /newsletter/)
- Verify newsletter/family.html action equals BASKET_SUBSCRIBE_URL
- Verify Foundation manage/unsubscribe links appear unconditionally on /newsletter/existing/
- Verify a Firefox page (e.g. newsletter/firefox.html) still uses mozilla-and-you → BASKET_SUBSCRIBE_URL with Firefox-worded copy
- Follow the unsubscribe path for a Firefox newsletter