### PR TITLE
Fix speaker request form links

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -29,7 +29,7 @@
         <li><a href="{{ url('foundation.trademarks.policy') }}">I have questions about using Mozilla’s trademarks</a></li>
         <li><a href="{{ url('legal.fraud-report') }}">I’d like to report misuse of a Mozilla trademark</a></li>
         <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines">I want to hold an event in a Mozilla space</a></li>
-        <li><a href="https://bugzilla.mozilla.org/form.dev-engagement-event">I want Mozilla to sponsor my event</a></li>
+        <li><a href="{{ url('press.speaker-request') }}">I want someone from Mozilla speak at my event</a></li>
         <li><a href="mailto:trademark-permissions@mozilla.com">I’d like permission to use a Mozilla logo</a></li>
         <li><a href="{{ url('press.press-inquiry') }}">I’m a member of the Press and have a question for Mozilla</a></li>
       </ul>

--- a/bedrock/press/templates/press/speaker-request.html
+++ b/bedrock/press/templates/press/speaker-request.html
@@ -9,7 +9,6 @@
   {% block page_title %}Speaker Request Form{% endblock %}
 
   {% block page_css %}
-  {{ css_bundle('protocol-emphasis-box') }}
   {{ css_bundle('press') }}
   {% endblock %}
 
@@ -26,16 +25,6 @@
   <h2>
     Please complete and submit the form below to request a speaker from Mozilla for your upcoming event.
   </h2>
-
-  {% endif %}
-  {% if not form_success %}
-  <section class="mzp-c-emphasis-box">
-    {% with url='https://bugzilla.mozilla.org/form.dev-engagement-event' %}
-    If you are hosting a developer conference or event and want someone from
-    Mozilla's developer team to speak, please fill out the
-    <a href="{{ url }}">Developer Events Request Form</a> instead.
-    {% endwith %}
-  </section>
 
   {% if form.errors %}
   <aside class="mzp-c-notification-bar mzp-t-error">


### PR DESCRIPTION
## One-line summary

Disabled intake form links removed, one occurrence replaced with the form of the second occurrence.

## Significant changes and points to review

The now unused component imports and conditionals were also removed since this was the last consumer.

## Issue / Bugzilla link

#17303

## Testing

http://localhost:8000/en-US/contact/
http://localhost:8000/en-US/press/speakerrequest/