### PR TITLE
fix: add GitHub auth to l10n commands to prevent rate limiting

### DIFF
--- a/bedrock/base/tests/test_sentry.py
+++ b/bedrock/base/tests/test_sentry.py
@@ -32,6 +32,8 @@ def test_pre_sentry_sanitisation__before_send_setup():
         # Substring of GIT_CONFIG_VALUE_0/_1/... — the env keys we use to
         # pass an http.extraheader containing the base64-encoded PAT to git.
         "git_config_value",
+        "authentication",
+        "fluent_repo_auth",
     ]
 
 
@@ -183,3 +185,67 @@ def test_pre_sentry_sanitisation_for_git_config_value_with_base64_padding():
     stringified = json.dumps(output)
 
     assert "blocklist" not in stringified
+
+
+def test_pre_sentry_sanitisation_authentication_in_nested_params_dict():
+    """``authentication`` nested one level inside a params dict is masked."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "vars": {
+                                    "params": {
+                                        "repo_dir": "/data/l10n",
+                                        "authentication": "ghp_secret123",
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    }
+
+    output = before_send(event=event, hint=None)
+
+    params = output["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["params"]
+    assert params["authentication"] == "********"
+    assert params["repo_dir"] == "/data/l10n"
+
+
+def test_pre_sentry_sanitisation_fluent_repo_auth_in_nested_env():
+    """``FLUENT_REPO_AUTH`` nested inside a git_options/env dict is masked."""
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "vars": {
+                                    "git_options": {
+                                        "env": {
+                                            "LANG": "en_US.UTF-8",
+                                            "FLUENT_REPO_AUTH": "user:secret",
+                                            "GIT_CONFIG_VALUE_0": "AUTHORIZATION: Basic dXNlcjpzZWNyZXQ=",
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    }
+
+    output = before_send(event=event, hint=None)
+
+    env = output["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["git_options"]["env"]
+    assert env["FLUENT_REPO_AUTH"] == "********"
+    assert env["GIT_CONFIG_VALUE_0"] == "********"
+    assert env["LANG"] == "en_US.UTF-8"

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1215,6 +1215,12 @@ SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
     # keys, so without this entry the encoded credential would survive into the
     # Sentry payload.
     "git_config_value",
+    # `authentication` masks the raw credential when it appears as a dict
+    # value in frame locals (e.g. a params dict passed to GitRepo(**params)).
+    "authentication",
+    # `fluent_repo_auth` masks the raw FLUENT_REPO_AUTH env var that
+    # GitRepo.git() copies from os.environ into its subprocess env dict.
+    "fluent_repo_auth",
 ]
 SENTRY_IGNORE_ERRORS = (
     BrokenPipeError,

--- a/bedrock/utils/git.py
+++ b/bedrock/utils/git.py
@@ -37,6 +37,14 @@ class GitRepo:
         self.db_latest_key = sha256(db_latest_key.encode()).hexdigest()
         self.repo_name = name or self.path.name
 
+    def _scrub(self, value):
+        """Redact ``self.auth`` from *value* (str or bytes)."""
+        if not self.auth or value is None:
+            return value
+        needle = self.auth.encode() if isinstance(value, bytes) else self.auth
+        replacement = b"***" if isinstance(value, bytes) else "***"
+        return value.replace(needle, replacement)
+
     def git(self, *args, env=None):
         """Run a git command against the current repo"""
         curdir = os.getcwd()
@@ -46,6 +54,12 @@ class GitRepo:
             if env is not None:
                 kwargs["env"] = {**os.environ, **env}
             output = check_output((GIT,) + args, **kwargs)
+        except CalledProcessError as cpe:
+            cpe.cmd = tuple(self._scrub(arg) for arg in cpe.cmd)
+            cpe.output = self._scrub(cpe.output)
+            cpe.stderr = self._scrub(cpe.stderr)
+            cpe.args = (cpe.returncode, cpe.cmd)
+            raise cpe from None
         finally:
             os.chdir(curdir)
 
@@ -197,6 +211,12 @@ class GitRepo:
         self.git("checkout", "-f", "FETCH_HEAD")
         return old_hash, self.current_hash
 
+    def push(self, refspec):
+        """Push *refspec* to the configured remote, authenticated."""
+        with self._auth_env() as env:
+            extra = {"env": env} if env else {}
+            return self.git("push", self.remote_url, refspec, **extra)
+
     def update(self):
         """Updates a repo, cloning if necessary.
 
@@ -237,12 +257,6 @@ class GitRepo:
             repo_base = repo_base[:-1]
 
         return repo_base
-
-    def remote_url_auth(self, auth):
-        url = self.clean_remote_url
-        # remove https://
-        url = url[8:]
-        return f"https://{auth}@{url}"
 
     def set_db_latest(self, latest_ref=None):
         latest_ref = latest_ref or self.current_hash

--- a/bedrock/utils/github.py
+++ b/bedrock/utils/github.py
@@ -15,7 +15,7 @@ def get_client():
         return GITHUB_CLIENT
 
     if settings.FLUENT_REPO_AUTH:
-        auth_token = settings.FLUENT_REPO_AUTH.split(":")[1]
+        auth_token = settings.FLUENT_REPO_AUTH.rsplit(":", 1)[-1]
         GITHUB_CLIENT = Github(auth_token)
 
     return GITHUB_CLIENT

--- a/bedrock/utils/tests/test_git.py
+++ b/bedrock/utils/tests/test_git.py
@@ -201,6 +201,75 @@ def test_git_pull_with_auth_only_authenticates_fetch():
     assert checkout_calls[0].kwargs == {}
 
 
+def test_git_push_with_auth():
+    g = git.GitRepo(".", "https://example.com/repo.git", auth="testserviceaccount:supersecret")
+    with patch.object(g, "git") as git_mock:
+        git_mock.return_value = "ok"
+        g.push("HEAD:main")
+
+    git_mock.assert_called_once()
+    call_args = git_mock.call_args
+    assert call_args.args == ("push", "https://example.com/repo.git", "HEAD:main")
+    for a in call_args.args:
+        assert "supersecret" not in str(a)
+    assert call_args.kwargs["env"]["GIT_CONFIG_KEY_0"] == "http.https://example.com/.extraheader"
+
+
+def test_git_push_without_auth_passes_no_env():
+    g = git.GitRepo(".", "https://example.com/repo.git")
+    with patch.object(g, "git") as git_mock:
+        git_mock.return_value = "ok"
+        g.push("HEAD:main")
+
+    call_args = git_mock.call_args
+    assert call_args.args == ("push", "https://example.com/repo.git", "HEAD:main")
+    assert call_args.kwargs == {}
+
+
+def test_git_scrubs_auth_from_called_process_error():
+    g = git.GitRepo(".", "https://example.com/repo.git", auth="supersecret")
+    with patch.object(git, "os") as os_mock, patch.object(git, "check_output") as co_mock:
+        os_mock.getcwd.return_value = "olddir"
+        co_mock.side_effect = git.CalledProcessError(
+            1,
+            cmd=(git.GIT, "push", "https://supersecret@example.com/repo.git"),
+            output=b"fatal: Authentication failed for 'supersecret'",
+        )
+
+        with pytest.raises(git.CalledProcessError) as exc_info:
+            g.git("push", "https://supersecret@example.com/repo.git")
+
+    cpe = exc_info.value
+    assert "supersecret" not in str(cpe.cmd)
+    assert "***" in str(cpe.cmd)
+    assert b"supersecret" not in cpe.output
+    assert b"***" in cpe.output
+    # .args is rebuilt from (returncode, scrubbed cmd)
+    assert cpe.args == (cpe.returncode, cpe.cmd)
+    # __cause__ is suppressed (raise ... from None)
+    assert cpe.__cause__ is None
+
+
+def test_git_reclone_propagates_auth():
+    g = git.GitRepo(".", "https://example.com/repo.git", auth="supersecret")
+    with (
+        patch.object(git, "rmtree"),
+        patch.object(git, "time", return_value=1234),
+        patch("bedrock.utils.git.GitRepo") as MockGitRepo,
+        patch.object(g, "path") as path_mock,
+    ):
+        path_mock.exists.return_value = True
+        path_mock.with_suffix.return_value = path_mock
+        g.reclone()
+
+    MockGitRepo.assert_called_once_with(
+        path_mock,
+        "https://example.com/repo.git",
+        "main",
+        auth="supersecret",
+    )
+
+
 def test_git_call_passes_env_when_provided():
     """The base git() helper merges the supplied env on top of os.environ."""
     with patch.object(git, "os") as os_mock, patch.object(git, "check_output") as co_mock:

--- a/bedrock/utils/tests/test_github.py
+++ b/bedrock/utils/tests/test_github.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from bedrock.utils import github
+
+
+@override_settings(FLUENT_REPO_AUTH="")
+def test_get_client_no_auth_configured():
+    github.GITHUB_CLIENT = None
+    assert github.get_client() is None
+
+
+@override_settings(FLUENT_REPO_AUTH="ghp_baretoken123")
+def test_get_client_bare_token():
+    github.GITHUB_CLIENT = None
+    with patch.object(github, "Github") as GithubMock:
+        client = github.get_client()
+    GithubMock.assert_called_once_with("ghp_baretoken123")
+    assert client is GithubMock.return_value
+    github.GITHUB_CLIENT = None
+
+
+@override_settings(FLUENT_REPO_AUTH="dude:abides")
+def test_get_client_legacy_username_and_token():
+    github.GITHUB_CLIENT = None
+    with patch.object(github, "Github") as GithubMock:
+        client = github.get_client()
+    GithubMock.assert_called_once_with("abides")
+    assert client is GithubMock.return_value
+    github.GITHUB_CLIENT = None

--- a/lib/l10n_utils/management/commands/_ftl_repo_base.py
+++ b/lib/l10n_utils/management/commands/_ftl_repo_base.py
@@ -24,8 +24,18 @@ class FTLRepoCommand(BaseCommand):
         if options["quiet"]:
             self.stdout._out = StringIO()
 
-        self.l10n_repo = GitRepo(settings.FLUENT_L10N_TEAM_REPO_PATH, settings.FLUENT_L10N_TEAM_REPO_URL, settings.FLUENT_L10N_TEAM_REPO_BRANCH)
-        self.meao_repo = GitRepo(settings.FLUENT_REPO_PATH, settings.FLUENT_REPO_URL, settings.FLUENT_REPO_BRANCH)
+        self.l10n_repo = GitRepo(
+            settings.FLUENT_L10N_TEAM_REPO_PATH,
+            settings.FLUENT_L10N_TEAM_REPO_URL,
+            settings.FLUENT_L10N_TEAM_REPO_BRANCH,
+            auth=settings.FLUENT_REPO_AUTH or None,
+        )
+        self.meao_repo = GitRepo(
+            settings.FLUENT_REPO_PATH,
+            settings.FLUENT_REPO_URL,
+            settings.FLUENT_REPO_BRANCH,
+            auth=settings.FLUENT_REPO_AUTH or None,
+        )
 
     def update_l10n_team_files(self):
         try:

--- a/lib/l10n_utils/management/commands/l10n_update.py
+++ b/lib/l10n_utils/management/commands/l10n_update.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
 
     def update_fluent_files(self, clean=False):
         for site, params in FLUENT_L10N_UPDATE_PARAMS.items():
-            repo = GitRepo(**params)
+            repo = GitRepo(**params, auth=settings.FLUENT_REPO_AUTH or None)
             if clean:
                 repo.reclone()
             else:

--- a/lib/l10n_utils/management/commands/open_ftl_pr.py
+++ b/lib/l10n_utils/management/commands/open_ftl_pr.py
@@ -91,21 +91,16 @@ class Command(FTLRepoCommand):
         return True
 
     def push_changes(self):
+        if not self.l10n_repo.auth:
+            raise CommandError("Git push authentication not configured")
         try:
-            result = self.l10n_repo.git("push", self.git_push_url, f"HEAD:{self.branch_name}")
+            result = self.l10n_repo.push(f"HEAD:{self.branch_name}")
             self.stdout.write(result)
         except CalledProcessError as cpe:
             raise CommandError(f"There was a problem pushing to {self.l10n_repo.remote_url}: {cpe}\n{cpe.output}")
 
         commit = self.l10n_repo.git("rev-parse", "--short", "HEAD")
         self.stdout.write(f"Pushed {commit} to {self.l10n_repo.remote_url} as {self.branch_name}")
-
-    @property
-    def git_push_url(self):
-        if not settings.FLUENT_REPO_AUTH:
-            raise CommandError("Git push authentication not configured")
-
-        return self.l10n_repo.remote_url_auth(settings.FLUENT_REPO_AUTH)
 
     def get_open_pr(self):
         if self.github is None:

--- a/lib/l10n_utils/management/commands/process_ftl.py
+++ b/lib/l10n_utils/management/commands/process_ftl.py
@@ -78,7 +78,7 @@ class Command(FTLRepoCommand):
         if not self.meao_repo.auth:
             raise CommandError("Git push authentication not configured")
         try:
-            self.meao_repo.push("HEAD:main")
+            self.meao_repo.push(f"HEAD:{self.meao_repo.branch_name}")
         except CalledProcessError:
             raise CommandError(f"There was a problem pushing to {self.meao_repo.remote_url}")
 

--- a/lib/l10n_utils/management/commands/process_ftl.py
+++ b/lib/l10n_utils/management/commands/process_ftl.py
@@ -75,20 +75,15 @@ class Command(FTLRepoCommand):
         return True
 
     def push_changes(self):
+        if not self.meao_repo.auth:
+            raise CommandError("Git push authentication not configured")
         try:
-            self.meao_repo.git("push", self.git_push_url, "HEAD:master")
+            self.meao_repo.push("HEAD:main")
         except CalledProcessError:
             raise CommandError(f"There was a problem pushing to {self.meao_repo.remote_url}")
 
         commit = self.meao_repo.git("rev-parse", "--short", "HEAD")
         self.stdout.write(f"Pushed {commit} to {self.meao_repo.remote_url}")
-
-    @property
-    def git_push_url(self):
-        if not settings.FLUENT_REPO_AUTH:
-            raise CommandError("Git push authentication not configured")
-
-        return self.meao_repo.remote_url_auth(settings.FLUENT_REPO_AUTH)
 
     def _copy_file(self, filepath):
         relative_filepath = filepath.relative_to(self.l10n_repo.path)


### PR DESCRIPTION
## Summary
- Authenticate all git operations (clone, fetch, push) in `l10n_update`, `open_ftl_pr`, and `process_ftl` using the existing `_auth_env()` mechanism (`GIT_CONFIG_COUNT` / `http.extraheader` env vars) instead of embedding credentials in URLs — prevents GitHub rate limiting on unauthenticated requests
- Add `GitRepo.push()` method and `CalledProcessError` credential scrubbing; remove the old `remote_url_auth()` that embedded tokens in URLs
- Fix `github.py` `get_client()` to handle bare tokens (no colon separator)
- Add `authentication` and `fluent_repo_auth` to Sentry sensitive field masking

Ports the auth behaviour from [Springfield df3a650b1](https://github.com/mozmeao/springfield/commit/df3a650b12ae70579eb739412f5ad457ec68ec53). The security advisories sync is unaffected — it already uses the `auth=` mechanism.

**Env var required:** `FLUENT_REPO_AUTH` must be set in deployed environments (bare GitHub PAT or legacy `username:token` format).

## Test plan
- [x] All existing tests pass
- [x] New tests for `push()`, credential scrubbing, `reclone` auth propagation, `get_client()` bare token handling, and Sentry field masking
- [x] Verify `FLUENT_REPO_AUTH` is configured in deployed environments before merging
- [ ] Confirm l10n_update no longer hits GitHub rate limits in EU Stage/Prod