### PR TITLE
chore: prepare for merge queue use

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - "main"
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -37,7 +38,7 @@ jobs:
           docker cp $CONTAINER_ID:/app/python_coverage .
         timeout-minutes: 60
       - name: "Store coverage as an artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-results
           path: python_coverage
@@ -53,7 +54,7 @@ jobs:
   test-python-more:
     # This is a preview `test-ci` to replace the previous `test-image` over time
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }} # Only run the extra release checks on PRs for now
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }} # Only run the extra release checks on PRs and Merge Queue prep for now
     steps:
       - uses: actions/checkout@v6
       - name: "Run Python tests (on Docker) with extra release service build"

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -11,6 +11,7 @@ moz-l10n-lint l10n/l10n-vendor.toml
 python manage.py lint_ftl -q
 python manage.py version
 python manage.py migrate --noinput
+python manage.py makemigrations --check
 pytest lib bedrock \
     --cov-config=.coveragerc \
     --cov-report=html \


### PR DESCRIPTION
1. Ensure the unit tests are runnable from the merge queue
2. Add extra migration-completness checks as part of running tests