### PR TITLE
feat(server-side): serve GA via first-party server

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -6,7 +6,7 @@
 
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific assets default to windows #}
-<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %} {% block html_attrs %}{% endblock %}>
+<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% if settings.GTM_SERVER_URL %}data-gtm-server-url="{{ settings.GTM_SERVER_URL }}"{% endif %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %} {% block html_attrs %}{% endblock %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -6,7 +6,7 @@
 
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific assets default to windows #}
-<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% if settings.GTM_SERVER_URL %}data-gtm-server-url="{{ settings.GTM_SERVER_URL }}"{% endif %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %} {% block html_attrs %}{% endblock %}>
+<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% if settings.GTM_SERVER_URL %}data-gtm-server-url="{{ settings.GTM_SERVER_URL }}" data-gtm-server-path="{{ settings.GTM_SERVER_PATH }}"{% endif %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}"{% endif %} {% block html_attrs %}{% endblock %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/tests/test_settings.py
+++ b/bedrock/base/tests/test_settings.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 
 import pytest
 
-from bedrock.settings.base import _get_media_cdn_hostname_for_storage_backend
+from bedrock.settings.base import _get_media_cdn_hostname_for_storage_backend, _normalize_gtm_server_url
 
 
 @override_settings(DEV=False, PROD_LANGUAGES=("de", "fr", "nb-NO", "ja", "ja-JP-mac", "en-US", "en-GB"))
@@ -33,3 +33,20 @@ def test_lang_groups():
 )
 def test_get_media_cdn_hostname(media_url, expected_hostname):
     assert _get_media_cdn_hostname_for_storage_backend(media_url) == expected_hostname
+
+
+@pytest.mark.parametrize(
+    "raw_url, expected_url",
+    (
+        ("https://gtm.mozilla.org", "https://gtm.mozilla.org"),
+        ("https://gtm.mozilla.org/", "https://gtm.mozilla.org"),
+        # A scheme-less value would resolve page-relative in the browser, so we add one.
+        ("gtm.mozilla.org", "https://gtm.mozilla.org"),
+        ("gtm.mozilla.org/", "https://gtm.mozilla.org"),
+        # Protocol-relative already resolves against the page's scheme.
+        ("//gtm.mozilla.org", "//gtm.mozilla.org"),
+        ("", ""),  # unset, which disables server-side dependency serving
+    ),
+)
+def test_normalize_gtm_server_url(raw_url, expected_url):
+    assert _normalize_gtm_server_url(raw_url) == expected_url

--- a/bedrock/base/tests/test_settings.py
+++ b/bedrock/base/tests/test_settings.py
@@ -40,12 +40,18 @@ def test_get_media_cdn_hostname(media_url, expected_hostname):
     (
         ("https://gtm.mozilla.org", "https://gtm.mozilla.org"),
         ("https://gtm.mozilla.org/", "https://gtm.mozilla.org"),
-        # A scheme-less value would resolve page-relative in the browser, so we add one.
+        # A scheme-less value would resolve page-relative in the browser.
         ("gtm.mozilla.org", "https://gtm.mozilla.org"),
         ("gtm.mozilla.org/", "https://gtm.mozilla.org"),
-        # Protocol-relative already resolves against the page's scheme.
-        ("//gtm.mozilla.org", "//gtm.mozilla.org"),
+        # Protocol-relative is not a valid CSP source expression.
+        ("//gtm.mozilla.org", "https://gtm.mozilla.org"),
+        # http:// would be mixed content on our https pages.
+        ("http://gtm.mozilla.org", "https://gtm.mozilla.org"),
+        ("http://gtm.mozilla.org/", "https://gtm.mozilla.org"),
         ("", ""),  # unset, which disables server-side dependency serving
+        # A scheme with no host is treated as unset rather than becoming garbage.
+        ("https://", ""),
+        ("//", ""),
     ),
 )
 def test_normalize_gtm_server_url(raw_url, expected_url):

--- a/bedrock/base/tests/test_settings.py
+++ b/bedrock/base/tests/test_settings.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 
 import pytest
 
-from bedrock.settings.base import _get_media_cdn_hostname_for_storage_backend, _normalize_gtm_server_url
+from bedrock.settings.base import _get_media_cdn_hostname_for_storage_backend, _normalize_gtm_server_path, _normalize_gtm_server_url
 
 
 @override_settings(DEV=False, PROD_LANGUAGES=("de", "fr", "nb-NO", "ja", "ja-JP-mac", "en-US", "en-GB"))
@@ -50,3 +50,19 @@ def test_get_media_cdn_hostname(media_url, expected_hostname):
 )
 def test_normalize_gtm_server_url(raw_url, expected_url):
     assert _normalize_gtm_server_url(raw_url) == expected_url
+
+
+@pytest.mark.parametrize(
+    "raw_path, expected_path",
+    (
+        ("/gtm.js", "/gtm.js"),  # the default
+        ("gtm.js", "/gtm.js"),
+        # A custom "Tag serving path" needs its trailing slash kept: the tagging
+        # server answers /script/ but 400s on /script.
+        ("/script/", "/script/"),
+        ("script/", "/script/"),
+        ("", ""),
+    ),
+)
+def test_normalize_gtm_server_path(raw_path, expected_path):
+    assert _normalize_gtm_server_path(raw_path) == expected_path

--- a/bedrock/firefox/templates/firefox/whatsnew/base-new-theme.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base-new-theme.html
@@ -27,7 +27,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% endif %}
 
 <!doctype html>
-<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}" {% endif %} {% if settings.GTM_SERVER_URL %}data-gtm-server-url="{{ settings.GTM_SERVER_URL }}" {% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}" {% endif %} {% block html_attrs %}{% endblock %}>
+<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}" {% endif %} {% if settings.GTM_SERVER_URL %}data-gtm-server-url="{{ settings.GTM_SERVER_URL }}" data-gtm-server-path="{{ settings.GTM_SERVER_PATH }}" {% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}" {% endif %} {% block html_attrs %}{% endblock %}>
 
   <head>
     <meta charset="utf-8">

--- a/bedrock/firefox/templates/firefox/whatsnew/base-new-theme.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base-new-theme.html
@@ -27,7 +27,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 {% endif %}
 
 <!doctype html>
-<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}" {% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}" {% endif %} {% block html_attrs %}{% endblock %}>
+<html class="windows no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-country-code="{{ country_code }}" data-needs-consent="{{ needs_data_consent(country_code) }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}" {% endif %} {% if settings.GTM_SERVER_URL %}data-gtm-server-url="{{ settings.GTM_SERVER_URL }}" {% endif %} {% if settings.SENTRY_FRONTEND_DSN %}data-sentry-dsn="{{ settings.SENTRY_FRONTEND_DSN }}" {% endif %} {% block html_attrs %}{% endblock %}>
 
   <head>
     <meta charset="utf-8">

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -131,6 +131,18 @@ _csp_style_src = {
 if TRANSCEND_AIRGAP_URL:  # noqa: F405
     _csp_style_src.add(csp.constants.UNSAFE_INLINE)
 
+# When server-side GTM is enabled, our own tagging server serves gtm.js
+# (`script-src`) and receives measurement hits. Google documents `connect-src`,
+# `img-src` and `frame-src` as all required for the tagging server URL, since hits
+# fall back from fetch to an image beacon, and some tags redirect via an iframe.
+# See https://developers.google.com/tag-platform/tag-manager/server-side/send-data
+# GTM_SERVER_URL is an origin with no path.
+if GTM_SERVER_URL:
+    _csp_script_src.add(GTM_SERVER_URL)
+    _csp_connect_src.add(GTM_SERVER_URL)
+    _csp_img_src.add(GTM_SERVER_URL)
+    _csp_frame_src.add(GTM_SERVER_URL)
+
 # 2. TEST-SPECIFIC SETTINGS
 # TODO: make this selectable by an env var, like the other modes
 if (len(sys.argv) > 1 and sys.argv[1] == "test") or "pytest" in sys.modules:

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1135,17 +1135,12 @@ GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")
 
 
 def _normalize_gtm_server_url(url):
-    # Tagging server URL for server-side GTM dependency serving, normalized here
-    # so both the CSP config and the front-end can just append a path.
-    #
-    # The front-end concatenates this with a path, so a scheme-less value would
-    # resolve page-relative and silently 404 instead of loading gtm.js. A bare
-    # hostname is a plausible mistake to make here, because the adjacent CSP
-    # entries and CSP_CONNECT_SRC are all written that way.
-    url = url.rstrip("/")
-    if url and "//" not in url:
-        url = f"https://{url}"
-    return url
+    # Coerce to an https:// origin so the front-end can append a path and CSP
+    # gets a valid source. A bare hostname is the likely mistake here, since the
+    # adjacent CSP entries and CSP_CONNECT_SRC are all written that way, and it
+    # would resolve page-relative in the browser and 404 without a CSP warning.
+    host = url.removeprefix("https://").removeprefix("http://").removeprefix("//").rstrip("/")
+    return f"https://{host}" if host else ""
 
 
 # When empty, Tag Manager dependencies load from Google as usual.
@@ -1153,16 +1148,10 @@ GTM_SERVER_URL = _normalize_gtm_server_url(config("GTM_SERVER_URL", default=""))
 
 
 def _normalize_gtm_server_path(path):
-    # Exact path the tagging server serves gtm.js from, i.e. the server
-    # container's "Tag serving path" for our container ID. Only used when
-    # GTM_SERVER_URL is set; Google's CDN always serves from /gtm.js.
-    #
-    # Taken verbatim apart from adding a leading slash, because the trailing
-    # slash is significant and differs by path: a custom path such as
-    # "/script/" 400s without it, while the default "/gtm.js" 400s with it.
-    #
-    # Kept separate from GTM_SERVER_URL so that stays a bare origin, which is
-    # what the CSP directives want.
+    # The server container's "Tag serving path". Kept separate from
+    # GTM_SERVER_URL so that stays a bare origin for CSP, and taken verbatim
+    # apart from a leading slash, because the trailing slash is significant and
+    # differs by path: "/script/" 400s without it, "/gtm.js" 400s with it.
     path = path.strip()
     if path and not path.startswith("/"):
         path = f"/{path}"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1132,6 +1132,10 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.PBKDF2PasswordHasher"]
 ADMINS = MANAGERS = config("ADMINS", parser=json.loads, default="[]")
 
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")
+# Tagging server URL for server-side GTM dependency serving, normalized here so
+# both the CSP config and the front-end can just append a path. When empty, Tag
+# Manager dependencies load as usual.
+GTM_SERVER_URL = config("GTM_SERVER_URL", default="").rstrip("/")
 
 # Transcend Consent Management - airgap.js script URL
 TRANSCEND_AIRGAP_URL = config("TRANSCEND_AIRGAP_URL", default="")

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1132,10 +1132,24 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.PBKDF2PasswordHasher"]
 ADMINS = MANAGERS = config("ADMINS", parser=json.loads, default="[]")
 
 GTM_CONTAINER_ID = config("GTM_CONTAINER_ID", default="")
-# Tagging server URL for server-side GTM dependency serving, normalized here so
-# both the CSP config and the front-end can just append a path. When empty, Tag
-# Manager dependencies load as usual.
-GTM_SERVER_URL = config("GTM_SERVER_URL", default="").rstrip("/")
+
+
+def _normalize_gtm_server_url(url):
+    # Tagging server URL for server-side GTM dependency serving, normalized here
+    # so both the CSP config and the front-end can just append a path.
+    #
+    # The front-end concatenates this with a path, so a scheme-less value would
+    # resolve page-relative and silently 404 instead of loading gtm.js. A bare
+    # hostname is a plausible mistake to make here, because the adjacent CSP
+    # entries and CSP_CONNECT_SRC are all written that way.
+    url = url.rstrip("/")
+    if url and "//" not in url:
+        url = f"https://{url}"
+    return url
+
+
+# When empty, Tag Manager dependencies load from Google as usual.
+GTM_SERVER_URL = _normalize_gtm_server_url(config("GTM_SERVER_URL", default=""))
 
 # Transcend Consent Management - airgap.js script URL
 TRANSCEND_AIRGAP_URL = config("TRANSCEND_AIRGAP_URL", default="")

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1151,6 +1151,26 @@ def _normalize_gtm_server_url(url):
 # When empty, Tag Manager dependencies load from Google as usual.
 GTM_SERVER_URL = _normalize_gtm_server_url(config("GTM_SERVER_URL", default=""))
 
+
+def _normalize_gtm_server_path(path):
+    # Exact path the tagging server serves gtm.js from, i.e. the server
+    # container's "Tag serving path" for our container ID. Only used when
+    # GTM_SERVER_URL is set; Google's CDN always serves from /gtm.js.
+    #
+    # Taken verbatim apart from adding a leading slash, because the trailing
+    # slash is significant and differs by path: a custom path such as
+    # "/script/" 400s without it, while the default "/gtm.js" 400s with it.
+    #
+    # Kept separate from GTM_SERVER_URL so that stays a bare origin, which is
+    # what the CSP directives want.
+    path = path.strip()
+    if path and not path.startswith("/"):
+        path = f"/{path}"
+    return path
+
+
+GTM_SERVER_PATH = _normalize_gtm_server_path(config("GTM_SERVER_PATH", default="/gtm.js"))
+
 # Transcend Consent Management - airgap.js script URL
 TRANSCEND_AIRGAP_URL = config("TRANSCEND_AIRGAP_URL", default="")
 

--- a/media/js/base/gtm/gtm-snippet.es6.js
+++ b/media/js/base/gtm/gtm-snippet.es6.js
@@ -19,10 +19,13 @@ const html = document.getElementsByTagName('html')[0];
 const GTM_CONTAINER_ID = html.getAttribute('data-gtm-container-id');
 
 // Load Tag Manager from our own tagging server when server-side dependency
-// serving is configured, else from Google.
-const GTM_BASE_URL =
-    html.getAttribute('data-gtm-server-url') ||
-    'https://www.googletagmanager.com';
+// serving is configured, else from Google. The tagging server serves gtm.js from
+// whatever path is set as its "Tag serving path", so that is configurable too,
+// but Google's CDN only ever serves it from /gtm.js.
+const GTM_SERVER_URL = html.getAttribute('data-gtm-server-url');
+const GTM_BASE_URL = GTM_SERVER_URL || 'https://www.googletagmanager.com';
+const GTM_SCRIPT_PATH =
+    (GTM_SERVER_URL && html.getAttribute('data-gtm-server-path')) || '/gtm.js';
 
 const GTMSnippet = {};
 
@@ -66,7 +69,7 @@ GTMSnippet.loadSnippet = () => {
         // prettier-ignore
         (function(w,d,s,l,i,j,f,dl,k,q){
             w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});f=d.getElementsByTagName(s)[0];
-            k=i.length;q=GTM_BASE_URL+'/gtm.js?id=@&l='+(l||'dataLayer');
+            k=i.length;q=GTM_BASE_URL+GTM_SCRIPT_PATH+'?id=@&l='+(l||'dataLayer');
             while(k--){j=d.createElement(s);j.async=!0;j.src=q.replace('@',i[k]);f.parentNode.insertBefore(j,f);}
         }(window,document,'script','dataLayer',[GTM_CONTAINER_ID]));
     }

--- a/media/js/base/gtm/gtm-snippet.es6.js
+++ b/media/js/base/gtm/gtm-snippet.es6.js
@@ -14,9 +14,15 @@ import {
     setGtagAnalyticsConsentMode
 } from '../consent/utils.es6';
 
-const GTM_CONTAINER_ID = document
-    .getElementsByTagName('html')[0]
-    .getAttribute('data-gtm-container-id');
+const html = document.getElementsByTagName('html')[0];
+
+const GTM_CONTAINER_ID = html.getAttribute('data-gtm-container-id');
+
+// Load Tag Manager from our own tagging server when server-side dependency
+// serving is configured, else from Google.
+const GTM_BASE_URL =
+    html.getAttribute('data-gtm-server-url') ||
+    'https://www.googletagmanager.com';
 
 const GTMSnippet = {};
 
@@ -60,7 +66,7 @@ GTMSnippet.loadSnippet = () => {
         // prettier-ignore
         (function(w,d,s,l,i,j,f,dl,k,q){
             w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});f=d.getElementsByTagName(s)[0];
-            k=i.length;q='//www.googletagmanager.com/gtm.js?id=@&l='+(l||'dataLayer');
+            k=i.length;q=GTM_BASE_URL+'/gtm.js?id=@&l='+(l||'dataLayer');
             while(k--){j=d.createElement(s);j.async=!0;j.src=q.replace('@',i[k]);f.parentNode.insertBefore(j,f);}
         }(window,document,'script','dataLayer',[GTM_CONTAINER_ID]));
     }


### PR DESCRIPTION
## One-line summary

Add optional `GTM_SERVER_URL` and `GTM_SERVER_PATH` settings that load `gtm.js` from our own sGTM tagging server. Inert until the env vars are set per environment.

## Significant changes and points to review

- **`bedrock/settings/base.py`** — two new settings, both empty-or-default so nothing changes until they're set:
  - `GTM_SERVER_URL` via `_normalize_gtm_server_url()`, which strips a trailing slash and prepends `https://` to a scheme-less value. 
  - `GTM_SERVER_PATH` via `_normalize_gtm_server_path()`, which is deliberately *not* normalized beyond adding a missing leading slash, because of the trailing-slash asymmetry above. Defaults to `/gtm.js`.
- **`bedrock/settings/__init__.py`** — when `GTM_SERVER_URL` is set, the origin is added to `script-src`, `connect-src`, `img-src` **and `frame-src`**. All four are required. 
- **Two templates** — both attributes are added to *both* `base-protocol.html` and `firefox/whatsnew/base-new-theme.html`, since the latter declares its own `<html>` tag rather than extending the base. Worth confirming there's no declaration I missed.
- **`gtm-snippet.es6.js`** — the `<html>` lookup is hoisted to a local since it's now needed three times. `GTM_BASE_URL` falls back to `https://www.googletagmanager.com`, and `GTM_SCRIPT_PATH` is only consulted when a server URL is present, falling back to `/gtm.js`, because Google's CDN only ever serves from that path. Consent gating (GPC, DNT, EU opt-in, the `/thanks/` case) is untouched. 

## Issue / Bugzilla link

https://mozilla-hub.atlassian.net/browse/WT-1536

## Testing

**Confirmed no-op while unset.** Rendered `CONTENT_SECURITY_POLICY["DIRECTIVES"]` inside the `bedrock_test` container and diffed:

- `main` with the vars unset vs this branch with them unset identical, zero CSP change. Which also means no existing test can regress.
- this branch with `GTM_SERVER_URL=https://gtm-dev.allizom.org/` → exactly four additions, one origin each into `connect-src`, `frame-src`, `img-src`, `script-src`, and nothing else. Trailing slash stripped as intended.
- a bare `gtm-dev.allizom.org` and the full `https://gtm-dev.allizom.org/` produce identical results, confirming the scheme coercion.

With the vars unset, no `data-gtm-server-url` or `data-gtm-server-path` attributes render, `getAttribute` returns `null`, and the snippet loads from `https://www.googletagmanager.com/gtm.js` exactly as before.

**Unit tests:** `bedrock/base/tests/test_settings.py` covers both normalizers, including cases pinning the trailing slash so a future refactor can't strip it. 17 passing in that file. `ruff check`, `ruff format --check` and `prettier --check` are clean on all changed files.

**Confirmed against the dev tagging server:** the custom path serves the real container (200, ~389 KB, correct container ID inside), and `/gtm.js` keeps serving alongside it, so the GTM-side and bedrock-side changes can land in either order with no breakage window.