### PR TITLE
Prefix SQLite DB export filename with "public"

### DIFF
--- a/bin/run-db-upload.py
+++ b/bin/run-db-upload.py
@@ -60,7 +60,7 @@ def upload_db_data(db_data):
 def get_db_file_name():
     git_sha = get_git_sha()
     checksum = get_db_checksum()
-    return f"{git_sha[:10]}-{checksum[:10]}.db"
+    return f"public-{git_sha[:10]}-{checksum[:10]}.db"
 
 
 def get_db_data():


### PR DESCRIPTION
Changes the GCS-uploaded DB filename from `{sha}-{checksum}.db` to `public-{sha}-{checksum}.db` so that it's apparent that the sqlite DB exports are allowed to be public. 

Backwards compatible because the downloader reads the filename from the JSON metadata file, never computing it locally.

