### PR TITLE
Update SF HQ address

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -42,10 +42,10 @@
       <span itemprop="name">Mozilla Corporation</span><br>
       <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
         Attn: <span itemprop="name">Mozilla - Privacy</span><br>
-        <span itemprop="streetAddress">235 Pine St, 7th Floor</span>,<br>
+        <span itemprop="streetAddress">1875 Mission Street, Suite 103</span>,<br>
         <span itemprop="addressLocality">San Francisco</span>,
         <span itemprop="addressRegion">CA</span>
-        <span itemprop="postalCode">94104</span><br>
+        <span itemprop="postalCode">94103</span><br>
         <span itemprop="addressCountry">USA</span><br>
         <span itemprop="email"><a href="mailto:compliance@mozilla.com">compliance@mozilla.com</a></span>
       </span>

--- a/root_files/info.txt
+++ b/root_files/info.txt
@@ -3,12 +3,12 @@
 
 url: mozilla.org/
 site_owner: Mozilla Corporation
-address1: 235 Pine Street
-address2: 7th floor
+address1: 1875 Mission Street
+address2: Suite 103
 city: San Francisco
 state: CA
 country: US
-postal_code: 94104
+postal_code: 94103
 phone_number:  1 650 903 0800
 display_email: webmaster@mozilla.org
 site_name:


### PR DESCRIPTION
## One-line summary

Updates current uses of legal HQ address.

## Significant changes and points to review

This is already published in the business registry as both the HQ and mailing address, so can be updated for all the purposes here. Pairs well with German Impressum tackled in #17337

## Issue / Bugzilla link

#17072

## Testing

http://localhost:8000/info.txt
http://localhost:8000/en-US/privacy/