### PR TITLE
Drop duplicate `width` and `height` attributes in annual report

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2019/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2019/index.html
@@ -284,7 +284,7 @@
         </div>
         <div class="mzp-c-card-feature-content">
           <div class="mzp-c-card-feature-content-container">
-            <img src="{{ static('img/foundation/annualreport/2019/modal-dots-2.svg') }}" alt="" width="448" height="40" width="448" height="40">
+            <img src="{{ static('img/foundation/annualreport/2019/modal-dots-2.svg') }}" alt="" width="448" height="40">
             <h2 class="mzp-c-card-feature-title"><span class="highlight green">Victory has a Ring to it </span></h2>
             <p class="mzp-c-card-feature-desc">At the beginning of 2020, it was <a href="https://www.washingtonpost.com/nation/2019/12/12/she-installed-ring-camera-her-childrens-room-peace-mind-hacker-accessed-it-harassed-her-year-old-daughter/">widely reported</a> that criminals were hijacking Ring cameras to spy on and harass people in the privacy of their own homes. Almost 10,000 people signed Mozilla’s petition calling on Amazon to protect Ring customers by requiring two-factor authentication (2FA). And it worked! By February, Ring updated its security and required 2FA, proving that even the mightiest tech companies will respond to consumer pressure.</p>
             <a target="_blank" rel="external noopener" class="mzp-c-button mzp-t-secondary" href="https://www.mozillafoundation.org/blog/ring-2fa-and-win-consumers/{{ referrals }}">Learn more</a>


### PR DESCRIPTION
An `<img>` in the 2019 annual report carried `width` and `height` twice. Browsers keep the first occurrence and drop the rest, so this is invalid markup rather than a visible bug. Both values were identical, so nothing renders differently.

Found while scanning all templates for duplicate attributes during #17344. This was the only other one in the repo.