### PR TITLE
Fix remaining fx/all linux32 esr-next 404s

### DIFF
--- a/bedrock/firefox/templates/firefox/all/download.html
+++ b/bedrock/firefox/templates/firefox/all/download.html
@@ -38,7 +38,7 @@
       {# ESR #}
       {% set is_esr_next_version = desktop_esr_next_version %}
       {# If there are multiple ESR's available, show next as well. #}
-      {% if is_esr_next_version %}
+      {% if is_esr_next_version and download_esr_next_url %}
         <p class="c-step-download">
           <a href="{{ download_esr_next_url }}" class="download-link mzp-c-button mzp-t-product mzp-t-xl c-download-button" data-download-version="{{ platform }}" data-cta-text="Download Now">
             {{ ftl('firefox-all-download-esr-version', esr_version=desktop_esr_next_version) }} {{ icon_download|safe }}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -399,6 +399,9 @@ def firefox_all(request, product_slug=None, platform=None, locale=None):
                 download_esr_next_url = list(filter(lambda b: b["locale"] == locale, firefox_desktop.get_filtered_full_builds("esr_next")))[0][
                     "platforms"
                 ][platform]["download_url"]
+                # ESR153+ builds do not exist for "linux" (i686) any longer (issue #16697)
+                if platform == "linux":
+                    download_esr_next_url = None
                 context.update(
                     download_esr_next_url=download_esr_next_url,
                 )


### PR DESCRIPTION
## One-line summary

Skips ESR–next condition if linux i686, which no longer ships.

## Significant changes and points to review

Porting https://github.com/mozmeao/springfield/pull/1732

## Issue / Bugzilla link

Fixes https://github.com/mozmeao/springfield/issues/1726
Closes #17290 and also resolves #17284 now complete

## Testing

http://localhost:8000/en-US/firefox/all/desktop-esr/linux/af/ (only single ESR, no 404)
http://localhost:8000/en-US/firefox/all/desktop-esr/linux64-aarch64/af/ (control, 2 ESRs)
http://localhost:8000/en-US/firefox/all/desktop-esr/win/af/ (control, 3 ESRs)